### PR TITLE
Add safe keyword support for class methods

### DIFF
--- a/lib/backends/typescriptBuilder.integration.test.ts
+++ b/lib/backends/typescriptBuilder.integration.test.ts
@@ -162,3 +162,43 @@ greet(name: "world", greeting: "Hi")
     ).not.toThrow();
   });
 });
+
+describe("Safe class methods", () => {
+  it("safe method does not emit __retryable = false for impure calls", () => {
+    const code = `
+import { saveItem } from "./tools.js"
+
+class Svc {
+  x: number
+
+  safe lookup(id: string): string {
+    return saveItem(id)
+  }
+}
+`;
+    const output = generateWithBuilder(code);
+    // The method body should NOT contain __retryable = false
+    // Extract just the lookup method body
+    const methodMatch = output.match(/async lookup\([\s\S]*?finally/);
+    expect(methodMatch).toBeTruthy();
+    expect(methodMatch![0]).not.toContain("__retryable = false");
+  });
+
+  it("non-safe method emits __retryable = false for impure calls", () => {
+    const code = `
+import { saveItem } from "./tools.js"
+
+class Svc {
+  x: number
+
+  doSave(id: string): string {
+    return saveItem(id)
+  }
+}
+`;
+    const output = generateWithBuilder(code);
+    const methodMatch = output.match(/async doSave\([\s\S]*?finally/);
+    expect(methodMatch).toBeTruthy();
+    expect(methodMatch![0]).toContain("__retryable = false");
+  });
+});

--- a/lib/backends/typescriptBuilder.integration.test.ts
+++ b/lib/backends/typescriptBuilder.integration.test.ts
@@ -164,41 +164,29 @@ greet(name: "world", greeting: "Hi")
 });
 
 describe("Safe class methods", () => {
-  it("safe method does not emit __retryable = false for impure calls", () => {
+  it.each([
+    { safe: true, methodName: "lookup", emitsRetryableFalse: false },
+    { safe: false, methodName: "doSave", emitsRetryableFalse: true },
+  ])("$methodName (safe=$safe) emitsRetryableFalse=$emitsRetryableFalse", ({ safe, methodName, emitsRetryableFalse }) => {
+    const safeKeyword = safe ? "safe " : "";
     const code = `
 import { saveItem } from "./tools.js"
 
 class Svc {
   x: number
 
-  safe lookup(id: string): string {
+  ${safeKeyword}${methodName}(id: string): string {
     return saveItem(id)
   }
 }
 `;
     const output = generateWithBuilder(code);
-    // The method body should NOT contain __retryable = false
-    // Extract just the lookup method body
-    const methodMatch = output.match(/async lookup\([\s\S]*?finally/);
+    const methodMatch = output.match(new RegExp(`async ${methodName}\\([\\s\\S]*?finally`));
     expect(methodMatch).toBeTruthy();
-    expect(methodMatch![0]).not.toContain("__retryable = false");
-  });
-
-  it("non-safe method emits __retryable = false for impure calls", () => {
-    const code = `
-import { saveItem } from "./tools.js"
-
-class Svc {
-  x: number
-
-  doSave(id: string): string {
-    return saveItem(id)
-  }
-}
-`;
-    const output = generateWithBuilder(code);
-    const methodMatch = output.match(/async doSave\([\s\S]*?finally/);
-    expect(methodMatch).toBeTruthy();
-    expect(methodMatch![0]).toContain("__retryable = false");
+    if (emitsRetryableFalse) {
+      expect(methodMatch![0]).toContain("__retryable = false");
+    } else {
+      expect(methodMatch![0]).not.toContain("__retryable = false");
+    }
   });
 });

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -936,7 +936,9 @@ export class TypeScriptBuilder {
     const methodScopeName = `${className}.${method.name}`;
     this.startScope({ type: "function", functionName: methodScopeName });
     this._sourceMapBuilder.enterScope(this.moduleId, methodScopeName);
-    const bodyCode = this.processBodyAsParts(method.body);
+    const bodyCode = this.processBodyAsParts(method.body, {
+      isInSafeFunction: !!method.safe,
+    });
     this.endScope();
 
     // Reuse the same function body logic as processFunctionDefinition

--- a/lib/parsers/function.test.ts
+++ b/lib/parsers/function.test.ts
@@ -7,7 +7,7 @@ import {
   _messageThreadParser,
   _submessageThreadParser,
 } from "./parsers.js";
-import { normalizeCode } from "@/parser.js";
+import { normalizeCode, parseAgency } from "@/parser.js";
 
 describe("docStringParser", () => {
   const testCases = [
@@ -3238,5 +3238,59 @@ x=1
         );
       }
     });
+  });
+});
+
+describe("classMethodParser with safe keyword", () => {
+  function parseClass(code: string) {
+    const result = parseAgency(code, {}, false);
+    expect(result.success).toBe(true);
+    if (!result.success) throw new Error("parse failed");
+    const classDef = result.result.nodes.find((n: any) => n.type === "classDefinition");
+    expect(classDef).toBeDefined();
+    return classDef as any;
+  }
+
+  it("parses safe method on a class", () => {
+    const classDef = parseClass(`class Foo {
+  x: number
+
+  safe add(y: number): number {
+    return this.x + y
+  }
+}`);
+    expect(classDef.methods).toHaveLength(1);
+    expect(classDef.methods[0].name).toBe("add");
+    expect(classDef.methods[0].safe).toBe(true);
+  });
+
+  it("does not set safe on a non-safe method", () => {
+    const classDef = parseClass(`class Foo {
+  x: number
+
+  add(y: number): number {
+    return this.x + y
+  }
+}`);
+    expect(classDef.methods[0].safe).toBeUndefined();
+  });
+
+  it("parses class with both safe and non-safe methods", () => {
+    const classDef = parseClass(`class Foo {
+  x: number
+
+  safe pureMethod(): number {
+    return this.x
+  }
+
+  impureMethod(): number {
+    return this.x
+  }
+}`);
+    expect(classDef.methods).toHaveLength(2);
+    expect(classDef.methods[0].name).toBe("pureMethod");
+    expect(classDef.methods[0].safe).toBe(true);
+    expect(classDef.methods[1].name).toBe("impureMethod");
+    expect(classDef.methods[1].safe).toBeUndefined();
   });
 });

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -2380,6 +2380,7 @@ const rejectConstructorParser: Parser<never> = (input: string) => {
 const classMethodParser: Parser<ClassMethod> = map(
   seqC(
     set("type", "classMethod"),
+    capture(safeKeywordParser, "safe"),
     capture(many1WithJoin(varNameChar), "name"),
     char("("),
     optionalSpaces,
@@ -2401,7 +2402,11 @@ const classMethodParser: Parser<ClassMethod> = map(
     char("}"),
     optionalSpacesOrNewline,
   ),
-  (result) => result as ClassMethod,
+  (result) => {
+    const method = result as ClassMethod;
+    if (!method.safe) delete method.safe;
+    return method;
+  },
 );
 
 // Class body member: field, constructor, or method.

--- a/lib/programInfo.test.ts
+++ b/lib/programInfo.test.ts
@@ -185,4 +185,37 @@ describe("collectProgramInfo", () => {
     const info = collectProgramInfo(program);
     expect(info.functionDefinitions["test"]).toBe(funcNode);
   });
+
+  it("registers safe class methods in safeFunctions", () => {
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        {
+          type: "classDefinition",
+          className: "Math",
+          fields: [{ type: "classField", name: "x", typeHint: { type: "primitiveType", value: "number" } }],
+          methods: [
+            {
+              type: "classMethod",
+              name: "add",
+              parameters: [],
+              body: [],
+              returnType: { type: "primitiveType", value: "number" },
+              safe: true,
+            },
+            {
+              type: "classMethod",
+              name: "save",
+              parameters: [],
+              body: [],
+              returnType: { type: "primitiveType", value: "number" },
+            },
+          ],
+        },
+      ],
+    };
+    const info = collectProgramInfo(program);
+    expect(info.safeFunctions["Math.add"]).toBe(true);
+    expect(info.safeFunctions["Math.save"]).toBeUndefined();
+  });
 });

