### PR TITLE
Add true keyword arguments with reordering

### DIFF
--- a/lib/backends/typescriptBuilder.integration.test.ts
+++ b/lib/backends/typescriptBuilder.integration.test.ts
@@ -129,7 +129,7 @@ describe("TypeScript Builder Integration Tests", () => {
 });
 
 describe("Named argument validation", () => {
-  it("should throw on mismatched named argument", () => {
+  it("should throw when skipping a required argument", () => {
     expect(() =>
       generateWithBuilder(`
 def greet(name: string, greeting: string = "Hello") {
@@ -137,10 +137,10 @@ def greet(name: string, greeting: string = "Hello") {
 }
 greet(greeting: "Hi")
 `),
-    ).toThrow("Named argument 'greeting' does not match parameter 'name' at position 1");
+    ).toThrow("Missing required argument 'name' in call to 'greet'");
   });
 
-  it("should throw on named argument beyond parameter list", () => {
+  it("should throw on unknown named argument", () => {
     expect(() =>
       generateWithBuilder(`
 def foo(a: string) {
@@ -148,7 +148,7 @@ def foo(a: string) {
 }
 foo(a: "hi", extra: "oops")
 `),
-    ).toThrow("Named argument 'extra' at position 2 is beyond the parameter list");
+    ).toThrow("Unknown named argument 'extra' in call to 'foo'");
   });
 
   it("should accept correct named arguments", () => {
@@ -160,6 +160,39 @@ def greet(name: string, greeting: string = "Hello") {
 greet(name: "world", greeting: "Hi")
 `),
     ).not.toThrow();
+  });
+
+  it("should accept reordered named arguments", () => {
+    expect(() =>
+      generateWithBuilder(`
+def greet(name: string, greeting: string = "Hello") {
+  print(name)
+}
+greet(greeting: "Hi", name: "world")
+`),
+    ).not.toThrow();
+  });
+
+  it("should throw on positional after named", () => {
+    expect(() =>
+      generateWithBuilder(`
+def greet(name: string, greeting: string = "Hello") {
+  print(name)
+}
+greet(name: "world", "Hi")
+`),
+    ).toThrow("Positional argument cannot follow a named argument");
+  });
+
+  it("should throw on duplicate named argument", () => {
+    expect(() =>
+      generateWithBuilder(`
+def greet(name: string, greeting: string = "Hello") {
+  print(name)
+}
+greet(name: "world", name: "other")
+`),
+    ).toThrow("Duplicate named argument 'name' in call to 'greet'");
   });
 });
 

--- a/lib/backends/typescriptBuilder.integration.test.ts
+++ b/lib/backends/typescriptBuilder.integration.test.ts
@@ -194,6 +194,19 @@ greet(name: "world", name: "other")
 `),
     ).toThrow("Duplicate named argument 'name' in call to 'greet'");
   });
+
+  it("should accept named args with block parameters", () => {
+    expect(() =>
+      generateWithBuilder(`
+def twice(label: string, block: () => string): string {
+  return block() + block()
+}
+twice(label: "test") as {
+  return "hi"
+}
+`),
+    ).not.toThrow();
+  });
 });
 
 describe("Safe functions and methods", () => {

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -555,7 +555,9 @@ export class TypeScriptBuilder {
     }
 
     // Collect named args, checking for duplicates and unknown names
-    const nonVariadicParams = paramList.filter((p) => !p.variadic);
+    const nonVariadicParams = paramList.filter(
+      (p) => !p.variadic && p.typeHint?.type !== "blockType",
+    );
     const namedArgMap = new Map<string, Expression>();
     for (let i = namedStartIdx; i < args.length; i++) {
       const arg = args[i] as NamedArgument;

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -512,33 +512,108 @@ export class TypeScriptBuilder {
 
   // ------- Node dispatch -------
 
-  /** Named args are cosmetic/positional — validate name matches the param at that index. */
-  private validateNamedArgs(
+  /**
+   * Resolve named arguments: reorder them to match the parameter list,
+   * inserting null for skipped optional params. Returns unwrapped args
+   * (no NamedArgument wrappers) in the correct positional order.
+   *
+   * Rules (Python-style):
+   * - Positional args must come before named args
+   * - Named args can be in any order
+   * - Named args can skip optional params (those with defaults)
+   * - Named args are only supported for Agency-defined functions
+   */
+  private resolveNamedArgs(
     node: FunctionCall,
     paramList: FunctionParameter[] | undefined,
-  ): void {
-    if (!paramList) return;
-    const lastParam = paramList[paramList.length - 1];
-    const hasVariadic = lastParam?.variadic;
-    for (let i = 0; i < node.arguments.length; i++) {
-      const arg = node.arguments[i];
-      if (arg.type !== "namedArgument") continue;
-      let expectedName: string;
-      if (i < paramList.length) {
-        expectedName = paramList[i].name;
-      } else if (hasVariadic) {
-        expectedName = lastParam.name;
-      } else {
+    isAgencyFunction: boolean,
+  ): (Expression | SplatExpression)[] {
+    const args = node.arguments;
+    const hasNamedArgs = args.some((a) => a.type === "namedArgument");
+
+    if (!hasNamedArgs) {
+      return args.map((a) =>
+        a.type === "namedArgument" ? a.value : a,
+      ) as (Expression | SplatExpression)[];
+    }
+
+    // Named args require a known Agency function
+    if (!isAgencyFunction || !paramList || paramList.length === 0) {
+      throw new Error(
+        `Named arguments can only be used with Agency-defined functions, not '${node.functionName}'`,
+      );
+    }
+
+    // Find where named args start
+    const namedStartIdx = args.findIndex((a) => a.type === "namedArgument");
+
+    // Validate no positional after named
+    for (let i = namedStartIdx + 1; i < args.length; i++) {
+      if (args[i].type !== "namedArgument") {
         throw new Error(
-          `Named argument '${arg.name}' at position ${i + 1} is beyond the parameter list in call to '${node.functionName}'`,
-        );
-      }
-      if (arg.name !== expectedName) {
-        throw new Error(
-          `Named argument '${arg.name}' does not match parameter '${expectedName}' at position ${i + 1} in call to '${node.functionName}'`,
+          `Positional argument cannot follow a named argument in call to '${node.functionName}'`,
         );
       }
     }
+
+    // Collect named args, checking for duplicates and unknown names
+    const nonVariadicParams = paramList.filter((p) => !p.variadic);
+    const namedArgMap = new Map<string, Expression>();
+    for (let i = namedStartIdx; i < args.length; i++) {
+      const arg = args[i] as NamedArgument;
+      if (namedArgMap.has(arg.name)) {
+        throw new Error(
+          `Duplicate named argument '${arg.name}' in call to '${node.functionName}'`,
+        );
+      }
+      const paramIdx = nonVariadicParams.findIndex((p) => p.name === arg.name);
+      if (paramIdx === -1) {
+        throw new Error(
+          `Unknown named argument '${arg.name}' in call to '${node.functionName}'`,
+        );
+      }
+      if (paramIdx < namedStartIdx) {
+        throw new Error(
+          `Named argument '${arg.name}' conflicts with positional argument at position ${paramIdx + 1} in call to '${node.functionName}'`,
+        );
+      }
+      namedArgMap.set(arg.name, arg.value);
+    }
+
+    // Build result: positional args first, then fill from named args in parameter order
+    const result: (Expression | SplatExpression)[] = [];
+
+    // Positional args stay in their positions (unwrapped)
+    for (let i = 0; i < namedStartIdx; i++) {
+      const a = args[i];
+      result.push(a.type === "namedArgument" ? a.value : a);
+    }
+
+    // Fill remaining parameter slots from named args
+    for (let i = namedStartIdx; i < nonVariadicParams.length; i++) {
+      const param = nonVariadicParams[i];
+      if (namedArgMap.has(param.name)) {
+        result.push(namedArgMap.get(param.name)!);
+        namedArgMap.delete(param.name);
+      } else if (param.defaultValue) {
+        // Check if any later param has a named arg — if so, insert null placeholder
+        const hasLaterNamedArg = nonVariadicParams
+          .slice(i + 1)
+          .some((p) => namedArgMap.has(p.name));
+        if (hasLaterNamedArg) {
+          result.push({ type: "null" } as Expression);
+        } else {
+          // Trailing skipped params — stop here, adjustCallArgs will pad
+          break;
+        }
+      } else {
+        throw new Error(
+          `Missing required argument '${param.name}' in call to '${node.functionName}'`,
+        );
+      }
+    }
+
+    return result;
   }
 
   /** Process a function call argument, unwrapping NamedArgument and SplatExpression. */
@@ -1662,14 +1737,13 @@ export class TypeScriptBuilder {
     const fnDef = this.programInfo.functionDefinitions[node.functionName];
     const imported = this.programInfo.importedFunctions[node.functionName];
     const paramList = fnDef?.parameters ?? imported?.parameters;
+    const isAgencyFunction = !!fnDef || (!!imported && imported.parameters.length > 0);
 
-    this.validateNamedArgs(node, paramList);
-
-    const rawArgNodes: TsNode[] = node.arguments.map((rawArg) => {
-      const arg = rawArg.type === "namedArgument" ? rawArg.value : rawArg;
+    const resolvedArgs = this.resolveNamedArgs(node, paramList, isAgencyFunction);
+    const rawArgNodes: TsNode[] = resolvedArgs.map((arg) => {
       if (arg.type === "functionCall") {
         this.functionsUsed.add(arg.functionName);
-        return this.generateFunctionCallExpression(arg, "functionArg");
+        return this.generateFunctionCallExpression(arg as FunctionCall, "functionArg");
       } else {
         return this.processCallArg(arg);
       }
@@ -1807,13 +1881,11 @@ export class TypeScriptBuilder {
     const targetNode = this.programInfo.graphNodes.find(
       (n) => n.nodeName === functionName,
     );
-    this.validateNamedArgs(node, targetNode?.parameters);
-
-    const argNodes: TsNode[] = node.arguments.map((rawArg) => {
-      const arg = rawArg.type === "namedArgument" ? rawArg.value : rawArg;
+    const resolvedArgs = this.resolveNamedArgs(node, targetNode?.parameters, true);
+    const argNodes: TsNode[] = resolvedArgs.map((arg) => {
       if (arg.type === "functionCall") {
         this.functionsUsed.add(arg.functionName);
-        return this.generateFunctionCallExpression(arg, "functionArg");
+        return this.generateFunctionCallExpression(arg as FunctionCall, "functionArg");
       } else {
         return this.processCallArg(arg);
       }

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -532,9 +532,7 @@ export class TypeScriptBuilder {
     const hasNamedArgs = args.some((a) => a.type === "namedArgument");
 
     if (!hasNamedArgs) {
-      return args.map((a) =>
-        a.type === "namedArgument" ? a.value : a,
-      ) as (Expression | SplatExpression)[];
+      return args as (Expression | SplatExpression)[];
     }
 
     // Named args require a known Agency function
@@ -627,6 +625,23 @@ export class TypeScriptBuilder {
       return ts.spread(this.processNode(arg.value as AgencyNode));
     }
     return this.processNode(arg as AgencyNode);
+  }
+
+  /** Process resolved arguments into TsNodes, tracking function usage. */
+  private processResolvedArgs(
+    args: (Expression | SplatExpression)[],
+  ): TsNode[] {
+    return args.map((arg) => {
+      if (arg.type === "functionCall") {
+        this.functionsUsed.add(arg.functionName);
+        return this.generateFunctionCallExpression(
+          arg as FunctionCall,
+          "functionArg",
+        );
+      } else {
+        return this.processCallArg(arg);
+      }
+    });
   }
 
   /**
@@ -1740,14 +1755,7 @@ export class TypeScriptBuilder {
     const isAgencyFunction = !!fnDef || (!!imported && imported.parameters.length > 0);
 
     const resolvedArgs = this.resolveNamedArgs(node, paramList, isAgencyFunction);
-    const rawArgNodes: TsNode[] = resolvedArgs.map((arg) => {
-      if (arg.type === "functionCall") {
-        this.functionsUsed.add(arg.functionName);
-        return this.generateFunctionCallExpression(arg as FunctionCall, "functionArg");
-      } else {
-        return this.processCallArg(arg);
-      }
-    });
+    const rawArgNodes = this.processResolvedArgs(resolvedArgs);
 
     const nonBlockParams = paramList?.filter(
       (p) => !p.typeHint || p.typeHint.type !== "blockType",
@@ -1882,14 +1890,7 @@ export class TypeScriptBuilder {
       (n) => n.nodeName === functionName,
     );
     const resolvedArgs = this.resolveNamedArgs(node, targetNode?.parameters, true);
-    const argNodes: TsNode[] = resolvedArgs.map((arg) => {
-      if (arg.type === "functionCall") {
-        this.functionsUsed.add(arg.functionName);
-        return this.generateFunctionCallExpression(arg as FunctionCall, "functionArg");
-      } else {
-        return this.processCallArg(arg);
-      }
-    });
+    const argNodes = this.processResolvedArgs(resolvedArgs);
 
     let dataNode: TsNode;
     if (targetNode && targetNode.parameters.length > 0) {

--- a/tests/agency/namedArgsNode.agency
+++ b/tests/agency/namedArgsNode.agency
@@ -1,0 +1,7 @@
+node main() {
+  return other(b: "world", a: "hello")
+}
+
+node other(a: string, b: string) {
+  return a + " " + b
+}

--- a/tests/agency/namedArgsNode.test.json
+++ b/tests/agency/namedArgsNode.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"hello world\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/namedArgsOptional.agency
+++ b/tests/agency/namedArgsOptional.agency
@@ -1,0 +1,22 @@
+safe def format(value: string, prefix?: string, suffix?: string): string {
+  let result = value
+  if (prefix != null) {
+    result = prefix + result
+  }
+  if (suffix != null) {
+    result = result + suffix
+  }
+  return result
+}
+
+node main() {
+  // Skip both optional params
+  let a = format(value: "hello")
+  // Provide only suffix, skip prefix
+  let b = format(value: "hello", suffix: "!")
+  // Provide only prefix, skip suffix
+  let c = format(value: "hello", prefix: ">")
+  // Provide both, reversed
+  let d = format(suffix: "!", prefix: ">", value: "hello")
+  return a + " | " + b + " | " + c + " | " + d
+}

--- a/tests/agency/namedArgsOptional.test.json
+++ b/tests/agency/namedArgsOptional.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"hello | hello! | >hello | >hello!\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/namedArgsReorder.agency
+++ b/tests/agency/namedArgsReorder.agency
@@ -8,7 +8,7 @@ node main() {
   // Skip middle optional param
   let b = greet(name: "world", punctuation: "?")
   // Mixed positional + named (positional first)
-  let c = greet("world", punctuation: "!")
+  let c = greet("world", punctuation: "...")
   // All named, same order (regression)
   let d = greet(name: "world", greeting: "Hey", punctuation: "!")
   // Skip trailing optional params

--- a/tests/agency/namedArgsReorder.agency
+++ b/tests/agency/namedArgsReorder.agency
@@ -1,0 +1,17 @@
+safe def greet(name: string, greeting: string = "Hello", punctuation: string = "!"): string {
+  return greeting + " " + name + punctuation
+}
+
+node main() {
+  // Basic reordering: all named, reversed order
+  let a = greet(punctuation: ".", greeting: "Hi", name: "world")
+  // Skip middle optional param
+  let b = greet(name: "world", punctuation: "?")
+  // Mixed positional + named (positional first)
+  let c = greet("world", punctuation: "!")
+  // All named, same order (regression)
+  let d = greet(name: "world", greeting: "Hey", punctuation: "!")
+  // Skip trailing optional params
+  let e = greet(name: "world")
+  return a + " | " + b + " | " + c + " | " + d + " | " + e
+}

--- a/tests/agency/namedArgsReorder.test.json
+++ b/tests/agency/namedArgsReorder.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "\"Hi world. | Hello world? | Hello world! | Hey world! | Hello world!\"",
+      "expectedOutput": "\"Hi world. | Hello world? | Hello world... | Hey world! | Hello world!\"",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/tests/agency/namedArgsReorder.test.json
+++ b/tests/agency/namedArgsReorder.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"Hi world. | Hello world? | Hello world! | Hey world! | Hello world!\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/typescriptGenerator/namedArgsReorder.agency
+++ b/tests/typescriptGenerator/namedArgsReorder.agency
@@ -1,0 +1,13 @@
+def greet(name: string, greeting: string = "Hello", punctuation: string = "!"): string {
+  return greeting + " " + name + punctuation
+}
+
+node main() {
+  // Reordered named args
+  let a = greet(greeting: "Hi", name: "world")
+  // Skip middle param with named args
+  let b = greet(name: "world", punctuation: ".")
+  // Mixed positional + named
+  let c = greet("world", punctuation: "?")
+  return a + " | " + b + " | " + c
+}

--- a/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -1,0 +1,335 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint, getCheckpoint, restore,
+  interrupt, isInterrupt, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupt as _respondToInterrupt,
+  approveInterrupt as _approveInterrupt,
+  rejectInterrupt as _rejectInterrupt,
+  resolveInterrupt as _resolveInterrupt,
+  modifyInterrupt as _modifyInterrupt,
+  resumeFromState as _resumeFromState,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  deepClone as __deepClone,
+  not, eq, neq, lt, lte, gt, gte, and, or,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  _builtinTool as __builtinTool,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname
+});
+const graph = __globalCtx.graph;
+
+// Path-dependent builtin wrappers
+export function readSkill({filepath}: {filepath: string}): string {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+
+// tool() function — looks up a tool by name from the module's __toolRegistry
+function tool(__name: string) {
+  return __builtinTool(__name, __toolRegistry);
+}
+
+// Handler result builtins
+function approve(value?: any) { return { type: "approved" as const, value }; }
+function reject(value?: any) { return { type: "rejected" as const, value }; }
+function propagate() { return { type: "propagated" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, isDebugger };
+export const respondToInterrupt = (interrupt: Interrupt, response: InterruptResponse, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupt({ ctx: __globalCtx, interrupt, interruptResponse: response, overrides: opts?.overrides, metadata: opts?.metadata });
+export const approveInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _approveInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rejectInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _rejectInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const modifyInterrupt = (interrupt: Interrupt, newArguments: Record<string, any>, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _modifyInterrupt({ ctx: __globalCtx, interrupt, newArguments, overrides: opts?.overrides, metadata: opts?.metadata });
+export const resolveInterrupt = (interrupt: Interrupt, value: any, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _resolveInterrupt({ ctx: __globalCtx, interrupt, value, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("namedArgsReorder.agency")
+}
+export const __greetTool = {
+  name: "greet",
+  description: `No description provided.`,
+  schema: z.object({"name": z.string(), "greeting": z.string().nullable().describe("Default: Hello"), "punctuation": z.string().nullable().describe("Default: !"), })
+};
+export const __greetToolParams = ["name", "greeting", "punctuation"];
+const __toolRegistry = {
+  greet: {
+    definition: __greetTool,
+    handler: {
+      name: "greet",
+      params: __greetToolParams,
+      execute: greet,
+      isBuiltin: false
+    }
+  },
+  readSkill: {
+    definition: __readSkillTool,
+    handler: {
+      name: "readSkill",
+      params: __readSkillToolParams,
+      execute: readSkill,
+      isBuiltin: true
+    }
+  }
+};
+async function greet(name: string, greeting: string | null = null, punctuation: string | null = null, __state: InternalFunctionState | undefined = undefined) {
+  const __setupData = setupFunction({
+    state: __state
+  });
+  // __state will be undefined if this function is being called as a tool by an llm
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state?.ctx || __globalCtx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("namedArgsReorder.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onFunctionStart",
+    data: {
+      functionName: "greet",
+      args: {
+        name: name,
+        greeting: greeting,
+        punctuation: punctuation
+      },
+      isBuiltin: false
+    }
+  })
+  __stack.args["name"] = name;
+  __stack.args["greeting"] = greeting ?? `Hello`;
+  __stack.args["punctuation"] = punctuation ?? `!`;
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "namedArgsReorder.agency", scopeName: "greet" });
+  let __resultCheckpointId = -1;
+if (__ctx.stateStack.currentNodeId()) {
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__ctx, { moduleId: "namedArgsReorder.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+}
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+  if ("name" in __overrides) {
+    name = __overrides["name"];
+    __stack.args["name"] = name;
+  }
+  if ("greeting" in __overrides) {
+    greeting = __overrides["greeting"];
+    __stack.args["greeting"] = greeting;
+  }
+  if ("punctuation" in __overrides) {
+    punctuation = __overrides["punctuation"];
+    __stack.args["punctuation"] = punctuation;
+  }
+
+}
+
+  try {
+    await runner.step(0, async (runner) => {
+__functionCompleted = true;
+runner.halt(__stack.args.greeting + ` ${__stack.args.name}${__stack.args.punctuation}`)
+return;
+    });
+    if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: __ctx.getResultCheckpoint(),
+    retryable: __self.__retryable,
+    functionName: "greet",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    if (!__state?.isForked) { __ctx.stateStack.pop() }
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "greet",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state.ctx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onNodeStart",
+    data: {
+      nodeName: "main"
+    }
+  })
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "namedArgsReorder.agency", scopeName: "main" });
+  try {
+    await runner.step(0, async (runner) => {
+//  Reordered named args
+    });
+    await runner.step(1, async (runner) => {
+__stack.locals.a = await greet(`world`, `Hi`, null, {
+        ctx: __ctx,
+        threads: __threads,
+        interruptData: __state?.interruptData
+      });
+if (isInterrupt(__stack.locals.a)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __stack.locals.a
+        })
+        return;
+      }
+//  Skip middle param with named args
+    });
+    await runner.step(2, async (runner) => {
+__stack.locals.b = await greet(`world`, null, `.`, {
+        ctx: __ctx,
+        threads: __threads,
+        interruptData: __state?.interruptData
+      });
+if (isInterrupt(__stack.locals.b)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __stack.locals.b
+        })
+        return;
+      }
+//  Mixed positional + named
+    });
+    await runner.step(3, async (runner) => {
+__stack.locals.c = await greet(`world`, null, `?`, {
+        ctx: __ctx,
+        threads: __threads,
+        interruptData: __state?.interruptData
+      });
+if (isInterrupt(__stack.locals.c)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __stack.locals.c
+        })
+        return;
+      }
+    });
+    await runner.step(4, async (runner) => {
+runner.halt({
+        messages: __threads,
+        data: __stack.locals.a + ` | ${__stack.locals.b} | ${__stack.locals.c}`
+      })
+return;
+    });
+    if (runner.halted) return runner.haltResult;
+    await callHook({
+      callbacks: __ctx.callbacks,
+      name: "onNodeEnd",
+      data: {
+        nodeName: "main",
+        data: undefined
+      }
+    })
+    return {
+      messages: __threads,
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    return {
+      messages: __threads,
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}) {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    await main(initialState)
+  } catch (__error: any) {
+    console.error(`\nAgent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"namedArgsReorder.agency:greet":{"0":{"line":-1,"col":2}},"namedArgsReorder.agency:main":{"1":{"line":4,"col":2},"2":{"line":6,"col":2},"3":{"line":8,"col":2},"4":{"line":9,"col":2}}};


### PR DESCRIPTION
## Summary
- Named arguments now support Python-style reordering: positional args first, then named args in any order
- Named args can skip optional parameters (those with defaults or `?` syntax) -- skipped params get `null` which triggers the `??` default at runtime
- Named args are only allowed on Agency-defined functions; using them on imported TS functions throws a compile-time error
- Validates: no positional after named, no duplicates, no unknown names, no conflict with positional slots, no skipping required params

## Test plan
- [x] All 1832 existing + new tests pass
- [x] Agency execution tests: reordering, skipping optionals, `?` syntax, mixing positional+named, node calls
- [x] Integration fixture verifies generated TypeScript
- [x] Builder integration tests for all error cases (unknown arg, duplicate, positional-after-named, missing required)
- [x] Existing namedArgs and defaultValues tests still pass (regression)

Generated with [Claude Code](https://claude.com/claude-code)