### PR TITLE
Add agency tests for all import styles

### DIFF
--- a/tests/agency/imports/agencyHelpers.agency
+++ b/tests/agency/imports/agencyHelpers.agency
@@ -1,0 +1,7 @@
+export def add(a: number, b: number): number {
+  return a + b
+}
+
+export def multiply(a: number, b: number): number {
+  return a * b
+}

--- a/tests/agency/imports/importStyles.agency
+++ b/tests/agency/imports/importStyles.agency
@@ -1,0 +1,39 @@
+import square from "./mathHelpers.js"
+import { double, triple } from "./mathHelpers.js"
+import * as strUtils from "./stringHelpers.js"
+import exclaim, { upper } from "./stringHelpers.js"
+import len, * as listHelpers from "./listHelpers.js"
+import { add, multiply } from "./agencyHelpers.agency"
+// default import from JS
+// named imports from JS
+// namespace import from JS
+// mixed: default + named import from JS
+// named import from agency file
+node testDefaultImport() {
+  return square(5)
+}
+
+node testNamedImport() {
+  return double(7) + triple(3)
+}
+
+node testNamespaceImport() {
+  return strUtils.lower("HELLO")
+}
+
+node testMixedDefaultNamed() {
+  return exclaim(upper("hello"))
+}
+
+node testAgencyNamedImport() {
+  return add(3, 4)
+}
+
+node testAgencyMultipleNamedImports() {
+  return multiply(add(2, 3), 4)
+}
+
+node testMixedDefaultNamespace() {
+  const items = [10, 20, 30]
+  return len(items) + listHelpers.first(items)
+}

--- a/tests/agency/imports/importStyles.agency
+++ b/tests/agency/imports/importStyles.agency
@@ -4,11 +4,7 @@ import * as strUtils from "./stringHelpers.js"
 import exclaim, { upper } from "./stringHelpers.js"
 import len, * as listHelpers from "./listHelpers.js"
 import { add, multiply } from "./agencyHelpers.agency"
-// default import from JS
-// named imports from JS
-// namespace import from JS
-// mixed: default + named import from JS
-// named import from agency file
+
 node testDefaultImport() {
   return square(5)
 }

--- a/tests/agency/imports/importStyles.test.json
+++ b/tests/agency/imports/importStyles.test.json
@@ -1,0 +1,81 @@
+{
+  "tests": [
+    {
+      "nodeName": "testDefaultImport",
+      "input": "",
+      "expectedOutput": "25",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "default import from JS file"
+    },
+    {
+      "nodeName": "testNamedImport",
+      "input": "",
+      "expectedOutput": "23",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "named imports from JS file"
+    },
+    {
+      "nodeName": "testNamespaceImport",
+      "input": "",
+      "expectedOutput": "\"hello\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "namespace import from JS file"
+    },
+    {
+      "nodeName": "testMixedDefaultNamed",
+      "input": "",
+      "expectedOutput": "\"HELLO!\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "mixed default + named import from JS file"
+    },
+    {
+      "nodeName": "testAgencyNamedImport",
+      "input": "",
+      "expectedOutput": "7",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "named import from agency file"
+    },
+    {
+      "nodeName": "testAgencyMultipleNamedImports",
+      "input": "",
+      "expectedOutput": "20",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "multiple named imports from agency file used together"
+    },
+    {
+      "nodeName": "testMixedDefaultNamespace",
+      "input": "",
+      "expectedOutput": "13",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "mixed default + namespace import from JS file"
+    }
+  ]
+}

--- a/tests/agency/imports/listHelpers.js
+++ b/tests/agency/imports/listHelpers.js
@@ -2,10 +2,6 @@ export function first(arr) {
   return arr[0];
 }
 
-export function last(arr) {
-  return arr[arr.length - 1];
-}
-
 function len(arr) {
   return arr.length;
 }

--- a/tests/agency/imports/listHelpers.js
+++ b/tests/agency/imports/listHelpers.js
@@ -1,0 +1,12 @@
+export function first(arr) {
+  return arr[0];
+}
+
+export function last(arr) {
+  return arr[arr.length - 1];
+}
+
+function len(arr) {
+  return arr.length;
+}
+export default len;

--- a/tests/agency/imports/mathHelpers.js
+++ b/tests/agency/imports/mathHelpers.js
@@ -1,0 +1,12 @@
+export function double(x) {
+  return x * 2;
+}
+
+export function triple(x) {
+  return x * 3;
+}
+
+function square(x) {
+  return x * x;
+}
+export default square;

--- a/tests/agency/imports/stringHelpers.js
+++ b/tests/agency/imports/stringHelpers.js
@@ -1,0 +1,12 @@
+export function upper(s) {
+  return s.toUpperCase();
+}
+
+export function lower(s) {
+  return s.toLowerCase();
+}
+
+function exclaim(s) {
+  return s + "!";
+}
+export default exclaim;


### PR DESCRIPTION
## Summary
- Adds tests covering all supported import styles: default, named, namespace (`* as`), mixed default+named, and mixed default+namespace from JS files, plus named imports from agency files
- Creates JS helper files (`mathHelpers.js`, `stringHelpers.js`, `listHelpers.js`) and an `agencyHelpers.agency` file as import targets
- All 7 tests are deterministic (pure math/string ops, no LLM calls)

## Test plan
- [x] All 7 tests pass via `pnpm run agency test tests/agency/imports/importStyles.test.json`
- [x] Verified the `.agency` file parses correctly via `pnpm run ast`
- [x] Verified compiled output uses correct JS import statements for each style
- [x] JS helper files are force-added past `*.js` gitignore (like existing `funcs.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)