### PR TITLE
Add Date, RegExp, URL, and Error revivers

### DIFF
--- a/docs-new/guide/classes.md
+++ b/docs-new/guide/classes.md
@@ -6,4 +6,15 @@ Agency has some initial support for defining classes. Here are some things to kn
 3. You can pass blocks into methods.
 4. If you instantiate an object for a class not defined in Agency, like `Set` for example, those objects will not serialize or deserialize correctly, which means you can't use them with interrupts, i.e. when you throw an interrupt the state stack cannot include a Set instance because it won't get serialized or deserialized correctly.
 
+## Support for built-in classes
+
+- Set
+- Map
+- Date
+- RegExp
+- URL
+- Error
+
+You can use these classes in your code, and they will serialize and deserialize correctly, which means you can use them with interrupts.
+
 *Class support is still experimental.*

--- a/lib/runtime/revivers/dateReviver.ts
+++ b/lib/runtime/revivers/dateReviver.ts
@@ -1,0 +1,23 @@
+import { BaseReviver } from "./baseReviver.js";
+
+export class DateReviver implements BaseReviver<Date> {
+  nativeTypeName(): string {
+    return "Date";
+  }
+
+  isInstance(value: unknown): value is Date {
+    return value instanceof Date;
+  }
+
+  serialize(value: Date): Record<string, unknown> {
+    return { __nativeType: this.nativeTypeName(), iso: value.toISOString() };
+  }
+
+  validate(value: Record<string, unknown>): boolean {
+    return typeof value.iso === "string";
+  }
+
+  revive(value: Record<string, unknown>): Date {
+    return new Date(value.iso as string);
+  }
+}

--- a/lib/runtime/revivers/dateReviver.ts
+++ b/lib/runtime/revivers/dateReviver.ts
@@ -10,14 +10,18 @@ export class DateReviver implements BaseReviver<Date> {
   }
 
   serialize(value: Date): Record<string, unknown> {
-    return { __nativeType: this.nativeTypeName(), iso: value.toISOString() };
+    const time = value.getTime();
+    return {
+      __nativeType: this.nativeTypeName(),
+      iso: Number.isNaN(time) ? null : value.toISOString(),
+    };
   }
 
   validate(value: Record<string, unknown>): boolean {
-    return typeof value.iso === "string";
+    return typeof value.iso === "string" || value.iso === null;
   }
 
   revive(value: Record<string, unknown>): Date {
-    return new Date(value.iso as string);
+    return value.iso === null ? new Date(NaN) : new Date(value.iso as string);
   }
 }

