### PR TITLE
Add stdlib test coverage for previously untested cases

### DIFF
--- a/stdlib/agent.agency
+++ b/stdlib/agent.agency
@@ -23,11 +23,12 @@ export safe def todoList(): Todo[] {
 
 export def question(prompt: string): string {
   """
-  Ask the user a question and wait for their reply. Unlike input(), this raises an interrupt so the host (CLI, web UI, etc.) can present the prompt in its own way.
+  Ask the user a question and wait for their reply. Unlike input(), this raises an interrupt so the host (CLI, web UI, etc.) can present the prompt in its own way; the host resolves the interrupt with the answer string.
   """
-  return interrupt({
+  let answer = interrupt({
     type: "std::question",
     message: prompt,
     prompt: prompt
   })
+  return answer
 }

--- a/stdlib/lib/shell.ts
+++ b/stdlib/lib/shell.ts
@@ -191,6 +191,20 @@ export function _glob(
 }
 
 function globToRegExp(glob: string): RegExp {
+  let depth = 0;
+  for (const c of glob) {
+    if (c === "{") depth++;
+    else if (c === "}") {
+      depth--;
+      if (depth < 0) {
+        throw new Error(`invalid glob pattern: unmatched '}' in ${glob}`);
+      }
+    }
+  }
+  if (depth !== 0) {
+    throw new Error(`invalid glob pattern: unmatched '{' in ${glob}`);
+  }
+
   const result = globParser(glob);
   if (!result.success || (result.rest ?? "") !== "") {
     throw new Error(`invalid glob pattern: ${glob}`);

--- a/stdlib/lib/shell.ts
+++ b/stdlib/lib/shell.ts
@@ -193,8 +193,14 @@ export function _glob(
 function globToRegExp(glob: string): RegExp {
   let depth = 0;
   for (const c of glob) {
-    if (c === "{") depth++;
-    else if (c === "}") {
+    if (c === "{") {
+      depth++;
+      if (depth > 1) {
+        throw new Error(
+          `invalid glob pattern: nested braces are not supported in ${glob}`,
+        );
+      }
+    } else if (c === "}") {
       depth--;
       if (depth < 0) {
         throw new Error(`invalid glob pattern: unmatched '}' in ${glob}`);

--- a/tests/agency-js/std-agent-question/agent.agency
+++ b/tests/agency-js/std-agent-question/agent.agency
@@ -1,0 +1,6 @@
+import { question } from "std::agent"
+
+node ask(prompt: string) {
+  const answer = question(prompt)
+  return answer
+}

--- a/tests/agency-js/std-agent-question/fixture.json
+++ b/tests/agency-js/std-agent-question/fixture.json
@@ -1,0 +1,4 @@
+{
+  "interrupted": true,
+  "resumedValue": "blue"
+}

--- a/tests/agency-js/std-agent-question/test.js
+++ b/tests/agency-js/std-agent-question/test.js
@@ -1,0 +1,17 @@
+import { writeFileSync } from "fs";
+import { ask, resolveInterrupt } from "./agent.js";
+
+const r = await ask("What is your favorite color?");
+const resumed = await resolveInterrupt(r.data, "blue");
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      interrupted: r.isInterrupt === true || r.data?.success === undefined,
+      resumedValue: resumed.data,
+    },
+    null,
+    2,
+  ),
+);

--- a/tests/agency-js/std-agent-question/test.js
+++ b/tests/agency-js/std-agent-question/test.js
@@ -1,14 +1,17 @@
 import { writeFileSync } from "fs";
-import { ask, resolveInterrupt } from "./agent.js";
+import { ask, isInterrupt, resolveInterrupt } from "./agent.js";
 
 const r = await ask("What is your favorite color?");
-const resumed = await resolveInterrupt(r.data, "blue");
+const interrupted = isInterrupt(r.data);
+const resumed = interrupted
+  ? await resolveInterrupt(r.data, "blue")
+  : { data: undefined };
 
 writeFileSync(
   "__result.json",
   JSON.stringify(
     {
-      interrupted: r.isInterrupt === true || r.data?.success === undefined,
+      interrupted,
       resumedValue: resumed.data,
     },
     null,

--- a/tests/agency-js/std-fs-edit-reject/agent.agency
+++ b/tests/agency-js/std-fs-edit-reject/agent.agency
@@ -1,20 +1,12 @@
 import { edit } from "std::fs"
 
 node writeFixture(filename: string, content: string) {
-  handle {
-    write(filename, content)
-  } with (data) {
-    return approve()
-  }
+  write(filename, content) with approve
   return true
 }
 
 node readBack(filename: string) {
-  handle {
-    const result = read(filename)
-  } with (data) {
-    return approve()
-  }
+  const result = read(filename) with approve
   return result
 }
 

--- a/tests/agency-js/std-fs-edit-reject/agent.agency
+++ b/tests/agency-js/std-fs-edit-reject/agent.agency
@@ -1,0 +1,24 @@
+import { edit } from "std::fs"
+
+node writeFixture(filename: string, content: string) {
+  handle {
+    write(filename, content)
+  } with (data) {
+    return approve()
+  }
+  return true
+}
+
+node readBack(filename: string) {
+  handle {
+    const result = read(filename)
+  } with (data) {
+    return approve()
+  }
+  return result
+}
+
+node runEdit(filename: string, oldText: string, newText: string, replaceAll: boolean) {
+  const result = edit(filename, oldText, newText, replaceAll)
+  return result
+}

--- a/tests/agency-js/std-fs-edit-reject/fixture.json
+++ b/tests/agency-js/std-fs-edit-reject/fixture.json
@@ -1,0 +1,4 @@
+{
+  "hadFailure": true,
+  "contentsUnchanged": true
+}

--- a/tests/agency-js/std-fs-edit-reject/test.js
+++ b/tests/agency-js/std-fs-edit-reject/test.js
@@ -1,0 +1,26 @@
+import { mkdtempSync, writeFileSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runEdit, rejectInterrupt } from "./agent.js";
+
+const TMP = mkdtempSync(join(tmpdir(), "agency-edit-reject-"));
+
+// Reject should short-circuit the edit: the failure comes back as a Result
+// and the file is never written to.
+const path = join(TMP, "reject.txt");
+writeFileSync(path, "alpha\n");
+const r = await runEdit(path, "alpha", "OMEGA", false);
+const rejected = await rejectInterrupt(r.data);
+const contents = readFileSync(path, "utf8");
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      hadFailure: rejected.data?.success === false,
+      contentsUnchanged: contents === "alpha\n",
+    },
+    null,
+    2,
+  ),
+);

--- a/tests/agency-js/std-fs-edit-reject/test.js
+++ b/tests/agency-js/std-fs-edit-reject/test.js
@@ -5,8 +5,6 @@ import { runEdit, rejectInterrupt } from "./agent.js";
 
 const TMP = mkdtempSync(join(tmpdir(), "agency-edit-reject-"));
 
-// Reject should short-circuit the edit: the failure comes back as a Result
-// and the file is never written to.
 const path = join(TMP, "reject.txt");
 writeFileSync(path, "alpha\n");
 const r = await runEdit(path, "alpha", "OMEGA", false);

--- a/tests/agency-js/std-fs-multiedit/agent.agency
+++ b/tests/agency-js/std-fs-multiedit/agent.agency
@@ -1,0 +1,34 @@
+import { multiedit } from "std::fs"
+
+node writeFixture(filename: string, content: string) {
+  handle {
+    write(filename, content)
+  } with (data) {
+    return approve()
+  }
+  return true
+}
+
+node readBack(filename: string) {
+  handle {
+    const result = read(filename)
+  } with (data) {
+    return approve()
+  }
+  return result
+}
+
+type Edit = {
+  oldText: string;
+  newText: string;
+  replaceAll: boolean
+}
+
+node runMultiedit(filename: string, edits: Edit[]) {
+  handle {
+    const result = multiedit(filename, edits)
+  } with (data) {
+    return approve()
+  }
+  return result
+}

--- a/tests/agency-js/std-fs-multiedit/agent.agency
+++ b/tests/agency-js/std-fs-multiedit/agent.agency
@@ -1,20 +1,12 @@
 import { multiedit } from "std::fs"
 
 node writeFixture(filename: string, content: string) {
-  handle {
-    write(filename, content)
-  } with (data) {
-    return approve()
-  }
+  write(filename, content) with approve
   return true
 }
 
 node readBack(filename: string) {
-  handle {
-    const result = read(filename)
-  } with (data) {
-    return approve()
-  }
+  const result = read(filename) with approve
   return result
 }
 
@@ -25,10 +17,6 @@ type Edit = {
 }
 
 node runMultiedit(filename: string, edits: Edit[]) {
-  handle {
-    const result = multiedit(filename, edits)
-  } with (data) {
-    return approve()
-  }
+  const result = multiedit(filename, edits) with approve
   return result
 }

--- a/tests/agency-js/std-fs-multiedit/fixture.json
+++ b/tests/agency-js/std-fs-multiedit/fixture.json
@@ -1,0 +1,18 @@
+{
+  "sequential": {
+    "ok": true,
+    "replacements": 2,
+    "contents": "X Y C\n"
+  },
+  "atomic": {
+    "ok": false,
+    "mentionsNotFound": true,
+    "contentsUnchanged": true
+  },
+  "empty": {
+    "ok": true,
+    "replacements": 0,
+    "edits": 0,
+    "contentsUnchanged": true
+  }
+}

--- a/tests/agency-js/std-fs-multiedit/test.js
+++ b/tests/agency-js/std-fs-multiedit/test.js
@@ -1,0 +1,65 @@
+import { mkdtempSync, writeFileSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { writeFixture, readBack, runMultiedit } from "./agent.js";
+
+const TMP = mkdtempSync(join(tmpdir(), "agency-multiedit-"));
+
+async function tryMultiedit(filename, edits) {
+  const r = await runMultiedit(filename, edits);
+  const result = r.data;
+  if (result && result.success === false) {
+    return { ok: false, error: String(result.error ?? "") };
+  }
+  return {
+    ok: true,
+    replacements: result.value.replacements,
+    edits: result.value.edits,
+  };
+}
+
+// --- Case 1: two sequential edits applied in order ---
+const seqPath = join(TMP, "sequential.txt");
+writeFileSync(seqPath, "A B C\n");
+const seqResult = await tryMultiedit(seqPath, [
+  { oldText: "A", newText: "X", replaceAll: false },
+  { oldText: "B", newText: "Y", replaceAll: false },
+]);
+const seqContents = (await readBack(seqPath)).data;
+
+// --- Case 2: atomicity - second edit fails, file unchanged ---
+const atomicPath = join(TMP, "atomic.txt");
+writeFileSync(atomicPath, "one two three\n");
+const atomicResult = await tryMultiedit(atomicPath, [
+  { oldText: "one", newText: "ONE", replaceAll: false },
+  { oldText: "MISSING", newText: "Z", replaceAll: false },
+]);
+const atomicContents = (await readBack(atomicPath)).data;
+
+// --- Case 3: empty edits array is a no-op ---
+const emptyPath = join(TMP, "empty.txt");
+writeFileSync(emptyPath, "unchanged\n");
+const emptyResult = await tryMultiedit(emptyPath, []);
+const emptyContents = (await readBack(emptyPath)).data;
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      sequential: { ok: seqResult.ok, replacements: seqResult.replacements, contents: seqContents },
+      atomic: {
+        ok: atomicResult.ok,
+        mentionsNotFound: /not found/.test(atomicResult.error ?? ""),
+        contentsUnchanged: atomicContents === "one two three\n",
+      },
+      empty: {
+        ok: emptyResult.ok,
+        replacements: emptyResult.replacements,
+        edits: emptyResult.edits,
+        contentsUnchanged: emptyContents === "unchanged\n",
+      },
+    },
+    null,
+    2,
+  ),
+);

--- a/tests/agency-js/std-fs-multiedit/test.js
+++ b/tests/agency-js/std-fs-multiedit/test.js
@@ -1,7 +1,7 @@
-import { mkdtempSync, writeFileSync, readFileSync } from "fs";
+import { mkdtempSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { writeFixture, readBack, runMultiedit } from "./agent.js";
+import { readBack, runMultiedit } from "./agent.js";
 
 const TMP = mkdtempSync(join(tmpdir(), "agency-multiedit-"));
 

--- a/tests/agency-js/std-shell-bash/agent.agency
+++ b/tests/agency-js/std-shell-bash/agent.agency
@@ -1,0 +1,10 @@
+import { bash } from "std::shell"
+
+node runBash(command: string, cwd: string, stdin: string) {
+  handle {
+    const result = bash(command, cwd, 0, stdin)
+  } with (data) {
+    return approve()
+  }
+  return result
+}

--- a/tests/agency-js/std-shell-bash/agent.agency
+++ b/tests/agency-js/std-shell-bash/agent.agency
@@ -1,10 +1,6 @@
 import { bash } from "std::shell"
 
 node runBash(command: string, cwd: string, stdin: string) {
-  handle {
-    const result = bash(command, cwd, 0, stdin)
-  } with (data) {
-    return approve()
-  }
+  const result = bash(command, cwd, 0, stdin) with approve
   return result
 }

--- a/tests/agency-js/std-shell-bash/fixture.json
+++ b/tests/agency-js/std-shell-bash/fixture.json
@@ -1,0 +1,18 @@
+{
+  "stdout": {
+    "stdout": "hello\n",
+    "exitCode": 0
+  },
+  "exit": {
+    "exitCode": 3,
+    "stdout": ""
+  },
+  "cwd": {
+    "matches": true,
+    "exitCode": 0
+  },
+  "stdin": {
+    "stdout": "piped-input",
+    "exitCode": 0
+  }
+}

--- a/tests/agency-js/std-shell-bash/test.js
+++ b/tests/agency-js/std-shell-bash/test.js
@@ -1,0 +1,39 @@
+import { mkdtempSync, realpathSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { runBash } from "./agent.js";
+
+const TMP = realpathSync(mkdtempSync(join(tmpdir(), "agency-bash-")));
+
+async function run(cmd, cwd = "", stdin = "") {
+  const r = await runBash(cmd, cwd, stdin);
+  return r.data;
+}
+
+// --- Case 1: stdout capture ---
+const stdoutCase = await run("echo hello");
+
+// --- Case 2: non-zero exit code ---
+const exitCase = await run("exit 3");
+
+// --- Case 3: cwd override ---
+// pwd -P prints the physical (symlink-resolved) path, matching what mkdtempSync
+// returns on macOS (where /tmp is a symlink to /private/tmp).
+const cwdCase = await run("pwd -P", TMP);
+
+// --- Case 4: stdin piping ---
+const stdinCase = await run("cat", "", "piped-input");
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      stdout: { stdout: stdoutCase.stdout, exitCode: stdoutCase.exitCode },
+      exit: { exitCode: exitCase.exitCode, stdout: exitCase.stdout },
+      cwd: { matches: cwdCase.stdout.trim() === TMP, exitCode: cwdCase.exitCode },
+      stdin: { stdout: stdinCase.stdout, exitCode: stdinCase.exitCode },
+    },
+    null,
+    2,
+  ),
+);

--- a/tests/agency/stdlib/glob-basic.agency
+++ b/tests/agency/stdlib/glob-basic.agency
@@ -1,11 +1,7 @@
 import { glob } from "std::shell"
 
 node main() {
-  handle {
-    const results = glob("**/*.{md,ts}", "tests/agency/stdlib/glob-fixtures") catch []
-  } with (data) {
-    return approve()
-  }
+  const results = glob("**/*.{md,ts}", "tests/agency/stdlib/glob-fixtures") catch [] with approve
   let sorted = sortBy(results) as r {
     return r
   }

--- a/tests/agency/stdlib/glob-malformed.agency
+++ b/tests/agency/stdlib/glob-malformed.agency
@@ -1,0 +1,13 @@
+import { glob } from "std::shell"
+
+node main() {
+  handle {
+    let result = glob("{ts", "tests/agency/stdlib/glob-fixtures")
+  } with (data) {
+    return approve()
+  }
+  return {
+    ok: isSuccess(result),
+    hasError: result.error != null
+  }
+}

--- a/tests/agency/stdlib/glob-malformed.agency
+++ b/tests/agency/stdlib/glob-malformed.agency
@@ -1,11 +1,7 @@
 import { glob } from "std::shell"
 
 node main() {
-  handle {
-    let result = glob("{ts", "tests/agency/stdlib/glob-fixtures")
-  } with (data) {
-    return approve()
-  }
+  let result = glob("{ts", "tests/agency/stdlib/glob-fixtures") with approve
   return {
     ok: isSuccess(result),
     hasError: result.error != null

--- a/tests/agency/stdlib/glob-malformed.test.json
+++ b/tests/agency/stdlib/glob-malformed.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"ok\":false,\"hasError\":true}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "glob with an unclosed brace returns a failure"
+    }
+  ]
+}

--- a/tests/agency/stdlib/glob-no-match.agency
+++ b/tests/agency/stdlib/glob-no-match.agency
@@ -1,11 +1,7 @@
 import { glob } from "std::shell"
 
 node main() {
-  handle {
-    let result = glob("*.xyz", "tests/agency/stdlib/glob-fixtures")
-  } with (data) {
-    return approve()
-  }
+  let result = glob("*.xyz", "tests/agency/stdlib/glob-fixtures") with approve
   if (isSuccess(result)) {
     return { ok: true, count: result.value.length }
   }

--- a/tests/agency/stdlib/glob-question.agency
+++ b/tests/agency/stdlib/glob-question.agency
@@ -1,11 +1,7 @@
 import { glob } from "std::shell"
 
 node main() {
-  handle {
-    const results = glob("?.md", "tests/agency/stdlib/glob-fixtures") catch []
-  } with (data) {
-    return approve()
-  }
+  const results = glob("?.md", "tests/agency/stdlib/glob-fixtures") catch [] with approve
   let sorted = sortBy(results) as r {
     return r
   }

--- a/tests/agency/stdlib/glob-single-star.agency
+++ b/tests/agency/stdlib/glob-single-star.agency
@@ -1,11 +1,7 @@
 import { glob } from "std::shell"
 
 node main() {
-  handle {
-    const results = glob("*.md", "tests/agency/stdlib/glob-fixtures") catch []
-  } with (data) {
-    return approve()
-  }
+  const results = glob("*.md", "tests/agency/stdlib/glob-fixtures") catch [] with approve
   let sorted = sortBy(results) as r {
     return r
   }

--- a/tests/agency/stdlib/grep-basic.agency
+++ b/tests/agency/stdlib/grep-basic.agency
@@ -1,11 +1,7 @@
 import { grep } from "std::shell"
 
 node main() {
-  handle {
-    const hits = grep("hello", "tests/agency/stdlib/grep-fixtures", "i", 100) catch []
-  } with (data) {
-    return approve()
-  }
+  const hits = grep("hello", "tests/agency/stdlib/grep-fixtures", "i", 100) catch [] with approve
   let sorted = sortBy(hits) as h {
     return "${h.file}:${h.line}"
   }

--- a/tests/agency/stdlib/grep-max-results.agency
+++ b/tests/agency/stdlib/grep-max-results.agency
@@ -1,0 +1,10 @@
+import { grep } from "std::shell"
+
+node main() {
+  handle {
+    const hits = grep("hello", "tests/agency/stdlib/grep-fixtures", "i", 2) catch []
+  } with (data) {
+    return approve()
+  }
+  return hits.length
+}

--- a/tests/agency/stdlib/grep-max-results.agency
+++ b/tests/agency/stdlib/grep-max-results.agency
@@ -1,10 +1,6 @@
 import { grep } from "std::shell"
 
 node main() {
-  handle {
-    const hits = grep("hello", "tests/agency/stdlib/grep-fixtures", "i", 2) catch []
-  } with (data) {
-    return approve()
-  }
+  const hits = grep("hello", "tests/agency/stdlib/grep-fixtures", "i", 2) catch [] with approve
   return hits.length
 }

--- a/tests/agency/stdlib/grep-max-results.test.json
+++ b/tests/agency/stdlib/grep-max-results.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "2",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "grep stops returning results once maxResults is reached (fixtures contain 3 case-insensitive matches for 'hello', maxResults=2)"
+    }
+  ]
+}

--- a/tests/agency/stdlib/ls-basic.agency
+++ b/tests/agency/stdlib/ls-basic.agency
@@ -1,11 +1,7 @@
 import { ls } from "std::shell"
 
 node main() {
-  handle {
-    const entries = ls("tests/agency/stdlib/glob-fixtures", false) catch []
-  } with (data) {
-    return approve()
-  }
+  const entries = ls("tests/agency/stdlib/glob-fixtures", false) catch [] with approve
   let sortedNames = sortBy(entries) as e {
     return e.name
   }

--- a/tests/agency/stdlib/ls-missing.agency
+++ b/tests/agency/stdlib/ls-missing.agency
@@ -1,0 +1,13 @@
+import { ls } from "std::shell"
+
+node main() {
+  handle {
+    let result = ls("tests/agency/stdlib/does-not-exist", false)
+  } with (data) {
+    return approve()
+  }
+  return {
+    ok: isSuccess(result),
+    hasError: isFailure(result)
+  }
+}

--- a/tests/agency/stdlib/ls-missing.agency
+++ b/tests/agency/stdlib/ls-missing.agency
@@ -1,11 +1,7 @@
 import { ls } from "std::shell"
 
 node main() {
-  handle {
-    let result = ls("tests/agency/stdlib/does-not-exist", false)
-  } with (data) {
-    return approve()
-  }
+  let result = ls("tests/agency/stdlib/does-not-exist", false) with approve
   return {
     ok: isSuccess(result),
     hasError: isFailure(result)

--- a/tests/agency/stdlib/ls-missing.test.json
+++ b/tests/agency/stdlib/ls-missing.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"ok\":false,\"hasError\":true}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "ls on a missing directory returns a failure"
+    }
+  ]
+}

--- a/tests/agency/stdlib/ls-recursive.agency
+++ b/tests/agency/stdlib/ls-recursive.agency
@@ -1,0 +1,16 @@
+import { ls } from "std::shell"
+
+node main() {
+  handle {
+    const entries = ls("tests/agency/stdlib/glob-fixtures", true) catch []
+  } with (data) {
+    return approve()
+  }
+  let sorted = sortBy(entries) as e {
+    return e.path
+  }
+  let paths = map(sorted) as e {
+    return e.path
+  }
+  return paths
+}

--- a/tests/agency/stdlib/ls-recursive.agency
+++ b/tests/agency/stdlib/ls-recursive.agency
@@ -1,11 +1,7 @@
 import { ls } from "std::shell"
 
 node main() {
-  handle {
-    const entries = ls("tests/agency/stdlib/glob-fixtures", true) catch []
-  } with (data) {
-    return approve()
-  }
+  const entries = ls("tests/agency/stdlib/glob-fixtures", true) catch [] with approve
   let sorted = sortBy(entries) as e {
     return e.path
   }

--- a/tests/agency/stdlib/ls-recursive.test.json
+++ b/tests/agency/stdlib/ls-recursive.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[\"tests/agency/stdlib/glob-fixtures/a.md\",\"tests/agency/stdlib/glob-fixtures/ab.md\",\"tests/agency/stdlib/glob-fixtures/b.txt\",\"tests/agency/stdlib/glob-fixtures/c.js\",\"tests/agency/stdlib/glob-fixtures/d.ts\",\"tests/agency/stdlib/glob-fixtures/sub\",\"tests/agency/stdlib/glob-fixtures/sub/nested.md\",\"tests/agency/stdlib/glob-fixtures/sub/nested.ts\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "ls with recursive=true walks into subdirectories"
+    }
+  ]
+}

--- a/tests/agency/stdlib/stat-dir.agency
+++ b/tests/agency/stdlib/stat-dir.agency
@@ -1,0 +1,9 @@
+import { stat } from "std::shell"
+
+node main() {
+  let info = stat("tests/agency/stdlib/glob-fixtures")
+  return {
+    exists: info.exists,
+    type: info.type
+  }
+}

--- a/tests/agency/stdlib/stat-dir.test.json
+++ b/tests/agency/stdlib/stat-dir.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"exists\":true,\"type\":\"dir\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "stat on a directory returns type='dir'"
+    }
+  ]
+}

--- a/tests/agency/stdlib/todo-reset.agency
+++ b/tests/agency/stdlib/todo-reset.agency
@@ -1,0 +1,14 @@
+import { todoWrite, todoList } from "std::agent"
+
+node main() {
+  todoWrite([
+    { id: "1", text: "initial", status: "pending" }
+  ])
+  const before = todoList()
+  todoWrite([])
+  const after = todoList()
+  return {
+    beforeCount: before.length,
+    afterCount: after.length
+  }
+}

--- a/tests/agency/stdlib/todo-reset.test.json
+++ b/tests/agency/stdlib/todo-reset.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"beforeCount\":1,\"afterCount\":0}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "todoWrite with an empty array resets the todo list"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fills in the untested-cases list from the previous PR review.

### Pure-agency tests (`tests/agency/stdlib/`)
- `ls-recursive` / `ls-missing`
- `stat-dir`
- `grep-max-results`
- `glob-malformed` (unclosed brace)
- `todo-reset` (empty-array reset)

### Agency-js tests (`tests/agency-js/`)
- `std-fs-multiedit` — sequential edits, atomicity on failure, empty-edits no-op
- `std-shell-bash` — stdout/exit/cwd/stdin
- `std-agent-question` — `resolveInterrupt` provides the answer
- `std-fs-edit-reject` — `rejectInterrupt` returns a failure and leaves the file untouched

Scratch directories use `fs.mkdtempSync(os.tmpdir(), ...)` so there's **no `rm` cleanup** and no collision between runs.

### Fixes found while writing tests
- `stdlib/lib/shell.ts` — `globToRegExp` now rejects unbalanced `{`/`}` instead of silently treating them as literals. Without this, the `glob-malformed` failure case had no way to surface.
- `stdlib/agent.agency` — `question` now assigns the interrupt result to a variable and returns it. A bare `return interrupt({...})` makes the runtime reject `resolveInterrupt` with `"Interrupt response of type 'resolve' cannot be returned from an interrupt call"`.

### Skipped
- Interrupt `modify()` against a direct Agency function interrupt: `respondToInterrupt`'s modify branch reads `interruptData.toolCall.arguments`, which is only populated for LLM-emitted tool-call interrupts. Testing modify requires a real LLM tool call, which is outside this wave.
- `std::http` (real network), symlink handling in `stat`/`ls` (OS-specific), `grep` 5 MB-skip (awkward fixture), `webfetch` HTML conversion (exporting a private helper just for tests).

## Test plan
- [x] `pnpm run test:run` — 1828 passing, 21 skipped, no regressions
- [x] `node ./dist/scripts/agency.js test tests/agency/stdlib` — 26/26 pass
- [x] `node ./dist/scripts/agency.js test js tests/agency-js` — all new tests pass (the only failure is the pre-existing LLM-backed `tool-retry`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
