### PR TITLE
fix(runtime): abort/cancel edge cases

### DIFF
--- a/docs-new/guide/ts-interop.md
+++ b/docs-new/guide/ts-interop.md
@@ -58,4 +58,53 @@ run();
 
 Other things like functions can't be imported and run, because Agency functions have a lot of extra functionality to make things like interrupts work.
 
-While we're on this topic, we should probably talk about Agency's execution model.
+## Cancelling an in-progress agent
+
+When you run an Agency agent from TypeScript, you can cancel it mid-execution. This tears down any in-flight LLM requests and throws an `AgencyCancelledError`. Here's how to abort an agent run.
+
+The `onAgentStart` callback receives a `cancel` function you can call at any time:
+
+```ts
+import { main } from "./main.js";
+
+let cancelAgent: (reason?: string) => void;
+
+const result = await main({
+  callbacks: {
+    onAgentStart: ({ cancel }) => {
+      cancelAgent = cancel;
+    },
+  },
+});
+
+// later, from a button handler, timeout, etc:
+cancelAgent("user clicked stop");
+```
+
+
+### What happens when you cancel
+
+When `cancel()` is called
+
+1. Any in-flight LLM request is aborted immediately.
+2. Any remaining tool calls in the current round are skipped.
+3. Any remaining interrupt handlers are skipped.
+4. An `AgencyCancelledError` is thrown, which propagates up to the caller.
+
+Cancellation is permanent for that execution. Once cancelled, no further LLM calls can be made on that particular agent run. However, you can start a new agent run. You can read more about Agency's [execution model](/guide/execution-model).
+
+To catch the abort in TypeScript, you can catch `AgencyCancelledError` (exported from `agency-lang/runtime`) or use the `isAbortError` helper:
+
+```ts
+import { AgencyCancelledError, isAbortError } from "agency-lang/runtime";
+
+try {
+  await main();
+} catch (error) {
+  if (isAbortError(error)) {
+    // handle cancellation
+  }
+}
+```
+
+Now let's talk about Agency's execution model.

--- a/lib/runtime/interrupts.ts
+++ b/lib/runtime/interrupts.ts
@@ -1,5 +1,5 @@
 import * as smoltalk from "smoltalk";
-import { RestoreSignal } from "./errors.js";
+import { AgencyCancelledError, RestoreSignal } from "./errors.js";
 import { applyOverrides } from "./rewind.js";
 import { Checkpoint } from "./state/checkpointStore.js";
 import { RuntimeContext } from "./state/context.js";
@@ -115,6 +115,9 @@ export async function interruptWithHandlers<T = any>(
   let hasApproval = false;
   let hasPropagation = false;
   for (let i = ctx.handlers.length - 1; i >= 0; i--) {
+    if (ctx.aborted) {
+      throw new AgencyCancelledError();
+    }
     const result = await ctx.handlers[i](data);
     if (result === undefined) {
       continue;

--- a/lib/runtime/prompt.ts
+++ b/lib/runtime/prompt.ts
@@ -70,6 +70,11 @@ async function _runPrompt({
     messages = MessageThread.fromJSON(startHookResult);
   }
 
+  // Re-check after hook — cancellation may have occurred during the callback
+  if (ctx.aborted) {
+    throw new AgencyCancelledError();
+  }
+
   let _completion: AsyncGenerator<StreamChunk> | Promise<Result<PromptResult>> =
     await (smoltalk.text as Function)({
       messages: messages.getMessages(),
@@ -184,6 +189,10 @@ async function executeToolCalls({
   toolErrorCounts: Record<string, number>;
 }): Promise<ExecuteToolCallsResult> {
   for (const toolCall of toolCalls) {
+    if (ctx.aborted) {
+      throw new AgencyCancelledError();
+    }
+
     const handler = toolHandlers.find((h) => h.name === toolCall.name);
     if (!handler) {
       console.error(
@@ -549,9 +558,12 @@ export async function runPrompt(args: {
       toolCalls = result.toolCalls;
     }
   } catch (error) {
-    if (!isAbortError(error)) {
-      ctx.cancel();
+    if (isAbortError(error)) {
+      // Abort errors propagate as-is — the context is already cancelled.
+      throw error;
     }
+    // Non-abort errors (network issues, malformed responses, etc.) propagate
+    // without cancelling the context. The caller may want to retry.
     throw error;
   }
 


### PR DESCRIPTION
## Summary

Fixes four edge cases in the abort/cancel implementation from #35:

- **Abort check between individual tool calls**: Previously, `executeToolCalls` only checked abort status between tool-call *rounds* (in `runPrompt`). If the LLM requested multiple tool calls in one message and `cancel()` was called mid-way, remaining tools would still execute. Now checks `ctx.aborted` before each tool call.

- **Don't cancel context on non-abort errors**: The catch block in `runPrompt` was calling `ctx.cancel()` on any non-abort error (network blips, malformed responses, etc.), permanently poisoning the `AbortController` so no future LLM calls could be made. Non-abort errors now propagate without side effects, leaving the context usable for retries.

- **Abort check after onLLMCallStart hook**: If `cancel()` was called during a slow `onLLMCallStart` callback, the cancellation wasn't detected until the LLM request was already in flight. Now re-checks `ctx.aborted` after the hook returns.

- **Abort check in handler chain**: `interruptWithHandlers` iterates handlers without checking abort status. If `cancel()` was called during handler execution, remaining handlers would still run. Now checks before each handler.

## Test plan

- [x] All 1932 existing tests pass
- [ ] Manual verification: cancel during multi-tool-call round skips remaining tools
- [ ] Manual verification: non-abort error leaves context usable for subsequent calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)