### PR TITLE
Add doc comment syntax and node docstring support

### DIFF
--- a/docs/superpowers/specs/2026-04-17-doc-comments-design.md
+++ b/docs/superpowers/specs/2026-04-17-doc-comments-design.md
@@ -249,4 +249,4 @@ Render doc comment above the type definition code block.
 ## Non-changes
 
 - **Type checker:** No changes needed. The type checker does not inspect doc comments or docstrings.
-- **Content trimming:** Doc comment `content` is stored as-is from the parser (the existing multi-line comment parser captures raw content between `/*` and `*/`). The doc generator renders this content directly. No additional trimming or normalization is applied — this matches how regular multi-line comments already work.
+- **Content trimming:** Doc comment `content` is stored as-is from the parser (the existing multi-line comment parser captures raw content between `/*` and `*/`). When rendering docs, the doc generator trims leading and trailing whitespace from this content before display. No other normalization is applied.

--- a/docs/superpowers/specs/2026-04-17-doc-comments-design.md
+++ b/docs/superpowers/specs/2026-04-17-doc-comments-design.md
@@ -1,0 +1,252 @@
+# Doc Comments Design Spec
+
+## Summary
+
+Add support for `/** ... */` doc comment syntax. Doc comments are documentation-only metadata that appear in generated docs (via the `doc` command) but not in generated TypeScript. They can be attached to functions, nodes, type aliases, or the file itself (file-level doc comment).
+
+Also add docstring support to nodes, which currently lack it.
+
+## Syntax
+
+Doc comments use the existing multi-line comment syntax with a leading `*`:
+
+```ts
+/** This is a doc comment */
+
+/**
+This is a multi-line
+doc comment
+*/
+```
+
+### File-level doc comment
+
+A doc comment that appears at the top of the file, before any imports or declarations, is the file-level doc comment. Regular comments and blank lines may precede it.
+
+```ts
+// regular comment is fine above
+/** This file implements email categorization. */
+
+import { foo } from "./bar.agency"
+```
+
+### Attached to declarations
+
+A doc comment immediately before a function, node, or type alias is attached to that declaration.
+
+```ts
+/** Categorizes user messages. */
+node categorize(message: string) {
+  """docstring for LLM tool description"""
+  const category: Category = llm("...")
+  return category
+}
+
+/** Adds two numbers. */
+def add(a: number, b: number): number {
+  """Returns the sum of a and b."""
+  return a + b
+}
+
+/** Possible message categories. */
+type Category = "reminder" | "todo"
+```
+
+### Doc comments vs docstrings
+
+- **Docstrings** (`"""..."""`) are sent to the LLM as tool descriptions AND appear in generated docs.
+- **Doc comments** (`/** ... */`) appear ONLY in generated docs, not in generated TypeScript or LLM calls.
+- Both can coexist on the same declaration.
+
+## AST Changes
+
+### Modify `AgencyMultiLineComment`
+
+Add an `isDoc` boolean field:
+
+```ts
+// lib/types.ts
+export type AgencyMultiLineComment = BaseNode & {
+  type: "multiLineComment";
+  content: string;
+  isDoc: boolean;
+};
+```
+
+When the comment starts with `/**`, `isDoc` is `true`. Regular `/* ... */` comments have `isDoc: false`.
+
+### Add `docComment` field to declarations
+
+```ts
+// lib/types/graphNode.ts
+export type GraphNodeDefinition = BaseNode & {
+  type: "graphNode";
+  nodeName: string;
+  parameters: FunctionParameter[];
+  body: AgencyNode[];
+  returnType?: VariableType | null;
+  visibility?: Visibility;
+  tags?: Tag[];
+  docComment?: AgencyMultiLineComment;  // NEW
+  docString?: DocString;                // NEW
+};
+```
+
+```ts
+// lib/types/function.ts
+export type FunctionDefinition = BaseNode & {
+  type: "function";
+  functionName: string;
+  parameters: FunctionParameter[];
+  body: AgencyNode[];
+  returnType?: VariableType | null;
+  docString?: DocString;
+  docComment?: AgencyMultiLineComment;  // NEW
+  async?: boolean;
+  safe?: boolean;
+  exported?: boolean;
+  callback?: boolean;
+  tags?: Tag[];
+};
+```
+
+```ts
+// lib/types/typeHints.ts
+export type TypeAlias = BaseNode & {
+  type: "typeAlias";
+  aliasName: string;
+  aliasedType: VariableType;
+  exported?: boolean;
+  docComment?: AgencyMultiLineComment;  // NEW
+};
+```
+
+### Add `docComment` field to `AgencyProgram`
+
+```ts
+// lib/types.ts
+export type AgencyProgram = {
+  type: "agencyProgram";
+  nodes: AgencyNode[];
+  docComment?: AgencyMultiLineComment;  // NEW
+};
+```
+
+## Parser Changes
+
+### Multi-line comment parser
+
+Extend the existing multi-line comment parser in `lib/parsers/parsers.ts` to detect `/**` and set `isDoc: true`. The parser already matches `/* ... */` — it needs to check if the opening is `/**` and set the flag accordingly. Existing `/* ... */` comments get `isDoc: false`.
+
+### Node body parser
+
+Extend the node body parser to optionally parse a docstring at the start of the body, the same way the function body parser already does. This gives nodes their new `docString` field.
+
+## Preprocessor Changes
+
+Add a new pass in the TypeScript preprocessor (`lib/preprocessors/typescriptPreprocessor.ts`) that handles doc comment attachment:
+
+1. **File-level doc comment:** Walk the top-level statements in order. Skip single-line comments, non-doc multi-line comments (`isDoc: false`), and newlines. If the first remaining statement is a `multiLineComment` with `isDoc: true`, AND it appears before any import or declaration, attach it to `AgencyProgram.docComment` and remove it from the statement list. If there are multiple doc comments before the first import/declaration, only the first one becomes the file-level doc comment; the rest follow rule 2 or 3.
+
+2. **Declaration-level doc comments:** Walk the remaining top-level statements. If a `multiLineComment` with `isDoc: true` is followed by a function, node, or type alias (with only newlines between them — intervening regular comments break attachment), attach it to that declaration's `docComment` field and remove it from the statement list. A doc comment before an import or variable declaration does not attach; it follows rule 3.
+
+3. **Unattached doc comments:** A doc comment that doesn't match either case above stays in the statement list as a regular multi-line comment. No error, no special treatment.
+
+This pass should run early in the preprocessor, before scope resolution and async marking, since it only restructures metadata and does not affect control flow or variable resolution.
+
+## Builder Changes (`lib/backends/typescriptBuilder.ts`)
+
+- Doc comments attached to declarations are already removed from the statement list by the preprocessor, so no extra skip logic needed in the builder.
+- Unattached doc comments in the statement list are emitted as regular `/* ... */` comments (existing behavior).
+- **Node docstrings:** Use `node.docString?.value` for the node description in `setupNode`, the same way function docstrings are used for tool descriptions.
+
+## Agency Generator Changes (`lib/backends/agencyGenerator.ts`)
+
+Update `processMultiLineComment` to preserve the `/**` syntax when `isDoc` is true:
+
+```ts
+protected processMultiLineComment(node: AgencyMultiLineComment): string {
+  if (node.isDoc) {
+    return this.indentStr(`/**${node.content}*/`);
+  }
+  return this.indentStr(`/*${node.content}*/`);
+}
+```
+
+Also, when generating code for functions, nodes, and type aliases that have a `docComment` field, emit the doc comment immediately before the declaration. Specifically, `processFunction`, `processGraphNode`, and the type alias processing need to check for `node.docComment` and emit it. Similarly, the generator must emit `AgencyProgram.docComment` at the top of the file when present.
+
+## Doc Generator Changes (`lib/cli/doc.ts`)
+
+### File-level doc comment
+
+If `AgencyProgram.docComment` is present, render its content immediately after the title heading, before the Types/Functions/Nodes sections.
+
+### Functions and nodes
+
+Render **docstring first**, then **doc comment second**. Both are optional. Note that node docstring rendering is new — nodes currently have no docstring output in the doc generator.
+
+Example output for a node with both:
+
+```md
+### categorize
+
+\`\`\`
+categorize(message: string)
+\`\`\`
+
+docstring for func, used in docs, also sent to llm
+
+Here's some extra context that gets added to the docs,
+but doesn't get sent to the llm
+
+**Parameters:**
+...
+```
+
+### Type aliases
+
+Render doc comment above the type definition code block.
+
+## Testing
+
+### Parser tests
+- Multi-line comment with `/**` sets `isDoc: true`
+- Multi-line comment with `/*` sets `isDoc: false`
+- `/** */` with various whitespace patterns
+
+### Preprocessor tests
+- Doc comment before a function attaches to `docComment` field
+- Doc comment before a node attaches to `docComment` field
+- Doc comment before a type alias attaches to `docComment` field
+- File-level doc comment (before any imports/declarations) attaches to `AgencyProgram.docComment`
+- Regular comments before the file-level doc comment are fine
+- Doc comment not followed by a declaration stays in statement list
+- Multiple doc comments: each attaches to the next declaration
+
+### Node docstring tests
+- Node with a docstring parses correctly
+- Node docstring value is accessible on `GraphNodeDefinition.docString`
+
+### Doc generator tests
+- File-level doc comment renders after title
+- Function with doc comment and docstring: docstring first, doc comment second
+- Node with doc comment and docstring: docstring first, doc comment second
+- Type alias with doc comment renders above type definition
+- Missing doc comment/docstring renders cleanly (no empty sections)
+
+### Agency generator tests
+- Round-trip: doc comments survive formatting as `/** ... */`
+- Regular multi-line comments still format as `/* ... */`
+- Declarations with attached doc comments: doc comment emitted before the declaration
+
+### Builder tests
+- Node with docstring: docstring value appears in generated `setupNode` description
+- Integration test fixture for node docstrings in generated TypeScript
+
+### Integration test fixtures
+- New `.agency` and `.mts` files in `tests/typescriptGenerator/` confirming doc comments do not appear in generated TypeScript
+
+## Non-changes
+
+- **Type checker:** No changes needed. The type checker does not inspect doc comments or docstrings.
+- **Content trimming:** Doc comment `content` is stored as-is from the parser (the existing multi-line comment parser captures raw content between `/*` and `*/`). The doc generator renders this content directly. No additional trimming or normalization is applied — this matches how regular multi-line comments already work.

