### PR TITLE
Add std::ui module for terminal agent UIs

### DIFF
--- a/docs-new/.vitepress/config.mts
+++ b/docs-new/.vitepress/config.mts
@@ -59,6 +59,7 @@ export default defineConfig({
           { text: "speech", link: "/stdlib/speech" },
           { text: "strategy", link: "/stdlib/strategy" },
           { text: "system", link: "/stdlib/system" },
+          { text: "ui", link: "/stdlib/ui" },
           { text: "weather", link: "/stdlib/weather" },
           { text: "wikipedia", link: "/stdlib/wikipedia" },
         ],

--- a/docs-new/stdlib/ui.md
+++ b/docs-new/stdlib/ui.md
@@ -1,0 +1,167 @@
+# ui
+
+## Functions
+
+### initUI
+
+```ts
+initUI(title: string)
+```
+
+Initialize a terminal UI with a scrollable output area and a fixed input bar at the bottom. Call this once at the start of your agent. The title appears in the status bar.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| title | string |  |
+
+### destroyUI
+
+```ts
+destroyUI()
+```
+
+Tear down the terminal UI and restore normal terminal behavior. Called automatically on exit, but you can call it early if needed.
+
+### log
+
+```ts
+log(message: string)
+```
+
+Print a message to the scrollable output area. Supports ANSI colors.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| message | string |  |
+
+### status
+
+```ts
+status(left: string, right: string)
+```
+
+Update the status bar. The left text appears on the left side, the right text on the right.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| left | string |  |
+| right | string | "" |
+
+### chat
+
+```ts
+chat(role: string, message: string)
+```
+
+Print a chat message with a colored role prefix. Built-in colors: "user" (blue), "agent" (green). Other roles appear in yellow.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| role | string |  |
+| message | string |  |
+
+### code
+
+```ts
+code(filename: string, content: string)
+```
+
+Display a code block with a filename header and line numbers, inside a bordered box.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| filename | string |  |
+| content | string |  |
+
+### diff
+
+```ts
+diff(filename: string, content: string)
+```
+
+Display a diff with colored +/- lines, inside a bordered box with the filename as a header.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| filename | string |  |
+| content | string |  |
+
+### separator
+
+```ts
+separator(label: string)
+```
+
+Print a horizontal line with an optional label. Useful for visually grouping output sections.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| label | string | "" |
+
+### startSpinner
+
+```ts
+startSpinner(text: string)
+```
+
+Show an animated spinner in the input bar with a label. Useful while the agent is thinking or running a long operation.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| text | string | "working" |
+
+### stopSpinner
+
+```ts
+stopSpinner()
+```
+
+Stop the spinner and clear the input bar.
+
+### prompt
+
+```ts
+prompt(question: string): string
+```
+
+Prompt the user for text input in the fixed input bar at the bottom of the screen. The question appears as a hint. Returns the user's input as a string.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| question | string |  |
+
+**Returns:** string
+
+### getConfirmation
+
+```ts
+getConfirmation(question: string): boolean
+```
+
+Ask the user a yes/no question in the input bar. Returns true if the user answers yes (y/yes), false otherwise. Useful inside handler blocks to approve or reject interrupts interactively.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| question | string |  |
+
+**Returns:** boolean

--- a/docs-new/stdlib/ui.md
+++ b/docs-new/stdlib/ui.md
@@ -65,8 +65,8 @@ Print a chat message with a colored role prefix. Built-in colors: "user" (blue),
 
 | Name | Type | Default |
 |---|---|---|
-| role | string |  |
-| message | string |  |
+| role | string | "" |
+| message | string | "" |
 
 ### code
 
@@ -165,3 +165,11 @@ Ask the user a yes/no question in the input bar. Returns true if the user answer
 | question | string |  |
 
 **Returns:** boolean
+
+### emptyLine
+
+```ts
+emptyLine()
+```
+
+Print an empty line. Useful for adding spacing in the output.

--- a/examples/coding-agent.agency
+++ b/examples/coding-agent.agency
@@ -27,8 +27,8 @@ node main() {
   //ui.emptyLine()
   ui.log("I can help you read, search, and edit code.")
   ui.log("Type your request below, or 'quit' to exit.")
-  ui.separator()
-  //ui.emptyLine()
+  ui.emptyLine()
+  ui.emptyLine()
   let userMessage = ui.prompt("What would you like to do?")
   print("User: ${userMessage}")
   handle {

--- a/examples/coding-agent.agency
+++ b/examples/coding-agent.agency
@@ -2,14 +2,15 @@ import * as ui from "std::ui"
 import { bash } from "std::shell"
 import { edit, multiedit, applyPatch, mkdir, copy, move, remove } from "std::fs"
 import { cwd } from "std::system"
-/* callback onLLMCallStart(data) {
+callback onLLMCallStart(data) {
   ui.chat("", data)
   ui.startSpinner("thinking")
 }
 
 callback onLLMCallEnd(data) {
   ui.stopSpinner()
-} */
+}
+
 callback onToolCallStart(data) {
   ui.log("  tool: ${data.toolName}")
 }

--- a/examples/coding-agent.agency
+++ b/examples/coding-agent.agency
@@ -1,0 +1,65 @@
+import { initUI, destroyUI, log, chat, code, diff, separator, status, startSpinner, stopSpinner, prompt, getConfirmation } from "std::ui"
+import { bash } from "std::shell"
+import { edit } from "std::fs"
+import { cwd } from "std::system"
+def onLLMCallStart(data) {
+  startSpinner("thinking")
+}
+
+def onLLMCallEnd(data) {
+  stopSpinner()
+}
+
+def onToolCallStart(data) {
+  log("\x1b[90m  tool: ${data.toolName}\x1b[0m")
+}
+
+type NextAction = 
+  | { type: "respond"; message: string }
+  | { type: "done"; summary: string }
+
+node main() {
+  initUI("Coding Agent")
+  status("Coding Agent", cwd())
+  separator("Welcome")
+  log("I can help you read, search, and edit code.")
+  log("Type your request below, or 'quit' to exit.")
+  separator()
+  let userMessage = prompt("What would you like to do?")
+  handle {
+    thread {
+      system("""
+                                You are a helpful coding assistant. You have tools to run shell commands,
+                                read and edit files. Use the bash tool to explore the codebase (ls, cat, grep, etc).
+                                Use the edit tool to make changes to files.
+                                Always explain what you're doing before and after using tools.
+                                When you're done with the user's request, set type to "done" with a summary.
+                                When you need to ask the user something or show results, set type to "respond".
+                              """)
+      let nextAction: NextAction = { 
+        type: "respond",
+        message: "How can I help?"
+      }
+      while (nextAction.type != "done") {
+        chat("user", userMessage)
+        nextAction: NextAction = llm(userMessage, { 
+          tools: [bash, edit, cwd]
+        })
+        if (nextAction.type == "respond") {
+          chat("agent", nextAction.message)
+          userMessage = prompt("Your reply?")
+        }
+      }
+    }
+    separator("Done")
+    chat("agent", nextAction.summary)
+  } with (data) {
+    log("\x1b[33m> ${JSON.stringify(data)}\x1b[0m")
+    if (getConfirmation("Approve?")) {
+      return approve()
+    }
+    return reject()
+  }
+  prompt("Press enter to exit")
+  destroyUI()
+}

--- a/examples/coding-agent.agency
+++ b/examples/coding-agent.agency
@@ -22,8 +22,8 @@ const systemPrompt = read("./examples/coding-agent/systemPrompt.md") with approv
 
 node main() {
   ui.initUI("Coding Agent")
-  ui.status("Coding Agent", cwd())
-  ui.separator("Welcome")
+  ui.status("", cwd())
+  //ui.separator("Welcome")
   //ui.emptyLine()
   ui.log("I can help you read, search, and edit code.")
   ui.log("Type your request below, or 'quit' to exit.")
@@ -52,7 +52,9 @@ node main() {
     ui.separator("Done")
     ui.chat("agent", nextAction.summary)
   } with (data) {
-    ui.log("\x1b[33m> ${JSON.stringify(data)}\x1b[0m")
+    ui.log(color.yellow("User approval needed"))
+    ui.log(color.yellow(JSON.stringify(data)))
+    ui.log(color.yellow("Approve? (y/n)"))
     if (ui.getConfirmation("Approve?")) {
       return approve()
     }

--- a/examples/coding-agent.agency
+++ b/examples/coding-agent.agency
@@ -1,65 +1,63 @@
-import { initUI, destroyUI, log, chat, code, diff, separator, status, startSpinner, stopSpinner, prompt, getConfirmation } from "std::ui"
+import * as ui from "std::ui"
 import { bash } from "std::shell"
-import { edit } from "std::fs"
+import { edit, multiedit, applyPatch, mkdir, copy, move, remove } from "std::fs"
 import { cwd } from "std::system"
-callback onLLMCallStart(data) {
-  startSpinner("thinking")
+/* callback onLLMCallStart(data) {
+  ui.chat("", data)
+  ui.startSpinner("thinking")
 }
 
 callback onLLMCallEnd(data) {
-  stopSpinner()
-}
-
+  ui.stopSpinner()
+} */
 callback onToolCallStart(data) {
-  log("  tool: ${data.toolName}")
+  ui.log("  tool: ${data.toolName}")
 }
 
 type NextAction = 
   | { type: "respond"; message: string }
   | { type: "done"; summary: string }
 
+const systemPrompt = read("./examples/coding-agent/systemPrompt.md") with approve
+
 node main() {
-  initUI("Coding Agent")
-  status("Coding Agent", cwd())
-  separator("Welcome")
-  log("I can help you read, search, and edit code.")
-  log("Type your request below, or 'quit' to exit.")
-  separator()
-  let userMessage = prompt("What would you like to do?")
+  ui.initUI("Coding Agent")
+  ui.status("Coding Agent", cwd())
+  ui.separator("Welcome")
+  //ui.emptyLine()
+  ui.log("I can help you read, search, and edit code.")
+  ui.log("Type your request below, or 'quit' to exit.")
+  ui.separator()
+  //ui.emptyLine()
+  let userMessage = ui.prompt("What would you like to do?")
+  print("User: ${userMessage}")
   handle {
     thread {
-      system("""
-                                You are a helpful coding assistant. You have tools to run shell commands,
-                                read and edit files. Use the bash tool to explore the codebase (ls, cat, grep, etc).
-                                Use the edit tool to make changes to files.
-                                Always explain what you're doing before and after using tools.
-                                When you're done with the user's request, set type to "done" with a summary.
-                                When you need to ask the user something or show results, set type to "respond".
-                              """)
+      system(systemPrompt)
       let nextAction: NextAction = { 
         type: "respond",
         message: "How can I help?"
       }
       while (nextAction.type != "done") {
-        chat("user", userMessage)
+        ui.chat("user", userMessage)
         nextAction: NextAction = llm(userMessage, { 
-          tools: [bash, edit, cwd]
+          tools: [bash, edit, cwd, read, write, multiedit, applyPatch, mkdir, copy, move, remove]
         })
         if (nextAction.type == "respond") {
-          chat("agent", nextAction.message)
-          userMessage = prompt("Your reply?")
+          ui.chat("agent", nextAction.message)
+          userMessage = ui.prompt("Your reply?")
         }
       }
     }
-    separator("Done")
-    chat("agent", nextAction.summary)
+    ui.separator("Done")
+    ui.chat("agent", nextAction.summary)
   } with (data) {
-    log("\x1b[33m> ${JSON.stringify(data)}\x1b[0m")
-    if (getConfirmation("Approve?")) {
+    ui.log("\x1b[33m> ${JSON.stringify(data)}\x1b[0m")
+    if (ui.getConfirmation("Approve?")) {
       return approve()
     }
     return reject()
   }
-  prompt("Press enter to exit")
-  destroyUI()
+  ui.prompt("Press enter to exit")
+  ui.destroyUI()
 }

--- a/examples/coding-agent.agency
+++ b/examples/coding-agent.agency
@@ -24,14 +24,11 @@ const systemPrompt = read("./examples/coding-agent/systemPrompt.md") with approv
 node main() {
   ui.initUI("Coding Agent")
   ui.status("", cwd())
-  //ui.separator("Welcome")
-  //ui.emptyLine()
   ui.log("I can help you read, search, and edit code.")
   ui.log("Type your request below, or 'quit' to exit.")
   ui.emptyLine()
   ui.emptyLine()
   let userMessage = ui.prompt("What would you like to do?")
-  print("User: ${userMessage}")
   handle {
     thread {
       system(systemPrompt)

--- a/examples/coding-agent.agency
+++ b/examples/coding-agent.agency
@@ -2,16 +2,16 @@ import { initUI, destroyUI, log, chat, code, diff, separator, status, startSpinn
 import { bash } from "std::shell"
 import { edit } from "std::fs"
 import { cwd } from "std::system"
-def onLLMCallStart(data) {
+callback onLLMCallStart(data) {
   startSpinner("thinking")
 }
 
-def onLLMCallEnd(data) {
+callback onLLMCallEnd(data) {
   stopSpinner()
 }
 
-def onToolCallStart(data) {
-  log("\x1b[90m  tool: ${data.toolName}\x1b[0m")
+callback onToolCallStart(data) {
+  log("  tool: ${data.toolName}")
 }
 
 type NextAction = 

--- a/examples/coding-agent/systemPrompt.md
+++ b/examples/coding-agent/systemPrompt.md
@@ -1,0 +1,6 @@
+You are a helpful coding assistant. You have tools to run shell commands,
+read and edit files. Use the bash tool to explore the codebase (ls, cat, grep, etc).
+Use the edit tool to make changes to files.
+Always explain what you're doing before and after using tools.
+When you're done with the user's request, set type to "done" with a summary.
+When you need to ask the user something or show results, set type to "respond".

--- a/lib/backends/agencyGenerator.test.ts
+++ b/lib/backends/agencyGenerator.test.ts
@@ -274,5 +274,14 @@ describe("AgencyGenerator - Class Definitions", () => {
     const output = formatAgency(input);
     expect(output).toContain("new Counter(0)");
   });
+
+  it("should format callback declarations with the callback keyword", () => {
+    const input = `callback onLLMCallEnd(data) {
+  log(data)
+}`;
+    const output = formatAgency(input);
+    expect(output).toContain("callback onLLMCallEnd(data)");
+    expect(output).not.toContain("def onLLMCallEnd");
+  });
 });
 

--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -503,8 +503,10 @@ export class AgencyGenerator {
 
     const exportPrefix = node.exported ? "export " : "";
 
+    const keyword = node.callback ? "callback" : "def";
+
     let result = this.indentStr(
-      `${exportPrefix}${safePrefix}def ${functionName}(${params})${returnTypeStr} {\n`,
+      `${exportPrefix}${safePrefix}${keyword} ${functionName}(${params})${returnTypeStr} {\n`,
     );
 
     this.increaseIndent();

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -896,6 +896,12 @@ export class TypeScriptBuilder {
 
   private processValueAccess(node: ValueAccess): TsNode {
     let result = this.processNode(node.base);
+    // If the base is a function call, await it before accessing properties/methods
+    // on the result. Without this, chaining like getGreeting().trim() would call
+    // .trim() on the Promise instead of the resolved value.
+    if (node.base.type === "functionCall" && node.chain.length > 0) {
+      result = ts.raw(`(${this.str(ts.await(result))})`);
+    }
     for (const element of node.chain) {
       switch (element.kind) {
         case "property":

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -911,6 +911,7 @@ export class TypeScriptBuilder {
           result = ts.index(result, this.processNode(element.index), { optional: element.optional });
           break;
         case "methodCall": {
+          const isLastInChain = element === node.chain[node.chain.length - 1];
           const callNode = this.generateFunctionCallExpression(
             element.functionCall,
             "valueAccess",
@@ -926,11 +927,18 @@ export class TypeScriptBuilder {
               : callNode.arguments;
             const propNode = ts.prop(result, callNode.callee.name, { optional: element.optional });
             const callExpr = ts.call(propNode, args);
-            result = ts.await(callExpr);
+            // Parenthesize awaited calls when more chain elements follow,
+            // so .next() runs on the resolved value, not the Promise.
+            result = isLastInChain
+              ? ts.await(callExpr)
+              : ts.raw(`(${this.str(ts.await(callExpr))})`);
           } else {
             // Fallback for complex cases (e.g. await-wrapped)
             const dot = element.optional ? "?." : ".";
-            result = ts.raw(`await ${this.str(result)}${dot}${this.str(callNode)}`);
+            const awaited = `await ${this.str(result)}${dot}${this.str(callNode)}`;
+            result = isLastInChain
+              ? ts.raw(awaited)
+              : ts.raw(`(${awaited})`);
           }
           break;
         }

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -920,11 +920,11 @@ export class TypeScriptBuilder {
               : callNode.arguments;
             const propNode = ts.prop(result, callNode.callee.name, { optional: element.optional });
             const callExpr = ts.call(propNode, args);
-            result = isClassMethod ? ts.await(callExpr) : callExpr;
+            result = ts.await(callExpr);
           } else {
             // Fallback for complex cases (e.g. await-wrapped)
             const dot = element.optional ? "?." : ".";
-            result = ts.raw(`${this.str(result)}${dot}${this.str(callNode)}`);
+            result = ts.raw(`await ${this.str(result)}${dot}${this.str(callNode)}`);
           }
           break;
         }

--- a/stdlib/lib/syntax.ts
+++ b/stdlib/lib/syntax.ts
@@ -1,0 +1,77 @@
+import { highlight, Theme } from "cli-highlight";
+import chalk from "chalk";
+
+// VS Code Dark+ color palette
+const blue = chalk.hex("#569CD6");
+const yellow = chalk.hex("#DCDCAA");
+const teal = chalk.hex("#4EC9B0");
+const lightGreen = chalk.hex("#B5CEA8");
+const red = chalk.hex("#D16969");
+const orange = chalk.hex("#CE9178");
+const lightBlue = chalk.hex("#9CDCFE");
+const green = chalk.hex("#6A9955");
+const darkGreen = chalk.hex("#608B4E");
+const gold = chalk.hex("#D7BA7D");
+const lightGray = chalk.hex("#D4D4D4");
+const magenta = chalk.hex("#C586C0");
+
+// VS Code Dark+ inspired theme
+const vscodeDarkTheme: Theme = {
+  keyword: blue,
+  built_in: yellow,
+  type: teal,
+  literal: blue,
+  number: lightGreen,
+  regexp: red,
+  string: orange,
+  subst: lightBlue,
+  symbol: blue,
+  class: teal,
+  function: yellow,
+  title: yellow,
+  params: lightBlue,
+  comment: green.italic,
+  doctag: darkGreen,
+  meta: blue,
+  "meta-keyword": blue,
+  "meta-string": orange,
+  section: blue.bold,
+  tag: blue,
+  name: blue,
+  "builtin-name": yellow,
+  attr: lightBlue,
+  attribute: lightBlue,
+  variable: lightBlue,
+  bullet: gold,
+  code: lightGray,
+  emphasis: chalk.italic,
+  strong: chalk.bold,
+  formula: magenta,
+  link: blue.underline,
+  quote: darkGreen,
+  "selector-tag": gold,
+  "selector-id": gold,
+  "selector-class": gold,
+  "selector-attr": gold,
+  "selector-pseudo": gold,
+  "template-tag": magenta,
+  "template-variable": lightBlue,
+  addition: lightGreen,
+  deletion: orange,
+  default: lightGray,
+};
+
+export function syntaxHighlight(code: string, _language: string): string {
+  try {
+    const language = _language === "agency" ? "ts" : _language;
+    const highlightedCode = highlight(code, {
+      language,
+      ignoreIllegals: true,
+      theme: vscodeDarkTheme,
+    });
+    return highlightedCode;
+  } catch (error) {
+    console.error(`Error highlighting code: ${error}`);
+    return code; // Return unhighlighted code on error
+  }
+}

--- a/stdlib/lib/ui.ts
+++ b/stdlib/lib/ui.ts
@@ -1,0 +1,293 @@
+import * as readline from "readline";
+import { color } from "termcolors";
+
+const ESC = "\x1b";
+const CSI = `${ESC}[`;
+
+function moveTo(row: number, col: number): string {
+  return `${CSI}${row};${col}H`;
+}
+
+function clearLine(): string {
+  return `${CSI}2K`;
+}
+
+function saveCursor(): string {
+  return `${CSI}s`;
+}
+
+function restoreCursor(): string {
+  return `${CSI}u`;
+}
+
+function setScrollRegion(top: number, bottom: number): string {
+  return `${CSI}${top};${bottom}r`;
+}
+
+function resetScrollRegion(): string {
+  return `${CSI}r`;
+}
+
+type UIConfig = {
+  title: string;
+  statusRight: string;
+};
+
+let config: UIConfig = { title: "", statusRight: "" };
+let initialized = false;
+let statusBarRow = 0;
+let inputRow = 0;
+let hintRow = 0;
+let cols = 80;
+let rows = 24;
+let currentStatusLeft = "";
+let currentStatusRight = "";
+let activeRl: readline.Interface | null = null;
+let spinnerInterval: ReturnType<typeof setInterval> | null = null;
+
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+let spinnerIdx = 0;
+let spinnerText = "";
+
+function getTermSize(): { rows: number; cols: number } {
+  return {
+    rows: process.stdout.rows || 24,
+    cols: process.stdout.columns || 80,
+  };
+}
+
+function updateLayout() {
+  const size = getTermSize();
+  rows = size.rows;
+  cols = size.cols;
+  statusBarRow = rows - 2;
+  inputRow = rows - 1;
+  hintRow = rows;
+}
+
+function renderStatusBar() {
+  const left = currentStatusLeft || config.title;
+  const right = currentStatusRight || config.statusRight;
+  const padding = Math.max(0, cols - left.length - right.length - 2);
+  const bar = color.cyan(` ${left}${"─".repeat(padding)} ${right}`);
+  process.stdout.write(
+    saveCursor() +
+      moveTo(statusBarRow, 1) +
+      clearLine() +
+      bar +
+      restoreCursor(),
+  );
+}
+
+function renderInputPrompt(prompt: string) {
+  process.stdout.write(
+    saveCursor() +
+      moveTo(inputRow, 1) +
+      clearLine() +
+      color.bold("❯") + ` ${prompt}` +
+      restoreCursor(),
+  );
+}
+
+function renderHintBar(hint: string) {
+  process.stdout.write(
+    saveCursor() +
+      moveTo(hintRow, 1) +
+      clearLine() +
+      color.dim(`  ${hint}`) +
+      restoreCursor(),
+  );
+}
+
+function clearBottomArea() {
+  process.stdout.write(
+    saveCursor() +
+      moveTo(statusBarRow, 1) +
+      clearLine() +
+      moveTo(inputRow, 1) +
+      clearLine() +
+      moveTo(hintRow, 1) +
+      clearLine() +
+      restoreCursor(),
+  );
+}
+
+function setupScrollRegion() {
+  updateLayout();
+  process.stdout.write(setScrollRegion(1, statusBarRow - 1));
+  process.stdout.write(moveTo(1, 1));
+}
+
+function writeInScrollRegion(text: string) {
+  process.stdout.write(
+    saveCursor() +
+      moveTo(statusBarRow - 1, 1) +
+      "\n" +
+      text +
+      restoreCursor(),
+  );
+}
+
+export function _initUI(title: string): void {
+  if (initialized) return;
+  initialized = true;
+  config.title = title;
+  config.statusRight = "";
+
+  setupScrollRegion();
+  renderStatusBar();
+  renderInputPrompt("");
+  renderHintBar("");
+
+  process.stdout.on("resize", () => {
+    updateLayout();
+    process.stdout.write(setScrollRegion(1, statusBarRow - 1));
+    renderStatusBar();
+  });
+
+  const cleanup = () => {
+    if (initialized) {
+      _destroyUI();
+    }
+  };
+  process.on("exit", cleanup);
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(0);
+  });
+}
+
+export function _destroyUI(): void {
+  if (!initialized) return;
+  initialized = false;
+  if (spinnerInterval) {
+    clearInterval(spinnerInterval);
+    spinnerInterval = null;
+  }
+  if (activeRl) {
+    activeRl.close();
+    activeRl = null;
+  }
+  process.stdout.write(resetScrollRegion());
+  clearBottomArea();
+  process.stdout.write(moveTo(rows, 1) + "\n");
+}
+
+export function _log(message: string): void {
+  if (!initialized) return;
+  writeInScrollRegion(message);
+  renderStatusBar();
+}
+
+export function _status(left: string, right: string): void {
+  if (!initialized) return;
+  currentStatusLeft = left;
+  currentStatusRight = right;
+  renderStatusBar();
+}
+
+export function _chat(role: string, message: string): void {
+  if (!initialized) return;
+  const colorFn = role === "user" ? color.blue.bold : role === "agent" ? color.green.bold : color.yellow.bold;
+  const prefix = colorFn(role);
+  const lines = message.split("\n");
+  writeInScrollRegion(`${prefix}: ${lines[0]}`);
+  for (let i = 1; i < lines.length; i++) {
+    writeInScrollRegion(`  ${lines[i]}`);
+  }
+  renderStatusBar();
+}
+
+export function _code(filename: string, content: string): void {
+  if (!initialized) return;
+  writeInScrollRegion(color.dim(`┌─ ${filename} ${"─".repeat(Math.max(0, cols - filename.length - 6))}`));
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const lineNum = String(i + 1).padStart(4, " ");
+    writeInScrollRegion(`${color.dim(`│${lineNum}`)} ${lines[i]}`);
+  }
+  writeInScrollRegion(color.dim(`└${"─".repeat(Math.max(0, cols - 2))}`));
+  renderStatusBar();
+}
+
+export function _diff(filename: string, content: string): void {
+  if (!initialized) return;
+  writeInScrollRegion(color.dim(`┌─ ${filename} ${"─".repeat(Math.max(0, cols - filename.length - 6))}`));
+  const lines = content.split("\n");
+  for (const line of lines) {
+    if (line.startsWith("+")) {
+      writeInScrollRegion(color.green(`│ ${line}`));
+    } else if (line.startsWith("-")) {
+      writeInScrollRegion(color.red(`│ ${line}`));
+    } else {
+      writeInScrollRegion(`${color.dim("│")} ${line}`);
+    }
+  }
+  writeInScrollRegion(color.dim(`└${"─".repeat(Math.max(0, cols - 2))}`));
+  renderStatusBar();
+}
+
+export function _separator(label: string): void {
+  if (!initialized) return;
+  const padding = Math.max(0, cols - label.length - 4);
+  writeInScrollRegion(color.dim(`── ${label} ${"─".repeat(padding)}`));
+  renderStatusBar();
+}
+
+export function _startSpinner(text: string): void {
+  if (!initialized || spinnerInterval) return;
+  spinnerText = text;
+  spinnerIdx = 0;
+  const update = () => {
+    const frame = SPINNER_FRAMES[spinnerIdx % SPINNER_FRAMES.length];
+    renderInputPrompt(`${color.cyan(frame)} ${spinnerText}`);
+    spinnerIdx++;
+  };
+  update();
+  spinnerInterval = setInterval(update, 80);
+}
+
+export function _stopSpinner(): void {
+  if (spinnerInterval) {
+    clearInterval(spinnerInterval);
+    spinnerInterval = null;
+  }
+  if (initialized) {
+    renderInputPrompt("");
+  }
+}
+
+export function _prompt(question: string): Promise<string> {
+  if (!initialized) {
+    return Promise.resolve("");
+  }
+  _stopSpinner();
+
+  return new Promise<string>((resolve) => {
+    process.stdout.write(
+      moveTo(inputRow, 1) + clearLine() + color.bold("❯") + " ",
+    );
+    renderHintBar(question);
+
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      terminal: true,
+      prompt: "",
+    });
+    activeRl = rl;
+
+    process.stdout.write(moveTo(inputRow, 4));
+
+    rl.on("line", (answer: string) => {
+      rl.close();
+      activeRl = null;
+      process.stdout.write(
+        moveTo(inputRow, 1) + clearLine() + moveTo(hintRow, 1) + clearLine(),
+      );
+      renderInputPrompt("");
+      renderHintBar("");
+      resolve(answer);
+    });
+  });
+}

--- a/stdlib/lib/ui.ts
+++ b/stdlib/lib/ui.ts
@@ -60,18 +60,30 @@ function getTermSize(): { rows: number; cols: number } {
   };
 }
 
+const MIN_ROWS = 6;
+
 function updateLayout() {
   const size = getTermSize();
-  rows = size.rows;
+  rows = Math.max(size.rows, MIN_ROWS);
   cols = size.cols;
   statusBarRow = rows - 2;
   inputRow = rows - 1;
   hintRow = rows;
 }
 
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str;
+  return str.slice(0, maxLen - 1) + "…";
+}
+
 function renderStatusBar() {
-  const left = currentStatusLeft || config.title;
-  const right = currentStatusRight || config.statusRight;
+  const rawLeft = currentStatusLeft || config.title;
+  const rawRight = currentStatusRight || config.statusRight;
+  const maxContent = cols - 4;
+  const rightLen = Math.min(rawRight.length, Math.floor(maxContent / 3));
+  const leftLen = Math.min(rawLeft.length, maxContent - rightLen);
+  const left = truncate(rawLeft, leftLen);
+  const right = truncate(rawRight, rightLen);
   const padding = Math.max(0, cols - left.length - right.length - 2);
   const bar = color.cyan(` ${left}${"─".repeat(padding)} ${right}`);
   process.stdout.write(

--- a/stdlib/lib/ui.ts
+++ b/stdlib/lib/ui.ts
@@ -36,8 +36,10 @@ function resetScrollRegion(): string {
   return `${CSI}r`;
 }
 
-export function _emptyLine(): string {
-  return " ".repeat(cols);
+export function _emptyLine(): void {
+  if (!initialized) return;
+  writeInScrollRegion("");
+  renderFixedArea();
 }
 
 // ---------------------------------------------------------------------------
@@ -85,9 +87,6 @@ let inputLineIndex = 0;
 function buildFixedLines(): string[] {
   const lines: string[] = [];
 
-  // const titlePadding = Math.max(0, cols - appTitle.length - 4);
-  // lines.push(color.green(`── ${appTitle} ${"─".repeat(titlePadding)}`));
-
   lines.push("");
   lines.push("");
   // prompt
@@ -97,7 +96,10 @@ function buildFixedLines(): string[] {
   lines.push(color.dim("─".repeat(cols)));
 
   // status bar
-  const left = truncate(statusLeft, Math.floor(((cols - 4) * 2) / 3));
+  const left = truncate(
+    statusLeft || hintContent,
+    Math.floor(((cols - 4) * 2) / 3),
+  );
   const right = truncate(statusRight, Math.floor((cols - 4) / 3));
   const padding = Math.max(0, cols - left.length - right.length - 2);
   lines.push(color.cyan(`${left} ${" ".repeat(padding)} ${right}`));

--- a/stdlib/lib/ui.ts
+++ b/stdlib/lib/ui.ts
@@ -1,5 +1,11 @@
 import * as readline from "readline";
 import { color } from "termcolors";
+import { syntaxHighlight } from "./syntax.js";
+
+/* CSI stands for Control Sequence Introducer — it's the escape sequence \x1B[ (ESC followed by [)
+used in ANSI terminal control codes. It's the prefix for commands that control cursor position,
+text color, clearing the screen, and other terminal formatting operations.
+*/
 
 const ESC = "\x1b";
 const CSI = `${ESC}[`;
@@ -12,6 +18,8 @@ function clearLine(): string {
   return `${CSI}2K`;
 }
 
+// These let you move the cursor around to draw/update part of the screen,
+// then jump back to where you were.
 function saveCursor(): string {
   return `${CSI}s`;
 }
@@ -28,21 +36,46 @@ function resetScrollRegion(): string {
   return `${CSI}r`;
 }
 
+export function _emptyLine(): string {
+  return " ".repeat(cols);
+}
+
 type UIConfig = {
   title: string;
   statusRight: string;
 };
 
+// UI title and default right-side status text, set once during _initUI()
 let config: UIConfig = { title: "", statusRight: "" };
+
+// Whether the UI has been initialized via _initUI()
 let initialized = false;
+
+// Terminal row where the status bar is drawn (2 rows from bottom)
 let statusBarRow = 0;
+
+// Terminal row where the input prompt is drawn (1 row from bottom)
 let inputRow = 0;
+
+// Terminal row where the hint text is drawn (last row)
 let hintRow = 0;
+
+// Current terminal width in columns
 let cols = 80;
+
+// Current terminal height in rows
 let rows = 24;
+
+// Dynamic left-side status bar text; overrides config.title when non-empty
 let currentStatusLeft = "";
+
+// Dynamic right-side status bar text; overrides config.statusRight when non-empty
 let currentStatusRight = "";
+
+// Active readline interface during _prompt(), closed when the user submits input
 let activeRl: readline.Interface | null = null;
+
+// Interval handle for the spinner animation, cleared by _stopSpinner()
 let spinnerInterval: ReturnType<typeof setInterval> | null = null;
 
 const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
@@ -100,7 +133,8 @@ function renderInputPrompt(prompt: string) {
     saveCursor() +
       moveTo(inputRow, 1) +
       clearLine() +
-      color.bold("❯") + ` ${prompt}` +
+      color.bold("❯") +
+      ` ${prompt}` +
       restoreCursor(),
   );
 }
@@ -136,11 +170,7 @@ function setupScrollRegion() {
 
 function writeInScrollRegion(text: string) {
   process.stdout.write(
-    saveCursor() +
-      moveTo(statusBarRow - 1, 1) +
-      "\n" +
-      text +
-      restoreCursor(),
+    saveCursor() + moveTo(statusBarRow - 1, 1) + "\n" + text + restoreCursor(),
   );
 }
 
@@ -149,7 +179,11 @@ function writeBox(
   lines: string[],
   renderLine: (line: string, index: number) => string,
 ): void {
-  writeInScrollRegion(color.dim(`┌─ ${filename} ${"─".repeat(Math.max(0, cols - filename.length - 6))}`));
+  writeInScrollRegion(
+    color.dim(
+      `┌─ ${filename} ${"─".repeat(Math.max(0, cols - filename.length - 6))}`,
+    ),
+  );
   for (let i = 0; i < lines.length; i++) {
     writeInScrollRegion(renderLine(lines[i], i));
   }
@@ -238,7 +272,12 @@ export function _status(left: string, right: string): void {
 
 export function _chat(role: string, message: string): void {
   if (!initialized) return;
-  const colorFn = role === "user" ? color.blue.bold : role === "agent" ? color.green.bold : color.yellow.bold;
+  const colorFn =
+    role === "user"
+      ? color.cyan.bold
+      : role === "agent"
+        ? color.white.bold
+        : color.dim;
   const prefix = colorFn(role);
   const lines = message.split("\n");
   writeInScrollRegion(`${prefix}: ${lines[0]}`);
@@ -256,22 +295,44 @@ export function _code(filename: string, content: string): void {
   });
 }
 
-export function _diff(filename: string, content: string): void {
+const languageMap: Record<string, string> = {
+  agency: "typescript",
+  ts: "typescript",
+  js: "javascript",
+  py: "python",
+  java: "java",
+  rb: "ruby",
+  go: "go",
+  rs: "rust",
+};
+
+export function _diff(filename: string, _content: string): void {
   if (!initialized) return;
+  const ext = filename.split(".").slice(-1)[0];
+  const language = languageMap[ext];
+  let content = _content;
+  if (language) {
+    content = syntaxHighlight(content, language);
+  }
   writeBox(filename, content.split("\n"), (line) => {
     if (line.startsWith("+")) {
-      return color.green(`│ ${line}`);
+      return color.bgGreen(`│ ${line}`);
     } else if (line.startsWith("-")) {
-      return color.red(`│ ${line}`);
+      return color.bgRed(`│ ${line}`);
     }
-    return `${color.dim("│")} ${line}`;
+    return `| ${line}`;
+    //return `${color.dim("│")} ${line}`;
   });
 }
 
 export function _separator(label: string): void {
   if (!initialized) return;
-  const padding = Math.max(0, cols - label.length - 4);
-  writeInScrollRegion(color.dim(`── ${label} ${"─".repeat(padding)}`));
+  if (label) {
+    const padding = Math.max(0, cols - label.length - 4);
+    writeInScrollRegion(color.dim(`── ${label} ${"─".repeat(padding)}`));
+  } else {
+    writeInScrollRegion(color.dim("─".repeat(cols)));
+  }
   renderStatusBar();
 }
 

--- a/stdlib/lib/ui.ts
+++ b/stdlib/lib/ui.ts
@@ -40,137 +40,121 @@ export function _emptyLine(): string {
   return " ".repeat(cols);
 }
 
-type UIConfig = {
-  title: string;
-  statusRight: string;
-};
+// ---------------------------------------------------------------------------
+// State
+// ---------------------------------------------------------------------------
 
-// UI title and default right-side status text, set once during _initUI()
-let config: UIConfig = { title: "", statusRight: "" };
-
-// Whether the UI has been initialized via _initUI()
 let initialized = false;
-
-// Terminal row where the status bar is drawn (2 rows from bottom)
-let statusBarRow = 0;
-
-// Terminal row where the input prompt is drawn (1 row from bottom)
-let inputRow = 0;
-
-// Terminal row where the hint text is drawn (last row)
-let hintRow = 0;
-
-// Current terminal width in columns
 let cols = 80;
-
-// Current terminal height in rows
 let rows = 24;
 
-// Dynamic left-side status bar text; overrides config.title when non-empty
-let currentStatusLeft = "";
+// Status bar content
+let statusLeft = "";
+let statusRight = "";
 
-// Dynamic right-side status bar text; overrides config.statusRight when non-empty
-let currentStatusRight = "";
+// Input bar content
+let inputContent = "";
+let hintContent = "";
 
-// Active readline interface during _prompt(), closed when the user submits input
+// Spinner
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+let spinnerInterval: ReturnType<typeof setInterval> | null = null;
+let spinnerIdx = 0;
+
+// Readline
 let activeRl: readline.Interface | null = null;
 
-// Interval handle for the spinner animation, cleared by _stopSpinner()
-let spinnerInterval: ReturnType<typeof setInterval> | null = null;
-
-const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-let spinnerIdx = 0;
-let spinnerText = "";
-
+// Event handlers (stored for cleanup)
 let resizeHandler: (() => void) | null = null;
 let exitHandler: (() => void) | null = null;
 let sigintHandler: (() => void) | null = null;
 
-function getTermSize(): { rows: number; cols: number } {
-  return {
-    rows: process.stdout.rows || 24,
-    cols: process.stdout.columns || 80,
-  };
+// ---------------------------------------------------------------------------
+// Fixed area — the single place that defines the bottom of the screen
+// ---------------------------------------------------------------------------
+
+// Returns an array of strings, one per line. The length of this array
+// determines how many rows are reserved at the bottom. Change this function
+// to add, remove, or restyle lines without touching anything else.
+function buildFixedLines(): string[] {
+  const lines: string[] = [];
+
+  // prompt
+  lines.push(color.dim("─".repeat(cols)));
+  lines.push(`${color.bold("❯")} ${inputContent}`);
+  lines.push(color.dim("─".repeat(cols)));
+
+  // status bar
+  const left = truncate(statusLeft, Math.floor(((cols - 4) * 2) / 3));
+  const right = truncate(statusRight, Math.floor((cols - 4) / 3));
+  const padding = Math.max(0, cols - left.length - right.length - 2);
+  lines.push(color.cyan(`${left} ${"─".repeat(padding)} ${right}`));
+
+  return lines;
 }
+
+function fixedLineCount(): number {
+  return buildFixedLines().length;
+}
+
+// The row where the fixed area starts (1-indexed)
+function fixedAreaStart(): number {
+  return rows - fixedLineCount() + 1;
+}
+
+// The last row of the scroll region (one above the fixed area)
+function scrollBottom(): number {
+  return fixedAreaStart() - 1;
+}
+
+// Renders the entire fixed area at the bottom of the screen.
+// This is the ONLY function that writes to the fixed rows.
+function renderFixedArea() {
+  const lines = buildFixedLines();
+  const startRow = fixedAreaStart();
+  let out = saveCursor();
+  for (let i = 0; i < lines.length; i++) {
+    out += moveTo(startRow + i, 1) + clearLine() + lines[i];
+  }
+  out += restoreCursor();
+  process.stdout.write(out);
+}
+
+function clearFixedArea() {
+  const startRow = fixedAreaStart();
+  const count = fixedLineCount();
+  let out = saveCursor();
+  for (let i = 0; i < count; i++) {
+    out += moveTo(startRow + i, 1) + clearLine();
+  }
+  out += restoreCursor();
+  process.stdout.write(out);
+}
+
+// ---------------------------------------------------------------------------
+// Terminal helpers
+// ---------------------------------------------------------------------------
 
 const MIN_ROWS = 6;
 
-function updateLayout() {
-  const size = getTermSize();
-  rows = Math.max(size.rows, MIN_ROWS);
-  cols = size.cols;
-  statusBarRow = rows - 2;
-  inputRow = rows - 1;
-  hintRow = rows;
+function updateSize() {
+  rows = Math.max(process.stdout.rows || 24, MIN_ROWS);
+  cols = process.stdout.columns || 80;
 }
 
 function truncate(str: string, maxLen: number): string {
+  if (maxLen <= 0) return "";
   if (str.length <= maxLen) return str;
   return str.slice(0, maxLen - 1) + "…";
 }
 
-function renderStatusBar() {
-  const rawLeft = currentStatusLeft || config.title;
-  const rawRight = currentStatusRight || config.statusRight;
-  const maxContent = cols - 4;
-  const rightLen = Math.min(rawRight.length, Math.floor(maxContent / 3));
-  const leftLen = Math.min(rawLeft.length, maxContent - rightLen);
-  const left = truncate(rawLeft, leftLen);
-  const right = truncate(rawRight, rightLen);
-  const padding = Math.max(0, cols - left.length - right.length - 2);
-  const bar = color.cyan(` ${left}${"─".repeat(padding)} ${right}`);
-  process.stdout.write(
-    saveCursor() +
-      moveTo(statusBarRow, 1) +
-      clearLine() +
-      bar +
-      restoreCursor(),
-  );
-}
-
-function renderInputPrompt(prompt: string) {
-  process.stdout.write(
-    saveCursor() +
-      moveTo(inputRow, 1) +
-      clearLine() +
-      color.bold("❯") +
-      ` ${prompt}` +
-      restoreCursor(),
-  );
-}
-
-function renderHintBar(hint: string) {
-  process.stdout.write(
-    saveCursor() +
-      moveTo(hintRow, 1) +
-      clearLine() +
-      color.dim(`  ${hint}`) +
-      restoreCursor(),
-  );
-}
-
-function clearBottomArea() {
-  process.stdout.write(
-    saveCursor() +
-      moveTo(statusBarRow, 1) +
-      clearLine() +
-      moveTo(inputRow, 1) +
-      clearLine() +
-      moveTo(hintRow, 1) +
-      clearLine() +
-      restoreCursor(),
-  );
-}
-
-function setupScrollRegion() {
-  updateLayout();
-  process.stdout.write(setScrollRegion(1, statusBarRow - 1));
-  process.stdout.write(moveTo(1, 1));
+function applyScrollRegion() {
+  process.stdout.write(setScrollRegion(1, scrollBottom()));
 }
 
 function writeInScrollRegion(text: string) {
   process.stdout.write(
-    saveCursor() + moveTo(statusBarRow - 1, 1) + "\n" + text + restoreCursor(),
+    saveCursor() + moveTo(scrollBottom(), 1) + "\n" + text + restoreCursor(),
   );
 }
 
@@ -188,32 +172,31 @@ function writeBox(
     writeInScrollRegion(renderLine(lines[i], i));
   }
   writeInScrollRegion(color.dim(`└${"─".repeat(Math.max(0, cols - 2))}`));
-  renderStatusBar();
+  renderFixedArea();
 }
 
-function resetState() {
-  config = { title: "", statusRight: "" };
-  currentStatusLeft = "";
-  currentStatusRight = "";
-  spinnerIdx = 0;
-  spinnerText = "";
-}
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
 
 export function _initUI(title: string): void {
   if (initialized) return;
   initialized = true;
-  config.title = title;
-  config.statusRight = "";
 
-  setupScrollRegion();
-  renderStatusBar();
-  renderInputPrompt("");
-  renderHintBar("");
+  statusLeft = title;
+  statusRight = "";
+  inputContent = "";
+  hintContent = "";
+
+  updateSize();
+  applyScrollRegion();
+  process.stdout.write(moveTo(1, 1));
+  renderFixedArea();
 
   resizeHandler = () => {
-    updateLayout();
-    process.stdout.write(setScrollRegion(1, statusBarRow - 1));
-    renderStatusBar();
+    updateSize();
+    applyScrollRegion();
+    renderFixedArea();
   };
   exitHandler = () => {
     if (initialized) _destroyUI();
@@ -231,6 +214,7 @@ export function _initUI(title: string): void {
 export function _destroyUI(): void {
   if (!initialized) return;
   initialized = false;
+
   if (spinnerInterval) {
     clearInterval(spinnerInterval);
     spinnerInterval = null;
@@ -251,23 +235,25 @@ export function _destroyUI(): void {
     process.removeListener("SIGINT", sigintHandler);
     sigintHandler = null;
   }
+
   process.stdout.write(resetScrollRegion());
-  clearBottomArea();
+  clearFixedArea();
   process.stdout.write(moveTo(rows, 1) + "\n");
-  resetState();
+
+  statusLeft = "";
+  statusRight = "";
+  inputContent = "";
+  hintContent = "";
 }
+
+// ---------------------------------------------------------------------------
+// Public API — scrollable output
+// ---------------------------------------------------------------------------
 
 export function _log(message: string): void {
   if (!initialized) return;
   writeInScrollRegion(message);
-  renderStatusBar();
-}
-
-export function _status(left: string, right: string): void {
-  if (!initialized) return;
-  currentStatusLeft = left;
-  currentStatusRight = right;
-  renderStatusBar();
+  renderFixedArea();
 }
 
 export function _chat(role: string, message: string): void {
@@ -284,7 +270,7 @@ export function _chat(role: string, message: string): void {
   for (let i = 1; i < lines.length; i++) {
     writeInScrollRegion(`  ${lines[i]}`);
   }
-  renderStatusBar();
+  renderFixedArea();
 }
 
 export function _code(filename: string, content: string): void {
@@ -321,7 +307,6 @@ export function _diff(filename: string, _content: string): void {
       return color.bgRed(`│ ${line}`);
     }
     return `| ${line}`;
-    //return `${color.dim("│")} ${line}`;
   });
 }
 
@@ -333,16 +318,27 @@ export function _separator(label: string): void {
   } else {
     writeInScrollRegion(color.dim("─".repeat(cols)));
   }
-  renderStatusBar();
+  renderFixedArea();
+}
+
+// ---------------------------------------------------------------------------
+// Public API — fixed area updates
+// ---------------------------------------------------------------------------
+
+export function _status(left: string, right: string): void {
+  if (!initialized) return;
+  statusLeft = left;
+  statusRight = right;
+  renderFixedArea();
 }
 
 export function _startSpinner(text: string): void {
   if (!initialized || spinnerInterval) return;
-  spinnerText = text;
   spinnerIdx = 0;
   const update = () => {
     const frame = SPINNER_FRAMES[spinnerIdx % SPINNER_FRAMES.length];
-    renderInputPrompt(`${color.cyan(frame)} ${spinnerText}`);
+    inputContent = `${color.cyan(frame)} ${text}`;
+    renderFixedArea();
     spinnerIdx++;
   };
   update();
@@ -355,7 +351,8 @@ export function _stopSpinner(): void {
     spinnerInterval = null;
   }
   if (initialized) {
-    renderInputPrompt("");
+    inputContent = "";
+    renderFixedArea();
   }
 }
 
@@ -366,10 +363,14 @@ export function _prompt(question: string): Promise<string> {
   _stopSpinner();
 
   return new Promise<string>((resolve) => {
-    process.stdout.write(
-      moveTo(inputRow, 1) + clearLine() + color.bold("❯") + " ",
-    );
-    renderHintBar(question);
+    // Update hint, clear input, position cursor on the input row
+    hintContent = question;
+    inputContent = "";
+    renderFixedArea();
+
+    // Position cursor after the prompt character for typing
+    const inputRow = fixedAreaStart() + 1; // second line of fixed area
+    process.stdout.write(moveTo(inputRow, 4));
 
     const rl = readline.createInterface({
       input: process.stdin,
@@ -379,16 +380,12 @@ export function _prompt(question: string): Promise<string> {
     });
     activeRl = rl;
 
-    process.stdout.write(moveTo(inputRow, 4));
-
     rl.on("line", (answer: string) => {
       rl.close();
       activeRl = null;
-      process.stdout.write(
-        moveTo(inputRow, 1) + clearLine() + moveTo(hintRow, 1) + clearLine(),
-      );
-      renderInputPrompt("");
-      renderHintBar("");
+      inputContent = "";
+      hintContent = "";
+      renderFixedArea();
       resolve(answer);
     });
   });

--- a/stdlib/lib/ui.ts
+++ b/stdlib/lib/ui.ts
@@ -49,6 +49,10 @@ const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", 
 let spinnerIdx = 0;
 let spinnerText = "";
 
+let resizeHandler: (() => void) | null = null;
+let exitHandler: (() => void) | null = null;
+let sigintHandler: (() => void) | null = null;
+
 function getTermSize(): { rows: number; cols: number } {
   return {
     rows: process.stdout.rows || 24,
@@ -128,6 +132,27 @@ function writeInScrollRegion(text: string) {
   );
 }
 
+function writeBox(
+  filename: string,
+  lines: string[],
+  renderLine: (line: string, index: number) => string,
+): void {
+  writeInScrollRegion(color.dim(`┌─ ${filename} ${"─".repeat(Math.max(0, cols - filename.length - 6))}`));
+  for (let i = 0; i < lines.length; i++) {
+    writeInScrollRegion(renderLine(lines[i], i));
+  }
+  writeInScrollRegion(color.dim(`└${"─".repeat(Math.max(0, cols - 2))}`));
+  renderStatusBar();
+}
+
+function resetState() {
+  config = { title: "", statusRight: "" };
+  currentStatusLeft = "";
+  currentStatusRight = "";
+  spinnerIdx = 0;
+  spinnerText = "";
+}
+
 export function _initUI(title: string): void {
   if (initialized) return;
   initialized = true;
@@ -139,22 +164,22 @@ export function _initUI(title: string): void {
   renderInputPrompt("");
   renderHintBar("");
 
-  process.stdout.on("resize", () => {
+  resizeHandler = () => {
     updateLayout();
     process.stdout.write(setScrollRegion(1, statusBarRow - 1));
     renderStatusBar();
-  });
-
-  const cleanup = () => {
-    if (initialized) {
-      _destroyUI();
-    }
   };
-  process.on("exit", cleanup);
-  process.on("SIGINT", () => {
-    cleanup();
+  exitHandler = () => {
+    if (initialized) _destroyUI();
+  };
+  sigintHandler = () => {
+    if (initialized) _destroyUI();
     process.exit(0);
-  });
+  };
+
+  process.stdout.on("resize", resizeHandler);
+  process.on("exit", exitHandler);
+  process.on("SIGINT", sigintHandler);
 }
 
 export function _destroyUI(): void {
@@ -168,9 +193,22 @@ export function _destroyUI(): void {
     activeRl.close();
     activeRl = null;
   }
+  if (resizeHandler) {
+    process.stdout.removeListener("resize", resizeHandler);
+    resizeHandler = null;
+  }
+  if (exitHandler) {
+    process.removeListener("exit", exitHandler);
+    exitHandler = null;
+  }
+  if (sigintHandler) {
+    process.removeListener("SIGINT", sigintHandler);
+    sigintHandler = null;
+  }
   process.stdout.write(resetScrollRegion());
   clearBottomArea();
   process.stdout.write(moveTo(rows, 1) + "\n");
+  resetState();
 }
 
 export function _log(message: string): void {
@@ -200,31 +238,22 @@ export function _chat(role: string, message: string): void {
 
 export function _code(filename: string, content: string): void {
   if (!initialized) return;
-  writeInScrollRegion(color.dim(`┌─ ${filename} ${"─".repeat(Math.max(0, cols - filename.length - 6))}`));
-  const lines = content.split("\n");
-  for (let i = 0; i < lines.length; i++) {
+  writeBox(filename, content.split("\n"), (line, i) => {
     const lineNum = String(i + 1).padStart(4, " ");
-    writeInScrollRegion(`${color.dim(`│${lineNum}`)} ${lines[i]}`);
-  }
-  writeInScrollRegion(color.dim(`└${"─".repeat(Math.max(0, cols - 2))}`));
-  renderStatusBar();
+    return `${color.dim(`│${lineNum}`)} ${line}`;
+  });
 }
 
 export function _diff(filename: string, content: string): void {
   if (!initialized) return;
-  writeInScrollRegion(color.dim(`┌─ ${filename} ${"─".repeat(Math.max(0, cols - filename.length - 6))}`));
-  const lines = content.split("\n");
-  for (const line of lines) {
+  writeBox(filename, content.split("\n"), (line) => {
     if (line.startsWith("+")) {
-      writeInScrollRegion(color.green(`│ ${line}`));
+      return color.green(`│ ${line}`);
     } else if (line.startsWith("-")) {
-      writeInScrollRegion(color.red(`│ ${line}`));
-    } else {
-      writeInScrollRegion(`${color.dim("│")} ${line}`);
+      return color.red(`│ ${line}`);
     }
-  }
-  writeInScrollRegion(color.dim(`└${"─".repeat(Math.max(0, cols - 2))}`));
-  renderStatusBar();
+    return `${color.dim("│")} ${line}`;
+  });
 }
 
 export function _separator(label: string): void {

--- a/stdlib/lib/ui.ts
+++ b/stdlib/lib/ui.ts
@@ -48,6 +48,8 @@ let initialized = false;
 let cols = 80;
 let rows = 24;
 
+let appTitle = "";
+
 // Status bar content
 let statusLeft = "";
 let statusRight = "";
@@ -73,14 +75,24 @@ let sigintHandler: (() => void) | null = null;
 // Fixed area — the single place that defines the bottom of the screen
 // ---------------------------------------------------------------------------
 
+// The index (within the fixed lines array) where the input prompt lives.
+// Set by buildFixedLines() so _prompt() can position the cursor correctly.
+let inputLineIndex = 0;
+
 // Returns an array of strings, one per line. The length of this array
 // determines how many rows are reserved at the bottom. Change this function
 // to add, remove, or restyle lines without touching anything else.
 function buildFixedLines(): string[] {
   const lines: string[] = [];
 
+  // const titlePadding = Math.max(0, cols - appTitle.length - 4);
+  // lines.push(color.green(`── ${appTitle} ${"─".repeat(titlePadding)}`));
+
+  lines.push("");
+  lines.push("");
   // prompt
   lines.push(color.dim("─".repeat(cols)));
+  inputLineIndex = lines.length;
   lines.push(`${color.bold("❯")} ${inputContent}`);
   lines.push(color.dim("─".repeat(cols)));
 
@@ -88,7 +100,8 @@ function buildFixedLines(): string[] {
   const left = truncate(statusLeft, Math.floor(((cols - 4) * 2) / 3));
   const right = truncate(statusRight, Math.floor((cols - 4) / 3));
   const padding = Math.max(0, cols - left.length - right.length - 2);
-  lines.push(color.cyan(`${left} ${"─".repeat(padding)} ${right}`));
+  lines.push(color.cyan(`${left} ${" ".repeat(padding)} ${right}`));
+  lines.push("");
 
   return lines;
 }
@@ -183,7 +196,8 @@ export function _initUI(title: string): void {
   if (initialized) return;
   initialized = true;
 
-  statusLeft = title;
+  appTitle = title;
+  statusLeft = "";
   statusRight = "";
   inputContent = "";
   hintContent = "";
@@ -192,6 +206,7 @@ export function _initUI(title: string): void {
   applyScrollRegion();
   process.stdout.write(moveTo(1, 1));
   renderFixedArea();
+  _separator(appTitle);
 
   resizeHandler = () => {
     updateSize();
@@ -369,8 +384,7 @@ export function _prompt(question: string): Promise<string> {
     renderFixedArea();
 
     // Position cursor after the prompt character for typing
-    const inputRow = fixedAreaStart() + 1; // second line of fixed area
-    process.stdout.write(moveTo(inputRow, 4));
+    process.stdout.write(moveTo(fixedAreaStart() + inputLineIndex, 4));
 
     const rl = readline.createInterface({
       input: process.stdin,

--- a/stdlib/lib/ui.ts
+++ b/stdlib/lib/ui.ts
@@ -150,11 +150,11 @@ function clearFixedArea() {
 // Terminal helpers
 // ---------------------------------------------------------------------------
 
-const MIN_ROWS = 6;
-
 function updateSize() {
-  rows = Math.max(process.stdout.rows || 24, MIN_ROWS);
   cols = process.stdout.columns || 80;
+  // Ensure at least enough rows for the fixed area plus one scroll line
+  const minRows = fixedLineCount() + 1;
+  rows = Math.max(process.stdout.rows || 24, minRows);
 }
 
 function truncate(str: string, maxLen: number): string {
@@ -323,7 +323,7 @@ export function _diff(filename: string, _content: string): void {
     } else if (line.startsWith("-")) {
       return color.bgRed(`│ ${line}`);
     }
-    return `| ${line}`;
+    return `│ ${line}`;
   });
 }
 

--- a/stdlib/ui.agency
+++ b/stdlib/ui.agency
@@ -1,0 +1,89 @@
+import { _initUI, _destroyUI, _log, _status, _chat, _code, _diff, _separator, _startSpinner, _stopSpinner, _prompt } from "./lib/ui.js"
+
+export def initUI(title: string) {
+  """
+  Initialize a terminal UI with a scrollable output area and a fixed input bar at the bottom. Call this once at the start of your agent. The title appears in the status bar.
+  """
+  _initUI(title)
+}
+
+export def destroyUI() {
+  """
+  Tear down the terminal UI and restore normal terminal behavior. Called automatically on exit, but you can call it early if needed.
+  """
+  _destroyUI()
+}
+
+export safe def log(message: string) {
+  """
+  Print a message to the scrollable output area. Supports ANSI colors.
+  """
+  _log(message)
+}
+
+export safe def status(left: string, right: string = "") {
+  """
+  Update the status bar. The left text appears on the left side, the right text on the right.
+  """
+  _status(left, right)
+}
+
+export safe def chat(role: string, message: string) {
+  """
+  Print a chat message with a colored role prefix. Built-in colors: "user" (blue), "agent" (green). Other roles appear in yellow.
+  """
+  _chat(role, message)
+}
+
+export safe def code(filename: string, content: string) {
+  """
+  Display a code block with a filename header and line numbers, inside a bordered box.
+  """
+  _code(filename, content)
+}
+
+export safe def diff(filename: string, content: string) {
+  """
+  Display a diff with colored +/- lines, inside a bordered box with the filename as a header.
+  """
+  _diff(filename, content)
+}
+
+export safe def separator(label: string = "") {
+  """
+  Print a horizontal line with an optional label. Useful for visually grouping output sections.
+  """
+  _separator(label)
+}
+
+export safe def startSpinner(text: string = "working") {
+  """
+  Show an animated spinner in the input bar with a label. Useful while the agent is thinking or running a long operation.
+  """
+  _startSpinner(text)
+}
+
+export safe def stopSpinner() {
+  """
+  Stop the spinner and clear the input bar.
+  """
+  _stopSpinner()
+}
+
+export def prompt(question: string): string {
+  """
+  Prompt the user for text input in the fixed input bar at the bottom of the screen. The question appears as a hint. Returns the user's input as a string.
+  """
+  return _prompt(question)
+}
+
+export def getConfirmation(question: string): boolean {
+  """
+  Ask the user a yes/no question in the input bar. Returns true if the user answers yes (y/yes), false otherwise. Useful inside handler blocks to approve or reject interrupts interactively.
+  """
+  let answer = _prompt(question + " (y/n)")
+  if (answer == "y" || answer == "yes" || answer == "Y" || answer == "YES") {
+    return true
+  }
+  return false
+}

--- a/stdlib/ui.agency
+++ b/stdlib/ui.agency
@@ -1,7 +1,7 @@
 import { _initUI, _destroyUI, _log, _status, _chat, _code, _diff, _separator, _startSpinner, _stopSpinner, _prompt, _emptyLine } from "./lib/ui.js"
 export def initUI(title: string) {
   """
-  Initialize a terminal UI with a scrollable output area and a fixed input bar at the bottom. Call this once at the start of your agent. The title appears in the status bar.
+  Initialize a terminal UI with a scrollable output area and a fixed input bar at the bottom. Call this once at the start of your agent. The title is shown in the scrollable output area on init; use status() to populate the status bar.
   """
   _initUI(title)
 }
@@ -29,7 +29,7 @@ export safe def status(left: string, right: string = "") {
 
 export safe def chat(role: string = "", message: string = "") {
   """
-  Print a chat message with a colored role prefix. Built-in colors: "user" (blue), "agent" (green). Other roles appear in yellow.
+  Print a chat message with a colored role prefix. Built-in colors: "user" (cyan), "agent" (white). Other roles appear dim.
   """
   _chat(role, message)
 }

--- a/stdlib/ui.agency
+++ b/stdlib/ui.agency
@@ -1,5 +1,4 @@
-import { _initUI, _destroyUI, _log, _status, _chat, _code, _diff, _separator, _startSpinner, _stopSpinner, _prompt } from "./lib/ui.js"
-
+import { _initUI, _destroyUI, _log, _status, _chat, _code, _diff, _separator, _startSpinner, _stopSpinner, _prompt, _emptyLine } from "./lib/ui.js"
 export def initUI(title: string) {
   """
   Initialize a terminal UI with a scrollable output area and a fixed input bar at the bottom. Call this once at the start of your agent. The title appears in the status bar.
@@ -28,7 +27,7 @@ export safe def status(left: string, right: string = "") {
   _status(left, right)
 }
 
-export safe def chat(role: string, message: string) {
+export safe def chat(role: string = "", message: string = "") {
   """
   Print a chat message with a colored role prefix. Built-in colors: "user" (blue), "agent" (green). Other roles appear in yellow.
   """
@@ -86,4 +85,11 @@ export def getConfirmation(question: string): boolean {
     return true
   }
   return false
+}
+
+export def emptyLine() {
+  """
+  Print an empty line. Useful for adding spacing in the output.
+  """
+  _emptyLine()
 }

--- a/stdlib/ui.agency
+++ b/stdlib/ui.agency
@@ -81,8 +81,8 @@ export def getConfirmation(question: string): boolean {
   """
   Ask the user a yes/no question in the input bar. Returns true if the user answers yes (y/yes), false otherwise. Useful inside handler blocks to approve or reject interrupts interactively.
   """
-  let answer = _prompt(question + " (y/n)")
-  if (answer == "y" || answer == "yes" || answer == "Y" || answer == "YES") {
+  let answer = _prompt(question + " (y/n)").trim().toLowerCase()
+  if (answer == "y" || answer == "yes") {
     return true
   }
   return false

--- a/tests/agency/method-chain-await.agency
+++ b/tests/agency/method-chain-await.agency
@@ -1,0 +1,8 @@
+def getGreeting(): string {
+  return "  Hello World  "
+}
+
+node main() {
+  let result = getGreeting().trim().toLowerCase()
+  return result
+}

--- a/tests/agency/method-chain-await.test.json
+++ b/tests/agency/method-chain-await.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"hello world\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "method calls chained on a function result should await the function first"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `std::ui` stdlib module providing a terminal UI with ANSI scroll regions — output scrolls naturally while a fixed input bar stays pinned at the bottom (like Claude Code)
- Single `buildFixedLines()` function defines the entire fixed bottom area — change the layout in one place without touching any other code
- `inputLineIndex` tracks which line has the input prompt, so the cursor auto-follows layout changes
- Uses `termcolors` for all text styling
- Fixes the Agency formatter to emit `callback` keyword for callback declarations
- **Compiler fix**: await function call bases before chaining methods — `getGreeting().trim()` now correctly produces `(await getGreeting()).trim()` instead of calling `.trim()` on a Promise
- **Compiler fix**: await ALL method calls in generated code, not just class methods — fixes namespace imports (`import * as ui`) silently returning Promises
- Includes `examples/coding-agent.agency` demonstrating callbacks + UI together

### std::ui exports
- `initUI` / `destroyUI` — lifecycle
- `log`, `chat`, `code`, `diff`, `separator` — scrollable output
- `status` — fixed status bar
- `prompt` — user input from the pinned bottom bar
- `getConfirmation` — yes/no prompt for handler blocks
- `startSpinner` / `stopSpinner` — animated spinner

## Test plan

- [x] `stdlib/lib/ui.ts` compiles with `make stdlib`
- [x] `examples/coding-agent.agency` compiles and runs
- [x] Method chain await test passes (`tests/agency/method-chain-await`)
- [x] AgencyGenerator callback round-trip test passes
- [x] Full test suite: 1909 tests pass, 0 failures
- [x] Manual testing of the UI (scroll region, input bar, spinner, layout changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)