--- a/lib/programInfo.ts
+++ b/lib/programInfo.ts
@@ -110,6 +110,11 @@ export function collectProgramInfo(
         break;
       case "classDefinition":
         info.classDefinitions[node.className] = node;
+        for (const method of node.methods) {
+          if (method.safe) {
+            info.safeFunctions[`${node.className}.${method.name}`] = true;
+          }
+        }
         break;
       case "importStatement":
         info.importStatements.push(node);

--- a/lib/types/classDefinition.ts
+++ b/lib/types/classDefinition.ts
@@ -14,6 +14,7 @@ export type ClassMethod = BaseNode & {
   parameters: FunctionParameter[];
   body: AgencyNode[];
   returnType: VariableType;
+  safe?: boolean;
 };
 
 export type ClassDefinition = BaseNode & {

--- a/tests/agency-js/tool-retry/agent.agency
+++ b/tests/agency-js/tool-retry/agent.agency
@@ -52,6 +52,32 @@ def resetCountersTool() {
   return resetCounters()
 }
 
+// --- Class with safe and non-safe methods ---
+
+class ItemService {
+  prefix: string
+
+  safe safeLookup(id: string): any {
+    return lookupItem("${this.prefix}-${id}")
+  }
+
+  unsafeSaveAndLookup(id: string): any {
+    saveItem(id)
+    return lookupItem("${this.prefix}-${id}")
+  }
+}
+
+// Tool wrappers for class methods
+def safeMethodTool(id: string) {
+  let svc = new ItemService("svc")
+  return svc.safeLookup(id)
+}
+
+def unsafeMethodTool(id: string) {
+  let svc = new ItemService("svc")
+  return svc.unsafeSaveAndLookup(id)
+}
+
 // --- Test nodes ---
 
 // Test 1: A tool that directly calls a safe imported function.
@@ -100,5 +126,23 @@ node testUnsafeChainNoRetry() {
   resetCountersTool()
   uses unsafeChainTool
   const result = llm("Save and look up item 'jkl'. Use the unsafeChainTool.")
+  return result
+}
+
+// Test 6: A tool that calls a safe class method.
+// The method is marked safe, so the tool remains retryable.
+node testSafeMethodRetry() {
+  resetCountersTool()
+  uses safeMethodTool
+  const result = llm("Look up item with id 'mno'. Use the safeMethodTool. If you get a temporary error, retry the same tool call.")
+  return result
+}
+
+// Test 7: A tool that calls a non-safe class method (calls saveItem internally).
+// The method is not marked safe, so the tool is not retryable.
+node testUnsafeMethodNoRetry() {
+  resetCountersTool()
+  uses unsafeMethodTool
+  const result = llm("Save and look up item 'pqr'. Use the unsafeMethodTool.")
   return result
 }

--- a/tests/agency-js/tool-retry/fixture.json
+++ b/tests/agency-js/tool-retry/fixture.json
@@ -36,5 +36,20 @@
       "unsafeChainTool"
     ],
     "hasResult": true
+  },
+  "safeMethodRetry": {
+    "toolCallCount": 2,
+    "toolCalls": [
+      "safeMethodTool",
+      "safeMethodTool"
+    ],
+    "succeeded": true
+  },
+  "unsafeMethodNoRetry": {
+    "toolCallCount": 1,
+    "toolCalls": [
+      "unsafeMethodTool"
+    ],
+    "hasResult": true
   }
 }

