### PR TITLE
Add optional parameter syntax (name?: type)

### DIFF
--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -611,6 +611,7 @@ export class TypeScriptBuilder {
       case "string":
       case "variableName":
       case "boolean":
+      case "null":
         return this.generateLiteral(node);
       case "returnStatement":
         return this.processReturnStatement(node);

--- a/lib/parsers/function.test.ts
+++ b/lib/parsers/function.test.ts
@@ -1856,6 +1856,87 @@ describe("functionParser", () => {
         },
       },
     },
+    // Optional parameter with ? syntax
+    {
+      input: "def foo(x: string, y?: number) { x }",
+      expected: {
+        success: true,
+        result: {
+          type: "function",
+          functionName: "foo",
+          parameters: [
+            {
+              type: "functionParameter",
+              name: "x",
+              typeHint: { type: "primitiveType", value: "string" },
+            },
+            {
+              type: "functionParameter",
+              name: "y",
+              typeHint: { type: "primitiveType", value: "number" },
+              defaultValue: { type: "null" },
+            },
+          ],
+          returnType: null,
+          docString: undefined,
+          body: [{ type: "variableName", value: "x" }],
+        },
+      },
+    },
+    // Optional parameter with ? syntax (no type hint)
+    {
+      input: "def foo(x, y?) { x }",
+      expected: {
+        success: true,
+        result: {
+          type: "function",
+          functionName: "foo",
+          parameters: [
+            {
+              type: "functionParameter",
+              name: "x",
+            },
+            {
+              type: "functionParameter",
+              name: "y",
+              defaultValue: { type: "null" },
+            },
+          ],
+          returnType: null,
+          docString: undefined,
+          body: [{ type: "variableName", value: "x" }],
+        },
+      },
+    },
+    // Optional param with ? should not conflict with explicit default
+    {
+      input: 'def foo(x?: string = "hi") { x }',
+      expected: {
+        success: true,
+        result: {
+          type: "function",
+          functionName: "foo",
+          parameters: [
+            {
+              type: "functionParameter",
+              name: "x",
+              typeHint: { type: "primitiveType", value: "string" },
+              defaultValue: { type: "string", segments: [{ type: "text", value: "hi" }] },
+            },
+          ],
+          returnType: null,
+          docString: undefined,
+          body: [{ type: "variableName", value: "x" }],
+        },
+      },
+    },
+    // Required param after optional ? param should fail
+    {
+      input: "def bad(a?: number, b: string) { b }",
+      expected: {
+        success: false,
+      },
+    },
     // Default value: object
     {
       input: 'def foo(config = {model: "gpt-4"}) { config }',

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -2154,7 +2154,7 @@ export const forLoopParser: Parser<ForLoop> = label("a for loop", withLoc(trace(
   ),
 )));
 
