### PR TITLE
feat: failure pass-through, Result validation, and schema(Type) syntax

### DIFF
--- a/lib/backends/agencyGenerator.test.ts
+++ b/lib/backends/agencyGenerator.test.ts
@@ -363,3 +363,40 @@ describe("AgencyGenerator - bang (!) validated type annotations", () => {
   });
 });
 
+describe("AgencyGenerator - Result type formatting", () => {
+  function formatAgency(input: string): string {
+    const parseResult = parseAgency(input, {}, false);
+    expect(parseResult.success).toBe(true);
+    if (!parseResult.success) return "";
+    const generator = new AgencyGenerator();
+    return generator.generate(parseResult.result).output.trim();
+  }
+
+  it("should format Result<Foo> with single type param", () => {
+    const input = `def check(): Result<number> {\n  return success(42)\n}`;
+    const output = formatAgency(input);
+    expect(output).toContain("Result<number>");
+    expect(output).not.toContain("Result<number,");
+  });
+
+  it("should format bare Result without type params", () => {
+    const input = `def check(): Result {\n  return success(42)\n}`;
+    const output = formatAgency(input);
+    expect(output).toContain(": Result");
+    expect(output).not.toContain("Result<");
+  });
+
+  it("should format Result<Foo, Bar> with non-default failure type", () => {
+    const input = `def check(): Result<number, number> {\n  return success(42)\n}`;
+    const output = formatAgency(input);
+    expect(output).toContain("Result<number, number>");
+  });
+
+  it("should normalize Result<Foo, string> to Result<Foo>", () => {
+    const input = `def check(): Result<number, string> {\n  return success(42)\n}`;
+    const output = formatAgency(input);
+    expect(output).toContain("Result<number>");
+    expect(output).not.toContain("Result<number, string>");
+  });
+});
+

--- a/lib/backends/agencyGenerator.test.ts
+++ b/lib/backends/agencyGenerator.test.ts
@@ -400,3 +400,25 @@ describe("AgencyGenerator - Result type formatting", () => {
   });
 });
 
+describe("AgencyGenerator - schema(Type) expressions", () => {
+  function formatAgency(input: string): string {
+    const parseResult = parseAgency(input, {}, false);
+    expect(parseResult.success).toBe(true);
+    if (!parseResult.success) return "";
+    const generator = new AgencyGenerator();
+    return generator.generate(parseResult.result).output.trim();
+  }
+
+  it("should format schema(number)", () => {
+    const input = `node main() {\n  const s = schema(number)\n}`;
+    const output = formatAgency(input);
+    expect(output).toContain("schema(number)");
+  });
+
+  it("should format schema(Result<number>)", () => {
+    const input = `node main() {\n  const s = schema(Result<number>)\n}`;
+    const output = formatAgency(input);
+    expect(output).toContain("schema(Result<number>)");
+  });
+});
+

--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -272,6 +272,8 @@ export class AgencyGenerator {
         return this.processClassDefinition(node);
       case "newExpression":
         return this.processNewExpression(node);
+      case "schemaExpression":
+        return `schema(${variableTypeToString(node.typeArg, this.typeAliases)})`;
       case "regex":
         return `re/${node.pattern}/${node.flags}`;
       default:

--- a/lib/backends/typescriptBuilder.integration.test.ts
+++ b/lib/backends/typescriptBuilder.integration.test.ts
@@ -269,36 +269,46 @@ ${safeKeyword}def ${funcName}(id: string, shouldSave: boolean, items: string[]):
   });
 });
 