--- a/lib/runtime/revivers/errorReviver.ts
+++ b/lib/runtime/revivers/errorReviver.ts
@@ -35,6 +35,7 @@ export class ErrorReviver implements BaseReviver<Error> {
   revive(value: Record<string, unknown>): Error {
     const Ctor = errorConstructors[value.name as string] ?? Error;
     const error = new Ctor(value.message as string);
+    error.name = value.name as string;
     if (typeof value.stack === "string") {
       error.stack = value.stack;
     }

--- a/lib/runtime/revivers/errorReviver.ts
+++ b/lib/runtime/revivers/errorReviver.ts
@@ -29,7 +29,7 @@ export class ErrorReviver implements BaseReviver<Error> {
   }
 
   validate(value: Record<string, unknown>): boolean {
-    return typeof value.message === "string";
+    return typeof value.name === "string" && typeof value.message === "string";
   }
 
   revive(value: Record<string, unknown>): Error {

--- a/lib/runtime/revivers/errorReviver.ts
+++ b/lib/runtime/revivers/errorReviver.ts
@@ -1,0 +1,43 @@
+import { BaseReviver } from "./baseReviver.js";
+
+const errorConstructors: Record<string, ErrorConstructor> = {
+  Error,
+  TypeError,
+  RangeError,
+  ReferenceError,
+  SyntaxError,
+  URIError,
+  EvalError,
+};
+
+export class ErrorReviver implements BaseReviver<Error> {
+  nativeTypeName(): string {
+    return "Error";
+  }
+
+  isInstance(value: unknown): value is Error {
+    return value instanceof Error;
+  }
+
+  serialize(value: Error): Record<string, unknown> {
+    return {
+      __nativeType: this.nativeTypeName(),
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+  }
+
+  validate(value: Record<string, unknown>): boolean {
+    return typeof value.message === "string";
+  }
+
+  revive(value: Record<string, unknown>): Error {
+    const Ctor = errorConstructors[value.name as string] ?? Error;
+    const error = new Ctor(value.message as string);
+    if (typeof value.stack === "string") {
+      error.stack = value.stack;
+    }
+    return error;
+  }
+}

--- a/lib/runtime/revivers/index.ts
+++ b/lib/runtime/revivers/index.ts
@@ -1,10 +1,16 @@
 import { BaseReviver } from "./baseReviver.js";
 import { SetReviver } from "./setReviver.js";
 import { MapReviver } from "./mapReviver.js";
+import { DateReviver } from "./dateReviver.js";
+import { RegExpReviver } from "./regExpReviver.js";
+import { URLReviver } from "./urlReviver.js";
 
 const revivers: BaseReviver<any>[] = [
   new SetReviver(),
   new MapReviver(),
+  new DateReviver(),
+  new RegExpReviver(),
+  new URLReviver(),
 ];
 
 const reviversByName: Record<string, BaseReviver<any>> = {};
@@ -12,10 +18,14 @@ for (const r of revivers) {
   reviversByName[r.nativeTypeName()] = r;
 }
 
-export function nativeTypeReplacer(_key: string, value: unknown): unknown {
+// Must be a regular function (not arrow) so `this` is the parent object.
+// JSON.stringify calls toJSON() on Date/URL/etc before the replacer sees
+// the value, so we check the raw value via this[key] instead.
+export function nativeTypeReplacer(this: any, key: string, value: unknown): unknown {
+  const raw = key === "" ? value : this[key];
   for (const r of revivers) {
-    if (r.isInstance(value)) {
-      return r.serialize(value);
+    if (r.isInstance(raw)) {
+      return r.serialize(raw);
     }
   }
   return value;

--- a/lib/runtime/revivers/index.ts
+++ b/lib/runtime/revivers/index.ts
@@ -4,6 +4,7 @@ import { MapReviver } from "./mapReviver.js";
 import { DateReviver } from "./dateReviver.js";
 import { RegExpReviver } from "./regExpReviver.js";
 import { URLReviver } from "./urlReviver.js";
+import { ErrorReviver } from "./errorReviver.js";
 
 const revivers: BaseReviver<any>[] = [
   new SetReviver(),
@@ -11,6 +12,7 @@ const revivers: BaseReviver<any>[] = [
   new DateReviver(),
   new RegExpReviver(),
   new URLReviver(),
+  new ErrorReviver(),
 ];
 
 const reviversByName: Record<string, BaseReviver<any>> = {};

--- a/lib/runtime/revivers/index.ts
+++ b/lib/runtime/revivers/index.ts
@@ -21,10 +21,10 @@ for (const r of revivers) {
 }
 
 // Must be a regular function (not arrow) so `this` is the parent object.
-// JSON.stringify calls toJSON() on Date/URL/etc before the replacer sees
-// the value, so we check the raw value via this[key] instead.
+// When value is a primitive but this[key] is an object, it means toJSON()
+// was called (Date, URL). Fall back to this[key] to get the raw value.
 export function nativeTypeReplacer(this: any, key: string, value: unknown): unknown {
-  const raw = key === "" ? value : this[key];
+  const raw = typeof value === "object" && value !== null ? value : (key === "" ? value : this[key]);
   if (typeof raw !== "object" || raw === null) return value;
   for (const r of revivers) {
     if (r.isInstance(raw)) {

--- a/lib/runtime/revivers/index.ts
+++ b/lib/runtime/revivers/index.ts
@@ -25,6 +25,7 @@ for (const r of revivers) {
 // the value, so we check the raw value via this[key] instead.
 export function nativeTypeReplacer(this: any, key: string, value: unknown): unknown {
   const raw = key === "" ? value : this[key];
+  if (typeof raw !== "object" || raw === null) return value;
   for (const r of revivers) {
     if (r.isInstance(raw)) {
       return r.serialize(raw);

--- a/lib/runtime/revivers/regExpReviver.ts
+++ b/lib/runtime/revivers/regExpReviver.ts
@@ -1,0 +1,23 @@
+import { BaseReviver } from "./baseReviver.js";
+
+export class RegExpReviver implements BaseReviver<RegExp> {
+  nativeTypeName(): string {
+    return "RegExp";
+  }
+
+  isInstance(value: unknown): value is RegExp {
+    return value instanceof RegExp;
+  }
+
+  serialize(value: RegExp): Record<string, unknown> {
+    return { __nativeType: this.nativeTypeName(), source: value.source, flags: value.flags };
+  }
+
+  validate(value: Record<string, unknown>): boolean {
+    return typeof value.source === "string" && typeof value.flags === "string";
+  }
+
+  revive(value: Record<string, unknown>): RegExp {
+    return new RegExp(value.source as string, value.flags as string);
+  }
+}

--- a/lib/runtime/revivers/urlReviver.ts
+++ b/lib/runtime/revivers/urlReviver.ts
@@ -1,0 +1,23 @@
+import { BaseReviver } from "./baseReviver.js";
+
+export class URLReviver implements BaseReviver<URL> {
+  nativeTypeName(): string {
+    return "URL";
+  }
+
+  isInstance(value: unknown): value is URL {
+    return value instanceof URL;
+  }
+
+  serialize(value: URL): Record<string, unknown> {
+    return { __nativeType: this.nativeTypeName(), href: value.href };
+  }
+
+  validate(value: Record<string, unknown>): boolean {
+    return typeof value.href === "string";
+  }
+
+  revive(value: Record<string, unknown>): URL {
+    return new URL(value.href as string);
+  }
+}

--- a/tests/agency/date-interrupt.agency
+++ b/tests/agency/date-interrupt.agency
@@ -1,0 +1,10 @@
+def check() {
+  return interrupt("confirm")
+  return "ok"
+}
+
+node main() {
+  const d = new Date("2025-06-15T12:00:00.000Z")
+  const r = check()
+  return d.toISOString()
+}

--- a/tests/agency/date-interrupt.test.json
+++ b/tests/agency/date-interrupt.test.json
@@ -1,0 +1,21 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Date survives serialization through an externally-resolved interrupt",
+      "input": "",
+      "expectedOutput": "\"2025-06-15T12:00:00.000Z\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "confirm"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/error-interrupt.agency
+++ b/tests/agency/error-interrupt.agency
@@ -1,0 +1,10 @@
+def check() {
+  return interrupt("confirm")
+  return "ok"
+}
+
+node main() {
+  const e = new Error("something went wrong")
+  const r = check()
+  return e.message
+}

--- a/tests/agency/error-interrupt.test.json
+++ b/tests/agency/error-interrupt.test.json
@@ -1,0 +1,21 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Error survives serialization through an externally-resolved interrupt",
+      "input": "",
+      "expectedOutput": "\"something went wrong\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "confirm"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/regex-interrupt.agency
+++ b/tests/agency/regex-interrupt.agency
@@ -1,0 +1,10 @@
+def check() {
+  return interrupt("confirm")
+  return "ok"
+}
+
+node main() {
+  const pattern = re/^hello/i
+  const r = check()
+  return "Hello world" =~ pattern
+}

--- a/tests/agency/regex-interrupt.test.json
+++ b/tests/agency/regex-interrupt.test.json
@@ -1,0 +1,21 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "RegExp survives serialization through an externally-resolved interrupt",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "confirm"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/url-interrupt.agency
+++ b/tests/agency/url-interrupt.agency
@@ -1,0 +1,10 @@
+def check() {
+  return interrupt("confirm")
+  return "ok"
+}
+
+node main() {
+  const u = new URL("https://example.com/path?q=test")
+  const r = check()
+  return u.hostname
+}

--- a/tests/agency/url-interrupt.test.json
+++ b/tests/agency/url-interrupt.test.json
@@ -1,0 +1,21 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "URL survives serialization through an externally-resolved interrupt",
+      "input": "",
+      "expectedOutput": "\"example.com\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "confirm"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add four new native type revivers: Date, RegExp, URL, Error
- Updated replacer to use `this[key]` to access raw values before `toJSON()` conversion (needed for Date and URL)
- Error reviver restores correct subclass (TypeError, RangeError, etc.)
- BigInt skipped for now -- crashes any `JSON.stringify` site without our replacer, needs a broader fix

## Test plan
- [x] `date-interrupt` -- Date survives externally-resolved interrupt
- [x] `regex-interrupt` -- RegExp survives externally-resolved interrupt
- [x] `url-interrupt` -- URL survives externally-resolved interrupt
- [x] `error-interrupt` -- Error survives externally-resolved interrupt
- [x] All 1908 existing unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)