### PR TITLE
Fix debugger stepping through compound constructs

### DIFF
--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -3226,11 +3226,28 @@ export class TypeScriptBuilder {
         currentPart.push(ts.assign(ts.self("__retryable"), ts.bool(false)));
       }
       const processed = this.processStatement(stmt);
-      if (!currentPart) currentPart = [];
-      currentPart.push(processed);
-      if (this._asyncBranchCheckNeeded) {
-        branchKeys[result.length] = this._subStepPath.join("_");
-        this._asyncBranchCheckNeeded = false;
+
+      // Compound constructs (handle, ifElse, loop, etc.) are already
+      // step-level IR nodes with their own Runner method that handles
+      // debug hooks, counter management, and path tracking. Push them
+      // directly to result[] instead of wrapping in another runnerStep.
+      const COMPOUND_RUNNER_KINDS = new Set([
+        "runnerHandle",
+        "runnerIfElse",
+        "runnerLoop",
+        "runnerWhileLoop",
+        "runnerThread",
+      ]);
+      if ("kind" in processed && COMPOUND_RUNNER_KINDS.has((processed as any).kind)) {
+        flushPart();
+        result.push(processed);
+      } else {
+        if (!currentPart) currentPart = [];
+        currentPart.push(processed);
+        if (this._asyncBranchCheckNeeded) {
+          branchKeys[result.length] = this._subStepPath.join("_");
+          this._asyncBranchCheckNeeded = false;
+        }
       }
       this._sourceMapBuilder.record([...this._subStepPath], stmt.loc);
       this._subStepPath.pop();

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -3216,7 +3216,6 @@ export class TypeScriptBuilder {
 
       if (!TYPES_THAT_DONT_TRIGGER_NEW_PART.includes(stmt.type)) {
         flushPart();
-        currentPart = [];
       }
 
       const stepIndex = result.length;

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -104,6 +104,17 @@ import { SourceMapBuilder } from "./sourceMap.js";
 
 const DEFAULT_PROMPT_NAME = "__promptVar";
 
+/** IR node kinds that correspond to compound Runner methods (handle, ifElse, loop, etc.).
+ *  These already have their own debug hooks / counter / path management,
+ *  so processBodyAsParts must NOT wrap them in an extra runnerStep. */
+const COMPOUND_RUNNER_KINDS: ReadonlySet<TsNode["kind"]> = new Set([
+  "runnerHandle",
+  "runnerIfElse",
+  "runnerLoop",
+  "runnerWhileLoop",
+  "runnerThread",
+]);
+
 export class TypeScriptBuilder {
   // Output assembly
   private generatedStatements: TsNode[] = [];
@@ -3230,14 +3241,7 @@ export class TypeScriptBuilder {
       // step-level IR nodes with their own Runner method that handles
       // debug hooks, counter management, and path tracking. Push them
       // directly to result[] instead of wrapping in another runnerStep.
-      const COMPOUND_RUNNER_KINDS = new Set([
-        "runnerHandle",
-        "runnerIfElse",
-        "runnerLoop",
-        "runnerWhileLoop",
-        "runnerThread",
-      ]);
-      if ("kind" in processed && COMPOUND_RUNNER_KINDS.has((processed as any).kind)) {
+      if (COMPOUND_RUNNER_KINDS.has(processed.kind)) {
         flushPart();
         result.push(processed);
       } else {

--- a/lib/debugger/driver.test.ts
+++ b/lib/debugger/driver.test.ts
@@ -628,6 +628,35 @@ describe("DebuggerDriver with loops", () => {
     // then the last interrupt is restored so the user can still interact
     expect(testUI.renderCalls.length).toBe(2);
   });
+
+  it("produces correct step paths without double-nesting", async () => {
+    const mod = await freshImport(loopCompiled);
+    const commands: DebuggerCommand[] = Array(30).fill({ type: "step" });
+    const testUI = new TestDebuggerIO(commands);
+    const driver = makeDriver(mod, testUI);
+    const initialResult = await getInitialResult(mod, driver);
+    await driver.run(initialResult, { interceptConsole: false });
+
+    const mainPaths = testUI.renderCalls
+      .filter((cp) => cp.scopeName === "main")
+      .map((cp) => cp.stepPath);
+
+    for (const sp of mainPaths) {
+      expect(sp).not.toContain("_");
+    }
+    expect(mainPaths).toContain("0");   // sum = 0
+    expect(mainPaths).toContain("1");   // for loop
+    expect(mainPaths).toContain("1.0"); // loop body: sum = sum + i
+    expect(mainPaths).toContain("2");   // return sum
+
+    // Loop body should appear 3 times (range(3) = [0, 1, 2])
+    const loopBodyCount = mainPaths.filter((p) => p === "1.0").length;
+    expect(loopBodyCount).toBe(3);
+
+    const log = testUI.state.getActivityLog();
+    const sourceMapErrors = log.filter((l) => l.includes("No source map entry found"));
+    expect(sourceMapErrors).toEqual([]);
+  });
 });
 
 describe("DebuggerDriver with if/else", () => {
@@ -654,6 +683,30 @@ describe("DebuggerDriver with if/else", () => {
 
     const returnValue = result?.data !== undefined ? result.data : result;
     expect(returnValue).toBe("non-positive");
+  });
+
+  it("produces correct step paths without double-nesting", async () => {
+    const mod = await freshImport(ifElseCompiled);
+    const commands: DebuggerCommand[] = Array(20).fill({ type: "step" });
+    const testUI = new TestDebuggerIO(commands);
+    const driver = makeDriver(mod, testUI);
+    const initialResult = await getInitialResult(mod, driver, 5);
+    await driver.run(initialResult, { interceptConsole: false });
+
+    const mainPaths = testUI.renderCalls
+      .filter((cp) => cp.scopeName === "main")
+      .map((cp) => cp.stepPath);
+
+    for (const sp of mainPaths) {
+      expect(sp).not.toContain("_");
+    }
+    expect(mainPaths).toContain("0");   // ifElse block
+    expect(mainPaths).toContain("0.0"); // then branch body
+    expect(mainPaths).toContain("1");   // return result
+
+    const log = testUI.state.getActivityLog();
+    const sourceMapErrors = log.filter((l) => l.includes("No source map entry found"));
+    expect(sourceMapErrors).toEqual([]);
   });
 });
 

--- a/lib/debugger/driver.test.ts
+++ b/lib/debugger/driver.test.ts
@@ -25,10 +25,13 @@ const ifElseCompiled = path.join(fixtureDir, "if-else-test.ts");
 const nestedAgency = path.join(fixtureDir, "nested-calls-test.agency");
 const nestedCompiled = path.join(fixtureDir, "nested-calls-test.ts");
 
+const handleAgency = path.join(fixtureDir, "handle-test.agency");
+const handleCompiled = path.join(fixtureDir, "handle-test.ts");
+
 // Compile all fixtures once, clean up after all tests
 const allCompiled = [
   stepTestCompiled, fnCallCompiled, interruptCompiled,
-  loopCompiled, ifElseCompiled, nestedCompiled,
+  loopCompiled, ifElseCompiled, nestedCompiled, handleCompiled,
 ];
 
 beforeAll(() => {
@@ -38,6 +41,7 @@ beforeAll(() => {
   compile({ debugger: true }, loopAgency, loopCompiled, { ts: true });
   compile({ debugger: true }, ifElseAgency, ifElseCompiled, { ts: true });
   compile({ debugger: true }, nestedAgency, nestedCompiled, { ts: true });
+  compile({ debugger: true }, handleAgency, handleCompiled, { ts: true });
 });
 
 afterAll(() => {
@@ -890,5 +894,73 @@ describe("DebuggerDriver with loaded single checkpoint", () => {
 
     // Should have at least the initial render + rewind attempt + step
     expect(testUI.renderCalls.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("DebuggerDriver with handle blocks", () => {
+  it("produces correct step paths without double-nesting", async () => {
+    const mod = await freshImport(handleCompiled);
+    const commands: DebuggerCommand[] = Array(20).fill({ type: "step" });
+    const testUI = new TestDebuggerIO(commands);
+    const driver = makeDriver(mod, testUI);
+    const initialResult = await getInitialResult(mod, driver);
+    await driver.run(initialResult, { interceptConsole: false });
+
+    const mainPaths = testUI.renderCalls
+      .filter((cp) => cp.scopeName === "main")
+      .map((cp) => cp.stepPath);
+
+    // No mangled paths with underscores
+    for (const sp of mainPaths) {
+      expect(sp).not.toContain("_");
+    }
+    // Should see the handle block and its body
+    expect(mainPaths).toContain("0");   // const name = "Alice"
+    expect(mainPaths).toContain("1");   // handle block
+    expect(mainPaths).toContain("1.0"); // const greeting = greet(name)
+  });
+
+  it("has no source map errors when stepping through handle block", async () => {
+    const mod = await freshImport(handleCompiled);
+    const commands: DebuggerCommand[] = Array(20).fill({ type: "step" });
+    const testUI = new TestDebuggerIO(commands);
+    const driver = makeDriver(mod, testUI);
+    const initialResult = await getInitialResult(mod, driver);
+    await driver.run(initialResult, { interceptConsole: false });
+
+    const log = testUI.state.getActivityLog();
+    const sourceMapErrors = log.filter((l) => l.includes("No source map entry found"));
+    expect(sourceMapErrors).toEqual([]);
+  });
+
+  it("continue runs through handle block to completion", async () => {
+    const mod = await freshImport(handleCompiled);
+    const commands: DebuggerCommand[] = [{ type: "continue" }];
+    const testUI = new TestDebuggerIO(commands);
+    const driver = makeDriver(mod, testUI);
+    const initialResult = await getInitialResult(mod, driver);
+    const result = await driver.run(initialResult, { interceptConsole: false });
+
+    const returnValue = result?.data !== undefined ? result.data : result;
+    expect(returnValue).toBe("Alice");
+    expect(testUI.renderCalls.length).toBe(2);
+  });
+
+  it("handler approves user interrupt without surfacing to debugger", async () => {
+    const mod = await freshImport(handleCompiled);
+    const commands: DebuggerCommand[] = Array(30).fill({ type: "step" });
+    const testUI = new TestDebuggerIO(commands);
+    const driver = makeDriver(mod, testUI);
+    const initialResult = await getInitialResult(mod, driver);
+    const result = await driver.run(initialResult, { interceptConsole: false });
+
+    const returnValue = result?.data !== undefined ? result.data : result;
+    expect(returnValue).toBe("Alice");
+
+    // The interrupt from greet() should have been handled by the handler,
+    // not surfaced as a user interrupt prompt
+    const log = testUI.state.getActivityLog();
+    const interruptPrompts = log.filter((l) => l.startsWith("Interrupt:"));
+    expect(interruptPrompts).toEqual([]);
   });
 });

--- a/lib/debugger/driver.test.ts
+++ b/lib/debugger/driver.test.ts
@@ -637,13 +637,15 @@ describe("DebuggerDriver with loops", () => {
     const initialResult = await getInitialResult(mod, driver);
     await driver.run(initialResult, { interceptConsole: false });
 
+    // No mangled paths with underscores in any scope
+    for (const cp of testUI.renderCalls) {
+      expect(cp.stepPath).not.toContain("_");
+    }
+
     const mainPaths = testUI.renderCalls
       .filter((cp) => cp.scopeName === "main")
       .map((cp) => cp.stepPath);
 
-    for (const sp of mainPaths) {
-      expect(sp).not.toContain("_");
-    }
     expect(mainPaths).toContain("0");   // sum = 0
     expect(mainPaths).toContain("1");   // for loop
     expect(mainPaths).toContain("1.0"); // loop body: sum = sum + i
@@ -693,13 +695,15 @@ describe("DebuggerDriver with if/else", () => {
     const initialResult = await getInitialResult(mod, driver, 5);
     await driver.run(initialResult, { interceptConsole: false });
 
+    // No mangled paths with underscores in any scope
+    for (const cp of testUI.renderCalls) {
+      expect(cp.stepPath).not.toContain("_");
+    }
+
     const mainPaths = testUI.renderCalls
       .filter((cp) => cp.scopeName === "main")
       .map((cp) => cp.stepPath);
 
-    for (const sp of mainPaths) {
-      expect(sp).not.toContain("_");
-    }
     expect(mainPaths).toContain("0");   // ifElse block
     expect(mainPaths).toContain("0.0"); // then branch body
     expect(mainPaths).toContain("1");   // return result
@@ -959,14 +963,15 @@ describe("DebuggerDriver with handle blocks", () => {
     const initialResult = await getInitialResult(mod, driver);
     await driver.run(initialResult, { interceptConsole: false });
 
+    // No mangled paths with underscores in any scope
+    for (const cp of testUI.renderCalls) {
+      expect(cp.stepPath).not.toContain("_");
+    }
+
     const mainPaths = testUI.renderCalls
       .filter((cp) => cp.scopeName === "main")
       .map((cp) => cp.stepPath);
 
-    // No mangled paths with underscores
-    for (const sp of mainPaths) {
-      expect(sp).not.toContain("_");
-    }
     // Should see the handle block and its body
     expect(mainPaths).toContain("0");   // const name = "Alice"
     expect(mainPaths).toContain("1");   // handle block

--- a/lib/runtime/runner.ts
+++ b/lib/runtime/runner.ts
@@ -273,6 +273,12 @@ export class Runner {
     if (this.shouldSkip()) return;
     if (this.getCounter() > id) return;
 
+    // INVARIANT: Debug interrupts bypass handlers entirely.
+    // maybeDebugHook fires BEFORE pushHandler, so if the debugger pauses
+    // here, the handler is never registered for this step. This is correct:
+    // debug interrupts are internal to the debugger and must not be routed
+    // through user-defined handlers. On resume, the debug flag causes the
+    // hook to be skipped, and pushHandler executes normally.
     if (await this.maybeDebugHook(id)) return;
 
     this.ctx.pushHandler(handlerFn);

--- a/tests/debugger/handle-test.agency
+++ b/tests/debugger/handle-test.agency
@@ -1,0 +1,15 @@
+def greet(name: string): string {
+  return interrupt("Confirm greet ${name}?")
+  return "Hello, ${name}!"
+}
+
+node main() {
+  const name = "Alice"
+  handle {
+    const greeting = greet(name)
+    print(greeting)
+  } with (data) {
+    return approve()
+  }
+  return name
+}

--- a/tests/typescriptGenerator/blockParams.mjs
+++ b/tests/typescriptGenerator/blockParams.mjs
@@ -171,24 +171,22 @@ if (__ctx._pendingArgOverrides) {
     await runner.step(0, async (runner) => {
 __stack.locals.results = [];
     });
-    await runner.step(1, async (runner) => {
-await runner.loop(1, __stack.args.items, async (item, _, runner) => {
+    await runner.loop(1, __stack.args.items, async (item, _, runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = await block(item);
 if (isInterrupt(__stack.locals.result)) {
-            await __ctx.pendingPromises.awaitAll()
-            runner.halt(__stack.locals.result)
-            return;
-          }
-        });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.result)
+          return;
+        }
+      });
 await runner.step(1, async (runner) => {
 __stack.locals.results = await append(__stack.locals.results, __stack.locals.result);
 if (isInterrupt(__stack.locals.results)) {
-            await __ctx.pendingPromises.awaitAll()
-            runner.halt(__stack.locals.results)
-            return;
-          }
-        });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.results)
+          return;
+        }
       });
     });
     await runner.step(2, async (runner) => {

--- a/tests/typescriptGenerator/comments.mjs
+++ b/tests/typescriptGenerator/comments.mjs
@@ -255,8 +255,7 @@ __stack.locals.age = 25;
     await runner.step(4, async (runner) => {
 __stack.locals.status = `active`;
     });
-    await runner.step(5, async (runner) => {
-await runner.ifElse(5, [
+    await runner.ifElse(5, [
 
   {
     condition: async () => __stack.locals.status === `inactive`,
@@ -266,6 +265,7 @@ await print(`Stopped`)
   },
 
 ]);
+    await runner.step(6, async (runner) => {
 //  Final comment at end of file
     });
     if (runner.halted) return runner.haltResult;

--- a/tests/typescriptGenerator/forLoop.mjs
+++ b/tests/typescriptGenerator/forLoop.mjs
@@ -127,33 +127,31 @@ let __functionCompleted = false;
     await runner.step(1, async (runner) => {
 __stack.locals.items = [`a`, `b`, `c`];
     });
-    await runner.step(2, async (runner) => {
-await runner.loop(2, __stack.locals.items, async (item, _, runner) => {
+    await runner.loop(2, __stack.locals.items, async (item, _, runner) => {
 await runner.step(0, async (runner) => {
 await print(item)
-        });
       });
-//  Range-based for loop
     });
     await runner.step(3, async (runner) => {
-await runner.loop(3, Array.from({length: 5 - 0}, (_, __i) => __i + 0), async (i, _, runner) => {
+//  Range-based for loop
+    });
+    await runner.loop(4, Array.from({length: 5 - 0}, (_, __i) => __i + 0), async (i, _, runner) => {
 await runner.step(0, async (runner) => {
 await print(i)
-        });
       });
-//  Indexed for loop
-    });
-    await runner.step(4, async (runner) => {
-__stack.locals.names = [`alice`, `bob`];
     });
     await runner.step(5, async (runner) => {
-await runner.loop(5, __stack.locals.names, async (name, index, runner) => {
+//  Indexed for loop
+    });
+    await runner.step(6, async (runner) => {
+__stack.locals.names = [`alice`, `bob`];
+    });
+    await runner.loop(7, __stack.locals.names, async (name, index, runner) => {
 await runner.step(0, async (runner) => {
 await print(name)
-        });
+      });
 await runner.step(1, async (runner) => {
 await print(index)
-        });
       });
     });
     if (runner.halted) return runner.haltResult;
@@ -203,4 +201,4 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 }
 export default graph
-export const __sourceMap = {"forLoop.agency:main":{"1":{"line":-1,"col":2},"2":{"line":0,"col":2},"3":{"line":5,"col":2},"4":{"line":10,"col":2},"5":{"line":11,"col":2},"2.0":{"line":1,"col":4},"3.0":{"line":6,"col":4},"5.0":{"line":12,"col":4},"5.1":{"line":13,"col":4}}};
+export const __sourceMap = {"forLoop.agency:main":{"1":{"line":-1,"col":2},"2":{"line":0,"col":2},"4":{"line":5,"col":2},"6":{"line":10,"col":2},"7":{"line":11,"col":2},"2.0":{"line":1,"col":4},"4.0":{"line":6,"col":4},"7.0":{"line":12,"col":4},"7.1":{"line":13,"col":4}}};

--- a/tests/typescriptGenerator/ifElse.mjs
+++ b/tests/typescriptGenerator/ifElse.mjs
@@ -127,68 +127,64 @@ let __functionCompleted = false;
     await runner.step(1, async (runner) => {
 __stack.locals.flag = true;
     });
-    await runner.step(2, async (runner) => {
-await runner.ifElse(2, [
+    await runner.ifElse(2, [
 
   {
     condition: async () => __stack.locals.flag,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `condition was true`;
-            });
+          });
     },
   },
 
 ]);
-    });
-    await runner.step(3, async (runner) => {
-await runner.ifElse(3, [
+    await runner.ifElse(3, [
 
   {
     condition: async () => await isReady(),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.status = `ready`;
-            });
+          });
     },
   },
 
 ]);
+    await runner.step(4, async (runner) => {
 //  If statement with property access
     });
-    await runner.step(4, async (runner) => {
+    await runner.step(5, async (runner) => {
 __stack.locals.obj = {
         "active": true
       };
     });
-    await runner.step(5, async (runner) => {
-await runner.ifElse(5, [
+    await runner.ifElse(6, [
 
   {
     condition: async () => __stack.locals.obj.active,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.message = `object is active`;
-            });
+          });
     },
   },
 
 ]);
+    await runner.step(7, async (runner) => {
 //  Nested if statements
     });
-    await runner.step(6, async (runner) => {
+    await runner.step(8, async (runner) => {
 __stack.locals.outer = true;
     });
-    await runner.step(7, async (runner) => {
-await runner.ifElse(7, [
+    await runner.ifElse(9, [
 
   {
     condition: async () => __stack.locals.outer,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.inner = false;
-            });
-await runner.step(1, async (runner) => {
+          });
 await runner.ifElse(1, [
 
   {
@@ -196,16 +192,16 @@ await runner.ifElse(1, [
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.nested = `both true`;
-                    });
+                });
     },
   },
 
 ]);
-            });
     },
   },
 
 ]);
+    await runner.step(10, async (runner) => {
 //  TODO fix
 //  If with index access
 //  arr = [1, 2, 3]
@@ -214,79 +210,78 @@ __stack.locals.nested = `both true`;
 //  }
 //  Multiple statements in then body
     });
-    await runner.step(8, async (runner) => {
+    await runner.step(11, async (runner) => {
 __stack.locals.condition = true;
     });
-    await runner.step(9, async (runner) => {
-await runner.ifElse(9, [
+    await runner.ifElse(12, [
 
   {
     condition: async () => __stack.locals.condition,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.a = 1;
-            });
+          });
 await runner.step(1, async (runner) => {
 __stack.locals.b = 2;
-            });
+          });
 await runner.step(2, async (runner) => {
 __stack.locals.c = 3;
-            });
+          });
     },
   },
 
 ]);
+    await runner.step(13, async (runner) => {
 //  Multiple statements in both then and else bodies
     });
-    await runner.step(10, async (runner) => {
+    await runner.step(14, async (runner) => {
 __stack.locals.value = false;
     });
-    await runner.step(11, async (runner) => {
-await runner.ifElse(11, [
+    await runner.ifElse(15, [
 
   {
     condition: async () => __stack.locals.value,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.x = 10;
-            });
+          });
 await runner.step(1, async (runner) => {
 __stack.locals.y = 20;
-            });
+          });
     },
   },
 
 ]);
+    await runner.step(16, async (runner) => {
 //  Basic else
     });
-    await runner.step(12, async (runner) => {
-await runner.ifElse(12, [
+    await runner.ifElse(17, [
 
   {
     condition: async () => __stack.locals.flag,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `yes`;
-            });
+          });
     },
   },
 
 ], async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `no`;
-          });
+        });
 });
+    await runner.step(18, async (runner) => {
 //  else if chain
     });
-    await runner.step(13, async (runner) => {
-await runner.ifElse(13, [
+    await runner.ifElse(19, [
 
   {
     condition: async () => __stack.locals.a === 1,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `one`;
-            });
+          });
     },
   },
 
@@ -295,16 +290,15 @@ __stack.locals.result = `one`;
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `two`;
-            });
+          });
     },
   },
 
 ], async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `other`;