-describe("TypeName.schema access", () => {
-  it("should throw on .schema for unrecognized type name", () => {
-    expect(() =>
-      generateWithBuilder(`
-node main() {
-  const schema = UnknownType.schema
-}
-`),
-    ).toThrow("UnknownType");
-  });
-
-  it("should compile .schema for named type aliases", () => {
+describe("schema(Type) expression", () => {
+  it("should compile schema(Type) for named type aliases", () => {
     expect(() =>
       generateWithBuilder(`
 type Category = "bug" | "feature"
 node main() {
-  const schema = Category.schema
+  const s = schema(Category)
 }
 `),
     ).not.toThrow();
   });
 
-  it("should compile .schema for builtin types", () => {
+  it("should compile schema(Type) for builtin types", () => {
     expect(() =>
       generateWithBuilder(`
 node main() {
-  const schema = number.schema
+  const s = schema(number)
 }
 `),
     ).not.toThrow();
+  });
+
+  it("should compile schema(Result<number>)", () => {
+    expect(() =>
+      generateWithBuilder(`
+node main() {
+  const s = schema(Result<number>)
+}
+`),
+    ).not.toThrow();
+  });
+
+  it("generated code contains new Schema(...)", () => {
+    const output = generateWithBuilder(`
+type Category = "bug" | "feature"
+node main() {
+  const s = schema(Category)
+}
+`);
+    expect(output).toContain("new Schema(");
   });
 });
 

--- a/lib/backends/typescriptBuilder.integration.test.ts
+++ b/lib/backends/typescriptBuilder.integration.test.ts
@@ -301,3 +301,34 @@ node main() {
     ).not.toThrow();
   });
 });
+
+import { mapTypeToValidationSchema } from "./typescriptGenerator/typeToZodSchema.js";
+
+describe("mapTypeToValidationSchema", () => {
+
+  it("generates Result validation schema for bare Result", () => {
+    const schema = mapTypeToValidationSchema(
+      { type: "resultType", successType: { type: "primitiveType", value: "any" }, failureType: { type: "primitiveType", value: "any" } },
+      {},
+    );
+    expect(schema).toContain("z.literal(true)");
+    expect(schema).toContain("z.literal(false)");
+  });
+
+  it("generates Result validation schema with typed success", () => {
+    const schema = mapTypeToValidationSchema(
+      { type: "resultType", successType: { type: "primitiveType", value: "number" }, failureType: { type: "primitiveType", value: "string" } },
+      {},
+    );
+    expect(schema).toContain("z.number()");
+    expect(schema).toContain("z.literal(true)");
+  });
+
+  it("delegates non-Result types to mapTypeToZodSchema", () => {
+    const schema = mapTypeToValidationSchema(
+      { type: "primitiveType", value: "number" },
+      {},
+    );
+    expect(schema).toBe("z.number()");
+  });
+});

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -7,7 +7,6 @@ import {
   Expression,
   Keyword,
   Literal,
-  VariableNameLiteral,
   NamedArgument,
   PromptSegment,
   FunctionScope,
@@ -27,6 +26,7 @@ import {
 } from "@/config.js";
 import type { SourceLocationOpts } from "@/runtime/state/checkpointStore.js";
 import { DebuggerStatement } from "@/types/debuggerStatement.js";
+import { SchemaExpression } from "@/types/schemaExpression.js";
 import { Sentinel } from "@/types/sentinel.js";
 import { expressionToString } from "@/utils/node.js";
 import { toCompiledImportPath } from "../importPaths.js";
@@ -88,6 +88,7 @@ import {
 import {
   DEFAULT_SCHEMA,
   mapTypeToZodSchema,
+  mapTypeToValidationSchema,
 } from "./typescriptGenerator/typeToZodSchema.js";
 
 import { $, ts } from "../ir/builders.js";
@@ -419,28 +420,6 @@ export class TypeScriptBuilder {
       default:
         return false;
     }
-  }
-
-  private static readonly BUILTIN_SCHEMA_TYPES = [
-    "number", "string", "boolean", "null", "undefined", "any", "unknown", "object",
-  ];
-
-  /**
-   * Resolve a type name (alias or builtin) to its Zod schema string.
-   * Returns null if the name is not a known type alias or builtin.
-   */
-  private resolveZodSchemaForTypeName(typeName: string): string | null {
-    const typeAliases = this.getVisibleTypeAliases();
-    if (typeAliases[typeName]) {
-      return mapTypeToZodSchema(typeAliases[typeName], typeAliases);
-    }
-    if (TypeScriptBuilder.BUILTIN_SCHEMA_TYPES.includes(typeName)) {
-      return mapTypeToZodSchema(
-        { type: "primitiveType" as const, value: typeName },
-        typeAliases,
-      );
-    }
-    return null;
   }
 
   private agencyFileToDefaultImportName(agencyFile: string): string {
@@ -847,6 +826,8 @@ export class TypeScriptBuilder {
         return this.processClassDefinition(node);
       case "newExpression":
         return this.processNewExpression(node);
+      case "schemaExpression":
+        return this.processSchemaExpression(node);
       case "regex":
         return ts.raw(`/${node.pattern}/${node.flags}`);
       default:
@@ -965,23 +946,6 @@ export class TypeScriptBuilder {
   }
 
   private processValueAccess(node: ValueAccess): TsNode {
-    // Check for TypeName.schema pattern
-    if (
-      node.base.type === "variableName" &&
-      node.chain.length === 1 &&
-      node.chain[0].kind === "property" &&
-      node.chain[0].name === "schema"
-    ) {
-      const baseName = (node.base as VariableNameLiteral).value;
-      const zodSchema = this.resolveZodSchemaForTypeName(baseName);
-      if (zodSchema) {
-        return ts.new(ts.id("Schema"), [ts.raw(zodSchema)]);
-      }
-      throw new Error(
-        `Cannot access .schema on '${baseName}': not a known type alias or builtin type`,
-      );
-    }
-
     let result = this.processNode(node.base);
     // If the base is a function call, await it before accessing properties/methods
     // on the result. Without this, chaining like getGreeting().trim() would call
@@ -1128,6 +1092,11 @@ export class TypeScriptBuilder {
   private processNewExpression(node: NewExpression): TsNode {
     const args = node.arguments.map((a) => this.processNode(a as AgencyNode));
     return ts.new(ts.id(node.className), args);
+  }
+
+  private processSchemaExpression(node: SchemaExpression): TsNode {
+    const zodSchema = mapTypeToValidationSchema(node.typeArg, this.getVisibleTypeAliases());
+    return ts.new(ts.id("Schema"), [ts.raw(zodSchema)]);
   }
 
   /**
@@ -1687,7 +1656,7 @@ export class TypeScriptBuilder {
     const validationGuards: TsNode[] = [];
     for (const param of parameters) {
       if (param.validated && param.typeHint) {
-        const zodSchema = mapTypeToZodSchema(param.typeHint, this.getVisibleTypeAliases());
+        const zodSchema = mapTypeToValidationSchema(param.typeHint, this.getVisibleTypeAliases());
         const stackArg = $(ts.stack("args")).index(ts.str(param.name)).done();
         const vrName = `__vr_${param.name}`;
         const vrId = ts.id(vrName);
@@ -2238,7 +2207,7 @@ export class TypeScriptBuilder {
     if (!this.getScopeReturnTypeValidated()) return valueNode;
     const returnType = this.getScopeReturnType();
     if (!returnType) return valueNode;
-    const zodSchema = mapTypeToZodSchema(returnType, this.getVisibleTypeAliases());
+    const zodSchema = mapTypeToValidationSchema(returnType, this.getVisibleTypeAliases());
     return ts.validateType(valueNode, ts.raw(zodSchema));
   }
 
@@ -2328,7 +2297,7 @@ export class TypeScriptBuilder {
     const result = this._processAssignmentInner(node);
     // If the type annotation has !, wrap the assigned value in __validateType
     if (node.validated && node.typeHint) {
-      const zodSchema = mapTypeToZodSchema(
+      const zodSchema = mapTypeToValidationSchema(
         node.typeHint,
         this.getVisibleTypeAliases(),
       );
@@ -3015,7 +2984,7 @@ export class TypeScriptBuilder {
 
     // If the assignment has ! (validated), wrap the final result in __validateType
     if (stmt.validated && stmt.typeHint) {
-      const zodSchema = mapTypeToZodSchema(stmt.typeHint, this.getVisibleTypeAliases());
+      const zodSchema = mapTypeToValidationSchema(stmt.typeHint, this.getVisibleTypeAliases());
       nodes.push(
         ts.runnerStep({
           id: baseId + stages.length,

--- a/lib/backends/typescriptGenerator/typeToString.ts
+++ b/lib/backends/typescriptGenerator/typeToString.ts
@@ -52,6 +52,7 @@ export function variableTypeToString(
     const s = variableTypeToString(variableType.successType, typeAliases);
     const f = variableTypeToString(variableType.failureType, typeAliases);
     if (s === "any" && f === "any") return "Result";
+    if (f === "string") return `Result<${s}>`;
     return `Result<${s}, ${f}>`;
   }
   return "unknown";

--- a/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -5,19 +5,18 @@ import { escape } from "../../utils.js";
 export const DEFAULT_SCHEMA = "z.string()";
 
 /**
- * Maps Agency types to Zod schema strings
+ * Internal recursive schema mapper. The `resultHandler` parameter controls
+ * how Result types are converted:
+ * - For LLM structured output: returns just the success type schema
+ * - For validation: returns a schema that validates the full Result shape
  */
-export function mapTypeToZodSchema(
+function mapTypeToSchema(
   variableType: VariableType,
   typeAliases: Record<string, VariableType>,
+  resultHandler: (vt: VariableType, ta: Record<string, VariableType>) => string,
 ): string {
-  /* console.log(
-    color.yellow(
-      `Variable type is`,
-      JSON.stringify(variableType),
-    ),
-  );
- */
+  const recurse = (vt: VariableType) => mapTypeToSchema(vt, typeAliases, resultHandler);
+
   if (!variableType) {
     throw new Error(
       `Received undefined variableType. typeAliases: ${JSON.stringify(typeAliases)}`,
@@ -34,7 +33,6 @@ export function mapTypeToZodSchema(
       case "null":
         return "z.null()";
       case "undefined":
-        // Undefined cannot be represented in JSON Schema
         return "z.null()";
       case "any":
         return "z.any()";
@@ -43,16 +41,10 @@ export function mapTypeToZodSchema(
       case "object":
         return "z.record(z.string(), z.any())";
       default:
-        // Default to string for unknown types
         return DEFAULT_SCHEMA;
     }
   } else if (variableType.type === "arrayType") {
-    // Recursively handle array element type
-    const elementSchema = mapTypeToZodSchema(
-      variableType.elementType,
-      typeAliases,
-    );
-    return `z.array(${elementSchema})`;
+    return `z.array(${recurse(variableType.elementType)})`;
   } else if (variableType.type === "stringLiteralType") {
     return `z.literal("${variableType.value.replace(/"/g, '\\"')}")`;
   } else if (variableType.type === "numberLiteralType") {
@@ -60,17 +52,12 @@ export function mapTypeToZodSchema(
   } else if (variableType.type === "booleanLiteralType") {
     return `z.literal(${variableType.value})`;
   } else if (variableType.type === "unionType") {
-    const unionSchemas = variableType.types.map((t) =>
-      mapTypeToZodSchema(t, typeAliases),
-    );
-    return `z.union([${unionSchemas.join(", ")}])`;
+    const schemas = variableType.types.map(recurse);
+    return `z.union([${schemas.join(", ")}])`;
   } else if (variableType.type === "objectType") {
     const props = variableType.properties
       .map((prop) => {
-        let str = `"${prop.key.replace(/"/g, '\\"')}": ${mapTypeToZodSchema(
-          prop.value,
-          typeAliases,
-        )}`;
+        let str = `"${prop.key.replace(/"/g, '\\"')}": ${recurse(prop.value)}`;
         if (prop.description) {
           str += `.describe("${escape(prop.description)}")`;
         }
@@ -79,61 +66,44 @@ export function mapTypeToZodSchema(
       .join(", ");
     return `z.object({ ${props} })`;
   } else if (variableType.type === "resultType") {
-    return mapTypeToZodSchema(variableType.successType, typeAliases);
+    return resultHandler(variableType, typeAliases);
   } else if (variableType.type === "typeAliasVariable") {
     if (!typeAliases || !typeAliases[variableType.aliasName]) {
       throw new Error(
         `Type alias '${variableType.aliasName}' not found in provided type aliases: ${JSON.stringify(typeAliases)}`,
       );
     }
-    return mapTypeToZodSchema(typeAliases[variableType.aliasName], typeAliases);
+    return recurse(typeAliases[variableType.aliasName]);
   }
 
-  // Fallback (should never reach here)
   return "z.string()";
 }
 
 /**
+ * Maps Agency types to Zod schema strings for LLM structured output.
+ * For Result types, returns only the success type schema (the LLM
+ * doesn't return Result objects).
+ */
+export function mapTypeToZodSchema(
+  variableType: VariableType,
+  typeAliases: Record<string, VariableType>,
+): string {
+  return mapTypeToSchema(variableType, typeAliases, (vt, ta) =>
+    mapTypeToZodSchema((vt as any).successType, ta),
+  );
+}
+
+/**
  * Maps Agency types to Zod schema strings for validation contexts.
- * Unlike mapTypeToZodSchema (used for LLM structured output), this generates
- * schemas that validate the full Result structure rather than just the success type.
+ * For Result types, generates a schema that validates the full Result
+ * structure ({success: true, value: T} | {success: false, error: any}).
  */
 export function mapTypeToValidationSchema(
   variableType: VariableType,
   typeAliases: Record<string, VariableType>,
 ): string {
-  if (variableType.type === "resultType") {
-    const successSchema = mapTypeToValidationSchema(variableType.successType, typeAliases);
+  return mapTypeToSchema(variableType, typeAliases, (vt, ta) => {
+    const successSchema = mapTypeToValidationSchema((vt as any).successType, ta);
     return `z.union([z.object({ success: z.literal(true), value: ${successSchema} }), z.object({ success: z.literal(false), error: z.any() })])`;
-  }
-  if (variableType.type === "typeAliasVariable") {
-    if (!typeAliases || !typeAliases[variableType.aliasName]) {
-      throw new Error(
-        `Type alias '${variableType.aliasName}' not found in provided type aliases: ${JSON.stringify(typeAliases)}`,
-      );
-    }
-    return mapTypeToValidationSchema(typeAliases[variableType.aliasName], typeAliases);
-  }
-  // Recurse into composite types so nested Result types are handled correctly
-  if (variableType.type === "arrayType") {
-    return `z.array(${mapTypeToValidationSchema(variableType.elementType, typeAliases)})`;
-  }
-  if (variableType.type === "unionType") {
-    const schemas = variableType.types.map((t) => mapTypeToValidationSchema(t, typeAliases));
-    return `z.union([${schemas.join(", ")}])`;
-  }
-  if (variableType.type === "objectType") {
-    const props = variableType.properties
-      .map((prop) => {
-        let str = `"${prop.key.replace(/"/g, '\\"')}": ${mapTypeToValidationSchema(prop.value, typeAliases)}`;
-        if (prop.description) {
-          str += `.describe("${escape(prop.description)}")`;
-        }
-        return str;
-      })
-      .join(", ");
-    return `z.object({ ${props} })`;
-  }
-  // Leaf types (primitives, literals) — delegate to existing function
-  return mapTypeToZodSchema(variableType, typeAliases);
+  });
 }

--- a/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -114,5 +114,26 @@ export function mapTypeToValidationSchema(
     }
     return mapTypeToValidationSchema(typeAliases[variableType.aliasName], typeAliases);
   }
+  // Recurse into composite types so nested Result types are handled correctly
+  if (variableType.type === "arrayType") {
+    return `z.array(${mapTypeToValidationSchema(variableType.elementType, typeAliases)})`;
+  }
+  if (variableType.type === "unionType") {
+    const schemas = variableType.types.map((t) => mapTypeToValidationSchema(t, typeAliases));
+    return `z.union([${schemas.join(", ")}])`;
+  }
+  if (variableType.type === "objectType") {
+    const props = variableType.properties
+      .map((prop) => {
+        let str = `"${prop.key.replace(/"/g, '\\"')}": ${mapTypeToValidationSchema(prop.value, typeAliases)}`;
+        if (prop.description) {
+          str += `.describe("${escape(prop.description)}")`;
+        }
+        return str;
+      })
+      .join(", ");
+    return `z.object({ ${props} })`;
+  }
+  // Leaf types (primitives, literals) — delegate to existing function
   return mapTypeToZodSchema(variableType, typeAliases);
 }

--- a/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -92,3 +92,27 @@ export function mapTypeToZodSchema(
   // Fallback (should never reach here)
   return "z.string()";
 }
+
+/**
+ * Maps Agency types to Zod schema strings for validation contexts.
+ * Unlike mapTypeToZodSchema (used for LLM structured output), this generates
+ * schemas that validate the full Result structure rather than just the success type.
+ */
+export function mapTypeToValidationSchema(
+  variableType: VariableType,
+  typeAliases: Record<string, VariableType>,
+): string {
+  if (variableType.type === "resultType") {
+    const successSchema = mapTypeToValidationSchema(variableType.successType, typeAliases);
+    return `z.union([z.object({ success: z.literal(true), value: ${successSchema} }), z.object({ success: z.literal(false), error: z.any() })])`;
+  }
+  if (variableType.type === "typeAliasVariable") {
+    if (!typeAliases || !typeAliases[variableType.aliasName]) {
+      throw new Error(
+        `Type alias '${variableType.aliasName}' not found in provided type aliases: ${JSON.stringify(typeAliases)}`,
+      );
+    }
+    return mapTypeToValidationSchema(typeAliases[variableType.aliasName], typeAliases);
+  }
+  return mapTypeToZodSchema(variableType, typeAliases);
+}

--- a/lib/parsers/expression.test.ts
+++ b/lib/parsers/expression.test.ts
@@ -404,4 +404,39 @@ describe("exprParser", () => {
       }
     });
   });
+
+  describe("schema expressions", () => {
+    it("should parse schema(number)", () => {
+      const result = exprParser("schema(number)");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.type).toBe("schemaExpression");
+        if (result.result.type === "schemaExpression") {
+          expect(result.result.typeArg).toEqual({ type: "primitiveType", value: "number" });
+        }
+      }
+    });
+
+    it("should parse schema(Result<number>)", () => {
+      const result = exprParser("schema(Result<number>)");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.type).toBe("schemaExpression");
+        if (result.result.type === "schemaExpression") {
+          expect(result.result.typeArg.type).toBe("resultType");
+        }
+      }
+    });
+
+    it("should parse schema({name: string, age: number})", () => {
+      const result = exprParser("schema({name: string, age: number})");
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.result.type).toBe("schemaExpression");
+        if (result.result.type === "schemaExpression") {
+          expect(result.result.typeArg.type).toBe("objectType");
+        }
+      }
+    });
+  });
 });

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -816,22 +816,30 @@ export const blockTypeParser: Parser<BlockType> = trace(
 export const resultTypeParser: Parser<ResultType> = trace(
   "resultTypeParser",
   or(
-    // Result<SuccessType, FailureType>
+    // Result<SuccessType, FailureType> — two type params
     seqC(
       set("type", "resultType"),
       str("Result"),
       char("<"),
-      captureCaptures(
-        parseError(
-          "expected two type parameters separated by comma, e.g. `Result<string, number>`",
-          capture(lazy(() => variableTypeParser), "successType"),
-          optionalSpaces,
-          char(","),
-          optionalSpaces,
-          capture(lazy(() => variableTypeParser), "failureType"),
-          char(">"),
-        ),
-      ),
+      captureCaptures(seqC(
+        capture(lazy(() => variableTypeParser), "successType"),
+        optionalSpaces,
+        char(","),
+        optionalSpaces,
+        capture(lazy(() => variableTypeParser), "failureType"),
+        char(">"),
+      )),
+    ),
+    // Result<SuccessType> — single type param (sugar for Result<SuccessType, string>)
+    seqC(
+      set("type", "resultType"),
+      str("Result"),
+      char("<"),
+      captureCaptures(seqC(
+        capture(lazy(() => variableTypeParser), "successType"),
+        char(">"),
+      )),
+      set("failureType", { type: "primitiveType", value: "string" }),
     ),
     // Bare Result (sugar for Result<any, any>)
     // Use not(varNameChar) to avoid matching "ResultFoo" as bare Result

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -104,6 +104,7 @@ import { BinOpExpression, Operator } from "../types/binop.js";
 import { Placeholder } from "../types/placeholder.js";
 import { TryExpression } from "../types/tryExpression.js";
 import { ClassDefinition, ClassField, ClassMethod, NewExpression } from "../types/classDefinition.js";
+import { SchemaExpression } from "../types/schemaExpression.js";
 import { ReturnStatement } from "../types/returnStatement.js";
 import { DebuggerStatement } from "../types/debuggerStatement.js";
 import { Keyword, keywords, createKeyword } from "@/types/keyword.js";
@@ -1435,12 +1436,26 @@ export const newExpressionParser: Parser<NewExpression> = (input: string) => {
 };
 
 // The base atom parser: the smallest unit of an expression.
+export const schemaExpressionParser: Parser<SchemaExpression> = trace(
+  "schemaExpressionParser",
+  seqC(
+    set("type", "schemaExpression"),
+    str("schema"),
+    char("("),
+    optionalSpaces,
+    capture(variableTypeParser, "typeArg"),
+    optionalSpaces,
+    char(")"),
+  ),
+);
+
 const baseAtom: Parser<Expression> = or(
   unaryTypeofParser,
   unaryVoidParser,
   unaryNotParser,
   tryExpressionParser,
   newExpressionParser,
+  schemaExpressionParser,
   placeholderParser,
   lazy(() => agencyArrayParser),
   lazy(() => agencyObjectParser),

--- a/lib/parsers/typeHints.test.ts
+++ b/lib/parsers/typeHints.test.ts
@@ -2428,10 +2428,16 @@ describe("resultTypeParser", () => {
     }
   });
 
-  it("Result<string> with one param throws a parse error", () => {
-    expect(() => resultTypeParser("Result<string>")).toThrow(
-      "expected two type parameters separated by comma",
-    );
+  it("parses Result<Foo> with single type param as sugar for Result<Foo, string>", () => {
+    const result = resultTypeParser("Result<number>");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toEqual({
+        type: "resultType",
+        successType: { type: "primitiveType", value: "number" },
+        failureType: { type: "primitiveType", value: "string" },
+      });
+    }
   });
 
   it("does not match ResultFoo as bare Result", () => {

--- a/lib/runtime/schema.test.ts
+++ b/lib/runtime/schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Schema, __validateType } from "./schema.js";
+import { failure } from "./result.js";
 import { z } from "zod";
 
 describe("Schema", () => {
@@ -67,5 +68,17 @@ describe("__validateType", () => {
     const result = __validateType({ name: "Alice" }, z.object({ name: z.string() }));
     expect(result.success).toBe(true);
     expect(result.success && result.value).toEqual({ name: "Alice" });
+  });
+
+  it("passes through failure Results unchanged", () => {
+    const f = failure("something went wrong");
+    const result = __validateType(f, z.number());
+    expect(result.success).toBe(false);
+    expect(result).toBe(f);
+  });
+
+  it("still validates non-failure values normally", () => {
+    const result = __validateType("not a number", z.number());
+    expect(result.success).toBe(false);
   });
 });

--- a/lib/runtime/schema.test.ts
+++ b/lib/runtime/schema.test.ts
@@ -81,4 +81,16 @@ describe("__validateType", () => {
     const result = __validateType("not a number", z.number());
     expect(result.success).toBe(false);
   });
+
+  it("returns Result directly when value is already a valid Result (no double-wrapping)", () => {
+    const resultSchema = z.union([
+      z.object({ success: z.literal(true), value: z.number() }),
+      z.object({ success: z.literal(false), error: z.any() }),
+    ]);
+    const original = { success: true as const, value: 42 };
+    const result = __validateType(original, resultSchema);
+    // Should return the Result directly, not success({success: true, value: 42})
+    expect(result).toEqual({ success: true, value: 42 });
+    expect((result as any).value).toBe(42);
+  });
 });

--- a/lib/runtime/schema.ts
+++ b/lib/runtime/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { success, failure } from "./result.js";
+import { success, failure, isFailure } from "./result.js";
 import type { ResultValue, ResultFailure } from "./result.js";
 
 export class Schema {
@@ -25,8 +25,8 @@ export class Schema {
 }
 
 export function __validateType(value: unknown, schema: z.ZodType): ResultValue {
-  // Universal rule: failures always pass through unchanged
-  if (value != null && typeof value === "object" && "success" in value && (value as any).success === false) {
+  // Don't validate failures — surface the original error, not a schema mismatch
+  if (isFailure(value as any)) {
     return value as ResultFailure;
   }
   const result = schema.safeParse(value);

--- a/lib/runtime/schema.ts
+++ b/lib/runtime/schema.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { success, failure, isFailure } from "./result.js";
+import { success, failure, isFailure, isSuccess } from "./result.js";
 import type { ResultValue, ResultFailure } from "./result.js";
 
 export class Schema {
@@ -31,6 +31,12 @@ export function __validateType(value: unknown, schema: z.ZodType): ResultValue {
   }
   const result = schema.safeParse(value);
   if (result.success) {
+    // If the validated value is already a Result, return it directly
+    // instead of wrapping it in another success(). This avoids double-wrapping
+    // when validating with Result types (e.g. const r: Result! = compute()).
+    if (isSuccess(result.data as any) || isFailure(result.data as any)) {
+      return result.data as ResultValue;
+    }
     return success(result.data);
   }
   return failure(result.error.message);

--- a/lib/runtime/schema.ts
+++ b/lib/runtime/schema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { success, failure } from "./result.js";
-import type { ResultValue } from "./result.js";
+import type { ResultValue, ResultFailure } from "./result.js";
 
 export class Schema {
   private zodSchema: z.ZodType;
@@ -25,6 +25,10 @@ export class Schema {
 }
 
 export function __validateType(value: unknown, schema: z.ZodType): ResultValue {
+  // Universal rule: failures always pass through unchanged
+  if (value != null && typeof value === "object" && "success" in value && (value as any).success === false) {
+    return value as ResultFailure;
+  }
   const result = schema.safeParse(value);
   if (result.success) {
     return success(result.data);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -33,6 +33,7 @@ import { WithModifier } from "./types/withModifier.js";
 import { Tag } from "./types/tag.js";
 import { TryExpression } from "./types/tryExpression.js";
 import { ClassDefinition, ClassField, ClassMethod, NewExpression } from "./types/classDefinition.js";
+import { SchemaExpression } from "./types/schemaExpression.js";
 export * from "./types/access.js";
 export * from "./types/awaitPending.js";
 export * from "./types/dataStructures.js";
@@ -58,6 +59,7 @@ export * from "./types/base.js";
 export * from "./types/tag.js";
 export type { TryExpression } from "./types/tryExpression.js";
 export * from "./types/classDefinition.js";
+export * from "./types/schemaExpression.js";
 
 export type Expression =
   | ValueAccess
@@ -69,7 +71,8 @@ export type Expression =
   | Placeholder
   | TryExpression
   | NewExpression
-  | RegexLiteral;
+  | RegexLiteral
+  | SchemaExpression;
 
 /**
  * Scope types for variable resolution.
@@ -244,7 +247,8 @@ export type AgencyNode =
   | ClassMethod
   | ClassField
   | NewExpression
-  | RegexLiteral;
+  | RegexLiteral
+  | SchemaExpression;
 
 export type AgencyProgram = {
   type: "agencyProgram";

--- a/lib/types/schemaExpression.ts
+++ b/lib/types/schemaExpression.ts
@@ -1,0 +1,7 @@
+import { BaseNode } from "./base.js";
+import { VariableType } from "./typeHints.js";
+
+export type SchemaExpression = BaseNode & {
+  type: "schemaExpression";
+  typeArg: VariableType;
+};

--- a/lib/utils/node.ts
+++ b/lib/utils/node.ts
@@ -118,6 +118,8 @@ export function expressionToString(expr: Expression): string {
     }
     case "regex":
       return `/${expr.pattern}/${expr.flags}`;
+    case "schemaExpression":
+      return `schema(...)`;
   }
 }
 

--- a/lib/utils/node.ts
+++ b/lib/utils/node.ts
@@ -13,6 +13,7 @@ import {
   nodeScope,
   Scope,
 } from "@/types.js";
+import { variableTypeToString } from "@/backends/typescriptGenerator/typeToString.js";
 import { color } from "@/utils/termcolors.js";
 
 /** Unwrap a function call argument to its inner expression. */
@@ -119,7 +120,7 @@ export function expressionToString(expr: Expression): string {
     case "regex":
       return `/${expr.pattern}/${expr.flags}`;
     case "schemaExpression":
-      return `schema(...)`;
+      return `schema(${variableTypeToString(expr.typeArg, {})})`;
   }
 }
 

--- a/tests/agency/validation/bangResultType.agency
+++ b/tests/agency/validation/bangResultType.agency
@@ -5,12 +5,7 @@ def compute(): Result {
 node main() {
   const r: Result! = compute()
   if (isSuccess(r)) {
-    const inner = r.value
-    if (isSuccess(inner)) {
-      if (inner.value == 42) {
-        return "double-wrapped correctly"
-      }
-    }
+    return r.value
   }
-  return "not double-wrapped"
+  return "failed"
 }

--- a/tests/agency/validation/bangResultType.agency
+++ b/tests/agency/validation/bangResultType.agency
@@ -1,0 +1,16 @@
+def compute(): Result {
+  return success(42)
+}
+
+node main() {
+  const r: Result! = compute()
+  if (isSuccess(r)) {
+    const inner = r.value
+    if (isSuccess(inner)) {
+      if (inner.value == 42) {
+        return "double-wrapped correctly"
+      }
+    }
+  }
+  return "not double-wrapped"
+}

--- a/tests/agency/validation/bangResultType.test.json
+++ b/tests/agency/validation/bangResultType.test.json
@@ -3,9 +3,9 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "\"double-wrapped correctly\"",
+      "expectedOutput": "42",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "Result! validates value is a Result and double-wraps it"
+      "description": "Result! validates value is a Result and returns it directly (no double-wrapping)"
     }
   ]
 }

--- a/tests/agency/validation/bangResultType.test.json
+++ b/tests/agency/validation/bangResultType.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"double-wrapped correctly\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Result! validates value is a Result and double-wraps it"
+    }
+  ]
+}

--- a/tests/agency/validation/bangResultTypeFail.agency
+++ b/tests/agency/validation/bangResultTypeFail.agency
@@ -1,0 +1,7 @@
+node main() {
+  const r: Result! = 42
+  if (isFailure(r)) {
+    return "correctly rejected"
+  }
+  return "unexpected"
+}

--- a/tests/agency/validation/bangResultTypeFail.test.json
+++ b/tests/agency/validation/bangResultTypeFail.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"correctly rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Result! rejects non-Result values"
+    }
+  ]
+}

--- a/tests/agency/validation/bangResultTypedInvalid.agency
+++ b/tests/agency/validation/bangResultTypedInvalid.agency
@@ -1,0 +1,9 @@
+type NumberResult = Result<number>
+
+node main() {
+  const r: NumberResult! = success("not a number")
+  if (isFailure(r)) {
+    return "correctly rejected"
+  }
+  return "unexpected"
+}

--- a/tests/agency/validation/bangResultTypedInvalid.test.json
+++ b/tests/agency/validation/bangResultTypedInvalid.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"correctly rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Result<number>! rejects success with wrong inner type"
+    }
+  ]
+}

