### PR TITLE
feat(runtime): add LLM abort/cancel via AbortController

### DIFF
--- a/lib/runtime/errors.test.ts
+++ b/lib/runtime/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { CheckpointError, RestoreSignal } from "./errors.js";
+import { CheckpointError, RestoreSignal, AgencyCancelledError, isAbortError } from "./errors.js";
 
 describe("CheckpointError", () => {
   it("should have correct name and message", () => {
@@ -25,5 +25,46 @@ describe("RestoreSignal", () => {
     const checkpoint = { id: 1, stack: {}, globals: {}, nodeId: "start" };
     const signal = new RestoreSignal(checkpoint as any);
     expect(signal.options).toBeUndefined();
+  });
+});
+
+describe("AgencyCancelledError", () => {
+  it("should have correct name and default message", () => {
+    const err = new AgencyCancelledError();
+    expect(err.name).toBe("AgencyCancelledError");
+    expect(err.message).toBe("Agent execution was cancelled");
+    expect(err instanceof Error).toBe(true);
+  });
+
+  it("should accept a custom reason", () => {
+    const err = new AgencyCancelledError("user clicked stop");
+    expect(err.message).toBe("user clicked stop");
+  });
+});
+
+describe("isAbortError", () => {
+  it("should detect AgencyCancelledError", () => {
+    expect(isAbortError(new AgencyCancelledError())).toBe(true);
+  });
+
+  it("should detect DOMException with name AbortError", () => {
+    const err = new DOMException("aborted", "AbortError");
+    expect(isAbortError(err)).toBe(true);
+  });
+
+  it("should detect Error with name AbortError", () => {
+    const err = new Error("aborted");
+    err.name = "AbortError";
+    expect(isAbortError(err)).toBe(true);
+  });
+
+  it("should return false for regular errors", () => {
+    expect(isAbortError(new Error("something else"))).toBe(false);
+  });
+
+  it("should return false for non-error values", () => {
+    expect(isAbortError(null)).toBe(false);
+    expect(isAbortError("string")).toBe(false);
+    expect(isAbortError(42)).toBe(false);
   });
 });

--- a/lib/runtime/errors.ts
+++ b/lib/runtime/errors.ts
@@ -40,3 +40,17 @@ export class ConcurrentInterruptError extends Error {
     this.name = "ConcurrentInterruptError";
   }
 }
+
+export class AgencyCancelledError extends Error {
+  constructor(reason?: string) {
+    super(reason ?? "Agent execution was cancelled");
+    this.name = "AgencyCancelledError";
+  }
+}
+
+export function isAbortError(error: unknown): boolean {
+  if (error instanceof AgencyCancelledError) return true;
+  if (error instanceof DOMException && error.name === "AbortError") return true;
+  if (error instanceof Error && error.name === "AbortError") return true;
+  return false;
+}

--- a/lib/runtime/hooks.ts
+++ b/lib/runtime/hooks.ts
@@ -17,6 +17,7 @@ export type CallbackMap = {
     nodeName: string;
     args: Record<string, any>;
     messages: MessageJSON[];
+    cancel: (reason?: string) => void;
   };
   onAgentEnd: { nodeName: string; result: RunNodeResult<any> };
   onNodeStart: { nodeName: string };

--- a/lib/runtime/index.ts
+++ b/lib/runtime/index.ts
@@ -68,6 +68,8 @@ export {
   ConcurrentInterruptError,
   CheckpointError,
   RestoreSignal,
+  AgencyCancelledError,
+  isAbortError,
 } from "./errors.js";
 export type { RestoreOptions } from "./errors.js";
 

--- a/lib/runtime/node.ts
+++ b/lib/runtime/node.ts
@@ -2,7 +2,7 @@ import { MessageJSON } from "smoltalk";
 import { callHook } from "./hooks.js";
 import type { AgencyCallbacks } from "./hooks.js";
 import type { RuntimeContext } from "./state/context.js";
-import { CheckpointError, RestoreSignal } from "./errors.js";
+import { AgencyCancelledError, CheckpointError, RestoreSignal } from "./errors.js";
 import { State, StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { GraphState, InternalFunctionState, RunNodeResult } from "./types.js";
@@ -77,6 +77,7 @@ export async function runNode({
   messages,
   callbacks,
   initializeGlobals,
+  abortSignal,
 }: {
   // global execution context
   ctx: RuntimeContext<GraphState>;
@@ -95,6 +96,10 @@ export async function runNode({
 
   // initializes global variables on the execution context
   initializeGlobals?: (ctx: RuntimeContext<GraphState>) => void | Promise<void>;
+
+  // An AbortSignal for cancelling the agent mid-execution.
+  // When aborted, in-flight LLM requests are torn down and a AgencyCancelledError is thrown.
+  abortSignal?: AbortSignal;
 }): Promise<RunNodeResult<any>> {
   const execCtx = ctx.createExecutionContext();
   if (initializeGlobals) {
@@ -105,10 +110,20 @@ export async function runNode({
   if (callbacks) {
     Object.assign(execCtx.callbacks, callbacks);
   }
+
+  // Wire external abort signal to the execution context
+  const cancel = (reason?: string) => execCtx.cancel(reason);
+  if (abortSignal) {
+    if (abortSignal.aborted) {
+      throw new AgencyCancelledError();
+    }
+    abortSignal.addEventListener("abort", () => execCtx.cancel(), { once: true });
+  }
+
   await callHook({
     callbacks: execCtx.callbacks,
     name: "onAgentStart",
-    data: { nodeName, args: data, messages: messages || [] },
+    data: { nodeName, args: data, messages: messages || [], cancel },
   });
   let isResume = false;
   let threadStore = ThreadStore.withDefaultActive();

--- a/lib/runtime/prompt.ts
+++ b/lib/runtime/prompt.ts
@@ -19,6 +19,7 @@ import { PromptResult, Result, StreamChunk, ToolCallJSON } from "smoltalk";
 import { ZodType } from "zod/v3";
 import { ThreadStore } from "./state/threadStore.js";
 import { isFailure } from "./result.js";
+import { AgencyCancelledError, isAbortError } from "./errors.js";
 
 export interface ToolHandler {
   name: string;
@@ -48,6 +49,10 @@ async function _runPrompt({
   responseFormat?: any;
   clientConfig: Partial<smoltalk.SmolPromptConfig>;
 }): Promise<{ messages: MessageThread; toolCalls: smoltalk.ToolCallJSON[] }> {
+  if (ctx.aborted) {
+    throw new AgencyCancelledError();
+  }
+
   const stream = !!(clientConfig as any)?.stream;
   const startTime = performance.now();
 
@@ -71,6 +76,7 @@ async function _runPrompt({
       tools,
       responseFormat,
       stream,
+      abortSignal: ctx.abortController.signal,
       ...clientConfig,
     });
 
@@ -452,89 +458,101 @@ export async function runPrompt(args: {
   // Restore state after interrupt
   let toolCalls: smoltalk.ToolCallJSON[] = [];
 
-  if (args.interruptData === undefined) {
-    // not resuming after an interrupt
-    messages.push(smoltalk.userMessage(prompt));
+  try {
+    if (args.interruptData === undefined) {
+      // not resuming after an interrupt
+      messages.push(smoltalk.userMessage(prompt));
 
-    const result = await _runPrompt({
-      ctx,
-      messages,
-      tools: tools || [],
-      prompt,
-      responseFormat,
-      clientConfig,
-    });
-    messages = result.messages;
-    toolCalls = result.toolCalls;
-  } else {
-    if (!args.interruptData.toolCall) {
-      throw new Error(
-        `Interrupt data is present but no tool call found. This shouldn't happen: ${JSON.stringify(args.interruptData)}`,
-      );
-    }
-    toolCalls = [args.interruptData.toolCall];
-  }
-
-  // Handle tool calls
-  const toolErrorCounts: Record<string, number> = {};
-  let toolCallRound = 0;
-  while (toolCalls.length > 0) {
-    if (toolCallRound++ >= maxToolCallRounds) {
-      throw new Error(
-        `Exceeded maximum tool call rounds (${maxToolCallRounds})`,
-      );
+      const result = await _runPrompt({
+        ctx,
+        messages,
+        tools: tools || [],
+        prompt,
+        responseFormat,
+        clientConfig,
+      });
+      messages = result.messages;
+      toolCalls = result.toolCalls;
+    } else {
+      if (!args.interruptData.toolCall) {
+        throw new Error(
+          `Interrupt data is present but no tool call found. This shouldn't happen: ${JSON.stringify(args.interruptData)}`,
+        );
+      }
+      toolCalls = [args.interruptData.toolCall];
     }
 
-    const executeToolCallsResult = await executeToolCalls({
-      toolCalls,
-      toolHandlers,
-      messages,
-      ctx,
-      clientConfig,
-      interruptData: args.interruptData,
-      removedTools,
-      toolErrorCounts,
-    });
+    // Handle tool calls
+    const toolErrorCounts: Record<string, number> = {};
+    let toolCallRound = 0;
+    while (toolCalls.length > 0) {
+      if (ctx.aborted) {
+        throw new AgencyCancelledError();
+      }
+      if (toolCallRound++ >= maxToolCallRounds) {
+        throw new Error(
+          `Exceeded maximum tool call rounds (${maxToolCallRounds})`,
+        );
+      }
 
-    messages = executeToolCallsResult.messages;
-
-    // Filter out tools that failed after side effects
-    tools = tools.filter((t) => !removedTools.includes(t.name));
-    toolHandlers = toolHandlers.filter((h) => !removedTools.includes(h.name));
-
-    if (executeToolCallsResult.isInterrupt) {
-      const { interrupt } = executeToolCallsResult;
-
-      ctx.statelogClient.debug(`Tool call interrupted execution.`, {
-        messages: messages.getMessages(),
-        model: clientConfig.model,
+      const executeToolCallsResult = await executeToolCalls({
+        toolCalls,
+        toolHandlers,
+        messages,
+        ctx,
+        clientConfig,
+        interruptData: args.interruptData,
+        removedTools,
+        toolErrorCounts,
       });
 
-      if (interrupt.debugger === false) {
-        // For real user interrupts, create a checkpoint at the LLM call site
-        // so we can resume the conversation. Debug interrupts keep their
-        // original checkpoint from debugStep (pointing to the tool's source).
-        const checkpointId = ctx.checkpoints.create(ctx, {
-          moduleId: checkpointInfo?.moduleId ?? "",
-          scopeName: checkpointInfo?.scopeName ?? "",
-          stepPath: checkpointInfo?.stepPath ?? "",
-        });
-        interrupt.checkpointId = checkpointId;
-        interrupt.checkpoint = ctx.checkpoints.get(checkpointId);
-      }
-      return interrupt;
-    }
+      messages = executeToolCallsResult.messages;
 
-    const result = await _runPrompt({
-      ctx,
-      messages,
-      tools: tools || [],
-      prompt,
-      responseFormat,
-      clientConfig,
-    });
-    messages = result.messages;
-    toolCalls = result.toolCalls;
+      // Filter out tools that failed after side effects
+      tools = tools.filter((t) => !removedTools.includes(t.name));
+      toolHandlers = toolHandlers.filter(
+        (h) => !removedTools.includes(h.name),
+      );
+
+      if (executeToolCallsResult.isInterrupt) {
+        const { interrupt } = executeToolCallsResult;
+
+        ctx.statelogClient.debug(`Tool call interrupted execution.`, {
+          messages: messages.getMessages(),
+          model: clientConfig.model,
+        });
+
+        if (interrupt.debugger === false) {
+          // For real user interrupts, create a checkpoint at the LLM call site
+          // so we can resume the conversation. Debug interrupts keep their
+          // original checkpoint from debugStep (pointing to the tool's source).
+          const checkpointId = ctx.checkpoints.create(ctx, {
+            moduleId: checkpointInfo?.moduleId ?? "",
+            scopeName: checkpointInfo?.scopeName ?? "",
+            stepPath: checkpointInfo?.stepPath ?? "",
+          });
+          interrupt.checkpointId = checkpointId;
+          interrupt.checkpoint = ctx.checkpoints.get(checkpointId);
+        }
+        return interrupt;
+      }
+
+      const result = await _runPrompt({
+        ctx,
+        messages,
+        tools: tools || [],
+        prompt,
+        responseFormat,
+        clientConfig,
+      });
+      messages = result.messages;
+      toolCalls = result.toolCalls;
+    }
+  } catch (error) {
+    if (!isAbortError(error)) {
+      ctx.cancel();
+    }
+    throw error;
   }
 
   const responseMessage = messages.getMessages().at(-1);

--- a/lib/runtime/state/context.test.ts
+++ b/lib/runtime/state/context.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { RuntimeContext } from "./context.js";
+import { AgencyCancelledError } from "../errors.js";
 
 function makeMockCtx() {
   return new RuntimeContext({
@@ -18,5 +19,49 @@ describe("RuntimeContext", () => {
   it("should initialize debugger field as null", () => {
     const ctx = makeMockCtx();
     expect(ctx.debuggerState).toBeNull();
+  });
+
+  describe("abort / cancel", () => {
+    it("should initialize with a fresh AbortController", () => {
+      const ctx = makeMockCtx();
+      expect(ctx.abortController).toBeInstanceOf(AbortController);
+      expect(ctx.aborted).toBe(false);
+    });
+
+    it("cancel() should abort the controller", () => {
+      const ctx = makeMockCtx();
+      ctx.cancel();
+      expect(ctx.aborted).toBe(true);
+      expect(ctx.abortController.signal.aborted).toBe(true);
+    });
+
+    it("cancel() should set an AgencyCancelledError as the abort reason", () => {
+      const ctx = makeMockCtx();
+      ctx.cancel("user stop");
+      expect(ctx.abortController.signal.reason).toBeInstanceOf(AgencyCancelledError);
+      expect(ctx.abortController.signal.reason.message).toBe("user stop");
+    });
+
+    it("cancel() should be idempotent", () => {
+      const ctx = makeMockCtx();
+      ctx.cancel("first");
+      ctx.cancel("second");
+      expect(ctx.abortController.signal.reason.message).toBe("first");
+    });
+
+    it("createExecutionContext should get a fresh AbortController", () => {
+      const ctx = makeMockCtx();
+      const execCtx = ctx.createExecutionContext();
+      expect(execCtx.abortController).toBeInstanceOf(AbortController);
+      expect(execCtx.abortController).not.toBe(ctx.abortController);
+      expect(execCtx.aborted).toBe(false);
+    });
+
+    it("cleanup() should abort the controller", () => {
+      const ctx = makeMockCtx();
+      expect(ctx.aborted).toBe(false);
+      ctx.cleanup();
+      expect(ctx.abortController.signal.aborted).toBe(true);
+    });
   });
 });

--- a/lib/runtime/state/context.ts
+++ b/lib/runtime/state/context.ts
@@ -13,6 +13,7 @@ import type { HandlerFn } from "../types.js";
 import type { DebuggerState } from "../../debugger/debuggerState.js";
 import type { TraceWriter } from "../trace/traceWriter.js";
 import { reviveWithClasses, type ClassRegistry } from "../classReviver.js";
+import { AgencyCancelledError } from "../errors.js";
 
 /* bunch of stuff that every node/function in the runtime needs access to,
 that we don't want to pass as individual arguments everywhere */
@@ -65,6 +66,8 @@ export class RuntimeContext<T> {
   // class registry for serialization/deserialization of Agency class instances
   classRegistry: ClassRegistry = {};
 
+  abortController: AbortController;
+
   // stored so createExecutionContext can create new StatelogClients
   private statelogConfig: StatelogConfig;
   maxRestores: number;
@@ -111,6 +114,7 @@ export class RuntimeContext<T> {
 
     this.smoltalkDefaults = args.smoltalkDefaults;
     this.classRegistry = {};
+    this.abortController = new AbortController();
   }
 
   createExecutionContext(): RuntimeContext<T> {
@@ -136,6 +140,7 @@ export class RuntimeContext<T> {
     execCtx.traceWriter = this.traceWriter;
     execCtx.pendingPromises = new PendingPromiseStore();
     execCtx.classRegistry = this.classRegistry;
+    execCtx.abortController = new AbortController();
     execCtx.statelogClient = new StatelogClient({
       ...this.statelogConfig,
       traceId: nanoid(),
@@ -206,6 +211,16 @@ export class RuntimeContext<T> {
     return this._toolCallDepth > 0;
   }
 
+  get aborted(): boolean {
+    return this.abortController.signal.aborted;
+  }
+
+  cancel(reason?: string): void {
+    if (!this.abortController.signal.aborted) {
+      this.abortController.abort(new AgencyCancelledError(reason));
+    }
+  }
+
   registerClass(name: string, cls: ClassRegistry[string]): void {
     this.classRegistry[name] = cls;
   }
@@ -216,6 +231,9 @@ export class RuntimeContext<T> {
 
   /** Sever references held by an execution context so GC can reclaim them. */
   cleanup(): void {
+    if (!this.abortController.signal.aborted) {
+      this.abortController.abort(new AgencyCancelledError("cleanup"));
+    }
     this.pendingPromises.clear();
     this.stateStack = null as any;
     this.globals = null as any;

--- a/lib/runtime/streaming.ts
+++ b/lib/runtime/streaming.ts
@@ -2,6 +2,7 @@ import { PromptResult, Result, StreamChunk, ToolCallJSON } from "smoltalk";
 import { builtinSleep } from "./builtins.js";
 import type { RuntimeContext } from "./state/context.js";
 import { GraphState } from "./types.js";
+import { isAbortError } from "./errors.js";
 
 export function isGenerator(variable: any): boolean {
   const toString = Object.prototype.toString.call(variable);
@@ -32,20 +33,26 @@ export async function handleStreamingResponse(args: {
       },
     );
     let syncResult: PromptResult;
-    for await (const chunk of completion) {
-      switch (chunk.type) {
-        case "tool_call":
-          toolCalls.push(chunk.toolCall);
-          break;
-        case "done":
-          syncResult = chunk.result;
-          break;
-        case "error":
-          console.error(`Error in LLM response stream: ${chunk.error}`);
-          break;
-        default:
-          break;
+    try {
+      for await (const chunk of completion) {
+        switch (chunk.type) {
+          case "tool_call":
+            toolCalls.push(chunk.toolCall);
+            break;
+          case "done":
+            syncResult = chunk.result;
+            break;
+          case "error":
+            console.error(`Error in LLM response stream: ${chunk.error}`);
+            break;
+          default:
+            break;
+        }
       }
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      console.error("Unexpected error consuming LLM stream:", error);
+      throw error;
     }
     return { success: true, value: { completion: syncResult!, toolCalls } };
   } else {
@@ -62,30 +69,36 @@ export async function handleStreamingResponse(args: {
     }
     ctx.onStreamLock = true;
 
-    for await (const chunk of completion) {
-      switch (chunk.type) {
-        case "text":
-          onStream({ type: "text", text: chunk.text });
-          break;
-        case "tool_call":
-          toolCalls.push(chunk.toolCall);
-          onStream({
-            type: "tool_call",
-            toolCall: chunk.toolCall,
-          });
-          break;
-        case "done":
-          onStream({ type: "done", result: chunk.result });
-          return {
-            success: true,
-            value: { completion: chunk.result, toolCalls },
-          };
-        case "error":
-          onStream({ type: "error", error: chunk.error });
-          break;
+    try {
+      for await (const chunk of completion) {
+        switch (chunk.type) {
+          case "text":
+            onStream({ type: "text", text: chunk.text });
+            break;
+          case "tool_call":
+            toolCalls.push(chunk.toolCall);
+            onStream({
+              type: "tool_call",
+              toolCall: chunk.toolCall,
+            });
+            break;
+          case "done":
+            onStream({ type: "done", result: chunk.result });
+            return {
+              success: true,
+              value: { completion: chunk.result, toolCalls },
+            };
+          case "error":
+            onStream({ type: "error", error: chunk.error });
+            break;
+        }
       }
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+      console.error("Unexpected error consuming LLM stream:", error);
+      throw error;
+    } finally {
+      ctx.onStreamLock = false;
     }
-
-    ctx.onStreamLock = false;
   }
 }


### PR DESCRIPTION
I don't expect for this to be merged; this is my first Claude-assisted change in a repo totally new to me but I figured I'd make a PR and learn something. I noticed that we are not using abort on error and callers didn't have an option to cancel in-flight streaming requests. According to information I recently learned, abort lets you cancel an LLM request while it’s still running, especially useful with streaming or long outputs. This prevents wasting time and tokens on responses you don’t need or already understand. It also enables more responsive apps (like a “Stop generating” button or early decision-making in agents).

Wire RuntimeContext.abortController into smoltalk.text (abortSignal), add cancel()/aborted, AgencyCancelledError and isAbortError, and preflight guards so cancelled runs skip further LLM rounds. On non-abort errors in runPrompt, call cancel() to tear down in-flight requests. Harden streaming with try/ catch/finally so onStreamLock is always released and abort errors propagate. Expose cancellation to embedders: runNode accepts optional abortSignal, onAgentStart receives cancel(), and cleanup() aborts on teardown. Add unit tests for errors and context abort behavior.