### PR TITLE
Add callback keyword for lifecycle hook declarations

### DIFF
--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -1635,7 +1635,7 @@ export class TypeScriptBuilder {
       defaultValue: ts.id("undefined"),
     });
 
-    const setupStmts = this.buildFunctionBody({ functionName, parameters, bodyCode, skipHooks: !!node.callback });
+    const setupStmts = this.buildFunctionBody({ functionName, parameters, bodyCode, skipHooks: node.callback });
 
     const funcDecl = ts.functionDecl(functionName, fnParams, ts.statements(setupStmts), {
       async: true,

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -1482,8 +1482,9 @@ export class TypeScriptBuilder {
     functionName: string;
     parameters: FunctionParameter[];
     bodyCode: TsNode[];
+    skipHooks?: boolean;
   }): TsNode[] {
-    const { functionName, parameters, bodyCode } = opts;
+    const { functionName, parameters, bodyCode, skipHooks } = opts;
     const args = parameters.map((p) => p.name);
 
     // Build args object for hook data
@@ -1522,13 +1523,15 @@ export class TypeScriptBuilder {
         ts.await(ts.call(ts.id("__initializeGlobals"), [ts.runtime.ctx])),
       ),
 
-      ts.time("__funcStartTime"),
-      ts.callHook("onFunctionStart", {
-        functionName: ts.str(functionName),
-        args: ts.obj(argsObj),
-        isBuiltin: ts.bool(false),
-        moduleId: ts.str(this.moduleId),
-      }),
+      ...(skipHooks ? [] : [
+        ts.time("__funcStartTime"),
+        ts.callHook("onFunctionStart", {
+          functionName: ts.str(functionName),
+          args: ts.obj(argsObj),
+          isBuiltin: ts.bool(false),
+          moduleId: ts.str(this.moduleId),
+        }),
+      ]),
     ];
 
     // Param assignments to stack
@@ -1583,17 +1586,19 @@ export class TypeScriptBuilder {
         // finally block: pop state stack and conditionally fire onFunctionEnd.
         ts.statements([
           ts.raw("if (!__state?.isForked) { __ctx.stateStack.pop() }"),
-          ts.if(
-            ts.id("__functionCompleted"),
-            ts.callHook("onFunctionEnd", {
-              functionName: ts.str(functionName),
-              timeTaken: $(ts.id("performance"))
-                .prop("now")
-                .call()
-                .minus(ts.id("__funcStartTime"))
-                .done(),
-            }),
-          ),
+          ...(skipHooks ? [] : [
+            ts.if(
+              ts.id("__functionCompleted"),
+              ts.callHook("onFunctionEnd", {
+                functionName: ts.str(functionName),
+                timeTaken: $(ts.id("performance"))
+                  .prop("now")
+                  .call()
+                  .minus(ts.id("__funcStartTime"))
+                  .done(),
+              }),
+            ),
+          ]),
         ]),
       ),
     );
@@ -1630,12 +1635,21 @@ export class TypeScriptBuilder {
       defaultValue: ts.id("undefined"),
     });
 
-    const setupStmts = this.buildFunctionBody({ functionName, parameters, bodyCode });
+    const setupStmts = this.buildFunctionBody({ functionName, parameters, bodyCode, skipHooks: !!node.callback });
 