--- a/tests/agency/validation/bangResultTypedValid.agency
+++ b/tests/agency/validation/bangResultTypedValid.agency
@@ -1,0 +1,12 @@
+type NumberResult = Result<number>
+
+node main() {
+  const r: NumberResult! = success(42)
+  if (isSuccess(r)) {
+    const inner = r.value
+    if (isSuccess(inner)) {
+      return inner.value
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/bangResultTypedValid.agency
+++ b/tests/agency/validation/bangResultTypedValid.agency
@@ -3,10 +3,7 @@ type NumberResult = Result<number>
 node main() {
   const r: NumberResult! = success(42)
   if (isSuccess(r)) {
-    const inner = r.value
-    if (isSuccess(inner)) {
-      return inner.value
-    }
+    return r.value
   }
   return "failed"
 }

--- a/tests/agency/validation/bangResultTypedValid.test.json
+++ b/tests/agency/validation/bangResultTypedValid.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "42",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Result<number>! validates inner value matches number"
+    }
+  ]
+}

--- a/tests/agency/validation/bangResultTypedValid.test.json
+++ b/tests/agency/validation/bangResultTypedValid.test.json
@@ -5,7 +5,7 @@
       "input": "",
       "expectedOutput": "42",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "Result<number>! validates inner value matches number"