--- a/lib/backends/agencyGenerator.test.ts
+++ b/lib/backends/agencyGenerator.test.ts
@@ -285,3 +285,40 @@ describe("AgencyGenerator - Class Definitions", () => {
   });
 });
 
+describe("AgencyGenerator - Doc Comments", () => {
+  function formatAgency(input: string): string {
+    const parseResult = parseAgency(input, {}, false);
+    expect(parseResult.success).toBe(true);
+    if (!parseResult.success) return "";
+    const generator = new AgencyGenerator();
+    return generator.generate(parseResult.result).output.trim();
+  }
+
+  it("should preserve /** syntax for doc comments", () => {
+    const input = `/** This is a doc comment */\ndef foo() {\n  print("hi")\n}`;
+    const output = formatAgency(input);
+    expect(output).toContain("/** This is a doc comment */");
+  });
+
+  it("should preserve /* syntax for regular multi-line comments", () => {
+    const input = `/* This is a regular comment */\ndef foo() {\n  print("hi")\n}`;
+    const output = formatAgency(input);
+    expect(output).toContain("/* This is a regular comment */");
+    expect(output).not.toContain("/**");
+  });
+
+  it("should preserve multi-line doc comments", () => {
+    const input = `/**\nThis is a multi-line\ndoc comment\n*/\ndef foo() {\n  print("hi")\n}`;
+    const output = formatAgency(input);
+    expect(output).toContain("/**");
+    expect(output).toContain("This is a multi-line");
+  });
+
+  it("should round-trip node docstrings", () => {
+    const input = `node main() {\n  """Main entry point."""\n  print("hello")\n}`;
+    const output = formatAgency(input);
+    expect(output).toContain('"""');
+    expect(output).toContain("Main entry point.");
+  });
+});
+