--- a/tests/agency-js/tool-retry/test.js
+++ b/tests/agency-js/tool-retry/test.js
@@ -4,6 +4,8 @@ import {
   testSafeDefRetry,
   testDerivedSafeRetry,
   testUnsafeChainNoRetry,
+  testSafeMethodRetry,
+  testUnsafeMethodNoRetry,
 } from "./agent.js";
 import { writeFileSync } from "fs";
 
@@ -107,6 +109,48 @@ const results = {};
     };
   } catch (e) {
     results.unsafeChainNoRetry = {
+      toolCallCount: toolCalls.length,
+      toolCalls,
+      error: e.message,
+    };
+  }
+}
+
+// Test 6: Safe method retry — safeMethodTool calls a safe class method.
+// The method is marked safe, so the tool remains retryable.
+{
+  const toolCalls = [];
+  const callbacks = {
+    onToolCallStart: ({ toolName }) => {
+      toolCalls.push(toolName);
+    },
+  };
+  const result = await testSafeMethodRetry({ callbacks });
+  results.safeMethodRetry = {
+    toolCallCount: toolCalls.length,
+    toolCalls,
+    succeeded: result.data !== undefined && result.data !== null,
+  };
+}
+
+// Test 7: Unsafe method no retry — unsafeMethodTool calls a non-safe class method.
+// The method calls saveItem (unsafe), so the tool is not retryable.
+{
+  const toolCalls = [];
+  const callbacks = {
+    onToolCallStart: ({ toolName }) => {
+      toolCalls.push(toolName);
+    },
+  };
+  try {
+    const result = await testUnsafeMethodNoRetry({ callbacks });
+    results.unsafeMethodNoRetry = {
+      toolCallCount: toolCalls.length,
+      toolCalls,
+      hasResult: result.data !== undefined,
+    };
+  } catch (e) {
+    results.unsafeMethodNoRetry = {
       toolCallCount: toolCalls.length,
       toolCalls,
       error: e.message,


### PR DESCRIPTION
## Summary
- Adds `safe` keyword support for class methods (`safe methodName(): Type { ... }`), bringing parity with the existing `safe def` syntax for functions
- Updates the parser, type system, builder, and programInfo to handle safe methods
- Adds tests covering parsing, code generation (retryable behavior), and programInfo registration

## Test plan
- [x] Parser tests: safe method parses correctly, non-safe has no `safe` field, mixed class works
- [x] ProgramInfo test: safe methods registered in `safeFunctions` as `ClassName.methodName`
- [x] Builder integration tests: safe method omits `__retryable = false`, non-safe method emits it
- [x] Full test suite passes (1817 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)