+      "description": "Result<number>! validates inner value and returns the Result directly"
     }
   ]
 }

--- a/tests/agency/validation/failurePassthrough.agency
+++ b/tests/agency/validation/failurePassthrough.agency
@@ -1,0 +1,22 @@
+def mayFail(x: number): Result {
+  if (x == 0) {
+    return failure("zero!")
+  }
+  return success(x * 10)
+}
+
+def validate(x: number!) {
+  return x + 1
+}
+
+node main() {
+  const f = mayFail(0)
+  const assignResult: number! = f
+  const paramResult = validate(f)
+  if (isFailure(assignResult)) {
+    if (isFailure(paramResult)) {
+      return assignResult.error
+    }
+  }
+  return "unexpected"
+}

--- a/tests/agency/validation/failurePassthrough.test.json
+++ b/tests/agency/validation/failurePassthrough.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"zero!\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Failure Results pass through ! validation unchanged, preserving original error"
+    }
+  ]
+}

--- a/tests/agency/validation/failurePassthroughPipe.agency
+++ b/tests/agency/validation/failurePassthroughPipe.agency
@@ -1,0 +1,15 @@
+def double(x: number): Result {
+  return success(x * 2)
+}
+
+def alwaysFail(x: number): Result {
+  return failure("pipe failed")
+}
+
+node main() {
+  const result: number! = success(5) |> double |> alwaysFail
+  if (isFailure(result)) {
+    return result.error
+  }
+  return "unexpected"
+}

