### PR TITLE
feat: runtime type validation with ! syntax and TypeName.schema

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 *.agency linguist-language=typescript
+tests/typescriptGenerator/*.mjs -diff
+tests/typescriptGenerator/*.mjs linguist-generated=true
+tests/typescriptBuilder/*.mjs -diff
+tests/typescriptBuilder/*.mjs linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.agency linguist-language=typescript

--- a/lib/backends/typescriptBuilder.integration.test.ts
+++ b/lib/backends/typescriptBuilder.integration.test.ts
@@ -268,3 +268,36 @@ ${safeKeyword}def ${funcName}(id: string, shouldSave: boolean, items: string[]):
     }
   });
 });
+
+describe("TypeName.schema access", () => {
+  it("should throw on .schema for unrecognized type name", () => {
+    expect(() =>
+      generateWithBuilder(`
+node main() {
+  const schema = UnknownType.schema
+}
+`),
+    ).toThrow("UnknownType");
+  });
+
+  it("should compile .schema for named type aliases", () => {
+    expect(() =>
+      generateWithBuilder(`
+type Category = "bug" | "feature"
+node main() {
+  const schema = Category.schema
+}
+`),
+    ).not.toThrow();
+  });
+
+  it("should compile .schema for builtin types", () => {
+    expect(() =>
+      generateWithBuilder(`
+node main() {
+  const schema = number.schema
+}
+`),
+    ).not.toThrow();
+  });
+});

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -2236,6 +2236,24 @@ export class TypeScriptBuilder {
   }
 
   private processAssignment(node: Assignment): TsNode {
+    const result = this._processAssignmentInner(node);
+    // If the type annotation has !, wrap the assigned value in __validateType
+    if (node.validated && node.typeHint) {
+      const zodSchema = mapTypeToZodSchema(
+        node.typeHint,
+        this.getVisibleTypeAliases(),
+      );
+      const varRef = ts.scopedVar(node.variableName, node.scope!, this.moduleId);
+      const validateStmt = ts.assign(varRef, ts.validateType(varRef, ts.raw(zodSchema)));
+      if (result.kind === "statements") {
+        return ts.statementsPush(result, validateStmt);
+      }
+      return ts.statements([result, validateStmt]);
+    }
+    return result;
+  }
+
+  private _processAssignmentInner(node: Assignment): TsNode {
     const { variableName, typeHint, value } = node;
 
     // `this.field = value` and `super.field = value` — emit as direct property assignment

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -401,6 +401,25 @@ export class TypeScriptBuilder {
     }
   }
 
+  private getScopeReturnTypeValidated(): boolean {
+    const currentScope = this.getCurrentScope();
+    switch (currentScope.type) {
+      case "function": {
+        const funcDef =
+          this.programInfo.functionDefinitions[currentScope.functionName];
+        return !!funcDef?.returnTypeValidated;
+      }
+      case "node": {
+        const graphNode = this.programInfo.graphNodes.find(
+          (n) => n.nodeName === currentScope.nodeName,
+        );
+        return !!graphNode?.returnTypeValidated;
+      }
+      default:
+        return false;
+    }
+  }
+
   private agencyFileToDefaultImportName(agencyFile: string): string {
     return `__graph_${agencyFile.replace(".agency", "").replace(/[^a-zA-Z0-9_]/g, "_")}`;
   }
@@ -2170,6 +2189,15 @@ export class TypeScriptBuilder {
       .done();
   }
 
+  /** If the enclosing function/node has returnTypeValidated, wrap value in __validateType */
+  private maybeWrapReturnValidation(valueNode: TsNode): TsNode {
+    if (!this.getScopeReturnTypeValidated()) return valueNode;
+    const returnType = this.getScopeReturnType();
+    if (!returnType) return valueNode;
+    const zodSchema = mapTypeToZodSchema(returnType, this.getVisibleTypeAliases());
+    return ts.validateType(valueNode, ts.raw(zodSchema));
+  }
+
   private processReturnStatement(node: ReturnStatement): TsNode {
     // Bare return (no value)
     if (!node.value) {
@@ -2215,7 +2243,7 @@ export class TypeScriptBuilder {
         );
         return ts.statements([
           llmNode,
-          ts.nodeResult(ts.self(DEFAULT_PROMPT_NAME)),
+          ts.nodeResult(this.maybeWrapReturnValidation(ts.self(DEFAULT_PROMPT_NAME))),
         ]);
       }
       const valueNode = this.processNode(node.value);
@@ -2225,7 +2253,7 @@ export class TypeScriptBuilder {
       ) {
         return valueNode;
       }
-      return ts.nodeResult(valueNode);
+      return ts.nodeResult(this.maybeWrapReturnValidation(valueNode));
     }
 
     if (
@@ -2245,11 +2273,11 @@ export class TypeScriptBuilder {
       );
       return ts.statements([
         llmNode,
-        ts.functionReturn(ts.self(DEFAULT_PROMPT_NAME)),
+        ts.functionReturn(this.maybeWrapReturnValidation(ts.self(DEFAULT_PROMPT_NAME))),
       ]);
     }
     const valueNode = this.processNode(node.value);
-    return ts.functionReturn(valueNode);
+    return ts.functionReturn(this.maybeWrapReturnValidation(valueNode));
   }
 
   private processAssignment(node: Assignment): TsNode {

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -3013,6 +3013,17 @@ export class TypeScriptBuilder {
       }),
     );
 
+    // If the assignment has ! (validated), wrap the final result in __validateType
+    if (stmt.validated && stmt.typeHint) {
+      const zodSchema = mapTypeToZodSchema(stmt.typeHint, this.getVisibleTypeAliases());
+      nodes.push(
+        ts.runnerStep({
+          id: baseId + stages.length,
+          body: [ts.assign(targetVar, ts.validateType(targetVar, ts.raw(zodSchema)))],
+        }),
+      );
+    }
+
     return nodes;
   }
 

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -421,6 +421,28 @@ export class TypeScriptBuilder {
     }
   }
 
+  private static readonly BUILTIN_SCHEMA_TYPES = [
+    "number", "string", "boolean", "null", "undefined", "any", "unknown", "object",
+  ];
+
+  /**
+   * Resolve a type name (alias or builtin) to its Zod schema string.
+   * Returns null if the name is not a known type alias or builtin.
+   */
+  private resolveZodSchemaForTypeName(typeName: string): string | null {
+    const typeAliases = this.getVisibleTypeAliases();
+    if (typeAliases[typeName]) {
+      return mapTypeToZodSchema(typeAliases[typeName], typeAliases);
+    }
+    if (TypeScriptBuilder.BUILTIN_SCHEMA_TYPES.includes(typeName)) {
+      return mapTypeToZodSchema(
+        { type: "primitiveType" as const, value: typeName },
+        typeAliases,
+      );
+    }
+    return null;
+  }
+
   private agencyFileToDefaultImportName(agencyFile: string): string {
     return `__graph_${agencyFile.replace(".agency", "").replace(/[^a-zA-Z0-9_]/g, "_")}`;
   }
@@ -951,23 +973,13 @@ export class TypeScriptBuilder {
       node.chain[0].name === "schema"
     ) {
       const baseName = (node.base as VariableNameLiteral).value;
-      const typeAliases = this.getVisibleTypeAliases();
-      const builtinTypes = ["number", "string", "boolean", "null", "undefined", "any", "unknown", "object"];
-
-      let zodSchema: string | null = null;
-
-      if (typeAliases[baseName]) {
-        zodSchema = mapTypeToZodSchema(typeAliases[baseName], typeAliases);
-      } else if (builtinTypes.includes(baseName)) {
-        zodSchema = mapTypeToZodSchema(
-          { type: "primitiveType" as const, value: baseName },
-          typeAliases,
-        );
-      }
-
+      const zodSchema = this.resolveZodSchemaForTypeName(baseName);
       if (zodSchema) {
         return ts.new(ts.id("Schema"), [ts.raw(zodSchema)]);
       }
+      throw new Error(
+        `Cannot access .schema on '${baseName}': not a known type alias or builtin type`,
+      );
     }
 
     let result = this.processNode(node.base);
