### PR TITLE
feat: add with approve/reject/propagate handler modifier

### DIFF
--- a/docs/dev/with-approve.md
+++ b/docs/dev/with-approve.md
@@ -1,0 +1,65 @@
+# `with approve/reject/propagate` Handler Modifier
+
+## Overview
+
+The `with` modifier is a shorthand for wrapping a single statement in a handler:
+
+```
+const text = read("file.txt") with approve
+```
+
+This is equivalent to:
+
+```
+handle {
+  const text = read("file.txt")
+} with approve
+```
+
+It supports the three builtin handler names: `approve`, `reject`, and `propagate`. Inline handlers are not supported — use a full `handle` block for those.
+
+## Why this syntax exists: global scope
+
+The primary motivation for `with` is that it works in global scope, where the regular `handle { } with` block syntax does not.
+
+### The problem with `handle` blocks in global scope
+
+Global-scope assignments compile into `__initializeGlobals`, a plain async function that runs once per execution context. Unlike node and function bodies, `__initializeGlobals` does not have a runner — there's no `Runner` instance, no step counter, no `__state`, and no `__threads`. These are all set up by `setupNode`/`setupFunction`, which only run inside graph nodes and Agency functions.
+
+The regular `handle { } with` block compiles to `runner.handle(id, handlerFn, callback)`, which requires a runner. Since there's no runner in global scope, `handle` blocks can't work there.
+
+### How `with` solves this
+
+The `with` modifier has two separate code generation paths:
+
+**In runner scopes (nodes and functions):** It compiles to `runner.handle()` — identical to `handle { } with approve`. No difference in behavior.
+
+**In global scope:** It compiles to raw `__ctx.pushHandler()` / `__ctx.popHandler()` calls with a try/finally:
+
+```ts
+async function __initializeGlobals(__ctx) {
+  __ctx.markInitialized("module.agency");
+  __ctx.pushHandler(async (__data) => approve(__data));
+  try {
+    __ctx.globals.set("module.agency", "text", await read("file.txt", { ctx: __ctx }));
+  } finally {
+    __ctx.popHandler();
+  }
+}
+```
+
+This works because the handler stack lives on `__ctx`, not on the runner. When the called function internally triggers an interrupt via `interruptWithHandlers()`, the runtime checks `__ctx.handlers`, finds the `approve` handler, evaluates it, and short-circuits — the interrupt is resolved immediately without needing state serialization, step counters, or any of the runner machinery.
+
+### Other differences in global scope
+
+Two additional adjustments make function calls work inside `__initializeGlobals`:
+
+1. **Minimal function call config.** In node/function scope, Agency function calls pass `{ ctx, threads, interruptData }`. In global scope, `__threads` and `__state` don't exist, so function calls pass only `{ ctx }`. The called function handles the missing fields gracefully (same path as when a function is called as a tool by the LLM).
+
+2. **Early `markInitialized`.** The `markInitialized` call is emitted *before* the init statements. Without this, a global init expression that calls a function defined in the same module would trigger `__initializeGlobals` again (via the `isInitialized` check in every function preamble), causing infinite recursion.
+
+## Limitations
+
+- Only builtin handlers (`approve`, `reject`, `propagate`) are supported. For custom handler logic, use a full `handle` block inside a node or function.
+- In global scope, `with propagate` will propagate the interrupt to the TypeScript caller. Whether this is useful depends on whether the caller handles interrupts.
+- Since global scope has no runner, `with` in global scope does not support debugger stepping through the handler. Adding a runner to `__initializeGlobals` would enable this in the future.