--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -401,11 +401,8 @@ export class AgencyGenerator {
     this.typeAliases[node.aliasName] = node.aliasedType;
     const aliasedTypeStr = this.aliasedTypeToString(node.aliasedType);
     const exportPrefix = node.exported ? "export " : "";
-    const docComment = node.docComment
-      ? this.processMultiLineComment(node.docComment) + "\n"
-      : "";
     return (
-      docComment +
+      this.formatDocComment(node) +
       this.indentStr(
         `${exportPrefix}type ${node.aliasName} = ${aliasedTypeStr}`,
       )
@@ -541,10 +538,7 @@ export class AgencyGenerator {
 
     result += this.indentStr(`}`);
 
-    const docComment = node.docComment
-      ? this.processMultiLineComment(node.docComment) + "\n"
-      : "";
-    return docComment + tags + result;
+    return this.formatDocComment(node) + tags + result;
   }
 
   protected processFunctionCall(node: FunctionCall): string {
@@ -803,6 +797,11 @@ export class AgencyGenerator {
     return this.indentStr(`/*${node.content}*/`);
   }
 
+  protected formatDocComment(node: { docComment?: AgencyMultiLineComment }): string {
+    if (!node.docComment) return "";
+    return this.processMultiLineComment(node.docComment) + "\n";
+  }
+
   protected processImportStatement(node: ImportStatement): string {
     const importedNames = node.importedNames.map((name) =>
       this.processImportNameType(name),
@@ -898,10 +897,7 @@ export class AgencyGenerator {
     this.decreaseIndent();
 
     result += this.indentStr(`}`);
-    const docComment = node.docComment
-      ? this.processMultiLineComment(node.docComment) + "\n"
-      : "";
-    return docComment + tags + result;
+    return this.formatDocComment(node) + tags + result;
   }
 
   protected processClassDefinition(node: ClassDefinition): string {

--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -151,9 +151,6 @@ export class AgencyGenerator {
 
     const output: string[] = [];
 
-    if (program.docComment) {
-      output.push(this.processMultiLineComment(program.docComment));
-    }
     this.addIfNonEmpty(this.preprocess(), output);
     this.addIfNonEmpty(this.importStatements.join("\n"), output);
     this.addIfNonEmpty(this.generateImports(), output);

--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -151,6 +151,9 @@ export class AgencyGenerator {
 
     const output: string[] = [];
 
+    if (program.docComment) {
+      output.push(this.processMultiLineComment(program.docComment));
+    }
     this.addIfNonEmpty(this.preprocess(), output);
     this.addIfNonEmpty(this.importStatements.join("\n"), output);
     this.addIfNonEmpty(this.generateImports(), output);
@@ -398,8 +401,14 @@ export class AgencyGenerator {
     this.typeAliases[node.aliasName] = node.aliasedType;
     const aliasedTypeStr = this.aliasedTypeToString(node.aliasedType);
     const exportPrefix = node.exported ? "export " : "";
-    return this.indentStr(
-      `${exportPrefix}type ${node.aliasName} = ${aliasedTypeStr}`,
+    const docComment = node.docComment
+      ? this.processMultiLineComment(node.docComment) + "\n"
+      : "";
+    return (
+      docComment +
+      this.indentStr(
+        `${exportPrefix}type ${node.aliasName} = ${aliasedTypeStr}`,
+      )
     );
   }
 
@@ -532,7 +541,10 @@ export class AgencyGenerator {
 
     result += this.indentStr(`}`);
 
-    return tags + result;
+    const docComment = node.docComment
+      ? this.processMultiLineComment(node.docComment) + "\n"
+      : "";
+    return docComment + tags + result;
   }
 
   protected processFunctionCall(node: FunctionCall): string {
@@ -785,6 +797,9 @@ export class AgencyGenerator {
   }
 
   protected processMultiLineComment(node: AgencyMultiLineComment): string {
+    if (node.isDoc) {
+      return this.indentStr(`/**${node.content}*/`);
+    }
     return this.indentStr(`/*${node.content}*/`);
   }
 
@@ -863,6 +878,12 @@ export class AgencyGenerator {
 
     this.increaseIndent();
 
+    if (node.docString) {
+      const docLines = [`"""`, ...node.docString.value.split("\n"), `"""`];
+      const docStr = docLines.map((line) => this.indentStr(line)).join("\n");
+      result += `${docStr}\n`;
+    }
+
     const lines: string[] = [];
     for (const stmt of body) {
       lines.push(this.processNode(stmt));
@@ -877,7 +898,10 @@ export class AgencyGenerator {
     this.decreaseIndent();
 
     result += this.indentStr(`}`);
-    return tags + result;
+    const docComment = node.docComment
+      ? this.processMultiLineComment(node.docComment) + "\n"
+      : "";
+    return docComment + tags + result;
   }
 
   protected processClassDefinition(node: ClassDefinition): string {

--- a/lib/cli/doc.test.ts
+++ b/lib/cli/doc.test.ts
@@ -305,4 +305,132 @@ type Status = "active" | "inactive"
     expect(output).toContain("### Status");
     expect(output).toContain('```ts\ntype Status = "active" | "inactive"\n```');
   });
+
+  it("adds page-level View source link when baseUrl is configured", () => {
+    const inputDir = path.join(tmpDir, "input");
+    const outputDir = path.join(tmpDir, "output");
+    fs.mkdirSync(inputDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(inputDir, "test.agency"),
+      `node main() {
+  print("hello")
+}
+`,
+    );
+
+    generateDoc(
+      { doc: { baseUrl: "https://example.com/src" } },
+      path.join(inputDir, "test.agency"),
+      outputDir,
+    );
+    const output = fs.readFileSync(
+      path.join(outputDir, "test.md"),
+      "utf-8",
+    );
+
+    expect(output).toContain("[View source](https://example.com/src/test.agency)");
+  });
+
+  it("adds item-level [source] links with line numbers", () => {
+    const inputDir = path.join(tmpDir, "input");
+    const outputDir = path.join(tmpDir, "output");
+    fs.mkdirSync(inputDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(inputDir, "funcs.agency"),
+      `def greet(name: string): string {
+  return "Hello, " + name
+}
+
+node main() {
+  print("hello")
+}
+`,
+    );
+
+    generateDoc(
+      { doc: { baseUrl: "https://example.com/src" } },
+      path.join(inputDir, "funcs.agency"),
+      outputDir,
+    );
+    const output = fs.readFileSync(
+      path.join(outputDir, "funcs.md"),
+      "utf-8",
+    );
+
+    // Function and node headings should have [source] links with line numbers
+    expect(output).toMatch(/### greet \[source\]\(https:\/\/example\.com\/src\/funcs\.agency#L\d+\)/);
+    expect(output).toMatch(/### main \[source\]\(https:\/\/example\.com\/src\/funcs\.agency#L\d+\)/);
+  });
+
+  it("generates cross-file type links in directory mode", () => {
+    const inputDir = path.join(tmpDir, "input");
+    const outputDir = path.join(tmpDir, "output");
+    fs.mkdirSync(inputDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(inputDir, "types.agency"),
+      `type User = {
+  name: string;
+  age: number
+}
+`,
+    );
+
+    fs.writeFileSync(
+      path.join(inputDir, "funcs.agency"),
+      `type Category = "a" | "b"
+
+def getCategory(): Category {
+  return "a"
+}
+`,
+    );
+
+    generateDoc(
+      { doc: { baseUrl: "https://example.com/src" } },
+      inputDir,
+      outputDir,
+    );
+
+    const funcsOutput = fs.readFileSync(
+      path.join(outputDir, "funcs.md"),
+      "utf-8",
+    );
+
+    // Return type Category is defined in same file — anchor link
+    expect(funcsOutput).toContain("[Category](#category)");
+
+    const typesOutput = fs.readFileSync(
+      path.join(outputDir, "types.md"),
+      "utf-8",
+    );
+
+    // Types file should have User with source link
+    expect(typesOutput).toContain("### User");
+  });
+
+  it("does not add source links when baseUrl is not configured", () => {
+    const inputDir = path.join(tmpDir, "input");
+    const outputDir = path.join(tmpDir, "output");
+    fs.mkdirSync(inputDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(inputDir, "test.agency"),
+      `def foo(): string {
+  return "bar"
+}
+`,
+    );
+
+    generateDoc({}, path.join(inputDir, "test.agency"), outputDir);
+    const output = fs.readFileSync(
+      path.join(outputDir, "test.md"),
+      "utf-8",
+    );
+
+    expect(output).not.toContain("[View source]");
+    expect(output).not.toContain("[source]");
+  });
 });

--- a/lib/cli/doc.test.ts
+++ b/lib/cli/doc.test.ts
@@ -372,7 +372,7 @@ node main() {
     fs.writeFileSync(
       path.join(inputDir, "types.agency"),
       `type User = {
-  name: string;
+  name: string
   age: number
 }
 `,

--- a/lib/cli/doc.test.ts
+++ b/lib/cli/doc.test.ts
@@ -174,6 +174,116 @@ def greet(name: string = "world"): string {
     expect(output).toContain('| name | string | "world" |');
   });
 
+  it("renders file-level doc comment after title", () => {
+    const inputDir = path.join(tmpDir, "input");
+    const outputDir = path.join(tmpDir, "output");
+    fs.mkdirSync(inputDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(inputDir, "filedoc.agency"),
+      `/** This file implements email categorization. */
+
+import { helper } from "./helper.ts"
+
+node main() {
+  print("hello")
+}
+`,
+    );
+
+    generateDoc({}, path.join(inputDir, "filedoc.agency"), outputDir);
+    const output = fs.readFileSync(
+      path.join(outputDir, "filedoc.md"),
+      "utf-8",
+    );
+
+    expect(output).toContain("# filedoc");
+    expect(output).toContain("This file implements email categorization.");
+    // File doc should come before nodes section
+    const fileDocIndex = output.indexOf("This file implements email categorization.");
+    const nodesIndex = output.indexOf("## Nodes");
+    expect(fileDocIndex).toBeLessThan(nodesIndex);
+  });
+
+  it("renders doc comment and docstring on a function (docstring first)", () => {
+    const inputDir = path.join(tmpDir, "input");
+    const outputDir = path.join(tmpDir, "output");
+    fs.mkdirSync(inputDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(inputDir, "funcdoc.agency"),
+      `/** Extra context for docs. */
+def add(a: number, b: number): number {
+  """Adds two numbers."""
+  return a + b
+}
+`,
+    );
+
+    generateDoc({}, path.join(inputDir, "funcdoc.agency"), outputDir);
+    const output = fs.readFileSync(
+      path.join(outputDir, "funcdoc.md"),
+      "utf-8",
+    );
+
+    expect(output).toContain("Adds two numbers.");
+    expect(output).toContain("Extra context for docs.");
+    // Docstring should come before doc comment
+    const docstringIndex = output.indexOf("Adds two numbers.");
+    const docCommentIndex = output.indexOf("Extra context for docs.");
+    expect(docstringIndex).toBeLessThan(docCommentIndex);
+  });
+
+  it("renders doc comment and docstring on a node (docstring first)", () => {
+    const inputDir = path.join(tmpDir, "input");
+    const outputDir = path.join(tmpDir, "output");
+    fs.mkdirSync(inputDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(inputDir, "nodedoc.agency"),
+      `/** Extra node context. */
+node main() {
+  """Main entry point."""
+  print("hello")
+}
+`,
+    );
+
+    generateDoc({}, path.join(inputDir, "nodedoc.agency"), outputDir);
+    const output = fs.readFileSync(
+      path.join(outputDir, "nodedoc.md"),
+      "utf-8",
+    );
+
+    expect(output).toContain("Main entry point.");
+    expect(output).toContain("Extra node context.");
+    const docstringIndex = output.indexOf("Main entry point.");
+    const docCommentIndex = output.indexOf("Extra node context.");
+    expect(docstringIndex).toBeLessThan(docCommentIndex);
+  });
+
+  it("renders doc comment on a type alias", () => {
+    const inputDir = path.join(tmpDir, "input");
+    const outputDir = path.join(tmpDir, "output");
+    fs.mkdirSync(inputDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(inputDir, "typedoc.agency"),
+      `/** Possible message categories. */
+type Category = "reminder" | "todo"
+`,
+    );
+
+    generateDoc({}, path.join(inputDir, "typedoc.agency"), outputDir);
+    const output = fs.readFileSync(
+      path.join(outputDir, "typedoc.md"),
+      "utf-8",
+    );
+
+    expect(output).toContain("Possible message categories.");
+    expect(output).toContain("### Category");
+  });
+
   it("handles type aliases that are not objects", () => {
     const inputDir = path.join(tmpDir, "input");
     const outputDir = path.join(tmpDir, "output");

--- a/lib/cli/doc.ts
+++ b/lib/cli/doc.ts
@@ -18,26 +18,67 @@ import {
 import * as fs from "fs";
 import * as path from "path";
 
+// Maps a symbol name to the relative .md path where it's documented
+type SymbolRegistry = Record<string, string>;
+
+type DocContext = {
+  baseUrl?: string;
+  sourceRelPath?: string;
+  symbolRegistry: SymbolRegistry;
+  currentMdPath?: string;
+};
+
 export function generateDoc(
   config: AgencyConfig,
   inputPath: string,
   outputDir: string,
 ): void {
+  const baseUrl = config.doc?.baseUrl;
+
   if (fs.statSync(inputPath).isDirectory()) {
-    for (const { path: filePath } of findRecursively(inputPath)) {
+    // First pass: build symbol registry across all files
+    const symbolRegistry: SymbolRegistry = {};
+    const files = [...findRecursively(inputPath)];
+
+    for (const { path: filePath } of files) {
       const relativePath = path.relative(inputPath, filePath);
-      const outputPath = path.join(
-        outputDir,
-        relativePath.replace(/\.agency$/, ".md"),
-      );
+      const mdRelPath = relativePath.replace(/\.agency$/, ".md");
+      const contents = readFile(filePath);
+      const program = parse(contents, config);
+
+      for (const node of program.nodes) {
+        if (node.type === "typeAlias") {
+          symbolRegistry[node.aliasName] = mdRelPath;
+        } else if (node.type === "function") {
+          symbolRegistry[node.functionName] = mdRelPath;
+        } else if (node.type === "graphNode") {
+          symbolRegistry[node.nodeName] = mdRelPath;
+        }
+      }
+    }
+
+    // Second pass: generate docs
+    for (const { path: filePath } of files) {
+      const relativePath = path.relative(inputPath, filePath);
+      const mdRelPath = relativePath.replace(/\.agency$/, ".md");
+      const outputPath = path.join(outputDir, mdRelPath);
       fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-      generateDocForFile(config, filePath, outputPath);
+      generateDocForFile(config, filePath, outputPath, {
+        baseUrl,
+        sourceRelPath: relativePath,
+        symbolRegistry,
+        currentMdPath: mdRelPath,
+      });
     }
   } else {
     const baseName = path.basename(inputPath).replace(/\.agency$/, ".md");
     const outputPath = path.join(outputDir, baseName);
     fs.mkdirSync(outputDir, { recursive: true });
-    generateDocForFile(config, inputPath, outputPath);
+    generateDocForFile(config, inputPath, outputPath, {
+      baseUrl,
+      sourceRelPath: path.basename(inputPath),
+      symbolRegistry: {},
+    });
   }
 }
 
@@ -45,6 +86,7 @@ function generateDocForFile(
   config: AgencyConfig,
   filePath: string,
   outputPath: string,
+  ctx: DocContext,
 ): void {
   const contents = readFile(filePath);
   const program = parse(contents, config);
@@ -74,17 +116,22 @@ function generateDocForFile(
   const title = path.basename(filePath).replace(/\.agency$/, "");
   const sections: string[] = [heading(1, title)];
 
+  // Page-level "View source" link
+  if (ctx.baseUrl && ctx.sourceRelPath) {
+    sections.push(`[View source](${ctx.baseUrl}/${ctx.sourceRelPath})`);
+  }
+
   if (program.docComment) {
     sections.push(formatDocComment(program.docComment));
   }
 
-  const typeSection = generateTypeSection(typeAliases);
+  const typeSection = generateTypeSection(typeAliases, ctx);
   if (typeSection) sections.push(typeSection);
 
-  const functionSection = generateFunctionSection(functions);
+  const functionSection = generateFunctionSection(functions, ctx);
   if (functionSection) sections.push(functionSection);
 
-  const nodeSection = generateNodeSection(nodes);
+  const nodeSection = generateNodeSection(nodes, ctx);
   if (nodeSection) sections.push(nodeSection);
 
   fs.writeFileSync(outputPath, sections.join("\n\n") + "\n");
@@ -94,6 +141,43 @@ function generateDocForFile(
 function formatType(type: VariableType | undefined | null): string {
   if (!type) return "";
   return variableTypeToString(type, {}).replace(/\s*\r?\n\s*/g, " ").trim();
+}
+
+function formatTypeLinked(
+  type: VariableType | undefined | null,
+  ctx: DocContext,
+): string {
+  if (!type) return "";
+  const plain = formatType(type);
+  if (!type || type.type !== "typeAliasVariable") return plain;
+
+  const name = type.aliasName;
+  const targetMdPath = ctx.symbolRegistry[name];
+  if (!targetMdPath) return plain;
+
+  if (targetMdPath === ctx.currentMdPath) {
+    // Same file — anchor link
+    return `[${name}](#${name.toLowerCase()})`;
+  }
+
+  // Cross-file — relative link to the other doc page
+  const from = path.dirname(ctx.currentMdPath || "");
+  const rel = path.relative(from, targetMdPath);
+  return `[${name}](${rel}#${name.toLowerCase()})`;
+}
+
+function sourceLink(loc: { line: number } | undefined, ctx: DocContext): string {
+  if (!ctx.baseUrl || !ctx.sourceRelPath || !loc) return "";
+  return ` [source](${ctx.baseUrl}/${ctx.sourceRelPath}#L${loc.line})`;
+}
+
+function crossFileSourceLink(name: string, ctx: DocContext): string {
+  const targetMdPath = ctx.symbolRegistry[name];
+  if (!targetMdPath) return "";
+  if (targetMdPath === ctx.currentMdPath) return "";
+  const from = path.dirname(ctx.currentMdPath || "");
+  const rel = path.relative(from, targetMdPath);
+  return ` [source](${rel}#${name.toLowerCase()})`;
 }
 
 function formatSignature(
@@ -119,11 +203,14 @@ function formatDefaultValue(node: FunctionParameter["defaultValue"]): string {
   return generator.processNode(node).trim();
 }
 
-function generateParamTable(params: FunctionParameter[]): string | null {
+function generateParamTable(
+  params: FunctionParameter[],
+  ctx: DocContext,
+): string | null {
   if (params.length === 0) return null;
   const rows = params.map((p) => [
     p.name,
-    formatType(p.typeHint),
+    p.typeHint ? formatTypeLinked(p.typeHint, ctx) : "",
     formatDefaultValue(p.defaultValue),
   ]);
   return `${bold("Parameters:")}\n\n${markdownTable(["Name", "Type", "Default"], rows)}`;
@@ -133,36 +220,39 @@ function formatDocComment(comment: AgencyMultiLineComment): string {
   return comment.content.trim();
 }
 
-function formatTypeAlias(alias: TypeAlias): string {
+function formatTypeAlias(alias: TypeAlias, ctx: DocContext): string {
   const code = generateAgency({
     type: "agencyProgram",
     nodes: [alias],
   });
+  const src = sourceLink(alias.loc, ctx);
   return section(
-    heading(3, alias.aliasName),
+    heading(3, alias.aliasName) + src,
     alias.docComment ? formatDocComment(alias.docComment) : null,
     codeFence(code),
   );
 }
 
-function generateTypeSection(aliases: TypeAlias[]): string | null {
+function generateTypeSection(aliases: TypeAlias[], ctx: DocContext): string | null {
   if (aliases.length === 0) return null;
-  return section(heading(2, "Types"), ...aliases.map(formatTypeAlias));
+  return section(heading(2, "Types"), ...aliases.map((a) => formatTypeAlias(a, ctx)));
 }
 
 function generateFunctionSection(
   fns: FunctionDefinition[],
+  ctx: DocContext,
 ): string | null {
   if (fns.length === 0) return null;
   const parts = fns.map((fn) => {
     const sig = formatSignature(fn.functionName, fn.parameters, fn.returnType);
+    const src = sourceLink(fn.loc, ctx);
     return section(
-      heading(3, fn.functionName),
+      heading(3, fn.functionName) + src,
       codeFence(sig),
       fn.docString ? fn.docString.value : null,
       fn.docComment ? formatDocComment(fn.docComment) : null,
-      generateParamTable(fn.parameters),
-      fn.returnType ? `${bold("Returns:")} ${formatType(fn.returnType)}` : null,
+      generateParamTable(fn.parameters, ctx),
+      fn.returnType ? `${bold("Returns:")} ${formatTypeLinked(fn.returnType, ctx)}` : null,
     );
   });
   return section(heading(2, "Functions"), ...parts);
@@ -170,17 +260,19 @@ function generateFunctionSection(
 
 function generateNodeSection(
   nodes: GraphNodeDefinition[],
+  ctx: DocContext,
 ): string | null {
   if (nodes.length === 0) return null;
   const parts = nodes.map((node) => {
     const sig = formatSignature(node.nodeName, node.parameters, node.returnType);
+    const src = sourceLink(node.loc, ctx);
     return section(
-      heading(3, node.nodeName),
+      heading(3, node.nodeName) + src,
       codeFence(sig),
       node.docString ? node.docString.value : null,
       node.docComment ? formatDocComment(node.docComment) : null,
-      generateParamTable(node.parameters),
-      node.returnType ? `${bold("Returns:")} ${formatType(node.returnType)}` : null,
+      generateParamTable(node.parameters, ctx),
+      node.returnType ? `${bold("Returns:")} ${formatTypeLinked(node.returnType, ctx)}` : null,
     );
   });
   return section(heading(2, "Nodes"), ...parts);

--- a/lib/cli/doc.ts
+++ b/lib/cli/doc.ts
@@ -119,7 +119,7 @@ function generateDocForFile(
 
   // Page-level "View source" link
   if (ctx.baseUrl && ctx.sourceRelPath) {
-    sections.push(`[View source](${ctx.baseUrl}/${ctx.sourceRelPath})`);
+    sections.push(`[View source](${ctx.baseUrl}/${toPosixPath(ctx.sourceRelPath)})`);
   }
 
   if (program.docComment) {
@@ -138,6 +138,10 @@ function generateDocForFile(
   fs.writeFileSync(outputPath, sections.join("\n\n") + "\n");
 }
 
+
+function toPosixPath(p: string): string {
+  return p.split(path.sep).join("/");
+}
 
 function formatType(type: VariableType | undefined | null): string {
   if (!type) return "";
@@ -164,12 +168,12 @@ function formatTypeLinked(
   // Cross-file — relative link to the other doc page
   const from = path.dirname(ctx.currentMdPath || "");
   const rel = path.relative(from, targetMdPath);
-  return `[${name}](${rel}#${name.toLowerCase()})`;
+  return `[${name}](${toPosixPath(rel)}#${name.toLowerCase()})`;
 }
 
 function sourceLink(loc: { line: number } | undefined, ctx: DocContext): string {
   if (!ctx.baseUrl || !ctx.sourceRelPath || !loc) return "";
-  return ` [source](${ctx.baseUrl}/${ctx.sourceRelPath}#L${loc.line})`;
+  return ` [source](${ctx.baseUrl}/${toPosixPath(ctx.sourceRelPath)}#L${loc.line})`;
 }
 
 function formatSignature(

--- a/lib/cli/doc.ts
+++ b/lib/cli/doc.ts
@@ -3,9 +3,11 @@ import { AgencyGenerator, generateAgency } from "@/backends/agencyGenerator.js";
 import { parse, readFile } from "./commands.js";
 import { findRecursively } from "./util.js";
 import { variableTypeToString } from "@/backends/typescriptGenerator/typeToString.js";
+import { AgencyMultiLineComment } from "@/types.js";
 import { TypeAlias, VariableType } from "@/types/typeHints.js";
 import { FunctionDefinition, FunctionParameter } from "@/types/function.js";
 import { GraphNodeDefinition } from "@/types/graphNode.js";
+import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
 import {
   heading,
   codeFence,
@@ -47,6 +49,10 @@ function generateDocForFile(
   const contents = readFile(filePath);
   const program = parse(contents, config);
 
+  // Run doc comment attachment so docComment fields are populated
+  const preprocessor = new TypescriptPreprocessor(program, config);
+  preprocessor["attachDocComments"]();
+
   const typeAliases: TypeAlias[] = [];
   const functions: FunctionDefinition[] = [];
   const nodes: GraphNodeDefinition[] = [];
@@ -67,6 +73,10 @@ function generateDocForFile(
 
   const title = path.basename(filePath).replace(/\.agency$/, "");
   const sections: string[] = [heading(1, title)];
+
+  if (program.docComment) {
+    sections.push(formatDocComment(program.docComment));
+  }
 
   const typeSection = generateTypeSection(typeAliases);
   if (typeSection) sections.push(typeSection);
@@ -119,12 +129,20 @@ function generateParamTable(params: FunctionParameter[]): string | null {
   return `${bold("Parameters:")}\n\n${markdownTable(["Name", "Type", "Default"], rows)}`;
 }
 
+function formatDocComment(comment: AgencyMultiLineComment): string {
+  return comment.content.trim();
+}
+
 function formatTypeAlias(alias: TypeAlias): string {
   const code = generateAgency({
     type: "agencyProgram",
     nodes: [alias],
   });
-  return section(heading(3, alias.aliasName), codeFence(code));
+  return section(
+    heading(3, alias.aliasName),
+    alias.docComment ? formatDocComment(alias.docComment) : null,
+    codeFence(code),
+  );
 }
 
 function generateTypeSection(aliases: TypeAlias[]): string | null {
@@ -142,6 +160,7 @@ function generateFunctionSection(
       heading(3, fn.functionName),
       codeFence(sig),
       fn.docString ? fn.docString.value : null,
+      fn.docComment ? formatDocComment(fn.docComment) : null,
       generateParamTable(fn.parameters),
       fn.returnType ? `${bold("Returns:")} ${formatType(fn.returnType)}` : null,
     );
@@ -158,6 +177,8 @@ function generateNodeSection(
     return section(
       heading(3, node.nodeName),
       codeFence(sig),
+      node.docString ? node.docString.value : null,
+      node.docComment ? formatDocComment(node.docComment) : null,
       generateParamTable(node.parameters),
       node.returnType ? `${bold("Returns:")} ${formatType(node.returnType)}` : null,
     );

--- a/lib/cli/doc.ts
+++ b/lib/cli/doc.ts
@@ -8,6 +8,7 @@ import { TypeAlias, VariableType } from "@/types/typeHints.js";
 import { FunctionDefinition, FunctionParameter } from "@/types/function.js";
 import { GraphNodeDefinition } from "@/types/graphNode.js";
 import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
+import { collectProgramInfo, GLOBAL_SCOPE_KEY } from "@/programInfo.js";
 import {
   heading,
   codeFence,
@@ -36,7 +37,7 @@ export function generateDoc(
   const baseUrl = config.doc?.baseUrl;
 
   if (fs.statSync(inputPath).isDirectory()) {
-    // First pass: parse all files and build symbol registry
+    // First pass: parse and preprocess all files, build symbol registry
     const symbolRegistry: SymbolRegistry = {};
     const files = [...findRecursively(inputPath)];
     const parsedPrograms = new Map<string, { program: AgencyProgram; relativePath: string; mdRelPath: string }>();
@@ -45,18 +46,19 @@ export function generateDoc(
       const relativePath = path.relative(inputPath, filePath);
       const mdRelPath = relativePath.replace(/\.agency$/, ".md");
       const contents = readFile(filePath);
-      const program = parse(contents, config);
+      const program = preprocessProgram(parse(contents, config), config);
 
       parsedPrograms.set(filePath, { program, relativePath, mdRelPath });
 
-      for (const node of program.nodes) {
-        if (node.type === "typeAlias") {
-          symbolRegistry[node.aliasName] = mdRelPath;
-        } else if (node.type === "function") {
-          symbolRegistry[node.functionName] = mdRelPath;
-        } else if (node.type === "graphNode") {
-          symbolRegistry[node.nodeName] = mdRelPath;
-        }
+      const info = collectProgramInfo(program);
+      for (const name of Object.keys(info.functionDefinitions)) {
+        symbolRegistry[name] = mdRelPath;
+      }
+      for (const node of info.graphNodes) {
+        symbolRegistry[node.nodeName] = mdRelPath;
+      }
+      for (const name of Object.keys(info.typeAliases[GLOBAL_SCOPE_KEY] || {})) {
+        symbolRegistry[name] = mdRelPath;
       }
     }
 
@@ -64,7 +66,7 @@ export function generateDoc(
     for (const [filePath, { program, relativePath, mdRelPath }] of parsedPrograms) {
       const outputPath = path.join(outputDir, mdRelPath);
       fs.mkdirSync(path.dirname(outputPath), { recursive: true });
-      generateDocForFile(config, filePath, outputPath, {
+      generateDocForFile(filePath, outputPath, {
         baseUrl,
         sourceRelPath: relativePath,
         symbolRegistry,
@@ -75,42 +77,33 @@ export function generateDoc(
     const baseName = path.basename(inputPath).replace(/\.agency$/, ".md");
     const outputPath = path.join(outputDir, baseName);
     fs.mkdirSync(outputDir, { recursive: true });
-    generateDocForFile(config, inputPath, outputPath, {
+    const program = preprocessProgram(parse(readFile(inputPath), config), config);
+    generateDocForFile(inputPath, outputPath, {
       baseUrl,
       sourceRelPath: path.basename(inputPath),
       symbolRegistry: {},
-    });
+    }, program);
   }
 }
 
+function preprocessProgram(program: AgencyProgram, config: AgencyConfig): AgencyProgram {
+  const preprocessor = new TypescriptPreprocessor(program, config);
+  preprocessor.attachDocComments();
+  return program;
+}
+
 function generateDocForFile(
-  config: AgencyConfig,
   filePath: string,
   outputPath: string,
   ctx: DocContext,
-  preParsed?: AgencyProgram,
+  program: AgencyProgram,
 ): void {
-  const program = preParsed ?? parse(readFile(filePath), config);
-
-  // Run doc comment attachment so docComment fields are populated
-  const preprocessor = new TypescriptPreprocessor(program, config);
-  preprocessor.attachDocComments();
+  const info = collectProgramInfo(program);
 
   const typeAliases: TypeAlias[] = [];
-  const functions: FunctionDefinition[] = [];
-  const nodes: GraphNodeDefinition[] = [];
-
   for (const node of program.nodes) {
-    switch (node.type) {
-      case "typeAlias":
-        typeAliases.push(node);
-        break;
-      case "function":
-        functions.push(node);
-        break;
-      case "graphNode":
-        nodes.push(node);
-        break;
+    if (node.type === "typeAlias") {
+      typeAliases.push(node);
     }
   }
 
@@ -129,10 +122,11 @@ function generateDocForFile(
   const typeSection = generateTypeSection(typeAliases, ctx);
   if (typeSection) sections.push(typeSection);
 
+  const functions = Object.values(info.functionDefinitions);
   const functionSection = generateFunctionSection(functions, ctx);
   if (functionSection) sections.push(functionSection);
 
-  const nodeSection = generateNodeSection(nodes, ctx);
+  const nodeSection = generateNodeSection(info.graphNodes, ctx);
   if (nodeSection) sections.push(nodeSection);
 
   fs.writeFileSync(outputPath, sections.join("\n\n") + "\n");
@@ -161,11 +155,9 @@ function formatTypeLinked(
   if (!targetMdPath) return plain;
 
   if (targetMdPath === ctx.currentMdPath) {
-    // Same file — anchor link
     return `[${name}](#${name.toLowerCase()})`;
   }
 
-  // Cross-file — relative link to the other doc page
   const from = path.dirname(ctx.currentMdPath || "");
   const rel = path.relative(from, targetMdPath);
   return `[${name}](${toPosixPath(rel)}#${name.toLowerCase()})`;

--- a/lib/cli/doc.ts
+++ b/lib/cli/doc.ts
@@ -3,7 +3,7 @@ import { AgencyGenerator, generateAgency } from "@/backends/agencyGenerator.js";
 import { parse, readFile } from "./commands.js";
 import { findRecursively } from "./util.js";
 import { variableTypeToString } from "@/backends/typescriptGenerator/typeToString.js";
-import { AgencyMultiLineComment } from "@/types.js";
+import { AgencyMultiLineComment, AgencyProgram } from "@/types.js";
 import { TypeAlias, VariableType } from "@/types/typeHints.js";
 import { FunctionDefinition, FunctionParameter } from "@/types/function.js";
 import { GraphNodeDefinition } from "@/types/graphNode.js";
@@ -36,15 +36,18 @@ export function generateDoc(
   const baseUrl = config.doc?.baseUrl;
 
   if (fs.statSync(inputPath).isDirectory()) {
-    // First pass: build symbol registry across all files
+    // First pass: parse all files and build symbol registry
     const symbolRegistry: SymbolRegistry = {};
     const files = [...findRecursively(inputPath)];
+    const parsedPrograms = new Map<string, { program: AgencyProgram; relativePath: string; mdRelPath: string }>();
 
     for (const { path: filePath } of files) {
       const relativePath = path.relative(inputPath, filePath);
       const mdRelPath = relativePath.replace(/\.agency$/, ".md");
       const contents = readFile(filePath);
       const program = parse(contents, config);
+
+      parsedPrograms.set(filePath, { program, relativePath, mdRelPath });
 
       for (const node of program.nodes) {
         if (node.type === "typeAlias") {
@@ -57,10 +60,8 @@ export function generateDoc(
       }
     }
 
-    // Second pass: generate docs
-    for (const { path: filePath } of files) {
-      const relativePath = path.relative(inputPath, filePath);
-      const mdRelPath = relativePath.replace(/\.agency$/, ".md");
+    // Second pass: generate docs (reusing parsed programs)
+    for (const [filePath, { program, relativePath, mdRelPath }] of parsedPrograms) {
       const outputPath = path.join(outputDir, mdRelPath);
       fs.mkdirSync(path.dirname(outputPath), { recursive: true });
       generateDocForFile(config, filePath, outputPath, {
@@ -68,7 +69,7 @@ export function generateDoc(
         sourceRelPath: relativePath,
         symbolRegistry,
         currentMdPath: mdRelPath,
-      });
+      }, program);
     }
   } else {
     const baseName = path.basename(inputPath).replace(/\.agency$/, ".md");
@@ -87,13 +88,13 @@ function generateDocForFile(
   filePath: string,
   outputPath: string,
   ctx: DocContext,
+  preParsed?: AgencyProgram,
 ): void {
-  const contents = readFile(filePath);
-  const program = parse(contents, config);
+  const program = preParsed ?? parse(readFile(filePath), config);
 
   // Run doc comment attachment so docComment fields are populated
   const preprocessor = new TypescriptPreprocessor(program, config);
-  preprocessor["attachDocComments"]();
+  preprocessor.attachDocComments();
 
   const typeAliases: TypeAlias[] = [];
   const functions: FunctionDefinition[] = [];
@@ -149,7 +150,7 @@ function formatTypeLinked(
 ): string {
   if (!type) return "";
   const plain = formatType(type);
-  if (!type || type.type !== "typeAliasVariable") return plain;
+  if (type.type !== "typeAliasVariable") return plain;
 
   const name = type.aliasName;
   const targetMdPath = ctx.symbolRegistry[name];
@@ -169,15 +170,6 @@ function formatTypeLinked(
 function sourceLink(loc: { line: number } | undefined, ctx: DocContext): string {
   if (!ctx.baseUrl || !ctx.sourceRelPath || !loc) return "";
   return ` [source](${ctx.baseUrl}/${ctx.sourceRelPath}#L${loc.line})`;
-}
-
-function crossFileSourceLink(name: string, ctx: DocContext): string {
-  const targetMdPath = ctx.symbolRegistry[name];
-  if (!targetMdPath) return "";
-  if (targetMdPath === ctx.currentMdPath) return "";
-  const from = path.dirname(ctx.currentMdPath || "");
-  const rel = path.relative(from, targetMdPath);
-  return ` [source](${rel}#${name.toLowerCase()})`;
 }
 
 function formatSignature(

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -140,6 +140,7 @@ export interface AgencyConfig {
     /** Output directory for generated documentation (default: "docs") */
     outDir?: string;
 
-    baseUrl?: string; // Base URL for links in generated docs
+    /** Base URL for source links in generated docs */
+    baseUrl?: string;
   }
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -135,4 +135,11 @@ export interface AgencyConfig {
     /** Number of test files to run in parallel. Default: 1 (sequential). */
     parallel?: number;
   };
+
+  doc?: {
+    /** Output directory for generated documentation (default: "docs") */
+    outDir?: string;
+
+    baseUrl?: string; // Base URL for links in generated docs
+  }
 }

--- a/lib/parsers/multiLineComment.test.ts
+++ b/lib/parsers/multiLineComment.test.ts
@@ -7,7 +7,7 @@ describe("multiLineCommentParser", () => {
       input: "/* this is a comment */",
       expected: {
         success: true,
-        result: { type: "multiLineComment", content: " this is a comment " },
+        result: { type: "multiLineComment", content: " this is a comment ", isDoc: false },
       },
     },
     {
@@ -17,6 +17,7 @@ describe("multiLineCommentParser", () => {
         result: {
           type: "multiLineComment",
           content: " multi\nline\ncomment ",
+          isDoc: false,
         },
       },
     },
@@ -24,7 +25,7 @@ describe("multiLineCommentParser", () => {
       input: "/*no spaces*/",
       expected: {
         success: true,
-        result: { type: "multiLineComment", content: "no spaces" },
+        result: { type: "multiLineComment", content: "no spaces", isDoc: false },
       },
     },
     {
@@ -34,6 +35,7 @@ describe("multiLineCommentParser", () => {
         result: {
           type: "multiLineComment",
           content: " comment with special chars !@# ",
+          isDoc: false,
         },
       },
     },
@@ -41,7 +43,33 @@ describe("multiLineCommentParser", () => {
       input: "/**/",
       expected: {
         success: true,
-        result: { type: "multiLineComment", content: "" },
+        result: { type: "multiLineComment", content: "", isDoc: false },
+      },
+    },
+    // Doc comment cases
+    {
+      input: "/** this is a doc comment */",
+      expected: {
+        success: true,
+        result: { type: "multiLineComment", content: " this is a doc comment ", isDoc: true },
+      },
+    },
+    {
+      input: "/** multi\nline\ndoc comment */",
+      expected: {
+        success: true,
+        result: {
+          type: "multiLineComment",
+          content: " multi\nline\ndoc comment ",
+          isDoc: true,
+        },
+      },
+    },
+    {
+      input: "/***/",
+      expected: {
+        success: true,
+        result: { type: "multiLineComment", content: "", isDoc: true },
       },
     },
     // Failure cases

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -239,10 +239,19 @@ export const multiLineCommentParser: Parser<AgencyMultiLineComment> = (
 ) => {
   const parser = seqC(
     set("type", "multiLineComment"),
+    set("isDoc", false as boolean),
     optionalSpaces,
     capture(map(between(str("/*"), str("*/"), anyChar), joinChars), "content"),
   );
-  return parser(input);
+  const result = parser(input);
+  if (result.success) {
+    const content = result.result.content;
+    if (content.startsWith("*")) {
+      result.result.isDoc = true;
+      result.result.content = content.slice(1);
+    }
+  }
+  return result;
 };
 
 // =============================================================================
@@ -2540,6 +2549,8 @@ export const graphNodeParser: Parser<GraphNodeDefinition> = label("a node defini
         "expected node body",
         optionalSpacesOrNewline,
         char("{"),
+        optionalSpacesOrNewline,
+        capture(or(docStringParser, succeed(undefined)), "docString"),
         optionalSpacesOrNewline,
         capture(bodyParser, "body"),
         optionalSpacesOrNewline,

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -599,17 +599,10 @@ export const booleanLiteralTypeParser: Parser<BooleanLiteralType> = trace(
   ),
 );
 
-export const objectPropertyDelimiter = or(
-  seqR(
-    optionalSpaces,
-    oneOf(",;"),
-    optionalSpacesOrNewline,
-  ),
-  seqR(
-    optionalSpaces,
-    char("\n"),
-    optionalSpacesOrNewline,
-  ),
+export const objectPropertyDelimiter = seqR(
+  optionalSpaces,
+  oneOf(",;\n"),
+  optionalSpacesOrNewline,
 );
 
 export const objectPropertyParser: Parser<ObjectProperty> = trace(

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -599,10 +599,17 @@ export const booleanLiteralTypeParser: Parser<BooleanLiteralType> = trace(
   ),
 );
 
-export const objectPropertyDelimiter = seqR(
-  optionalSpaces,
-  oneOf(",;"),
-  optionalSpacesOrNewline,
+export const objectPropertyDelimiter = or(
+  seqR(
+    optionalSpaces,
+    oneOf(",;"),
+    optionalSpacesOrNewline,
+  ),
+  seqR(
+    optionalSpaces,
+    char("\n"),
+    optionalSpacesOrNewline,
+  ),
 );
 
 export const objectPropertyParser: Parser<ObjectProperty> = trace(

--- a/lib/parsers/typeHints.test.ts
+++ b/lib/parsers/typeHints.test.ts
@@ -1645,6 +1645,49 @@ describe("objectTypeParser", () => {
         },
       },
     },
+    // Newline-delimited properties (no semicolons)
+    {
+      input: "{\n  name: string\n  age: number\n}",
+      expected: {
+        success: true,
+        result: {
+          type: "objectType",
+          properties: [
+            {
+              key: "name",
+              value: { type: "primitiveType", value: "string" },
+            },
+            {
+              key: "age",
+              value: { type: "primitiveType", value: "number" },
+            },
+          ],
+        },
+      },
+    },
+    {
+      input: "{\n  name: string\n  age: number\n  active: boolean\n}",
+      expected: {
+        success: true,
+        result: {
+          type: "objectType",
+          properties: [
+            {
+              key: "name",
+              value: { type: "primitiveType", value: "string" },
+            },
+            {
+              key: "age",
+              value: { type: "primitiveType", value: "number" },
+            },
+            {
+              key: "active",
+              value: { type: "primitiveType", value: "boolean" },
+            },
+          ],
+        },
+      },
+    },
     // Failure cases
     {
       input: "{ x number }",

--- a/lib/preprocessors/typescriptPreprocessor.core.test.ts
+++ b/lib/preprocessors/typescriptPreprocessor.core.test.ts
@@ -1218,4 +1218,224 @@ describe("TypescriptPreprocessor Core Functionality", () => {
       expect(combined).toContain("tool1");
     });
   });
+
+  describe("attachDocComments", () => {
+    it("should attach a file-level doc comment to program.docComment", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          { type: "multiLineComment", content: " File docs ", isDoc: true },
+          {
+            type: "importStatement",
+            modulePath: "./foo.js",
+            importedNames: [],
+          } as any,
+          {
+            type: "function",
+            functionName: "foo",
+            parameters: [],
+            body: [],
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+      expect(program.docComment).toBeDefined();
+      expect(program.docComment!.content).toBe(" File docs ");
+      // Should be removed from nodes
+      expect(program.nodes.every((n) => n.type !== "multiLineComment")).toBe(true);
+    });
+
+    it("should skip regular comments before file-level doc comment", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          { type: "comment", content: " regular comment" },
+          { type: "multiLineComment", content: " File docs ", isDoc: true },
+          {
+            type: "importStatement",
+            modulePath: "./foo.js",
+            importedNames: [],
+          } as any,
+          {
+            type: "function",
+            functionName: "foo",
+            parameters: [],
+            body: [],
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+      expect(program.docComment).toBeDefined();
+      expect(program.docComment!.content).toBe(" File docs ");
+    });
+
+    it("should attach doc comment to a function when directly before it", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          { type: "multiLineComment", content: " Func docs ", isDoc: true },
+          {
+            type: "function",
+            functionName: "foo",
+            parameters: [],
+            body: [],
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+      // Doc comment directly before a declaration attaches to the declaration, not file-level
+      expect(program.docComment).toBeUndefined();
+      const fn = program.nodes.find((n) => n.type === "function") as any;
+      expect(fn.docComment).toBeDefined();
+      expect(fn.docComment.content).toBe(" Func docs ");
+    });
+
+    it("should attach doc comment to a function after an import", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "importStatement",
+            modulePath: "./foo.js",
+            importedNames: [],
+          } as any,
+          { type: "multiLineComment", content: " Func docs ", isDoc: true },
+          {
+            type: "function",
+            functionName: "foo",
+            parameters: [],
+            body: [],
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+      expect(program.docComment).toBeUndefined();
+      const fn = program.nodes.find((n) => n.type === "function") as any;
+      expect(fn.docComment).toBeDefined();
+      expect(fn.docComment.content).toBe(" Func docs ");
+    });
+
+    it("should attach doc comment to a node", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "importStatement",
+            modulePath: "./foo.js",
+            importedNames: [],
+          } as any,
+          { type: "multiLineComment", content: " Node docs ", isDoc: true },
+          {
+            type: "graphNode",
+            nodeName: "main",
+            parameters: [],
+            body: [],
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+      const node = program.nodes.find((n) => n.type === "graphNode") as any;
+      expect(node.docComment).toBeDefined();
+      expect(node.docComment.content).toBe(" Node docs ");
+    });
+
+    it("should attach doc comment to a type alias", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "importStatement",
+            modulePath: "./foo.js",
+            importedNames: [],
+          } as any,
+          { type: "multiLineComment", content: " Type docs ", isDoc: true },
+          {
+            type: "typeAlias",
+            aliasName: "Foo",
+            aliasedType: { type: "primitiveType", value: "string" },
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+      const alias = program.nodes.find((n) => n.type === "typeAlias") as any;
+      expect(alias.docComment).toBeDefined();
+      expect(alias.docComment.content).toBe(" Type docs ");
+    });
+
+    it("should not attach non-doc multi-line comments", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          { type: "multiLineComment", content: " regular ", isDoc: false },
+          {
+            type: "function",
+            functionName: "foo",
+            parameters: [],
+            body: [],
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+      expect(program.docComment).toBeUndefined();
+      const fn = program.nodes.find((n) => n.type === "function") as any;
+      expect(fn.docComment).toBeUndefined();
+    });
+
+    it("should leave unattached doc comments in statement list", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "importStatement",
+            modulePath: "./foo.js",
+            importedNames: [],
+          } as any,
+          { type: "multiLineComment", content: " orphan doc ", isDoc: true },
+          {
+            type: "importStatement",
+            modulePath: "./bar.js",
+            importedNames: [],
+          } as any,
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+      expect(program.docComment).toBeUndefined();
+      const comments = program.nodes.filter((n) => n.type === "multiLineComment");
+      expect(comments.length).toBe(1);
+    });
+
+    it("should attach doc comments with newlines between comment and declaration", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "importStatement",
+            modulePath: "./foo.js",
+            importedNames: [],
+          } as any,
+          { type: "multiLineComment", content: " Func docs ", isDoc: true },
+          { type: "newLine" },
+          {
+            type: "function",
+            functionName: "foo",
+            parameters: [],
+            body: [],
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+      const fn = program.nodes.find((n) => n.type === "function") as any;
+      expect(fn.docComment).toBeDefined();
+      expect(fn.docComment.content).toBe(" Func docs ");
+    });
+  });
 });

--- a/lib/preprocessors/typescriptPreprocessor.ts
+++ b/lib/preprocessors/typescriptPreprocessor.ts
@@ -169,7 +169,62 @@ export class TypescriptPreprocessor {
     }
   }
 
+  protected attachDocComments(): void {
+    const nodes = this.program.nodes;
+    const DECLARATION_TYPES = ["function", "graphNode", "typeAlias"];
+
+    // Helper: check if an import is a stdlib import (auto-injected by template)
+    const isStdlibImport = (node: AgencyNode): boolean =>
+      node.type === "importStatement" &&
+      (node as any).modulePath?.startsWith("std::");
+
+    // 1. Declaration-level doc comments: attach to the next function/node/typeAlias
+    const toRemove: number[] = [];
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      if (node.type !== "multiLineComment" || !node.isDoc) continue;
+
+      // Find next non-newline node
+      let nextIndex = i + 1;
+      while (nextIndex < nodes.length && nodes[nextIndex].type === "newLine") {
+        nextIndex++;
+      }
+
+      if (nextIndex < nodes.length && DECLARATION_TYPES.includes(nodes[nextIndex].type)) {
+        const decl = nodes[nextIndex] as
+          | import("@/types.js").FunctionDefinition
+          | import("@/types.js").GraphNodeDefinition
+          | import("@/types/typeHints.js").TypeAlias;
+        decl.docComment = node as import("@/types.js").AgencyMultiLineComment;
+        toRemove.push(i);
+      }
+    }
+
+    // Remove attached doc comments from statement list (in reverse to preserve indices)
+    for (let i = toRemove.length - 1; i >= 0; i--) {
+      nodes.splice(toRemove[i], 1);
+    }
+
+    // 2. File-level doc comment: first unmatched doc comment before any user import/declaration
+    for (let i = 0; i < nodes.length; i++) {
+      const node = nodes[i];
+      // Skip comments, newlines, and stdlib imports
+      if (node.type === "comment" || node.type === "newLine") continue;
+      if (node.type === "multiLineComment" && !node.isDoc) continue;
+      if (isStdlibImport(node)) continue;
+
+      // If we hit an unmatched doc comment, it's the file-level doc comment
+      if (node.type === "multiLineComment" && node.isDoc) {
+        this.program.docComment = node as import("@/types.js").AgencyMultiLineComment;
+        nodes.splice(i, 1);
+      }
+      // Stop at the first non-skippable node regardless
+      break;
+    }
+  }
+
   preprocess(): AgencyProgram {
+    this.attachDocComments();
     this.program.nodes = collectTags(this.program.nodes);
     if (Object.keys(this.functionDefinitions).length === 0) {
       this.getFunctionDefinitions();

--- a/lib/preprocessors/typescriptPreprocessor.ts
+++ b/lib/preprocessors/typescriptPreprocessor.ts
@@ -1,18 +1,22 @@
 import { AgencyConfig, BUILTIN_FUNCTIONS } from "@/config.js";
 import type { ProgramInfo } from "@/programInfo.js";
 import {
+  AgencyMultiLineComment,
   AgencyNode,
   AgencyProgram,
   Assignment,
   FunctionCall,
   FunctionDefinition,
+  GraphNodeDefinition,
   getImportedNames,
   IfElse,
+  ImportStatement,
   RawCode,
   Scope,
   ScopeType,
   Sentinel,
   Tag,
+  TypeAlias,
   WhileLoop,
   isClassKeyword,
 } from "@/types.js";
@@ -169,14 +173,13 @@ export class TypescriptPreprocessor {
     }
   }
 
-  protected attachDocComments(): void {
+  attachDocComments(): void {
     const nodes = this.program.nodes;
     const DECLARATION_TYPES = ["function", "graphNode", "typeAlias"];
 
-    // Helper: check if an import is a stdlib import (auto-injected by template)
     const isStdlibImport = (node: AgencyNode): boolean =>
       node.type === "importStatement" &&
-      (node as any).modulePath?.startsWith("std::");
+      (node as ImportStatement).modulePath.startsWith("std::");
 
     // 1. Declaration-level doc comments: attach to the next function/node/typeAlias
     const toRemove: number[] = [];
@@ -184,23 +187,18 @@ export class TypescriptPreprocessor {
       const node = nodes[i];
       if (node.type !== "multiLineComment" || !node.isDoc) continue;
 
-      // Find next non-newline node
       let nextIndex = i + 1;
       while (nextIndex < nodes.length && nodes[nextIndex].type === "newLine") {
         nextIndex++;
       }
 
       if (nextIndex < nodes.length && DECLARATION_TYPES.includes(nodes[nextIndex].type)) {
-        const decl = nodes[nextIndex] as
-          | import("@/types.js").FunctionDefinition
-          | import("@/types.js").GraphNodeDefinition
-          | import("@/types/typeHints.js").TypeAlias;
-        decl.docComment = node as import("@/types.js").AgencyMultiLineComment;
+        const decl = nodes[nextIndex] as FunctionDefinition | GraphNodeDefinition | TypeAlias;
+        decl.docComment = node as AgencyMultiLineComment;
         toRemove.push(i);
       }
     }
 
-    // Remove attached doc comments from statement list (in reverse to preserve indices)
     for (let i = toRemove.length - 1; i >= 0; i--) {
       nodes.splice(toRemove[i], 1);
     }
@@ -208,14 +206,12 @@ export class TypescriptPreprocessor {
     // 2. File-level doc comment: first unmatched doc comment before any user import/declaration
     for (let i = 0; i < nodes.length; i++) {
       const node = nodes[i];
-      // Skip comments, newlines, and stdlib imports
       if (node.type === "comment" || node.type === "newLine") continue;
       if (node.type === "multiLineComment" && !node.isDoc) continue;
       if (isStdlibImport(node)) continue;
 
-      // If we hit an unmatched doc comment, it's the file-level doc comment
       if (node.type === "multiLineComment" && node.isDoc) {
-        this.program.docComment = node as import("@/types.js").AgencyMultiLineComment;
+        this.program.docComment = node as AgencyMultiLineComment;
         nodes.splice(i, 1);
       }
       // Stop at the first non-skippable node regardless

--- a/lib/preprocessors/typescriptPreprocessor.ts
+++ b/lib/preprocessors/typescriptPreprocessor.ts
@@ -188,7 +188,10 @@ export class TypescriptPreprocessor {
       if (node.type !== "multiLineComment" || !node.isDoc) continue;
 
       let nextIndex = i + 1;
-      while (nextIndex < nodes.length && nodes[nextIndex].type === "newLine") {
+      while (
+        nextIndex < nodes.length &&
+        (nodes[nextIndex].type === "newLine" || nodes[nextIndex].type === "tag")
+      ) {
         nextIndex++;
       }
 

--- a/lib/preprocessors/typescriptPreprocessor.ts
+++ b/lib/preprocessors/typescriptPreprocessor.ts
@@ -176,48 +176,59 @@ export class TypescriptPreprocessor {
   attachDocComments(): void {
     const nodes = this.program.nodes;
     const DECLARATION_TYPES = ["function", "graphNode", "typeAlias"];
+    const SKIP_TYPES = ["newLine", "tag"];
 
     const isStdlibImport = (node: AgencyNode): boolean =>
       node.type === "importStatement" &&
       (node as ImportStatement).modulePath.startsWith("std::");
 
-    // 1. Declaration-level doc comments: attach to the next function/node/typeAlias
-    const toRemove: number[] = [];
-    for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i];
-      if (node.type !== "multiLineComment" || !node.isDoc) continue;
+    // Build a new node list, attaching doc comments to declarations and dropping them from the list
+    const result: AgencyNode[] = [];
+    let pendingDocComment: AgencyMultiLineComment | null = null;
 
-      let nextIndex = i + 1;
-      while (
-        nextIndex < nodes.length &&
-        (nodes[nextIndex].type === "newLine" || nodes[nextIndex].type === "tag")
-      ) {
-        nextIndex++;
+    for (const node of nodes) {
+      if (node.type === "multiLineComment" && node.isDoc) {
+        pendingDocComment = node as AgencyMultiLineComment;
+        continue;
       }
 
-      if (nextIndex < nodes.length && DECLARATION_TYPES.includes(nodes[nextIndex].type)) {
-        const decl = nodes[nextIndex] as FunctionDefinition | GraphNodeDefinition | TypeAlias;
-        decl.docComment = node as AgencyMultiLineComment;
-        toRemove.push(i);
+      // Skip nodes that shouldn't break doc comment attachment
+      if (pendingDocComment && SKIP_TYPES.includes(node.type)) {
+        result.push(node);
+        continue;
       }
+
+      if (pendingDocComment && DECLARATION_TYPES.includes(node.type)) {
+        const decl = node as FunctionDefinition | GraphNodeDefinition | TypeAlias;
+        decl.docComment = pendingDocComment;
+        pendingDocComment = null;
+      } else if (pendingDocComment) {
+        // Doc comment wasn't followed by a declaration — keep it as a regular comment
+        result.push(pendingDocComment);
+        pendingDocComment = null;
+      }
+
+      result.push(node);
     }
 
-    for (let i = toRemove.length - 1; i >= 0; i--) {
-      nodes.splice(toRemove[i], 1);
+    // Handle trailing doc comment
+    if (pendingDocComment) {
+      result.push(pendingDocComment);
     }
 
-    // 2. File-level doc comment: first unmatched doc comment before any user import/declaration
-    for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i];
+    this.program.nodes = result;
+
+    // File-level doc comment: first unmatched doc comment before any user import/declaration
+    for (let i = 0; i < this.program.nodes.length; i++) {
+      const node = this.program.nodes[i];
       if (node.type === "comment" || node.type === "newLine") continue;
       if (node.type === "multiLineComment" && !node.isDoc) continue;
       if (isStdlibImport(node)) continue;
 
       if (node.type === "multiLineComment" && node.isDoc) {
         this.program.docComment = node as AgencyMultiLineComment;
-        nodes.splice(i, 1);
+        this.program.nodes.splice(i, 1);
       }
-      // Stop at the first non-skippable node regardless
       break;
     }
   }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -197,6 +197,7 @@ export type AgencyComment = BaseNode & {
 export type AgencyMultiLineComment = BaseNode & {
   type: "multiLineComment";
   content: string;
+  isDoc: boolean;
 };
 
 export type NewLine = BaseNode & {
@@ -247,6 +248,7 @@ export type AgencyNode =
 export type AgencyProgram = {
   type: "agencyProgram";
   nodes: AgencyNode[];
+  docComment?: AgencyMultiLineComment;
 };
 
 export type JSONEdge =

--- a/lib/types/function.ts
+++ b/lib/types/function.ts
@@ -1,4 +1,5 @@
 import {
+  AgencyMultiLineComment,
   AgencyNode,
   Expression,
   Literal,
@@ -42,6 +43,7 @@ export type FunctionDefinition = BaseNode & {
   body: AgencyNode[];
   returnType?: VariableType | null;
   docString?: DocString;
+  docComment?: AgencyMultiLineComment;
   async?: boolean;
   safe?: boolean;
   exported?: boolean;

--- a/lib/types/graphNode.ts
+++ b/lib/types/graphNode.ts
@@ -1,7 +1,7 @@
-import { AgencyNode, FunctionCall, VariableType } from "../types.js";
+import { AgencyMultiLineComment, AgencyNode, FunctionCall, VariableType } from "../types.js";
 import { ValueAccess } from "./access.js";
 import { BaseNode } from "./base.js";
-import { FunctionParameter } from "./function.js";
+import { DocString, FunctionParameter } from "./function.js";
 import { Literal } from "./literals.js";
 import { Tag } from "./tag.js";
 
@@ -26,6 +26,8 @@ export type GraphNodeDefinition = BaseNode & {
   returnType?: VariableType | null;
   visibility?: Visibility;
   tags?: Tag[];
+  docComment?: AgencyMultiLineComment;
+  docString?: DocString;
 };
 
 export type NodeCall = {

--- a/lib/types/typeHints.ts
+++ b/lib/types/typeHints.ts
@@ -1,3 +1,4 @@
+import { AgencyMultiLineComment } from "../types.js";
 import { BaseNode } from "./base.js";
 
 export type VariableType =
@@ -70,6 +71,7 @@ export type TypeAlias = BaseNode & {
   aliasName: string;
   aliasedType: VariableType;
   exported?: boolean;
+  docComment?: AgencyMultiLineComment;
 };
 
 export type TypeAliasVariable = {

--- a/scripts/agency.ts
+++ b/scripts/agency.ts
@@ -418,11 +418,7 @@ program
   .option("-o, --output <dir>", "Output directory for generated docs")
   .action((input: string, opts: { output?: string }) => {
     const config = getConfig();
-    const outputDir = opts.output || config.doc?.outDir;
-    if (!outputDir) {
-      console.error("Error: No output directory specified. Use -o or set doc.outDir in agency.json.");
-      process.exit(1);
-    }
+    const outputDir = opts.output || config.doc?.outDir || "docs";
     generateDoc(config, input, outputDir);
   });
 

--- a/scripts/agency.ts
+++ b/scripts/agency.ts
@@ -415,10 +415,15 @@ program
   .command("doc")
   .description("Generate Markdown documentation for .agency file(s)")
   .argument("<input>", "Path to .agency file or directory")
-  .requiredOption("-o, --output <dir>", "Output directory for generated docs")
-  .action((input: string, opts: { output: string }) => {
+  .option("-o, --output <dir>", "Output directory for generated docs")
+  .action((input: string, opts: { output?: string }) => {
     const config = getConfig();
-    generateDoc(config, input, opts.output);
+    const outputDir = opts.output || config.doc?.outDir;
+    if (!outputDir) {
+      console.error("Error: No output directory specified. Use -o or set doc.outDir in agency.json.");
+      process.exit(1);
+    }
+    generateDoc(config, input, outputDir);
   });
 
 program


### PR DESCRIPTION
## Summary

- Adds `/** ... */` doc comment syntax — documentation-only metadata that appears in generated docs but not in generated TypeScript or LLM calls
- Doc comments can be attached to functions, nodes, type aliases, or the file itself (file-level, before any imports)
- Adds docstring (`"""..."""`) support to nodes, which previously lacked it
- In generated docs: docstring renders first, doc comment second

## Changes

- **AST**: `isDoc` flag on `AgencyMultiLineComment`; `docComment` field on `FunctionDefinition`, `GraphNodeDefinition`, `TypeAlias`, `AgencyProgram`; `docString` field on `GraphNodeDefinition`
- **Parser**: Detects `/**` and sets `isDoc: true`; node body parser supports docstrings
- **Preprocessor**: New `attachDocComments()` pass — matches doc comments to declarations first, then detects unmatched file-level doc comments
- **Agency generator**: Preserves `/**` syntax; emits attached doc comments before declarations
- **Doc generator**: Renders file-level doc comment after title; docstring first, doc comment second for all declaration types

## Test plan

- [x] Parser tests: `isDoc` detection for `/**` vs `/*` (12 tests)
- [x] Preprocessor tests: attachment logic for functions, nodes, type aliases, file-level (9 tests)
- [x] Doc generator tests: file-level, function, node, type alias rendering (4 tests)
- [x] Agency generator tests: round-trip preservation of `/**` syntax, node docstrings (4 tests)
- [x] Full suite passes: 1953 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)