### PR TITLE
Add weather tool to standard library

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,9 @@ pnpm run agency hello.agency
 
 Now read [the docs](https://agency-lang.com) to learn more about the language and how to use it!
 
+## Attributions
+
+Weather data in the standard library (`std::weather`) is provided by [Open-Meteo](https://open-meteo.com/). Data is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/). The free API is for non-commercial use only; commercial use requires a [paid subscription](https://open-meteo.com/en/pricing).
+
 ## License
 [FSL](https://fsl.software).

--- a/stdlib/lib/weather.ts
+++ b/stdlib/lib/weather.ts
@@ -52,6 +52,11 @@ export async function _geocode(location: string): Promise<GeoResult> {
     );
   }
   const place = results[0];
+  if (typeof place.latitude !== "number" || typeof place.longitude !== "number") {
+    throw new Error(
+      `Geocoding returned invalid coordinates for "${location}".`,
+    );
+  }
   return {
     name: place.name ?? location,
     country: place.country ?? "",
@@ -107,6 +112,11 @@ export async function _weather(
   }
   const data = await response.json();
   const current = data.current;
+  if (!current) {
+    throw new Error(
+      `Weather API returned no current data for "${location}".`,
+    );
+  }
 
   const weatherCode: number = current.weather_code ?? 0;
   const description = WMO_DESCRIPTIONS[weatherCode] ?? "Unknown";

--- a/stdlib/lib/weather.ts
+++ b/stdlib/lib/weather.ts
@@ -73,12 +73,14 @@ export type WeatherResult = {
   windDirection: number;
   precipitation: number;
   cloudCover: number;
-  units: string;
+  units: "metric" | "imperial";
 };
+
+const CURRENT_VARS = "temperature_2m,relative_humidity_2m,apparent_temperature,precipitation,weather_code,wind_speed_10m,wind_direction_10m,cloud_cover";
 
 export async function _weather(
   location: string,
-  units: string,
+  units: "metric" | "imperial",
 ): Promise<WeatherResult> {
   const geo = await _geocode(location);
 
@@ -87,22 +89,11 @@ export async function _weather(
   const windUnit = isImperial ? "mph" : "kmh";
   const precipUnit = isImperial ? "inch" : "mm";
 
-  const currentVars = [
-    "temperature_2m",
-    "relative_humidity_2m",
-    "apparent_temperature",
-    "precipitation",
-    "weather_code",
-    "wind_speed_10m",
-    "wind_direction_10m",
-    "cloud_cover",
-  ].join(",");
-
   const url =
     `https://api.open-meteo.com/v1/forecast` +
     `?latitude=${geo.latitude}` +
     `&longitude=${geo.longitude}` +
-    `&current=${currentVars}` +
+    `&current=${CURRENT_VARS}` +
     `&temperature_unit=${tempUnit}` +
     `&wind_speed_unit=${windUnit}` +
     `&precipitation_unit=${precipUnit}` +

--- a/stdlib/lib/weather.ts
+++ b/stdlib/lib/weather.ts
@@ -1,0 +1,138 @@
+const WMO_DESCRIPTIONS: Record<number, string> = {
+  0: "Clear sky",
+  1: "Mainly clear",
+  2: "Partly cloudy",
+  3: "Overcast",
+  45: "Fog",
+  48: "Depositing rime fog",
+  51: "Light drizzle",
+  53: "Moderate drizzle",
+  55: "Dense drizzle",
+  56: "Light freezing drizzle",
+  57: "Dense freezing drizzle",
+  61: "Slight rain",
+  63: "Moderate rain",
+  65: "Heavy rain",
+  66: "Light freezing rain",
+  67: "Heavy freezing rain",
+  71: "Slight snow fall",
+  73: "Moderate snow fall",
+  75: "Heavy snow fall",
+  77: "Snow grains",
+  80: "Slight rain showers",
+  81: "Moderate rain showers",
+  82: "Violent rain showers",
+  85: "Slight snow showers",
+  86: "Heavy snow showers",
+  95: "Thunderstorm",
+  96: "Thunderstorm with slight hail",
+  99: "Thunderstorm with heavy hail",
+};
+
+export type GeoResult = {
+  name: string;
+  country: string;
+  latitude: number;
+  longitude: number;
+};
+
+export async function _geocode(location: string): Promise<GeoResult> {
+  const url = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(location)}&count=1`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Geocoding failed for "${location}": ${response.status} ${response.statusText}`,
+    );
+  }
+  const data = await response.json();
+  const results = data.results;
+  if (!results || results.length === 0) {
+    throw new Error(
+      `No location found for "${location}". Try a different city name or zip code.`,
+    );
+  }
+  const place = results[0];
+  return {
+    name: place.name ?? location,
+    country: place.country ?? "",
+    latitude: place.latitude,
+    longitude: place.longitude,
+  };
+}
+
+export type WeatherResult = {
+  location: string;
+  country: string;
+  latitude: number;
+  longitude: number;
+  temperature: number;
+  feelsLike: number;
+  humidity: number;
+  description: string;
+  windSpeed: number;
+  windDirection: number;
+  precipitation: number;
+  cloudCover: number;
+  units: string;
+};
+
+export async function _weather(
+  location: string,
+  units: string,
+): Promise<WeatherResult> {
+  const geo = await _geocode(location);
+
+  const isImperial = units === "imperial";
+  const tempUnit = isImperial ? "fahrenheit" : "celsius";
+  const windUnit = isImperial ? "mph" : "kmh";
+  const precipUnit = isImperial ? "inch" : "mm";
+
+  const currentVars = [
+    "temperature_2m",
+    "relative_humidity_2m",
+    "apparent_temperature",
+    "precipitation",
+    "weather_code",
+    "wind_speed_10m",
+    "wind_direction_10m",
+    "cloud_cover",
+  ].join(",");
+
+  const url =
+    `https://api.open-meteo.com/v1/forecast` +
+    `?latitude=${geo.latitude}` +
+    `&longitude=${geo.longitude}` +
+    `&current=${currentVars}` +
+    `&temperature_unit=${tempUnit}` +
+    `&wind_speed_unit=${windUnit}` +
+    `&precipitation_unit=${precipUnit}` +
+    `&timezone=auto`;
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(
+      `Weather request failed for "${location}": ${response.status} ${response.statusText}`,
+    );
+  }
+  const data = await response.json();
+  const current = data.current;
+
+  const weatherCode: number = current.weather_code ?? 0;
+  const description = WMO_DESCRIPTIONS[weatherCode] ?? "Unknown";
+
+  return {
+    location: geo.name,
+    country: geo.country,
+    latitude: geo.latitude,
+    longitude: geo.longitude,
+    temperature: current.temperature_2m ?? 0,
+    feelsLike: current.apparent_temperature ?? 0,
+    humidity: current.relative_humidity_2m ?? 0,
+    description,
+    windSpeed: current.wind_speed_10m ?? 0,
+    windDirection: current.wind_direction_10m ?? 0,
+    precipitation: current.precipitation ?? 0,
+    cloudCover: current.cloud_cover ?? 0,
+    units,
+  };
+}

--- a/stdlib/weather.agency
+++ b/stdlib/weather.agency
@@ -28,5 +28,5 @@ export safe def weather(location: string, units: string = "metric"): Result {
   """
   Get current weather for a city name or zip code. Returns temperature, feels-like temperature, humidity, wind speed/direction, precipitation, cloud cover, and a weather description. Set units to "imperial" for Fahrenheit/mph or "metric" (default) for Celsius/km/h. Weather data provided by Open-Meteo (https://open-meteo.com), licensed under CC BY 4.0. Free API usage is for non-commercial purposes only.
   """
-  return try   _weather(location, units)
+  return try _weather(location, units)
 }

--- a/stdlib/weather.agency
+++ b/stdlib/weather.agency
@@ -1,0 +1,32 @@
+import { _weather } from "./lib/weather.js"
+type WeatherResult = {
+  location: string;
+  country: string;
+  latitude: number;
+  longitude: number;
+  temperature: number;
+  feelsLike: number;
+  humidity: number;
+  description: string;
+  windSpeed: number;
+  windDirection: number;
+  precipitation: number;
+  cloudCover: number;
+  units: string
+}
+
+/*
+  Usage from Agency code:
+  import { weather } from "std::weather"
+
+  node main() {
+    const w = weather("San Francisco")
+    print(w)
+  }
+*/
+export safe def weather(location: string, units: string = "metric"): Result {
+  """
+  Get current weather for a city name or zip code. Returns temperature, feels-like temperature, humidity, wind speed/direction, precipitation, cloud cover, and a weather description. Set units to "imperial" for Fahrenheit/mph or "metric" (default) for Celsius/km/h. Weather data provided by Open-Meteo (https://open-meteo.com), licensed under CC BY 4.0. Free API usage is for non-commercial purposes only.
+  """
+  return try   _weather(location, units)
+}


### PR DESCRIPTION
## Summary
- Adds `std::weather` module using the [Open-Meteo](https://open-meteo.com/) API (free, no API key required)
- Supports lookup by city name or zip code, returns current temperature, feels-like, humidity, wind, precipitation, cloud cover, and a human-readable weather description
- Supports metric (Celsius/km/h) and imperial (Fahrenheit/mph) units
- Adds Open-Meteo attribution to README per CC BY 4.0 license requirements

## Test plan
- [ ] Run `make stdlib` to verify the TypeScript backing file compiles
- [ ] Run `pnpm run ast stdlib/weather.agency` to verify the Agency file parses
- [ ] Test with `import { weather } from "std::weather"` in an Agency program using a city name
- [ ] Test with a zip code
- [ ] Test with `units: "imperial"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)