-          });
+        });
 });
-    });
     if (runner.halted) return runner.haltResult;
     await callHook({
       callbacks: __ctx.callbacks,
@@ -352,4 +346,4 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 }
 export default graph
-export const __sourceMap = {"ifElse.agency:main":{"1":{"line":-1,"col":2},"2":{"line":0,"col":2},"3":{"line":4,"col":2},"4":{"line":9,"col":2},"5":{"line":12,"col":2},"6":{"line":17,"col":2},"7":{"line":18,"col":2},"8":{"line":32,"col":2},"9":{"line":33,"col":2},"10":{"line":40,"col":2},"11":{"line":41,"col":2},"12":{"line":47,"col":2},"13":{"line":54,"col":2},"2.0":{"line":1,"col":4},"3.0":{"line":5,"col":4},"5.0":{"line":13,"col":4},"7.0":{"line":19,"col":4},"7.1.0":{"line":21,"col":6},"7.1":{"line":20,"col":4},"9.0":{"line":34,"col":4},"9.1":{"line":35,"col":4},"9.2":{"line":36,"col":4},"11.0":{"line":42,"col":4},"11.1":{"line":43,"col":4},"12.0":{"line":50,"col":4},"13.0":{"line":59,"col":4}}};
+export const __sourceMap = {"ifElse.agency:main":{"1":{"line":-1,"col":2},"2":{"line":0,"col":2},"3":{"line":4,"col":2},"5":{"line":9,"col":2},"6":{"line":12,"col":2},"8":{"line":17,"col":2},"9":{"line":18,"col":2},"11":{"line":32,"col":2},"12":{"line":33,"col":2},"14":{"line":40,"col":2},"15":{"line":41,"col":2},"17":{"line":47,"col":2},"19":{"line":54,"col":2},"2.0":{"line":1,"col":4},"3.0":{"line":5,"col":4},"6.0":{"line":13,"col":4},"9.0":{"line":19,"col":4},"9.1.0":{"line":21,"col":6},"9.1":{"line":20,"col":4},"12.0":{"line":34,"col":4},"12.1":{"line":35,"col":4},"12.2":{"line":36,"col":4},"15.0":{"line":42,"col":4},"15.1":{"line":43,"col":4},"17.0":{"line":50,"col":4},"19.0":{"line":59,"col":4}}};

--- a/tests/typescriptGenerator/matchBlock.mjs
+++ b/tests/typescriptGenerator/matchBlock.mjs
@@ -128,8 +128,7 @@ let __functionCompleted = false;
     await runner.step(1, async (runner) => {
 __stack.locals.action = `start`;
     });
-    await runner.step(2, async (runner) => {
-await runner.ifElse(2, [
+    await runner.ifElse(2, [
 
   {
     condition: async () => __stack.locals.action === `start`,
@@ -155,13 +154,13 @@ await print(`Restarting...`)
 ], async (runner) => {
 await print(`Unknown action`)
 });
+    await runner.step(3, async (runner) => {
 //  Match with number literals
     });
-    await runner.step(3, async (runner) => {
+    await runner.step(4, async (runner) => {
 __stack.locals.statusCode = 200;
     });
-    await runner.step(4, async (runner) => {
-await runner.ifElse(4, [
+    await runner.ifElse(5, [
 
   {
     condition: async () => __stack.locals.statusCode === 200,
@@ -187,16 +186,16 @@ await print(`Internal Server Error`)
 ], async (runner) => {
 await print(`Unknown status`)
 });
+    await runner.step(6, async (runner) => {
 //  Match with variable assignment in body
     });
-    await runner.step(5, async (runner) => {
+    await runner.step(7, async (runner) => {
 __stack.locals.grade = `A`;
     });
-    await runner.step(6, async (runner) => {
+    await runner.step(8, async (runner) => {
 __stack.locals.points = 0;
     });
-    await runner.step(7, async (runner) => {
-await runner.ifElse(7, [
+    await runner.ifElse(9, [
 
   {
     condition: async () => __stack.locals.grade === `A`,
@@ -229,13 +228,13 @@ __stack.locals.d = 55;
 ], async (runner) => {
 __stack.locals.e = 0;
 });
+    await runner.step(10, async (runner) => {
 //  Match with function calls in body
     });
-    await runner.step(8, async (runner) => {
+    await runner.step(11, async (runner) => {
 __stack.locals.level = `debug`;
     });
-    await runner.step(9, async (runner) => {
-await runner.ifElse(9, [
+    await runner.ifElse(12, [
 
   {
     condition: async () => __stack.locals.level === `debug`,
@@ -266,13 +265,13 @@ await print(`Error level`)
   },
 
 ]);
+    await runner.step(13, async (runner) => {
 //  Match with array results
     });
-    await runner.step(10, async (runner) => {
+    await runner.step(14, async (runner) => {
 __stack.locals.resultType = `array`;
     });
-    await runner.step(11, async (runner) => {
-await runner.ifElse(11, [
+    await runner.ifElse(15, [
 
   {
     condition: async () => __stack.locals.resultType === `array`,
@@ -285,30 +284,30 @@ __stack.locals.data1 = [1, 2, 3];
     condition: async () => __stack.locals.resultType === `object`,
     body: async (runner) => {
 __stack.locals.data2 = {
-              "x": 1,
-              "y": 2
-            };
+            "x": 1,
+            "y": 2
+          };
     },
   },
 
 ], async (runner) => {
 __stack.locals.data3 = [];
 });
+    await runner.step(16, async (runner) => {
 //  Match with object results
     });
-    await runner.step(12, async (runner) => {
+    await runner.step(17, async (runner) => {
 __stack.locals.format = `json`;
     });
-    await runner.step(13, async (runner) => {
-await runner.ifElse(13, [
+    await runner.ifElse(18, [
 
   {
     condition: async () => __stack.locals.format === `xml`,
     body: async (runner) => {
 __stack.locals.output1 = {
-              "type": `xml`,
-              "ext": `.xml`
-            };
+            "type": `xml`,
+            "ext": `.xml`
+          };
     },
   },
 
@@ -316,9 +315,9 @@ __stack.locals.output1 = {
     condition: async () => __stack.locals.format === `json`,
     body: async (runner) => {
 __stack.locals.output2 = {
-              "type": `json`,
-              "ext": `.json`
-            };
+            "type": `json`,
+            "ext": `.json`
+          };
     },
   },
 
@@ -326,19 +325,18 @@ __stack.locals.output2 = {
     condition: async () => __stack.locals.format === `csv`,
     body: async (runner) => {
 __stack.locals.output3 = {
-              "type": `csv`,
-              "ext": `.csv`
-            };
+            "type": `csv`,
+            "ext": `.csv`
+          };
     },
   },
 
 ], async (runner) => {
 __stack.locals.output4 = {
-            "type": `unknown`,
-            "ext": ``
-          };
+          "type": `unknown`,
+          "ext": ``
+        };
 });
-    });
     if (runner.halted) return runner.haltResult;
     await callHook({
       callbacks: __ctx.callbacks,
@@ -386,4 +384,4 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 }
 export default graph
-export const __sourceMap = {"matchBlock.agency:main":{"1":{"line":1,"col":2},"3":{"line":10,"col":2},"5":{"line":19,"col":2},"6":{"line":20,"col":2},"8":{"line":30,"col":2},"10":{"line":39,"col":2},"12":{"line":50,"col":2}}};
+export const __sourceMap = {"matchBlock.agency:main":{"1":{"line":1,"col":2},"4":{"line":10,"col":2},"7":{"line":19,"col":2},"8":{"line":20,"col":2},"11":{"line":30,"col":2},"14":{"line":39,"col":2},"17":{"line":50,"col":2}}};

--- a/tests/typescriptGenerator/pipe-operator.mjs
+++ b/tests/typescriptGenerator/pipe-operator.mjs
@@ -368,8 +368,7 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.step(0, async (runner) => {
-await runner.ifElse(0, [
+    await runner.ifElse(0, [
 
   {
     condition: async () => __stack.args.b === 0,
@@ -378,12 +377,11 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(failure(`division by zero`, { checkpoint: __ctx.getResultCheckpoint(), functionName: "safeDivide", args: __stack.args }))
 return;
-            });
+          });
     },
   },
 
 ]);
-    });
     await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(await success(__stack.args.a / __stack.args.b))

--- a/tests/typescriptGenerator/result-basic.mjs
+++ b/tests/typescriptGenerator/result-basic.mjs
@@ -162,8 +162,7 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.step(0, async (runner) => {
-await runner.ifElse(0, [
+    await runner.ifElse(0, [
 
   {
     condition: async () => __stack.args.age >= 18,
@@ -172,12 +171,11 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(await success(__stack.args.age))
 return;
-            });
+          });
     },
   },
 
 ]);
-    });
     await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(failure(`too young`, { checkpoint: __ctx.getResultCheckpoint(), functionName: "checkAge", args: __stack.args }))

--- a/tests/typescriptGenerator/result-guards.mjs
+++ b/tests/typescriptGenerator/result-guards.mjs
@@ -162,8 +162,7 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.step(0, async (runner) => {
-await runner.ifElse(0, [
+    await runner.ifElse(0, [
 
   {
     condition: async () => await isSuccess(__stack.args.r),
@@ -172,12 +171,11 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(`ok`)
 return;
-            });
+          });
     },
   },
 
 ]);
-    });
     await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(`error`)

--- a/tests/typescriptGenerator/sourceMap.mjs
+++ b/tests/typescriptGenerator/sourceMap.mjs
@@ -240,29 +240,25 @@ let __functionCompleted = false;
     await runner.step(0, async (runner) => {
 __stack.locals.x = 1;
     });
-    await runner.step(1, async (runner) => {
-await runner.ifElse(1, [
+    await runner.ifElse(1, [
 
   {
     condition: async () => __stack.locals.x === 1,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.y = 2;
-            });
+          });
     },
   },
 
 ], async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.y = 3;
-          });
+        });
 });
-    });
-    await runner.step(2, async (runner) => {
-await runner.loop(2, [`a`, `b`], async (item, _, runner) => {
+    await runner.loop(2, [`a`, `b`], async (item, _, runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.z = item;
-        });
       });
     });
     if (runner.halted) return runner.haltResult;

--- a/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -155,13 +155,35 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.step(0, async (runner) => {
-await runner.thread(0, __threads, "create", async (runner) => {
+    await runner.thread(0, __threads, "create", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res1 = await runPrompt({
+          ctx: __ctx,
+          prompt: `What are the first 5 prime numbers?`,
+          messages: __threads.getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.array(z.number())
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          interruptData: __state?.interruptData,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
+// halt if this is an interrupt
+if (isInterrupt(__stack.locals.res1)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.res1)
+          return;
+        }
+      });
+await runner.thread(1, __threads, "createSubthread", async (runner) => {
+await runner.step(0, async (runner) => {
+__self.__removedTools = __self.__removedTools || [];
+__stack.locals.res2 = await runPrompt({
             ctx: __ctx,
-            prompt: `What are the first 5 prime numbers?`,
+            prompt: `What are the next 2 prime numbers after those?`,
             messages: __threads.getOrCreateActive(),
             responseFormat: z.object({
               response: z.array(z.number())
@@ -173,115 +195,83 @@ __stack.locals.res1 = await runPrompt({
             checkpointInfo: runner.getCheckpointInfo()
           });
 // halt if this is an interrupt
-if (isInterrupt(__stack.locals.res1)) {
+if (isInterrupt(__stack.locals.res2)) {
             await __ctx.pendingPromises.awaitAll()
-            runner.halt(__stack.locals.res1)
+            runner.halt(__stack.locals.res2)
             return;
           }
         });
-await runner.step(1, async (runner) => {
-await runner.thread(1, __threads, "createSubthread", async (runner) => {
-await runner.step(0, async (runner) => {
-__self.__removedTools = __self.__removedTools || [];
-__stack.locals.res2 = await runPrompt({
-                ctx: __ctx,
-                prompt: `What are the next 2 prime numbers after those?`,
-                messages: __threads.getOrCreateActive(),
-                responseFormat: z.object({
-                  response: z.array(z.number())
-                }),
-                clientConfig: {},
-                maxToolCallRounds: 10,
-                interruptData: __state?.interruptData,
-                removedTools: __self.__removedTools,
-                checkpointInfo: runner.getCheckpointInfo()
-              });
-// halt if this is an interrupt
-if (isInterrupt(__stack.locals.res2)) {
-                await __ctx.pendingPromises.awaitAll()
-                runner.halt(__stack.locals.res2)
-                return;
-              }
-            });
-await runner.step(1, async (runner) => {
 await runner.thread(1, __threads, "createSubthread", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res3 = await runPrompt({
-                    ctx: __ctx,
-                    prompt: `And what is the sum of all those numbers combined?`,
-                    messages: __threads.getOrCreateActive(),
-                    responseFormat: z.object({
-                      response: z.number()
-                    }),
-                    clientConfig: {},
-                    maxToolCallRounds: 10,
-                    interruptData: __state?.interruptData,
-                    removedTools: __self.__removedTools,
-                    checkpointInfo: runner.getCheckpointInfo()
-                  });
+              ctx: __ctx,
+              prompt: `And what is the sum of all those numbers combined?`,
+              messages: __threads.getOrCreateActive(),
+              responseFormat: z.object({
+                response: z.number()
+              }),
+              clientConfig: {},
+              maxToolCallRounds: 10,
+              interruptData: __state?.interruptData,
+              removedTools: __self.__removedTools,
+              checkpointInfo: runner.getCheckpointInfo()
+            });
 // halt if this is an interrupt
 if (isInterrupt(__stack.locals.res3)) {
-                    await __ctx.pendingPromises.awaitAll()
-                    runner.halt(__stack.locals.res3)
-                    return;
-                  }
-                });
-              });
-            });
-await runner.step(2, async (runner) => {
+              await __ctx.pendingPromises.awaitAll()
+              runner.halt(__stack.locals.res3)
+              return;
+            }
+          });
+        });
 await runner.thread(2, __threads, "create", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res5 = await runPrompt({
-                    ctx: __ctx,
-                    prompt: `And what is the sum of all those numbers combined?`,
-                    messages: __threads.getOrCreateActive(),
-                    responseFormat: z.object({
-                      response: z.number()
-                    }),
-                    clientConfig: {},
-                    maxToolCallRounds: 10,
-                    interruptData: __state?.interruptData,
-                    removedTools: __self.__removedTools,
-                    checkpointInfo: runner.getCheckpointInfo()
-                  });
+              ctx: __ctx,
+              prompt: `And what is the sum of all those numbers combined?`,
+              messages: __threads.getOrCreateActive(),
+              responseFormat: z.object({
+                response: z.number()
+              }),
+              clientConfig: {},
+              maxToolCallRounds: 10,
+              interruptData: __state?.interruptData,
+              removedTools: __self.__removedTools,
+              checkpointInfo: runner.getCheckpointInfo()
+            });
 // halt if this is an interrupt
 if (isInterrupt(__stack.locals.res5)) {
-                    await __ctx.pendingPromises.awaitAll()
-                    runner.halt(__stack.locals.res5)
-                    return;
-                  }
-                });
-              });
-            });
+              await __ctx.pendingPromises.awaitAll()
+              runner.halt(__stack.locals.res5)
+              return;
+            }
           });
         });
-await runner.step(2, async (runner) => {
+      });
 await runner.thread(2, __threads, "createSubthread", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res4 = await runPrompt({
-                ctx: __ctx,
-                prompt: `And what is the sum of all those numbers combined?`,
-                messages: __threads.getOrCreateActive(),
-                responseFormat: z.object({
-                  response: z.number()
-                }),
-                clientConfig: {},
-                maxToolCallRounds: 10,
-                interruptData: __state?.interruptData,
-                removedTools: __self.__removedTools,
-                checkpointInfo: runner.getCheckpointInfo()
-              });
+            ctx: __ctx,
+            prompt: `And what is the sum of all those numbers combined?`,
+            messages: __threads.getOrCreateActive(),
+            responseFormat: z.object({
+              response: z.number()
+            }),
+            clientConfig: {},
+            maxToolCallRounds: 10,
+            interruptData: __state?.interruptData,
+            removedTools: __self.__removedTools,
+            checkpointInfo: runner.getCheckpointInfo()
+          });
 // halt if this is an interrupt
 if (isInterrupt(__stack.locals.res4)) {
-                await __ctx.pendingPromises.awaitAll()
-                runner.halt(__stack.locals.res4)
-                return;
-              }
-            });
-          });
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt(__stack.locals.res4)
+            return;
+          }
         });
       });
     });
