### PR TITLE
Add export/import support for types across agency files

### DIFF
--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -392,7 +392,8 @@ export class AgencyGenerator {
   protected processTypeAlias(node: TypeAlias): string {
     this.typeAliases[node.aliasName] = node.aliasedType;
     const aliasedTypeStr = this.aliasedTypeToString(node.aliasedType);
-    return this.indentStr(`type ${node.aliasName} = ${aliasedTypeStr}`);
+    const exportPrefix = node.exported ? "export " : "";
+    return this.indentStr(`${exportPrefix}type ${node.aliasName} = ${aliasedTypeStr}`);
   }
 
   // Assignment and literals

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -793,8 +793,9 @@ export class TypeScriptBuilder {
   // ------- Type system (side effects only) -------
 
   private processTypeAlias(node: TypeAlias): TsNode {
+    const exportPrefix = node.exported ? "export " : "";
     return ts.raw(
-      `type ${node.aliasName} = ${formatTypeHint(node.aliasedType)};`,
+      `${exportPrefix}type ${node.aliasName} = ${formatTypeHint(node.aliasedType)};`,
     );
   }
 

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -852,7 +852,31 @@ export const variableTypeParser: Parser<VariableType> = trace(
   ),
 );
 
-export const typeAliasParser: Parser<TypeAlias> = label("a type alias", withLoc(trace(
+const exportedTypeAliasParser: Parser<TypeAlias> = withLoc(trace(
+  "exportedTypeAliasParser",
+  seqC(
+    set("type", "typeAlias"),
+    set("exported", true),
+    str("export"),
+    spaces,
+    str("type"),
+    spaces,
+    captureCaptures(
+      parseError(
+        "expected a statement of the form `export type Foo = X'`",
+        capture(many1WithJoin(varNameChar), "aliasName"),
+        optionalSpaces,
+        str("="),
+        optionalSpaces,
+        capture(variableTypeParser, "aliasedType"),
+        optionalSemicolon,
+        optionalSpacesOrNewline,
+      ),
+    ),
+  ),
+));
+
+const plainTypeAliasParser: Parser<TypeAlias> = withLoc(trace(
   "typeAliasParser",
   seqC(
     set("type", "typeAlias"),
@@ -871,7 +895,11 @@ export const typeAliasParser: Parser<TypeAlias> = label("a type alias", withLoc(
       ),
     ),
   ),
-)));
+));
+
+export const typeAliasParser: Parser<TypeAlias> = label("a type alias",
+  or(exportedTypeAliasParser, plainTypeAliasParser),
+);
 
 // =============================================================================
 // keyword.ts

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -852,31 +852,7 @@ export const variableTypeParser: Parser<VariableType> = trace(
   ),
 );
 