--- a/foo.agency
+++ b/foo.agency
@@ -1,4 +1,4 @@
-const text = read("/Users/adityabhargava/agency-lang/README.md")
+const text = read("/Users/adityabhargava/agency-lang/README.md") with approve
 
 node main() {
   print(text)

--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -250,6 +250,8 @@ export class AgencyGenerator {
         return this.processMessageThread(node);
       case "handleBlock":
         return this.processHandleBlock(node);
+      case "withModifier":
+        return `${this.processNode(node.statement)} with ${node.handlerName}`;
       case "skill":
         return this.processSkill(node);
       case "binOpExpression":

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -419,9 +419,7 @@ export class TypeScriptBuilder {
     const globalInitStatements: TsNode[] = [];
     for (const node of program.nodes) {
       if (node.type === "assignment" && node.scope === "global") {
-        this.insideGlobalInit = true;
-        const valueNode = this.processNode(node.value);
-        this.insideGlobalInit = false;
+        const valueNode = this.processNodeInGlobalInit(node.value);
         globalInitStatements.push(
           ts.globalSet(this.moduleId, node.variableName, valueNode),
         );
@@ -430,20 +428,10 @@ export class TypeScriptBuilder {
         node.statement.type === "assignment" &&
         node.statement.scope === "global"
       ) {
-        // Global assignment with handler modifier — wrap in pushHandler/popHandler
         const stmt = node.statement;
-        this.insideGlobalInit = true;
-        const valueNode = this.processNode(stmt.value);
-        this.insideGlobalInit = false;
+        const valueNode = this.processNodeInGlobalInit(stmt.value);
         const setNode = ts.globalSet(this.moduleId, stmt.variableName, valueNode);
-
-        const handlerName = node.handlerName;
-        const args = handlerName === "propagate" ? [] : [ts.id("__data")];
-        const handler = ts.arrowFn(
-          [{ name: "__data", typeAnnotation: "any" }],
-          ts.call(ts.id(handlerName), args),
-          { async: true },
-        );
+        const handler = this.buildBuiltinHandlerArrow(node.handlerName);
 
         globalInitStatements.push(ts.withHandler(handler, setNode));
       } else {
@@ -2310,6 +2298,24 @@ export class TypeScriptBuilder {
     );
   }
 
+  private processNodeInGlobalInit(node: AgencyNode): TsNode {
+    this.insideGlobalInit = true;
+    try {
+      return this.processNode(node);
+    } finally {
+      this.insideGlobalInit = false;
+    }
+  }
+
+  private buildBuiltinHandlerArrow(handlerName: string): TsNode {
+    const args = handlerName === "propagate" ? [] : [ts.id("__data")];
+    return ts.arrowFn(
+      [{ name: "__data", typeAnnotation: "any" }],
+      ts.call(ts.id(handlerName), args),
+      { async: true },
+    );
+  }
+
   private processHandleBlockWithSteps(node: HandleBlock): TsNode {
     const id = this._subStepPath[this._subStepPath.length - 1];
     const subKey = this._subStepPath.join("_");
@@ -2336,14 +2342,7 @@ export class TypeScriptBuilder {
     } else {
       const fnName = node.handler.functionName;
       if (fnName === "approve" || fnName === "reject" || fnName === "propagate") {
-        // Built-in handler: wrap the built-in factory function directly
-        const args = fnName === "propagate" ? [] : [ts.id("__data")];
-        handler =
-          ts.arrowFn(
-            [{ name: "__data", typeAnnotation: "any" }],
-            ts.call(ts.id(fnName), args),
-            { async: true },
-          );
+        handler = this.buildBuiltinHandlerArrow(fnName);
       } else {
         // Function ref: wrap in arrow that calls the named function
         handler =
@@ -2372,19 +2371,8 @@ export class TypeScriptBuilder {
 
   private processWithModifier(node: WithModifier): TsNode {
     const id = this._subStepPath[this._subStepPath.length - 1];
-    const handlerName = node.handlerName;
-
-    // Build the handler arrow — same pattern as processHandleBlockWithSteps for builtin refs
-    const args = handlerName === "propagate" ? [] : [ts.id("__data")];
-    const handler = ts.arrowFn(
-      [{ name: "__data", typeAnnotation: "any" }],
-      ts.call(ts.id(handlerName), args),
-      { async: true },
-    );
-
-    // Process inner statement via processBodyAsParts for proper substep tracking
+    const handler = this.buildBuiltinHandlerArrow(node.handlerName);
     const bodyNodes = this.processBodyAsParts([node.statement]);
-
     return ts.runnerHandle({ id, handler, body: bodyNodes });
   }
 

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -66,6 +66,7 @@ import {
 } from "../types/function.js";
 import { GraphNodeDefinition } from "../types/graphNode.js";
 import { HandleBlock } from "../types/handleBlock.js";
+import { WithModifier } from "../types/withModifier.js";
 import { IfElse } from "../types/ifElse.js";
 import {
   ImportNodeStatement,
@@ -125,6 +126,7 @@ export class TypeScriptBuilder {
   // Threading & control flow
   private loopVars: string[] = [];
   private insideHandlerBody: boolean = false;
+  private insideGlobalInit: boolean = false;
   private _blockCounter: number = 0;
 
   /** Stack of loop subKeys for generating break/continue cleanup code.
@@ -417,10 +419,33 @@ export class TypeScriptBuilder {
     const globalInitStatements: TsNode[] = [];
     for (const node of program.nodes) {
       if (node.type === "assignment" && node.scope === "global") {
+        this.insideGlobalInit = true;
         const valueNode = this.processNode(node.value);
+        this.insideGlobalInit = false;
         globalInitStatements.push(
           ts.globalSet(this.moduleId, node.variableName, valueNode),
         );
+      } else if (
+        node.type === "withModifier" &&
+        node.statement.type === "assignment" &&
+        node.statement.scope === "global"
+      ) {
+        // Global assignment with handler modifier — wrap in pushHandler/popHandler
+        const stmt = node.statement;
+        this.insideGlobalInit = true;
+        const valueNode = this.processNode(stmt.value);
+        this.insideGlobalInit = false;
+        const setNode = ts.globalSet(this.moduleId, stmt.variableName, valueNode);
+
+        const handlerName = node.handlerName;
+        const args = handlerName === "propagate" ? [] : [ts.id("__data")];
+        const handler = ts.arrowFn(
+          [{ name: "__data", typeAnnotation: "any" }],
+          ts.call(ts.id(handlerName), args),
+          { async: true },
+        );
+
+        globalInitStatements.push(ts.withHandler(handler, setNode));
       } else {
         const result = this.processNode(node);
         this.generatedStatements.push(result);
@@ -461,16 +486,15 @@ export class TypeScriptBuilder {
         "__initializeGlobals",
         [{ name: "__ctx" }],
         ts.statements([
-          ...globalInitStatements,
-          // Mark this module as initialized on the GlobalStore. The flag is
-          // serialized with the store, so on interrupt resume the restored
-          // GlobalStore already has this flag set and __initializeGlobals
-          // won't be called again — avoiding re-evaluation of init expressions
-          // and overwriting of restored global values.
+          // Mark this module as initialized BEFORE running init statements.
+          // This prevents infinite recursion when a global init expression
+          // calls a function defined in the same module (which would trigger
+          // __initializeGlobals again via the isInitialized check).
           ts.call(
             $(ts.runtime.ctx).prop("globals").prop("markInitialized").done(),
             [ts.str(this.moduleId)],
           ),
+          ...globalInitStatements,
         ]),
         { async: true },
       ),
@@ -627,6 +651,8 @@ export class TypeScriptBuilder {
         return this.processMessageThread(node);
       case "handleBlock":
         return this.processHandleBlockWithSteps(node);
+      case "withModifier":
+        return this.processWithModifier(node);
       case "skill":
         return ts.empty();
       case "binOpExpression":
@@ -1498,15 +1524,18 @@ export class TypeScriptBuilder {
     const shouldAwait = !node.async && context !== "valueAccess";
 
     if (this.isAgencyFunction(node.functionName, context)) {
-      // Always pass the caller's ThreadStore so the function shares the thread context
-      const threadsExpr = ts.runtime.threads;
-      const configObj = ts.functionCallConfig({
-        ctx: ts.runtime.ctx,
-        threads: threadsExpr,
-        interruptData: ts.raw("__state?.interruptData"),
-        stateStack: options?.stateStack,
-        isForked: node.async,
-      });
+      // In global init scope, __threads and __state don't exist — pass only ctx
+      const configObj = this.insideGlobalInit
+        ? ts.functionCallConfig({
+            ctx: ts.runtime.ctx,
+          })
+        : ts.functionCallConfig({
+            ctx: ts.runtime.ctx,
+            threads: ts.runtime.threads,
+            interruptData: ts.raw("__state?.interruptData"),
+            stateStack: options?.stateStack,
+            isForked: node.async,
+          });
       const call = ts.call(ts.id(functionName), [...argNodes, configObj]);
       return shouldAwait ? ts.await(call) : call;
     } else if (node.functionName === "system") {
@@ -2337,6 +2366,24 @@ export class TypeScriptBuilder {
 
     // Body: process each statement with substep tracking
     const bodyNodes = this.processBodyAsParts(node.body);
+
+    return ts.runnerHandle({ id, handler, body: bodyNodes });
+  }
+
+  private processWithModifier(node: WithModifier): TsNode {
+    const id = this._subStepPath[this._subStepPath.length - 1];
+    const handlerName = node.handlerName;
+
+    // Build the handler arrow — same pattern as processHandleBlockWithSteps for builtin refs
+    const args = handlerName === "propagate" ? [] : [ts.id("__data")];
+    const handler = ts.arrowFn(
+      [{ name: "__data", typeAnnotation: "any" }],
+      ts.call(ts.id(handlerName), args),
+      { async: true },
+    );
+
+    // Process inner statement via processBodyAsParts for proper substep tracking
+    const bodyNodes = this.processBodyAsParts([node.statement]);
 
     return ts.runnerHandle({ id, handler, body: bodyNodes });
   }

--- a/lib/ir/builders.ts
+++ b/lib/ir/builders.ts
@@ -51,6 +51,7 @@ import type {
   TsPostfixOp,
   TsTernary,
   TsRunnerDebugger,
+  TsWithHandler,
 } from "./tsIR.js";
 
 export { $, TsChain } from "./fluent.js";
@@ -378,6 +379,10 @@ export const ts = {
     return { kind: "runnerHandle", ...opts };
   },
 
+  withHandler(handler: TsNode, body: TsNode): TsWithHandler {
+    return { kind: "withHandler", handler, body };
+  },
+
   runnerIfElse(opts: { id: number; branches: { condition: TsNode; body: TsNode[] }[]; elseBranch?: TsNode[] }): TsRunnerIfElse {
     return { kind: "runnerIfElse", ...opts };
   },
@@ -527,16 +532,20 @@ export const ts = {
     isForked,
   }: {
     ctx: TsNode;
-    threads: TsNode;
-    interruptData: TsNode;
+    threads?: TsNode;
+    interruptData?: TsNode;
     stateStack?: TsNode;
     isForked?: boolean;
   }): TsNode {
     const entries: Record<string, TsNode> = {
       ctx,
-      threads,
-      interruptData,
     };
+    if (threads) {
+      entries.threads = threads;
+    }
+    if (interruptData) {
+      entries.interruptData = interruptData;
+    }
     if (stateStack) {
       entries.stateStack = stateStack;
     }

--- a/lib/ir/prettyPrint.ts
+++ b/lib/ir/prettyPrint.ts
@@ -262,6 +262,12 @@ export function printTs(node: TsNode, indent = 0): string {
       return `await runner.handle(${node.id}, ${handler}, async (runner) => {\n${body}\n${ind(indent)}});`;
     }
 
+    case "withHandler": {
+      const handler = printTs(node.handler, indent);
+      const body = `${ind(indent + 1)}${printTs(node.body, indent + 1)}`;
+      return `__ctx.pushHandler(${handler});\n${ind(indent)}try {\n${body}\n${ind(indent)}} finally {\n${ind(indent + 1)}__ctx.popHandler();\n${ind(indent)}}`;
+    }
+
     case "runnerDebugger": {
       return `await runner.debugger(${node.id}, ${JSON.stringify(node.label)});`;
     }

--- a/lib/ir/tsIR.ts
+++ b/lib/ir/tsIR.ts
@@ -48,7 +48,15 @@ export type TsNode =
   | TsAnd
   | TsOr
   | TsNot
+  | TsWithHandler
   | TsTernary;
+
+/** Raw pushHandler/popHandler wrapping for global scope (no runner) */
+export interface TsWithHandler {
+  kind: "withHandler";
+  handler: TsNode;
+  body: TsNode;
+}
 
 /** Escape hatch: verbatim string */
 export interface TsRaw {

--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -34,6 +34,7 @@ import {
   messageThreadParser,
   sharedAssignmentParser,
   whileLoopParser,
+  withModifierParser,
 } from "./parsers/function.js";
 import {
   importNodeStatmentParser,
@@ -74,6 +75,7 @@ const nodeParser = or(
   returnStatementParser,
   specialVarParser,
   sharedAssignmentParser,
+  withModifierParser,
   assignmentParser,
   binOpParser,
   booleanParser,

--- a/lib/parsers/function.ts
+++ b/lib/parsers/function.ts
@@ -66,6 +66,7 @@ import { binOpParser } from "./binop.js";
 import { multiLineCommentParser } from "./multiLineComment.js";
 import { keywordParser } from "./keyword.js";
 import { HandleBlock } from "@/types/handleBlock.js";
+import { WithModifier } from "@/types/withModifier.js";
 import { debuggerParser } from "./debuggerStatement.js";
 import { exprParser } from "./expression.js";
 import { withLoc } from "./loc.js";
@@ -179,6 +180,7 @@ export const bodyParser = (input: string): ParserResult<AgencyNode[]> => {
     debuggerParser,
     multiLineCommentParser,
     skillParser,
+    withModifierParser,
     assignmentParser,
     binOpParser,
     booleanParser,
@@ -299,6 +301,34 @@ export const handleBlockParser: Parser<HandleBlock> = trace(
     capture(or(inlineHandlerParser, functionRefHandlerParser), "handler"),
   ),
 );
+
+export const withModifierParser: Parser<WithModifier> = (input: string) => {
+  // Try to parse an assignment or a bare function call as the inner statement.
+  const stmtResult = or(assignmentParser, functionCallParser)(input);
+  if (!stmtResult.success) return failure("expected statement before 'with'", input);
+
+  // Look for "with <builtin>" on remaining input.
+  // assignmentParser consumes trailing whitespace, so rest starts at "with...".
+  // functionCallParser does NOT consume trailing whitespace, so we need optionalSpaces first.
+  const modParser = seqC(
+    optionalSpaces,
+    str("with"),
+    spaces,
+    capture(or(str("approve"), str("reject"), str("propagate")), "handlerName"),
+    optionalSpacesOrNewline,
+  );
+  const modResult = modParser(stmtResult.rest);
+  if (!modResult.success) return failure("expected 'with approve/reject/propagate'", input);
+
+  return success(
+    {
+      type: "withModifier" as const,
+      statement: stmtResult.result,
+      handlerName: modResult.result.handlerName as WithModifier["handlerName"],
+    },
+    modResult.rest,
+  );
+};
 
 const elseClauseParser: Parser<AgencyNode[]> = (input: string) => {
   const parser = seqC(optionalSpaces, str("else"), optionalSpaces);

--- a/lib/parsers/withModifier.test.ts
+++ b/lib/parsers/withModifier.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { withModifierParser } from "./function.js";
+import { normalizeCode } from "@/index.js";
+
+describe("withModifierParser", () => {
+  it("should parse const assignment with approve", () => {
+    const input = 'const text = read("file.txt") with approve';
+    const result = withModifierParser(normalizeCode(input));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.type).toBe("withModifier");
+      expect(result.result.handlerName).toBe("approve");
+      expect(result.result.statement.type).toBe("assignment");
+    }
+  });
+
+  it("should parse assignment with reject", () => {
+    const input = 'const text = read("file.txt") with reject';
+    const result = withModifierParser(normalizeCode(input));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.handlerName).toBe("reject");
+    }
+  });
+
+  it("should parse assignment with propagate", () => {
+    const input = 'const text = read("file.txt") with propagate';
+    const result = withModifierParser(normalizeCode(input));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.handlerName).toBe("propagate");
+    }
+  });
+
+  it("should parse let assignment with approve", () => {
+    const input = 'let text = read("file.txt") with approve';
+    const result = withModifierParser(normalizeCode(input));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.statement.type).toBe("assignment");
+    }
+  });
+
+  it("should parse bare function call with approve", () => {
+    const input = "doSomething() with approve";
+    const result = withModifierParser(normalizeCode(input));
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.type).toBe("withModifier");
+      expect(result.result.handlerName).toBe("approve");
+    }
+  });
+
+  it("should fail without handler name", () => {
+    const input = 'const text = read("file.txt") with';
+    const result = withModifierParser(normalizeCode(input));
+    expect(result.success).toBe(false);
+  });
+
+  it("should fail with non-builtin handler name", () => {
+    const input = 'const text = read("file.txt") with myHandler';
+    const result = withModifierParser(normalizeCode(input));
+    expect(result.success).toBe(false);
+  });
+
+  it("should not interfere with regular assignments", () => {
+    const input = 'const text = read("file.txt")';
+    const result = withModifierParser(normalizeCode(input));
+    expect(result.success).toBe(false);
+  });
+});

--- a/lib/preprocessors/typescriptPreprocessor.ts
+++ b/lib/preprocessors/typescriptPreprocessor.ts
@@ -990,7 +990,9 @@ export class TypescriptPreprocessor {
           node.handler.body = this.filterNodesByType(node.handler.body, excludeSet);
         }
       } else if (node.type === "withModifier") {
-        node.statement = this.filterNodesByType([node.statement], excludeSet)[0];
+        const filtered = this.filterNodesByType([node.statement], excludeSet)[0];
+        if (!filtered) continue;
+        node.statement = filtered;
       } else if (node.type === "matchBlock") {
         // Filter case bodies - Note: match block bodies are single nodes, not arrays
         // We don't filter them here as they're of a specific type
@@ -1091,7 +1093,9 @@ export class TypescriptPreprocessor {
           node.handler.body = this.filterBuiltinFunctionCalls(node.handler.body, excludeSet);
         }
       } else if (node.type === "withModifier") {
-        node.statement = this.filterBuiltinFunctionCalls([node.statement], excludeSet)[0];
+        const filtered = this.filterBuiltinFunctionCalls([node.statement], excludeSet)[0];
+        if (!filtered) continue;
+        node.statement = filtered;
       } else if (node.type === "matchBlock") {
         node.cases = node.cases.map((caseItem) => {
           if (caseItem.type === "comment") {

--- a/lib/preprocessors/typescriptPreprocessor.ts
+++ b/lib/preprocessors/typescriptPreprocessor.ts
@@ -51,6 +51,8 @@ function walkBody(
       if (node.handler.kind === "inline") {
         node.handler.body = walkBody(node.handler.body, fn);
       }
+    } else if (node.type === "withModifier") {
+      node.statement = walkBody([node.statement], fn)[0];
     } else if (node.type === "functionCall" && node.block) {
       node.block.body = walkBody(node.block.body, fn);
     }
@@ -727,6 +729,8 @@ export class TypescriptPreprocessor {
         }
       } else if (node.type === "handleBlock") {
         this._collectAsyncVariablesInScope(node.body, asyncVarToAssignment);
+      } else if (node.type === "withModifier") {
+        this._collectAsyncVariablesInScope([node.statement], asyncVarToAssignment);
       }
     }
   }
@@ -779,6 +783,14 @@ export class TypescriptPreprocessor {
       } else if (node.type === "handleBlock") {
         const found = this._findFirstUsageInScope(
           node.body,
+          varName,
+          assignmentNode,
+          [...bodyPath, i],
+        );
+        if (found) return found;
+      } else if (node.type === "withModifier") {
+        const found = this._findFirstUsageInScope(
+          [node.statement],
           varName,
           assignmentNode,
           [...bodyPath, i],
@@ -876,6 +888,11 @@ export class TypescriptPreprocessor {
           ...currentPath,
           i,
         ]);
+      } else if (node.type === "withModifier") {
+        node.statement = this._insertAwaitPendingCalls([node.statement], locationToVars, [
+          ...currentPath,
+          i,
+        ])[0];
       } else if (node.type === "ifElse") {
         node.thenBody = this._insertAwaitPendingCalls(
           node.thenBody,
@@ -972,6 +989,8 @@ export class TypescriptPreprocessor {
         if (node.handler.kind === "inline") {
           node.handler.body = this.filterNodesByType(node.handler.body, excludeSet);
         }
+      } else if (node.type === "withModifier") {
+        node.statement = this.filterNodesByType([node.statement], excludeSet)[0];
       } else if (node.type === "matchBlock") {
         // Filter case bodies - Note: match block bodies are single nodes, not arrays
         // We don't filter them here as they're of a specific type
@@ -1071,6 +1090,8 @@ export class TypescriptPreprocessor {
         if (node.handler.kind === "inline") {
           node.handler.body = this.filterBuiltinFunctionCalls(node.handler.body, excludeSet);
         }
+      } else if (node.type === "withModifier") {
+        node.statement = this.filterBuiltinFunctionCalls([node.statement], excludeSet)[0];
       } else if (node.type === "matchBlock") {
         node.cases = node.cases.map((caseItem) => {
           if (caseItem.type === "comment") {

--- a/lib/runtime/state/checkpointStore.ts
+++ b/lib/runtime/state/checkpointStore.ts
@@ -154,7 +154,7 @@ export class Checkpoint implements SourceLocation {
     const nodeId = ctx.stateStack.currentNodeId();
     if (!nodeId) {
       throw new CheckpointError(
-        "Cannot create checkpoint: no current node id in state stack.",
+        "Cannot create checkpoint: no current node id in state stack. This error can happen if you call a function that throws an interrupt from the global namespace. Please use `const foo = funcName() with approve` syntax.",
       );
     }
     return new Checkpoint({

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -30,6 +30,7 @@ import { HandleBlock } from "./types/handleBlock.js";
 import { Sentinel } from "./types/sentinel.js";
 import { DebuggerStatement } from "./types/debuggerStatement.js";
 import { Placeholder } from "./types/placeholder.js";
+import { WithModifier } from "./types/withModifier.js";
 export * from "./types/access.js";
 export * from "./types/awaitPending.js";
 export * from "./types/dataStructures.js";
@@ -51,6 +52,7 @@ export * from "./types/sentinel.js";
 export * from "./types/debuggerStatement.js";
 export * from "./types/blockArgument.js";
 export * from "./types/placeholder.js";
+export * from "./types/withModifier.js";
 export * from "./types/base.js"
 
 export type Expression =
@@ -223,6 +225,7 @@ export type AgencyNode =
   | ForLoop
   | AwaitPending
   | HandleBlock
+  | WithModifier
   | Sentinel
   | DebuggerStatement
   | Placeholder;

--- a/lib/types/withModifier.ts
+++ b/lib/types/withModifier.ts
@@ -1,0 +1,8 @@
+import type { BaseNode } from "./base.js";
+import type { AgencyNode } from "../types.js";
+
+export type WithModifier = BaseNode & {
+  type: "withModifier";
+  statement: AgencyNode;
+  handlerName: "approve" | "reject" | "propagate";
+};

--- a/lib/utils/node.ts
+++ b/lib/utils/node.ts
@@ -224,6 +224,8 @@ export function* getAllVariablesInBody(
       if (node.handler.kind === "inline") {
         yield* getAllVariablesInBody(node.handler.body);
       }
+    } else if (node.type === "withModifier") {
+      yield* getAllVariablesInBody([node.statement]);
     }
   }
 }
@@ -286,6 +288,8 @@ export function* walkNodes(
       if (node.handler.kind === "inline") {
         yield* walkNodes(node.handler.body, [...ancestors, node], scopes);
       }
+    } else if (node.type === "withModifier") {
+      yield* walkNodes([node.statement], [...ancestors, node], scopes);
     } else if (node.type === "returnStatement") {
       yield* walkNodes([node.value], [...ancestors, node], scopes);
     } else if (node.type === "assignment") {

--- a/tests/agency/handlers/with-modifier-approve.agency
+++ b/tests/agency/handlers/with-modifier-approve.agency
@@ -1,0 +1,9 @@
+def foo() {
+  const result = interrupt("check")
+  return result
+}
+
+node main() {
+  const result = foo() with approve
+  return result
+}

--- a/tests/agency/handlers/with-modifier-approve.test.json
+++ b/tests/agency/handlers/with-modifier-approve.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "with approve auto-approves, approved value is interrupt data",
+      "input": "",
+      "expectedOutput": "\"check\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/handlers/with-modifier-bare-call.agency
+++ b/tests/agency/handlers/with-modifier-bare-call.agency
@@ -1,0 +1,13 @@
+const log = []
+
+def foo() {
+  log.push("before interrupt")
+  return interrupt("check")
+  log.push("after interrupt")
+  return "done"
+}
+
+node main() {
+  foo() with approve
+  return log
+}

--- a/tests/agency/handlers/with-modifier-bare-call.test.json
+++ b/tests/agency/handlers/with-modifier-bare-call.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "bare function call (no assignment) with approve — interrupt auto-approved, execution continues",
+      "input": "",
+      "expectedOutput": "[\"before interrupt\",\"after interrupt\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/handlers/with-modifier-global.agency
+++ b/tests/agency/handlers/with-modifier-global.agency
@@ -1,0 +1,10 @@
+def interruptingRead(filename: string) {
+  const result = interrupt(filename)
+  return result
+}
+
+const text = interruptingRead("test.txt") with approve
+
+node main() {
+  return text
+}

--- a/tests/agency/handlers/with-modifier-global.test.json
+++ b/tests/agency/handlers/with-modifier-global.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "with approve in global scope auto-approves interrupt during global init",
+      "input": "",
+      "expectedOutput": "\"test.txt\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/handlers/with-modifier-in-loop.agency
+++ b/tests/agency/handlers/with-modifier-in-loop.agency
@@ -1,0 +1,13 @@
+def foo(val: string) {
+  const result = interrupt(val)
+  return result
+}
+
+node main() {
+  const results = []
+  for (item in ["a", "b", "c"]) {
+    const result = foo(item) with approve
+    results.push(result)
+  }
+  return results
+}

--- a/tests/agency/handlers/with-modifier-in-loop.test.json
+++ b/tests/agency/handlers/with-modifier-in-loop.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "with approve inside a for loop auto-approves each iteration",
+      "input": "",
+      "expectedOutput": "[\"a\",\"b\",\"c\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/handlers/with-modifier-nested.agency
+++ b/tests/agency/handlers/with-modifier-nested.agency
@@ -1,0 +1,12 @@
+def foo() {
+  const result = interrupt("check")
+  return result
+}
+
+node main() {
+  let result = null
+  handle {
+    result = foo() with approve
+  } with approve
+  return result
+}

--- a/tests/agency/handlers/with-modifier-nested.test.json
+++ b/tests/agency/handlers/with-modifier-nested.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "with approve nested inside handle with approve — both approve, interrupt handled",
+      "input": "",
+      "expectedOutput": "\"check\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/handlers/with-modifier-propagate.agency
+++ b/tests/agency/handlers/with-modifier-propagate.agency
@@ -1,0 +1,9 @@
+def foo() {
+  const result = interrupt("check")
+  return result
+}
+
+node main() {
+  const result = foo() with propagate
+  return result
+}

--- a/tests/agency/handlers/with-modifier-propagate.test.json
+++ b/tests/agency/handlers/with-modifier-propagate.test.json
@@ -1,0 +1,21 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "with propagate — interrupt propagates to TypeScript caller, which approves it",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "check"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/handlers/with-modifier-reject-global.agency
+++ b/tests/agency/handlers/with-modifier-reject-global.agency
@@ -1,0 +1,13 @@
+def interruptingRead(filename: string) {
+  const result = interrupt(filename)
+  return result
+}
+
+const text = interruptingRead("test.txt") with reject
+
+node main() {
+  if (isFailure(text)) {
+    return text.error
+  }
+  return text
+}

--- a/tests/agency/handlers/with-modifier-reject-global.test.json
+++ b/tests/agency/handlers/with-modifier-reject-global.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "with reject in global scope auto-rejects interrupt during global init",
+      "input": "",
+      "expectedOutput": "\"test.txt\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/handlers/with-modifier-reject.agency
+++ b/tests/agency/handlers/with-modifier-reject.agency
@@ -1,0 +1,12 @@
+def foo() {
+  return interrupt("check")
+  return "after interrupt"
+}
+
+node main() {
+  const result = foo() with reject
+  if (isFailure(result)) {
+    return result.error
+  }
+  return result
+}

--- a/tests/agency/handlers/with-modifier-reject.test.json
+++ b/tests/agency/handlers/with-modifier-reject.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "with reject auto-rejects, result is a failure with interrupt data as error",
+      "input": "",
+      "expectedOutput": "\"check\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/typescriptBuilder/assignment.mjs
+++ b/tests/typescriptBuilder/assignment.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("assignment.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptBuilder/safe-function.mjs
+++ b/tests/typescriptBuilder/safe-function.mjs
@@ -85,7 +85,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("safe-function.agency")
 }
 export const __safeLookupTool = {
@@ -145,7 +145,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("safe-function.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -224,7 +224,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("safe-function.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptBuilder/simple.mjs
+++ b/tests/typescriptBuilder/simple.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("simple.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/array.mjs
+++ b/tests/typescriptGenerator/array.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("array.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/tests/typescriptGenerator/arrayAndObject.mjs
@@ -84,7 +84,8 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("arrayAndObject.agency")
   __ctx.globals.set("arrayAndObject.agency", "nums", [1, 2, 3, 4, 5])
   __ctx.globals.set("arrayAndObject.agency", "names", [`Alice`, `Bob`, `Charlie`])
   __ctx.globals.set("arrayAndObject.agency", "matrix", [[1, 2], [3, 4], [5, 6]])
@@ -117,7 +118,6 @@ function __initializeGlobals(__ctx) {
   })
   __ctx.globals.set("arrayAndObject.agency", "firstNum", __ctx.globals.get("arrayAndObject.agency", "nums")[0])
   __ctx.globals.set("arrayAndObject.agency", "personName", __ctx.globals.get("arrayAndObject.agency", "person").name)
-  __ctx.globals.markInitialized("arrayAndObject.agency")
 }
 const __toolRegistry = {
   readSkill: {

--- a/tests/typescriptGenerator/assignment.mjs
+++ b/tests/typescriptGenerator/assignment.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("assignment.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/tests/typescriptGenerator/asyncAssigned.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("asyncAssigned.agency")
 }
 export const __computeTool = {
@@ -128,7 +128,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("asyncAssigned.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/asyncKeyword.mjs
+++ b/tests/typescriptGenerator/asyncKeyword.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("asyncKeyword.agency")
 }
 export const __openaiTool = {
@@ -158,7 +158,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("asyncKeyword.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -255,7 +255,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("asyncKeyword.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -357,7 +357,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("asyncKeyword.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/asyncLlm.mjs
+++ b/tests/typescriptGenerator/asyncLlm.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("asyncLlm.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("asyncUnassigned.agency")
 }
 export const __appendTool = {
@@ -128,7 +128,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("asyncUnassigned.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/blockBasic.mjs
+++ b/tests/typescriptGenerator/blockBasic.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("blockBasic.agency")
 }
 export const __twiceTool = {
@@ -128,7 +128,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("blockBasic.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/blockParams.mjs
+++ b/tests/typescriptGenerator/blockParams.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("blockParams.agency")
 }
 export const __mapItemsTool = {
@@ -128,7 +128,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("blockParams.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("checkpoint-restore.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/comments.mjs
+++ b/tests/typescriptGenerator/comments.mjs
@@ -84,10 +84,10 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("comments.agency")
   __ctx.globals.set("comments.agency", "x", 42)
   __ctx.globals.set("comments.agency", "y", `hello`)
-  __ctx.globals.markInitialized("comments.agency")
 }
 export const __greetTool = {
   name: "greet",
@@ -136,7 +136,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("comments.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/defaultValues.mjs
+++ b/tests/typescriptGenerator/defaultValues.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("defaultValues.agency")
 }
 export const __greetTool = {
@@ -128,7 +128,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("defaultValues.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/docstrings.mjs
+++ b/tests/typescriptGenerator/docstrings.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("docstrings.agency")
 }
 export const __addTool = {
@@ -181,7 +181,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -259,7 +259,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -333,7 +333,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -411,7 +411,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/forLoop.mjs
+++ b/tests/typescriptGenerator/forLoop.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("forLoop.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/function-with-types.mjs
+++ b/tests/typescriptGenerator/function-with-types.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("function-with-types.agency")
 }
 export const __addTool = {
@@ -188,7 +188,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -289,7 +289,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -386,7 +386,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -487,7 +487,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -584,7 +584,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/function.mjs
+++ b/tests/typescriptGenerator/function.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("function.agency")
 }
 export const __testTool = {
@@ -143,7 +143,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -215,7 +215,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("graph-node-with-types.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/ifElse.mjs
+++ b/tests/typescriptGenerator/ifElse.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("ifElse.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/imports.mjs
+++ b/tests/typescriptGenerator/imports.mjs
@@ -97,7 +97,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("imports.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/input.mjs
+++ b/tests/typescriptGenerator/input.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("input.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/interpolation.mjs
+++ b/tests/typescriptGenerator/interpolation.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("interpolation.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("interrupt-2-deep-in-function.agency")
 }
 export const __greetTool = {
@@ -143,7 +143,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("interrupt-2-deep-in-function.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -274,7 +274,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("interrupt-2-deep-in-function.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("interrupt-assignment.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("interrupt-in-node.agency")
 }
 export const __greetTool = {
@@ -128,7 +128,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("interrupt-in-node.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/tests/typescriptGenerator/llmConfigParam.mjs
@@ -84,11 +84,11 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("llmConfigParam.agency")
   __ctx.globals.set("llmConfigParam.agency", "config", {
     "model": `gemini-2.5-flash-lite`
   })
-  __ctx.globals.markInitialized("llmConfigParam.agency")
 }
 const __toolRegistry = {
   readSkill: {

--- a/tests/typescriptGenerator/matchBlock.mjs
+++ b/tests/typescriptGenerator/matchBlock.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("matchBlock.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/multiLineComment.mjs
+++ b/tests/typescriptGenerator/multiLineComment.mjs
@@ -84,9 +84,9 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
-  __ctx.globals.set("multiLineComment.agency", "x", 42)
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("multiLineComment.agency")
+  __ctx.globals.set("multiLineComment.agency", "x", 42)
 }
 export const __greetTool = {
   name: "greet",
@@ -131,7 +131,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("multiLineComment.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/multipleNodes.mjs
+++ b/tests/typescriptGenerator/multipleNodes.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("multipleNodes.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/namedArgs.mjs
+++ b/tests/typescriptGenerator/namedArgs.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("namedArgs.agency")
 }
 export const __greetTool = {
@@ -128,7 +128,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("namedArgs.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/objectDescription.mjs
+++ b/tests/typescriptGenerator/objectDescription.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("objectDescription.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/pipe-operator.mjs
+++ b/tests/typescriptGenerator/pipe-operator.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("pipe-operator.agency")
 }
 export const __doubleTool = {
@@ -158,7 +158,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("pipe-operator.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -237,7 +237,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("pipe-operator.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({
@@ -320,7 +320,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("pipe-operator.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/result-basic.mjs
+++ b/tests/typescriptGenerator/result-basic.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("result-basic.agency")
 }
 export const __checkAgeTool = {
@@ -128,7 +128,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("result-basic.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/result-guards.mjs
+++ b/tests/typescriptGenerator/result-guards.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("result-guards.agency")
 }
 export const __checkValueTool = {
@@ -128,7 +128,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("result-guards.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/returnValue.mjs
+++ b/tests/typescriptGenerator/returnValue.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("returnValue.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("rewindCheckpoint.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/safe.mjs
+++ b/tests/typescriptGenerator/safe.mjs
@@ -85,7 +85,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("safe.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/shared.mjs
+++ b/tests/typescriptGenerator/shared.mjs
@@ -85,7 +85,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 let foo;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("shared.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/simple.mjs
+++ b/tests/typescriptGenerator/simple.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("simple.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/skill.mjs
+++ b/tests/typescriptGenerator/skill.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("skill.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/sourceMap.mjs
+++ b/tests/typescriptGenerator/sourceMap.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("sourceMap.agency")
 }
 export const __greetTool = {
@@ -128,7 +128,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("sourceMap.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/specialVar.mjs
+++ b/tests/typescriptGenerator/specialVar.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("specialVar.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/splat.mjs
+++ b/tests/typescriptGenerator/splat.mjs
@@ -84,7 +84,8 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("splat.agency")
   __ctx.globals.set("splat.agency", "arr1", [1, 2])
   __ctx.globals.set("splat.agency", "arr2", [3, 4])
   __ctx.globals.set("splat.agency", "combined", [...__ctx.globals.get("splat.agency", "arr1"), ...__ctx.globals.get("splat.agency", "arr2")])
@@ -103,7 +104,6 @@ function __initializeGlobals(__ctx) {
     ...__ctx.globals.get("splat.agency", "obj1"),
     "c": 3
   })
-  __ctx.globals.markInitialized("splat.agency")
 }
 const __toolRegistry = {
   readSkill: {

--- a/tests/typescriptGenerator/streaming.mjs
+++ b/tests/typescriptGenerator/streaming.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("streaming.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/string-interpolation.mjs
+++ b/tests/typescriptGenerator/string-interpolation.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("string-interpolation.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/stringConcat.mjs
+++ b/tests/typescriptGenerator/stringConcat.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("stringConcat.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("threadsAndSubthreads.agency")
 }
 export const __fooTool = {
@@ -128,7 +128,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("threadsAndSubthreads.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/typeHints.mjs
+++ b/tests/typescriptGenerator/typeHints.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("typeHints.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/types/literal.mjs
+++ b/tests/typescriptGenerator/types/literal.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("literal.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/tests/typescriptGenerator/types/typeAlias.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("typeAlias.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("valueAccessInterpolation.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/varTypes.mjs
+++ b/tests/typescriptGenerator/varTypes.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("varTypes.agency")
 }
 const __toolRegistry = {

--- a/tests/typescriptGenerator/variadic.mjs
+++ b/tests/typescriptGenerator/variadic.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("variadic.agency")
 }
 export const __logTool = {
@@ -128,7 +128,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("variadic.agency")) {
-    __initializeGlobals(__ctx)
+    await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
   await callHook({

--- a/tests/typescriptGenerator/withModifier.agency
+++ b/tests/typescriptGenerator/withModifier.agency
@@ -1,0 +1,8 @@
+def foo() {
+  return interrupt("check")
+}
+
+node main() {
+  const result = foo() with approve
+  return result
+}

--- a/tests/typescriptGenerator/withModifier.mjs
+++ b/tests/typescriptGenerator/withModifier.mjs
@@ -85,9 +85,24 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 async function __initializeGlobals(__ctx) {
-  __ctx.globals.markInitialized("noResponseFormat.agency")
+  __ctx.globals.markInitialized("withModifier.agency")
 }
+export const __fooTool = {
+  name: "foo",
+  description: `No description provided.`,
+  schema: z.object({})
+};
+export const __fooToolParams = [];
 const __toolRegistry = {
+  foo: {
+    definition: __fooTool,
+    handler: {
+      name: "foo",
+      params: __fooToolParams,
+      execute: foo,
+      isBuiltin: false
+    }
+  },
   readSkill: {
     definition: __readSkillTool,
     handler: {
@@ -98,6 +113,123 @@ const __toolRegistry = {
     }
   }
 };
+async function foo(__state: InternalFunctionState | undefined = undefined) {
+  const __setupData = setupFunction({
+    state: __state
+  });
+  // __state will be undefined if this function is being called as a tool by an llm
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state?.ctx || __globalCtx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("withModifier.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onFunctionStart",
+    data: {
+      functionName: "foo",
+      args: {},
+      isBuiltin: false
+    }
+  })
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "withModifier.agency", scopeName: "foo" });
+  let __resultCheckpointId = -1;
+if (__ctx.stateStack.currentNodeId()) {
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__ctx, { moduleId: "withModifier.agency", scopeName: "foo", stepPath: "", label: "result-entry" });
+}
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+
+}
+
+  try {
+    await runner.step(0, async (runner) => {
+// Remember this will be called both in a tool call context
+// and when the user is simply calling a function.
+
+if (__state.interruptData?.interruptResponse?.type === "approve") {
+  // approved, clear interrupt response and continue execution
+  __state.interruptData.interruptResponse = null;
+} else if (__state.interruptData?.interruptResponse?.type === "reject" && !__state.isToolCall) {
+  // rejected, clear interrupt response and halt
+  // tool calls will instead tell the llm that the call was rejected
+  __state.interruptData.interruptResponse = null;
+  
+  
+  runner.halt(failure("interrupt rejected", { retryable: false, checkpoint: __ctx.getResultCheckpoint() }));
+  
+  return;
+} else if (__state.interruptData?.interruptResponse?.type === "modify") {
+  if (__state.isToolCall) {
+    // continue, args will get modified in the tool call handler
+  } else {
+    throw new Error("Interrupt response of type 'modify' is not supported outside of tool calls yet.");
+  }
+} else if (__state.interruptData?.interruptResponse?.type === "resolve") {
+  throw new Error("Interrupt response of type 'resolve' cannot be returned from an interrupt call. It can only be assigned to a variable.");
+} else {
+  const __handlerResult = await interruptWithHandlers(`check`, __ctx);
+  if (isRejected(__handlerResult)) {
+    
+    
+    runner.halt(failure(__handlerResult.value ?? "interrupt rejected", { retryable: false, checkpoint: __ctx.checkpoints.get(__resultCheckpointId) }));
+    
+    return;
+  }
+  if (!isApproved(__handlerResult)) {
+    // No handler — propagate interrupt to TypeScript caller
+    const __checkpointId = __ctx.checkpoints.create(__ctx, { moduleId: "withModifier.agency", scopeName: "foo", stepPath: "0" });
+    __handlerResult.checkpointId = __checkpointId;
+    __handlerResult.checkpoint = __ctx.checkpoints.get(__checkpointId);
+    
+    
+    runner.halt(__handlerResult);
+    
+    return;
+  }
+  // Approved — continue execution past interrupt
+}
+
+    });
+    if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: __ctx.getResultCheckpoint(),
+    retryable: __self.__retryable,
+    functionName: "foo",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    if (!__state?.isForked) { __ctx.stateStack.pop() }
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "foo",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
@@ -118,31 +250,33 @@ let __functionCompleted = false;
       nodeName: "main"
     }
   })
-  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "noResponseFormat.agency", scopeName: "main" });
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "withModifier.agency", scopeName: "main" });
   try {
     await runner.step(0, async (runner) => {
-__self.__removedTools = __self.__removedTools || [];
-__stack.locals.response1 = await runPrompt({
-        ctx: __ctx,
-        prompt: `say hello`,
-        messages: __threads.getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        interruptData: __state?.interruptData,
-        removedTools: __self.__removedTools
+await runner.handle(0, async (__data: any) => approve(__data), async (runner) => {
+await runner.step(0, async (runner) => {
+__stack.locals.result = await foo({
+            ctx: __ctx,
+            threads: __threads,
+            interruptData: __state?.interruptData
+          });
+if (isInterrupt(__stack.locals.result)) {
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt({
+              ...__state,
+              data: __stack.locals.result
+            })
+            return;
+          }
+        });
       });
-// halt if this is an interrupt
-if (isInterrupt(__stack.locals.response1)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads,
-          data: __stack.locals.response1
-        })
-        return;
-      }
     });
     await runner.step(1, async (runner) => {
-await print(__stack.locals.response1)
+runner.halt({
+        messages: __threads,
+        data: __stack.locals.result
+      })
+return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
@@ -191,4 +325,4 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 }
 export default graph
-export const __sourceMap = {"noResponseFormat.agency:main":{"0":{"line":-1,"col":2},"1":{"line":0,"col":2}}};
+export const __sourceMap = {"withModifier.agency:foo":{"0":{"line":-1,"col":2}},"withModifier.agency:main":{"1":{"line":4,"col":2},"0.0":{"line":3,"col":2}}};

--- a/tests/typescriptGenerator/withParam.mjs
+++ b/tests/typescriptGenerator/withParam.mjs
@@ -84,7 +84,7 @@ export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<strin
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
-function __initializeGlobals(__ctx) {
+async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("withParam.agency")
 }
 const __toolRegistry = {


### PR DESCRIPTION
## Summary

- Adds `with approve/reject/propagate` expression modifier syntax for wrapping a single statement in a handler, e.g. `const text = read("file.txt") with approve`
- Works in both runner scopes (nodes/functions) and global scope (`__initializeGlobals`)
- In runner scopes, reuses existing `runner.handle()` infrastructure
- In global scope, emits raw `pushHandler`/`popHandler` with a new `TsWithHandler` IR node
- Fixes function calls in global init to pass only `{ ctx }` (no threads/interruptData which don't exist in that scope)
- Moves `markInitialized` to top of `__initializeGlobals` to prevent infinite recursion when globals call same-module functions

## Test plan

- [x] 8 parser unit tests (const/let/bare call, approve/reject/propagate, failure cases)
- [x] Integration fixture for codegen output
- [x] E2E: with approve in node scope
- [x] E2E: with reject in node scope
- [x] E2E: with approve in global scope
- [x] E2E: with reject in global scope
- [x] E2E: with approve inside a for loop
- [x] E2E: with approve nested inside a handle block
- [x] E2E: bare function call (no assignment) with approve
- [x] E2E: with propagate (interrupt propagates to TypeScript caller)
- [x] All 51 handler tests pass, full suite 1792/1792 pass

Generated with [Claude Code](https://claude.com/claude-code)