### PR TITLE
Add optional chaining (?.) and nullish coalescing (??) operators

### DIFF
--- a/docs-new/guide/basic-syntax.md
+++ b/docs-new/guide/basic-syntax.md
@@ -49,3 +49,19 @@ for (const name of names) {
   print(name)
 }
 ```
+
+You can have single-line or multi-line comments.
+
+```ts
+// This is a single-line comment
+/*
+This is a multi-line comment
+*/
+```
+
+> Note: comments must be on their own line, they cannot be at the end of a line containing code.
+
+### JavaScript features that don't exist in Agency
+- lambdas
+- async/await. Everything is awaited by default, and there are specific constructs for async, such as [fork](./fork/)
+- custom constructors for [classes](./classes/). A default constructor is generated for you.

--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -1029,8 +1029,10 @@ export class AgencyGenerator {
     switch (node.kind) {
       case "property":
         return `${dot}${node.name}`;
-      case "index":
-        return node.optional ? `?.[${this.processNode(node.index).trim()}]` : `[${this.processNode(node.index).trim()}]`;
+      case "index": {
+        const inner = this.processNode(node.index).trim();
+        return node.optional ? `?.[${inner}]` : `[${inner}]`;
+      }
       case "methodCall":
         return `${dot}${this.generateFunctionCallExpression(node.functionCall, "valueAccess")}`;
       default:

--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -1025,13 +1025,14 @@ export class AgencyGenerator {
   }
 
   protected processAccessChainElement(node: AccessChainElement): string {
+    const dot = node.optional ? "?." : ".";
     switch (node.kind) {
       case "property":
-        return `.${node.name}`;
+        return `${dot}${node.name}`;
       case "index":
-        return `[${this.processNode(node.index).trim()}]`;
+        return node.optional ? `?.[${this.processNode(node.index).trim()}]` : `[${this.processNode(node.index).trim()}]`;
       case "methodCall":
-        return `.${this.generateFunctionCallExpression(node.functionCall, "valueAccess")}`;
+        return `${dot}${this.generateFunctionCallExpression(node.functionCall, "valueAccess")}`;
       default:
         throw new Error(
           `Unknown access chain element kind: ${(node as any).kind}`,

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -897,16 +897,17 @@ export class TypeScriptBuilder {
     for (const element of node.chain) {
       switch (element.kind) {
         case "property":
-          result = ts.prop(result, element.name);
+          result = ts.prop(result, element.name, { optional: element.optional });
           break;
         case "index":
-          result = ts.index(result, this.processNode(element.index));
+          result = ts.index(result, this.processNode(element.index), { optional: element.optional });
           break;
         case "methodCall": {
           const callNode = this.generateFunctionCallExpression(
             element.functionCall,
             "valueAccess",
           );
+          const dot = element.optional ? "?." : ".";
           // The call node is ts.call(ts.id(name), args) — extract callee name and args
           if (
             callNode.kind === "call" &&
@@ -916,14 +917,12 @@ export class TypeScriptBuilder {
             const args = isClassMethod
               ? [...callNode.arguments, this.buildMethodCallConfig()]
               : callNode.arguments;
-            const callExpr = $(result)
-              .prop(callNode.callee.name)
-              .call(args)
-              .done();
+            const propNode = ts.prop(result, callNode.callee.name, { optional: element.optional });
+            const callExpr = ts.call(propNode, args);
             result = isClassMethod ? ts.await(callExpr) : callExpr;
           } else {
             // Fallback for complex cases (e.g. await-wrapped)
-            result = ts.raw(`${this.str(result)}.${this.str(callNode)}`);
+            result = ts.raw(`${this.str(result)}${dot}${this.str(callNode)}`);
           }
           break;
         }

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -907,7 +907,6 @@ export class TypeScriptBuilder {
             element.functionCall,
             "valueAccess",
           );
-          const dot = element.optional ? "?." : ".";
           // The call node is ts.call(ts.id(name), args) — extract callee name and args
           if (
             callNode.kind === "call" &&
@@ -922,6 +921,7 @@ export class TypeScriptBuilder {
             result = isClassMethod ? ts.await(callExpr) : callExpr;
           } else {
             // Fallback for complex cases (e.g. await-wrapped)
+            const dot = element.optional ? "?." : ".";
             result = ts.raw(`${this.str(result)}${dot}${this.str(callNode)}`);
           }
           break;

--- a/lib/ir/builders.ts
+++ b/lib/ir/builders.ts
@@ -311,11 +311,11 @@ export const ts = {
   },
 
   prop(object: TsNode, property: string, opts?: { optional?: boolean }): TsPropertyAccess {
-    return { kind: "propertyAccess", object, property, computed: false, optional: opts?.optional };
+    return { kind: "propertyAccess", object, property, computed: false, ...(opts?.optional && { optional: true }) };
   },
 
   index(object: TsNode, property: TsNode, opts?: { optional?: boolean }): TsPropertyAccess {
-    return { kind: "propertyAccess", object, property, computed: true, optional: opts?.optional };
+    return { kind: "propertyAccess", object, property, computed: true, ...(opts?.optional && { optional: true }) };
   },
 
   spread(expr: TsNode): TsSpread {

--- a/lib/ir/builders.ts
+++ b/lib/ir/builders.ts
@@ -310,12 +310,12 @@ export const ts = {
     };
   },
 
-  prop(object: TsNode, property: string): TsPropertyAccess {
-    return { kind: "propertyAccess", object, property, computed: false };
+  prop(object: TsNode, property: string, opts?: { optional?: boolean }): TsPropertyAccess {
+    return { kind: "propertyAccess", object, property, computed: false, optional: opts?.optional };
   },
 
-  index(object: TsNode, property: TsNode): TsPropertyAccess {
-    return { kind: "propertyAccess", object, property, computed: true };
+  index(object: TsNode, property: TsNode, opts?: { optional?: boolean }): TsPropertyAccess {
+    return { kind: "propertyAccess", object, property, computed: true, optional: opts?.optional };
   },
 
   spread(expr: TsNode): TsSpread {

--- a/lib/ir/fluent.ts
+++ b/lib/ir/fluent.ts
@@ -11,8 +11,8 @@ export class TsChain {
   constructor(public readonly node: TsNode) {}
 
   /** Property access: .prop("foo") → ts.prop(this, "foo") */
-  prop(name: string): TsChain {
-    return new TsChain(ts.prop(this.node, name));
+  prop(name: string, opts?: { optional?: boolean }): TsChain {
+    return new TsChain(ts.prop(this.node, name, opts));
   }
 
   map(fn: TsNode): TsChain {

--- a/lib/ir/prettyPrint.ts
+++ b/lib/ir/prettyPrint.ts
@@ -206,10 +206,12 @@ export function printTs(node: TsNode, indent = 0): string {
 
     case "propertyAccess": {
       const obj = printTs(node.object, indent);
+      const dot = node.optional ? "?." : ".";
       if (node.computed) {
-        return `${obj}[${printTs(node.property as TsNode, indent)}]`;
+        const bracket = node.optional ? "?.[" : "[";
+        return `${obj}${bracket}${printTs(node.property as TsNode, indent)}]`;
       }
-      return `${obj}.${node.property as string}`;
+      return `${obj}${dot}${node.property as string}`;
     }
 
     case "spread":

--- a/lib/ir/prettyPrint.ts
+++ b/lib/ir/prettyPrint.ts
@@ -206,11 +206,11 @@ export function printTs(node: TsNode, indent = 0): string {
 
     case "propertyAccess": {
       const obj = printTs(node.object, indent);
-      const dot = node.optional ? "?." : ".";
       if (node.computed) {
-        const bracket = node.optional ? "?.[" : "[";
-        return `${obj}${bracket}${printTs(node.property as TsNode, indent)}]`;
+        const prefix = node.optional ? "?." : "";
+        return `${obj}${prefix}[${printTs(node.property as TsNode, indent)}]`;
       }
+      const dot = node.optional ? "?." : ".";
       return `${obj}${dot}${node.property as string}`;
     }
 

--- a/lib/ir/tsIR.ts
+++ b/lib/ir/tsIR.ts
@@ -227,6 +227,7 @@ export interface TsPropertyAccess {
   object: TsNode;
   property: string | TsNode;
   computed: boolean;
+  optional?: boolean;
 }
 
 export interface TsSpread {

--- a/lib/parsers/access.test.ts
+++ b/lib/parsers/access.test.ts
@@ -360,6 +360,78 @@ describe("valueAccessParser", () => {
     });
   });
 
+  describe("optional chaining", () => {
+    it('should parse "foo?.bar" with optional property access', () => {
+      const result = valueAccessParser("foo?.bar");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toEqualWithoutLoc({
+          type: "valueAccess",
+          base: { type: "variableName", value: "foo" },
+          chain: [{ kind: "property", name: "bar", optional: true }],
+        });
+      }
+    });
+
+    it('should parse "foo?.bar?.baz" with chained optional access', () => {
+      const result = valueAccessParser("foo?.bar?.baz");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toEqualWithoutLoc({
+          type: "valueAccess",
+          base: { type: "variableName", value: "foo" },
+          chain: [
+            { kind: "property", name: "bar", optional: true },
+            { kind: "property", name: "baz", optional: true },
+          ],
+        });
+      }
+    });
+
+    it('should parse "foo?.bar.baz" mixing optional and regular access', () => {
+      const result = valueAccessParser("foo?.bar.baz");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toEqualWithoutLoc({
+          type: "valueAccess",
+          base: { type: "variableName", value: "foo" },
+          chain: [
+            { kind: "property", name: "bar", optional: true },
+            { kind: "property", name: "baz" },
+          ],
+        });
+      }
+    });
+
+    it('should parse "arr?.[0]" with optional index access', () => {
+      const result = valueAccessParser("arr?.[0]");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toEqualWithoutLoc({
+          type: "valueAccess",
+          base: { type: "variableName", value: "arr" },
+          chain: [{ kind: "index", index: { type: "number", value: "0" }, optional: true }],
+        });
+      }
+    });
+
+    it('should parse "obj?.method()" with optional method call', () => {
+      const result = valueAccessParser("obj?.method()");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result).toEqualWithoutLoc({
+          type: "valueAccess",
+          base: { type: "variableName", value: "obj" },
+          chain: [{
+            kind: "methodCall",
+            functionCall: { type: "functionCall", functionName: "method", arguments: [] },
+            optional: true,
+          }],
+        });
+      }
+    });
+  });
+
   describe("failure cases", () => {
     it('should fail to parse ""', () => {
       expect(valueAccessParser("").success).toBe(false);

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1219,11 +1219,9 @@ const indexChainParser = (input: string): ParserResult<AccessChainElement> => {
   }
 
   const ws1 = optionalSpaces(rest);
-  if (!ws1.success) return failure("expected expression", input);
-  const exprResult = lazy(() => exprParser)(ws1.rest);
+  const exprResult = exprParser(ws1.rest);
   if (!exprResult.success) return failure("expected expression inside brackets", input);
   const ws2 = optionalSpaces(exprResult.rest);
-  if (!ws2.success) return failure("expected ]", input);
   const closeResult = char("]")(ws2.rest);
   if (!closeResult.success) return failure("expected closing bracket", input);
 

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1172,45 +1172,64 @@ export const functionCallParser: Parser<FunctionCall> = label("a function call",
 const dotMethodCallParser = (
   input: string,
 ): ParserResult<AccessChainElement> => {
-  // First try: . followed by functionCall (name + parens)
-  const dotResult = char(".")(input);
-  if (!dotResult.success) return failure("expected dot", input);
-
-  const fcResult = _functionCallParser(dotResult.rest);
-  if (fcResult.success) {
-    return success(
-      { kind: "methodCall" as const, functionCall: fcResult.result },
-      fcResult.rest,
-    );
+  // Try ?. (optional chaining) first, then . (regular)
+  let optional = false;
+  let afterDot: string;
+  const optDotResult = str("?.")(input);
+  if (optDotResult.success) {
+    optional = true;
+    afterDot = optDotResult.rest;
+  } else {
+    const dotResult = char(".")(input);
+    if (!dotResult.success) return failure("expected dot", input);
+    afterDot = dotResult.rest;
   }
 
-  // Second try: . followed by just a property name
-  const nameResult = variableNameParser(dotResult.rest);
+  // First try: functionCall (name + parens)
+  const fcResult = _functionCallParser(afterDot);
+  if (fcResult.success) {
+    const element: AccessChainElement = { kind: "methodCall" as const, functionCall: fcResult.result };
+    if (optional) element.optional = true;
+    return success(element, fcResult.rest);
+  }
+
+  // Second try: just a property name
+  const nameResult = variableNameParser(afterDot);
   if (nameResult.success) {
-    return success(
-      { kind: "property" as const, name: nameResult.result.value },
-      nameResult.rest,
-    );
+    const element: AccessChainElement = { kind: "property" as const, name: nameResult.result.value };
+    if (optional) element.optional = true;
+    return success(element, nameResult.rest);
   }
 
   return failure("expected property name or method call after dot", input);
 };
 
 const indexChainParser = (input: string): ParserResult<AccessChainElement> => {
-  const parser = seqC(
-    set("kind", "index" as const),
-    char("["),
-    optionalSpaces,
-    capture(
-      lazy(() => exprParser),
-      "index",
-    ),
-    optionalSpaces,
-    char("]"),
-  );
+  // Try ?.[ (optional index access) first, then [ (regular)
+  let optional = false;
+  let rest: string;
+  const optBracketResult = str("?.[")(input);
+  if (optBracketResult.success) {
+    optional = true;
+    rest = optBracketResult.rest;
+  } else {
+    const bracketResult = char("[")(input);
+    if (!bracketResult.success) return failure("expected [", input);
+    rest = bracketResult.rest;
+  }
 
-  const result = parser(input);
-  return result;
+  const ws1 = optionalSpaces(rest);
+  if (!ws1.success) return failure("expected expression", input);
+  const exprResult = lazy(() => exprParser)(ws1.rest);
+  if (!exprResult.success) return failure("expected expression inside brackets", input);
+  const ws2 = optionalSpaces(exprResult.rest);
+  if (!ws2.success) return failure("expected ]", input);
+  const closeResult = char("]")(ws2.rest);
+  if (!closeResult.success) return failure("expected closing bracket", input);
+
+  const element: AccessChainElement = { kind: "index" as const, index: exprResult.result };
+  if (optional) element.optional = true;
+  return success(element, closeResult.rest);
 };
 
 const chainElementParser: Parser<AccessChainElement> = or(

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1168,66 +1168,62 @@ export const functionCallParser: Parser<FunctionCall> = label("a function call",
 // access.ts
 // =============================================================================
 
-// Parse a single chain element: .method(), .property, or [index]
+// Parse "?." or "." — returns true for optional, false for regular
+const dotParser: Parser<boolean> = or(
+  map(str("?."), () => true),
+  map(char("."), () => false),
+);
+
+// Parse a single chain element: .method(), ?.method(), .property, ?.property, [index], ?.[index]
 const dotMethodCallParser = (
   input: string,
 ): ParserResult<AccessChainElement> => {
-  // Try ?. (optional chaining) first, then . (regular)
-  let optional = false;
-  let afterDot: string;
-  const optDotResult = str("?.")(input);
-  if (optDotResult.success) {
-    optional = true;
-    afterDot = optDotResult.rest;
-  } else {
-    const dotResult = char(".")(input);
-    if (!dotResult.success) return failure("expected dot", input);
-    afterDot = dotResult.rest;
-  }
+  const dotResult = dotParser(input);
+  if (!dotResult.success) return failure("expected dot", input);
+  const optional = dotResult.result;
+  const afterDot = dotResult.rest;
 
   // First try: functionCall (name + parens)
   const fcResult = _functionCallParser(afterDot);
   if (fcResult.success) {
-    const element: AccessChainElement = { kind: "methodCall" as const, functionCall: fcResult.result };
-    if (optional) element.optional = true;
-    return success(element, fcResult.rest);
+    return success(
+      { kind: "methodCall" as const, functionCall: fcResult.result, ...(optional && { optional: true }) },
+      fcResult.rest,
+    );
   }
 
   // Second try: just a property name
   const nameResult = variableNameParser(afterDot);
   if (nameResult.success) {
-    const element: AccessChainElement = { kind: "property" as const, name: nameResult.result.value };
-    if (optional) element.optional = true;
-    return success(element, nameResult.rest);
+    return success(
+      { kind: "property" as const, name: nameResult.result.value, ...(optional && { optional: true }) },
+      nameResult.rest,
+    );
   }
 
   return failure("expected property name or method call after dot", input);
 };
 
-const indexChainParser = (input: string): ParserResult<AccessChainElement> => {
-  // Try ?.[ (optional index access) first, then [ (regular)
-  let optional = false;
-  let rest: string;
-  const optBracketResult = str("?.[")(input);
-  if (optBracketResult.success) {
-    optional = true;
-    rest = optBracketResult.rest;
-  } else {
-    const bracketResult = char("[")(input);
-    if (!bracketResult.success) return failure("expected [", input);
-    rest = bracketResult.rest;
-  }
+// Parse "?.[" or "[" — returns true for optional, false for regular
+const bracketParser: Parser<boolean> = or(
+  map(str("?.["), () => true),
+  map(char("["), () => false),
+);
 
-  const ws1 = optionalSpaces(rest);
-  const exprResult = exprParser(ws1.rest);
-  if (!exprResult.success) return failure("expected expression inside brackets", input);
-  const ws2 = optionalSpaces(exprResult.rest);
-  const closeResult = char("]")(ws2.rest);
-  if (!closeResult.success) return failure("expected closing bracket", input);
-
-  const element: AccessChainElement = { kind: "index" as const, index: exprResult.result };
-  if (optional) element.optional = true;
-  return success(element, closeResult.rest);
+const indexChainParser: Parser<AccessChainElement> = (input: string) => {
+  const parser = seqC(
+    capture(bracketParser, "optional"),
+    optionalSpaces,
+    capture(lazy(() => exprParser), "index"),
+    optionalSpaces,
+    char("]"),
+  );
+  const result = parser(input);
+  if (!result.success) return result;
+  return success(
+    { kind: "index" as const, index: result.result.index, ...(result.result.optional && { optional: true }) },
+    result.rest,
+  );
 };
 
 const chainElementParser: Parser<AccessChainElement> = or(

--- a/lib/types/access.ts
+++ b/lib/types/access.ts
@@ -2,9 +2,9 @@ import { AgencyNode, Expression, FunctionCall } from "../types.js";
 import { BaseNode } from "./base.js";
 
 export type AccessChainElement =
-  | { kind: "property"; name: string }
-  | { kind: "index"; index: Expression }
-  | { kind: "methodCall"; functionCall: FunctionCall };
+  | { kind: "property"; name: string; optional?: boolean }
+  | { kind: "index"; index: Expression; optional?: boolean }
+  | { kind: "methodCall"; functionCall: FunctionCall; optional?: boolean };
 
 export type ValueAccess = BaseNode & {
   type: "valueAccess";

--- a/tests/agency/nullish-operators.agency
+++ b/tests/agency/nullish-operators.agency
@@ -1,0 +1,56 @@
+// Tests for ?? (nullish coalescing) and ?. (optional chaining)
+
+def makeObj(): { name: string, nested: { value: number } } {
+  return { name: "hello", nested: { value: 42 } }
+}
+
+node testNullishCoalescing() {
+  // ?? with non-null left side returns left
+  const a = "hello" ?? "default"
+
+  // ?? with null left side returns right
+  const b = null ?? "fallback"
+
+  // ?? chaining
+  const c = null ?? null ?? "last"
+
+  return { a: a, b: b, c: c }
+}
+
+node testOptionalChaining() {
+  const obj = makeObj()
+
+  // regular chaining still works
+  const a = obj.name
+  const b = obj.nested.value
+
+  return { a: a, b: b }
+}
+
+node testOptionalChainingOnNull() {
+  const obj = null
+
+  // ?. on null returns undefined
+  const a = obj?.name
+  const b = obj?.nested?.value
+
+  return { a: a, b: b }
+}
+
+node testOptionalIndex() {
+  const arr = [10, 20, 30]
+  const nothing = null
+
+  const a = arr?.[1]
+  const b = nothing?.[0]
+
+  return { a: a, b: b }
+}
+
+node testCombined() {
+  // ?. combined with ??
+  const obj = null
+  const result = obj?.name ?? "default"
+
+  return result
+}

--- a/tests/agency/nullish-operators.agency
+++ b/tests/agency/nullish-operators.agency
@@ -4,6 +4,10 @@ def makeObj(): { name: string, nested: { value: number } } {
   return { name: "hello", nested: { value: 42 } }
 }
 
+def getNull() {
+  return null
+}
+
 node testNullishCoalescing() {
   // ?? with non-null left side returns left
   const a = "hello" ?? "default"
@@ -53,4 +57,36 @@ node testCombined() {
   const result = obj?.name ?? "default"
 
   return result
+}
+
+node testNullishWithFalsyValues() {
+  // ?? should NOT replace falsy-but-not-nullish values
+  // This is the key difference between ?? and ||
+  const a = 0 ?? "default"
+  const b = "" ?? "default"
+  const c = false ?? "default"
+
+  return { a: a, b: b, c: c }
+}
+
+node testNullishWithUndefined() {
+  // ?? should replace undefined, not just null
+  const a = undefined ?? "fallback"
+
+  // ?. returns undefined which ?? then replaces
+  const obj = null
+  const b = obj?.name ?? "got it"
+
+  return { a: a, b: b }
+}
+
+node testOptionalMethodCall() {
+  // ?. on method calls
+  const obj = makeObj()
+  const nothing = getNull()
+
+  const a = obj?.name
+  const b = nothing?.name
+
+  return { a: a, b: b }
 }

--- a/tests/agency/nullish-operators.test.json
+++ b/tests/agency/nullish-operators.test.json
@@ -34,6 +34,27 @@
       "expectedOutput": "\"default\"",
       "evaluationCriteria": [{ "type": "exact" }],
       "description": "?. combined with ?? provides a default for null chains"
+    },
+    {
+      "nodeName": "testNullishWithFalsyValues",
+      "input": "",
+      "expectedOutput": "{\"a\":0,\"b\":\"\",\"c\":false}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "?? preserves falsy-but-not-nullish values (0, empty string, false) unlike ||"
+    },
+    {
+      "nodeName": "testNullishWithUndefined",
+      "input": "",
+      "expectedOutput": "{\"a\":\"fallback\",\"b\":\"got it\"}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "?? replaces undefined (not just null), and ?. + ?? compose correctly"
+    },
+    {
+      "nodeName": "testOptionalMethodCall",
+      "input": "",
+      "expectedOutput": "{\"a\":\"hello\"}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "?. works when accessing properties via function return values (null vs non-null)"
     }
   ]
 }

--- a/tests/agency/nullish-operators.test.json
+++ b/tests/agency/nullish-operators.test.json
@@ -1,0 +1,39 @@
+{
+  "tests": [
+    {
+      "nodeName": "testNullishCoalescing",
+      "input": "",
+      "expectedOutput": "{\"a\":\"hello\",\"b\":\"fallback\",\"c\":\"last\"}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "?? returns left if non-null, right if null, and chains correctly"
+    },
+    {
+      "nodeName": "testOptionalChaining",
+      "input": "",
+      "expectedOutput": "{\"a\":\"hello\",\"b\":42}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "?. works on non-null objects (same as regular dot access)"
+    },
+    {
+      "nodeName": "testOptionalChainingOnNull",
+      "input": "",
+      "expectedOutput": "{}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "?. on null returns undefined (dropped from JSON)"
+    },
+    {
+      "nodeName": "testOptionalIndex",
+      "input": "",
+      "expectedOutput": "{\"a\":20}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "?.[] works for index access on arrays and null"
+    },
+    {
+      "nodeName": "testCombined",
+      "input": "",
+      "expectedOutput": "\"default\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "?. combined with ?? provides a default for null chains"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds the `??` nullish coalescing operator, same semantics as JS/TS
- Adds `?.` optional chaining for property access (`foo?.bar`), index access (`arr?.[0]`), and method calls (`obj?.method()`)
- Both operators compile directly to their TypeScript equivalents with no special transformation needed

## Test plan
- [x] Added 4 parser tests for `??` (basic, chaining, precedence, literal RHS)
- [x] Added 5 parser tests for `?.` (property, chained, mixed, index, method call)
- [x] Full test suite passes (1882 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)