-// Parses: name, name: type, name = default, name: type = default, name?: type
+// Parses: name, name?, name: type, name?: type, name = default, name? = default, name: type = default
 export const functionParameterParser: Parser<FunctionParameter> = trace(
   "functionParameterParser",
   map(

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -2154,32 +2154,42 @@ export const forLoopParser: Parser<ForLoop> = label("a for loop", withLoc(trace(
   ),
 )));
 
-// Parses: name, name: type, name = default, name: type = default
-export const functionParameterParser = trace(
+// Parses: name, name: type, name = default, name: type = default, name?: type
+export const functionParameterParser: Parser<FunctionParameter> = trace(
   "functionParameterParser",
-  seqC(
-    set("type", "functionParameter"),
-    capture(many1WithJoin(varNameChar), "name"),
-    optional(
-      captureCaptures(
-        seqC(
-          optionalSpaces,
-          char(":"),
-          optionalSpaces,
-          capture(variableTypeParser, "typeHint"),
+  map(
+    seqC(
+      set("type", "functionParameter"),
+      capture(many1WithJoin(varNameChar), "name"),
+      capture(optional(char("?")), "__optional"),
+      optional(
+        captureCaptures(
+          seqC(
+            optionalSpaces,
+            char(":"),
+            optionalSpaces,
+            capture(variableTypeParser, "typeHint"),
+          ),
+        ),
+      ),
+      optional(
+        captureCaptures(
+          seqC(
+            optionalSpaces,
+            str("="),
+            optionalSpaces,
+            capture(or(agencyArrayParser, agencyObjectParser, literalParserNoVarName), "defaultValue"),
+          ),
         ),
       ),
     ),
-    optional(
-      captureCaptures(
-        seqC(
-          optionalSpaces,
-          str("="),
-          optionalSpaces,
-          capture(or(agencyArrayParser, agencyObjectParser, literalParserNoVarName), "defaultValue"),
-        ),
-      ),
-    ),
+    (result: any) => {
+      const { __optional, ...rest } = result;
+      if (__optional && !rest.defaultValue) {
+        rest.defaultValue = { type: "null" };
+      }
+      return rest as FunctionParameter;
+    },
   ),
 );
 

--- a/tests/typescriptGenerator/optionalParams.agency
+++ b/tests/typescriptGenerator/optionalParams.agency
@@ -1,0 +1,6 @@
+def greet(name: string, greeting?: string) {
+  print(greeting, name)
+}
+
+greet("world")
+greet("world", "Hi")

--- a/tests/typescriptGenerator/optionalParams.mjs
+++ b/tests/typescriptGenerator/optionalParams.mjs
@@ -1,0 +1,212 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint, getCheckpoint, restore,
+  interrupt, isInterrupt, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupt as _respondToInterrupt,
+  approveInterrupt as _approveInterrupt,
+  rejectInterrupt as _rejectInterrupt,
+  resolveInterrupt as _resolveInterrupt,
+  modifyInterrupt as _modifyInterrupt,
+  resumeFromState as _resumeFromState,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  deepClone as __deepClone,
+  not, eq, neq, lt, lte, gt, gte, and, or,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  _builtinTool as __builtinTool,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname
+});
+const graph = __globalCtx.graph;
+
+// Path-dependent builtin wrappers
+export function readSkill({filepath}: {filepath: string}): string {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+
+// tool() function — looks up a tool by name from the module's __toolRegistry
+function tool(__name: string) {
+  return __builtinTool(__name, __toolRegistry);
+}
+
+// Handler result builtins
+function approve(value?: any) { return { type: "approved" as const, value }; }
+function reject(value?: any) { return { type: "rejected" as const, value }; }
+function propagate() { return { type: "propagated" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, isDebugger };
+export const respondToInterrupt = (interrupt: Interrupt, response: InterruptResponse, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupt({ ctx: __globalCtx, interrupt, interruptResponse: response, overrides: opts?.overrides, metadata: opts?.metadata });
+export const approveInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _approveInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rejectInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _rejectInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const modifyInterrupt = (interrupt: Interrupt, newArguments: Record<string, any>, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _modifyInterrupt({ ctx: __globalCtx, interrupt, newArguments, overrides: opts?.overrides, metadata: opts?.metadata });
+export const resolveInterrupt = (interrupt: Interrupt, value: any, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _resolveInterrupt({ ctx: __globalCtx, interrupt, value, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("optionalParams.agency")
+}
+export const __greetTool = {
+  name: "greet",
+  description: `No description provided.`,
+  schema: z.object({"name": z.string(), "greeting": z.string().nullable().describe("Default: null"), })
+};
+export const __greetToolParams = ["name", "greeting"];
+const __toolRegistry = {
+  greet: {
+    definition: __greetTool,
+    handler: {
+      name: "greet",
+      params: __greetToolParams,
+      execute: greet,
+      isBuiltin: false
+    }
+  },
+  readSkill: {
+    definition: __readSkillTool,
+    handler: {
+      name: "readSkill",
+      params: __readSkillToolParams,
+      execute: readSkill,
+      isBuiltin: true
+    }
+  }
+};
+async function greet(name: string, greeting: string | null = null, __state: InternalFunctionState | undefined = undefined) {
+  const __setupData = setupFunction({
+    state: __state
+  });
+  // __state will be undefined if this function is being called as a tool by an llm
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state?.ctx || __globalCtx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("optionalParams.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onFunctionStart",
+    data: {
+      functionName: "greet",
+      args: {
+        name: name,
+        greeting: greeting
+      },
+      isBuiltin: false
+    }
+  })
+  __stack.args["name"] = name;
+  __stack.args["greeting"] = greeting ?? null;
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "optionalParams.agency", scopeName: "greet" });
+  let __resultCheckpointId = -1;
+if (__ctx.stateStack.currentNodeId()) {
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__ctx, { moduleId: "optionalParams.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+}
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+  if ("name" in __overrides) {
+    name = __overrides["name"];
+    __stack.args["name"] = name;
+  }
+  if ("greeting" in __overrides) {
+    greeting = __overrides["greeting"];
+    __stack.args["greeting"] = greeting;
+  }
+
+}
+
+  try {
+    await runner.step(0, async (runner) => {
+await print(__stack.args.greeting, __stack.args.name)
+    });
+    if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: __ctx.getResultCheckpoint(),
+    retryable: __self.__retryable,
+    functionName: "greet",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    if (!__state?.isForked) { __ctx.stateStack.pop() }
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "greet",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
+await greet(`world`, null, {
+  ctx: __ctx,
+  threads: __threads,
+  interruptData: __state?.interruptData
+})
+await greet(`world`, `Hi`, {
+  ctx: __ctx,
+  threads: __threads,
+  interruptData: __state?.interruptData
+})
+export default graph
+export const __sourceMap = {"optionalParams.agency:greet":{"0":{"line":-1,"col":2}}};


### PR DESCRIPTION
## Summary
- Adds support for `name?: type` syntax in function and node parameters, treating it as syntactic sugar for `name: type = null`
- Reuses the existing default value machinery -- no new AST fields or builder changes needed beyond adding null to processNode literal cases
- Includes parser tests (typed/untyped optional, interaction with explicit defaults, required-after-optional rejection) and an integration fixture

## Test plan
- [x] All 1828 existing + new tests pass
- [x] `def foo(x: string, y?: number) { x }` parses correctly
- [x] `def bad(a?: number, b: string) { b }` rejected (required after optional)
- [x] Integration fixture compiles to correct TypeScript (nullable param, null padding at call site)

Generated with [Claude Code](https://claude.com/claude-code)