@@ -1678,13 +1690,14 @@ export class TypeScriptBuilder {
         const zodSchema = mapTypeToZodSchema(param.typeHint, this.getVisibleTypeAliases());
         const stackArg = $(ts.stack("args")).index(ts.str(param.name)).done();
         const vrName = `__vr_${param.name}`;
+        const vrId = ts.id(vrName);
         validationGuards.push(
           ts.constDecl(vrName, ts.validateType(stackArg, ts.raw(zodSchema))),
           ts.if(
-            ts.raw(`!${vrName}.success`),
-            ts.return(ts.id(vrName)),
+            ts.not(ts.prop(vrId, "success")),
+            ts.return(vrId),
           ),
-          ts.assign(stackArg, ts.raw(`${vrName}.value`)),
+          ts.assign(stackArg, ts.prop(vrId, "value")),
         );
       }
     }

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -7,6 +7,7 @@ import {
   Expression,
   Keyword,
   Literal,
+  VariableNameLiteral,
   NamedArgument,
   PromptSegment,
   FunctionScope,
@@ -949,7 +950,7 @@ export class TypeScriptBuilder {
       node.chain[0].kind === "property" &&
       node.chain[0].name === "schema"
     ) {
-      const baseName = (node.base as any).value;
+      const baseName = (node.base as VariableNameLiteral).value;
       const typeAliases = this.getVisibleTypeAliases();
       const builtinTypes = ["number", "string", "boolean", "null", "object"];
 

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -1605,6 +1605,23 @@ export class TypeScriptBuilder {
       }
     }
 
+    // Validation guards for parameters with ! (bang) syntax
+    for (const param of parameters) {
+      if (param.validated && param.typeHint) {
+        const zodSchema = mapTypeToZodSchema(param.typeHint, this.getVisibleTypeAliases());
+        const stackArg = $(ts.stack("args")).index(ts.str(param.name)).done();
+        const vrName = `__vr_${param.name}`;
+        setupStmts.push(
+          ts.constDecl(vrName, ts.validateType(stackArg, ts.raw(zodSchema))),
+          ts.if(
+            ts.raw(`!${vrName}.success`),
+            ts.return(ts.id(vrName)),
+          ),
+          ts.assign(stackArg, ts.raw(`${vrName}.value`)),
+        );
+      }
+    }
+
     // __self.__retryable
     setupStmts.push(
       ts.assign(

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -952,7 +952,7 @@ export class TypeScriptBuilder {
     ) {
       const baseName = (node.base as VariableNameLiteral).value;
       const typeAliases = this.getVisibleTypeAliases();
-      const builtinTypes = ["number", "string", "boolean", "null", "object"];
+      const builtinTypes = ["number", "string", "boolean", "null", "undefined", "any", "unknown", "object"];
 
       let zodSchema: string | null = null;
 
@@ -1652,23 +1652,6 @@ export class TypeScriptBuilder {
       }
     }
 
-    // Validation guards for parameters with ! (bang) syntax
-    for (const param of parameters) {
-      if (param.validated && param.typeHint) {
-        const zodSchema = mapTypeToZodSchema(param.typeHint, this.getVisibleTypeAliases());
-        const stackArg = $(ts.stack("args")).index(ts.str(param.name)).done();
-        const vrName = `__vr_${param.name}`;
-        setupStmts.push(
-          ts.constDecl(vrName, ts.validateType(stackArg, ts.raw(zodSchema))),
-          ts.if(
-            ts.raw(`!${vrName}.success`),
-            ts.return(ts.id(vrName)),
-          ),
-          ts.assign(stackArg, ts.raw(`${vrName}.value`)),
-        );
-      }
-    }
-
     // __self.__retryable
     setupStmts.push(
       ts.assign(
@@ -1687,10 +1670,30 @@ export class TypeScriptBuilder {
     // Pinned checkpoint at entry (enables result.retry and error-to-failure wrapping)
     setupStmts.push(this.buildResultCheckpointSetup(functionName, parameters));
 
+    // Validation guards for parameters with ! (bang) syntax.
+    // Placed inside the try block so the finally cleanup (stateStack.pop) always runs.
+    const validationGuards: TsNode[] = [];
+    for (const param of parameters) {
+      if (param.validated && param.typeHint) {
+        const zodSchema = mapTypeToZodSchema(param.typeHint, this.getVisibleTypeAliases());
+        const stackArg = $(ts.stack("args")).index(ts.str(param.name)).done();
+        const vrName = `__vr_${param.name}`;
+        validationGuards.push(
+          ts.constDecl(vrName, ts.validateType(stackArg, ts.raw(zodSchema))),
+          ts.if(
+            ts.raw(`!${vrName}.success`),
+            ts.return(ts.id(vrName)),
+          ),
+          ts.assign(stackArg, ts.raw(`${vrName}.value`)),
+        );
+      }
+    }
+
     // Try/catch wrapping the body, with finally to always pop the state stack
     setupStmts.push(
       ts.tryCatch(
         ts.statements([
+          ...validationGuards,
           ...bodyCode,
           ts.raw(
             "if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }",

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -942,6 +942,33 @@ export class TypeScriptBuilder {
   }
 
   private processValueAccess(node: ValueAccess): TsNode {
+    // Check for TypeName.schema pattern
+    if (
+      node.base.type === "variableName" &&
+      node.chain.length === 1 &&
+      node.chain[0].kind === "property" &&
+      node.chain[0].name === "schema"
+    ) {
+      const baseName = (node.base as any).value;
+      const typeAliases = this.getVisibleTypeAliases();
+      const builtinTypes = ["number", "string", "boolean", "null", "object"];
+
+      let zodSchema: string | null = null;
+
+      if (typeAliases[baseName]) {
+        zodSchema = mapTypeToZodSchema(typeAliases[baseName], typeAliases);
+      } else if (builtinTypes.includes(baseName)) {
+        zodSchema = mapTypeToZodSchema(
+          { type: "primitiveType" as const, value: baseName },
+          typeAliases,
+        );
+      }
+
+      if (zodSchema) {
+        return ts.new(ts.id("Schema"), [ts.raw(zodSchema)]);
+      }
+    }
+
     let result = this.processNode(node.base);
     // If the base is a function call, await it before accessing properties/methods
     // on the result. Without this, chaining like getGreeting().trim() would call

--- a/lib/ir/builders.ts
+++ b/lib/ir/builders.ts
@@ -350,6 +350,10 @@ export const ts = {
     return { kind: "newExpr", callee, arguments: args };
   },
 
+  validateType(value: TsNode, zodSchema: TsNode): TsCall {
+    return ts.call(ts.id("__validateType"), [value, zodSchema]);
+  },
+
   scopedVar(
     name: string,
     scope: TsScopedVar["scope"],

--- a/lib/parsers/assignment.test.ts
+++ b/lib/parsers/assignment.test.ts
@@ -642,4 +642,30 @@ describe("sharedAssignmentParser", () => {
       expect(result.result.shared).toBeUndefined();
     }
   });
+
+  it("parses assignment with validated type annotation", () => {
+    const result = assignmentParser("const x: number! = foo");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.typeHint).toEqual({ type: "primitiveType", value: "number" });
+      expect(result.result.validated).toBe(true);
+    }
+  });
+
+  it("parses assignment with validated union type", () => {
+    const result = assignmentParser('const x: "happy"|"sad"! = foo');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.typeHint?.type).toBe("unionType");
+      expect(result.result.validated).toBe(true);
+    }
+  });
+
+  it("parses assignment without ! as not validated", () => {
+    const result = assignmentParser("const x: number = foo");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.validated).toBeUndefined();
+    }
+  });
 });

--- a/lib/parsers/function.test.ts
+++ b/lib/parsers/function.test.ts
@@ -3437,3 +3437,55 @@ describe("callback declarations", () => {
     }
   });
 });
+
+describe("bang (!) validated type annotations", () => {
+  it("parses function param with validated type", () => {
+    const result = functionParser("def process(data: number!) { }");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.parameters[0].typeHint).toEqual({ type: "primitiveType", value: "number" });
+      expect(result.result.parameters[0].validated).toBe(true);
+    }
+  });
+
+  it("parses function param without ! as not validated", () => {
+    const result = functionParser("def process(data: number) { }");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.parameters[0].validated).toBeUndefined();
+    }
+  });
+
+  it("parses function with validated return type", () => {
+    const result = functionParser("def process(x: string): number! { }");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.returnTypeValidated).toBe(true);
+      expect(result.result.returnType).toEqual({ type: "primitiveType", value: "number" });
+    }
+  });
+
+  it("parses function return type without ! as not validated", () => {
+    const result = functionParser("def process(x: string): number { }");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.returnTypeValidated).toBeUndefined();
+    }
+  });
+
+  it("parses node with validated return type", () => {
+    const result = graphNodeParser("node main(): number! { }");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.returnTypeValidated).toBe(true);
+    }
+  });
+
+  it("parses node return type without ! as not validated", () => {
+    const result = graphNodeParser("node main(): number { }");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.returnTypeValidated).toBeUndefined();
+    }
+  });
+});

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -156,7 +156,7 @@ export const varNameChar: Parser<string> = oneOf(
 However, because every agency code gets rendered in a template that imports some standard functions,
 the line numbers would be off if we didn't account for the template lines.
 */
-const AGENCY_TEMPLATE_OFFSET = 3;
+export const AGENCY_TEMPLATE_OFFSET = 3;
 
 /**
  * Wraps a parser to add a `loc` field from tarsec's withSpan.
@@ -1945,6 +1945,7 @@ const _assignmentParserInner: Parser<Assignment> = (input: string) => {
             char(":"),
             optionalSpaces,
             capture(variableTypeParser, "typeHint"),
+            capture(optional(map(str("!"), () => true)), "validated"),
           ),
         ),
       ),
@@ -1988,8 +1989,9 @@ const _assignmentParserInner: Parser<Assignment> = (input: string) => {
     );
   }
 
-  const { target: _target, value, ...rest } = parsed;
+  const { target: _target, validated: _validated, value, ...rest } = parsed;
   const out: Assignment = { ...rest, variableName, value, accessChain };
+  if (_validated) out.validated = true;
   return success(out, result.rest);
 };
 export const assignmentParser: Parser<Assignment> = label("an assignment", withLoc(_assignmentParserInner));
@@ -2329,6 +2331,7 @@ export const functionParameterParser: Parser<FunctionParameter> = trace(
             char(":"),
             optionalSpaces,
             capture(variableTypeParser, "typeHint"),
+            capture(optional(map(str("!"), () => true)), "validated"),
           ),
         ),
       ),
@@ -2344,10 +2347,11 @@ export const functionParameterParser: Parser<FunctionParameter> = trace(
       ),
     ),
     (result: any) => {
-      const { __optional, ...rest } = result;
+      const { __optional, validated: _validated, ...rest } = result;
       if (__optional && !rest.defaultValue) {
         rest.defaultValue = { type: "null" };
       }
+      if (_validated) rest.validated = true;
       return rest as FunctionParameter;
     },
   ),
@@ -2387,7 +2391,7 @@ export const functionReturnTypeParser: Parser<VariableType> = trace(
   ),
 );
 
-const _baseFunctionParser: Parser<FunctionDefinition> = trace(
+const _baseFunctionParser: Parser<any> = trace(
   "_baseFunctionParser",
   seqC(
     set("type", "function"),
@@ -2407,6 +2411,7 @@ const _baseFunctionParser: Parser<FunctionDefinition> = trace(
     char(")"),
     optionalSpaces,
     capture(optional(functionReturnTypeParser), "returnType"),
+    capture(optional(map(str("!"), () => true)), "returnTypeValidated"),
     captureCaptures(
       parseError(
         "Expected function body",
@@ -2446,8 +2451,9 @@ const _functionParserInner: Parser<FunctionDefinition> = (input: string) => {
   const baseResult = _baseFunctionParser(safeResult.rest);
   if (!baseResult.success) return baseResult;
 
-  const { keyword, ...rest } = baseResult.result as FunctionDefinition & { keyword?: string };
-  const result = { ...rest };
+  const { keyword, returnTypeValidated: _rtv, ...rest } = baseResult.result as any;
+  const result = { ...rest } as FunctionDefinition;
+  if (_rtv) result.returnTypeValidated = true;
   const isCallback = keyword === "callback";
   if (isExported) result.exported = true;
   if (isSafe) result.safe = true;
@@ -2515,38 +2521,46 @@ const visibilityParser: Parser<Visibility> = or(
 
 export const graphNodeParser: Parser<GraphNodeDefinition> = label("a node definition", withLoc(trace(
   "graphNodeParser",
-  seqC(
-    set("type", "graphNode"),
-    capture(visibilityParser, "visibility"),
-    optionalSpaces,
-    str("node"),
-    many1(space),
-    capture(many1Till(char("(")), "nodeName"),
-    char("("),
-    optionalSpaces,
-    capture(
-      sepBy(
-        comma,
-        functionParameterParser,
+  map(
+    seqC(
+      set("type", "graphNode"),
+      capture(visibilityParser, "visibility"),
+      optionalSpaces,
+      str("node"),
+      many1(space),
+      capture(many1Till(char("(")), "nodeName"),
+      char("("),
+      optionalSpaces,
+      capture(
+        sepBy(
+          comma,
+          functionParameterParser,
+        ),
+        "parameters",
       ),
-      "parameters",
-    ),
-    optionalSpaces,
-    char(")"),
-    optionalSpaces,
-    capture(optional(functionReturnTypeParser), "returnType"),
-    captureCaptures(
-      parseError(
-        "expected node body",
-        optionalSpacesOrNewline,
-        char("{"),
-        optionalSpacesOrNewline,
-        capture(bodyParser, "body"),
-        optionalSpacesOrNewline,
-        char("}"),
-        optionalSemicolon,
+      optionalSpaces,
+      char(")"),
+      optionalSpaces,
+      capture(optional(functionReturnTypeParser), "returnType"),
+      capture(optional(map(str("!"), () => true)), "returnTypeValidated"),
+      captureCaptures(
+        parseError(
+          "expected node body",
+          optionalSpacesOrNewline,
+          char("{"),
+          optionalSpacesOrNewline,
+          capture(bodyParser, "body"),
+          optionalSpacesOrNewline,
+          char("}"),
+          optionalSemicolon,
+        ),
       ),
     ),
+    (result: any) => {
+      const { returnTypeValidated: _rtv, ...rest } = result;
+      if (_rtv) rest.returnTypeValidated = true;
+      return rest;
+    },
   ),
 )));
 

--- a/lib/runtime/index.ts
+++ b/lib/runtime/index.ts
@@ -89,3 +89,4 @@ export { DebuggerState } from "../debugger/debuggerState.js";
 
 export { success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult } from "./result.js";
 export type { ResultValue, ResultSuccess, ResultFailure } from "./result.js";
+export { Schema, __validateType } from "./schema.js";

--- a/lib/runtime/schema.test.ts
+++ b/lib/runtime/schema.test.ts
@@ -7,7 +7,7 @@ describe("Schema", () => {
     const schema = new Schema(z.object({ name: z.string(), age: z.number() }));
     const result = schema.parse({ name: "Alice", age: 30 });
     expect(result.success).toBe(true);
-    expect(result.value).toEqual({ name: "Alice", age: 30 });
+    expect(result.success && result.value).toEqual({ name: "Alice", age: 30 });
   });
 
   it("parse returns failure for invalid data", () => {
@@ -20,7 +20,7 @@ describe("Schema", () => {
     const schema = new Schema(z.object({ x: z.number() }));
     const result = schema.parseJSON('{"x": 42}');
     expect(result.success).toBe(true);
-    expect(result.value).toEqual({ x: 42 });
+    expect(result.success && result.value).toEqual({ x: 42 });
   });
 
   it("parseJSON returns failure for invalid JSON", () => {
@@ -55,7 +55,7 @@ describe("__validateType", () => {
   it("returns success when value matches schema", () => {
     const result = __validateType(42, z.number());
     expect(result.success).toBe(true);
-    expect(result.value).toBe(42);
+    expect(result.success && result.value).toBe(42);
   });
 
   it("returns failure when value doesn't match", () => {
@@ -66,6 +66,6 @@ describe("__validateType", () => {
   it("works with complex schemas", () => {
     const result = __validateType({ name: "Alice" }, z.object({ name: z.string() }));
     expect(result.success).toBe(true);
-    expect(result.value).toEqual({ name: "Alice" });
+    expect(result.success && result.value).toEqual({ name: "Alice" });
   });
 });

--- a/lib/runtime/schema.test.ts
+++ b/lib/runtime/schema.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { Schema, __validateType } from "./schema.js";
+import { z } from "zod";
+
+describe("Schema", () => {
+  it("parse returns success for valid data", () => {
+    const schema = new Schema(z.object({ name: z.string(), age: z.number() }));
+    const result = schema.parse({ name: "Alice", age: 30 });
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual({ name: "Alice", age: 30 });
+  });
+
+  it("parse returns failure for invalid data", () => {
+    const schema = new Schema(z.number());
+    const result = schema.parse("not a number");
+    expect(result.success).toBe(false);
+  });
+
+  it("parseJSON parses valid JSON and validates", () => {
+    const schema = new Schema(z.object({ x: z.number() }));
+    const result = schema.parseJSON('{"x": 42}');
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual({ x: 42 });
+  });
+
+  it("parseJSON returns failure for invalid JSON", () => {
+    const schema = new Schema(z.number());
+    const result = schema.parseJSON("not json");
+    expect(result.success).toBe(false);
+  });
+
+  it("parseJSON returns failure for valid JSON with wrong shape", () => {
+    const schema = new Schema(z.object({ x: z.number() }));
+    const result = schema.parseJSON('{"x": "hello"}');
+    expect(result.success).toBe(false);
+  });
+
+  it("validates primitive types", () => {
+    expect(new Schema(z.number()).parse(42).success).toBe(true);
+    expect(new Schema(z.number()).parse("hi").success).toBe(false);
+    expect(new Schema(z.string()).parse("hi").success).toBe(true);
+    expect(new Schema(z.string()).parse(42).success).toBe(false);
+    expect(new Schema(z.boolean()).parse(true).success).toBe(true);
+    expect(new Schema(z.boolean()).parse("true").success).toBe(false);
+  });
+
+  it("validates union types", () => {
+    const schema = new Schema(z.union([z.literal("happy"), z.literal("sad")]));
+    expect(schema.parse("happy").success).toBe(true);
+    expect(schema.parse("angry").success).toBe(false);
+  });
+});
+
+describe("__validateType", () => {
+  it("returns success when value matches schema", () => {
+    const result = __validateType(42, z.number());
+    expect(result.success).toBe(true);
+    expect(result.value).toBe(42);
+  });
+
+  it("returns failure when value doesn't match", () => {
+    const result = __validateType("nope", z.number());
+    expect(result.success).toBe(false);
+  });
+
+  it("works with complex schemas", () => {
+    const result = __validateType({ name: "Alice" }, z.object({ name: z.string() }));
+    expect(result.success).toBe(true);
+    expect(result.value).toEqual({ name: "Alice" });
+  });
+});

--- a/lib/runtime/schema.ts
+++ b/lib/runtime/schema.ts
@@ -10,11 +10,7 @@ export class Schema {
   }
 
   parse(data: unknown): ResultValue {
-    const result = this.zodSchema.safeParse(data);
-    if (result.success) {
-      return success(result.data);
-    }
-    return failure(result.error.message);
+    return __validateType(data, this.zodSchema);
   }
 
   parseJSON(jsonString: string): ResultValue {

--- a/lib/runtime/schema.ts
+++ b/lib/runtime/schema.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import { success, failure } from "./result.js";
+import type { ResultValue } from "./result.js";
+
+export class Schema {
+  private zodSchema: z.ZodType;
+
+  constructor(zodSchema: z.ZodType) {
+    this.zodSchema = zodSchema;
+  }
+
+  parse(data: unknown): ResultValue {
+    const result = this.zodSchema.safeParse(data);
+    if (result.success) {
+      return success(result.data);
+    }
+    return failure(result.error.message);
+  }
+
+  parseJSON(jsonString: string): ResultValue {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonString);
+    } catch (e) {
+      return failure(`Invalid JSON: ${e instanceof Error ? e.message : String(e)}`);
+    }
+    return this.parse(parsed);
+  }
+}
+
+export function __validateType(value: unknown, schema: z.ZodType): ResultValue {
+  const result = schema.safeParse(value);
+  if (result.success) {
+    return success(result.data);
+  }
+  return failure(result.error.message);
+}

--- a/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/lib/templates/backends/typescriptGenerator/imports.ts
@@ -28,6 +28,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -170,6 +170,7 @@ export type Assignment = BaseNode & {
   variableName: string;
   accessChain?: AccessChainElement[];
   typeHint?: VariableType;
+  validated?: boolean;
   scope?: ScopeType;
   shared?: boolean;
   declKind?: "let" | "const";

--- a/lib/types/function.ts
+++ b/lib/types/function.ts
@@ -14,6 +14,7 @@ export type FunctionParameter = {
   type: "functionParameter";
   name: string;
   typeHint?: VariableType;
+  validated?: boolean;
   variadic?: boolean;
   defaultValue?: Literal | AgencyArray | AgencyObject;
 };
@@ -41,6 +42,7 @@ export type FunctionDefinition = BaseNode & {
   parameters: FunctionParameter[];
   body: AgencyNode[];
   returnType?: VariableType | null;
+  returnTypeValidated?: boolean;
   docString?: DocString;
   async?: boolean;
   safe?: boolean;

--- a/lib/types/graphNode.ts
+++ b/lib/types/graphNode.ts
@@ -24,6 +24,7 @@ export type GraphNodeDefinition = BaseNode & {
   parameters: FunctionParameter[];
   body: AgencyNode[];
   returnType?: VariableType | null;
+  returnTypeValidated?: boolean;
   visibility?: Visibility;
   tags?: Tag[];
 };

--- a/tests/agency/validation/bangAssignment.agency
+++ b/tests/agency/validation/bangAssignment.agency
@@ -1,0 +1,7 @@
+node main() {
+  const x: number! = 42
+  if (isSuccess(x)) {
+    return "validated"
+  }
+  return "failed"
+}

--- a/tests/agency/validation/bangAssignment.test.json
+++ b/tests/agency/validation/bangAssignment.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"validated\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/validation/bangAssignmentFail.agency
+++ b/tests/agency/validation/bangAssignmentFail.agency
@@ -1,0 +1,7 @@
+node main() {
+  const x: number! = "not a number"
+  if (isFailure(x)) {
+    return "validation failed"
+  }
+  return "unexpected success"
+}

--- a/tests/agency/validation/bangAssignmentFail.test.json
+++ b/tests/agency/validation/bangAssignmentFail.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"validation failed\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "Bang on assignment returns failure Result when value doesn't match type"
+    }
+  ]
+}

--- a/tests/agency/validation/bangAssignmentInline.agency
+++ b/tests/agency/validation/bangAssignmentInline.agency
@@ -1,0 +1,10 @@
+node main() {
+  const x: "happy"|"sad"! = "happy"
+  const y: "happy"|"sad"! = "angry"
+  if (isSuccess(x)) {
+    if (isFailure(y)) {
+      return x.value
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/bangAssignmentInline.test.json
+++ b/tests/agency/validation/bangAssignmentInline.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"happy\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Bang with inline union type validates correctly"
+    }
+  ]
+}

--- a/tests/agency/validation/bangAssignmentObject.agency
+++ b/tests/agency/validation/bangAssignmentObject.agency
@@ -1,0 +1,10 @@
+node main() {
+  const good: {name: string, age: number}! = {name: "Alice", age: 30}
+  const bad: {name: string, age: number}! = {name: "Alice", age: "thirty"}
+  if (isSuccess(good)) {
+    if (isFailure(bad)) {
+      return good.value.name
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/bangAssignmentObject.test.json
+++ b/tests/agency/validation/bangAssignmentObject.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"Alice\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Bang with inline object type validates correctly"
+    }
+  ]
+}

--- a/tests/agency/validation/bangInForLoop.agency
+++ b/tests/agency/validation/bangInForLoop.agency
@@ -1,0 +1,17 @@
+def validate(x: number!) {
+  return x * 2
+}
+
+node main() {
+  const items = [1, "bad", 3]
+  const results = []
+  for (item in items) {
+    const r = validate(item)
+    if (isFailure(r)) {
+      results.push("fail")
+    } else {
+      results.push(r)
+    }
+  }
+  return results
+}

--- a/tests/agency/validation/bangInForLoop.test.json
+++ b/tests/agency/validation/bangInForLoop.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[2,\"fail\",6]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Bang validation works correctly inside a for loop"
+    }
+  ]
+}

--- a/tests/agency/validation/bangInIfElse.agency
+++ b/tests/agency/validation/bangInIfElse.agency
@@ -1,0 +1,15 @@
+node main() {
+  let flag = true
+  if (flag) {
+    const x: number! = 42
+    if (isSuccess(x)) {
+      return "validated in if"
+    }
+  } else {
+    const y: number! = "bad"
+    if (isFailure(y)) {
+      return "failed in else"
+    }
+  }
+  return "unexpected"
+}

--- a/tests/agency/validation/bangInIfElse.agency
+++ b/tests/agency/validation/bangInIfElse.agency
@@ -1,15 +1,25 @@
 node main() {
+  const results = []
+
   let flag = true
   if (flag) {
     const x: number! = 42
     if (isSuccess(x)) {
-      return "validated in if"
+      results.push("if-success")
     }
+  } else {
+    results.push("wrong branch")
+  }
+
+  flag = false
+  if (flag) {
+    results.push("wrong branch")
   } else {
     const y: number! = "bad"
     if (isFailure(y)) {
-      return "failed in else"
+      results.push("else-failure")
     }
   }
-  return "unexpected"
+
+  return results
 }

--- a/tests/agency/validation/bangInIfElse.test.json
+++ b/tests/agency/validation/bangInIfElse.test.json
@@ -3,9 +3,9 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "\"validated in if\"",
+      "expectedOutput": "[\"if-success\",\"else-failure\"]",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "Bang validation works inside if/else blocks"
+      "description": "Bang validation works in both if and else branches"
     }
   ]
 }

--- a/tests/agency/validation/bangInIfElse.test.json
+++ b/tests/agency/validation/bangInIfElse.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"validated in if\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Bang validation works inside if/else blocks"
+    }
+  ]
+}

--- a/tests/agency/validation/bangMultipleParams.agency
+++ b/tests/agency/validation/bangMultipleParams.agency
@@ -1,0 +1,15 @@
+def add(a: number!, b: number!) {
+  return a + b
+}
+
+node main() {
+  const good = add(3, 4)
+  const badFirst = add("x", 4)
+  const badSecond = add(3, "y")
+  if (isFailure(badFirst)) {
+    if (isFailure(badSecond)) {
+      return good
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/bangMultipleParams.test.json
+++ b/tests/agency/validation/bangMultipleParams.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "7",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Multiple validated params each validate independently"
+    }
+  ]
+}

--- a/tests/agency/validation/bangNodeReturnType.agency
+++ b/tests/agency/validation/bangNodeReturnType.agency
@@ -1,0 +1,3 @@
+node main(): number! {
+  return 42
+}

--- a/tests/agency/validation/bangNodeReturnType.test.json
+++ b/tests/agency/validation/bangNodeReturnType.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"success\":true,\"value\":42}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Node return type ! wraps return value in validation Result"
+    }
+  ]
+}

--- a/tests/agency/validation/bangParamAndReturn.agency
+++ b/tests/agency/validation/bangParamAndReturn.agency
@@ -1,0 +1,14 @@
+def process(x: number!): string! {
+  return x
+}
+
+node main() {
+  const paramFail = process("bad")
+  const returnFail = process(42)
+  if (isFailure(paramFail)) {
+    if (isFailure(returnFail)) {
+      return "both failed correctly"
+    }
+  }
+  return "unexpected"
+}

--- a/tests/agency/validation/bangParamAndReturn.test.json
+++ b/tests/agency/validation/bangParamAndReturn.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"both failed correctly\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Combined ! on param and return type: param fails for string, return fails for number (expected string)"
+    }
+  ]
+}

--- a/tests/agency/validation/bangParams.agency
+++ b/tests/agency/validation/bangParams.agency
@@ -1,0 +1,8 @@
+def double(x: number!) {
+  return x * 2
+}
+
+node main() {
+  const result = double(5)
+  return result
+}

--- a/tests/agency/validation/bangParams.test.json
+++ b/tests/agency/validation/bangParams.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "10",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/validation/bangParamsFail.agency
+++ b/tests/agency/validation/bangParamsFail.agency
@@ -1,0 +1,11 @@
+def double(x: number!) {
+  return x * 2
+}
+
+node main() {
+  const result = double("not a number")
+  if (isFailure(result)) {
+    return "validation failed"
+  }
+  return "unexpected success"
+}

--- a/tests/agency/validation/bangParamsFail.test.json
+++ b/tests/agency/validation/bangParamsFail.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"validation failed\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/validation/bangParamsMultipleCalls.agency
+++ b/tests/agency/validation/bangParamsMultipleCalls.agency
@@ -1,0 +1,15 @@
+def process(x: number!) {
+  return x + 1
+}
+
+node main() {
+  const a = process("bad")
+  const b = process(5)
+  const c = process("also bad")
+  if (isFailure(a)) {
+    if (isFailure(c)) {
+      return b
+    }
+  }
+  return "unexpected"
+}

--- a/tests/agency/validation/bangParamsMultipleCalls.test.json
+++ b/tests/agency/validation/bangParamsMultipleCalls.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "6",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "Multiple calls with validation failures don't corrupt state stack"
+    }
+  ]
+}

--- a/tests/agency/validation/bangReturnType.agency
+++ b/tests/agency/validation/bangReturnType.agency
@@ -1,0 +1,11 @@
+def stringify(x: number): string! {
+  return x
+}
+
+node main() {
+  const result = stringify(42)
+  if (isFailure(result)) {
+    return "correctly failed"
+  }
+  return "unexpected success"
+}

--- a/tests/agency/validation/bangReturnType.test.json
+++ b/tests/agency/validation/bangReturnType.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"correctly failed\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "Return type ! validates the return value and returns failure when wrong type"
+    }
+  ]
+}

--- a/tests/agency/validation/bangReturnTypeSuccess.agency
+++ b/tests/agency/validation/bangReturnTypeSuccess.agency
@@ -1,0 +1,11 @@
+def double(x: number): number! {
+  return x * 2
+}
+
+node main() {
+  const result = double(5)
+  if (isSuccess(result)) {
+    return result.value
+  }
+  return "failed"
+}

--- a/tests/agency/validation/bangReturnTypeSuccess.test.json
+++ b/tests/agency/validation/bangReturnTypeSuccess.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "10",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Return type ! wraps valid return value in success Result"
+    }
+  ]
+}

--- a/tests/agency/validation/bangWithPipe.agency
+++ b/tests/agency/validation/bangWithPipe.agency
@@ -7,9 +7,10 @@ def addOne(x: number): Result {
 }
 
 node main() {
-  const result: number! = success(5) |> double |> addOne
-  if (isSuccess(result)) {
-    return result.value
+  const result = success(5) |> double |> addOne
+  const validated: number! = result.value
+  if (isSuccess(validated)) {
+    return validated.value
   }
   return "failed"
 }

--- a/tests/agency/validation/bangWithPipe.agency
+++ b/tests/agency/validation/bangWithPipe.agency
@@ -1,0 +1,15 @@
+def double(x: number): Result {
+  return success(x * 2)
+}
+
+def addOne(x: number): Result {
+  return success(x + 1)
+}
+
+node main() {
+  const result: number! = success(5) |> double |> addOne
+  if (isSuccess(result)) {
+    return result.value
+  }
+  return "failed"
+}

--- a/tests/agency/validation/bangWithPipe.test.json
+++ b/tests/agency/validation/bangWithPipe.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "11",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Bang combined with pipe operator validates the final result"
+    }
+  ]
+}

--- a/tests/agency/validation/bangWithTry.agency
+++ b/tests/agency/validation/bangWithTry.agency
@@ -1,0 +1,17 @@
+def mayFail(x: number) {
+  if (x == 0) {
+    return failure("zero not allowed")
+  }
+  return success(x * 10)
+}
+
+node main() {
+  const result = try mayFail(5)
+  if (isSuccess(result)) {
+    const validated: number! = result.value
+    if (isSuccess(validated)) {
+      return validated.value
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/bangWithTry.agency
+++ b/tests/agency/validation/bangWithTry.agency
@@ -1,12 +1,9 @@
-def mayFail(x: number) {
-  if (x == 0) {
-    return failure("zero not allowed")
-  }
-  return success(x * 10)
+def getNumber() {
+  return 42
 }
 
 node main() {
-  const result = try mayFail(5)
+  const result = try getNumber()
   if (isSuccess(result)) {
     const validated: number! = result.value
     if (isSuccess(validated)) {

--- a/tests/agency/validation/bangWithTry.test.json
+++ b/tests/agency/validation/bangWithTry.test.json
@@ -3,9 +3,9 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "50",
+      "expectedOutput": "42",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "Bang combined with try keyword works correctly"
+      "description": "Bang validates the unwrapped value from a try expression"
     }
   ]
 }

--- a/tests/agency/validation/bangWithTry.test.json
+++ b/tests/agency/validation/bangWithTry.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "50",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Bang combined with try keyword works correctly"
+    }
+  ]
+}

--- a/tests/agency/validation/schemaAccess.agency
+++ b/tests/agency/validation/schemaAccess.agency
@@ -1,0 +1,10 @@
+type Category = "bug" | "feature"
+
+node main() {
+  const schema = Category.schema
+  const good = schema.parse("bug")
+  if (isSuccess(good)) {
+    return good.value
+  }
+  return "failed"
+}

--- a/tests/agency/validation/schemaAccess.test.json
+++ b/tests/agency/validation/schemaAccess.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"bug\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/validation/schemaBuiltin.agency
+++ b/tests/agency/validation/schemaBuiltin.agency
@@ -1,0 +1,11 @@
+node main() {
+  const numSchema = number.schema
+  const good = numSchema.parse(42)
+  const bad = numSchema.parse("hello")
+  if (isSuccess(good)) {
+    if (isFailure(bad)) {
+      return good.value
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/schemaBuiltin.test.json
+++ b/tests/agency/validation/schemaBuiltin.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "42",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "Built-in type number.schema works for validation"
+    }
+  ]
+}

--- a/tests/agency/validation/schemaBuiltinTypes.agency
+++ b/tests/agency/validation/schemaBuiltinTypes.agency
@@ -1,0 +1,20 @@
+node main() {
+  const strSchema = string.schema
+  const boolSchema = boolean.schema
+
+  const strGood = strSchema.parse("hello")
+  const strBad = strSchema.parse(42)
+  const boolGood = boolSchema.parse(true)
+  const boolBad = boolSchema.parse("true")
+
+  if (isSuccess(strGood)) {
+    if (isFailure(strBad)) {
+      if (isSuccess(boolGood)) {
+        if (isFailure(boolBad)) {
+          return "all correct"
+        }
+      }
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/schemaBuiltinTypes.test.json
+++ b/tests/agency/validation/schemaBuiltinTypes.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"all correct\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "string.schema and boolean.schema work for validation"
+    }
+  ]
+}

--- a/tests/agency/validation/schemaFailurePath.agency
+++ b/tests/agency/validation/schemaFailurePath.agency
@@ -1,0 +1,10 @@
+type Color = "red" | "green" | "blue"
+
+node main() {
+  const schema = Color.schema
+  const result = schema.parse("yellow")
+  if (isFailure(result)) {
+    return "correctly rejected"
+  }
+  return "unexpected success"
+}

--- a/tests/agency/validation/schemaFailurePath.test.json
+++ b/tests/agency/validation/schemaFailurePath.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"correctly rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Schema.parse returns failure for invalid data"
+    }
+  ]
+}

--- a/tests/agency/validation/schemaObjectType.agency
+++ b/tests/agency/validation/schemaObjectType.agency
@@ -1,0 +1,18 @@
+type Config = {
+  host: string,
+  port: number
+}
+
+node main() {
+  const schema = Config.schema
+  const goodObj = {host: "localhost", port: 8080}
+  const badObj = {host: "localhost", port: "not a number"}
+  const good = schema.parse(goodObj)
+  const bad = schema.parse(badObj)
+  if (isSuccess(good)) {
+    if (isFailure(bad)) {
+      return good.value.host
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/schemaObjectType.test.json
+++ b/tests/agency/validation/schemaObjectType.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"localhost\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Schema for object type validates structure correctly"
+    }
+  ]
+}

--- a/tests/agency/validation/schemaParseJSON.agency
+++ b/tests/agency/validation/schemaParseJSON.agency
@@ -1,0 +1,11 @@
+node main() {
+  const schema = number.schema
+  const good = schema.parseJSON("42")
+  const bad = schema.parseJSON("not json")
+  if (isSuccess(good)) {
+    if (isFailure(bad)) {
+      return good.value
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/schemaParseJSON.test.json
+++ b/tests/agency/validation/schemaParseJSON.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "42",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Schema.parseJSON validates JSON strings end-to-end"
+    }
+  ]
+}

--- a/tests/typescriptBuilder/assignment.mjs
+++ b/tests/typescriptBuilder/assignment.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptBuilder/safe-function.mjs
+++ b/tests/typescriptBuilder/safe-function.mjs
@@ -24,6 +24,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptBuilder/simple.mjs
+++ b/tests/typescriptBuilder/simple.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/array.mjs
+++ b/tests/typescriptGenerator/array.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/tests/typescriptGenerator/arrayAndObject.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/assignment.mjs
+++ b/tests/typescriptGenerator/assignment.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/tests/typescriptGenerator/asyncAssigned.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/asyncLlm.mjs
+++ b/tests/typescriptGenerator/asyncLlm.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/bangParams.agency
+++ b/tests/typescriptGenerator/bangParams.agency
@@ -1,0 +1,9 @@
+def process(data: number!) {
+  print(data)
+  return data
+}
+
+node main() {
+  const result = process("not a number")
+  print(result)
+}

--- a/tests/typescriptGenerator/bangParams.mjs
+++ b/tests/typescriptGenerator/bangParams.mjs
@@ -145,11 +145,6 @@ let __functionCompleted = false;
     }
   })
   __stack.args["data"] = data;
-  const __vr_data = __validateType(__stack.args["data"], z.number());
-  if (!__vr_data.success) {
-    return __vr_data;
-  }
-  __stack.args["data"] = __vr_data.value;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "bangParams.agency", scopeName: "process" });
   let __resultCheckpointId = -1;
@@ -167,6 +162,11 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
+    const __vr_data = __validateType(__stack.args["data"], z.number());
+    if (!__vr_data.success) {
+      return __vr_data;
+    }
+    __stack.args["data"] = __vr_data.value;
     await runner.step(0, async (runner) => {
 await print(__stack.args.data)
     });

--- a/tests/typescriptGenerator/bangParams.mjs
+++ b/tests/typescriptGenerator/bangParams.mjs
@@ -1,0 +1,294 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint, getCheckpoint, restore,
+  interrupt, isInterrupt, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupt as _respondToInterrupt,
+  approveInterrupt as _approveInterrupt,
+  rejectInterrupt as _rejectInterrupt,
+  resolveInterrupt as _resolveInterrupt,
+  modifyInterrupt as _modifyInterrupt,
+  resumeFromState as _resumeFromState,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  deepClone as __deepClone,
+  not, eq, neq, lt, lte, gt, gte, and, or,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  _builtinTool as __builtinTool,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname
+});
+const graph = __globalCtx.graph;
+
+// Path-dependent builtin wrappers
+export function readSkill({filepath}: {filepath: string}): string {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+
+// tool() function — looks up a tool by name from the module's __toolRegistry
+function tool(__name: string) {
+  return __builtinTool(__name, __toolRegistry);
+}
+
+// Handler result builtins
+function approve(value?: any) { return { type: "approved" as const, value }; }
+function reject(value?: any) { return { type: "rejected" as const, value }; }
+function propagate() { return { type: "propagated" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, isDebugger };
+export const respondToInterrupt = (interrupt: Interrupt, response: InterruptResponse, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupt({ ctx: __globalCtx, interrupt, interruptResponse: response, overrides: opts?.overrides, metadata: opts?.metadata });
+export const approveInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _approveInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rejectInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _rejectInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const modifyInterrupt = (interrupt: Interrupt, newArguments: Record<string, any>, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _modifyInterrupt({ ctx: __globalCtx, interrupt, newArguments, overrides: opts?.overrides, metadata: opts?.metadata });
+export const resolveInterrupt = (interrupt: Interrupt, value: any, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _resolveInterrupt({ ctx: __globalCtx, interrupt, value, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("bangParams.agency")
+}
+export const __processTool = {
+  name: "process",
+  description: `No description provided.`,
+  schema: z.object({"data": z.number(), })
+};
+export const __processToolParams = ["data"];
+const __toolRegistry = {
+  process: {
+    definition: __processTool,
+    handler: {
+      name: "process",
+      params: __processToolParams,
+      execute: process,
+      isBuiltin: false
+    }
+  },
+  readSkill: {
+    definition: __readSkillTool,
+    handler: {
+      name: "readSkill",
+      params: __readSkillToolParams,
+      execute: readSkill,
+      isBuiltin: true
+    }
+  }
+};
+async function process(data: number, __state: InternalFunctionState | undefined = undefined) {
+  const __setupData = setupFunction({
+    state: __state
+  });
+  // __state will be undefined if this function is being called as a tool by an llm
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state?.ctx || __globalCtx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("bangParams.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onFunctionStart",
+    data: {
+      functionName: "process",
+      args: {
+        data: data
+      },
+      isBuiltin: false,
+      moduleId: "bangParams.agency"
+    }
+  })
+  __stack.args["data"] = data;
+  const __vr_data = __validateType(__stack.args["data"], z.number());
+  if (!__vr_data.success) {
+    return __vr_data;
+  }
+  __stack.args["data"] = __vr_data.value;
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "bangParams.agency", scopeName: "process" });
+  let __resultCheckpointId = -1;
+if (__ctx.stateStack.currentNodeId()) {
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__ctx, { moduleId: "bangParams.agency", scopeName: "process", stepPath: "", label: "result-entry" });
+}
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+  if ("data" in __overrides) {
+    data = __overrides["data"];
+    __stack.args["data"] = data;
+  }
+
+}
+
+  try {
+    await runner.step(0, async (runner) => {
+await print(__stack.args.data)
+    });
+    await runner.step(1, async (runner) => {
+__functionCompleted = true;
+runner.halt(__stack.args.data)
+return;
+    });
+    if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: __ctx.getResultCheckpoint(),
+    retryable: __self.__retryable,
+    functionName: "process",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    if (!__state?.isForked) { __ctx.stateStack.pop() }
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "process",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state.ctx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onNodeStart",
+    data: {
+      nodeName: "main"
+    }
+  })
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "bangParams.agency", scopeName: "main" });
+  try {
+    await runner.step(0, async (runner) => {
+__stack.locals.result = await process(`not a number`, {
+        ctx: __ctx,
+        threads: __threads,
+        interruptData: __state?.interruptData
+      });
+if (isInterrupt(__stack.locals.result)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __stack.locals.result
+        })
+        return;
+      }
+    });
+    await runner.step(1, async (runner) => {
+await print(__stack.locals.result)
+    });
+    if (runner.halted) return runner.haltResult;
+    await callHook({
+      callbacks: __ctx.callbacks,
+      name: "onNodeEnd",
+      data: {
+        nodeName: "main",
+        data: undefined
+      }
+    })
+    return {
+      messages: __threads,
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    return {
+      messages: __threads,
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}) {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    await main(initialState)
+  } catch (__error: any) {
+    console.error(`\nAgent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"bangParams.agency:process":{"0":{"line":-2,"col":2},"1":{"line":-1,"col":2}},"bangParams.agency:main":{"0":{"line":3,"col":2},"1":{"line":4,"col":2}}};

--- a/tests/typescriptGenerator/bangReturnType.agency
+++ b/tests/typescriptGenerator/bangReturnType.agency
@@ -1,0 +1,8 @@
+def process(x: number): number! {
+  return x
+}
+
+node main() {
+  const result = process(42)
+  print(result)
+}

--- a/tests/typescriptGenerator/bangReturnType.mjs
+++ b/tests/typescriptGenerator/bangReturnType.mjs
@@ -1,0 +1,286 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint, getCheckpoint, restore,
+  interrupt, isInterrupt, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupt as _respondToInterrupt,
+  approveInterrupt as _approveInterrupt,
+  rejectInterrupt as _rejectInterrupt,
+  resolveInterrupt as _resolveInterrupt,
+  modifyInterrupt as _modifyInterrupt,
+  resumeFromState as _resumeFromState,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  deepClone as __deepClone,
+  not, eq, neq, lt, lte, gt, gte, and, or,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  _builtinTool as __builtinTool,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname
+});
+const graph = __globalCtx.graph;
+
+// Path-dependent builtin wrappers
+export function readSkill({filepath}: {filepath: string}): string {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+
+// tool() function — looks up a tool by name from the module's __toolRegistry
+function tool(__name: string) {
+  return __builtinTool(__name, __toolRegistry);
+}
+
+// Handler result builtins
+function approve(value?: any) { return { type: "approved" as const, value }; }
+function reject(value?: any) { return { type: "rejected" as const, value }; }
+function propagate() { return { type: "propagated" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, isDebugger };
+export const respondToInterrupt = (interrupt: Interrupt, response: InterruptResponse, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupt({ ctx: __globalCtx, interrupt, interruptResponse: response, overrides: opts?.overrides, metadata: opts?.metadata });
+export const approveInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _approveInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rejectInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _rejectInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const modifyInterrupt = (interrupt: Interrupt, newArguments: Record<string, any>, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _modifyInterrupt({ ctx: __globalCtx, interrupt, newArguments, overrides: opts?.overrides, metadata: opts?.metadata });
+export const resolveInterrupt = (interrupt: Interrupt, value: any, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _resolveInterrupt({ ctx: __globalCtx, interrupt, value, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("bangReturnType.agency")
+}
+export const __processTool = {
+  name: "process",
+  description: `No description provided.`,
+  schema: z.object({"x": z.number(), })
+};
+export const __processToolParams = ["x"];
+const __toolRegistry = {
+  process: {
+    definition: __processTool,
+    handler: {
+      name: "process",
+      params: __processToolParams,
+      execute: process,
+      isBuiltin: false
+    }
+  },
+  readSkill: {
+    definition: __readSkillTool,
+    handler: {
+      name: "readSkill",
+      params: __readSkillToolParams,
+      execute: readSkill,
+      isBuiltin: true
+    }
+  }
+};
+async function process(x: number, __state: InternalFunctionState | undefined = undefined) {
+  const __setupData = setupFunction({
+    state: __state
+  });
+  // __state will be undefined if this function is being called as a tool by an llm
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state?.ctx || __globalCtx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("bangReturnType.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onFunctionStart",
+    data: {
+      functionName: "process",
+      args: {
+        x: x
+      },
+      isBuiltin: false,
+      moduleId: "bangReturnType.agency"
+    }
+  })
+  __stack.args["x"] = x;
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "bangReturnType.agency", scopeName: "process" });
+  let __resultCheckpointId = -1;
+if (__ctx.stateStack.currentNodeId()) {
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__ctx, { moduleId: "bangReturnType.agency", scopeName: "process", stepPath: "", label: "result-entry" });
+}
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+  if ("x" in __overrides) {
+    x = __overrides["x"];
+    __stack.args["x"] = x;
+  }
+
+}
+
+  try {
+    await runner.step(0, async (runner) => {
+__functionCompleted = true;
+runner.halt(__validateType(__stack.args.x, z.number()))
+return;
+    });
+    if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: __ctx.getResultCheckpoint(),
+    retryable: __self.__retryable,
+    functionName: "process",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    if (!__state?.isForked) { __ctx.stateStack.pop() }
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "process",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state.ctx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onNodeStart",
+    data: {
+      nodeName: "main"
+    }
+  })
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "bangReturnType.agency", scopeName: "main" });
+  try {
+    await runner.step(0, async (runner) => {
+__stack.locals.result = await process(42, {
+        ctx: __ctx,
+        threads: __threads,
+        interruptData: __state?.interruptData
+      });
+if (isInterrupt(__stack.locals.result)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __stack.locals.result
+        })
+        return;
+      }
+    });
+    await runner.step(1, async (runner) => {
+await print(__stack.locals.result)
+    });
+    if (runner.halted) return runner.haltResult;
+    await callHook({
+      callbacks: __ctx.callbacks,
+      name: "onNodeEnd",
+      data: {
+        nodeName: "main",
+        data: undefined
+      }
+    })
+    return {
+      messages: __threads,
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    return {
+      messages: __threads,
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}) {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    await main(initialState)
+  } catch (__error: any) {
+    console.error(`\nAgent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"bangReturnType.agency:process":{"0":{"line":-2,"col":2}},"bangReturnType.agency:main":{"0":{"line":2,"col":2},"1":{"line":3,"col":2}}};

--- a/tests/typescriptGenerator/bangValidation.agency
+++ b/tests/typescriptGenerator/bangValidation.agency
@@ -1,0 +1,6 @@
+type Category = "bug" | "feature" | "docs"
+
+node main() {
+  const result: Category! = "bug"
+  print(result)
+}

--- a/tests/typescriptGenerator/bangValidation.mjs
+++ b/tests/typescriptGenerator/bangValidation.mjs
@@ -1,0 +1,179 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint, getCheckpoint, restore,
+  interrupt, isInterrupt, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupt as _respondToInterrupt,
+  approveInterrupt as _approveInterrupt,
+  rejectInterrupt as _rejectInterrupt,
+  resolveInterrupt as _resolveInterrupt,
+  modifyInterrupt as _modifyInterrupt,
+  resumeFromState as _resumeFromState,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  deepClone as __deepClone,
+  not, eq, neq, lt, lte, gt, gte, and, or,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  _builtinTool as __builtinTool,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname
+});
+const graph = __globalCtx.graph;
+
+// Path-dependent builtin wrappers
+export function readSkill({filepath}: {filepath: string}): string {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+
+// tool() function — looks up a tool by name from the module's __toolRegistry
+function tool(__name: string) {
+  return __builtinTool(__name, __toolRegistry);
+}
+
+// Handler result builtins
+function approve(value?: any) { return { type: "approved" as const, value }; }
+function reject(value?: any) { return { type: "rejected" as const, value }; }
+function propagate() { return { type: "propagated" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, isDebugger };
+export const respondToInterrupt = (interrupt: Interrupt, response: InterruptResponse, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupt({ ctx: __globalCtx, interrupt, interruptResponse: response, overrides: opts?.overrides, metadata: opts?.metadata });
+export const approveInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _approveInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rejectInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _rejectInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const modifyInterrupt = (interrupt: Interrupt, newArguments: Record<string, any>, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _modifyInterrupt({ ctx: __globalCtx, interrupt, newArguments, overrides: opts?.overrides, metadata: opts?.metadata });
+export const resolveInterrupt = (interrupt: Interrupt, value: any, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _resolveInterrupt({ ctx: __globalCtx, interrupt, value, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("bangValidation.agency")
+}
+const __toolRegistry = {
+  readSkill: {
+    definition: __readSkillTool,
+    handler: {
+      name: "readSkill",
+      params: __readSkillToolParams,
+      execute: readSkill,
+      isBuiltin: true
+    }
+  }
+};
+type Category = "bug" | "feature" | "docs";
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state.ctx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onNodeStart",
+    data: {
+      nodeName: "main"
+    }
+  })
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "bangValidation.agency", scopeName: "main" });
+  try {
+    await runner.step(0, async (runner) => {
+__stack.locals.result = `bug`;
+__stack.locals.result = __validateType(__stack.locals.result, z.union([z.literal("bug"), z.literal("feature"), z.literal("docs")]));
+    });
+    await runner.step(1, async (runner) => {
+await print(__stack.locals.result)
+    });
+    if (runner.halted) return runner.haltResult;
+    await callHook({
+      callbacks: __ctx.callbacks,
+      name: "onNodeEnd",
+      data: {
+        nodeName: "main",
+        data: undefined
+      }
+    })
+    return {
+      messages: __threads,
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    return {
+      messages: __threads,
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}) {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    await main(initialState)
+  } catch (__error: any) {
+    console.error(`\nAgent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"bangValidation.agency:main":{"0":{"line":0,"col":2},"1":{"line":1,"col":2}}};

--- a/tests/typescriptGenerator/blockBasic.mjs
+++ b/tests/typescriptGenerator/blockBasic.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/blockParams.mjs
+++ b/tests/typescriptGenerator/blockParams.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/class-basic.mjs
+++ b/tests/typescriptGenerator/class-basic.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/class-inheritance.mjs
+++ b/tests/typescriptGenerator/class-inheritance.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/comments.mjs
+++ b/tests/typescriptGenerator/comments.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/defaultValues.mjs
+++ b/tests/typescriptGenerator/defaultValues.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/docstrings.mjs
+++ b/tests/typescriptGenerator/docstrings.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/forLoop.mjs
+++ b/tests/typescriptGenerator/forLoop.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/function-with-types.mjs
+++ b/tests/typescriptGenerator/function-with-types.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/function.mjs
+++ b/tests/typescriptGenerator/function.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/ifElse.mjs
+++ b/tests/typescriptGenerator/ifElse.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/imports.mjs
+++ b/tests/typescriptGenerator/imports.mjs
@@ -38,6 +38,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/input.mjs
+++ b/tests/typescriptGenerator/input.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/interpolation.mjs
+++ b/tests/typescriptGenerator/interpolation.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/tests/typescriptGenerator/llmConfigParam.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/matchBlock.mjs
+++ b/tests/typescriptGenerator/matchBlock.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/multiLineComment.mjs
+++ b/tests/typescriptGenerator/multiLineComment.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/multipleNodes.mjs
+++ b/tests/typescriptGenerator/multipleNodes.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/namedArgs.mjs
+++ b/tests/typescriptGenerator/namedArgs.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/tests/typescriptGenerator/noResponseFormat.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/objectDescription.mjs
+++ b/tests/typescriptGenerator/objectDescription.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/optionalParams.mjs
+++ b/tests/typescriptGenerator/optionalParams.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/pipe-operator.mjs
+++ b/tests/typescriptGenerator/pipe-operator.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/result-basic.mjs
+++ b/tests/typescriptGenerator/result-basic.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/result-guards.mjs
+++ b/tests/typescriptGenerator/result-guards.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/returnValue.mjs
+++ b/tests/typescriptGenerator/returnValue.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/safe.mjs
+++ b/tests/typescriptGenerator/safe.mjs
@@ -24,6 +24,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/schemaAccess.agency
+++ b/tests/typescriptGenerator/schemaAccess.agency
@@ -1,0 +1,7 @@
+type Category = "bug" | "feature" | "docs"
+
+node main() {
+  const schema = Category.schema
+  const result = schema.parse("bug")
+  print(result)
+}

--- a/tests/typescriptGenerator/schemaAccess.mjs
+++ b/tests/typescriptGenerator/schemaAccess.mjs
@@ -1,0 +1,181 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint, getCheckpoint, restore,
+  interrupt, isInterrupt, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupt as _respondToInterrupt,
+  approveInterrupt as _approveInterrupt,
+  rejectInterrupt as _rejectInterrupt,
+  resolveInterrupt as _resolveInterrupt,
+  modifyInterrupt as _modifyInterrupt,
+  resumeFromState as _resumeFromState,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  deepClone as __deepClone,
+  not, eq, neq, lt, lte, gt, gte, and, or,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  _builtinTool as __builtinTool,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname
+});
+const graph = __globalCtx.graph;
+
+// Path-dependent builtin wrappers
+export function readSkill({filepath}: {filepath: string}): string {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+
+// tool() function — looks up a tool by name from the module's __toolRegistry
+function tool(__name: string) {
+  return __builtinTool(__name, __toolRegistry);
+}
+
+// Handler result builtins
+function approve(value?: any) { return { type: "approved" as const, value }; }
+function reject(value?: any) { return { type: "rejected" as const, value }; }
+function propagate() { return { type: "propagated" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, isDebugger };
+export const respondToInterrupt = (interrupt: Interrupt, response: InterruptResponse, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupt({ ctx: __globalCtx, interrupt, interruptResponse: response, overrides: opts?.overrides, metadata: opts?.metadata });
+export const approveInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _approveInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rejectInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _rejectInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const modifyInterrupt = (interrupt: Interrupt, newArguments: Record<string, any>, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _modifyInterrupt({ ctx: __globalCtx, interrupt, newArguments, overrides: opts?.overrides, metadata: opts?.metadata });
+export const resolveInterrupt = (interrupt: Interrupt, value: any, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _resolveInterrupt({ ctx: __globalCtx, interrupt, value, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("schemaAccess.agency")
+}
+const __toolRegistry = {
+  readSkill: {
+    definition: __readSkillTool,
+    handler: {
+      name: "readSkill",
+      params: __readSkillToolParams,
+      execute: readSkill,
+      isBuiltin: true
+    }
+  }
+};
+type Category = "bug" | "feature" | "docs";
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state.ctx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onNodeStart",
+    data: {
+      nodeName: "main"
+    }
+  })
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "schemaAccess.agency", scopeName: "main" });
+  try {
+    await runner.step(0, async (runner) => {
+__stack.locals.schema = new Schema(z.union([z.literal("bug"), z.literal("feature"), z.literal("docs")]));
+    });
+    await runner.step(1, async (runner) => {
+__stack.locals.result = await __stack.locals.schema.parse(`bug`);
+    });
+    await runner.step(2, async (runner) => {
+await print(__stack.locals.result)
+    });
+    if (runner.halted) return runner.haltResult;
+    await callHook({
+      callbacks: __ctx.callbacks,
+      name: "onNodeEnd",
+      data: {
+        nodeName: "main",
+        data: undefined
+      }
+    })
+    return {
+      messages: __threads,
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    return {
+      messages: __threads,
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}) {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    await main(initialState)
+  } catch (__error: any) {
+    console.error(`\nAgent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"schemaAccess.agency:main":{"0":{"line":0,"col":2},"1":{"line":1,"col":2},"2":{"line":2,"col":2}}};

--- a/tests/typescriptGenerator/shared.mjs
+++ b/tests/typescriptGenerator/shared.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/simple.mjs
+++ b/tests/typescriptGenerator/simple.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/skill.mjs
+++ b/tests/typescriptGenerator/skill.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/slice.mjs
+++ b/tests/typescriptGenerator/slice.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/sliceAssign.mjs
+++ b/tests/typescriptGenerator/sliceAssign.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/sourceMap.mjs
+++ b/tests/typescriptGenerator/sourceMap.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/splat.mjs
+++ b/tests/typescriptGenerator/splat.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/streaming.mjs
+++ b/tests/typescriptGenerator/streaming.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/string-interpolation.mjs
+++ b/tests/typescriptGenerator/string-interpolation.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/stringConcat.mjs
+++ b/tests/typescriptGenerator/stringConcat.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/typeHints.mjs
+++ b/tests/typescriptGenerator/typeHints.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/types/literal.mjs
+++ b/tests/typescriptGenerator/types/literal.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/tests/typescriptGenerator/types/typeAlias.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/varTypes.mjs
+++ b/tests/typescriptGenerator/varTypes.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/variadic.mjs
+++ b/tests/typescriptGenerator/variadic.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/withModifier.mjs
+++ b/tests/typescriptGenerator/withModifier.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/tests/typescriptGenerator/withParam.mjs
+++ b/tests/typescriptGenerator/withParam.mjs
@@ -23,6 +23,7 @@ import {
   not, eq, neq, lt, lte, gt, gte, and, or,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,


### PR DESCRIPTION
## Summary
- Add `!` (bang) postfix on type annotations for runtime validation: assignments (`const x: number! = expr`), function parameters (`def f(x: number!)`), and return types (`def f(): number!`)
- Add `TypeName.schema` access to get a `Schema` wrapper around the Zod schema for any named or built-in type, with `parse()` and `parseJSON()` methods returning Result values
- Add `ts.validateType()` IR builder helper for consistent code generation

## Test plan
- [x] Unit tests for `Schema` class and `__validateType` helper (10 tests)
- [x] Parser tests for `!` syntax on assignments, function params, and return types (9 tests)
- [x] Generator fixtures for bang validation, bang params, bang return types, and schema access
- [x] End-to-end execution tests: bang assignment, bang params (happy + failure path), schema access (4 tests)
- [x] Full test suite passes (1956 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)