-const exportedTypeAliasParser: Parser<TypeAlias> = withLoc(trace(
-  "exportedTypeAliasParser",
-  seqC(
-    set("type", "typeAlias"),
-    set("exported", true),
-    str("export"),
-    spaces,
-    str("type"),
-    spaces,
-    captureCaptures(
-      parseError(
-        "expected a statement of the form `export type Foo = X'`",
-        capture(many1WithJoin(varNameChar), "aliasName"),
-        optionalSpaces,
-        str("="),
-        optionalSpaces,
-        capture(variableTypeParser, "aliasedType"),
-        optionalSemicolon,
-        optionalSpacesOrNewline,
-      ),
-    ),
-  ),
-));
-
-const plainTypeAliasParser: Parser<TypeAlias> = withLoc(trace(
+const baseTypeAliasParser: Parser<TypeAlias> = withLoc(trace(
   "typeAliasParser",
   seqC(
     set("type", "typeAlias"),
@@ -898,7 +874,18 @@ const plainTypeAliasParser: Parser<TypeAlias> = withLoc(trace(
 ));
 
 export const typeAliasParser: Parser<TypeAlias> = label("a type alias",
-  or(exportedTypeAliasParser, plainTypeAliasParser),
+  (input: string) => {
+    const exportResult = exportKeywordParser(input);
+    if (!exportResult.success) return exportResult;
+    const isExported = exportResult.result;
+
+    const baseResult = baseTypeAliasParser(exportResult.rest);
+    if (!baseResult.success) return baseResult;
+
+    const result = { ...baseResult.result };
+    if (isExported) result.exported = true;
+    return { ...baseResult, result };
+  },
 );
 
 // =============================================================================

--- a/lib/preprocessors/importResolver.test.ts
+++ b/lib/preprocessors/importResolver.test.ts
@@ -64,7 +64,7 @@ describe("resolveImports", () => {
     };
     const symbolTable: SymbolTable = {
       "/project/types.agency": {
-        Config: { kind: "type", name: "Config" },
+        Config: { kind: "type", name: "Config", exported: true },
       },
     };
     const result = resolveImports(program, symbolTable, "/project/main.agency");
@@ -88,7 +88,7 @@ describe("resolveImports", () => {
       "/project/mixed.agency": {
         greet: { kind: "node", name: "greet" },
         add: { kind: "function", name: "add", exported: true },
-        Config: { kind: "type", name: "Config" },
+        Config: { kind: "type", name: "Config", exported: true },
       },
     };
     const result = resolveImports(program, symbolTable, "/project/main.agency");
@@ -163,7 +163,7 @@ describe("resolveImports", () => {
     };
     const symbolTable: SymbolTable = {
       "/project/types.agency": {
-        Config: { kind: "type", name: "Config" },
+        Config: { kind: "type", name: "Config", exported: true },
       },
     };
     const result = resolveImports(program, symbolTable, "/project/main.agency");
@@ -199,7 +199,7 @@ describe("resolveImports", () => {
     const symbolTable: SymbolTable = {
       "/project/mixed.agency": {
         add: { kind: "function", name: "add", exported: true },
-        Config: { kind: "type", name: "Config" },
+        Config: { kind: "type", name: "Config", exported: true },
       },
     };
     const result = resolveImports(program, symbolTable, "/project/main.agency");

--- a/lib/preprocessors/importResolver.ts
+++ b/lib/preprocessors/importResolver.ts
@@ -17,10 +17,10 @@ import { resolveAgencyImportPath, isAgencyImport } from "../importPaths.js";
  * (.agency files, std:: imports, or pkg:: imports).
  * Leaves import node / import tool statements and non-Agency imports untouched.
  */
-function assertExported(name: string, modulePath: string, exported?: boolean): void {
+function assertExported(name: string, modulePath: string, exported?: boolean, symbolKind = "Function"): void {
   if (!exported) {
     throw new Error(
-      `Function '${name}' in '${modulePath}' is not exported. Add the 'export' keyword to its definition.`,
+      `${symbolKind} '${name}' in '${modulePath}' is not exported. Add the 'export' keyword to its definition.`,
     );
   }
 }
@@ -104,6 +104,7 @@ export function resolveImports(
             }
             break;
           case "type":
+            assertExported(name, node.modulePath, symbol.exported, "Type");
             typeNames.push(name);
             break;
         }

--- a/lib/programInfo.ts
+++ b/lib/programInfo.ts
@@ -177,5 +177,27 @@ export function collectProgramInfo(
     }
   }
 
+  // Collect type definitions from imported agency files via the symbol table.
+  // This makes imported types available for Zod schema generation in LLM calls.
+  if (symbolTable) {
+    for (const importStmt of info.importStatements) {
+      for (const nameType of importStmt.importedNames) {
+        if (nameType.type !== "namedImport") continue;
+        for (const name of nameType.importedNames) {
+          const localName = nameType.aliases[name] ?? name;
+          // Look up the type definition in any file's symbols
+          for (const fileSymbols of Object.values(symbolTable)) {
+            const symbol = fileSymbols[name];
+            if (symbol?.kind === "type" && symbol.aliasedType) {
+              ensureScope(info.typeAliases, GLOBAL_SCOPE_KEY)[localName] =
+                symbol.aliasedType;
+              break;
+            }
+          }
+        }
+      }
+    }
+  }
+
   return info;
 }

--- a/lib/symbolTable.test.ts
+++ b/lib/symbolTable.test.ts
@@ -32,7 +32,7 @@ def add(a: number, b: number) {
     const symbols = parseAndClassify(`
 type Greeting = string
 `);
-    expect(symbols.Greeting).toEqual({ kind: "type", name: "Greeting" });
+    expect(symbols.Greeting).toMatchObject({ kind: "type", name: "Greeting" });
   });
 
   it("classifies multiple symbols from one file", () => {
@@ -47,7 +47,7 @@ node main() {
   return helper()
 }
 `);
-    expect(symbols.Config).toEqual({ kind: "type", name: "Config" });
+    expect(symbols.Config).toMatchObject({ kind: "type", name: "Config" });
     expect(symbols.helper).toMatchObject({ kind: "function", name: "helper" });
     expect(symbols.main).toEqual({ kind: "node", name: "main" });
   });
@@ -59,7 +59,7 @@ def myFunc() {
   return 1
 }
 `);
-    expect(symbols.Inner).toEqual({ kind: "type", name: "Inner" });
+    expect(symbols.Inner).toMatchObject({ kind: "type", name: "Inner" });
     expect(symbols.myFunc).toMatchObject({ kind: "function", name: "myFunc" });
   });
 });

--- a/lib/symbolTable.ts
+++ b/lib/symbolTable.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { parseAgency } from "./parser.js";
 import type { AgencyConfig } from "./config.js";
-import type { AgencyProgram, FunctionParameter } from "./types.js";
+import type { AgencyProgram, FunctionParameter, VariableType } from "./types.js";
 import { walkNodes } from "./utils/node.js";
 import { resolveAgencyImportPath, isAgencyImport, getStdlibDir } from "./importPaths.js";
 
@@ -14,6 +14,7 @@ export type SymbolInfo = {
   safe?: boolean;
   exported?: boolean;
   parameters?: FunctionParameter[];
+  aliasedType?: VariableType;
 };
 
 /** Maps symbol name → info for a single file. */
@@ -44,7 +45,12 @@ export function classifySymbols(program: AgencyProgram): FileSymbols {
         };
         break;
       case "typeAlias":
-        symbols[node.aliasName] = { kind: "type", name: node.aliasName };
+        symbols[node.aliasName] = {
+          kind: "type",
+          name: node.aliasName,
+          exported: node.exported,
+          aliasedType: node.aliasedType,
+        };
         break;
       case "classDefinition":
         symbols[node.className] = { kind: "class", name: node.className };

--- a/lib/types/typeHints.ts
+++ b/lib/types/typeHints.ts
@@ -69,6 +69,7 @@ export type TypeAlias = BaseNode & {
   type: "typeAlias";
   aliasName: string;
   aliasedType: VariableType;
+  exported?: boolean;
 };
 
 export type TypeAliasVariable = {

--- a/tests/agency/imports/agencyHelpers.agency
+++ b/tests/agency/imports/agencyHelpers.agency
@@ -5,3 +5,7 @@ export def add(a: number, b: number): number {
 export def multiply(a: number, b: number): number {
   return a * b
 }
+
+export type MathResult = {
+  answer: number
+}

--- a/tests/agency/imports/typeImport.agency
+++ b/tests/agency/imports/typeImport.agency
@@ -1,0 +1,6 @@
+import { MathResult } from "./agencyHelpers.agency"
+
+node testTypeImport() {
+  const response: MathResult = llm("What is 2 + 3? Return the answer as a number.")
+  return response
+}

--- a/tests/agency/imports/typeImport.test.json
+++ b/tests/agency/imports/typeImport.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "testTypeImport",
+      "input": "",
+      "expectedOutput": "{\"answer\":5}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "imported type used as structured LLM response"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `export type Foo = { ... }` syntax so types can be exported from agency files
- Imported types are resolved via the symbol table and made available for Zod schema generation, so they work as structured output in LLM calls
- Import resolver now validates that imported types are marked `export`

## Changes
- **AST**: `exported?: boolean` on `TypeAlias`
- **Parser**: New `exportedTypeAliasParser` handles `export type Foo = ...`
- **Symbol table**: Stores `exported` flag and `aliasedType` on type symbols
- **Import resolver**: `assertExported` validation for type imports
- **Program info**: Collects type definitions from imported files into `typeAliases` for Zod schema generation
- **Builder/generator**: Emit `export type` when exported

## Test plan
- [x] All 1852 unit tests pass
- [x] All 9 existing agency import tests pass
- [x] New agency execution test: imports `MathResult` type from another file, uses it as structured LLM output, verifies exact match `{"answer": 5}`
- [x] Fixtures regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)