-    return ts.functionDecl(functionName, fnParams, ts.statements(setupStmts), {
+    const funcDecl = ts.functionDecl(functionName, fnParams, ts.statements(setupStmts), {
       async: true,
       export: !!node.exported,
     });
+
+    if (node.callback) {
+      return ts.statements([
+        funcDecl,
+        ts.raw(`__globalCtx._registeredCallbacks.${functionName} = ${functionName};`),
+      ]);
+    }
+
+    return funcDecl;
   }
 
   private processStatement(node: AgencyNode): TsNode {

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -397,7 +397,7 @@ export class TypeScriptBuilder {
     // Pass 5: Generate code for tools
     const functionDefs: FunctionDefinition[] = [];
     for (const node of program.nodes) {
-      if (node.type === "function") {
+      if (node.type === "function" && !node.callback) {
         functionDefs.push(node);
         this.generatedStatements.push(this.processTool(node));
       }

--- a/lib/parsers/function.test.ts
+++ b/lib/parsers/function.test.ts
@@ -3389,19 +3389,28 @@ describe("callback declarations", () => {
     }
   });
 
-  it("rejects unknown callback names", () => {
-    const result = functionParser(`callback onFoo(data) { log(data) }`);
-    expect(result.success).toBe(false);
+  it("throws on unknown callback names", () => {
+    expect(() => functionParser(`callback onFoo(data) { log(data) }`)).toThrow("Unknown callback 'onFoo'");
   });
 
-  it("rejects exported callbacks", () => {
-    const result = functionParser(`export callback onLLMCallEnd(data) { log(data) }`);
-    expect(result.success).toBe(false);
+  it("throws on exported callbacks", () => {
+    expect(() => functionParser(`export callback onLLMCallEnd(data) { log(data) }`)).toThrow("cannot be exported");
   });
 
-  it("rejects safe callbacks", () => {
-    const result = functionParser(`safe callback onLLMCallEnd(data) { log(data) }`);
-    expect(result.success).toBe(false);
+  it("throws on safe callbacks", () => {
+    expect(() => functionParser(`safe callback onLLMCallEnd(data) { log(data) }`)).toThrow("cannot be marked safe");
+  });
+
+  it("throws when callback has no parameters", () => {
+    expect(() => functionParser(`callback onNodeStart() { log("hi") }`)).toThrow("must declare exactly one parameter");
+  });
+
+  it("throws when callback has multiple parameters", () => {
+    expect(() => functionParser(`callback onNodeStart(a, b) { log(a) }`)).toThrow("must declare exactly one parameter");
+  });
+
+  it("throws when callback parameter is variadic", () => {
+    expect(() => functionParser(`callback onNodeStart(...data) { log(data) }`)).toThrow("cannot be variadic");
   });
 
   it("parses all valid callback names", () => {

--- a/lib/parsers/function.test.ts
+++ b/lib/parsers/function.test.ts
@@ -3375,3 +3375,56 @@ describe("classMethodParser with safe keyword", () => {
     expect(classDef.methods[1].safe).toBeUndefined();
   });
 });
+
+describe("callback declarations", () => {
+  it("parses a basic callback", () => {
+    const result = functionParser(`callback onLLMCallEnd(data) { log(data) }`);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.type).toBe("function");
+      expect(result.result.callback).toBe(true);
+      expect(result.result.functionName).toBe("onLLMCallEnd");
+      expect(result.result.parameters).toHaveLength(1);
+      expect(result.result.parameters[0].name).toBe("data");
+    }
+  });
+
+  it("rejects unknown callback names", () => {
+    const result = functionParser(`callback onFoo(data) { log(data) }`);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects exported callbacks", () => {
+    const result = functionParser(`export callback onLLMCallEnd(data) { log(data) }`);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects safe callbacks", () => {
+    const result = functionParser(`safe callback onLLMCallEnd(data) { log(data) }`);
+    expect(result.success).toBe(false);
+  });
+
+  it("parses all valid callback names", () => {
+    const validNames = [
+      "onAgentStart", "onAgentEnd", "onNodeStart", "onNodeEnd",
+      "onLLMCallStart", "onLLMCallEnd", "onFunctionStart", "onFunctionEnd",
+      "onToolCallStart", "onToolCallEnd", "onStream", "onCheckpoint",
+    ];
+    for (const name of validNames) {
+      const result = functionParser(`callback ${name}(data) { log(data) }`);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.callback).toBe(true);
+        expect(result.result.functionName).toBe(name);
+      }
+    }
+  });
+
+  it("def functions do not have callback set", () => {
+    const result = functionParser(`def test() { log("hi") }`);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.callback).toBeUndefined();
+    }
+  });
+});

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -63,6 +63,7 @@ import {
   Expression,
   FunctionCall,
   FunctionDefinition,
+  VALID_CALLBACK_NAMES,
   FunctionParameter,
   InterpolationSegment,
   Literal,
@@ -2368,7 +2369,7 @@ const _baseFunctionParser: Parser<FunctionDefinition> = trace(
   "_baseFunctionParser",
   seqC(
     set("type", "function"),
-    str("def"),
+    capture(or(str("callback"), str("def")), "keyword"),
     many1(space),
     capture(many1Till(char("(")), "functionName"),
     char("("),
@@ -2424,8 +2425,25 @@ const _functionParserInner: Parser<FunctionDefinition> = (input: string) => {
   if (!baseResult.success) return baseResult;
 
   const result = { ...baseResult.result };
+  const isCallback = (result as any).keyword === "callback";
+  delete (result as any).keyword;
   if (isExported) result.exported = true;
   if (isSafe) result.safe = true;
+  if (isCallback) {
+    result.callback = true;
+    if (isExported) {
+      return failure(`Callback '${result.functionName}' cannot be exported`, input);
+    }
+    if (isSafe) {
+      return failure(`Callback '${result.functionName}' cannot be marked safe`, input);
+    }
+    if (!VALID_CALLBACK_NAMES.includes(result.functionName as any)) {
+      return failure(
+        `Unknown callback '${result.functionName}'. Valid callbacks: ${VALID_CALLBACK_NAMES.join(", ")}`,
+        input,
+      );
+    }
+  }
 
   // Validate parameter ordering: required → optional (with defaults) → variadic
   const params = result.parameters;

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -2432,16 +2432,30 @@ const _functionParserInner: Parser<FunctionDefinition> = (input: string) => {
   if (isCallback) {
     result.callback = true;
     if (isExported) {
-      return failure(`Callback '${result.functionName}' cannot be exported`, input);
+      throw new Error(`Callback '${result.functionName}' cannot be exported`);
     }
     if (isSafe) {
-      return failure(`Callback '${result.functionName}' cannot be marked safe`, input);
+      throw new Error(`Callback '${result.functionName}' cannot be marked safe`);
     }
     const validNames: ReadonlySet<string> = new Set(VALID_CALLBACK_NAMES);
     if (!validNames.has(result.functionName)) {
-      return failure(
+      throw new Error(
         `Unknown callback '${result.functionName}'. Valid callbacks: ${VALID_CALLBACK_NAMES.join(", ")}`,
-        input,
+      );
+    }
+    if (result.parameters.length !== 1) {
+      throw new Error(
+        `Callback '${result.functionName}' must declare exactly one parameter`,
+      );
+    }
+    if (result.parameters[0].variadic) {
+      throw new Error(
+        `Callback '${result.functionName}' parameter '${result.parameters[0].name}' cannot be variadic`,
+      );
+    }
+    if (result.parameters[0].defaultValue) {
+      throw new Error(
+        `Callback '${result.functionName}' parameter '${result.parameters[0].name}' cannot have a default value`,
       );
     }
   }

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -2424,9 +2424,9 @@ const _functionParserInner: Parser<FunctionDefinition> = (input: string) => {
   const baseResult = _baseFunctionParser(safeResult.rest);
   if (!baseResult.success) return baseResult;
 
-  const result = { ...baseResult.result };
-  const isCallback = (result as any).keyword === "callback";
-  delete (result as any).keyword;
+  const { keyword, ...rest } = baseResult.result as FunctionDefinition & { keyword?: string };
+  const result = { ...rest };
+  const isCallback = keyword === "callback";
   if (isExported) result.exported = true;
   if (isSafe) result.safe = true;
   if (isCallback) {
@@ -2437,7 +2437,8 @@ const _functionParserInner: Parser<FunctionDefinition> = (input: string) => {
     if (isSafe) {
       return failure(`Callback '${result.functionName}' cannot be marked safe`, input);
     }
-    if (!VALID_CALLBACK_NAMES.includes(result.functionName as any)) {
+    const validNames: ReadonlySet<string> = new Set(VALID_CALLBACK_NAMES);
+    if (!validNames.has(result.functionName)) {
       return failure(
         `Unknown callback '${result.functionName}'. Valid callbacks: ${VALID_CALLBACK_NAMES.join(", ")}`,
         input,

--- a/lib/runtime/hooks.ts
+++ b/lib/runtime/hooks.ts
@@ -10,6 +10,7 @@ import type {
 } from "smoltalk";
 import type { RunNodeResult } from "./types.js";
 import type { RewindCheckpoint } from "./rewind.js";
+import type { CallbackName } from "../types/function.js";
 
 export type CallbackMap = {
   onAgentStart: {
@@ -50,6 +51,10 @@ export type CallbackMap = {
     | { type: "error"; error: any };
   onCheckpoint: RewindCheckpoint;
 };
+
+// Compile-time guard: ensures VALID_CALLBACK_NAMES stays in sync with CallbackMap.
+type _AssertNamesMatchMap = CallbackName extends keyof CallbackMap ? keyof CallbackMap extends CallbackName ? true : false : false;
+const _callbackNamesInSync: _AssertNamesMatchMap = true;
 
 export type CallbackReturn<K extends keyof CallbackMap> = K extends
   | "onLLMCallStart"

--- a/lib/runtime/hooks.ts
+++ b/lib/runtime/hooks.ts
@@ -68,6 +68,10 @@ export type AgencyCallbacks = {
   ) => CallbackReturn<K> | Promise<CallbackReturn<K>>;
 };
 
+// Tracks which hooks are currently executing to prevent infinite recursion
+// when a callback calls a helper function that would re-trigger the same hook.
+const _activeHooks = new Set<string>();
+
 export async function callHook<K extends keyof CallbackMap>(args: {
   callbacks: AgencyCallbacks;
   name: K;
@@ -75,11 +79,14 @@ export async function callHook<K extends keyof CallbackMap>(args: {
 }): Promise<CallbackReturn<K> | undefined> {
   const { callbacks, name, data } = args;
   const hook = callbacks[name];
-  if (hook) {
+  if (hook && !_activeHooks.has(name)) {
+    _activeHooks.add(name);
     try {
       return (await hook(data)) as CallbackReturn<K>;
     } catch (error) {
       console.error(`[agency] ${name} callback error:`, error);
+    } finally {
+      _activeHooks.delete(name);
     }
   }
   return undefined;

--- a/lib/runtime/interrupts.ts
+++ b/lib/runtime/interrupts.ts
@@ -197,8 +197,9 @@ export async function respondToInterrupt(args: {
   const execCtx = ctx.createExecutionContext();
   execCtx.restoreState(checkpoint);
 
+  execCtx.installRegisteredCallbacks(ctx);
   if (metadata.callbacks) {
-    execCtx.callbacks = metadata.callbacks;
+    Object.assign(execCtx.callbacks, metadata.callbacks);
   }
 
   if (metadata.debugger) {
@@ -354,8 +355,9 @@ export async function resumeFromState(args: {
   execCtx.stateStack.deserializeMode();
   execCtx.globals = GlobalStore.fromJSON(state.globals);
 
+  execCtx.installRegisteredCallbacks(ctx);
   if (metadata.callbacks) {
-    execCtx.callbacks = metadata.callbacks;
+    Object.assign(execCtx.callbacks, metadata.callbacks);
   }
 
   if (metadata.debugger) {

--- a/lib/runtime/node.ts
+++ b/lib/runtime/node.ts
@@ -100,7 +100,17 @@ export async function runNode({
   if (initializeGlobals) {
     await initializeGlobals(execCtx);
   }
-  execCtx.callbacks = callbacks || {};
+  // Wrap Agency-defined callbacks (registered via the `callback` keyword) to
+  // inject the current execution context. This gives them access to the right
+  // globals/state without exposing ctx to external TypeScript callers.
+  for (const [name, fn] of Object.entries(ctx._registeredCallbacks)) {
+    execCtx.callbacks[name as keyof AgencyCallbacks] =
+      ((data: any) => fn(data, { ctx: execCtx })) as any;
+  }
+  // Externally-passed callbacks override registered ones and receive only data.
+  if (callbacks) {
+    Object.assign(execCtx.callbacks, callbacks);
+  }
   await callHook({
     callbacks: execCtx.callbacks,
     name: "onAgentStart",

--- a/lib/runtime/node.ts
+++ b/lib/runtime/node.ts
@@ -100,14 +100,7 @@ export async function runNode({
   if (initializeGlobals) {
     await initializeGlobals(execCtx);
   }
-  // Wrap Agency-defined callbacks (registered via the `callback` keyword) to
-  // inject the current execution context. This gives them access to the right
-  // globals/state without exposing ctx to external TypeScript callers.
-  for (const name in ctx._registeredCallbacks) {
-    const fn = ctx._registeredCallbacks[name as keyof AgencyCallbacks]!;
-    execCtx.callbacks[name as keyof AgencyCallbacks] =
-      ((data: any) => fn(data, { ctx: execCtx })) as any;
-  }
+  execCtx.installRegisteredCallbacks(ctx);
   // Externally-passed callbacks override registered ones and receive only data.
   if (callbacks) {
     Object.assign(execCtx.callbacks, callbacks);

--- a/lib/runtime/node.ts
+++ b/lib/runtime/node.ts
@@ -103,7 +103,8 @@ export async function runNode({
   // Wrap Agency-defined callbacks (registered via the `callback` keyword) to
   // inject the current execution context. This gives them access to the right
   // globals/state without exposing ctx to external TypeScript callers.
-  for (const [name, fn] of Object.entries(ctx._registeredCallbacks)) {
+  for (const name in ctx._registeredCallbacks) {
+    const fn = ctx._registeredCallbacks[name as keyof AgencyCallbacks]!;
     execCtx.callbacks[name as keyof AgencyCallbacks] =
       ((data: any) => fn(data, { ctx: execCtx })) as any;
   }

--- a/lib/runtime/rewind.ts
+++ b/lib/runtime/rewind.ts
@@ -42,8 +42,9 @@ export async function rewindFrom(args: {
   execCtx.restoreState(checkpoint.checkpoint);
   execCtx._skipNextCheckpoint = true;
 
+  execCtx.installRegisteredCallbacks(ctx);
   if (metadata.callbacks) {
-    execCtx.callbacks = metadata.callbacks;
+    Object.assign(execCtx.callbacks, metadata.callbacks);
   }
 
   if (metadata.debugger) {

--- a/lib/runtime/state/context.ts
+++ b/lib/runtime/state/context.ts
@@ -127,6 +127,7 @@ export class RuntimeContext<T> {
     execCtx.checkpoints = new CheckpointStore(this.maxRestores);
     execCtx.handlers = [];
     execCtx.callbacks = {};
+    execCtx._registeredCallbacks = {};
     execCtx.onStreamLock = false;
     execCtx._skipNextCheckpoint = false;
     execCtx._restoreCount = 0;
@@ -173,6 +174,19 @@ export class RuntimeContext<T> {
   async threads. But we could just replace all calls to `forkStack`
   with `new StateStack()`.
   */
+  /**
+   * Install Agency-defined callbacks (from `callback` declarations) onto this
+   * execution context, wrapping each one to inject ctx so it accesses the
+   * correct per-execution globals/state.
+   */
+  installRegisteredCallbacks(source: RuntimeContext<T>): void {
+    for (const name in source._registeredCallbacks) {
+      const fn = source._registeredCallbacks[name as keyof AgencyCallbacks]!;
+      (this.callbacks as any)[name] =
+        (data: any) => fn(data, { ctx: this });
+    }
+  }
+
   pushHandler(fn: HandlerFn): void {
     this.handlers.push(fn);
   }

--- a/lib/runtime/state/context.ts
+++ b/lib/runtime/state/context.ts
@@ -60,7 +60,7 @@ export class RuntimeContext<T> {
   // etc.), but at registration time only __globalCtx exists. External TypeScript
   // callers pass callbacks via runNode's `callbacks` option and should NOT receive
   // the execution context — wrapping at execution time keeps that boundary clean.
-  _registeredCallbacks: Record<string, Function> = {};
+  _registeredCallbacks: Partial<Record<keyof AgencyCallbacks, (...args: any[]) => any>> = {};
 
   // class registry for serialization/deserialization of Agency class instances
   classRegistry: ClassRegistry = {};

--- a/lib/runtime/state/context.ts
+++ b/lib/runtime/state/context.ts
@@ -53,6 +53,15 @@ export class RuntimeContext<T> {
   // this is the directory that the runtime is running in. We need this to be able to read files relative to the runtime.
   dirname: string;
 
+  // Callback functions registered via the `callback` keyword in Agency code.
+  // Stored separately from `callbacks` so that runNode can wrap them with the
+  // current execution context. We can't register them directly on `callbacks`
+  // because they need access to the per-execution ctx (for globals, state stack,
+  // etc.), but at registration time only __globalCtx exists. External TypeScript
+  // callers pass callbacks via runNode's `callbacks` option and should NOT receive
+  // the execution context — wrapping at execution time keeps that boundary clean.
+  _registeredCallbacks: Record<string, Function> = {};
+
   // class registry for serialization/deserialization of Agency class instances
   classRegistry: ClassRegistry = {};
 

--- a/lib/types/function.ts
+++ b/lib/types/function.ts
@@ -18,6 +18,23 @@ export type FunctionParameter = {
   defaultValue?: Literal | AgencyArray | AgencyObject;
 };
 
+export const VALID_CALLBACK_NAMES = [
+  "onAgentStart",
+  "onAgentEnd",
+  "onNodeStart",
+  "onNodeEnd",
+  "onLLMCallStart",
+  "onLLMCallEnd",
+  "onFunctionStart",
+  "onFunctionEnd",
+  "onToolCallStart",
+  "onToolCallEnd",
+  "onStream",
+  "onCheckpoint",
+] as const;
+
+export type CallbackName = (typeof VALID_CALLBACK_NAMES)[number];
+
 export type FunctionDefinition = BaseNode & {
   type: "function";
   functionName: string;
@@ -28,6 +45,7 @@ export type FunctionDefinition = BaseNode & {
   async?: boolean;
   safe?: boolean;
   exported?: boolean;
+  callback?: boolean;
   tags?: Tag[];
 };
 

--- a/tests/agency/callback-basic.agency
+++ b/tests/agency/callback-basic.agency
@@ -1,0 +1,14 @@
+let callbackFired: boolean = false
+
+def helper(): string {
+  return "hello"
+}
+
+callback onFunctionStart(data) {
+  callbackFired = true
+}
+
+node main() {
+  let result = helper()
+  return callbackFired
+}

--- a/tests/agency/callback-basic.test.json
+++ b/tests/agency/callback-basic.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "callback onFunctionStart fires when a function is called"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a `callback` keyword that lets users declare lifecycle hook handlers directly in Agency code (e.g., `callback onLLMCallEnd(data) { ... }`)
- Reuses the function definition infrastructure — `callback` is a boolean field on `FunctionDefinition`, not a separate AST type
- Validates callback names at parse time against the known set of lifecycle hooks; rejects `export` and `safe` modifiers on callbacks
- Stores Agency-defined callbacks in `_registeredCallbacks` on the global context, then wraps them with the correct execution context in `runNode` — this keeps per-execution isolation while not exposing `ctx` to external TypeScript callers
- Skips emitting `onFunctionStart`/`onFunctionEnd` hooks inside callback functions to prevent infinite recursion

## Test plan

- [x] Parser tests: valid callback names, rejected unknown names, rejected export/safe, all 12 hook names accepted (lib/parsers/function.test.ts)
- [x] Integration test: `callback onFunctionStart` fires and writes to a global variable correctly (tests/agency/callback-basic)
- [ ] Verify existing agency-js lifecycle hooks tests still pass
- [ ] Verify existing agency tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)