@@ -351,13 +341,38 @@ let __functionCompleted = false;
   })
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "threadsAndSubthreads.agency", scopeName: "main" });
   try {
-    await runner.step(0, async (runner) => {
-await runner.thread(0, __threads, "create", async (runner) => {
+    await runner.thread(0, __threads, "create", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res1 = await runPrompt({
+          ctx: __ctx,
+          prompt: `What are the first 5 prime numbers?`,
+          messages: __threads.getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.array(z.number())
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          interruptData: __state?.interruptData,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
+// halt if this is an interrupt
+if (isInterrupt(__stack.locals.res1)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads,
+            data: __stack.locals.res1
+          })
+          return;
+        }
+      });
+await runner.thread(1, __threads, "createSubthread", async (runner) => {
+await runner.step(0, async (runner) => {
+__self.__removedTools = __self.__removedTools || [];
+__stack.locals.res2 = await runPrompt({
             ctx: __ctx,
-            prompt: `What are the first 5 prime numbers?`,
+            prompt: `What are the next 2 prime numbers after those?`,
             messages: __threads.getOrCreateActive(),
             responseFormat: z.object({
               response: z.array(z.number())
@@ -369,130 +384,95 @@ __stack.locals.res1 = await runPrompt({
             checkpointInfo: runner.getCheckpointInfo()
           });
 // halt if this is an interrupt
-if (isInterrupt(__stack.locals.res1)) {
+if (isInterrupt(__stack.locals.res2)) {
             await __ctx.pendingPromises.awaitAll()
             runner.halt({
               messages: __threads,
-              data: __stack.locals.res1
+              data: __stack.locals.res2
             })
             return;
           }
         });
-await runner.step(1, async (runner) => {
-await runner.thread(1, __threads, "createSubthread", async (runner) => {
-await runner.step(0, async (runner) => {
-__self.__removedTools = __self.__removedTools || [];
-__stack.locals.res2 = await runPrompt({
-                ctx: __ctx,
-                prompt: `What are the next 2 prime numbers after those?`,
-                messages: __threads.getOrCreateActive(),
-                responseFormat: z.object({
-                  response: z.array(z.number())
-                }),
-                clientConfig: {},
-                maxToolCallRounds: 10,
-                interruptData: __state?.interruptData,
-                removedTools: __self.__removedTools,
-                checkpointInfo: runner.getCheckpointInfo()
-              });
-// halt if this is an interrupt
-if (isInterrupt(__stack.locals.res2)) {
-                await __ctx.pendingPromises.awaitAll()
-                runner.halt({
-                  messages: __threads,
-                  data: __stack.locals.res2
-                })
-                return;
-              }
-            });
-await runner.step(1, async (runner) => {
 await runner.thread(1, __threads, "createSubthread", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res3 = await runPrompt({
-                    ctx: __ctx,
-                    prompt: `And what is the sum of all those numbers combined?`,
-                    messages: __threads.getOrCreateActive(),
-                    responseFormat: z.object({
-                      response: z.number()
-                    }),
-                    clientConfig: {},
-                    maxToolCallRounds: 10,
-                    interruptData: __state?.interruptData,
-                    removedTools: __self.__removedTools,
-                    checkpointInfo: runner.getCheckpointInfo()
-                  });
+              ctx: __ctx,
+              prompt: `And what is the sum of all those numbers combined?`,
+              messages: __threads.getOrCreateActive(),
+              responseFormat: z.object({
+                response: z.number()
+              }),
+              clientConfig: {},
+              maxToolCallRounds: 10,
+              interruptData: __state?.interruptData,
+              removedTools: __self.__removedTools,
+              checkpointInfo: runner.getCheckpointInfo()
+            });
 // halt if this is an interrupt
 if (isInterrupt(__stack.locals.res3)) {
-                    await __ctx.pendingPromises.awaitAll()
-                    runner.halt({
-                      messages: __threads,
-                      data: __stack.locals.res3
-                    })
-                    return;
-                  }
-                });
-              });
-            });
-await runner.step(2, async (runner) => {
+              await __ctx.pendingPromises.awaitAll()
+              runner.halt({
+                messages: __threads,
+                data: __stack.locals.res3
+              })
+              return;
+            }
+          });
+        });
 await runner.thread(2, __threads, "create", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res5 = await runPrompt({
-                    ctx: __ctx,
-                    prompt: `And what is the sum of all those numbers combined?`,
-                    messages: __threads.getOrCreateActive(),
-                    responseFormat: z.object({
-                      response: z.number()
-                    }),
-                    clientConfig: {},
-                    maxToolCallRounds: 10,
-                    interruptData: __state?.interruptData,
-                    removedTools: __self.__removedTools,
-                    checkpointInfo: runner.getCheckpointInfo()
-                  });
+              ctx: __ctx,
+              prompt: `And what is the sum of all those numbers combined?`,
+              messages: __threads.getOrCreateActive(),
+              responseFormat: z.object({
+                response: z.number()
+              }),
+              clientConfig: {},
+              maxToolCallRounds: 10,
+              interruptData: __state?.interruptData,
+              removedTools: __self.__removedTools,
+              checkpointInfo: runner.getCheckpointInfo()
+            });
 // halt if this is an interrupt
 if (isInterrupt(__stack.locals.res5)) {
-                    await __ctx.pendingPromises.awaitAll()
-                    runner.halt({
-                      messages: __threads,
-                      data: __stack.locals.res5
-                    })
-                    return;
-                  }
-                });
-              });
-            });
+              await __ctx.pendingPromises.awaitAll()
+              runner.halt({
+                messages: __threads,
+                data: __stack.locals.res5
+              })
+              return;
+            }
           });
         });
