### PR TITLE
Show colored diffs on test failures

### DIFF
--- a/lib/cli/test.ts
+++ b/lib/cli/test.ts
@@ -16,6 +16,7 @@ import {
   promptForTarget,
 } from "./util.js";
 import { color } from "@/utils/termcolors.js";
+import { formatDiff } from "@/utils/diff.js";
 import { AgencyConfig } from "@/config.js";
 import path from "path";
 import { compile, loadConfig } from "./commands.js";
@@ -431,8 +432,7 @@ async function runSingleTest(
         log(color.green("  ✓ Exact match passed"));
       } else {
         log(color.red("  ✗ Exact match failed"));
-        log("    Expected: " + testCase.expectedOutput);
-        log("    Actual:   " + actual);
+        log(formatDiff(testCase.expectedOutput, actual));
         testPassed = false;
       }
     } else if (criterion.type === "llmJudge") {
@@ -718,8 +718,10 @@ async function runTsTestDir(
       return { success: true, dir };
     } else {
       log(color.red(`  ✗ Fixture match failed`));
-      log("    Expected: " + JSON.stringify(expectedParsed, null, 2));
-      log("    Actual:   " + JSON.stringify(resultParsed, null, 2));
+      log(formatDiff(
+        JSON.stringify(expectedParsed, null, 2),
+        JSON.stringify(resultParsed, null, 2),
+      ));
       return { success: false, dir };
     }
   } finally {

--- a/lib/utils/diff.test.ts
+++ b/lib/utils/diff.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { formatDiff } from "./diff.js";
+import { color } from "./termcolors.js";
+
+describe("formatDiff", () => {
+  it("returns all dim text for identical strings", () => {
+    const result = formatDiff("hello", "hello");
+    expect(result).toContain("hello");
+    expect(result).not.toContain("- ");
+    expect(result).not.toContain("+ ");
+  });
+
+  it("shows deletions in red and insertions in green", () => {
+    const result = formatDiff("alice", "bob");
+    expect(result).toContain(color.red("- alice"));
+    expect(result).toContain(color.green("+ bob"));
+  });
+
+  it("shows unchanged parts as dim", () => {
+    const result = formatDiff("hello world", "hello there");
+    expect(result).toContain(color.dim("  hello "));
+  });
+
+  it("handles multiline diffs", () => {
+    const expected = "line1\nline2\nline3";
+    const actual = "line1\nchanged\nline3";
+    const result = formatDiff(expected, actual);
+    expect(result).toContain(color.red("- line2"));
+    expect(result).toContain(color.green("+ changed"));
+  });
+
+  it("handles empty expected string", () => {
+    const result = formatDiff("", "new content");
+    expect(result).toContain(color.green("+ new content"));
+    expect(result).not.toContain("- ");
+  });
+
+  it("handles empty actual string", () => {
+    const result = formatDiff("old content", "");
+    expect(result).toContain(color.red("- old content"));
+    expect(result).not.toContain("+ ");
+  });
+
+  it("handles both strings empty", () => {
+    const result = formatDiff("", "");
+    expect(result).toBe("");
+  });
+
+  it("works with JSON-like fixture output", () => {
+    const expected = JSON.stringify({ name: "Alice", age: 30 }, null, 2);
+    const actual = JSON.stringify({ name: "Bob", age: 30 }, null, 2);
+    const result = formatDiff(expected, actual);
+    expect(result).toContain(color.red("- Alice"));
+    expect(result).toContain(color.green("+ Bob"));
+    // age is unchanged
+    expect(result).toContain("30");
+  });
+});

--- a/lib/utils/diff.ts
+++ b/lib/utils/diff.ts
@@ -5,14 +5,15 @@ const DIFF_DELETE = -1;
 const DIFF_INSERT = 1;
 const DIFF_EQUAL = 0;
 
+const dmp = new DiffMatchPatch();
+
 /**
  * Formats a colored, line-based diff between two strings.
  * Deletions (expected) are shown in red with a "-" prefix.
  * Insertions (actual) are shown in green with a "+" prefix.
- * Equal lines are shown dimmed with a " " prefix.
+ * Equal lines are shown dimmed with a "  " prefix.
  */
 export function formatDiff(expected: string, actual: string): string {
-  const dmp = new DiffMatchPatch();
   const diffs = dmp.diff_main(expected, actual);
   dmp.diff_cleanupSemantic(diffs);
 
@@ -28,10 +29,6 @@ export function formatDiff(expected: string, actual: string): string {
         lines.push(color.green(`+ ${part}`));
       } else {
         lines.push(color.dim(`  ${part}`));
-      }
-      // Add a newline marker between parts (but not after the last one)
-      if (i < parts.length - 1) {
-        lines.push("");
       }
     }
   }

--- a/lib/utils/diff.ts
+++ b/lib/utils/diff.ts
@@ -1,0 +1,39 @@
+import DiffMatchPatch from "diff-match-patch";
+import { color } from "./termcolors.js";
+
+const DIFF_DELETE = -1;
+const DIFF_INSERT = 1;
+const DIFF_EQUAL = 0;
+
+/**
+ * Formats a colored, line-based diff between two strings.
+ * Deletions (expected) are shown in red with a "-" prefix.
+ * Insertions (actual) are shown in green with a "+" prefix.
+ * Equal lines are shown dimmed with a " " prefix.
+ */
+export function formatDiff(expected: string, actual: string): string {
+  const dmp = new DiffMatchPatch();
+  const diffs = dmp.diff_main(expected, actual);
+  dmp.diff_cleanupSemantic(diffs);
+
+  const lines: string[] = [];
+  for (const [op, text] of diffs) {
+    // Split text into individual lines to get per-line prefixes
+    const parts = text.split("\n");
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i];
+      if (op === DIFF_DELETE) {
+        lines.push(color.red(`- ${part}`));
+      } else if (op === DIFF_INSERT) {
+        lines.push(color.green(`+ ${part}`));
+      } else {
+        lines.push(color.dim(`  ${part}`));
+      }
+      // Add a newline marker between parts (but not after the last one)
+      if (i < parts.length - 1) {
+        lines.push("");
+      }
+    }
+  }
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
- Replace raw "Expected: ... / Actual: ..." output with colored line-based diffs when agency or JS fixture tests fail
- Add `lib/utils/diff.ts` utility using `diff-match-patch` for diffing and `termcolors` for coloring (red deletions, green insertions, dim unchanged)
- Apply to both `runSingleTest` (agency exact match) and `runTsTestDir` (JS fixture match)

## Test plan
- [x] Unit tests added in `lib/utils/diff.test.ts` (8 tests covering identical strings, insertions, deletions, multiline, empty strings, JSON fixtures)
- [ ] Manually trigger a test failure and verify the diff output is readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)