### PR TITLE
feat: add Result type foundations (Stage 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,10 @@ Users can also set `audit.logFile` in `agency.json` (or use `agency run -l <file
 ## CRITICAL: Handlers are safety infrastructure
 Handlers (`handle` blocks) are a crucial part of what makes Agency safe. They must NEVER be accidentally skipped or left unregistered. Any feature that affects execution flow (rewind, interrupts, checkpoints, state restoration) must ensure handlers are correctly registered and invoked. If there is any risk of a handler being skipped, treat it as a critical issue and flag it immediately. Handlers are registered on `__ctx.handlers` via `pushHandler()` in the generated code and are NOT serialized as part of checkpoint state — be aware of this when working on state restoration features.
 
+## VERY IMPORTANT: Agency syntax rules
+- `if`, `while`, and `for` statements REQUIRE parentheses around the condition. Example: `if (x > 5) { ... }`, NOT `if x > 5 { ... }`.
+- Always check `DOCS.md` for correct Agency syntax when writing Agency code.
+
 ## General code Guidelines
 - NEVER use dynamic imports
 - Use objects instead of maps.

--- a/docs/superpowers/plans/2026-04-10-stage1-result-type-foundations.md
+++ b/docs/superpowers/plans/2026-04-10-stage1-result-type-foundations.md
@@ -1,0 +1,519 @@
+# Result Type Foundations Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the Result type, success/failure constructors, and isSuccess/isFailure type guards to Agency's type system, parser, runtime, and code generation.
+
+**Architecture:** Result is represented as a dedicated `ResultType` variant in the `VariableType` union: `{ type: "resultType", successType: VariableType, failureType: VariableType }`. Bare `Result` (no angle brackets) is sugar for `Result<any, any>`. `Result<S, E>` parses the two type parameters explicitly — both are required when using angle brackets. A new `resultTypeParser` handles this, following the `angleBracketsArrayTypeParser` pattern. Runtime functions `success()`, `failure()`, `isSuccess()`, `isFailure()` are added as builtins. Guard-based property narrowing (`.value` inside `isSuccess`, `.error` inside `isFailure`) is deferred to a follow-up enhancement.
+
+**Note on naming:** `lib/types/result.ts` already exists as a compiler-internal file (used for parser/AST result types). The new `lib/runtime/result.ts` created in this plan is for the Agency language runtime. These won't collide because generated code has its own import scope — generated code imports from `agency-lang/runtime`, not from `lib/types/`.
+
+**Tech Stack:** TypeScript, tarsec (parser combinators), vitest (testing)
+
+---
+
+## Task 1: Add `ResultType` to the type system
+
+Add a new `ResultType` variant to the `VariableType` union, export it from `lib/types.ts`, and update `formatTypeHint` to handle it.
+
+- [ ] **1a. Define `ResultType` in `lib/types/typeHints.ts`**
+
+Add the new type alongside the other type definitions:
+
+```typescript
+export type ResultType = {
+  type: "resultType";
+  successType: VariableType;
+  failureType: VariableType;
+};
+```
+
+Add `ResultType` to the `VariableType` union:
+
+```typescript
+export type VariableType =
+  | PrimitiveType
+  | ArrayType
+  | StringLiteralType
+  | NumberLiteralType
+  | BooleanLiteralType
+  | UnionType
+  | ObjectType
+  | TypeAliasVariable
+  | BlockType
+  | ResultType;
+```
+
+- [ ] **1b. Export `ResultType` from `lib/types.ts`**
+
+Add `ResultType` to the exports in `lib/types.ts`, alongside the other type hint exports.
+
+- [ ] **1c. Update `formatTypeHint` in `lib/cli/util.ts`**
+
+Add a case for `resultType`:
+
+```typescript
+case "resultType": {
+  const s = vt.successType;
+  const f = vt.failureType;
+  const isAny = (t: VariableType) => t.type === "primitiveType" && t.value === "any";
+  if (isAny(s) && isAny(f)) {
+    return "Result";
+  }
+  return `Result<${formatTypeHint(s)}, ${formatTypeHint(f)}>`;
+}
+```
+
+Run: `pnpm run build` to verify no compilation errors.
+
+- [ ] **1d. Commit**
+
+---
+
+## Task 2: Parse `Result` and `Result<S, E>` as type annotations
+
+Create a new `resultTypeParser` that parses both bare `Result` and `Result<SuccessType, FailureType>`.
+
+- [ ] **2a. Write failing parser tests**
+
+In `lib/parsers/typeHints.test.ts`, add tests:
+
+```typescript
+describe("resultTypeParser", () => {
+  it("parses bare Result as resultType with any/any", () => {
+    const result = resultTypeParser.run("Result");
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual({
+      type: "resultType",
+      successType: { type: "primitiveType", value: "any" },
+      failureType: { type: "primitiveType", value: "any" },
+    });
+  });
+
+  it("parses Result<string, number> with explicit type params", () => {
+    const result = resultTypeParser.run("Result<string, number>");
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual({
+      type: "resultType",
+      successType: { type: "primitiveType", value: "string" },
+      failureType: { type: "primitiveType", value: "number" },
+    });
+  });
+
+  it("parses Result with object failure type", () => {
+    const result = variableTypeParser.run("Result<string, { message: string }>");
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual({
+      type: "resultType",
+      successType: { type: "primitiveType", value: "string" },
+      failureType: {
+        type: "objectType",
+        properties: [{ key: "message", value: { type: "primitiveType", value: "string" } }],
+      },
+    });
+  });
+
+  it("parses Result with type alias params", () => {
+    const result = resultTypeParser.run("Result<MySuccess, MyError>");
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual({
+      type: "resultType",
+      successType: { type: "typeAliasVariable", aliasName: "MySuccess" },
+      failureType: { type: "typeAliasVariable", aliasName: "MyError" },
+    });
+  });
+
+  it("Result<string> with one param fails", () => {
+    // Must have either zero or two type params
+    const result = resultTypeParser.run("Result<string>");
+    expect(result.success).toBe(false);
+  });
+});
+```
+
+Run: `pnpm test:run -- lib/parsers/typeHints.test.ts`
+
+Expected: tests fail because `resultTypeParser` does not exist.
+
+- [ ] **2b. Create `resultTypeParser` in `lib/parsers/typeHints.ts`**
+
+Follow the `angleBracketsArrayTypeParser` pattern. The parser should:
+1. Match `str("Result")`
+2. Optionally match `<Type1, Type2>` using angle brackets
+3. If no angle brackets, produce `{ type: "resultType", successType: { type: "primitiveType", value: "any" }, failureType: { type: "primitiveType", value: "any" } }`
+4. If angle brackets present, parse two comma-separated types and produce `{ type: "resultType", successType: <Type1>, failureType: <Type2> }`
+
+```typescript
+export const resultTypeParser: Parser<ResultType> = trace(
+  "resultTypeParser",
+  or(
+    // Result<SuccessType, FailureType>
+    seqC(
+      set("type", "resultType"),
+      str("Result"),
+      char("<"),
+      captureCaptures(
+        parseError(
+          "expected two type parameters separated by comma, e.g. `Result<string, number>`",
+          capture(variableTypeParser, "successType"),
+          char(","),
+          optionalWhitespace,
+          capture(variableTypeParser, "failureType"),
+          char(">"),
+        ),
+      ),
+    ),
+    // Bare Result (sugar for Result<any, any>)
+    seqC(
+      set("type", "resultType"),
+      str("Result"),
+      set("successType", { type: "primitiveType", value: "any" }),
+      set("failureType", { type: "primitiveType", value: "any" }),
+    ),
+  ),
+);
+```
+
+**Note:** The `resultTypeParser` references `variableTypeParser` for parsing the type parameters, but `variableTypeParser` also needs to include `resultTypeParser`. This is a circular reference. To handle this, use the `lazy()` combinator from tarsec (like other parsers in the codebase do for circular references), OR define `resultTypeParser` before `variableTypeParser` and only use `primitiveTypeParser`, `objectTypeParser`, and `typeAliasVariableParser` inside the angle brackets (which covers the practical cases). Check how the codebase handles similar circular references and follow that pattern.
+
+- [ ] **2c. Wire `resultTypeParser` into `variableTypeParser` and `unionItemParser`**
+
+In `lib/parsers/typeHints.ts`, add `resultTypeParser` to the `variableTypeParser` `or()` list. Place it before `primitiveTypeParser` and `typeAliasVariableParser` so that `Result` is matched by the result parser rather than being treated as a type alias:
+
+```typescript
+export const variableTypeParser: Parser<VariableType> = trace(
+  "variableTypeParser",
+  or(
+    blockTypeParser,
+    unionTypeParser,
+    arrayTypeParser,
+    objectTypeParser,
+    angleBracketsArrayTypeParser,
+    resultTypeParser,               // <-- add here, before primitiveTypeParser
+    stringLiteralTypeParser,
+    numberLiteralTypeParser,
+    booleanLiteralTypeParser,
+    primitiveTypeParser,
+    typeAliasVariableParser,
+  ),
+);
+```
+
+Also add `resultTypeParser` to `unionItemParser` if it exists as a separate parser, following the same pattern.
+
+- [ ] **2d. Write a parser test for function with Result return type**
+
+In the relevant function definition parser test file, add a test verifying that a function definition like `def foo(): Result` parses correctly with the return type `{ type: "resultType", successType: { type: "primitiveType", value: "any" }, failureType: { type: "primitiveType", value: "any" } }`.
+
+Also add a test for `def foo(): Result<string, { message: string }>` to verify generic Result works as a return type.
+
+Run: `pnpm test:run -- lib/parsers/`
+
+Expected: all parser tests pass.
+
+- [ ] **2e. Commit**
+
+---
+
+## Task 3: Runtime `success()` and `failure()` functions
+
+Create the runtime Result module with constructor functions.
+
+- [ ] **3a. Write failing runtime tests**
+
+Create `lib/runtime/result.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { success, failure, isSuccess, isFailure } from "./result";
+
+describe("success", () => {
+  it("creates a success result", () => {
+    const result = success(42);
+    expect(result).toEqual({ success: true, value: 42 });
+  });
+
+  it("creates a success result with a string value", () => {
+    const result = success("hello");
+    expect(result).toEqual({ success: true, value: "hello" });
+  });
+
+  it("creates a success result with null value", () => {
+    const result = success(null);
+    expect(result).toEqual({ success: true, value: null });
+  });
+});
+
+describe("failure", () => {
+  it("creates a failure result with string error", () => {
+    const result = failure("something went wrong");
+    expect(result).toEqual({ success: false, error: "something went wrong", checkpoint: null });
+  });
+
+  it("creates a failure result with object error", () => {
+    const result = failure({ code: 404, message: "not found" });
+    expect(result).toEqual({
+      success: false,
+      error: { code: 404, message: "not found" },
+      checkpoint: null,
+    });
+  });
+
+  it("always sets checkpoint to null", () => {
+    const result = failure("error");
+    expect(result.checkpoint).toBeNull();
+  });
+});
+```
+
+Run: `pnpm test:run -- lib/runtime/result.test.ts`
+
+Expected: test fails because `lib/runtime/result.ts` does not exist.
+
+- [ ] **3b. Create `lib/runtime/result.ts`**
+
+```typescript
+// lib/runtime/result.ts
+export type ResultValue = ResultSuccess | ResultFailure;
+
+export type ResultSuccess = {
+  success: true;
+  value: any;
+};
+
+export type ResultFailure = {
+  success: false;
+  error: any;
+  checkpoint: any;
+};
+
+export function success(value: any): ResultSuccess {
+  return { success: true, value };
+}
+
+export function failure(error: any): ResultFailure {
+  return { success: false, error, checkpoint: null };
+}
+
+export function isSuccess(result: ResultValue): result is ResultSuccess {
+  return result != null && result.success === true;
+}
+
+export function isFailure(result: ResultValue): result is ResultFailure {
+  return result != null && result.success === false;
+}
+```
+
+Also add type guard tests in the same test file:
+
+```typescript
+describe("isSuccess", () => {
+  it("returns true for success results", () => {
+    expect(isSuccess(success(42))).toBe(true);
+  });
+
+  it("returns false for failure results", () => {
+    expect(isSuccess(failure("error"))).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isSuccess(null as any)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isSuccess(undefined as any)).toBe(false);
+  });
+});
+
+describe("isFailure", () => {
+  it("returns true for failure results", () => {
+    expect(isFailure(failure("error"))).toBe(true);
+  });
+
+  it("returns false for success results", () => {
+    expect(isFailure(success(42))).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isFailure(null as any)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isFailure(undefined as any)).toBe(false);
+  });
+});
+```
+
+Run: `pnpm test:run -- lib/runtime/result.test.ts`
+
+Expected: all tests pass.
+
+- [ ] **3c. Export from runtime index**
+
+In `lib/runtime/index.ts`, add:
+
+```typescript
+export { success, failure, isSuccess, isFailure } from "./result";
+```
+
+Run: `pnpm run build` to verify no compilation errors.
+
+- [ ] **3d. Commit**
+
+---
+
+## Task 4: Code generation - emit Result runtime imports and map builtins
+
+The builder/codegen needs to: (a) recognize `success`, `failure`, `isSuccess`, `isFailure` as builtin functions, and (b) emit the correct import for them in generated code.
+
+- [ ] **4a. Add to `BUILTIN_FUNCTIONS` in `lib/backends/typescriptGenerator/builtins.ts`**
+
+Add entries mapping Agency builtin names to their runtime equivalents:
+
+```typescript
+success: "success",
+failure: "failure",
+isSuccess: "isSuccess",
+isFailure: "isFailure",
+```
+
+This ensures `isBuiltinFunction()` returns true for these names and `mapFunctionName()` returns the correct runtime name.
+
+- [ ] **4b. Add runtime import for Result functions**
+
+Add `success, failure, isSuccess, isFailure` to the import from `agency-lang/runtime` in `lib/templates/backends/typescriptGenerator/imports.mustache`. These should be added to the existing destructured import block that imports other runtime builtins like `setupNode`, `setupFunction`, `runNode`, etc.
+
+After editing the mustache file, run `pnpm run templates` to recompile the template to TypeScript.
+
+Run: `pnpm run templates && pnpm run build` to verify compilation.
+
+- [ ] **4c. Commit**
+
+---
+
+## Task 5: Integration test fixtures (builder + generator)
+
+Add integration test fixtures that compile Agency code using Result types and verify the generated TypeScript.
+
+- [ ] **5a. Create generator fixture: `tests/typescriptGenerator/result-basic.agency`**
+
+```
+def checkAge(age: number): Result {
+  if age >= 18 {
+    return success(age)
+  }
+  return failure("too young")
+}
+```
+
+- [ ] **5b. Generate the expected `.mjs` fixture**
+
+Run: `make fixtures`
+
+This will compile the `.agency` file and produce the expected `.mjs` output. Review the generated `.mjs` to verify:
+- It imports `success`, `failure` from the runtime
+- The function body correctly calls `success(age)` and `failure("too young")`
+- The function is set up with `setupFunction()` as expected
+
+- [ ] **5c. Create generator fixture: `tests/typescriptGenerator/result-guards.agency`**
+
+```
+def checkValue(r: Result): string {
+  if isSuccess(r) {
+    return "ok"
+  }
+  return "error"
+}
+```
+
+Run: `make fixtures`
+
+Review the generated `.mjs` to verify `isSuccess` is correctly imported and called.
+
+- [ ] **5d. Create builder fixture**
+
+If the builder has its own fixture directory (`tests/typescriptBuilder/`), create matching fixtures there as well. Follow the same pattern as existing builder fixtures.
+
+Run: `make fixtures`
+
+- [ ] **5e. Run all integration tests**
+
+Run: `pnpm test:run -- lib/backends/typescriptGenerator.integration.test.ts`
+Run: `pnpm test:run -- lib/backends/typescriptBuilder.integration.test.ts`
+
+Expected: all tests pass.
+
+- [ ] **5f. Commit**
+
+---
+
+## Task 6: E2E test
+
+Create an end-to-end test that compiles and executes an Agency program using Result types, without any LLM calls.
+
+- [ ] **6a. Create `tests/agency/result-basic.agency`**
+
+Agency has no `assert` keyword. E2E tests use `.test.json` files with `expectedOutput` and `evaluationCriteria`. Also, direct property access like `r.value` requires guard-based narrowing (deferred), so use `isSuccess`/`isFailure` guards and return a verifiable value.
+
+```
+def tryParse(input: string): Result {
+  if input == "ok" {
+    return success(42)
+  }
+  return failure("invalid input")
+}
+
+node main() {
+  let r1 = tryParse("ok")
+  let r2 = tryParse("bad")
+  if isSuccess(r1) {
+    if isFailure(r2) {
+      return "both correct"
+    }
+  }
+  return "unexpected"
+}
+```
+
+- [ ] **6b. Create `tests/agency/result-basic.test.json`**
+
+Follow the existing `.test.json` pattern (see e.g. `tests/agency/binop.test.json`):
+
+```json
+{
+  "sourceFile": "result-basic.agency",
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"both correct\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}
+```
+
+- [ ] **6c. Run the E2E test**
+
+Run: `pnpm test:run -- tests/agency/`
+
+Expected: program executes successfully, output matches "both correct".
+
+- [ ] **6d. Commit**
+
+---
+
+## Deferred to follow-up
+
+The following are explicitly NOT in scope for this plan:
+
+- **All typechecker work**: Registering builtins in `BUILTIN_FUNCTION_TYPES`, Result assignability rules, constructor enforcement (only in Result-returning functions), return path enforcement (all paths must use success/failure). All typechecker tasks are deferred to Stage 7.
+- **Guard-based property narrowing**: Inside `if isSuccess(r) { ... }`, accessing `r.value` should be typed as `any` and `r.error` should be a type error (and vice versa for `isFailure`). This requires flow-sensitive type narrowing in the typechecker, which is complex. For now, property access on Result values (.value, .error, .checkpoint) will work at runtime but won't have typechecker enforcement.
+- **Pipe operator** (`|>`): Separate feature, separate plan.
+- **Checkpoint integration**: The `checkpoint` field on failures is `null` for now. Stage 3 will integrate with the checkpointing system.
+- **`retry()` method**: Will be added when checkpoint integration is done.
+- **`try`/`catch` keywords**: Future enhancement for ergonomic Result handling.

--- a/docs/superpowers/plans/2026-04-10-stage2-pipe-operator.md
+++ b/docs/superpowers/plans/2026-04-10-stage2-pipe-operator.md
@@ -1,0 +1,665 @@
+# Pipe Operator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Dependency:** This plan depends on Stage 1 (Result type) being complete. Specifically, `success()`, `failure()`, and the `Result` type must already exist. The `__pipeBind` function will be added to `lib/runtime/result.ts`, which is created in Stage 1.
+
+**Goal:** Add the `|>` pipe operator and `?` placeholder for partial application, enabling chaining of Result-returning operations with automatic short-circuiting on failure.
+
+**Architecture:** `|>` is parsed as the lowest-precedence left-associative binary operator using the existing `buildExpressionParser`. The `?` placeholder is a new atom type scoped to pipe right-hand sides. The builder desugars `|>` expressions to `__pipeBind(left, (x) => rightSide(x))` calls, where `__pipeBind` handles both bind (Result-returning) and fmap (plain-returning) cases at runtime. Typechecker rules for `|>` and `?` are deferred to Stage 7 (consolidated typechecker work).
+
+**Tech Stack:** TypeScript, tarsec (parser combinators), vitest (testing)
+
+---
+
+## Task 1: Add `"|>"` to the Operator type and PRECEDENCE map
+
+- [ ] Done
+
+**Files to modify:**
+- `lib/types/binop.ts`
+
+**Changes:**
+
+1. Add `"|>"` to the `Operator` type union:
+
+```typescript
+export type Operator = "+" | "-" | "*" | "/" | "==" | "!=" | "+=" | "-=" | "*=" | "/=" | "<" | ">" | "<=" | ">=" | "&&" | "||" | "!" | "|>";
+```
+
+2. Add `"|>"` to the `PRECEDENCE` map with the lowest value (`-1`), below all other operators:
+
+```typescript
+export const PRECEDENCE: Record<string, number> = {
+  "|>": -1, "||": 1, "&&": 2, "==": 3, "!=": 3, "<": 4, ">": 4, "<=": 4, ">=": 4,
+  "+": 5, "-": 5, "*": 6, "/": 6, "+=": 0, "-=": 0, "*=": 0, "/=": 0, "!": 7,
+};
+```
+
+**Tests:**
+
+No new tests needed for this step alone. Existing tests should still pass.
+
+```bash
+pnpm test:run -- lib/types
+```
+
+---
+
+## Task 2: Parse `|>` in the expression parser
+
+- [ ] Done
+
+**Files to modify:**
+- `lib/parsers/expression.ts`
+
+**Changes:**
+
+Add a new precedence level at the END of the operator table array in `buildExpressionParser` (lowest precedence, parsed last). The `|>` operator must come after `||` to ensure it binds less tightly than everything else:
+
+```typescript
+export const exprParser: Parser<Expression> = label("an expression", buildExpressionParser<Expression>(
+  atom,
+  [
+    // Precedence 6: multiplicative
+    [
+      { op: wsOp("*="), assoc: "right" as const, apply: makeBinOp("*=") },
+      { op: wsOp("/="), assoc: "right" as const, apply: makeBinOp("/=") },
+      { op: wsOp("*"), assoc: "left" as const, apply: makeBinOp("*") },
+      { op: wsOp("/"), assoc: "left" as const, apply: makeBinOp("/") },
+    ],
+    // Precedence 5: additive
+    [
+      { op: wsOp("+="), assoc: "right" as const, apply: makeBinOp("+=") },
+      { op: wsOp("-="), assoc: "right" as const, apply: makeBinOp("-=") },
+      { op: wsOp("+"), assoc: "left" as const, apply: makeBinOp("+") },
+      { op: wsOp("-"), assoc: "left" as const, apply: makeBinOp("-") },
+    ],
+    // Precedence 4: relational
+    [
+      { op: wsOp("<="), assoc: "left" as const, apply: makeBinOp("<=") },
+      { op: wsOp(">="), assoc: "left" as const, apply: makeBinOp(">=") },
+      { op: wsOp("<"), assoc: "left" as const, apply: makeBinOp("<") },
+      { op: wsOp(">"), assoc: "left" as const, apply: makeBinOp(">") },
+    ],
+    // Precedence 3: equality
+    [
+      { op: wsOp("=="), assoc: "left" as const, apply: makeBinOp("==") },
+      { op: wsOp("!="), assoc: "left" as const, apply: makeBinOp("!=") },
+    ],
+    // Precedence 2: logical AND
+    [
+      { op: wsOp("&&"), assoc: "left" as const, apply: makeBinOp("&&") },
+    ],
+    // Precedence 1: logical OR
+    [
+      { op: wsOp("||"), assoc: "left" as const, apply: makeBinOp("||") },
+    ],
+    // Precedence 0 (lowest): pipe
+    [
+      { op: wsOp("|>"), assoc: "left" as const, apply: makeBinOp("|>") },
+    ],
+  ],
+  parenParser,
+));
+```
+
+IMPORTANT: The `wsOp("|>")` parser must match the two-character sequence `|>`. Since `|` is not used as a standalone operator in the expression parser, there should be no ambiguity. However, verify that no existing parser tries to match a bare `|` that could conflict.
+
+**Tests:**
+
+Add parser unit tests in `lib/parsers/expression.test.ts`:
+
+```typescript
+describe("pipe operator |>", () => {
+  it("parses a simple pipe expression", () => {
+    const result = exprParser("a |> b");
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({
+      type: "binOpExpression",
+      operator: "|>",
+      left: { type: "valueAccess", path: ["a"] },
+      right: { type: "valueAccess", path: ["b"] },
+    });
+  });
+
+  it("parses chained pipe expressions left-to-right", () => {
+    const result = exprParser("a |> b |> c");
+    expect(result.success).toBe(true);
+    // Left-associative: (a |> b) |> c
+    expect(result.result).toEqual({
+      type: "binOpExpression",
+      operator: "|>",
+      left: {
+        type: "binOpExpression",
+        operator: "|>",
+        left: { type: "valueAccess", path: ["a"] },
+        right: { type: "valueAccess", path: ["b"] },
+      },
+      right: { type: "valueAccess", path: ["c"] },
+    });
+  });
+
+  it("pipe has lower precedence than ||", () => {
+    const result = exprParser("a || b |> c");
+    expect(result.success).toBe(true);
+    // Should parse as (a || b) |> c
+    expect(result.result.type).toBe("binOpExpression");
+    expect(result.result.operator).toBe("|>");
+    expect(result.result.left.operator).toBe("||");
+  });
+
+  it("parses pipe with function call on right side", () => {
+    const result = exprParser("a |> foo(10)");
+    expect(result.success).toBe(true);
+    expect(result.result.operator).toBe("|>");
+    expect(result.result.right.type).toBe("functionCall");
+  });
+});
+```
+
+```bash
+pnpm test:run -- lib/parsers/expression.test.ts
+```
+
+---
+
+## Task 3: Add `Placeholder` AST node type and parse `?` as an atom
+
+- [ ] Done
+
+**Files to create:**
+- `lib/types/placeholder.ts`
+
+**Files to modify:**
+- `lib/types.ts`
+- `lib/parsers/expression.ts`
+
+**Changes:**
+
+1. Create `lib/types/placeholder.ts`:
+
+```typescript
+export type Placeholder = {
+  type: "placeholder";
+};
+```
+
+2. In `lib/types.ts`, export the new type and add it to the `Expression` union:
+
+```typescript
+// Add to imports/exports
+export type { Placeholder } from "./types/placeholder.js";
+
+// Update the Expression union
+export type Expression = ValueAccess | Literal | FunctionCall | BinOpExpression | AgencyArray | AgencyObject | Placeholder;
+```
+
+3. In `lib/parsers/expression.ts`, add a parser for `?` as an atom. The `?` must be parsed as a standalone token that doesn't consume surrounding identifiers. Add it to the `atom` parser:
+
+```typescript
+import { char } from "tarsec";
+
+const placeholderParser: Parser<Placeholder> = (input: string) => {
+  const result = char("?")(input);
+  if (!result.success) return result;
+  // Make sure `?` is not followed by an identifier character (e.g., `?foo` should not match)
+  if (result.rest.length > 0 && /[a-zA-Z0-9_]/.test(result.rest[0])) {
+    return failure("placeholder", input);
+  }
+  return { success: true as const, result: { type: "placeholder" as const }, rest: result.rest };
+};
+```
+
+Then add `placeholderParser` as one of the alternatives in the `atom` parser (the `or(...)` that combines all atom-level expressions). Place it before the identifier/valueAccess parser so `?` is recognized before it tries to parse it as a variable name.
+
+**Tests:**
+
+Add parser unit tests in `lib/parsers/expression.test.ts`:
+
+```typescript
+describe("placeholder ?", () => {
+  it("parses ? as a placeholder", () => {
+    const result = exprParser("?");
+    expect(result.success).toBe(true);
+    expect(result.result).toEqual({ type: "placeholder" });
+  });
+
+  it("parses ? inside function call arguments", () => {
+    const result = exprParser("foo(10, ?)");
+    expect(result.success).toBe(true);
+    expect(result.result.type).toBe("functionCall");
+    expect(result.result.arguments[1]).toEqual({ type: "placeholder" });
+  });
+
+  it("parses ? as first argument in function call", () => {
+    const result = exprParser("foo(?, 10)");
+    expect(result.success).toBe(true);
+    expect(result.result.type).toBe("functionCall");
+    expect(result.result.arguments[0]).toEqual({ type: "placeholder" });
+  });
+
+  it("parses pipe with partial application", () => {
+    const result = exprParser("a |> multiply(10, ?)");
+    expect(result.success).toBe(true);
+    expect(result.result.operator).toBe("|>");
+    expect(result.result.right.type).toBe("functionCall");
+    expect(result.result.right.arguments[1]).toEqual({ type: "placeholder" });
+  });
+});
+```
+
+```bash
+pnpm test:run -- lib/parsers/expression.test.ts
+```
+
+---
+
+## Task 4: Add `__pipeBind` runtime function
+
+- [ ] Done
+
+**Files to modify:**
+- `lib/runtime/result.ts` (created in Stage 1 — this task depends on Stage 1 being complete)
+
+**Changes:**
+
+Add the `__pipeBind` function to `lib/runtime/result.ts`. This function handles both bind (when the piped function returns a Result) and fmap (when it returns a plain value) cases at runtime:
+
+```typescript
+/**
+ * Pipe bind for the |> operator. If the input result is a failure, short-circuit
+ * and return it immediately. Otherwise, apply fn to the unwrapped value.
+ * If fn returns a Result, use it directly (bind). If fn returns a plain value,
+ * wrap it in success (fmap).
+ */
+export function __pipeBind(result: ResultValue, fn: (value: any) => any): ResultValue {
+  if (!result.success) return result;
+  const output = fn(result.value);
+  // Smart bind/fmap: if fn already returns a Result, use it directly
+  if (output != null && typeof output === "object" && "success" in output && typeof output.success === "boolean") {
+    return output;
+  }
+  return { success: true, value: output };
+}
+```
+
+Also export `__pipeBind` from `lib/runtime/index.ts` if it is not already re-exported from there.
+
+Additionally, add `__pipeBind` to the import list in `lib/templates/backends/typescriptGenerator/imports.mustache`, then run `pnpm run templates`. This ensures compiled Agency code imports `__pipeBind` from the runtime.
+
+**Tests:**
+
+Add unit tests in `lib/runtime/result.test.ts` (create if it does not already exist):
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { success, failure, __pipeBind } from "./result.js";
+
+describe("__pipeBind", () => {
+  it("short-circuits on failure", () => {
+    const fail = failure("something went wrong");
+    const result = __pipeBind(fail, (x) => success(x + 1));
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("something went wrong");
+  });
+
+  it("applies function on success (bind: fn returns Result)", () => {
+    const ok = success(5);
+    const result = __pipeBind(ok, (x) => success(x * 2));
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(10);
+  });
+
+  it("wraps plain return value in success (fmap)", () => {
+    const ok = success(5);
+    const result = __pipeBind(ok, (x) => x * 2);
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(10);
+  });
+
+  it("propagates failure from fn (bind)", () => {
+    const ok = success(5);
+    const result = __pipeBind(ok, (_x) => failure("downstream error"));
+    expect(result.success).toBe(false);
+    expect(result.error).toBe("downstream error");
+  });
+
+  it("chains multiple pipes", () => {
+    const start = success(2);
+    const r1 = __pipeBind(start, (x) => success(x + 3));  // 5
+    const r2 = __pipeBind(r1, (x) => x * 10);              // 50, fmap
+    const r3 = __pipeBind(r2, (x) => success(x + 1));      // 51
+    expect(r3.success).toBe(true);
+    expect(r3.value).toBe(51);
+  });
+
+  it("chains stop at first failure", () => {
+    const start = success(2);
+    const r1 = __pipeBind(start, (_x) => failure("oops"));
+    const r2 = __pipeBind(r1, (x) => success(x + 100));
+    expect(r2.success).toBe(false);
+    expect(r2.error).toBe("oops");
+  });
+});
+```
+
+```bash
+pnpm test:run -- lib/runtime/result.test.ts
+```
+
+---
+
+## Task 5: Builder — desugar `|>` with bare function reference (no `?`)
+
+- [ ] Done
+
+**Files to modify:**
+- `lib/backends/typescriptBuilder.ts`
+
+**Changes:**
+
+In `processBinOpExpression()`, add a special case for the `"|>"` operator. When the right-hand side is a bare function reference (a `valueAccess` node), desugar it:
+
+For a bare function reference on the right (`a |> bar`):
+```
+__pipeBind(<left>, (__pipeArg) => bar(__pipeArg))
+```
+
+The generated IR should be:
+```typescript
+ts.call(
+  ts.raw("__pipeBind"),
+  [
+    processedLeft,
+    ts.arrowFn([{ name: "__pipeArg" }], ts.call(processedRight, [ts.raw("__pipeArg")]))
+  ]
+)
+```
+
+Where `processedLeft` is the recursively processed left-hand side, and `processedRight` is the right-hand side processed as a callee (not invoked yet).
+
+Handle the case where the right side is a `valueAccess` (bare name like `bar` or dotted like `obj.method`). Note that `obj.method` is represented as a `valueAccess` node with `path: ["obj", "method"]` in the AST. The desugaring wraps it into `(__pipeArg) => obj.method(__pipeArg)`, which works correctly since `processNode` for a `valueAccess` produces the dotted access expression:
+
+```typescript
+case "|>": {
+  const left = this.processNode(node.left);
+  const right = node.right;
+
+  if (right.type === "valueAccess") {
+    // Bare function reference: a |> bar → __pipeBind(a, (__pipeArg) => bar(__pipeArg))
+    const callee = this.processNode(right);
+    return ts.call(ts.raw("__pipeBind"), [
+      left,
+      ts.arrowFn([{ name: "__pipeArg" }], ts.call(callee, [ts.raw("__pipeArg")]))
+    ]);
+  }
+
+  // ... functionCall cases in Task 6
+}
+```
+
+Also add a `case "placeholder"` to the builder's `processNode` switch statement. It should throw a clear error, since placeholders should always be desugared by the `|>` handler and should never reach `processNode` directly:
+
+```typescript
+case "placeholder":
+  throw new Error("Placeholder '?' can only appear on the right side of a |> pipe operator");
+```
+
+Also ensure that `__pipeBind` is imported in the generated code. This likely means adding it to the runtime import list in the builder/generator. Look for where other runtime functions like `success` and `failure` are imported, and add `__pipeBind` alongside them.
+
+**Tests:**
+
+Add builder integration test fixtures. Create two files:
+
+`tests/typescriptBuilder/pipe-bare-function.agency`:
+```
+function double(x: number) -> number:
+  return x * 2
+
+node main -> end:
+  result = success(5) |> double
+```
+
+`tests/typescriptBuilder/pipe-bare-function.mjs` (expected output — fill in after generating):
+The generated code should contain a `__pipeBind(...)` call wrapping a lambda.
+
+Run:
+```bash
+make fixtures
+pnpm test:run -- tests/typescriptBuilder
+```
+
+Also add a unit test in the builder test file to verify the IR structure if such a test file exists.
+
+---
+
+## Task 6: Builder — desugar `|>` with partial application (`?` placeholder)
+
+- [ ] Done
+
+**Files to modify:**
+- `lib/backends/typescriptBuilder.ts`
+
+**Changes:**
+
+Extend the `"|>"` case in `processBinOpExpression()` to handle function calls with `?` placeholders.
+
+When the right-hand side is a `functionCall` containing a `?` placeholder in its arguments:
+- Replace the `?` with the lambda parameter `__pipeArg`
+- Wrap in a lambda
+
+**Note:** `FunctionCall.arguments` is broader than `Expression[]` — it also includes `SplatExpression` and `NamedArgument` variants. When checking for `?` placeholder, handle these cases: using `?` alongside named or splat arguments should be treated as a type error. Add a check that rejects pipes where the right-side function call uses named or splat arguments alongside `?`.
+
+For `a |> multiply(10, ?)`:
+```
+__pipeBind(<left>, (__pipeArg) => multiply(10, __pipeArg))
+```
+
+```typescript
+if (right.type === "functionCall") {
+  const hasPlaceholder = right.arguments.some(
+    (arg) => arg.type === "placeholder"
+  );
+
+  if (!hasPlaceholder) {
+    // A function call on the right side of |> MUST have exactly one ?.
+    // Zero placeholders in a function call is a type error (caught by the typechecker).
+    // The builder should never reach this path if the typechecker runs first,
+    // but throw defensively.
+    throw new Error("Function call on right side of |> must contain exactly one ? placeholder");
+  }
+
+  // Partial application: a |> foo(10, ?) → __pipeBind(a, (__pipeArg) => foo(10, __pipeArg))
+  const processedArgs = right.arguments.map((arg) => {
+    if (arg.type === "placeholder") {
+      return ts.raw("__pipeArg");
+    }
+    return this.processNode(arg);
+  });
+  const callee = this.processNode({
+    type: "valueAccess",
+    path: [right.functionName],
+  });
+  return ts.call(ts.raw("__pipeBind"), [
+    left,
+    ts.arrowFn([{ name: "__pipeArg" }], ts.call(callee, processedArgs))
+  ]);
+}
+```
+
+**Tests:**
+
+Add builder integration test fixtures:
+
+`tests/typescriptBuilder/pipe-partial.agency`:
+```
+function multiply(a: number, b: number) -> number:
+  return a * b
+
+node main -> end:
+  result = success(5) |> multiply(10, ?)
+```
+
+Also test chained pipes:
+
+`tests/typescriptBuilder/pipe-chain.agency`:
+```
+function double(x: number) -> number:
+  return x * 2
+
+function add(a: number, b: number) -> number:
+  return a + b
+
+node main -> end:
+  result = success(5) |> double |> add(10, ?)
+```
+
+Expected generated code for the chain should nest `__pipeBind` calls:
+```typescript
+__pipeBind(__pipeBind(success(5), (__pipeArg) => double(__pipeArg)), (__pipeArg) => add(10, __pipeArg))
+```
+
+Run:
+```bash
+make fixtures
+pnpm test:run -- tests/typescriptBuilder
+```
+
+---
+
+## Task 7: Integration test fixtures
+
+- [ ] Done
+
+**Files to create:**
+- `tests/typescriptGenerator/pipe-operator.agency`
+- `tests/typescriptGenerator/pipe-operator.mjs`
+
+**Changes:**
+
+Create a comprehensive integration test that exercises the pipe operator through the full compilation pipeline (parse -> build -> generate).
+
+`tests/typescriptGenerator/pipe-operator.agency`:
+```
+function double(x: number) -> number:
+  return x * 2
+
+function multiply(a: number, b: number) -> number:
+  return a * b
+
+function safeDivide(a: number, b: number) -> Result:
+  if b == 0:
+    return failure("division by zero")
+  return success(a / b)
+
+node main -> end:
+  // Bare function reference
+  r1 = success(5) |> double
+
+  // Partial application with ?
+  r2 = success(5) |> multiply(10, ?)
+
+  // Chained pipes
+  r3 = success(10) |> double |> multiply(3, ?)
+
+  // Short-circuit on failure
+  r4 = failure("nope") |> double
+
+  // Chain with Result-returning function (bind)
+  r5 = success(10) |> safeDivide(?, 2)
+```
+
+Generate the expected `.mjs` output by running:
+```bash
+make fixtures
+```
+
+Then verify the fixture matches expectations and tests pass:
+```bash
+pnpm test:run -- tests/typescriptGenerator
+```
+
+---
+
+## Task 8: E2E test
+
+- [ ] Done
+
+**Files to create:**
+- `tests/agency/pipe-operator.agency`
+- `tests/agency/pipe-operator.test.json`
+
+**Changes:**
+
+Create an end-to-end test that compiles and runs a pipe operator program. Agency E2E tests do NOT require LLM calls, so we can test pure logic.
+
+`tests/agency/pipe-operator.agency`:
+```
+function double(x: number) -> number:
+  return x * 2
+
+function multiply(a: number, b: number) -> number:
+  return a * b
+
+node main -> end:
+  r1 = success(5) |> double
+  r2 = success(5) |> multiply(10, ?)
+  r3 = success(10) |> double |> multiply(3, ?)
+  r4 = failure("nope") |> double
+  return { r1: r1, r2: r2, r3: r3, r4: r4 }
+```
+
+`tests/agency/pipe-operator.test.json`:
+```json
+{
+  "sourceFile": "pipe-operator.agency",
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"r1\":{\"success\":true,\"value\":10},\"r2\":{\"success\":true,\"value\":50},\"r3\":{\"success\":true,\"value\":60},\"r4\":{\"success\":false,\"error\":\"nope\"}}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Run:
+```bash
+pnpm test:run -- tests/agency/pipe-operator
+```
+
+---
+
+## Summary of all files to create or modify
+
+**New files:**
+- `lib/types/placeholder.ts` — Placeholder AST node type
+- `lib/runtime/result.test.ts` — Unit tests for `__pipeBind` (if not already existing)
+- `tests/typescriptGenerator/pipe-operator.agency` — Generator integration test
+- `tests/typescriptGenerator/pipe-operator.mjs` — Generator integration test expected output
+- `tests/typescriptBuilder/pipe-bare-function.agency` — Builder integration test
+- `tests/typescriptBuilder/pipe-bare-function.mjs` — Builder integration test expected output
+- `tests/typescriptBuilder/pipe-partial.agency` — Builder integration test
+- `tests/typescriptBuilder/pipe-partial.mjs` — Builder integration test expected output
+- `tests/typescriptBuilder/pipe-chain.agency` — Builder integration test
+- `tests/typescriptBuilder/pipe-chain.mjs` — Builder integration test expected output
+- `tests/agency/pipe-operator.agency` — E2E test
+- `tests/agency/pipe-operator.test.json` — E2E test expected output
+
+**Modified files:**
+- `lib/types/binop.ts` — Add `"|>"` to Operator type and PRECEDENCE map
+- `lib/types.ts` — Export Placeholder, add to Expression union
+- `lib/parsers/expression.ts` — Parse `|>` operator and `?` placeholder
+- `lib/parsers/expression.test.ts` — Parser unit tests
+- `lib/runtime/result.ts` — Add `__pipeBind` function (depends on Stage 1)
+- `lib/runtime/index.ts` — Re-export `__pipeBind`
+- `lib/templates/backends/typescriptGenerator/imports.mustache` — Add `__pipeBind` to runtime imports
+- `lib/backends/typescriptBuilder.ts` — Desugar `|>` to `__pipeBind` calls, add `case "placeholder"` error
+
+**Deferred to Stage 7:** Typechecker enforcement for `|>` (left must be Result, result type is Result) and `?` (only valid on right side of `|>`) is consolidated in Stage 7.

--- a/docs/superpowers/plans/2026-04-10-stage3-result-checkpointing-retry.md
+++ b/docs/superpowers/plans/2026-04-10-stage3-result-checkpointing-retry.md
@@ -1,0 +1,293 @@
+# Result Checkpointing and Retry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Dependency:** This plan depends on Stage 1 (Result type foundations) being complete. Stage 1 creates `lib/runtime/result.ts` with `success()`, `failure()`, `isSuccess()`, `isFailure()`. Do not begin this plan until Stage 1 is merged.
+
+**Goal:** Add automatic checkpointing at Result-returning function entry, embed checkpoints in failure objects, extend RestoreOptions for argument overrides, and implement the `result.retry()` compiler desugaring.
+
+**Architecture:** The builder detects Result-returning functions and emits a pinned checkpoint creation after the setup block at function entry. `failure()` is updated to accept a checkpoint — but this is purely a builder concern; in Agency source code, users write `failure("error")` with one argument, and the builder injects the checkpoint as the second argument in generated code. `RestoreOptions` gains `args` and `globals` fields. `result.retry(newArgs)` is desugared by the builder into `restore(checkpoint, { args })`. Retry limits are enforced via `CheckpointStore.trackRestore()` using the existing `maxRestores` mechanism, configured through `result.maxRetries`. Typechecker rules for `.retry()` validation are deferred to Stage 7 (consolidated typechecker work).
+
+**Tech Stack:** TypeScript, vitest (testing)
+
+---
+
+## Task 1: Extend `RestoreOptions` with `args` and `globals` fields
+
+- [ ] In `lib/runtime/errors.ts`, update the `RestoreOptions` type:
+  ```typescript
+  export type RestoreOptions = {
+    messages?: MessageJSON[];
+    args?: any[];
+    globals?: Record<string, Record<string, any>>;
+  };
+  ```
+- [ ] Add unit tests in `lib/runtime/errors.test.ts` (or co-located test file) verifying that `RestoreSignal` can be constructed with the new fields and that they are accessible on the instance:
+  ```typescript
+  const cp = { id: 1, stack: {}, globals: {}, nodeId: "n", moduleId: "m", scopeName: "s", stepPath: "", label: undefined, pinned: false } as any;
+  const signal = new RestoreSignal(cp, { args: [1, 2], globals: { mod: { x: 10 } } });
+  expect(signal.options?.args).toEqual([1, 2]);
+  expect(signal.options?.globals).toEqual({ mod: { x: 10 } });
+  ```
+- [ ] Run: `pnpm vitest run lib/runtime/errors`
+
+---
+
+## Task 2: Apply argument and globals overrides in state restoration
+
+When restoring from a checkpoint with `args` or `globals` in `RestoreOptions`, these overrides must be applied.
+
+**Argument overrides:** Function arguments are regular TypeScript parameters — they are NOT read from the stack frame by `setupFunction`. The correct approach is to store pending arg overrides on the `RuntimeContext` and apply them in the generated function preamble.
+
+- [ ] In `lib/runtime/state/context.ts`, add an optional `_pendingArgOverrides?: any[]` field to `RuntimeContext`.
+- [ ] In `lib/runtime/node.ts`, in the `catch (e)` block that handles `RestoreSignal`, after calling `execCtx.restoreState(cp)`, add logic to apply both argument and globals overrides:
+  ```typescript
+  if (e instanceof RestoreSignal) {
+    const cp = e.checkpoint;
+    execCtx.restoreState(cp);
+    if (e.options?.args) {
+      execCtx._pendingArgOverrides = e.options.args;
+    }
+    if (e.options?.globals) {
+      execCtx.globals.patchGlobals(e.options.globals);
+    }
+    // ... existing audit, reset state ...
+  }
+  ```
+- [ ] In `lib/backends/typescriptBuilder.ts`, in `processFunctionDefinition()`, for Result-returning functions, emit a preamble step in the generated function setup code that checks for pending arg overrides and applies them to the local parameter variables:
+  ```typescript
+  // Generated code in the function preamble:
+  if (__ctx._pendingArgOverrides) {
+    [param1, param2, ...] = __ctx._pendingArgOverrides;
+    __ctx._pendingArgOverrides = undefined;
+  }
+  ```
+  The builder knows the parameter names from the function definition, so it can emit the destructuring assignment.
+- [ ] In `lib/runtime/state/globalStore.ts`, add a `patchGlobals(overrides: Record<string, Record<string, any>>)` method to `GlobalStore`:
+  ```typescript
+  patchGlobals(overrides: Record<string, Record<string, any>>): void {
+    for (const [moduleId, vars] of Object.entries(overrides)) {
+      for (const [varName, value] of Object.entries(vars)) {
+        this.set(moduleId, varName, value);
+      }
+    }
+  }
+  ```
+- [ ] Add unit tests:
+  - In `lib/runtime/state/context.test.ts` (or co-located): verify `_pendingArgOverrides` can be set and cleared.
+  - In `lib/runtime/state/globalStore.test.ts`: Create a GlobalStore, initialize a module, call `patchGlobals({ mod: { x: 42 } })`, verify `get("mod", "x")` returns 42. Verify patching a non-existent module creates it or handles it gracefully.
+- [ ] Run: `pnpm vitest run lib/runtime/state/globalStore` and `pnpm vitest run lib/runtime/state/context`
+
+---
+
+## Task 3: Update `failure()` to accept an optional checkpoint parameter
+
+**Note:** In Agency source code, users write `failure("error")` with one argument. The builder (Task 5) is responsible for injecting the checkpoint as the second argument in generated code. The user never sees or passes the checkpoint.
+
+- [ ] In `lib/runtime/result.ts`, update the `failure()` function signature:
+  ```typescript
+  export function failure(error: any, checkpoint?: any): ResultFailure {
+    return { success: false, error, checkpoint: checkpoint ?? null };
+  }
+  ```
+- [ ] Add unit tests in `lib/runtime/result.test.ts`:
+  - `failure("bad")` produces `{ success: false, error: "bad", checkpoint: null }`.
+  - `failure("bad", someCp)` produces `{ success: false, error: "bad", checkpoint: someCp }`.
+  - `isFailure(failure("bad", cp))` returns `true`.
+- [ ] Run: `pnpm vitest run lib/runtime/result`
+
+---
+
+## Task 4: Builder — auto-checkpoint at Result-returning function entry
+
+The builder must detect when a function's return type is `Result` and emit a pinned checkpoint creation at function entry.
+
+**Important:** The checkpoint creation must go AFTER the `setupEnv` block in the generated code, so `__ctx` and `__state` are properly initialized.
+
+- [ ] In `lib/backends/typescriptBuilder.ts`, in `processFunctionDefinition()`, after the existing setup code (setupFunction, setupEnv, audit calls, etc.), add a check:
+  ```typescript
+  if (node.returnType && isResultType(node.returnType)) {
+    // Emit: const __resultCheckpointId = __ctx.checkpoints.createPinned(__ctx, { ... });
+  }
+  ```
+- [ ] Create a helper `isResultType(type: AgencyType): boolean` in `lib/backends/utils.ts` (or inline in the builder) that checks whether a type node represents `Result` or `Result<T, E>`.
+- [ ] Emit the checkpoint creation using `createPinned()` (not `create()`) so that Result checkpoints survive `deleteAfterCheckpoint()` calls and garbage collection. Use the IR builder:
+  ```typescript
+  ts.constDecl("__resultCheckpointId", ts.call("__ctx.checkpoints.createPinned", [
+    ts.id("__ctx"),
+    ts.object({ nodeId: ts.string(nodeId), moduleId: ts.string(moduleId), scopeName: ts.string(scopeName), label: ts.string("result-entry") })
+  ]))
+  ```
+  This must be wrapped in a step so it participates in the step counter system for interrupt/restore support.
+- [ ] Update the imports template (`lib/templates/backends/`) so generated code can access `createPinned` and any other checkpoint functions needed by the new generated code. Verify that the runtime imports in compiled output include the necessary checkpoint-related symbols.
+- [ ] Add a unit test fixture in `tests/typescriptBuilder/` with a `.agency` file containing a Result-returning function:
+  ```
+  function validate(input: string) -> Result<string, string>:
+    if input == "":
+      return failure("empty input")
+    return success(input)
+  ```
+  And a corresponding `.mts` fixture showing the expected generated code includes the pinned checkpoint creation at function entry (after setup).
+- [ ] Run: `pnpm vitest run tests/typescriptBuilder`
+
+---
+
+## Task 5: Builder — emit `failure()` with checkpoint in Result-returning functions
+
+When generating code for `failure(error)` inside a Result-returning function, the builder must pass the stored checkpoint.
+
+- [ ] In `lib/backends/typescriptBuilder.ts`, when processing a `failure()` call expression inside a function whose return type is `Result`, transform the call:
+  - Original Agency: `failure(errorExpr)`
+  - Generated TS: `failure(errorExpr, __ctx.checkpoints.get(__resultCheckpointId))`
+- [ ] The detection logic: when processing a call expression node where the callee is `failure`, check if the enclosing function definition has a Result return type. If so, append the checkpoint argument.
+- [ ] Update the fixture from Task 4 to verify that `failure("empty input")` compiles to `failure("empty input", __ctx.checkpoints.get(__resultCheckpointId))`.
+- [ ] Run: `pnpm vitest run tests/typescriptBuilder`
+
+---
+
+## Task 6: Add `result.maxRetries` config
+
+Retry limits are enforced through the existing `CheckpointStore.trackRestore()` mechanism, which tracks restore counts per checkpoint ID and throws `CheckpointError` when exceeding `maxRestores`. The `result.maxRetries` config feeds into `maxRestores` for Result checkpoints.
+
+- [ ] In `lib/config.ts`, add to `AgencyConfig`:
+  ```typescript
+  result?: {
+    maxRetries?: number;  // default: 50
+  };
+  ```
+- [ ] In the config defaults/resolution logic in `lib/config.ts`, set the default for `result.maxRetries` to 50.
+- [ ] In the builder (Task 4), when emitting the `createPinned()` call for Result-returning function entry, pass the `maxRestores` value from config so the checkpoint store can enforce the limit:
+  ```typescript
+  // The CheckpointStore.trackRestore() mechanism already throws CheckpointError
+  // when maxRestores is exceeded. Configure maxRestores on the CheckpointStore
+  // using the result.maxRetries config value.
+  ```
+  If `CheckpointStore` does not yet support per-checkpoint `maxRestores`, update it to accept an optional `maxRestores` in `createPinned()` options, or set it globally from the config before checkpoint creation.
+- [ ] Add unit tests in `lib/config.test.ts` (or co-located test file) verifying that the default is 50 and that a user-provided value overrides it.
+- [ ] Run: `pnpm vitest run lib/config`
+
+---
+
+## Task 7: Builder — desugar `result.retry()` to `restore()` call
+
+`result.retry(arg1, arg2)` is not a real method — the compiler must recognize it and desugar it.
+
+- [ ] In `lib/backends/typescriptBuilder.ts`, when processing a method call expression, detect the `.retry(...)` pattern:
+  - The receiver is a variable of type `Result` (or `ResultFailure`)
+  - The method name is `retry`
+  - This appears inside an `isFailure()` guard (the typechecker enforces this, but the builder can assume it)
+- [ ] Desugar to:
+  ```typescript
+  restore(receiverVar.checkpoint, { args: [arg1, arg2] }, __state)
+  ```
+  Using the IR builder:
+  ```typescript
+  ts.call("restore", [
+    ts.member(ts.id(receiverVarName), "checkpoint"),
+    ts.object({ args: ts.array([...argNodes]) }),
+    ts.id("__state"),
+  ])
+  ```
+- [ ] No separate retry counter is needed. The `restore()` call internally invokes `CheckpointStore.trackRestore()`, which already tracks restore counts per checkpoint ID and throws `CheckpointError` when the `maxRestores` limit (configured via `result.maxRetries` in Task 6) is exceeded. Since the checkpoint is created with `createPinned()`, it persists across restores, and the restore count accumulates correctly.
+- [ ] Add a builder fixture in `tests/typescriptBuilder/`:
+  ```
+  function process(input: string) -> Result<string, string>:
+    let result = validate(input)
+    if isFailure(result):
+      result.retry("fallback")
+    return result
+  ```
+  Verify it compiles to the `restore(result.checkpoint, { args: ["fallback"] }, __state)` pattern (no local retry counter).
+- [ ] Run: `pnpm vitest run tests/typescriptBuilder`
+
+---
+
+## Task 8: Integration test fixtures
+
+- [ ] Create `tests/typescriptGenerator/result-checkpoint.agency`:
+  ```
+  function validate(input: string) -> Result<string, string>:
+    if input == "":
+      return failure("empty")
+    return success(input)
+  ```
+- [ ] Create the corresponding `tests/typescriptGenerator/result-checkpoint.mts` with the expected compiled output showing:
+  - `__resultCheckpointId` creation at function entry
+  - `failure("empty", __ctx.checkpoints.get(__resultCheckpointId))` in the failure branch
+  - `success(input)` unchanged
+- [ ] Create `tests/typescriptGenerator/result-retry.agency`:
+  ```
+  function process(input: string) -> Result<string, string>:
+    let result = validate(input)
+    if isFailure(result):
+      result.retry("default")
+    return success(result.value)
+  ```
+- [ ] Create the corresponding `tests/typescriptGenerator/result-retry.mts` with expected output showing the `restore()` desugaring.
+- [ ] Run: `pnpm vitest run tests/typescriptGenerator`
+
+---
+
+## Task 9: E2E test — retry with new arguments
+
+- [ ] Create `tests/agency/result-retry.agency`:
+  ```
+  shared attempt = 0
+
+  function flaky(input: string) -> Result<string, string>:
+    attempt = attempt + 1
+    if attempt < 3:
+      return failure("not yet")
+    return success(input)
+
+  node main:
+    let result = flaky("hello")
+    if isFailure(result):
+      result.retry("hello")
+    return result.value
+  ```
+  Note: `shared` (not `global`) is used for `attempt` because shared variables are not serialized/restored — they persist across retries. A `global` variable would be restored to its checkpointed value on each retry, resetting the counter and causing an infinite loop.
+- [ ] Create `tests/agency/result-retry.test.ts`:
+  ```typescript
+  import { describe, it, expect } from "vitest";
+  import { compileAndRun } from "../helpers";
+
+  describe("result retry", () => {
+    it("retries until success", async () => {
+      const result = await compileAndRun("tests/agency/result-retry.agency");
+      expect(result).toBe("hello");
+    });
+
+    it("tracks attempt count across retries", async () => {
+      // The shared `attempt` should be 3 after successful execution
+      // (shared vars persist across restores, unlike globals which are restored)
+      const result = await compileAndRun("tests/agency/result-retry.agency");
+      expect(result).toBe("hello");
+    });
+
+    it("throws when retry limit exceeded", async () => {
+      // Create a program that always fails, exceeding result.maxRetries
+      await expect(
+        compileAndRun("tests/agency/result-retry-limit.agency", {
+          config: { result: { maxRetries: 3 } },
+        })
+      ).rejects.toThrow(/retry limit/i);
+    });
+  });
+  ```
+- [ ] Create `tests/agency/result-retry-limit.agency`:
+  ```
+  function alwaysFails(input: string) -> Result<string, string>:
+    return failure("nope")
+
+  node main:
+    let result = alwaysFails("hello")
+    if isFailure(result):
+      result.retry("hello")
+    return result.value
+  ```
+- [ ] Run: `pnpm vitest run tests/agency/result-retry`
+
+---
+
+**Deferred to Stage 7:** Typechecker enforcement for `.retry()` usage (must be called on a Result inside an `isFailure()` guard, arity matching against the originating function) is consolidated in Stage 7.

--- a/docs/superpowers/plans/2026-04-10-stage4-try-keyword.md
+++ b/docs/superpowers/plans/2026-04-10-stage4-try-keyword.md
@@ -1,0 +1,385 @@
+# Try Keyword Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the `try` keyword that converts exceptions thrown by function calls into `Result` values, bridging JavaScript's exception-based error handling with Agency's value-based Result type.
+
+**Architecture:** `try` is parsed as a unary prefix keyword applied to function call expressions, producing a `TryExpression` AST node. The builder desugars to `__tryCall(() => fn(args))` or `await __tryCallAsync(async () => fn(args))` runtime helpers. Typechecker rules (inferring `Result` type for `try` expressions and warning on double-wrapping) are deferred to Stage 7 (consolidated typechecker work).
+
+**Tech Stack:** TypeScript, tarsec (parser combinators), vitest (testing)
+
+---
+
+## Task 1: Define `TryExpression` AST node type
+
+- [ ] Create `lib/types/tryExpression.ts` with the following type:
+
+```typescript
+import { FunctionCall } from "./function.js";
+
+export type TryExpression = {
+  type: "tryExpression";
+  call: FunctionCall;
+  isAsync?: boolean;
+};
+```
+
+- [ ] In `lib/types.ts`, import and re-export `TryExpression`:
+
+```typescript
+export { TryExpression } from "./types/tryExpression.js";
+```
+
+- [ ] Add `TryExpression` to the `Expression` union type in `lib/types.ts`:
+
+```typescript
+export type Expression = ValueAccess | Literal | FunctionCall | BinOpExpression | AgencyArray | AgencyObject | TryExpression;
+```
+
+- [ ] Add `TryExpression` to the `AgencyNode` union type in `lib/types.ts`.
+
+**Verify:** `pnpm run build` compiles without errors.
+
+---
+
+## Task 2: Parse `try functionCall()` and `try async functionCall()`
+
+- [ ] Create `lib/parsers/tryExpression.ts` with the parser:
+
+```typescript
+import { str, seq, optional, map } from "tarsec";
+import { functionCallParser } from "./function.js";
+import { TryExpression } from "../types.js";
+
+// Parses: try functionCall(args)
+// Parses: try async functionCall(args)
+export const tryExpressionParser = map(
+  seq(str("try "), optional(str("async ")), functionCallParser),
+  ([_try, async_, call]): TryExpression => ({
+    type: "tryExpression",
+    call,
+    ...(async_ ? { isAsync: true } : {}),
+  })
+);
+```
+
+Note: The exact tarsec combinators and function call parser import may need slight adjustment to match the actual exports. The key idea is: parse `try`, optional `async`, then delegate to `functionCallParser`.
+
+- [ ] Wire `tryExpressionParser` into the `atom` parser in `lib/parsers/expression.ts`. Add it to the `or(...)` list that defines `atom`, before `valueAccessParser` (since `try` is a keyword prefix that won't conflict with identifiers):
+
+```typescript
+atom = or(unaryNotParser, tryExpressionParser, agencyArrayParser, agencyObjectParser, booleanParser, valueAccessParser, literalParser)
+```
+
+- [ ] Create `lib/parsers/tryExpression.test.ts` with unit tests:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { tryExpressionParser } from "./tryExpression.js";
+
+describe("tryExpressionParser", () => {
+  it("parses try with a simple function call", () => {
+    const result = tryExpressionParser.run("try fetchData(url)");
+    expect(result.success).toBe(true);
+    expect(result.value).toMatchObject({
+      type: "tryExpression",
+      call: { type: "functionCall", functionName: "fetchData" },
+    });
+    expect(result.value.isAsync).toBeUndefined();
+  });
+
+  it("parses try async with a function call", () => {
+    const result = tryExpressionParser.run("try async fetchData(url)");
+    expect(result.success).toBe(true);
+    expect(result.value).toMatchObject({
+      type: "tryExpression",
+      call: { type: "functionCall", functionName: "fetchData" },
+      isAsync: true,
+    });
+  });
+
+  it("fails on try without a function call", () => {
+    const result = tryExpressionParser.run("try 42");
+    expect(result.success).toBe(false);
+  });
+
+  it("parses try with no-arg function call", () => {
+    const result = tryExpressionParser.run("try doSomething()");
+    expect(result.success).toBe(true);
+    expect(result.value.call.functionName).toBe("doSomething");
+  });
+
+  it("parses try with multiple arguments", () => {
+    const result = tryExpressionParser.run("try sendEmail(to, subject, body)");
+    expect(result.success).toBe(true);
+    expect(result.value.call.functionName).toBe("sendEmail");
+  });
+});
+```
+
+**Verify:** `pnpm vitest run lib/parsers/tryExpression.test.ts`
+
+- [ ] Test that `try` expressions parse correctly within full Agency programs by running `pnpm run ast` on a small test file that uses `try`.
+
+---
+
+## Task 3: Add `__tryCall` and `__tryCallAsync` runtime helpers
+
+**Note:** This task depends on Stage 1 (Result type) being complete, which creates `lib/runtime/result.ts` with the `ResultValue` type. If Stage 1 has not been completed yet, **create** `lib/runtime/result.ts` with the `ResultValue` type definition:
+
+```typescript
+export type ResultValue =
+  | { success: true; value: any }
+  | { success: false; error: any; checkpoint: any | null };
+```
+
+- [ ] Add the following functions to `lib/runtime/result.ts` (create the file if it doesn't exist — see note above):
+
+```typescript
+// Note: The `checkpoint` parameter is always `null` unless Stage 3 (checkpointing)
+// has been completed. In this plan, the builder never passes a checkpoint argument,
+// so it will always default to `null` via the `??` operator.
+export function __tryCall(fn: () => any, checkpoint?: any): ResultValue {
+  try {
+    const value = fn();
+    return { success: true, value };
+  } catch (error) {
+    return { success: false, error, checkpoint: checkpoint ?? null };
+  }
+}
+
+export async function __tryCallAsync(fn: () => Promise<any>, checkpoint?: any): Promise<ResultValue> {
+  try {
+    const value = await fn();
+    return { success: true, value };
+  } catch (error) {
+    return { success: false, error, checkpoint: checkpoint ?? null };
+  }
+}
+```
+
+- [ ] Export `__tryCall` and `__tryCallAsync` from `lib/runtime/index.ts`.
+
+- [ ] Create `lib/runtime/result.test.ts` (or add to existing test file) with unit tests:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { __tryCall, __tryCallAsync } from "./result.js";
+
+describe("__tryCall", () => {
+  it("returns success for a function that succeeds", () => {
+    const result = __tryCall(() => 42);
+    expect(result).toEqual({ success: true, value: 42 });
+  });
+
+  it("returns failure for a function that throws", () => {
+    const result = __tryCall(() => { throw new Error("boom"); });
+    expect(result.success).toBe(false);
+    expect(result.error).toBeInstanceOf(Error);
+    expect((result as any).error.message).toBe("boom");
+    expect(result.checkpoint).toBeNull();
+  });
+
+  it("includes checkpoint when provided", () => {
+    const cp = { step: 3 };
+    const result = __tryCall(() => { throw new Error("fail"); }, cp);
+    expect(result.success).toBe(false);
+    expect(result.checkpoint).toBe(cp);
+  });
+});
+
+describe("__tryCallAsync", () => {
+  it("returns success for an async function that resolves", async () => {
+    const result = await __tryCallAsync(async () => "hello");
+    expect(result).toEqual({ success: true, value: "hello" });
+  });
+
+  it("returns failure for an async function that rejects", async () => {
+    const result = await __tryCallAsync(async () => { throw new Error("async boom"); });
+    expect(result.success).toBe(false);
+    expect((result as any).error.message).toBe("async boom");
+    expect(result.checkpoint).toBeNull();
+  });
+
+  it("includes checkpoint when provided", async () => {
+    const cp = { step: 5 };
+    const result = await __tryCallAsync(async () => { throw new Error("fail"); }, cp);
+    expect(result.success).toBe(false);
+    expect(result.checkpoint).toBe(cp);
+  });
+});
+```
+
+**Verify:** `pnpm vitest run lib/runtime/result.test.ts`
+
+---
+
+## Task 4: Builder — desugar `try` expressions to runtime helper calls
+
+- [ ] In `lib/backends/typescriptBuilder.ts`, add a case for `"tryExpression"` in `processNode()`:
+
+```typescript
+case "tryExpression":
+  return this.processTryExpression(node);
+```
+
+- [ ] Implement `processTryExpression` method on the builder class:
+
+```typescript
+private processTryExpression(node: TryExpression): TsNode {
+  const callNode = this.processFunctionCall(node.call);
+
+  if (node.isAsync) {
+    // try async fn(args) → await __tryCallAsync(async () => fn(args))
+    return ts.await(
+      ts.call(ts.id("__tryCallAsync"), [
+        ts.arrowFn([], callNode, { async: true }),
+      ])
+    );
+  } else {
+    // try fn(args) → __tryCall(() => fn(args))
+    return ts.call(ts.id("__tryCall"), [
+      ts.arrowFn([], callNode),
+    ]);
+  }
+}
+```
+
+Note: `ts.call()` takes a `TsNode` as its callee (not a string), so use `ts.id("__tryCall")`. `ts.arrowFn()` takes a single `TsNode` body (not an array). The key desugaring is:
+- `try someFunction(args)` becomes `__tryCall(() => someFunction(args))`
+- `try async someFunction(args)` becomes `await __tryCallAsync(async () => someFunction(args))`
+
+- [ ] Ensure the generated code includes the import for `__tryCall` / `__tryCallAsync` from the runtime. Add `__tryCall` and `__tryCallAsync` to the import list in `lib/templates/backends/typescriptGenerator/imports.mustache` (in the `from "agency-lang/runtime"` import block, alongside other runtime helpers like `deepClone`). Then run `pnpm run templates` to regenerate `imports.ts`.
+
+**Verify:** `pnpm run build` compiles. Then test with `pnpm run compile` on a small `.agency` file containing `try` to inspect the generated TypeScript.
+
+---
+
+## Task 5: Integration test fixtures
+
+- [ ] Create `tests/typescriptGenerator/try-expression.agency`:
+
+```
+function riskyOperation(x: string) -> string:
+  return x
+
+node main:
+  result = try riskyOperation("hello")
+  return result
+```
+
+- [ ] Create the corresponding expected output `tests/typescriptGenerator/try-expression.mts` by running:
+
+```bash
+pnpm run compile tests/typescriptGenerator/try-expression.agency
+```
+
+Inspect the output to confirm it contains `__tryCall(() => riskyOperation("hello"))` and looks correct. Then copy/save as the `.mts` fixture.
+
+- [ ] Create `tests/typescriptGenerator/try-async-expression.agency`:
+
+```
+function asyncOperation(x: string) -> string:
+  return x
+
+node main:
+  result = try async asyncOperation("hello")
+  return result
+```
+
+- [ ] Create the corresponding `.mts` fixture similarly.
+
+- [ ] Run `make fixtures` to regenerate all fixtures and verify nothing else broke.
+
+**Verify:** `pnpm vitest run` — all tests pass including the new fixtures.
+
+---
+
+## Task 6: E2E test
+
+Agency does not have a `throw` keyword, so the E2E test uses an imported TypeScript helper function that throws.
+
+- [ ] Create a TypeScript helper `tests/agency/try-expression-helper.ts`:
+
+```typescript
+export function mightFail(x: number): number {
+  if (x < 0) {
+    throw new Error("negative number");
+  }
+  return x * 2;
+}
+```
+
+- [ ] Create `tests/agency/try-expression.agency`:
+
+```
+import mightFail from "./try-expression-helper.js"
+
+node main:
+  successResult = try mightFail(5)
+  failResult = try mightFail(-1)
+
+  if successResult.success:
+    successValue = successResult.value
+  else:
+    successValue = -1
+
+  if failResult.success:
+    failValue = failResult.value
+  else:
+    failValue = -1
+
+  return { successValue: successValue, failValue: failValue }
+```
+
+Note: The exact Agency syntax for conditionals, object literals, property access, and JS imports may need adjustment to match the actual language. The key test is: `try` on a succeeding call returns `{ success: true, value: 10 }`, `try` on a failing call returns `{ success: false, error: ... }`.
+
+- [ ] Create `tests/agency/try-expression.test.json` following the E2E test convention:
+
+```json
+{
+  "sourceFile": "try-expression.agency",
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"successValue\":10,\"failValue\":-1}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Verify:** `pnpm vitest run tests/agency/try-expression` — the E2E test passes.
+
+---
+
+## Summary of files to create/modify
+
+**New files:**
+- `lib/types/tryExpression.ts` — AST node type
+- `lib/parsers/tryExpression.ts` — parser
+- `lib/parsers/tryExpression.test.ts` — parser unit tests
+- `tests/typescriptGenerator/try-expression.agency` — generator fixture
+- `tests/typescriptGenerator/try-expression.mts` — generator fixture expected output
+- `tests/typescriptGenerator/try-async-expression.agency` — async generator fixture
+- `tests/typescriptGenerator/try-async-expression.mts` — async generator fixture expected output
+- `tests/agency/try-expression-helper.ts` — TypeScript helper that throws (for E2E test)
+- `tests/agency/try-expression.agency` — E2E test
+- `tests/agency/try-expression.test.json` — E2E test assertions
+
+**Modified files (or created if Stage 1 not yet complete):**
+- `lib/runtime/result.ts` — add `__tryCall` and `__tryCallAsync` (create file if Stage 1 has not been completed yet; see Task 3 note)
+
+**Modified files:**
+- `lib/types.ts` — add `TryExpression` to `Expression` and `AgencyNode` unions, re-export type
+- `lib/parsers/expression.ts` — add `tryExpressionParser` to `atom`
+- `lib/runtime/index.ts` — export new runtime helpers
+- `lib/backends/typescriptBuilder.ts` — add `processTryExpression` case
+- `lib/templates/backends/typescriptGenerator/imports.mustache` — add `__tryCall` and `__tryCallAsync` to runtime imports (then run `pnpm run templates`)
+
+**Deferred to Stage 7:** Typechecker enforcement for `try` expressions (inferring `Result` type, validating operand is a function call, warning when `try` is applied to a function that already returns `Result`) is consolidated in Stage 7.

--- a/docs/superpowers/plans/2026-04-10-stage5-catch-keyword.md
+++ b/docs/superpowers/plans/2026-04-10-stage5-catch-keyword.md
@@ -1,0 +1,317 @@
+# Catch Keyword Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the `catch` keyword that unwraps a `Result` with a fallback value, supporting chaining for sequential fallback attempts.
+
+**Architecture:** `catch` is parsed as a binary operator with precedence between `|>` (lower) and `||` (higher). The builder desugars to `__catchResult(result, () => fallback)` where the fallback is lazily evaluated. Chaining works naturally: when the fallback is a `try` expression (which produces a `Result`), the next `catch` handles that Result. Typechecker rules for `catch` are deferred to Stage 7 (consolidated typechecker work).
+
+**Tech Stack:** TypeScript, tarsec (parser combinators), vitest (testing)
+
+**Dependencies:** This plan depends on the `Result` type and `ResultValue` from `lib/runtime/result.ts` (Stage 1). That file must exist before Task 3.
+
+---
+
+## Task 1: Add `"catch"` to the Operator type
+
+**File:** `lib/types/binop.ts`
+
+- [ ] Add `"catch"` to the `Operator` type union:
+  ```typescript
+  export type Operator = "+" | "-" | "*" | "/" | "==" | "!=" | "+=" | "-=" | "*=" | "/=" | "<" | ">" | "<=" | ">=" | "&&" | "||" | "!" | "|>" | "catch";
+  ```
+
+- [ ] Add `"catch"` to the `PRECEDENCE` map. Use precedence `0`, which sits between `|>` at `-1` and `||` at `1`:
+  ```typescript
+  "catch": 0,
+  ```
+
+**Verify:** `pnpm run build` — confirm no type errors.
+
+---
+
+## Task 2: Add `catch` to the expression parser precedence table
+
+**File:** `lib/parsers/expression.ts`
+
+- [ ] Add a new precedence level for `catch` in the operator table passed to `buildExpressionParser`. It must sit between `|>` (lowest) and `||` (next highest). In the array (which is ordered highest-first), `catch` goes just before `|>`:
+  ```
+  // ... existing levels ...
+  // level for ||
+  // level for catch  <-- new
+  // level for |>     <-- lowest
+  ```
+  The entry should look like (matching the existing operator table format):
+  ```typescript
+  [
+    { op: wsOp("catch"), assoc: "left" as const, apply: makeBinOp("catch") },
+  ],
+  ```
+
+  **Important:** `wsOp` uses `str("catch")` internally, which will greedily match identifiers like "catcher" or "catching". You must add a word boundary check. Create a `wsKeyword` helper (or modify the `wsOp` call for "catch") that verifies the next character after "catch" is NOT alphanumeric or underscore. For example:
+  ```typescript
+  function wsKeyword(kw: string): Parser<string> {
+    return (input: string) => {
+      const r1 = optionalSpaces(input);
+      if (!r1.success) return r1;
+      const r2 = str(kw)(r1.rest);
+      if (!r2.success) return r2;
+      // Word boundary: next char must not be alphanumeric or underscore
+      if (r2.rest.length > 0 && /[\w]/.test(r2.rest[0])) {
+        return failure(`expected word boundary after '${kw}'`, input);
+      }
+      const r3 = optionalSpaces(r2.rest);
+      if (!r3.success) return r3;
+      return { success: true as const, result: kw, rest: r3.rest };
+    };
+  }
+  ```
+  Then use `wsKeyword("catch")` instead of `wsOp("catch")` in the operator table entry.
+
+- [ ] Write a unit test in `lib/parsers/expression.test.ts`:
+  ```typescript
+  test("catch binary operator", () => {
+    const result = exprParser("x catch 0");
+    expect(result).toEqual({
+      type: "binOpExpression",
+      operator: "catch",
+      left: { type: "identifier", value: "x" },
+      right: { type: "numberLiteral", value: 0 },
+    });
+  });
+
+  test("catch precedence with pipe", () => {
+    // catch binds tighter than |>
+    const result = exprParser("x catch 0 |> bar");
+    expect(result).toEqual({
+      type: "binOpExpression",
+      operator: "|>",
+      left: {
+        type: "binOpExpression",
+        operator: "catch",
+        left: { type: "identifier", value: "x" },
+        right: { type: "numberLiteral", value: 0 },
+      },
+      right: { type: "identifier", value: "bar" },
+    });
+  });
+
+  test("catch chaining", () => {
+    // try foo() catch try bar() catch default
+    // parses as: (try foo() catch (try bar())) catch default
+    // but since catch is left-assoc: ((try foo()) catch (try bar())) catch default
+    const result = exprParser("x catch y catch z");
+    expect(result.type).toBe("binOpExpression");
+    expect(result.operator).toBe("catch");
+    expect(result.left.type).toBe("binOpExpression");
+    expect(result.left.operator).toBe("catch");
+  });
+  ```
+
+**Verify:** `pnpm vitest run lib/parsers/expression.test.ts`
+
+---
+
+## Task 3: Add `__catchResult` runtime function
+
+**File:** `lib/runtime/result.ts` (or wherever Result-related runtime helpers live — if this file doesn't exist, add the function to `lib/runtime/builtins.ts` and export it from `lib/runtime/index.ts`)
+
+- [ ] Implement the runtime helper:
+  ```typescript
+  export function __catchResult(result: ResultValue, fallback: () => any): any {
+    if (result.success) {
+      return result.value;
+    }
+    return fallback();
+  }
+  ```
+  The fallback is a thunk (zero-argument function) so it is lazily evaluated — the fallback expression only runs if the result is a failure.
+
+- [ ] Export `__catchResult` from `lib/runtime/index.ts` so compiled code can import it.
+
+- [ ] Write a unit test in the same directory (co-located test file):
+  ```typescript
+  import { __catchResult } from "./result";
+
+  describe("__catchResult", () => {
+    test("returns value on success", () => {
+      const result = { success: true, value: 42 };
+      expect(__catchResult(result, () => 0)).toBe(42);
+    });
+
+    test("returns fallback on failure", () => {
+      const result = { success: false, error: "oops" };
+      expect(__catchResult(result, () => 0)).toBe(0);
+    });
+
+    test("fallback is lazy — not called on success", () => {
+      const result = { success: true, value: 42 };
+      const fallback = vi.fn(() => 0);
+      __catchResult(result, fallback);
+      expect(fallback).not.toHaveBeenCalled();
+    });
+
+    test("returns Result when fallback produces Result (chaining)", () => {
+      const result = { success: false, error: "oops" };
+      const fallbackResult = { success: true, value: 99 };
+      expect(__catchResult(result, () => fallbackResult)).toEqual(fallbackResult);
+    });
+  });
+  ```
+
+**Verify:** `pnpm vitest run lib/runtime/result.test.ts` (or wherever the test file lives)
+
+---
+
+## Task 4: Builder — desugar `catch` to `__catchResult` call
+
+**File:** `lib/backends/typescriptBuilder.ts`
+
+- [ ] `processBinOpExpression()` is a simple pass-through that calls `ts.binOp()` for all operators — there is no switch statement. Add a conditional check at the top of the method to intercept `"catch"` before the generic path, then define a new `processCatchExpression` method:
+  ```typescript
+  private processBinOpExpression(node: BinOpExpression): TsNode {
+    if (node.operator === "catch") {
+      return this.processCatchExpression(node);
+    }
+    // ... existing code unchanged ...
+  }
+
+  private processCatchExpression(node: BinOpExpression): TsNode {
+    const left = this.processNode(node.left);
+    const right = this.processNode(node.right);
+    return ts.call(ts.identifier("__catchResult"), [
+      left,
+      ts.arrowFn([], right),
+    ]);
+  }
+  ```
+  This generates: `__catchResult(<left>, () => <right>)`
+
+- [ ] Add `__catchResult` to the import list in `lib/templates/backends/typescriptGenerator/imports.mustache`. Add it to the existing `import { ... } from "agency-lang/runtime"` block, alongside the other runtime helpers. Then run `pnpm run templates` to regenerate the compiled template file.
+
+**Verify:** `pnpm run build` — confirm no type errors. Then compile a small test file manually:
+```
+pnpm run compile tests/typescriptGenerator/catch-basic.agency
+```
+(We will create this fixture in Task 6.)
+
+---
+
+## Task 5: Integration test fixtures
+
+**Directory:** `tests/typescriptGenerator/`
+
+- [ ] Create `tests/typescriptGenerator/catch-basic.agency`:
+  ```
+  function riskyCall() -> Result<number> {
+    return { success: true, value: 42 }
+  }
+
+  node main {
+    result = try riskyCall()
+    value = result catch 0
+    return value
+  }
+  ```
+
+- [ ] Generate the expected `.mts` fixture by running:
+  ```bash
+  pnpm run compile tests/typescriptGenerator/catch-basic.agency
+  ```
+  Review the output and save it as the `.mts` fixture file. Then verify:
+  ```bash
+  pnpm vitest run tests/typescriptGenerator/catch-basic
+  ```
+
+- [ ] Create `tests/typescriptGenerator/catch-chain.agency`:
+  ```
+  function foo() -> Result<string> {
+    return { success: false, error: "foo failed" }
+  }
+
+  function bar() -> Result<string> {
+    return { success: false, error: "bar failed" }
+  }
+
+  node main {
+    value = try foo() catch try bar() catch "default"
+    return value
+  }
+  ```
+  Generate and save the `.mts` fixture the same way.
+
+**Verify:** `make fixtures` to regenerate all fixtures, then `pnpm test:run` to confirm all pass.
+
+---
+
+## Task 6: E2E tests — basic catch and chained catch
+
+**Directory:** `tests/agency/`
+
+- [ ] Create `tests/agency/catch-basic.agency`:
+  ```
+  function riskyFunc() -> Result<number> {
+    return { success: true, value: 42 }
+  }
+
+  function failingFunc() -> Result<number> {
+    return { success: false, error: "failed" }
+  }
+
+  node main {
+    result1 = try riskyFunc()
+    value1 = result1 catch 0
+    assert(value1 == 42, "should unwrap success")
+
+    result2 = try failingFunc()
+    value2 = result2 catch 0
+    assert(value2 == 0, "should use fallback on failure")
+
+    return value1
+  }
+  ```
+
+- [ ] Create `tests/agency/catch-chain.agency`:
+  ```
+  function fail1() -> Result<number> {
+    return { success: false, error: "fail1" }
+  }
+
+  function fail2() -> Result<number> {
+    return { success: false, error: "fail2" }
+  }
+
+  node main {
+    value = try fail1() catch try fail2() catch 99
+    assert(value == 99, "should fall through chain to default")
+    return value
+  }
+  ```
+
+- [ ] Add test entries in the relevant E2E test runner file (check how existing `tests/agency/*.agency` files are wired up — likely via a glob or explicit list).
+
+**Verify:**
+```bash
+pnpm vitest run tests/agency/catch-basic
+pnpm vitest run tests/agency/catch-chain
+```
+
+---
+
+## Summary of files to modify
+
+| File | Change |
+|------|--------|
+| `lib/types/binop.ts` | Add `"catch"` to `Operator` union and `PRECEDENCE` map |
+| `lib/parsers/expression.ts` | Add `catch` precedence level |
+| `lib/parsers/expression.test.ts` | Parser unit tests |
+| `lib/runtime/result.ts` (or `builtins.ts`) | `__catchResult` helper |
+| `lib/runtime/index.ts` | Export `__catchResult` |
+| `lib/backends/typescriptBuilder.ts` | Desugar `catch` to `__catchResult(...)` via new `processCatchExpression` method |
+| `lib/templates/backends/typescriptGenerator/imports.mustache` | Add `__catchResult` to runtime imports (then run `pnpm run templates`) |
+| `tests/typescriptGenerator/catch-basic.agency` | Generator fixture |
+| `tests/typescriptGenerator/catch-chain.agency` | Generator fixture |
+| `tests/agency/catch-basic.agency` | E2E test |
+| `tests/agency/catch-chain.agency` | E2E test |
+
+**Deferred to Stage 7:** Typechecker enforcement for `catch` (left operand must be `Result`, inferring result type based on fallback type, chaining support) is consolidated in Stage 7.

--- a/docs/superpowers/plans/2026-04-10-stage6-top-level-safety-net.md
+++ b/docs/superpowers/plans/2026-04-10-stage6-top-level-safety-net.md
@@ -1,0 +1,90 @@
+# Top-Level Safety Net Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wrap top-level node execution in a try-catch that produces readable error messages for unhandled exceptions, preventing raw stack trace crashes.
+
+**Architecture:** Add a catch clause in `runNode()` that wraps unhandled errors in a formatted `AgencyRuntimeError` with the node name, error type, and message. Known signal errors (`RestoreSignal`, interrupts) are re-thrown. All other errors are caught and formatted.
+
+**Tech Stack:** TypeScript, vitest (testing)
+
+---
+
+## Tasks
+
+- [ ] **Task 1: Create `AgencyRuntimeError` class in `lib/runtime/errors.ts`**
+
+  Add a new error class that formats a readable message from the node name and original error:
+
+  ```typescript
+  export class AgencyRuntimeError extends Error {
+    constructor(nodeName: string, originalError: unknown) {
+      const errorType = originalError instanceof Error ? originalError.constructor.name : "Error";
+      const errorMessage = originalError instanceof Error ? originalError.message : String(originalError);
+      const message = `Error in node '${nodeName}': ${errorType}: ${errorMessage}`;
+      super(message);
+      this.name = "AgencyRuntimeError";
+      this.cause = originalError;
+    }
+  }
+  ```
+
+  **Files:** `lib/runtime/errors.ts`
+
+- [ ] **Task 2: Add safety net catch in `runNode()`**
+
+  In `runNode()` in `lib/runtime/node.ts`, wrap the top-level node execution in a try-catch. The catch clause should:
+  1. Re-throw `RestoreSignal` (already handled by the existing inner try-catch, but be defensive).
+  2. Re-throw `ConcurrentInterruptError` and any interrupt-related errors.
+  3. Re-throw `CheckpointError` and `ToolCallError` — these are internal infrastructure errors, not user code errors, and should propagate without wrapping.
+  4. For all other errors, throw a new `AgencyRuntimeError` with the node name and original error.
+
+  The node name is available from the function parameters. Place the catch on the outer try block (the one with the `finally` clause), turning it into a try-catch-finally. This ensures it acts as a last-resort handler around the outermost execution scope.
+
+  **Files:** `lib/runtime/node.ts`
+
+- [ ] **Task 3: Unit tests for error formatting and pass-through**
+
+  Add a test file `lib/runtime/errors.test.ts` (or add to existing tests) that verifies:
+  - Constructing `AgencyRuntimeError` with a node name and a `TypeError` produces a message like `Error in node 'main': TypeError: Cannot read properties of undefined (reading 'x')`.
+  - Constructing with a non-Error value (e.g. a string) still produces a readable message.
+  - `RestoreSignal` and `ConcurrentInterruptError` are not instances of `AgencyRuntimeError` (sanity check that the class hierarchy is correct and they won't be accidentally caught).
+  - `RestoreSignal` and `ConcurrentInterruptError` propagate through `runNode()` without being wrapped in `AgencyRuntimeError`. Mock or set up a minimal `runNode()` call that throws each of these, and assert the thrown error is the original instance, not an `AgencyRuntimeError`.
+
+  **Files:** `lib/runtime/errors.test.ts`
+
+- [ ] **Task 4: E2E test — unhandled exception produces readable error**
+
+  Add an Agency e2e test in `tests/agency/` with the following concrete fixtures:
+
+  **`tests/agency/safety-net-error.agency`:**
+  ```
+  import { throwError } from "./safety-net-helper.ts"
+
+  node main {
+    result = throwError()
+    -> END result
+  }
+  ```
+
+  **`tests/agency/safety-net-helper.ts`:**
+  ```typescript
+  export function throwError(): string {
+    const obj: any = undefined;
+    return obj.foo; // throws TypeError
+  }
+  ```
+
+  **`tests/agency/safety-net-error.test.json`:**
+  ```json
+  {
+    "expectError": {
+      "type": "AgencyRuntimeError",
+      "messageContains": ["Error in node 'main'", "TypeError"]
+    }
+  }
+  ```
+
+  The test should assert that execution fails with an `AgencyRuntimeError` whose message includes the node name and the original error type, rather than a raw stack trace.
+
+  **Files:** `tests/agency/safety-net-error.agency`, `tests/agency/safety-net-helper.ts`, `tests/agency/safety-net-error.test.json`

--- a/docs/superpowers/plans/2026-04-10-stage7-result-typechecker.md
+++ b/docs/superpowers/plans/2026-04-10-stage7-result-typechecker.md
@@ -1,0 +1,837 @@
+# Result Typechecker Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement all typechecker rules for the Result type system: builtin signatures, assignability, constructor enforcement, return path enforcement, pipe operator typing, try/catch typing, generic type parameter tracking, and type guard narrowing.
+
+**Architecture:** This is a pure typechecker plan — no parser, runtime, or builder changes. All type checking centers on the `ResultType` variant (`{ type: "resultType", successType, failureType }`). The typechecker registers Result builtins, enforces Result-specific constraints (constructors only in Result-returning functions, unwrap-before-use), tracks generic type parameters through pipe chains and try/catch expressions, and implements flow-sensitive narrowing for `isSuccess`/`isFailure` type guards.
+
+**Dependency:** Requires Stages 1-6 to be complete (Result type system, pipe operator, checkpointing, try, catch, safety net all implemented).
+
+**Tech Stack:** TypeScript, vitest (testing)
+
+---
+
+## File structure
+
+All work is in two files:
+
+- **Modify:** `lib/typeChecker.ts` — all typechecker logic
+- **Test:** `lib/typeChecker.test.ts` (or co-located test file) — all tests
+
+Helper used in error messages (already updated in Stage 1):
+- `lib/cli/util.ts` — `formatTypeHint()` already handles `resultType`
+
+---
+
+## Helpers
+
+Several tasks reference a `isResultType` helper. Define it once at the top of the typechecker file:
+
+```typescript
+function isResultType(t: VariableType | "any"): t is ResultType {
+  return t !== "any" && t.type === "resultType";
+}
+```
+
+Also useful: a helper to create a bare Result type:
+
+```typescript
+function bareResult(): ResultType {
+  return {
+    type: "resultType",
+    successType: { type: "primitiveType", value: "any" },
+    failureType: { type: "primitiveType", value: "any" },
+  };
+}
+```
+
+---
+
+## Task 1: Register Result builtins in `BUILTIN_FUNCTION_TYPES`
+
+**Files:**
+- Modify: `lib/typeChecker.ts`
+- Test: `lib/typeChecker.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe("Result builtins", () => {
+  it("success() is recognized with correct signature", () => {
+    // success(42) inside a Result-returning function — no errors
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [{
+        type: "function",
+        functionName: "foo",
+        parameters: [],
+        returnType: { type: "resultType", successType: { type: "primitiveType", value: "any" }, failureType: { type: "primitiveType", value: "any" } },
+        body: [{
+          type: "returnStatement",
+          value: { type: "functionCall", functionName: "success", arguments: [{ type: "number", value: "42" }] },
+        }],
+      }],
+    };
+    const { errors } = typeCheck(program);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("failure() is recognized with correct signature", () => {
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [{
+        type: "function",
+        functionName: "foo",
+        parameters: [],
+        returnType: { type: "resultType", successType: { type: "primitiveType", value: "any" }, failureType: { type: "primitiveType", value: "any" } },
+        body: [{
+          type: "returnStatement",
+          value: { type: "functionCall", functionName: "failure", arguments: [{ type: "string", segments: [{ type: "text", value: "err" }] }] },
+        }],
+      }],
+    };
+    const { errors } = typeCheck(program);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("isSuccess() accepts Result and returns boolean", () => {
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [{
+        type: "function",
+        functionName: "foo",
+        parameters: [],
+        returnType: { type: "primitiveType", value: "boolean" },
+        body: [
+          {
+            type: "assignment",
+            variableName: "r",
+            declKind: "const",
+            typeHint: { type: "resultType", successType: { type: "primitiveType", value: "any" }, failureType: { type: "primitiveType", value: "any" } },
+            value: { type: "functionCall", functionName: "success", arguments: [{ type: "number", value: "1" }] },
+          },
+          {
+            type: "returnStatement",
+            value: { type: "functionCall", functionName: "isSuccess", arguments: [{ type: "variableName", value: "r" }] },
+          },
+        ],
+      }],
+    };
+    const { errors } = typeCheck(program);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("isFailure() accepts Result and returns boolean", () => {
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [{
+        type: "function",
+        functionName: "foo",
+        parameters: [],
+        returnType: { type: "primitiveType", value: "boolean" },
+        body: [
+          {
+            type: "assignment",
+            variableName: "r",
+            declKind: "const",
+            typeHint: { type: "resultType", successType: { type: "primitiveType", value: "any" }, failureType: { type: "primitiveType", value: "any" } },
+            value: { type: "functionCall", functionName: "failure", arguments: [{ type: "string", segments: [{ type: "text", value: "e" }] }] },
+          },
+          {
+            type: "returnStatement",
+            value: { type: "functionCall", functionName: "isFailure", arguments: [{ type: "variableName", value: "r" }] },
+          },
+        ],
+      }],
+    };
+    const { errors } = typeCheck(program);
+    expect(errors).toHaveLength(0);
+  });
+});
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests fail — builtins not registered.
+
+- [ ] **Step 2: Add builtins to `BUILTIN_FUNCTION_TYPES`**
+
+```typescript
+success: {
+  params: ["any"],
+  returnType: bareResult(),
+},
+failure: {
+  params: ["any"],
+  returnType: bareResult(),
+},
+isSuccess: {
+  params: [bareResult()],
+  returnType: { type: "primitiveType", value: "boolean" },
+},
+isFailure: {
+  params: [bareResult()],
+  returnType: { type: "primitiveType", value: "boolean" },
+},
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/typeChecker.ts lib/typeChecker.test.ts
+git commit -m "feat(typechecker): register Result builtins"
+```
+
+---
+
+## Task 2: Result assignability rules
+
+**Files:**
+- Modify: `lib/typeChecker.ts` — `isAssignable()` method
+- Test: `lib/typeChecker.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe("Result assignability", () => {
+  it("Result<S,E> is assignable to Result<S,E>", () => {
+    // success() returning Result in a Result-returning function — no errors
+    // (already tested in Task 1, but verify assignability specifically)
+  });
+
+  it("Result<string,any> is assignable to Result<any,any> (bare Result)", () => {
+    // Assign a Result<string,any> to a variable typed as bare Result
+  });
+
+  it("Result<any,any> is assignable to Result<string,any>", () => {
+    // Bare Result assignable to specific Result (any is flexible)
+  });
+
+  it("Result is NOT assignable to string", () => {
+    // Function returns string but returns success(...) — error
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [{
+        type: "function",
+        functionName: "foo",
+        parameters: [],
+        returnType: { type: "primitiveType", value: "string" },
+        body: [{
+          type: "returnStatement",
+          value: { type: "functionCall", functionName: "success", arguments: [{ type: "number", value: "1" }] },
+        }],
+      }],
+    };
+    const { errors } = typeCheck(program);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("string is NOT assignable to Result", () => {
+    // Function returns Result but returns bare string — error
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [{
+        type: "function",
+        functionName: "foo",
+        parameters: [],
+        returnType: { type: "resultType", successType: { type: "primitiveType", value: "any" }, failureType: { type: "primitiveType", value: "any" } },
+        body: [{
+          type: "returnStatement",
+          value: { type: "string", segments: [{ type: "text", value: "hello" }] },
+        }],
+      }],
+    };
+    const { errors } = typeCheck(program);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: some tests fail.
+
+- [ ] **Step 2: Add Result assignability to `isAssignable()`**
+
+In `isAssignable(source, target)`, after the existing union/literal checks and before the final `return false`, add:
+
+```typescript
+// ResultType assignability
+if (isResultType(resolvedSource) && isResultType(resolvedTarget)) {
+  return (
+    this.isAssignable(resolvedSource.successType, resolvedTarget.successType) &&
+    this.isAssignable(resolvedSource.failureType, resolvedTarget.failureType)
+  );
+}
+
+// Result is not assignable to non-Result (except any/unknown, handled above)
+if (isResultType(resolvedSource) || isResultType(resolvedTarget)) {
+  return false;
+}
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/typeChecker.ts lib/typeChecker.test.ts
+git commit -m "feat(typechecker): Result assignability rules with generic params"
+```
+
+---
+
+## Task 3: Constructor enforcement — success()/failure() only in Result-returning functions
+
+**Files:**
+- Modify: `lib/typeChecker.ts`
+- Test: `lib/typeChecker.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe("Result constructor enforcement", () => {
+  it("success() inside Result-returning function is allowed", () => {
+    // Already passes from Task 1
+  });
+
+  it("success() inside non-Result function is an error", () => {
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [{
+        type: "function",
+        functionName: "foo",
+        parameters: [],
+        returnType: { type: "primitiveType", value: "string" },
+        body: [{
+          type: "returnStatement",
+          value: { type: "functionCall", functionName: "success", arguments: [{ type: "number", value: "42" }] },
+        }],
+      }],
+    };
+    const { errors } = typeCheck(program);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toContain("success");
+  });
+
+  it("failure() inside non-Result function is an error", () => {
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [{
+        type: "function",
+        functionName: "foo",
+        parameters: [],
+        returnType: { type: "primitiveType", value: "number" },
+        body: [{
+          type: "returnStatement",
+          value: { type: "functionCall", functionName: "failure", arguments: [{ type: "string", segments: [{ type: "text", value: "err" }] }] },
+        }],
+      }],
+    };
+    const { errors } = typeCheck(program);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toContain("failure");
+  });
+});
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: last two tests fail.
+
+- [ ] **Step 2: Add constructor enforcement**
+
+In `checkSingleFunctionCall()` (or a new check within scope iteration), when the function being called is `"success"` or `"failure"`:
+
+1. Find the enclosing scope's `returnType` — this is available as `scope.returnType` in the scope iteration in `checkScopes()`. You may need to pass the scope's return type down to the function call checker, or add a new check in the scope iteration.
+2. If `scope.returnType` is not a `resultType`, emit error: `"'success()' can only be used inside a function that returns Result"` (or `failure`).
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/typeChecker.ts lib/typeChecker.test.ts
+git commit -m "feat(typechecker): enforce success/failure only in Result-returning functions"
+```
+
+---
+
+## Task 4: Return path enforcement — Result functions must use success()/failure()
+
+**Files:**
+- Modify: `lib/typeChecker.ts`
+- Test: `lib/typeChecker.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe("Result return path enforcement", () => {
+  it("returning bare value from Result function is an error", () => {
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [{
+        type: "function",
+        functionName: "foo",
+        parameters: [],
+        returnType: { type: "resultType", successType: { type: "primitiveType", value: "any" }, failureType: { type: "primitiveType", value: "any" } },
+        body: [{
+          type: "returnStatement",
+          value: { type: "number", value: "42" },
+        }],
+      }],
+    };
+    const { errors } = typeCheck(program);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toMatch(/success|failure/i);
+  });
+
+  it("all paths using success/failure is valid", () => {
+    // Function with if/else, both branches return success/failure — no errors
+  });
+});
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: first test fails.
+
+- [ ] **Step 2: Add return path enforcement**
+
+In `checkReturnTypesInScope()`, when `scope.returnType` is a `resultType`:
+
+For each return statement, check that its value is a `functionCall` with `functionName` of `"success"` or `"failure"`. If not, emit error: `"Functions returning Result must return success(...) or failure(...), not a bare value"`.
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/typeChecker.ts lib/typeChecker.test.ts
+git commit -m "feat(typechecker): enforce return paths use success/failure in Result functions"
+```
+
+---
+
+## Task 5: Generic type checking for success()/failure()
+
+**Files:**
+- Modify: `lib/typeChecker.ts`
+- Test: `lib/typeChecker.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe("Result generic type checking", () => {
+  it("success(42) in Result<number, string> is valid", () => {
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [{
+        type: "function",
+        functionName: "foo",
+        parameters: [],
+        returnType: {
+          type: "resultType",
+          successType: { type: "primitiveType", value: "number" },
+          failureType: { type: "primitiveType", value: "string" },
+        },
+        body: [{
+          type: "returnStatement",
+          value: { type: "functionCall", functionName: "success", arguments: [{ type: "number", value: "42" }] },
+        }],
+      }],
+    };
+    const { errors } = typeCheck(program);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("success('hello') in Result<number, string> is an error", () => {
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [{
+        type: "function",
+        functionName: "foo",
+        parameters: [],
+        returnType: {
+          type: "resultType",
+          successType: { type: "primitiveType", value: "number" },
+          failureType: { type: "primitiveType", value: "string" },
+        },
+        body: [{
+          type: "returnStatement",
+          value: { type: "functionCall", functionName: "success", arguments: [{ type: "string", segments: [{ type: "text", value: "hello" }] }] },
+        }],
+      }],
+    };
+    const { errors } = typeCheck(program);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("failure(42) in Result<string, number> is valid", () => {
+    // number matches the failureType
+  });
+
+  it("failure(42) in Result<string, string> is an error", () => {
+    // number does not match string failureType
+  });
+
+  it("bare Result<any,any> skips generic checks", () => {
+    // success("anything") in a bare Result function — no errors
+  });
+});
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: the "is an error" tests fail (no generic checking yet).
+
+- [ ] **Step 2: Implement generic checking for constructors**
+
+In the return path enforcement or function call checking:
+
+When `success(val)` is called inside a function returning `Result<S, E>` where `S` is not `any`:
+1. Infer the type of `val` via `synthType(val, scopeVars)`
+2. Check `isAssignable(valType, S)` — if not, emit error: `"Argument type 'X' is not assignable to Result success type 'S'"`
+
+When `failure(err)` is called inside a function returning `Result<S, E>` where `E` is not `any`:
+1. Infer the type of `err`
+2. Check `isAssignable(errType, E)` — if not, emit error
+
+To find the enclosing Result's generic params: the scope's `returnType` is available as a `ResultType` node — read `.successType` and `.failureType`.
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/typeChecker.ts lib/typeChecker.test.ts
+git commit -m "feat(typechecker): generic type checking for success/failure constructors"
+```
+
+---
+
+## Task 6: synthType for pipe operator (`|>`)
+
+**Files:**
+- Modify: `lib/typeChecker.ts` — `synthType()` method
+- Test: `lib/typeChecker.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe("Pipe operator type checking", () => {
+  it("left side of |> must be Result", () => {
+    // 42 |> someFunc — error: left side is number, not Result
+  });
+
+  it("|> expression has Result type", () => {
+    // success(1) |> someFunc — result type is Result
+  });
+});
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests fail.
+
+- [ ] **Step 2: Add `|>` case to synthType**
+
+In `synthType()`, in the `binOpExpression` case, add handling for `operator === "|>"`:
+
+```typescript
+if (op === "|>") {
+  const leftType = this.synthType(expr.left, scopeVars);
+  if (leftType !== "any" && !isResultType(leftType)) {
+    this.errors.push({
+      message: `Left side of '|>' must be a Result, but got '${formatTypeHint(leftType)}'.`,
+    });
+  }
+  // The right side is desugared by the builder to a function call.
+  // The result of a pipe expression is always Result.
+  return bareResult();
+}
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/typeChecker.ts lib/typeChecker.test.ts
+git commit -m "feat(typechecker): pipe operator type checking"
+```
+
+---
+
+## Task 7: synthType for try expression
+
+**Files:**
+- Modify: `lib/typeChecker.ts` — `synthType()` method
+- Test: `lib/typeChecker.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe("try expression type checking", () => {
+  it("try expression has Result type", () => {
+    // try someFunc() — synthType should return resultType
+  });
+
+  it("warns when try is applied to Result-returning function", () => {
+    // try resultReturningFunc() — should emit a warning
+  });
+});
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests fail.
+
+- [ ] **Step 2: Add tryExpression case to synthType**
+
+```typescript
+case "tryExpression": {
+  // try always produces a Result
+  // Check for double-wrapping: if the wrapped function already returns Result, warn
+  const callReturnType = this.synthType(expr.call, scopeVars);
+  if (callReturnType !== "any" && isResultType(callReturnType)) {
+    this.errors.push({
+      message: `Warning: 'try' applied to a function that already returns Result. This will double-wrap the Result.`,
+    });
+  }
+  return bareResult();
+}
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/typeChecker.ts lib/typeChecker.test.ts
+git commit -m "feat(typechecker): try expression type checking with double-wrap warning"
+```
+
+---
+
+## Task 8: synthType for catch operator
+
+**Files:**
+- Modify: `lib/typeChecker.ts` — `synthType()` method
+- Test: `lib/typeChecker.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe("catch operator type checking", () => {
+  it("left side of catch must be Result", () => {
+    // 42 catch 0 — error: left side is number, not Result
+  });
+
+  it("catch with plain fallback returns fallback type", () => {
+    // success(1) catch 0 — result type is number
+  });
+
+  it("catch with Result fallback returns Result (for chaining)", () => {
+    // try foo() catch try bar() — result type is Result
+  });
+});
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests fail.
+
+- [ ] **Step 2: Add catch case to synthType**
+
+In `synthType()` binOpExpression case, add handling for `operator === "catch"`:
+
+```typescript
+if (op === "catch") {
+  const leftType = this.synthType(expr.left, scopeVars);
+  if (leftType !== "any" && !isResultType(leftType)) {
+    this.errors.push({
+      message: `Left side of 'catch' must be a Result, but got '${formatTypeHint(leftType)}'.`,
+    });
+  }
+  const fallbackType = this.synthType(expr.right, scopeVars);
+  // catch always unwraps. If fallback is Result, the chain continues.
+  return fallbackType;
+}
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/typeChecker.ts lib/typeChecker.test.ts
+git commit -m "feat(typechecker): catch operator type checking"
+```
+
+---
+
+## Task 9: Placeholder validation
+
+**Files:**
+- Modify: `lib/typeChecker.ts` — `synthType()` method
+- Test: `lib/typeChecker.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+it("placeholder outside of pipe is a type error", () => {
+  // Construct an AST with a placeholder node not inside |>
+  // synthType should emit an error
+});
+```
+
+- [ ] **Step 2: Add placeholder case to synthType**
+
+```typescript
+case "placeholder":
+  this.errors.push({
+    message: "'?' placeholder can only be used on the right side of '|>'.",
+  });
+  return "any";
+```
+
+Note: The builder desugars `?` away before codegen. The typechecker sees the raw AST, so `?` nodes that appear outside `|>` right-hand sides will hit this case. Inside `|>`, the typechecker skips deep-checking the right side's arguments (since they're desugared by the builder).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/typeChecker.ts lib/typeChecker.test.ts
+git commit -m "feat(typechecker): placeholder validation"
+```
+
+---
+
+## Task 10: Type guard narrowing for isSuccess/isFailure
+
+This is the most complex task. Inside `if isSuccess(r) { ... }`, property access `r.value` should be typed as the Result's success type. Inside `if isFailure(r) { ... }`, `r.error` should be typed as the failure type.
+
+**Files:**
+- Modify: `lib/typeChecker.ts`
+- Test: `lib/typeChecker.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe("Result type guard narrowing", () => {
+  it("r.value inside isSuccess guard is typed as successType", () => {
+    // def foo(): string {
+    //   const r: Result<string, number> = success("hello")
+    //   if isSuccess(r) {
+    //     return r.value   // should be string, assignable to return type string
+    //   }
+    //   return ""
+    // }
+    // Construct AST with: function returning string, assignment of r as Result<string, number>,
+    // ifElse with condition isSuccess(r), thenBody with return r.value (valueAccess: base=r, chain=[{kind: "property", name: "value"}])
+    // Expect: no errors
+  });
+
+  it("r.error inside isFailure guard is typed as failureType", () => {
+    // Similar but with isFailure and .error access
+  });
+
+  it("r.value outside any guard is a type error", () => {
+    // Direct access r.value on a Result without a guard — error
+  });
+});
+```
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests fail.
+
+- [ ] **Step 2: Implement narrowing in collectVariableTypes**
+
+The approach: in `collectVariableTypes`, when processing an `ifElse` node, detect the type guard pattern.
+
+**Detection:** Check if the ifElse condition is a `functionCall` where `functionName` is `"isSuccess"` or `"isFailure"` and the single argument is a `variableName`.
+
+**Narrowing:** If detected:
+1. Look up the variable's type in `vars` — must be a `resultType`
+2. Save the original type
+3. For `isSuccess`: temporarily set `vars[varName]` to an `objectType` with property `{ key: "value", value: resultType.successType }`
+4. For `isFailure`: temporarily set `vars[varName]` to an `objectType` with properties `{ key: "error", value: resultType.failureType }` and `{ key: "checkpoint", value: { type: "primitiveType", value: "any" } }`
+5. Recurse into `thenBody` with the narrowed vars
+6. Restore the original type after processing thenBody
+
+This leverages the existing `synthValueAccess` which already knows how to resolve property access on `objectType`. The narrowing just temporarily changes the variable's type so property access works.
+
+**For the "outside guard" case:** Without narrowing, `r` has type `resultType`, and `synthValueAccess` will try to do property access on a `resultType` which is not an `objectType` — it will emit an error. This is the desired behavior.
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/typeChecker.ts lib/typeChecker.test.ts
+git commit -m "feat(typechecker): type guard narrowing for isSuccess/isFailure"
+```
+
+---
+
+## Task 11: .retry() validation (simplified)
+
+**Files:**
+- Modify: `lib/typeChecker.ts`
+- Test: `lib/typeChecker.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+describe(".retry() validation", () => {
+  it(".retry() on a Result-typed variable is allowed", () => {
+    // r.retry("new arg") where r is typed as Result — no error from typechecker
+    // (the builder handles desugaring; the typechecker just validates the base type)
+  });
+
+  it(".retry() on a non-Result variable is an error", () => {
+    // x.retry("arg") where x is typed as string — error
+  });
+});
+```
+
+- [ ] **Step 2: Add retry validation**
+
+In `synthValueAccess`, when processing a `methodCall` element named `"retry"`:
+- Check that the current type being accessed is a `resultType`
+- If not, emit error: `"'.retry()' can only be called on a Result value"`.
+- Return type is `"any"` (since retry never returns — it throws a RestoreSignal).
+
+Note: Full validation (must be inside `isFailure` guard, arity must match) is hard to enforce statically. This simplified check catches the most common mistake (calling retry on a non-Result).
+
+Run: `pnpm test:run -- lib/typeChecker`
+Expected: tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/typeChecker.ts lib/typeChecker.test.ts
+git commit -m "feat(typechecker): .retry() validation on Result types"
+```
+
+---
+
+## Summary
+
+| Task | What | Complexity |
+|------|------|------------|
+| 1 | Register builtins | Easy |
+| 2 | Result assignability (with generics) | Easy |
+| 3 | Constructor enforcement | Easy |
+| 4 | Return path enforcement | Easy |
+| 5 | Generic type checking for success/failure args | Medium |
+| 6 | Pipe operator typing | Easy |
+| 7 | Try expression typing + double-wrap warning | Easy |
+| 8 | Catch operator typing | Easy |
+| 9 | Placeholder validation | Trivial |
+| 10 | Type guard narrowing | Hard |
+| 11 | .retry() validation | Easy |

--- a/docs/superpowers/specs/2026-04-08-result-type-and-pipe-operator-design.md
+++ b/docs/superpowers/specs/2026-04-08-result-type-and-pipe-operator-design.md
@@ -1,0 +1,324 @@
+# Result Type and Pipe Operator Design
+
+## Overview
+
+This spec introduces three related features to Agency:
+
+1. A built-in `Result` type for explicit error handling
+2. A `|>` pipe operator for chaining Result-returning operations
+3. Scoped partial application within `|>` chains
+
+Together, these features give Agency users a principled way to handle errors — leveraging the type system to enforce that failures are handled, and leveraging Agency's checkpoint system to enable retrying from the point of failure.
+
+## Motivation
+
+In agent workflows, operations fail frequently: LLM calls time out, structured output doesn't match the schema, external APIs return errors. Today, Agency users handle these failures with ad-hoc patterns — checking return values, throwing exceptions, or ignoring errors entirely. None of these approaches leverage the type system.
+
+The Result type makes failure explicit in function signatures. The typechecker enforces that callers handle failures before using return values. The pipe operator eliminates the boilerplate of chaining multiple fallible operations. And because Agency already has checkpoint/restore infrastructure, failures can carry execution snapshots that allow retrying from the point of failure with modified inputs — something no other language can do.
+
+## Design
+
+### The Result Type
+
+`Result` is a new built-in opaque primitive type. Users cannot access its internals directly — they must use the provided built-in functions to inspect and unwrap it.
+
+At runtime, a Result is a discriminated union:
+
+```typescript
+// Success case
+{ success: true, value: any }
+
+// Failure case
+{ success: false, error: any, checkpoint: Checkpoint }
+```
+
+`Result` is opaque in the Agency type system — the typechecker does not track the inner success or failure types. When unwrapped, the value is typed as `any`. This is a deliberate scope decision; full type tracking (e.g., `Result<SuccessType, FailureType>`) requires generics, which will be added as a follow-up feature.
+
+### Constructors
+
+Two built-in functions construct Result values:
+
+```
+def riskyOperation(): Result {
+  if someCondition {
+    return success(userData)
+  }
+  return failure("user not found")
+}
+```
+
+- `success(value)` — wraps a value as a successful Result
+- `failure(error)` — wraps an error as a failed Result. The checkpoint is not created here — it was captured automatically at the function's entry point (see Checkpointing section). `failure()` retrieves that stored checkpoint and embeds it in the failure object.
+
+**Typechecker rules:**
+- `success()` and `failure()` can only be used inside functions that declare `Result` as their return type. Using them in a function with a different return type is a type error.
+- If a function declares `Result` as its return type, every return path must use `success()` or `failure()`. Returning a bare value is a type error.
+
+### Unwrapping and Type Guards
+
+Two built-in functions inspect Result values:
+
+```
+const result = riskyOperation()
+
+if isSuccess(result) {
+  // Inside this branch, result.value is accessible (typed as any)
+  print(result.value)
+}
+
+if isFailure(result) {
+  // Inside this branch, result.error and result.checkpoint are accessible
+  print(result.error)
+}
+```
+
+- `isSuccess(result)` — returns true if the Result is a success. Acts as a type guard: inside the if-branch, `.value` is accessible.
+- `isFailure(result)` — returns true if the Result is a failure. Acts as a type guard: inside the if-branch, `.error` and `.checkpoint` are accessible.
+
+These are the only ways to unwrap a Result. Accessing `.value`, `.error`, `.checkpoint`, or `.retry()` outside of a guarded branch is a type error.
+
+### Type Assignability Rules
+
+`Result` is its own type. The typechecker enforces:
+
+- `Result` is assignable to `Result` and `any`
+- `Result` is NOT assignable to any other type (`string`, `number`, etc.)
+- You can pass a `Result` to functions that accept `Result` or `any`
+- You can `print()` a Result (since `print` accepts `any`)
+- You can store a Result in a variable
+- You can return a Result from a function that returns `Result`
+- You CANNOT use a Result where a non-Result type is expected — this is a hard type error
+
+The key guarantee: you cannot accidentally use a Result as if it were the underlying value. You must unwrap it first.
+
+### The Pipe Operator (`|>`)
+
+`|>` is a new left-associative binary operator with the lowest precedence (below `||`). It sits below all logical/arithmetic operators but is still an expression-level operator — it does not interact with assignment or declaration syntax. `const x = foo() |> bar` parses as `const x = (foo() |> bar)`.
+
+```
+const result = foo(x) |> bar |> baz
+// Parses as: (foo(x) |> bar) |> baz
+```
+
+**Semantics:**
+
+The left side must be a `Result`. The right side must be a function (either a function reference or a partial application — see below). The operator:
+
+1. If the left side is a failure, short-circuit: return the failure as-is (with its checkpoint).
+2. If the left side is a success, unwrap `.value` and pass it to the right-side function.
+3. If the right-side function returns `Result`, the overall expression is that `Result` (monadic bind).
+4. If the right-side function returns a non-Result type, wrap it in `success()` automatically (functorial fmap).
+
+In all cases, the type of a `|>` expression is `Result`.
+
+**Smart bind/fmap:** The typechecker inspects the return type of the right-side function to determine whether to bind (function returns `Result`) or fmap (function returns a plain type). This means the same operator handles both cases, and the user doesn't need to think about the distinction.
+
+**Typechecker rules:**
+- Left side of `|>` must be `Result`
+- Right side must be a callable (function reference or partial application)
+- Since `Result` is opaque (no inner type tracking), the typechecker cannot verify that the unwrapped value matches the function's parameter type. This will become a compile-time check when generics are added. For now, a type mismatch here is a runtime error.
+
+### Scoped Partial Application in Pipe Chains
+
+On the right side of `|>`, function calls use the `?` placeholder to indicate where the piped value should be inserted.
+
+```
+def multiply(factor: number, value: number): Result {
+  return success(factor * value)
+}
+
+def validate(min: number, max: number, value: number): Result {
+  if value < min || value > max {
+    return failure("out of range")
+  }
+  return success(value)
+}
+
+const result = foo(1) |> multiply(10, ?) |> validate(0, ?, 100)
+// multiply(10, unwrapped) then validate(0, unwrapped, 100)
+```
+
+The `?` placeholder makes it explicit which parameter receives the piped value, and allows it to be any parameter — not just the last one.
+
+```
+// Piped value as first argument:
+foo(1) |> add(?, 10)
+
+// Piped value as middle argument:
+foo(1) |> validate(0, ?, 100)
+
+// Piped value as last argument:
+foo(1) |> multiply(10, ?)
+```
+
+**Rules:**
+- Exactly one argument in the right-side function call must be `?`. Zero placeholders or more than one placeholder is a type error.
+- A bare function reference (no call syntax) is also valid on the right side of `|>` for single-argument functions: `foo(1) |> bar` is equivalent to `foo(1) |> bar(?)`.
+- A property access (method reference) is also valid on the right side of `|>`: `foo(1) |> obj.method` is equivalent to `foo(1) |> obj.method(?)`. The compiler preserves the `this` binding automatically (see Code Generation below).
+- The `?` placeholder is only valid on the right side of `|>`. Using `?` as a function argument outside of a pipe chain is a syntax error.
+
+**Code generation:** The compiler desugars the right side of `|>` into a lambda:
+
+- Bare function reference: `bar` becomes `(x) => bar(x)`.
+- Method reference: `obj.method` becomes `(x) => obj.method(x)`. This preserves the `this` binding — the compiler generates a call expression on the original object, not a detached function reference. This means users never need to think about JavaScript's `this` binding issues when piping to methods.
+- Partial application: `multiply(10, ?)` becomes `(x) => multiply(10, x)`. `validate(0, ?, 100)` becomes `(x) => validate(0, x, 100)`.
+- Method with partial application: `obj.method(10, ?)` becomes `(x) => obj.method(10, x)`. The same `this`-preserving rule applies.
+
+### Automatic Checkpointing and Retry
+
+**Checkpoint capture:** At the entry of every function that returns `Result`, the runtime automatically calls `checkpoint()`. This captures the StateStack (call stack frames, locals, arguments, step counters, message threads) and GlobalStore (module-scoped globals). The checkpoint ID is stored internally in the function's scope. When `failure()` is called within that function, it retrieves this stored checkpoint ID and embeds it in the failure object.
+
+**Retry:** Failures support a `retry` call, which is syntactic sugar desugared by the compiler (not a real method on the runtime object):
+
+```
+shared attempts = 0
+
+def riskyOperation(input: string): Result {
+  attempts = attempts + 1
+  if someCondition {
+    return success(data)
+  }
+  return failure("bad input")
+}
+
+node main() {
+  const result = riskyOperation("first try")
+  if isFailure(result) {
+    if attempts < 5 {
+      result.retry("different input")
+    }
+    // gave up after 5 attempts
+    print(result.error)
+  }
+}
+```
+
+`result.retry(newArg)` is compiler-desugared to `restore(result.checkpoint, { args: [newArg] })`. It is not a real method on the failure object — the compiler recognizes `.retry(...)` on a Result inside an `isFailure` guard and emits the corresponding `restore` call. Using `.retry()` outside an `isFailure` guard is a type error.
+
+`retry` accepts variadic arguments that replace all of the original function's parameters. For a function `def riskyOp(a: string, b: number): Result`, `result.retry("new", 42)` replaces both arguments. The number of arguments passed to `retry` must match the original function's arity — the compiler knows this from the checkpoint metadata. A mismatch is a type error.
+
+The desugared `restore` call:
+
+1. Throws a `RestoreSignal` (never returns)
+2. Rewinds execution to the checkpointed function entry
+3. The `RestoreSignal` is caught by `runNode()`, which calls `ctx.restoreState(checkpoint)`
+4. During state restoration, after the StateStack is deserialized from the checkpoint, the argument overrides from `RestoreOptions.args` are patched onto the top stack frame's arguments, replacing the original values
+5. Execution re-enters the checkpointed node; step counters skip past already-executed statements up to the function entry
+6. The function re-executes with the new arguments, along with everything after it (including remaining steps in a `|>` pipeline)
+
+Because `retry` uses the checkpoint/restore mechanism, the full pipeline after the failed function re-executes naturally. Shared variables persist across retries (they are not serialized), while local variables and arguments are restored from the checkpoint (then overridden with the new arguments).
+
+**Retry limit:** Result retries are governed by a separate `result.maxRetries` configuration, distinct from the existing `checkpoints.maxRestores` that governs manually-created checkpoints. The default is 50. This can be overridden:
+
+```json
+{
+  "result": {
+    "maxRetries": 50
+  }
+}
+```
+
+After N retries, the runtime throws a hard error and halts execution. The count tracks across all retries of the same checkpoint. This is separate from `checkpoints.maxRestores`, which governs manually-created checkpoints.
+
+### Extensions to `restore()`
+
+Currently, `restore()` supports overriding messages via `RestoreOptions`. This design extends `RestoreOptions` to also support:
+
+- **Argument overrides** — replace the arguments the function was called with. This is what `retry` uses.
+- **Global variable overrides** — modify module-scoped global variables before re-execution.
+
+Updated `RestoreOptions`:
+
+```typescript
+type RestoreOptions = {
+  messages?: MessageJSON[];
+  args?: any[];           // new: override function arguments
+  globals?: Record<string, Record<string, any>>;  // new: override globals by module
+};
+```
+
+**How argument overrides work in the restore flow:**
+
+1. `restore()` throws a `RestoreSignal` containing the checkpoint and the `RestoreOptions`
+2. `runNode()` catches the signal and calls `ctx.restoreState(checkpoint)`
+3. `restoreState` deserializes the `StateStack` from the checkpoint, entering deserialize mode
+4. After deserialization, if `RestoreOptions.args` is provided, the runtime patches the top stack frame's `args` object with the override values, replacing the original arguments positionally
+5. Similarly, if `RestoreOptions.globals` is provided, the runtime patches the `GlobalStore` with the override values after deserialization
+6. Execution re-enters the checkpointed node with the modified state
+
+### Interaction Between Features
+
+**`|>` with retry:** When `foo |> bar |> baz` fails at `bar`, the failure carries a checkpoint from `bar`'s entry. Calling `result.retry(newArg)` restores to `bar`'s entry with the new argument. Since the checkpoint was taken within the pipeline's execution, the step counters ensure that `baz` re-executes after `bar` completes.
+
+**`isSuccess`/`isFailure` with `|>`:** The result of a `|>` chain is a `Result`, so the user unwraps it with the same type guards:
+
+```
+const result = foo(1) |> bar |> baz
+
+if isSuccess(result) {
+  print(result.value)
+}
+
+if isFailure(result) {
+  result.retry(newArg)
+}
+```
+
+**Nested Results:** Since `|>` uses smart bind/fmap, there's no risk of `Result<Result<T>>` nesting. If the right-side function returns `Result`, the operator uses bind (no re-wrapping). If it returns a plain value, the operator uses fmap (wraps in `success()`).
+
+**Sequentiality:** `|>` chains are inherently sequential — each step depends on the previous step's result. Even if functions in the chain make LLM calls or other async operations, they execute one at a time.
+
+**Nested Result-returning functions:** When Result-returning functions call other Result-returning functions, each gets its own checkpoint at entry. The failure carries the checkpoint of the function that called `failure()` — the innermost one. This means the caller can only retry the innermost function, not an outer one. This is a known limitation. Users who need to retry at a higher level can use manual `checkpoint()` / `restore()` calls. A future enhancement could attach a checkpoint stack to failures, but this is out of scope for the initial implementation.
+
+## Configuration
+
+| Setting | Location | Default | Description |
+|---------|----------|---------|-------------|
+| `result.maxRetries` | `agency.json` | 50 | Max retries per Result failure checkpoint before hard error |
+| `checkpoints.maxRestores` | `agency.json` | 100 | Max restores per manually-created checkpoint (existing, unchanged) |
+
+## Design Decisions and Rationale
+
+### Why Result is opaque (no generic type parameters)
+
+Agency does not currently support generics. Adding `Result<SuccessType, FailureType>` would require either full generics or a special-case parser for Result-specific type parameters. To keep scope contained, Result is opaque — the typechecker knows something is a Result but doesn't track inner types. This still provides the key safety guarantee (must unwrap before use). Full type tracking is a natural follow-up when generics are added.
+
+### Why `|>` is hardcoded to Result (not general-purpose monadic bind)
+
+We considered generalizing `|>` to work with any "wrapper" type (Optional, arrays, etc.). Analysis of agent workflow patterns showed that Result is the dominant use case. Other patterns are either already handled by Agency features (threads for state, implicit async for promises) or too niche to justify language-level support. Starting with Result-only keeps the implementation simple; the operator can be extended to other types later if needed.
+
+### Why smart bind/fmap instead of two operators
+
+We considered separate operators for bind (`|>` for monadic) and fmap (`|>` for functorial). While mathematically cleaner, this would confuse users who don't know the distinction. The smart approach — inspect the return type of the right-side function — is unambiguous and handles both cases transparently. The typechecker already knows the return type, so the implementation cost is minimal.
+
+### Why automatic checkpointing (not opt-in)
+
+Every function returning Result gets a checkpoint at entry automatically. This is simpler than requiring annotations or opt-in syntax. The performance overhead is bounded (one checkpoint per Result-returning function call, not per step). Users who don't need retry simply ignore the checkpoint on failures.
+
+### Why retry rewinds (not returns)
+
+`retry` uses the existing checkpoint/restore mechanism, which throws a `RestoreSignal` and rewinds the entire execution state. This means `retry` never returns a value — it replaces the call stack. This is consistent with how `restore()` already works and avoids introducing a new control flow pattern.
+
+### Why explicit `?` placeholder instead of implicit parameter position
+
+We initially considered having the piped value implicitly fill the last parameter (Haskell-style). The `?` placeholder is better because: (1) it's readable — you can see exactly where the piped value goes at a glance, (2) it's flexible — not locked to a fixed position, (3) there's no hidden convention to remember, and (4) it simplifies typechecking since the compiler doesn't need to infer which parameter is missing.
+
+## Analogs in Other Languages
+
+| Language | Error type | Chaining | Partial application |
+|----------|-----------|----------|-------------------|
+| Rust | `Result<T, E>` | `?` operator (early return on Err) | No built-in partial application |
+| Haskell | `Either a b` | `>>=` (monadic bind) | All functions curried by default |
+| Swift | `Result<Success, Failure>` | `flatMap` / `map` | No built-in partial application |
+| Elixir | `{:ok, value}` / `{:error, reason}` | `with` blocks | Pipe `\|>` passes as first arg |
+| **Agency** | `Result` (opaque) | `\|>` (smart bind/fmap) | Scoped to `\|>`, explicit `?` placeholder |
+
+Agency's unique contribution is **checkpoint-backed retry on failure** — no other language can rewind execution state to the point of failure and retry with modified inputs.
+
+## Known Omissions and Future Work
+
+- **Generics:** `Result` is opaque — no inner type tracking. Adding `Result<SuccessType, FailureType>` is a natural follow-up when generics are added to Agency.
+- **`unwrap()` convenience function:** A built-in that returns the value or throws on failure (common in Rust/Swift). Useful but not essential for the initial implementation.
+- **Nested checkpoint retry:** Failures only carry the innermost checkpoint. A checkpoint stack for multi-level retry is a potential future enhancement.
+- **`|>` for other types:** The operator is hardcoded to Result. Extending to Optional, arrays, or user-defined wrapper types is possible if demand arises.
+- **`failure()` in nodes:** Nodes don't have return type annotations in the same way functions do. Using `success()` / `failure()` at the top level of a node is not supported in this design — these constructors are scoped to functions with an explicit `Result` return type.

--- a/docs/superpowers/specs/2026-04-10-try-keyword-design.md
+++ b/docs/superpowers/specs/2026-04-10-try-keyword-design.md
@@ -1,0 +1,288 @@
+# Try Keyword Design
+
+## Overview
+
+This spec introduces the `try` and `catch` keywords to Agency. `try` converts exceptions thrown by any function call into `Result` values, bridging the gap between JavaScript's exception-based error handling and Agency's value-based error handling. `catch` provides a concise way to unwrap a `Result` with a fallback value on failure.
+
+## Motivation
+
+Agency does not use exceptions. Errors are values represented by the `Result` type (see the Result Type and Pipe Operator spec). However, Agency users can import TypeScript/JavaScript code that may throw exceptions. Without `try`, an exception from imported code crashes the program.
+
+The `try` keyword lets users opt into exception-to-Result conversion at the call site. This keeps Agency's default behavior close to JavaScript (functions return values, not Results) while giving users a principled way to handle exceptions when they choose to.
+
+### Design goals
+
+- **Opt-in, not mandatory.** Users choose which calls to wrap with `try`. Functions that don't throw can be called normally.
+- **Familiar to JavaScript developers.** Agency should not force a Rust-style "everything is a Result" paradigm. `try` is there when you need it, invisible when you don't.
+- **Composable with `|>`.** A `try` expression produces a `Result`, which feeds naturally into pipe chains.
+
+## Design
+
+### Syntax
+
+```
+const result = try someFunction(args)
+```
+
+`try` is a unary prefix keyword that applies to a single function call expression. It wraps the call in a try-catch at runtime, converting the outcome into a `Result`:
+
+- If the function returns normally, the return value is wrapped in `success()`.
+- If the function throws, the caught exception is wrapped in `failure()`.
+
+### Semantics
+
+`try` can be applied to any function call — imported TypeScript, imported Agency functions, or Agency-defined functions. The type of a `try` expression is always `Result`.
+
+```
+import { parseJSON } from "./utils.js"
+
+const result = try parseJSON(rawString)
+
+if isSuccess(result) {
+  print(result.value)
+}
+
+if isFailure(result) {
+  print("Parse failed: " + result.error)
+}
+```
+
+### Code generation
+
+`try someFunction(args)` compiles to a runtime helper call:
+
+```typescript
+const result = __tryCall(() => someFunction(args));
+```
+
+Where `__tryCall` is a runtime function:
+
+```typescript
+function __tryCall(fn: () => any): Result {
+  try {
+    const value = fn();
+    return { success: true, value };
+  } catch (error) {
+    return { success: false, error, checkpoint: __currentCheckpoint() };
+  }
+}
+```
+
+If the call is inside a function that returns `Result` (and therefore has automatic checkpointing), the failure includes the checkpoint. If the call is outside a Result-returning function, the checkpoint field is `null` and `retry` is not available.
+
+### Async calls
+
+For async function calls, `try` also awaits the result:
+
+```
+const result = try async fetchData(url)
+```
+
+Compiles to:
+
+```typescript
+const result = await __tryCallAsync(async () => fetchData(url));
+```
+
+### The `catch` Keyword
+
+`catch` fully unwraps a `Result`, providing a fallback value if the Result is a failure. It always produces a **plain value** (not a Result) — on both the success and failure branches.
+
+```
+const data = try parseJSON(rawString) catch defaultData
+```
+
+- If `parseJSON` returns normally → `data` is the return value (unwrapped from the Result)
+- If `parseJSON` throws → `data` is `defaultData`
+
+In both cases, `data` is a plain value. `catch` is an assertion: "I will handle both outcomes right here, give me a value."
+
+This is distinct from `try` alone:
+
+- `try foo()` → gives you a `Result` to inspect later
+- `try foo() catch default` → gives you a plain value, guaranteed
+
+**`catch` applies to any `Result`, not just `try` expressions:**
+
+```
+const value = riskyOperation() catch 0
+const config = loadConfig("app.json") catch defaultConfig
+```
+
+**The right side of `catch` is any expression:**
+
+```
+const data = try parseJSON(raw) catch {}
+const port = try readPort() catch 8080
+const user = fetchUser(id) catch createDefaultUser()
+```
+
+The right-side expression is only evaluated if the left side is a failure (short-circuit evaluation).
+
+**Code generation:** `<result> catch <fallback>` compiles to:
+
+```typescript
+const data = __catchResult(try_result, () => fallback);
+```
+
+Where `__catchResult` is a runtime function:
+
+```typescript
+function __catchResult(result: Result, fallback: () => any): any {
+  if (result.success) {
+    return result.value;
+  }
+  return fallback();
+}
+```
+
+### Chaining `catch`
+
+`catch` can be chained to create a sequence of fallbacks. When the right side of `catch` is itself a `try` expression (which produces a `Result`), the next `catch` can handle that Result:
+
+```
+const data = try fetchFromCache(key) catch try fetchFromDB(key) catch try fetchFromAPI(key) catch defaultData
+```
+
+This reads left-to-right: try the cache; if that fails, try the database; if that fails, try the API; if that fails, use the default.
+
+**How it evaluates:**
+
+1. `try fetchFromCache(key)` produces a `Result`.
+2. The first `catch` checks it. If success, return the cached value — done.
+3. If failure, evaluate the fallback: `try fetchFromDB(key)`. This produces a new `Result`.
+4. The second `catch` checks it. If success, return the DB value — done.
+5. If failure, evaluate: `try fetchFromAPI(key)`. Another `Result`.
+6. The third `catch` checks it. If success, return the API value — done.
+7. If failure, return `defaultData`.
+
+**The key rule:** `catch` always unwraps. If the right side of `catch` produces a `Result`, that `Result` becomes the new left side for the next `catch`. If the right side produces a plain value, that's the final value and the chain terminates.
+
+**Precedence:** `catch` binds tighter than `|>` but looser than function calls and `try`. In a `try ... catch ... |>` expression, `catch` resolves first:
+
+```
+try foo() catch default |> bar
+// Parses as: (try foo() catch default) |> bar
+// Type error: left side of |> is a plain value, not a Result
+
+// To pipe then catch, use parentheses:
+(try foo() |> bar |> baz) catch default
+```
+
+### Interaction with `|>`
+
+`try` produces a `Result`, so it composes directly with pipe chains:
+
+```
+const result = try parseJSON(rawString) |> validate |> transform
+```
+
+This reads as: try parsing the JSON; if it succeeds, pipe the value through validate and transform. If `parseJSON` throws, the failure short-circuits the entire chain.
+
+**Combining `|>` and `catch`:**
+
+```
+// Pipe chain with a catch at the end — always produces a plain value
+const value = (try parseJSON(raw) |> validate |> transform) catch defaultValue
+
+// Fallback chain with its own pipe
+const value = (try fetchData(url) |> process) catch (try fetchFallback() |> process) catch defaultValue
+```
+
+### Interaction with Result-returning functions
+
+If the function being called already returns `Result`, `try` still wraps the call. This means:
+
+- If the function returns `success(value)` normally, `try` wraps it in another `success()` — producing `success(Result)`. This is likely not what the user wants.
+- If the function throws (which Result-returning functions shouldn't do), `try` catches the exception.
+
+**Typechecker rule:** The typechecker emits a warning when `try` is applied to a function that already returns `Result`, since the double-wrapping is almost certainly a mistake. The user should call Result-returning functions directly without `try`.
+
+### Interaction with checkpointing and retry
+
+When `try` is used inside a function that returns `Result`, the function already has an automatic checkpoint at entry. The failure produced by `try` includes this checkpoint, so `retry` works:
+
+```
+def loadConfig(path: string): Result {
+  const parsed = try parseJSON(readFile(path))
+  if isFailure(parsed) {
+    return failure("invalid config: " + parsed.error)
+  }
+  return success(parsed.value)
+}
+
+node main() {
+  const config = loadConfig("config.json")
+  if isFailure(config) {
+    config.retry("fallback.json")
+  }
+}
+```
+
+When `try` is used outside a Result-returning function, the failure has no checkpoint and `retry` is not available. Accessing `.retry()` on such a failure is a type error.
+
+### Top-level safety net
+
+Independent of `try`, the top-level node execution is wrapped in a try-catch that produces a readable error message for any unhandled exception. This ensures that even without `try`, an exception from imported code does not produce a raw stack trace crash. Instead, the user sees a clear error message indicating which function threw and what the error was.
+
+This is not a Result — it is a hard error that terminates execution. `try` is the mechanism for converting exceptions into handleable values; the top-level catch is a last resort for exceptions the user did not anticipate.
+
+## Typechecker Rules
+
+### `try`
+
+- The type of `try <expr>` is `Result`.
+- `try` can only be applied to function call expressions (not arbitrary expressions, variable references, or literals). `try 5` or `try someVariable` is a syntax error.
+- The typechecker warns when `try` is applied to a function that returns `Result`, since this produces a double-wrapped Result.
+- `Result` values produced by `try` follow all existing Result assignability rules (must unwrap before use, cannot be used where a non-Result type is expected, etc.).
+
+### `catch`
+
+- The left side of `catch` must be a `Result`. Using `catch` on a non-Result value is a type error.
+- The type of `<result> catch <fallback>` is the type of the fallback expression. Since `Result` is opaque, the typechecker cannot verify that the success value and fallback have the same type — this will be checked when generics are added.
+- Exception: when the right side of `catch` is a `Result` (e.g., `try foo() catch try bar()`), the type of the overall expression is `Result`, enabling further chaining. The final `catch` in a chain should have a plain value to ensure the chain always resolves to a non-Result type.
+
+## Design Decisions and Rationale
+
+### Why `try` is opt-in (not automatic wrapping)
+
+We considered automatically wrapping all imported TypeScript function calls in try-catch. This was rejected because:
+
+1. It would make every imported function call return `Result`, forcing users to unwrap on every call — even for functions that never throw. This makes the language feel fundamentally different from JavaScript.
+2. It removes the user's choice. Some users may prefer to let exceptions propagate to the top-level safety net rather than handling them explicitly.
+3. It adds overhead to every imported call, even when unnecessary.
+
+### Why `try` wraps in Result (not a separate error type)
+
+`try` produces the same `Result` type as `success()`/`failure()`. This means `try` expressions compose with `|>` pipes, `isSuccess`/`isFailure` guards, and `retry` — all the existing Result infrastructure. A separate error type would require duplicate handling code.
+
+### Why not reuse `handle` blocks for exceptions
+
+We considered routing exceptions through Agency's existing `handle` blocks (which are used for interrupts). This was rejected because interrupts and exceptions are semantically different:
+
+- **Interrupts are intentional pauses** that expect resumption. The handler can approve, reject, modify, or resolve, and execution continues.
+- **Exceptions are accidental failures.** There is no meaningful "approve" response to a TypeError. The only useful actions are to log the error, provide a fallback, or retry.
+
+Unifying them under `handle` would conflate two different concerns and make handle blocks harder to reason about.
+
+### Why `catch` always unwraps (returns a plain value)
+
+We considered two alternatives:
+
+1. **`catch` returns a `Result`** — wrapping the fallback in `success()`. This is clean but trivially implementable by the user (`if isSuccess(val) { return val } return success(defaultVal)`), so it doesn't justify a keyword.
+2. **`catch` returns a plain value on the fallback branch but a `Result` on the success branch.** This means the variable's type depends on which branch was taken at runtime, which is confusing and breaks type safety.
+
+The chosen design — always unwrap, always return a plain value — is the most useful. It covers the common case of "I want a value right now with a fallback" and eliminates five lines of `isSuccess`/`isFailure` boilerplate. When chained with another `try` on the right side, the intermediate `catch` evaluates to a `Result` (because `try` produces one), enabling the chain to continue.
+
+### Why not a `?` operator
+
+We considered Rust's `?` operator (unwrap or early-return the error). This was deferred because:
+
+1. `try` + `catch` + `isSuccess`/`isFailure` already cover the main use cases.
+2. `?` requires the enclosing function to return `Result`, adding an implicit contract that is less obvious than explicit `if isFailure` checks.
+3. It can be added later without breaking existing code if verbosity proves to be a problem.
+
+## Future Work
+
+- **`?` operator:** A potential addition for early return on failure (Rust-style). Deferred until we see whether verbosity is a real pain point.
+- **Typechecker warnings for unhandled exceptions:** When the typechecker is more mature, it could warn when an imported function is called without `try` and outside a `handle` block. This would help users identify potential crash points.

--- a/lib/backends/typescriptGenerator/typeToString.ts
+++ b/lib/backends/typescriptGenerator/typeToString.ts
@@ -48,6 +48,11 @@ export function variableTypeToString(
       .join(", ");
     const ret = variableTypeToString(variableType.returnType, typeAliases);
     return `(${params}) => ${ret}`;
+  } else if (variableType.type === "resultType") {
+    const s = variableTypeToString(variableType.successType, typeAliases);
+    const f = variableTypeToString(variableType.failureType, typeAliases);
+    if (s === "any" && f === "any") return "Result";
+    return `Result<${s}, ${f}>`;
   }
   return "unknown";
 }

--- a/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -78,6 +78,8 @@ export function mapTypeToZodSchema(
       })
       .join(", ");
     return `z.object({ ${props} })`;
+  } else if (variableType.type === "resultType") {
+    return mapTypeToZodSchema(variableType.successType, typeAliases);
   } else if (variableType.type === "typeAliasVariable") {
     if (!typeAliases || !typeAliases[variableType.aliasName]) {
       throw new Error(

--- a/lib/cli/util.ts
+++ b/lib/cli/util.ts
@@ -244,6 +244,15 @@ export function formatTypeHint(vt: VariableType): string {
       const ret = formatTypeHint(vt.returnType);
       return `(${params}) => ${ret}`;
     }
+    case "resultType": {
+      const s = vt.successType;
+      const f = vt.failureType;
+      const isAny = (t: VariableType) => t.type === "primitiveType" && t.value === "any";
+      if (isAny(s) && isAny(f)) {
+        return "Result";
+      }
+      return `Result<${formatTypeHint(s)}, ${formatTypeHint(f)}>`;
+    }
     default:
       throw new Error(`Unknown variable type: ${(vt as any).type}`);
   }

--- a/lib/cli/util.ts
+++ b/lib/cli/util.ts
@@ -245,13 +245,12 @@ export function formatTypeHint(vt: VariableType): string {
       return `(${params}) => ${ret}`;
     }
     case "resultType": {
-      const s = vt.successType;
-      const f = vt.failureType;
-      const isAny = (t: VariableType) => t.type === "primitiveType" && t.value === "any";
-      if (isAny(s) && isAny(f)) {
+      const { successType, failureType } = vt;
+      if (successType.type === "primitiveType" && successType.value === "any" &&
+          failureType.type === "primitiveType" && failureType.value === "any") {
         return "Result";
       }
-      return `Result<${formatTypeHint(s)}, ${formatTypeHint(f)}>`;
+      return `Result<${formatTypeHint(successType)}, ${formatTypeHint(failureType)}>`;
     }
     default:
       throw new Error(`Unknown variable type: ${(vt as any).type}`);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,7 +3,7 @@ export * from "./types.js";
 export * from "./backends/index.js";
 export * from "./simplemachine/index.js";
 export * from "./statelogClient.js";
-export * from "smoltalk";
+export * as smoltalk from "smoltalk";
 export type { StreamChunk } from "smoltalk";
 export { nanoid } from "nanoid";
 export { AgencyConfig } from "./config.js";

--- a/lib/ir/prettyPrint.ts
+++ b/lib/ir/prettyPrint.ts
@@ -1,4 +1,5 @@
 import type { TsNode, TsParam, TsScopedVar } from "./tsIR.js";
+import renderRunnerIfElse from "../templates/backends/typescriptGenerator/runnerIfElse.js";
 
 const INDENT = "  ";
 
@@ -266,21 +267,19 @@ export function printTs(node: TsNode, indent = 0): string {
     }
 
     case "runnerIfElse": {
-      const branches = node.branches
-        .map((b) => {
-          const cond = printTs(b.condition, indent + 2);
-          const body = b.body.map((n) => printTs(n, indent + 3)).join("\n");
-          return `${ind(indent + 1)}{\n${ind(indent + 2)}condition: () => ${cond},\n${ind(indent + 2)}body: async (runner) => {\n${body}\n${ind(indent + 2)}},\n${ind(indent + 1)}}`;
-        })
-        .join(",\n");
-
-      let result = `await runner.ifElse(${node.id}, [\n${branches}\n${ind(indent)}]`;
-      if (node.elseBranch) {
-        const elsBody = node.elseBranch.map((n) => printTs(n, indent + 2)).join("\n");
-        result += `, async (runner) => {\n${elsBody}\n${ind(indent)}}`;
-      }
-      result += ");";
-      return result;
+      const branches = node.branches.map((b) => ({
+        condition: printTs(b.condition, indent + 2),
+        body: b.body.map((n) => printTs(n, indent + 3)).join("\n"),
+      }));
+      const elseBranch = node.elseBranch
+        ? node.elseBranch.map((n) => printTs(n, indent + 2)).join("\n")
+        : "";
+      return renderRunnerIfElse({
+        id: node.id,
+        branches,
+        hasElse: !!node.elseBranch,
+        elseBranch,
+      });
     }
 
     case "runnerLoop": {

--- a/lib/parsers/typeHints.test.ts
+++ b/lib/parsers/typeHints.test.ts
@@ -11,6 +11,7 @@ import {
   objectPropertyDescriptionParser,
   objectPropertyWithDescriptionParser,
   objectTypeParser,
+  resultTypeParser,
   typeAliasParser,
   typeAliasVariableParser,
   variableTypeParser,
@@ -2328,6 +2329,93 @@ describe("unionTypeParser", () => {
           const result = unionTypeParser(input);
           expect(result.success).toBe(false);
         });
+    }
+  });
+});
+
+describe("resultTypeParser", () => {
+  it("parses bare Result as resultType with any/any", () => {
+    const result = resultTypeParser("Result");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toEqual({
+        type: "resultType",
+        successType: { type: "primitiveType", value: "any" },
+        failureType: { type: "primitiveType", value: "any" },
+      });
+    }
+  });
+
+  it("parses Result<string, number> with explicit type params", () => {
+    const result = resultTypeParser("Result<string, number>");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toEqual({
+        type: "resultType",
+        successType: { type: "primitiveType", value: "string" },
+        failureType: { type: "primitiveType", value: "number" },
+      });
+    }
+  });
+
+  it("parses Result with object failure type", () => {
+    const result = variableTypeParser("Result<string, { message: string }>");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toEqual({
+        type: "resultType",
+        successType: { type: "primitiveType", value: "string" },
+        failureType: {
+          type: "objectType",
+          properties: [{ key: "message", value: { type: "primitiveType", value: "string" } }],
+        },
+      });
+    }
+  });
+
+  it("parses Result with type alias params", () => {
+    const result = resultTypeParser("Result<MySuccess, MyError>");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toEqual({
+        type: "resultType",
+        successType: { type: "typeAliasVariable", aliasName: "MySuccess" },
+        failureType: { type: "typeAliasVariable", aliasName: "MyError" },
+      });
+    }
+  });
+
+  it("Result<string> with one param throws a parse error", () => {
+    expect(() => resultTypeParser("Result<string>")).toThrow(
+      "expected two type parameters separated by comma",
+    );
+  });
+
+  it("does not match ResultFoo as bare Result", () => {
+    const result = resultTypeParser("ResultFoo");
+    expect(result.success).toBe(false);
+  });
+
+  it("parses bare Result via variableTypeParser", () => {
+    const result = variableTypeParser("Result");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toEqual({
+        type: "resultType",
+        successType: { type: "primitiveType", value: "any" },
+        failureType: { type: "primitiveType", value: "any" },
+      });
+    }
+  });
+
+  it("parses ResultFoo as a type alias via variableTypeParser", () => {
+    const result = variableTypeParser("ResultFoo");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toEqual({
+        type: "typeAliasVariable",
+        aliasName: "ResultFoo",
+      });
     }
   });
 });

--- a/lib/parsers/typeHints.ts
+++ b/lib/parsers/typeHints.ts
@@ -11,6 +11,7 @@ import {
   ObjectProperty,
   ObjectType,
   PrimitiveType,
+  ResultType,
   StringLiteralType,
   TypeAlias,
   TypeAliasVariable,
@@ -27,6 +28,7 @@ import {
   many1Till,
   many1WithJoin,
   newline,
+  not,
   oneOf,
   optional,
   or,
@@ -289,6 +291,7 @@ export const unionItemParser: Parser<VariableType> = trace(
     objectTypeParser,
     angleBracketsArrayTypeParser,
     arrayTypeParser,
+    lazy(() => resultTypeParser),
     stringLiteralTypeParser,
     numberLiteralTypeParser,
     booleanLiteralTypeParser,
@@ -365,6 +368,38 @@ export const blockTypeParser: Parser<BlockType> = trace(
   },
 );
 
+export const resultTypeParser: Parser<ResultType> = trace(
+  "resultTypeParser",
+  or(
+    // Result<SuccessType, FailureType>
+    seqC(
+      set("type", "resultType"),
+      str("Result"),
+      char("<"),
+      captureCaptures(
+        parseError(
+          "expected two type parameters separated by comma, e.g. `Result<string, number>`",
+          capture(lazy(() => variableTypeParser), "successType"),
+          optionalSpaces,
+          char(","),
+          optionalSpaces,
+          capture(lazy(() => variableTypeParser), "failureType"),
+          char(">"),
+        ),
+      ),
+    ),
+    // Bare Result (sugar for Result<any, any>)
+    // Use not(varNameChar) to avoid matching "ResultFoo" as bare Result
+    seqC(
+      set("type", "resultType"),
+      str("Result"),
+      not(varNameChar),
+      set("successType", { type: "primitiveType", value: "any" }),
+      set("failureType", { type: "primitiveType", value: "any" }),
+    ),
+  ),
+);
+
 export const variableTypeParser: Parser<VariableType> = trace(
   "variableTypeParser",
   or(
@@ -373,6 +408,7 @@ export const variableTypeParser: Parser<VariableType> = trace(
     arrayTypeParser,
     objectTypeParser,
     angleBracketsArrayTypeParser,
+    resultTypeParser,
     stringLiteralTypeParser,
     numberLiteralTypeParser,
     booleanLiteralTypeParser,

--- a/lib/runtime/index.ts
+++ b/lib/runtime/index.ts
@@ -85,3 +85,6 @@ export type { RewindCheckpoint } from "./rewind.js";
 
 export { debugStep } from "./debugger.js";
 export { DebuggerState } from "../debugger/debuggerState.js";
+
+export { success, failure, isSuccess, isFailure } from "./result.js";
+export type { ResultValue, ResultSuccess, ResultFailure } from "./result.js";

--- a/lib/runtime/result.test.ts
+++ b/lib/runtime/result.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { success, failure, isSuccess, isFailure } from "./result.js";
+
+describe("success", () => {
+  it("creates a success result", () => {
+    const result = success(42);
+    expect(result).toEqual({ success: true, value: 42 });
+  });
+
+  it("creates a success result with a string value", () => {
+    const result = success("hello");
+    expect(result).toEqual({ success: true, value: "hello" });
+  });
+
+  it("creates a success result with null value", () => {
+    const result = success(null);
+    expect(result).toEqual({ success: true, value: null });
+  });
+});
+
+describe("failure", () => {
+  it("creates a failure result with string error", () => {
+    const result = failure("something went wrong");
+    expect(result).toEqual({ success: false, error: "something went wrong", checkpoint: null });
+  });
+
+  it("creates a failure result with object error", () => {
+    const result = failure({ code: 404, message: "not found" });
+    expect(result).toEqual({
+      success: false,
+      error: { code: 404, message: "not found" },
+      checkpoint: null,
+    });
+  });
+
+  it("always sets checkpoint to null", () => {
+    const result = failure("error");
+    expect(result.checkpoint).toBeNull();
+  });
+});
+
+describe("isSuccess", () => {
+  it("returns true for success results", () => {
+    expect(isSuccess(success(42))).toBe(true);
+  });
+
+  it("returns false for failure results", () => {
+    expect(isSuccess(failure("error"))).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isSuccess(null as any)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isSuccess(undefined as any)).toBe(false);
+  });
+});
+
+describe("isFailure", () => {
+  it("returns true for failure results", () => {
+    expect(isFailure(failure("error"))).toBe(true);
+  });
+
+  it("returns false for success results", () => {
+    expect(isFailure(success(42))).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isFailure(null as any)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isFailure(undefined as any)).toBe(false);
+  });
+});

--- a/lib/runtime/result.ts
+++ b/lib/runtime/result.ts
@@ -1,0 +1,28 @@
+export type ResultValue = ResultSuccess | ResultFailure;
+
+export type ResultSuccess = {
+  success: true;
+  value: any;
+};
+
+export type ResultFailure = {
+  success: false;
+  error: any;
+  checkpoint: any;
+};
+
+export function success(value: any): ResultSuccess {
+  return { success: true, value };
+}
+
+export function failure(error: any): ResultFailure {
+  return { success: false, error, checkpoint: null };
+}
+
+export function isSuccess(result: ResultValue): result is ResultSuccess {
+  return result != null && result.success === true;
+}
+
+export function isFailure(result: ResultValue): result is ResultFailure {
+  return result != null && result.success === false;
+}

--- a/lib/runtime/runner.ts
+++ b/lib/runtime/runner.ts
@@ -252,7 +252,7 @@ export class Runner {
 
   async ifElse(
     id: number,
-    branches: { condition: () => boolean; body: (runner: Runner) => Promise<void> }[],
+    branches: { condition: () => boolean | Promise<boolean>; body: (runner: Runner) => Promise<void> }[],
     elseBranch?: (runner: Runner) => Promise<void>,
   ): Promise<void> {
     if (this.shouldSkip()) return;
@@ -270,7 +270,7 @@ export class Runner {
     if (this.frame.locals[condKey] === undefined) {
       let branchIndex = -1;
       for (let i = 0; i < branches.length; i++) {
-        if (branches[i].condition()) {
+        if (await branches[i].condition()) {
           branchIndex = i;
           break;
         }

--- a/lib/runtime/state/context.ts
+++ b/lib/runtime/state/context.ts
@@ -6,7 +6,7 @@ import type { Checkpoint } from "./checkpointStore.js";
 import { StatelogClient, StatelogConfig } from "../../statelogClient.js";
 import { SimpleMachine } from "../../simplemachine/index.js";
 import { nanoid } from "nanoid";
-import { SmolPromptConfig } from "@/index.js";
+import { SmolPromptConfig } from "smoltalk";
 import { callHook } from "../hooks.js";
 import type { AgencyCallbacks } from "../hooks.js";
 import type { HandlerFn } from "../types.js";

--- a/lib/runtime/streaming.ts
+++ b/lib/runtime/streaming.ts
@@ -1,4 +1,4 @@
-import { PromptResult, Result, StreamChunk, ToolCallJSON } from "@/index.js";
+import { PromptResult, Result, StreamChunk, ToolCallJSON } from "smoltalk";
 import { builtinSleep } from "./builtins.js";
 import type { RuntimeContext } from "./state/context.js";
 import { GraphState } from "./types.js";

--- a/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/lib/templates/backends/typescriptGenerator/imports.ts
@@ -7,8 +7,8 @@ export const template = `import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -28,6 +28,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/lib/templates/backends/typescriptGenerator/runnerIfElse.mustache
+++ b/lib/templates/backends/typescriptGenerator/runnerIfElse.mustache
@@ -1,0 +1,12 @@
+await runner.ifElse({{{id}}}, [
+{{#branches}}
+  {
+    condition: async () => {{{this.condition}}},
+    body: async (runner) => {
+{{{this.body}}}
+    },
+  },
+{{/branches}}
+]{{#hasElse}}, async (runner) => {
+{{{elseBranch}}}
+}{{/hasElse}});

--- a/lib/templates/backends/typescriptGenerator/runnerIfElse.ts
+++ b/lib/templates/backends/typescriptGenerator/runnerIfElse.ts
@@ -1,0 +1,34 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/backends/typescriptGenerator/runnerIfElse.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `await runner.ifElse({{{id}}}, [
+{{#branches}}
+  {
+    condition: async () => {{{this.condition}}},
+    body: async (runner) => {
+{{{this.body}}}
+    },
+  },
+{{/branches}}
+]{{#hasElse}}, async (runner) => {
+{{{elseBranch}}}
+}{{/hasElse}});`;
+
+export type TemplateType = {
+  id: string | boolean | number;
+  branches: {
+    condition: string | boolean | number;
+    body: string | boolean | number;
+  }[];
+  hasElse: boolean;
+  elseBranch: string | boolean | number;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/lib/types/typeHints.ts
+++ b/lib/types/typeHints.ts
@@ -9,7 +9,14 @@ export type VariableType =
   | UnionType
   | ObjectType
   | TypeAliasVariable
-  | BlockType;
+  | BlockType
+  | ResultType;
+
+export type ResultType = {
+  type: "resultType";
+  successType: VariableType;
+  failureType: VariableType;
+};
 
 export type BlockType = {
   type: "blockType";

--- a/tests/agency/fork/fork-nested-call.agency
+++ b/tests/agency/fork/fork-nested-call.agency
@@ -1,0 +1,15 @@
+def double(n: number): number {
+  return n * 2
+}
+
+def addTen(n: number): number {
+  let doubled = double(n)
+  return doubled + 10
+}
+
+node main() {
+  let results = fork([1, 2, 3]) as item {
+    return addTen(item)
+  }
+  return results
+}

--- a/tests/agency/fork/fork-nested-call.test.json
+++ b/tests/agency/fork/fork-nested-call.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Fork with nested function calls — addTen calls double internally, each branch must have isolated state",
+      "input": "",
+      "expectedOutput": "[12,14,16]",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/tests/agency/result-basic.agency
+++ b/tests/agency/result-basic.agency
@@ -1,0 +1,17 @@
+def tryParse(input: string): Result {
+  if (input == "ok") {
+    return success(42)
+  }
+  return failure("invalid input")
+}
+
+node main() {
+  let r1 = tryParse("ok")
+  let r2 = tryParse("bad")
+  if (isSuccess(r1)) {
+    if (isFailure(r2)) {
+      return "both correct"
+    }
+  }
+  return "unexpected"
+}

--- a/tests/agency/result-basic.test.json
+++ b/tests/agency/result-basic.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"both correct\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/typescriptBuilder/assignment.mjs
+++ b/tests/typescriptBuilder/assignment.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptBuilder/safe-function.mjs
+++ b/tests/typescriptBuilder/safe-function.mjs
@@ -3,8 +3,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -24,6 +24,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/array.mjs
+++ b/tests/typescriptGenerator/array.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/tests/typescriptGenerator/arrayAndObject.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/assignment.mjs
+++ b/tests/typescriptGenerator/assignment.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/tests/typescriptGenerator/asyncAssigned.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/asyncKeyword.mjs
+++ b/tests/typescriptGenerator/asyncKeyword.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/asyncLlm.mjs
+++ b/tests/typescriptGenerator/asyncLlm.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/blockBasic.mjs
+++ b/tests/typescriptGenerator/blockBasic.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/blockParams.mjs
+++ b/tests/typescriptGenerator/blockParams.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/comments.mjs
+++ b/tests/typescriptGenerator/comments.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
@@ -239,13 +240,15 @@ __stack.locals.status = `active`;
   });
   await runner.step(5, async (runner) => {
 await runner.ifElse(5, [
-      {
-        condition: () => __stack.locals.status === `inactive`,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.status === `inactive`,
+    body: async (runner) => {
 await print(`Stopped`)
-        },
-      }
-    ]);
+    },
+  },
+
+]);
 //  Final comment at end of file
   });
   if (runner.halted) return runner.haltResult;

--- a/tests/typescriptGenerator/defaultValues.mjs
+++ b/tests/typescriptGenerator/defaultValues.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/docstrings.mjs
+++ b/tests/typescriptGenerator/docstrings.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/forLoop.mjs
+++ b/tests/typescriptGenerator/forLoop.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/function-with-types.mjs
+++ b/tests/typescriptGenerator/function-with-types.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/function.mjs
+++ b/tests/typescriptGenerator/function.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/ifElse.mjs
+++ b/tests/typescriptGenerator/ifElse.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
@@ -127,27 +128,31 @@ __stack.locals.flag = true;
   });
   await runner.step(2, async (runner) => {
 await runner.ifElse(2, [
-      {
-        condition: () => __stack.locals.flag,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.flag,
+    body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `condition was true`;
           });
-        },
-      }
-    ]);
+    },
+  },
+
+]);
   });
   await runner.step(3, async (runner) => {
 await runner.ifElse(3, [
-      {
-        condition: () => await isReady(),
-        body: async (runner) => {
+
+  {
+    condition: async () => await isReady(),
+    body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.status = `ready`;
           });
-        },
-      }
-    ]);
+    },
+  },
+
+]);
 //  If statement with property access
   });
   await runner.step(4, async (runner) => {
@@ -157,15 +162,17 @@ __stack.locals.obj = {
   });
   await runner.step(5, async (runner) => {
 await runner.ifElse(5, [
-      {
-        condition: () => __stack.locals.obj.active,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.obj.active,
+    body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.message = `object is active`;
           });
-        },
-      }
-    ]);
+    },
+  },
+
+]);
 //  Nested if statements
   });
   await runner.step(6, async (runner) => {
@@ -173,27 +180,31 @@ __stack.locals.outer = true;
   });
   await runner.step(7, async (runner) => {
 await runner.ifElse(7, [
-      {
-        condition: () => __stack.locals.outer,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.outer,
+    body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.inner = false;
           });
 await runner.step(1, async (runner) => {
 await runner.ifElse(1, [
-              {
-                condition: () => __stack.locals.inner,
-                body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.inner,
+    body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.nested = `both true`;
                   });
-                },
-              }
-            ]);
+    },
+  },
+
+]);
           });
-        },
-      }
-    ]);
+    },
+  },
+
+]);
 //  TODO fix
 //  If with index access
 //  arr = [1, 2, 3]
@@ -207,9 +218,10 @@ __stack.locals.condition = true;
   });
   await runner.step(9, async (runner) => {
 await runner.ifElse(9, [
-      {
-        condition: () => __stack.locals.condition,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.condition,
+    body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.a = 1;
           });
@@ -219,9 +231,10 @@ __stack.locals.b = 2;
 await runner.step(2, async (runner) => {
 __stack.locals.c = 3;
           });
-        },
-      }
-    ]);
+    },
+  },
+
+]);
 //  Multiple statements in both then and else bodies
   });
   await runner.step(10, async (runner) => {
@@ -229,60 +242,67 @@ __stack.locals.value = false;
   });
   await runner.step(11, async (runner) => {
 await runner.ifElse(11, [
-      {
-        condition: () => __stack.locals.value,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.value,
+    body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.x = 10;
           });
 await runner.step(1, async (runner) => {
 __stack.locals.y = 20;
           });
-        },
-      }
-    ]);
+    },
+  },
+
+]);
 //  Basic else
   });
   await runner.step(12, async (runner) => {
 await runner.ifElse(12, [
-      {
-        condition: () => __stack.locals.flag,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.flag,
+    body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `yes`;
           });
-        },
-      }
-    ], async (runner) => {
+    },
+  },
+
+], async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `no`;
         });
-    });
+});
 //  else if chain
   });
   await runner.step(13, async (runner) => {
 await runner.ifElse(13, [
-      {
-        condition: () => __stack.locals.a == 1,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.a == 1,
+    body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `one`;
           });
-        },
-      },
-      {
-        condition: () => __stack.locals.a == 2,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.a == 2,
+    body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `two`;
           });
-        },
-      }
-    ], async (runner) => {
+    },
+  },
+
+], async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `other`;
         });
-    });
+});
   });
   if (runner.halted) return runner.haltResult;
   await callHook({

--- a/tests/typescriptGenerator/imports.mjs
+++ b/tests/typescriptGenerator/imports.mjs
@@ -15,8 +15,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -36,6 +36,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/input.mjs
+++ b/tests/typescriptGenerator/input.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/interpolation.mjs
+++ b/tests/typescriptGenerator/interpolation.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/tests/typescriptGenerator/llmConfigParam.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/matchBlock.mjs
+++ b/tests/typescriptGenerator/matchBlock.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
@@ -128,27 +129,31 @@ __stack.locals.action = `start`;
   });
   await runner.step(2, async (runner) => {
 await runner.ifElse(2, [
-      {
-        condition: () => __stack.locals.action === `start`,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.action === `start`,
+    body: async (runner) => {
 await print(`Starting...`)
-        },
-      },
-      {
-        condition: () => __stack.locals.action === `stop`,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.action === `stop`,
+    body: async (runner) => {
 await print(`Stopping...`)
-        },
-      },
-      {
-        condition: () => __stack.locals.action === `restart`,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.action === `restart`,
+    body: async (runner) => {
 await print(`Restarting...`)
-        },
-      }
-    ], async (runner) => {
+    },
+  },
+
+], async (runner) => {
 await print(`Unknown action`)
-    });
+});
 //  Match with number literals
   });
   await runner.step(3, async (runner) => {
@@ -156,27 +161,31 @@ __stack.locals.statusCode = 200;
   });
   await runner.step(4, async (runner) => {
 await runner.ifElse(4, [
-      {
-        condition: () => __stack.locals.statusCode === 200,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.statusCode === 200,
+    body: async (runner) => {
 await print(`OK`)
-        },
-      },
-      {
-        condition: () => __stack.locals.statusCode === 404,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.statusCode === 404,
+    body: async (runner) => {
 await print(`Not Found`)
-        },
-      },
-      {
-        condition: () => __stack.locals.statusCode === 500,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.statusCode === 500,
+    body: async (runner) => {
 await print(`Internal Server Error`)
-        },
-      }
-    ], async (runner) => {
+    },
+  },
+
+], async (runner) => {
 await print(`Unknown status`)
-    });
+});
 //  Match with variable assignment in body
   });
   await runner.step(5, async (runner) => {
@@ -187,33 +196,38 @@ __stack.locals.points = 0;
   });
   await runner.step(7, async (runner) => {
 await runner.ifElse(7, [
-      {
-        condition: () => __stack.locals.grade === `A`,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.grade === `A`,
+    body: async (runner) => {
 __stack.locals.a = 100;
-        },
-      },
-      {
-        condition: () => __stack.locals.grade === `B`,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.grade === `B`,
+    body: async (runner) => {
 __stack.locals.b = 85;
-        },
-      },
-      {
-        condition: () => __stack.locals.grade === `C`,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.grade === `C`,
+    body: async (runner) => {
 __stack.locals.c = 70;
-        },
-      },
-      {
-        condition: () => __stack.locals.grade === `D`,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.grade === `D`,
+    body: async (runner) => {
 __stack.locals.d = 55;
-        },
-      }
-    ], async (runner) => {
+    },
+  },
+
+], async (runner) => {
 __stack.locals.e = 0;
-    });
+});
 //  Match with function calls in body
   });
   await runner.step(8, async (runner) => {
@@ -221,31 +235,36 @@ __stack.locals.level = `debug`;
   });
   await runner.step(9, async (runner) => {
 await runner.ifElse(9, [
-      {
-        condition: () => __stack.locals.level === `debug`,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.level === `debug`,
+    body: async (runner) => {
 await print(`Debug mode enabled`)
-        },
-      },
-      {
-        condition: () => __stack.locals.level === `info`,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.level === `info`,
+    body: async (runner) => {
 await print(`Info level logging`)
-        },
-      },
-      {
-        condition: () => __stack.locals.level === `warn`,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.level === `warn`,
+    body: async (runner) => {
 await print(`Warning level`)
-        },
-      },
-      {
-        condition: () => __stack.locals.level === `error`,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.level === `error`,
+    body: async (runner) => {
 await print(`Error level`)
-        },
-      }
-    ]);
+    },
+  },
+
+]);
 //  Match with array results
   });
   await runner.step(10, async (runner) => {
@@ -253,24 +272,27 @@ __stack.locals.resultType = `array`;
   });
   await runner.step(11, async (runner) => {
 await runner.ifElse(11, [
-      {
-        condition: () => __stack.locals.resultType === `array`,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.resultType === `array`,
+    body: async (runner) => {
 __stack.locals.data1 = [1, 2, 3];
-        },
-      },
-      {
-        condition: () => __stack.locals.resultType === `object`,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.resultType === `object`,
+    body: async (runner) => {
 __stack.locals.data2 = {
             "x": 1,
             "y": 2
           };
-        },
-      }
-    ], async (runner) => {
+    },
+  },
+
+], async (runner) => {
 __stack.locals.data3 = [];
-    });
+});
 //  Match with object results
   });
   await runner.step(12, async (runner) => {
@@ -278,39 +300,43 @@ __stack.locals.format = `json`;
   });
   await runner.step(13, async (runner) => {
 await runner.ifElse(13, [
-      {
-        condition: () => __stack.locals.format === `xml`,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.format === `xml`,
+    body: async (runner) => {
 __stack.locals.output1 = {
             "type": `xml`,
             "ext": `.xml`
           };
-        },
-      },
-      {
-        condition: () => __stack.locals.format === `json`,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.format === `json`,
+    body: async (runner) => {
 __stack.locals.output2 = {
             "type": `json`,
             "ext": `.json`
           };
-        },
-      },
-      {
-        condition: () => __stack.locals.format === `csv`,
-        body: async (runner) => {
+    },
+  },
+
+  {
+    condition: async () => __stack.locals.format === `csv`,
+    body: async (runner) => {
 __stack.locals.output3 = {
             "type": `csv`,
             "ext": `.csv`
           };
-        },
-      }
-    ], async (runner) => {
+    },
+  },
+
+], async (runner) => {
 __stack.locals.output4 = {
           "type": `unknown`,
           "ext": ``
         };
-    });
+});
   });
   if (runner.halted) return runner.haltResult;
   await callHook({

--- a/tests/typescriptGenerator/multiLineComment.mjs
+++ b/tests/typescriptGenerator/multiLineComment.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/multipleNodes.mjs
+++ b/tests/typescriptGenerator/multipleNodes.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/namedArgs.mjs
+++ b/tests/typescriptGenerator/namedArgs.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/tests/typescriptGenerator/noResponseFormat.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/objectDescription.mjs
+++ b/tests/typescriptGenerator/objectDescription.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/result-basic.agency
+++ b/tests/typescriptGenerator/result-basic.agency
@@ -1,0 +1,6 @@
+def checkAge(age: number): Result {
+  if (age >= 18) {
+    return success(age)
+  }
+  return failure("too young")
+}

--- a/tests/typescriptGenerator/result-basic.mjs
+++ b/tests/typescriptGenerator/result-basic.mjs
@@ -86,9 +86,24 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 function __initializeGlobals(__ctx) {
-  __ctx.globals.markInitialized("simple.agency")
+  __ctx.globals.markInitialized("result-basic.agency")
 }
+export const __checkAgeTool = {
+  name: "checkAge",
+  description: `No description provided.`,
+  schema: z.object({"age": z.number(), })
+};
+export const __checkAgeToolParams = ["age"];
 const __toolRegistry = {
+  checkAge: {
+    definition: __checkAgeTool,
+    handler: {
+      name: "checkAge",
+      params: __checkAgeToolParams,
+      execute: checkAge,
+      isBuiltin: false
+    }
+  },
   readSkill: {
     definition: __readSkillTool,
     handler: {
@@ -99,87 +114,83 @@ const __toolRegistry = {
     }
   }
 };
-graph.node("main", async (__state: GraphState) => {
-  const __setupData = setupNode({
+async function checkAge(age: number, __state: InternalFunctionState | undefined = undefined) {
+  const __setupData = setupFunction({
     state: __state
   });
+  // __state will be undefined if this function is being called as a tool by an llm
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __threads = __setupData.threads;
-const __ctx = __state.ctx;
+const __ctx = __state?.ctx || __globalCtx;
 const statelogClient = __ctx.statelogClient;
 const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("result-basic.agency")) {
+    __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
   await callHook({
     callbacks: __ctx.callbacks,
-    name: "onNodeStart",
+    name: "onFunctionStart",
     data: {
-      nodeName: "main"
+      functionName: "checkAge",
+      args: {
+        age: age
+      },
+      isBuiltin: false
     }
   })
-  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "simple.agency", scopeName: "main" });
-  await runner.step(0, async (runner) => {
-__self.__removedTools = __self.__removedTools || [];
-__stack.locals.greeting = await runPrompt({
-      ctx: __ctx,
-      prompt: `say hello`,
-      messages: __threads.createAndReturnThread(),
-      clientConfig: {},
-      maxToolCallRounds: 10,
-      interruptData: __state?.interruptData,
-      removedTools: __self.__removedTools
-    });
-// halt if this is an interrupt
-if (isInterrupt(__stack.locals.greeting)) {
-      await __ctx.pendingPromises.awaitAll()
-      runner.halt({
-        messages: __threads,
-        data: __stack.locals.greeting
-      })
-      return;
-    }
-  });
-  await runner.step(1, async (runner) => {
-await print(__stack.locals.greeting)
-  });
-  if (runner.halted) return runner.haltResult;
-  await callHook({
-    callbacks: __ctx.callbacks,
-    name: "onNodeEnd",
-    data: {
-      nodeName: "main",
-      data: undefined
-    }
-  })
-  return {
-    messages: __threads,
-    data: undefined
-  };
-})
-export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}) {
-  return runNode({
-    ctx: __globalCtx,
-    nodeName: "main",
-    data: {},
-    messages: messages,
-    callbacks: callbacks,
-    initializeGlobals: __initializeGlobals
-  });
-}
-export const __mainNodeParams = [];
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  __stack.args["age"] = age;
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "result-basic.agency", scopeName: "checkAge" });
   try {
-    const initialState = {
-      messages: new ThreadStore(),
-      data: {}
-    };
-    await main(initialState)
-  } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
-    throw __error
+    await runner.step(0, async (runner) => {
+await runner.ifElse(0, [
+
+  {
+    condition: async () => __stack.args.age >= 18,
+    body: async (runner) => {
+await runner.step(0, async (runner) => {
+__functionCompleted = true;
+runner.halt(await success(__stack.args.age))
+return;
+            });
+    },
+  },
+
+]);
+    });
+    await runner.step(1, async (runner) => {
+__functionCompleted = true;
+runner.halt(await failure(`too young`))
+return;
+    });
+    if (runner.halted) return runner.haltResult;
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof ToolCallError) {
+      __error.retryable = __error.retryable && __self.__retryable
+      throw __error
+    }
+    throw new ToolCallError(__error, { retryable: __self.__retryable })
+  } finally {
+    if (!__state?.isForked) { __ctx.stateStack.pop() }
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "checkAge",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
   }
 }
 export default graph
-export const __sourceMap = {"simple.agency:main":{"0":{"line":-1,"col":2},"1":{"line":0,"col":2}}};
+export const __sourceMap = {"result-basic.agency:checkAge":{"0":{"line":-1,"col":2},"1":{"line":2,"col":2},"0.0":{"line":0,"col":4}}};

--- a/tests/typescriptGenerator/result-guards.agency
+++ b/tests/typescriptGenerator/result-guards.agency
@@ -1,0 +1,6 @@
+def checkValue(r: Result): string {
+  if (isSuccess(r)) {
+    return "ok"
+  }
+  return "error"
+}

--- a/tests/typescriptGenerator/result-guards.mjs
+++ b/tests/typescriptGenerator/result-guards.mjs
@@ -86,9 +86,24 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 function __initializeGlobals(__ctx) {
-  __ctx.globals.markInitialized("simple.agency")
+  __ctx.globals.markInitialized("result-guards.agency")
 }
+export const __checkValueTool = {
+  name: "checkValue",
+  description: `No description provided.`,
+  schema: z.object({"r": z.string(), })
+};
+export const __checkValueToolParams = ["r"];
 const __toolRegistry = {
+  checkValue: {
+    definition: __checkValueTool,
+    handler: {
+      name: "checkValue",
+      params: __checkValueToolParams,
+      execute: checkValue,
+      isBuiltin: false
+    }
+  },
   readSkill: {
     definition: __readSkillTool,
     handler: {
@@ -99,87 +114,83 @@ const __toolRegistry = {
     }
   }
 };
-graph.node("main", async (__state: GraphState) => {
-  const __setupData = setupNode({
+async function checkValue(r: Result, __state: InternalFunctionState | undefined = undefined) {
+  const __setupData = setupFunction({
     state: __state
   });
+  // __state will be undefined if this function is being called as a tool by an llm
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __threads = __setupData.threads;
-const __ctx = __state.ctx;
+const __ctx = __state?.ctx || __globalCtx;
 const statelogClient = __ctx.statelogClient;
 const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("result-guards.agency")) {
+    __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
   await callHook({
     callbacks: __ctx.callbacks,
-    name: "onNodeStart",
+    name: "onFunctionStart",
     data: {
-      nodeName: "main"
+      functionName: "checkValue",
+      args: {
+        r: r
+      },
+      isBuiltin: false
     }
   })
-  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "simple.agency", scopeName: "main" });
-  await runner.step(0, async (runner) => {
-__self.__removedTools = __self.__removedTools || [];
-__stack.locals.greeting = await runPrompt({
-      ctx: __ctx,
-      prompt: `say hello`,
-      messages: __threads.createAndReturnThread(),
-      clientConfig: {},
-      maxToolCallRounds: 10,
-      interruptData: __state?.interruptData,
-      removedTools: __self.__removedTools
-    });
-// halt if this is an interrupt
-if (isInterrupt(__stack.locals.greeting)) {
-      await __ctx.pendingPromises.awaitAll()
-      runner.halt({
-        messages: __threads,
-        data: __stack.locals.greeting
-      })
-      return;
-    }
-  });
-  await runner.step(1, async (runner) => {
-await print(__stack.locals.greeting)
-  });
-  if (runner.halted) return runner.haltResult;
-  await callHook({
-    callbacks: __ctx.callbacks,
-    name: "onNodeEnd",
-    data: {
-      nodeName: "main",
-      data: undefined
-    }
-  })
-  return {
-    messages: __threads,
-    data: undefined
-  };
-})
-export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}) {
-  return runNode({
-    ctx: __globalCtx,
-    nodeName: "main",
-    data: {},
-    messages: messages,
-    callbacks: callbacks,
-    initializeGlobals: __initializeGlobals
-  });
-}
-export const __mainNodeParams = [];
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  __stack.args["r"] = r;
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "result-guards.agency", scopeName: "checkValue" });
   try {
-    const initialState = {
-      messages: new ThreadStore(),
-      data: {}
-    };
-    await main(initialState)
-  } catch (__error: any) {
-    console.error(`\nAgent crashed: ${__error.message}`)
-    throw __error
+    await runner.step(0, async (runner) => {
+await runner.ifElse(0, [
+
+  {
+    condition: async () => await isSuccess(__stack.args.r),
+    body: async (runner) => {
+await runner.step(0, async (runner) => {
+__functionCompleted = true;
+runner.halt(`ok`)
+return;
+            });
+    },
+  },
+
+]);
+    });
+    await runner.step(1, async (runner) => {
+__functionCompleted = true;
+runner.halt(`error`)
+return;
+    });
+    if (runner.halted) return runner.haltResult;
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof ToolCallError) {
+      __error.retryable = __error.retryable && __self.__retryable
+      throw __error
+    }
+    throw new ToolCallError(__error, { retryable: __self.__retryable })
+  } finally {
+    if (!__state?.isForked) { __ctx.stateStack.pop() }
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "checkValue",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
   }
 }
 export default graph
-export const __sourceMap = {"simple.agency:main":{"0":{"line":-1,"col":2},"1":{"line":0,"col":2}}};
+export const __sourceMap = {"result-guards.agency:checkValue":{"0":{"line":-1,"col":2},"1":{"line":2,"col":2},"0.0":{"line":0,"col":4}}};

--- a/tests/typescriptGenerator/result-guards.mjs
+++ b/tests/typescriptGenerator/result-guards.mjs
@@ -91,7 +91,7 @@ function __initializeGlobals(__ctx) {
 export const __checkValueTool = {
   name: "checkValue",
   description: `No description provided.`,
-  schema: z.object({"r": z.string(), })
+  schema: z.object({"r": z.any(), })
 };
 export const __checkValueToolParams = ["r"];
 const __toolRegistry = {

--- a/tests/typescriptGenerator/returnValue.mjs
+++ b/tests/typescriptGenerator/returnValue.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/safe.mjs
+++ b/tests/typescriptGenerator/safe.mjs
@@ -3,8 +3,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -24,6 +24,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/shared.mjs
+++ b/tests/typescriptGenerator/shared.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/simple.mjs
+++ b/tests/typescriptGenerator/simple.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/skill.mjs
+++ b/tests/typescriptGenerator/skill.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/sourceMap.mjs
+++ b/tests/typescriptGenerator/sourceMap.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
@@ -219,19 +220,21 @@ __stack.locals.x = 1;
   });
   await runner.step(1, async (runner) => {
 await runner.ifElse(1, [
-      {
-        condition: () => __stack.locals.x == 1,
-        body: async (runner) => {
+
+  {
+    condition: async () => __stack.locals.x == 1,
+    body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.y = 2;
           });
-        },
-      }
-    ], async (runner) => {
+    },
+  },
+
+], async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.y = 3;
         });
-    });
+});
   });
   await runner.step(2, async (runner) => {
 await runner.loop(2, [`a`, `b`], async (item, _, runner) => {

--- a/tests/typescriptGenerator/specialVar.mjs
+++ b/tests/typescriptGenerator/specialVar.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/splat.mjs
+++ b/tests/typescriptGenerator/splat.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/streaming.mjs
+++ b/tests/typescriptGenerator/streaming.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/string-interpolation.mjs
+++ b/tests/typescriptGenerator/string-interpolation.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/stringConcat.mjs
+++ b/tests/typescriptGenerator/stringConcat.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/typeHints.mjs
+++ b/tests/typescriptGenerator/typeHints.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/types/literal.mjs
+++ b/tests/typescriptGenerator/types/literal.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/tests/typescriptGenerator/types/typeAlias.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/varTypes.mjs
+++ b/tests/typescriptGenerator/varTypes.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/variadic.mjs
+++ b/tests/typescriptGenerator/variadic.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/withParam.mjs
+++ b/tests/typescriptGenerator/withParam.mjs
@@ -2,8 +2,8 @@ import { fileURLToPath } from "url";
 import process from "process";
 import { readFileSync, writeFileSync } from "fs";
 import { z } from "zod";
-import { goToNode, color, nanoid, registerProvider, registerTextModel } from "agency-lang";
-import * as smoltalk from "agency-lang";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
 import path from "path";
 import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
 import {
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
+  success, failure, isSuccess, isFailure,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,


### PR DESCRIPTION
## Summary

- Adds `Result` type to Agency with generic support (`Result<S, E>` or bare `Result` for `Result<any, any>`)
- Adds runtime `success()`, `failure()`, `isSuccess()`, `isFailure()` functions
- Adds parser, code generation, integration fixtures, and e2e test
- Changes smoltalk to namespace re-export (`export * as smoltalk`) to avoid naming collision
- Extracts `runnerIfElse` codegen to mustache template, fixing async condition bug

## Test plan

- [x] Parser tests: bare `Result`, `Result<string, number>`, object types, type aliases, word boundary (`ResultFoo`), single-param error
- [x] Runtime unit tests: success/failure constructors, isSuccess/isFailure guards, null/undefined safety
- [x] Integration fixtures: `result-basic.agency`, `result-guards.agency` with generated `.mjs`
- [x] E2E test: compile and execute `result-basic.agency`, verify exact output
- [x] All 1765 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)