### PR TITLE
Support bare return statements

### DIFF
--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -765,6 +765,7 @@ export class AgencyGenerator {
   }
 
   protected processReturnStatement(node: ReturnStatement): string {
+    if (!node.value) return this.indentStr("return");
     const valueCode = this.processNode(node.value).trim();
     return this.indentStr(`return ${valueCode}`);
   }

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -2085,6 +2085,14 @@ export class TypeScriptBuilder {
   }
 
   private processReturnStatement(node: ReturnStatement): TsNode {
+    // Bare return (no value)
+    if (!node.value) {
+      if (this.insideHandlerBody) return ts.return();
+      if (this.getCurrentScope().type === "block") return ts.runnerHalt(ts.id("undefined"));
+      if (this.isInsideGraphNode) return ts.nodeResult(ts.id("undefined"));
+      return ts.functionReturn(ts.id("undefined"));
+    }
+
     // Handler bodies use plain returns — no node/function wrapping
     if (this.insideHandlerBody) {
       return ts.return(this.processNode(node.value));

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1547,33 +1547,26 @@ export const exprParser: Parser<Expression> = label("an expression", buildExpres
 // Wire up the circular reference for parenParser
 _exprParser = exprParser;
 
+const returnPrefix = seqC(set("type", "returnStatement"), str("return"));
+const returnWordBoundary = not(varNameChar);
+const returnValueParser = seqC(optionalSpaces, capture(exprParser, "value"), optionalSemicolon, optionalSpacesOrNewline);
+const returnTrailing = seqC(optionalSemicolon, optionalSpacesOrNewline);
+
 export const returnStatementParser: Parser<ReturnStatement> = label("a return statement", withLoc((input: string) => {
-  const prefixParser = seqC(
-    set("type", "returnStatement"),
-    str("return"),
-  );
-  const prefixResult = prefixParser(input);
+  const prefixResult = returnPrefix(input);
   if (!prefixResult.success) return prefixResult;
 
   // Require word boundary so "returnValue" isn't parsed as "return" + "Value"
-  if (!not(varNameChar)(prefixResult.rest).success) {
+  if (!returnWordBoundary(prefixResult.rest).success) {
     return failure("expected whitespace after return", input);
   }
 
-  // Try to parse a return value; if none, bare "return" is valid
-  const withValue = seqC(
-    optionalSpaces,
-    capture(exprParser, "value"),
-    optionalSemicolon,
-    optionalSpacesOrNewline,
-  )(prefixResult.rest);
-
+  const withValue = returnValueParser(prefixResult.rest);
   if (withValue.success) {
     return success({ ...prefixResult.result, ...withValue.result }, withValue.rest);
   }
 
-  // Bare return (no value)
-  const trailing = seqC(optionalSemicolon, optionalSpacesOrNewline)(prefixResult.rest);
+  const trailing = returnTrailing(prefixResult.rest);
   return success(prefixResult.result, trailing.success ? trailing.rest : prefixResult.rest);
 }));
 

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1547,19 +1547,35 @@ export const exprParser: Parser<Expression> = label("an expression", buildExpres
 // Wire up the circular reference for parenParser
 _exprParser = exprParser;
 
-export const returnStatementParser: Parser<ReturnStatement> = label("a return statement", withLoc(seqC(
-  set("type", "returnStatement"),
-  str("return"),
-  captureCaptures(
-    parseError(
-      "expected a return value (expression, prompt, or literal)",
-      optionalSpaces,
-      capture(exprParser, "value"),
-      optionalSemicolon,
-      optionalSpacesOrNewline,
-    ),
-  ),
-)));
+export const returnStatementParser: Parser<ReturnStatement> = label("a return statement", withLoc((input: string) => {
+  const prefixParser = seqC(
+    set("type", "returnStatement"),
+    str("return"),
+  );
+  const prefixResult = prefixParser(input);
+  if (!prefixResult.success) return prefixResult;
+
+  // Require word boundary so "returnValue" isn't parsed as "return" + "Value"
+  if (!not(varNameChar)(prefixResult.rest).success) {
+    return failure("expected whitespace after return", input);
+  }
+
+  // Try to parse a return value; if none, bare "return" is valid
+  const withValue = seqC(
+    optionalSpaces,
+    capture(exprParser, "value"),
+    optionalSemicolon,
+    optionalSpacesOrNewline,
+  )(prefixResult.rest);
+
+  if (withValue.success) {
+    return success({ ...prefixResult.result, ...withValue.result }, withValue.rest);
+  }
+
+  // Bare return (no value)
+  const trailing = seqC(optionalSemicolon, optionalSpacesOrNewline)(prefixResult.rest);
+  return success(prefixResult.result, trailing.success ? trailing.rest : prefixResult.rest);
+}));
 
 // =============================================================================
 // binop.ts

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1547,28 +1547,22 @@ export const exprParser: Parser<Expression> = label("an expression", buildExpres
 // Wire up the circular reference for parenParser
 _exprParser = exprParser;
 
-const returnPrefix = seqC(set("type", "returnStatement"), str("return"));
-const returnWordBoundary = not(varNameChar);
-const returnValueParser = seqC(optionalSpaces, capture(exprParser, "value"), optionalSemicolon, optionalSpacesOrNewline);
-const returnTrailing = seqC(optionalSemicolon, optionalSpacesOrNewline);
-
-export const returnStatementParser: Parser<ReturnStatement> = label("a return statement", withLoc((input: string) => {
-  const prefixResult = returnPrefix(input);
-  if (!prefixResult.success) return prefixResult;
-
-  // Require word boundary so "returnValue" isn't parsed as "return" + "Value"
-  if (!returnWordBoundary(prefixResult.rest).success) {
-    return failure("expected whitespace after return", input);
-  }
-
-  const withValue = returnValueParser(prefixResult.rest);
-  if (withValue.success) {
-    return success({ ...prefixResult.result, ...withValue.result }, withValue.rest);
-  }
-
-  const trailing = returnTrailing(prefixResult.rest);
-  return success(prefixResult.result, trailing.success ? trailing.rest : prefixResult.rest);
-}));
+export const returnStatementParser: Parser<ReturnStatement> = label("a return statement", withLoc(seqC(
+  set("type", "returnStatement"),
+  str("return"),
+  not(varNameChar),
+  optional(
+    captureCaptures(
+      seqC(
+        optionalSpaces,
+        capture(exprParser, "value"),
+      ),
+    ),
+  ),
+  optionalSpaces,
+  optionalSemicolon,
+  optionalSpacesOrNewline,
+)));
 
 // =============================================================================
 // binop.ts

--- a/lib/parsers/returnStatement.test.ts
+++ b/lib/parsers/returnStatement.test.ts
@@ -248,10 +248,12 @@ describe("returnStatementParser", () => {
       },
     },
 
+    // Bare return (no value)
+    { input: "return", expected: { success: true, result: { type: "returnStatement" } } },
+    { input: "return;", expected: { success: true, result: { type: "returnStatement" } } },
+    { input: "return ", expected: { success: true, result: { type: "returnStatement" } } },
+
     // Failure cases
-    { input: "return", expected: { success: false }, throws: true },
-    { input: "return;", expected: { success: false }, throws: true },
-    { input: "return ", expected: { success: false }, throws: true },
     { input: "retur 5", expected: { success: false } },
     { input: "", expected: { success: false } },
     { input: "42", expected: { success: false } },

--- a/lib/parsers/returnStatement.test.ts
+++ b/lib/parsers/returnStatement.test.ts
@@ -252,6 +252,7 @@ describe("returnStatementParser", () => {
     { input: "return", expected: { success: true, result: { type: "returnStatement" } } },
     { input: "return;", expected: { success: true, result: { type: "returnStatement" } } },
     { input: "return ", expected: { success: true, result: { type: "returnStatement" } } },
+    { input: "return ;", expected: { success: true, result: { type: "returnStatement" } } },
 
     // Failure cases
     { input: "retur 5", expected: { success: false } },

--- a/lib/preprocessors/typescriptPreprocessor.core.test.ts
+++ b/lib/preprocessors/typescriptPreprocessor.core.test.ts
@@ -664,7 +664,7 @@ describe("TypescriptPreprocessor Core Functionality", () => {
         );
         expect(returnNode).toBeDefined();
         if (returnNode && returnNode.type === "returnStatement") {
-          expect(returnNode.value.type).toBe("functionCall");
+          expect(returnNode.value?.type).toBe("functionCall");
         }
       }
     });

--- a/lib/preprocessors/typescriptPreprocessor.ts
+++ b/lib/preprocessors/typescriptPreprocessor.ts
@@ -78,7 +78,7 @@ function isLlmCall(node: AgencyNode): node is FunctionCall {
 function getLlmCall(node: AgencyNode): FunctionCall | null {
   if (isLlmCall(node)) return node;
   if (node.type === "assignment" && isLlmCall(node.value)) return node.value;
-  if (node.type === "returnStatement" && isLlmCall(node.value)) return node.value;
+  if (node.type === "returnStatement" && node.value && isLlmCall(node.value)) return node.value;
   return null;
 }
 
@@ -276,7 +276,7 @@ export class TypescriptPreprocessor {
         }
       } else if (
         node.type === "returnStatement" &&
-        node.value.type === "prompt"
+        node.value?.type === "prompt"
       ) {
         newBody.push(node);
       } else {

--- a/lib/typeChecker/checker.ts
+++ b/lib/typeChecker/checker.ts
@@ -116,7 +116,7 @@ function checkReturnTypesInScope(
   if (!scope.returnType) return;
 
   for (const { node } of walkNodes(scope.body)) {
-    if (node.type === "returnStatement") {
+    if (node.type === "returnStatement" && node.value) {
       checkType(
         node.value,
         scope.returnType,
@@ -135,7 +135,7 @@ function checkExpressionsInScope(
   for (const { node } of walkNodes(scope.body)) {
     if (node.type === "valueAccess") {
       synthType(node, scope.variableTypes, ctx);
-    } else if (node.type === "returnStatement") {
+    } else if (node.type === "returnStatement" && node.value) {
       synthType(node.value, scope.variableTypes, ctx);
     }
   }

--- a/lib/typeChecker/inference.ts
+++ b/lib/typeChecker/inference.ts
@@ -59,7 +59,7 @@ export function inferReturnTypeFor(
 
     const returnValues: AgencyNode[] = [];
     for (const { node, ancestors } of walkNodes(def.body)) {
-      if (node.type === "returnStatement") {
+      if (node.type === "returnStatement" && node.value) {
         const insideNested = ancestors.some(
           (a) => a.type === "function" || a.type === "graphNode",
         );

--- a/lib/types/returnStatement.ts
+++ b/lib/types/returnStatement.ts
@@ -3,5 +3,5 @@ import { BaseNode } from "./base.js";
 
 export type ReturnStatement = BaseNode & {
   type: "returnStatement";
-  value: Expression;
+  value?: Expression;
 };

--- a/lib/utils/node.ts
+++ b/lib/utils/node.ts
@@ -216,7 +216,7 @@ export function* getAllVariablesInBody(
         }
       }
     } else if (node.type === "returnStatement") {
-      yield* getAllVariablesInBody([node.value]);
+      if (node.value) yield* getAllVariablesInBody([node.value]);
     } else if (node.type === "forLoop") {
       yield* getAllVariablesInBody([node.iterable]);
       yield* getAllVariablesInBody(node.body);
@@ -310,7 +310,7 @@ export function* walkNodes(
     } else if (node.type === "withModifier") {
       yield* walkNodes([node.statement], [...ancestors, node], scopes);
     } else if (node.type === "returnStatement") {
-      yield* walkNodes([node.value], [...ancestors, node], scopes);
+      if (node.value) yield* walkNodes([node.value], [...ancestors, node], scopes);
     } else if (node.type === "assignment") {
       /* console.log(
         color.red(


### PR DESCRIPTION
## Summary
- Allow `return` with no value, matching JavaScript behavior
- `ReturnStatement.value` is now optional in the AST type
- Builder emits `return` (handlers), `return undefined` (functions/nodes/blocks) for bare returns
- Added guards in 7 files that access `node.value` without checking for undefined

## Test plan
- [x] Updated 3 parser tests from failure cases to success cases (`return`, `return;`, `return `)
- [x] Full test suite passes (1898 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)