--- a/tests/agency/validation/failurePassthroughPipe.test.json
+++ b/tests/agency/validation/failurePassthroughPipe.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pipe failed\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Failure from pipe chain passes through ! validation"
+    }
+  ]
+}

--- a/tests/agency/validation/failurePassthroughReturn.agency
+++ b/tests/agency/validation/failurePassthroughReturn.agency
@@ -1,0 +1,16 @@
+def inner(): Result {
+  return failure("inner failed")
+}
+
+def outer(): number! {
+  const result = inner()
+  return result
+}
+
+node main() {
+  const r = outer()
+  if (isFailure(r)) {
+    return r.error
+  }
+  return "unexpected"
+}

--- a/tests/agency/validation/failurePassthroughReturn.test.json
+++ b/tests/agency/validation/failurePassthroughReturn.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"inner failed\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Failure passes through ! return type validation"
+    }
+  ]
+}

--- a/tests/agency/validation/schemaAccess.agency
+++ b/tests/agency/validation/schemaAccess.agency
@@ -1,8 +1,8 @@
 type Category = "bug" | "feature"
 
 node main() {
-  const schema = Category.schema
-  const good = schema.parse("bug")
+  const s = schema(Category)
+  const good = s.parse("bug")
   if (isSuccess(good)) {
     return good.value
   }

--- a/tests/agency/validation/schemaBuiltin.agency
+++ b/tests/agency/validation/schemaBuiltin.agency
@@ -1,5 +1,5 @@
 node main() {
-  const numSchema = number.schema
+  const numSchema = schema(number)
   const good = numSchema.parse(42)
   const bad = numSchema.parse("hello")
   if (isSuccess(good)) {

--- a/tests/agency/validation/schemaBuiltinTypes.agency
+++ b/tests/agency/validation/schemaBuiltinTypes.agency
@@ -1,6 +1,6 @@
 node main() {
-  const strSchema = string.schema
-  const boolSchema = boolean.schema
+  const strSchema = schema(string)
+  const boolSchema = schema(boolean)
 
   const strGood = strSchema.parse("hello")
   const strBad = strSchema.parse(42)

--- a/tests/agency/validation/schemaFailurePath.agency
+++ b/tests/agency/validation/schemaFailurePath.agency
@@ -1,8 +1,8 @@
 type Color = "red" | "green" | "blue"
 
 node main() {
-  const schema = Color.schema
-  const result = schema.parse("yellow")
+  const s = schema(Color)
+  const result = s.parse("yellow")
   if (isFailure(result)) {
     return "correctly rejected"
   }

--- a/tests/agency/validation/schemaNestedResultArray.agency
+++ b/tests/agency/validation/schemaNestedResultArray.agency
@@ -1,0 +1,14 @@
+type NumResult = Result<number>
+type ResultArray = NumResult[]
+
+node main() {
+  const s = schema(ResultArray)
+  const good = s.parse([success(1), success(2)])
+  const bad = s.parse([success("not a number")])
+  if (isSuccess(good)) {
+    if (isFailure(bad)) {
+      return "nested array works"
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/schemaNestedResultArray.test.json
+++ b/tests/agency/validation/schemaNestedResultArray.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"nested array works\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "schema() validates Result types nested inside arrays"
+    }
+  ]
+}

--- a/tests/agency/validation/schemaNestedResultObject.agency
+++ b/tests/agency/validation/schemaNestedResultObject.agency
@@ -1,0 +1,15 @@
+type Wrapper = {
+  result: Result<string>
+}
+
+node main() {
+  const s = schema(Wrapper)
+  const good = s.parse({result: success("hello")})
+  const bad = s.parse({result: success(42)})
+  if (isSuccess(good)) {
+    if (isFailure(bad)) {
+      return "nested object works"
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/schemaNestedResultObject.test.json
+++ b/tests/agency/validation/schemaNestedResultObject.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"nested object works\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "schema() validates Result types nested inside objects"
+    }
+  ]
+}

--- a/tests/agency/validation/schemaNestedResultUnion.agency
+++ b/tests/agency/validation/schemaNestedResultUnion.agency
@@ -1,0 +1,16 @@
+type MaybeResult = Result<number> | string
+
+node main() {
+  const s = schema(MaybeResult)
+  const goodResult = s.parse(success(42))
+  const goodString = s.parse("hello")
+  const badResult = s.parse(success("not a number"))
+  if (isSuccess(goodResult)) {
+    if (isSuccess(goodString)) {
+      if (isFailure(badResult)) {
+        return "nested union works"
+      }
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/schemaNestedResultUnion.test.json
+++ b/tests/agency/validation/schemaNestedResultUnion.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"nested union works\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "schema() validates Result types nested inside unions"
+    }
+  ]
+}

--- a/tests/agency/validation/schemaObjectType.agency
+++ b/tests/agency/validation/schemaObjectType.agency
@@ -4,11 +4,11 @@ type Config = {
 }
 
 node main() {
-  const schema = Config.schema
+  const s = schema(Config)
   const goodObj = {host: "localhost", port: 8080}
   const badObj = {host: "localhost", port: "not a number"}
-  const good = schema.parse(goodObj)
-  const bad = schema.parse(badObj)
+  const good = s.parse(goodObj)
+  const bad = s.parse(badObj)
   if (isSuccess(good)) {
     if (isFailure(bad)) {
       return good.value.host

--- a/tests/agency/validation/schemaParseFailure.agency
+++ b/tests/agency/validation/schemaParseFailure.agency
@@ -1,0 +1,9 @@
+node main() {
+  const s = schema(number)
+  const f = failure("original error")
+  const result = s.parse(f)
+  if (isFailure(result)) {
+    return result.error
+  }
+  return "unexpected"
+}

--- a/tests/agency/validation/schemaParseFailure.test.json
+++ b/tests/agency/validation/schemaParseFailure.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"original error\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Schema.parse passes through failure Results unchanged"
+    }
+  ]
+}

--- a/tests/agency/validation/schemaParseJSON.agency
+++ b/tests/agency/validation/schemaParseJSON.agency
@@ -1,7 +1,7 @@
 node main() {
-  const schema = number.schema
-  const good = schema.parseJSON("42")
-  const bad = schema.parseJSON("not json")
+  const s = schema(number)
+  const good = s.parseJSON("42")
+  const bad = s.parseJSON("not json")
   if (isSuccess(good)) {
     if (isFailure(bad)) {
       return good.value

--- a/tests/agency/validation/schemaResultBare.agency
+++ b/tests/agency/validation/schemaResultBare.agency
@@ -1,0 +1,11 @@
+node main() {
+  const s = schema(Result)
+  const good = s.parse(success(42))
+  const bad = s.parse("not a result")
+  if (isSuccess(good)) {
+    if (isFailure(bad)) {
+      return "works"
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/schemaResultBare.test.json
+++ b/tests/agency/validation/schemaResultBare.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"works\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "schema(Result) validates Result objects"
+    }
+  ]
+}

--- a/tests/agency/validation/schemaResultGeneric.agency
+++ b/tests/agency/validation/schemaResultGeneric.agency
@@ -1,0 +1,11 @@
+node main() {
+  const s = schema(Result<number>)
+  const good = s.parse(success(42))
+  const bad = s.parse(success("nope"))
+  if (isSuccess(good)) {
+    if (isFailure(bad)) {
+      return "generic works"
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/schemaResultGeneric.test.json
+++ b/tests/agency/validation/schemaResultGeneric.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"generic works\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "schema(Result<number>) works directly without type alias"
+    }
+  ]
+}

--- a/tests/agency/validation/schemaResultTyped.agency
+++ b/tests/agency/validation/schemaResultTyped.agency
@@ -1,0 +1,16 @@
+type NumberResult = Result<number>
+
+node main() {
+  const s = schema(NumberResult)
+  const good = s.parse(success(42))
+  const badValue = s.parse(success("not a number"))
+  const notResult = s.parse("hello")
+  if (isSuccess(good)) {
+    if (isFailure(badValue)) {
+      if (isFailure(notResult)) {
+        return "all correct"
+      }
+    }
+  }
+  return "failed"
+}

--- a/tests/agency/validation/schemaResultTyped.test.json
+++ b/tests/agency/validation/schemaResultTyped.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"all correct\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "schema(Result<number>) validates Result shape and inner type"
+    }
+  ]
+}

--- a/tests/typescriptGenerator/schemaAccess.agency
+++ b/tests/typescriptGenerator/schemaAccess.agency
@@ -1,7 +1,7 @@
 type Category = "bug" | "feature" | "docs"
 
 node main() {
-  const schema = Category.schema
-  const result = schema.parse("bug")
+  const s = schema(Category)
+  const result = s.parse("bug")
   print(result)
 }

--- a/tests/typescriptGenerator/schemaAccess.mjs
+++ b/tests/typescriptGenerator/schemaAccess.mjs
@@ -123,10 +123,10 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "schemaAccess.agency", scopeName: "main" });
   try {
     await runner.step(0, async (runner) => {
-__stack.locals.schema = Category.schema;
+__stack.locals.s = new Schema(z.union([z.literal("bug"), z.literal("feature"), z.literal("docs")]));
     });
     await runner.step(1, async (runner) => {
-__stack.locals.result = await __stack.locals.schema.parse(`bug`);
+__stack.locals.result = await __stack.locals.s.parse(`bug`);
     });
     await runner.step(2, async (runner) => {
 await print(__stack.locals.result)

--- a/tests/typescriptGenerator/schemaAccess.mjs
+++ b/tests/typescriptGenerator/schemaAccess.mjs
@@ -123,7 +123,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "schemaAccess.agency", scopeName: "main" });
   try {
     await runner.step(0, async (runner) => {
-__stack.locals.schema = new Schema(z.union([z.literal("bug"), z.literal("feature"), z.literal("docs")]));
+__stack.locals.schema = Category.schema;
     });
     await runner.step(1, async (runner) => {
 __stack.locals.result = await __stack.locals.schema.parse(`bug`);


### PR DESCRIPTION
## Summary
- **Failure pass-through**: `__validateType` now returns failure Results unchanged — failures are never re-validated, preserving the original error message. This applies universally to `!` assignments, params, return types, pipes, and `Schema.parse()`.
- **`Result<Foo>` syntax**: New single-param Result type, sugar for `Result<Foo, string>`. Parser, formatter, and schema generation all support it.
- **`schema(Type)` replaces `TypeName.schema`**: A built-in that takes a type argument parsed in type context, so `schema(Result<number>)` works without ambiguity. The old `.schema` property access is removed.
- **Result validation schemas**: New `mapTypeToValidationSchema` generates Zod schemas that validate the full Result structure (`{success: true, value: T} | {success: false, error: any}`), used by `!` and `schema()`. LLM structured output continues using the original `mapTypeToZodSchema`.

## Test plan
- [x] Unit tests for failure pass-through in `__validateType` (2 tests)
- [x] Unit tests for `mapTypeToValidationSchema` (3 tests)
- [x] Parser tests for `Result<Foo>` single-param syntax + regression tests (3 tests)
- [x] Parser tests for `schema(Type)` expressions (3 tests)
- [x] Generator tests for `Result<Foo>` formatting (4 tests)
- [x] Generator tests for `schema(Type)` formatting (2 tests)
- [x] Builder integration tests for `schema(Type)` compilation (4 tests)
- [x] Execution tests: failure pass-through in assignments, params, returns, pipes (3 tests)
- [x] Execution tests: `Result!`, `Result<Type>!`, `schema(Result)`, `schema(Result<Type>)`, `schema(Result<number>)` direct, `Schema.parse` failure pass-through (8 tests)
- [x] All existing `.schema` tests migrated to `schema()` syntax (6 tests)
- [x] Full vitest suite passes (2036 tests)
- [x] Full execution test suite passes (33 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)