### PR TITLE
Add per-checkpoint maxRestores option to restore()

### DIFF
--- a/docs-new/guide/checkpointing.md
+++ b/docs-new/guide/checkpointing.md
@@ -36,6 +36,14 @@ Or local variables:
 restore(result.checkpoint, { locals: { x: 8 } })
 ```
 
+Max restores:
+
+```ts
+restore(result.checkpoint, { maxRestores: 3 })
+```
+
+Limit the number of times you restore a checkpoint. This is useful if you are retrying flaky LLM calls but don't want to retry too many times.
+
 ## Example usage
 
 Retry loop with 3 attempts:

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -1725,6 +1725,11 @@ export class TypeScriptBuilder {
 
     if (this.isAgencyFunction(node.functionName, context)) {
       // In global init scope, __threads and __state don't exist — pass only ctx
+      const locationOpts = node.functionName === "checkpoint" ? {
+        moduleId: ts.str(this.moduleId),
+        scopeName: ts.str(this.currentScopeName()),
+        stepPath: ts.str(this._subStepPath.join(".")),
+      } : {};
       const configObj = this.insideGlobalInit
         ? ts.functionCallConfig({
           ctx: ts.runtime.ctx,
@@ -1735,11 +1740,7 @@ export class TypeScriptBuilder {
           interruptData: ts.raw("__state?.interruptData"),
           stateStack: options?.stateStack,
           isForked: node.async,
-          ...(node.functionName === "checkpoint" ? {
-            moduleId: ts.str(this.moduleId),
-            scopeName: ts.str(this.currentScopeName()),
-            stepPath: ts.str(this._subStepPath.join(".")),
-          } : {}),
+          ...locationOpts,
         });
       const call = ts.call(ts.id(functionName), [...argNodes, configObj]);
       return shouldAwait ? ts.await(call) : call;

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -1735,6 +1735,11 @@ export class TypeScriptBuilder {
           interruptData: ts.raw("__state?.interruptData"),
           stateStack: options?.stateStack,
           isForked: node.async,
+          ...(node.functionName === "checkpoint" ? {
+            moduleId: ts.str(this.moduleId),
+            scopeName: ts.str(this.currentScopeName()),
+            stepPath: ts.str(this._subStepPath.join(".")),
+          } : {}),
         });
       const call = ts.call(ts.id(functionName), [...argNodes, configObj]);
       return shouldAwait ? ts.await(call) : call;

--- a/lib/ir/builders.ts
+++ b/lib/ir/builders.ts
@@ -530,12 +530,18 @@ export const ts = {
     interruptData,
     stateStack,
     isForked,
+    moduleId,
+    scopeName,
+    stepPath,
   }: {
     ctx: TsNode;
     threads?: TsNode;
     interruptData?: TsNode;
     stateStack?: TsNode;
     isForked?: boolean;
+    moduleId?: TsNode;
+    scopeName?: TsNode;
+    stepPath?: TsNode;
   }): TsNode {
     const entries: Record<string, TsNode> = {
       ctx,
@@ -551,6 +557,15 @@ export const ts = {
     }
     if (isForked) {
       entries.isForked = ts.bool(true);
+    }
+    if (moduleId) {
+      entries.moduleId = moduleId;
+    }
+    if (scopeName) {
+      entries.scopeName = scopeName;
+    }
+    if (stepPath) {
+      entries.stepPath = stepPath;
     }
     return ts.obj(entries);
   },

--- a/lib/runtime/checkpoint.ts
+++ b/lib/runtime/checkpoint.ts
@@ -55,7 +55,9 @@ export function restore(
     return;
   }
 
-  ctx.checkpoints.trackLocationRestore(location);
+  if (options.maxRestores !== undefined) {
+    ctx.checkpoints.trackLocationRestore(location);
+  }
   ctx.checkpoints.trackRestore(cp.id);
   ctx.checkpoints.deleteAfterCheckpoint(cp.id);
   ctx.pendingPromises.clear();

--- a/lib/runtime/checkpoint.ts
+++ b/lib/runtime/checkpoint.ts
@@ -9,9 +9,9 @@ export async function checkpoint(
   const ctx = __state.ctx;
   await ctx.pendingPromises.awaitAll();
   return ctx.checkpoints.create(ctx, {
-    moduleId: "",
-    scopeName: "",
-    stepPath: "",
+    moduleId: __state.moduleId ?? "",
+    scopeName: __state.scopeName ?? "",
+    stepPath: __state.stepPath ?? "",
   });
 }
 
@@ -32,7 +32,7 @@ export function restore(
   checkpointIdOrCheckpoint: number | Checkpoint,
   options: RestoreOptions,
   __state?: InternalFunctionState,
-): never {
+): void {
   const ctx = __state!.ctx;
   let cp: Checkpoint;
   if (typeof checkpointIdOrCheckpoint === "number") {
@@ -45,6 +45,17 @@ export function restore(
   } else {
     cp = checkpointIdOrCheckpoint;
   }
+
+  const location = cp.getLocation();
+
+  if (
+    options.maxRestores !== undefined &&
+    ctx.checkpoints.getLocationRestoreCount(location) >= options.maxRestores
+  ) {
+    return;
+  }
+
+  ctx.checkpoints.trackLocationRestore(location);
   ctx.checkpoints.trackRestore(cp.id);
   ctx.checkpoints.deleteAfterCheckpoint(cp.id);
   ctx.pendingPromises.clear();

--- a/lib/runtime/checkpoint.ts
+++ b/lib/runtime/checkpoint.ts
@@ -55,10 +55,10 @@ export function restore(
     return;
   }
 
+  ctx.checkpoints.trackRestore(cp.id);
   if (options.maxRestores !== undefined) {
     ctx.checkpoints.trackLocationRestore(location);
   }
-  ctx.checkpoints.trackRestore(cp.id);
   ctx.checkpoints.deleteAfterCheckpoint(cp.id);
   ctx.pendingPromises.clear();
   throw new RestoreSignal(cp, options);

--- a/lib/runtime/errors.ts
+++ b/lib/runtime/errors.ts
@@ -8,10 +8,10 @@ export type RestoreOptions = {
    * Only affects globals defined in the same file as the checkpoint.
    * Globals in other imported files are restored from checkpoint state. */
   globals?: Record<string, any>;
-  /** Maximum number of times this specific restore call may fire.
+  /** Maximum number of times this checkpoint's source location may be restored.
    * Once the limit is reached, the restore is skipped (returns instead of throwing).
-   * Unlike the global per-checkpoint limit on CheckpointStore, this limit is
-   * scoped to a single call site. */
+   * The count is keyed by the checkpoint's source location (moduleId:scopeName#stepPath),
+   * so it persists across checkpoint ID changes caused by restore cycles. */
   maxRestores?: number;
 };
 

--- a/lib/runtime/errors.ts
+++ b/lib/runtime/errors.ts
@@ -8,6 +8,11 @@ export type RestoreOptions = {
    * Only affects globals defined in the same file as the checkpoint.
    * Globals in other imported files are restored from checkpoint state. */
   globals?: Record<string, any>;
+  /** Maximum number of times this specific restore call may fire.
+   * Once the limit is reached, the restore is skipped (returns instead of throwing).
+   * Unlike the global per-checkpoint limit on CheckpointStore, this limit is
+   * scoped to a single call site. */
+  maxRestores?: number;
 };
 
 export class CheckpointError extends Error {

--- a/lib/runtime/state/checkpointStore.ts
+++ b/lib/runtime/state/checkpointStore.ts
@@ -185,6 +185,7 @@ export type CheckpointStoreJSON = {
 export class CheckpointStore {
   private checkpoints: Record<number, Checkpoint> = {};
   private restoreCounts: Record<number, number> = {};
+  private locationRestoreCounts: Record<string, number> = {};
   private maxRestores: number;
   private maxSize: number;
 
@@ -339,6 +340,14 @@ export class CheckpointStore {
         delete this.restoreCounts[numericKey];
       }
     }
+  }
+
+  getLocationRestoreCount(location: string): number {
+    return this.locationRestoreCounts[location] || 0;
+  }
+
+  trackLocationRestore(location: string): void {
+    this.locationRestoreCounts[location] = (this.locationRestoreCounts[location] || 0) + 1;
   }
 
   trackRestore(id: number): void {

--- a/lib/runtime/types.ts
+++ b/lib/runtime/types.ts
@@ -29,6 +29,9 @@ export type InternalFunctionState = {
   interruptData?: InterruptData;
   isToolCall?: boolean;
   stateStack?: StateStack;  // per-thread stack for async calls
+  moduleId?: string;
+  scopeName?: string;
+  stepPath?: string;
 };
 
 export type NodeReturnValue<T> = {

--- a/tests/agency/maxRestores.agency
+++ b/tests/agency/maxRestores.agency
@@ -1,0 +1,8 @@
+shared let attempts = 0
+
+node main() {
+  const cp = checkpoint()
+  attempts = attempts + 1
+  restore(cp, { maxRestores: 3 })
+  return attempts
+}

--- a/tests/agency/maxRestores.test.json
+++ b/tests/agency/maxRestores.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "4",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "restore with maxRestores: 3 should retry 3 times then continue, resulting in 4 total attempts"
+    }
+  ]
+}

--- a/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -124,7 +124,10 @@ let __functionCompleted = false;
 __stack.locals.cp = await checkpoint({
         ctx: __ctx,
         threads: __threads,
-        interruptData: __state?.interruptData
+        interruptData: __state?.interruptData,
+        moduleId: "checkpoint-restore.agency",
+        scopeName: "main",
+        stepPath: "0"
       });
 if (isInterrupt(__stack.locals.cp)) {
         await __ctx.pendingPromises.awaitAll()


### PR DESCRIPTION
## Summary
- Adds `maxRestores` field to `RestoreOptions` so callers can limit how many times a specific checkpoint is restored, e.g. `restore(cp, { maxRestores: 3 })`
- Populates user-created checkpoints with real source location data (moduleId, scopeName, stepPath) so restore counts are keyed by stable location strings that survive checkpoint ID changes across restore cycles
- Adds location-keyed restore counting (`locationRestoreCounts`) to `CheckpointStore`, separate from the existing ID-keyed global safety limit

## Test plan
- [x] New agency execution test (`tests/agency/maxRestores`) verifies `maxRestores: 3` causes exactly 3 retries then continues
- [x] Updated `checkpoint-restore.mjs` generator fixture to reflect new location fields
- [x] All 1823 vitest tests pass
- [x] `pnpm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)