-await runner.step(2, async (runner) => {
+      });
 await runner.thread(2, __threads, "createSubthread", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res4 = await runPrompt({
-                ctx: __ctx,
-                prompt: `And what is the sum of all those numbers combined?`,
-                messages: __threads.getOrCreateActive(),
-                responseFormat: z.object({
-                  response: z.number()
-                }),
-                clientConfig: {},
-                maxToolCallRounds: 10,
-                interruptData: __state?.interruptData,
-                removedTools: __self.__removedTools,
-                checkpointInfo: runner.getCheckpointInfo()
-              });
+            ctx: __ctx,
+            prompt: `And what is the sum of all those numbers combined?`,
+            messages: __threads.getOrCreateActive(),
+            responseFormat: z.object({
+              response: z.number()
+            }),
+            clientConfig: {},
+            maxToolCallRounds: 10,
+            interruptData: __state?.interruptData,
+            removedTools: __self.__removedTools,
+            checkpointInfo: runner.getCheckpointInfo()
+          });
 // halt if this is an interrupt
 if (isInterrupt(__stack.locals.res4)) {
-                await __ctx.pendingPromises.awaitAll()
-                runner.halt({
-                  messages: __threads,
-                  data: __stack.locals.res4
-                })
-                return;
-              }
-            });
-          });
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt({
+              messages: __threads,
+              data: __stack.locals.res4
+            })
+            return;
+          }
         });
       });
     });

--- a/tests/typescriptGenerator/withModifier.mjs
+++ b/tests/typescriptGenerator/withModifier.mjs
@@ -254,23 +254,21 @@ let __functionCompleted = false;
   })
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "withModifier.agency", scopeName: "main" });
   try {
-    await runner.step(0, async (runner) => {
-await runner.handle(0, async (__data: any) => approve(__data), async (runner) => {
+    await runner.handle(0, async (__data: any) => approve(__data), async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = await foo({
-            ctx: __ctx,
-            threads: __threads,
-            interruptData: __state?.interruptData
-          });
-if (isInterrupt(__stack.locals.result)) {
-            await __ctx.pendingPromises.awaitAll()
-            runner.halt({
-              ...__state,
-              data: __stack.locals.result
-            })
-            return;
-          }
+          ctx: __ctx,
+          threads: __threads,
+          interruptData: __state?.interruptData
         });
+if (isInterrupt(__stack.locals.result)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.result
+          })
+          return;
+        }
       });
     });
     await runner.step(1, async (runner) => {


### PR DESCRIPTION
## Summary

- Fix the debugger inability to step through compound constructs (handle, if/else, for, while, thread) by removing redundant runnerStep wrapping in the builder processBodyAsParts()
- Compound IR nodes (runnerHandle, runnerIfElse, runnerLoop, runnerWhileLoop, runnerThread) already have their own Runner method with debug hooks, counter management, and path tracking. Wrapping them in an additional runnerStep caused double-nested runtime paths (e.g. 1_1.0) that did not match source map paths (1.0)
- Add driver tests for handle blocks (step paths, source map errors, continue-to-completion, handler auto-approves user interrupt)
- Add step path assertions to existing if/else and loop debugger tests
- Document the debug-interrupt-bypasses-handlers invariant in Runner.handle()

## Test plan

- [ ] All 2027 existing tests pass (pnpm test:run)
- [ ] New handle block tests verify step paths have no double-nesting
- [ ] New if/else and loop step path tests verify correct paths
- [ ] Manual smoke test: pnpm run agency debug foo.agency with a handle block -- stepping highlights correct lines, no source map errors

Generated with [Claude Code](https://claude.com/claude-code)