### PR TITLE
feat: add __type discriminant to Result type

### DIFF
--- a/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -96,7 +96,7 @@ export function mapTypeToZodSchema(
 /**
  * Maps Agency types to Zod schema strings for validation contexts.
  * For Result types, generates a schema that validates the full Result
- * structure ({success: true, value: T} | {success: false, error: any}).
+ * structure ({__type: "resultType", success: true, value: T} | {__type: "resultType", success: false, error: any}).
  */
 export function mapTypeToValidationSchema(
   variableType: VariableType,

--- a/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -104,6 +104,6 @@ export function mapTypeToValidationSchema(
 ): string {
   return mapTypeToSchema(variableType, typeAliases, (vt, ta) => {
     const successSchema = mapTypeToValidationSchema((vt as any).successType, ta);
-    return `z.union([z.object({ success: z.literal(true), value: ${successSchema} }), z.object({ success: z.literal(false), error: z.any() })])`;
+    return `z.union([z.object({ __type: z.literal("resultType"), success: z.literal(true), value: ${successSchema} }), z.object({ __type: z.literal("resultType"), success: z.literal(false), error: z.any() })])`;
   });
 }

--- a/lib/runtime/result.test.ts
+++ b/lib/runtime/result.test.ts
@@ -4,17 +4,17 @@ import { success, failure, isSuccess, isFailure, __pipeBind } from "./result.js"
 describe("success", () => {
   it("creates a success result", () => {
     const result = success(42);
-    expect(result).toEqual({ success: true, value: 42 });
+    expect(result).toEqual({ __type: "resultType", success: true, value: 42 });
   });
 
   it("creates a success result with a string value", () => {
     const result = success("hello");
-    expect(result).toEqual({ success: true, value: "hello" });
+    expect(result).toEqual({ __type: "resultType", success: true, value: "hello" });
   });
 
   it("creates a success result with null value", () => {
     const result = success(null);
-    expect(result).toEqual({ success: true, value: null });
+    expect(result).toEqual({ __type: "resultType", success: true, value: null });
   });
 });
 
@@ -22,6 +22,7 @@ describe("failure", () => {
   it("creates a failure result with string error", () => {
     const result = failure("something went wrong");
     expect(result).toEqual({
+      __type: "resultType",
       success: false,
       error: "something went wrong",
       checkpoint: null,
@@ -34,6 +35,7 @@ describe("failure", () => {
   it("creates a failure result with object error", () => {
     const result = failure({ code: 404, message: "not found" });
     expect(result).toEqual({
+      __type: "resultType",
       success: false,
       error: { code: 404, message: "not found" },
       checkpoint: null,

--- a/lib/runtime/result.ts
+++ b/lib/runtime/result.ts
@@ -3,11 +3,12 @@ import { z } from "zod";
 export type ResultValue = ResultSuccess | ResultFailure;
 
 const resultValueSchema = z.union([
-  z.object({ success: z.literal(true), value: z.any() }),
-  z.object({ success: z.literal(false), error: z.any() }),
+  z.object({ __type: z.literal("resultType"), success: z.literal(true), value: z.any() }),
+  z.object({ __type: z.literal("resultType"), success: z.literal(false), error: z.any() }),
 ]);
 
 export type ResultSuccess = {
+  __type: "resultType";
   success: true;
   value: any;
 };
@@ -20,6 +21,7 @@ export type FailureOpts = {
 };
 
 export type ResultFailure = {
+  __type: "resultType";
   success: false;
   error: any;
   checkpoint: any;
@@ -29,11 +31,12 @@ export type ResultFailure = {
 };
 
 export function success(value: any): ResultSuccess {
-  return { success: true, value };
+  return { __type: "resultType", success: true, value };
 }
 
 export function failure(error: any, opts?: FailureOpts): ResultFailure {
   return {
+    __type: "resultType",
     success: false,
     error,
     checkpoint: opts?.checkpoint ?? null,
@@ -44,11 +47,11 @@ export function failure(error: any, opts?: FailureOpts): ResultFailure {
 }
 
 export function isSuccess(result: ResultValue): result is ResultSuccess {
-  return result != null && result.success === true;
+  return result != null && (result as any).__type === "resultType" && result.success === true;
 }
 
 export function isFailure(result: ResultValue): result is ResultFailure {
-  return result != null && result.success === false;
+  return result != null && (result as any).__type === "resultType" && result.success === false;
 }
 
 /** Wrap a function call in try-catch, returning a Result.
@@ -82,8 +85,8 @@ export async function __pipeBind(result: ResultValue, fn: (value: any) => any): 
     return output;
   }
   // Smart bind/fmap: if fn returns a Result, use it directly
-  if (output != null && typeof output === "object" && "success" in output && typeof output.success === "boolean") {
+  if (output != null && typeof output === "object" && (output as any).__type === "resultType") {
     return output;
   }
-  return { success: true, value: output };
+  return success(output);
 }

--- a/lib/runtime/result.ts
+++ b/lib/runtime/result.ts
@@ -46,12 +46,12 @@ export function failure(error: any, opts?: FailureOpts): ResultFailure {
   };
 }
 
-export function isSuccess(result: ResultValue): result is ResultSuccess {
-  return result != null && (result as any).__type === "resultType" && result.success === true;
+export function isSuccess(result: unknown): result is ResultSuccess {
+  return result != null && typeof result === "object" && (result as any).__type === "resultType" && (result as any).success === true;
 }
 
-export function isFailure(result: ResultValue): result is ResultFailure {
-  return result != null && (result as any).__type === "resultType" && result.success === false;
+export function isFailure(result: unknown): result is ResultFailure {
+  return result != null && typeof result === "object" && (result as any).__type === "resultType" && (result as any).success === false;
 }
 
 /** Wrap a function call in try-catch, returning a Result.
@@ -85,7 +85,7 @@ export async function __pipeBind(result: ResultValue, fn: (value: any) => any): 
     return output;
   }
   // Smart bind/fmap: if fn returns a Result, use it directly
-  if (output != null && typeof output === "object" && (output as any).__type === "resultType") {
+  if (output != null && typeof output === "object" && (output as any).__type === "resultType" && typeof output.success === "boolean") {
     return output;
   }
   return success(output);

--- a/lib/runtime/schema.test.ts
+++ b/lib/runtime/schema.test.ts
@@ -84,13 +84,12 @@ describe("__validateType", () => {
 
   it("returns Result directly when value is already a valid Result (no double-wrapping)", () => {
     const resultSchema = z.union([
-      z.object({ success: z.literal(true), value: z.number() }),
-      z.object({ success: z.literal(false), error: z.any() }),
+      z.object({ __type: z.literal("resultType"), success: z.literal(true), value: z.number() }),
+      z.object({ __type: z.literal("resultType"), success: z.literal(false), error: z.any() }),
     ]);
-    const original = { success: true as const, value: 42 };
+    const original = { __type: "resultType" as const, success: true as const, value: 42 };
     const result = __validateType(original, resultSchema);
-    // Should return the Result directly, not success({success: true, value: 42})
-    expect(result).toEqual({ success: true, value: 42 });
+    expect(result).toEqual({ __type: "resultType", success: true, value: 42 });
     expect((result as any).value).toBe(42);
   });
 });

--- a/lib/runtime/schema.ts
+++ b/lib/runtime/schema.ts
@@ -26,7 +26,7 @@ export class Schema {
 
 export function __validateType(value: unknown, schema: z.ZodType): ResultValue {
   // Don't validate failures — surface the original error, not a schema mismatch
-  if (isFailure(value as any)) {
+  if (isFailure(value)) {
     return value as ResultFailure;
   }
   const result = schema.safeParse(value);
@@ -34,7 +34,7 @@ export function __validateType(value: unknown, schema: z.ZodType): ResultValue {
     // If the validated value is already a Result, return it directly
     // instead of wrapping it in another success(). This avoids double-wrapping
     // when validating with Result types (e.g. const r: Result! = compute()).
-    if (isSuccess(result.data as any) || isFailure(result.data as any)) {
+    if (isSuccess(result.data) || isFailure(result.data)) {
       return result.data as ResultValue;
     }
     return success(result.data);

--- a/tests/agency-js/interrupt-overrides/fixture.json
+++ b/tests/agency-js/interrupt-overrides/fixture.json
@@ -4,6 +4,7 @@
     "result": true
   },
   "reject": {
+    "__type": "resultType",
     "success": false,
     "error": "interrupt rejected",
     "checkpoint": null,

--- a/tests/agency/interrupts/interruptAssignmentReject.test.json
+++ b/tests/agency/interrupts/interruptAssignmentReject.test.json
@@ -4,7 +4,7 @@
       "nodeName": "foo",
       "description": "Test that rejecting an interrupt assigned to a variable returns null",
       "input": "",
-      "expectedOutput": "{\"success\":false,\"error\":\"interrupt rejected\",\"checkpoint\":null,\"retryable\":false,\"functionName\":null,\"args\":null}",
+      "expectedOutput": "{\"__type\":\"resultType\",\"success\":false,\"error\":\"interrupt rejected\",\"checkpoint\":null,\"retryable\":false,\"functionName\":null,\"args\":null}",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/tests/agency/result/pipe-interrupt.test.json
+++ b/tests/agency/result/pipe-interrupt.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "{\"value\":{\"success\":true,\"value\":23},\"callCount\":1}",
+      "expectedOutput": "{\"value\":{\"__type\":\"resultType\",\"success\":true,\"value\":23},\"callCount\":1}",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/tests/agency/result/pipe-operator.test.json
+++ b/tests/agency/result/pipe-operator.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "{\"r1\":{\"success\":true,\"value\":10},\"r2\":{\"success\":true,\"value\":50},\"r3\":{\"success\":true,\"value\":60},\"r4\":{\"success\":false,\"error\":\"nope\",\"checkpoint\":null,\"retryable\":false,\"functionName\":null,\"args\":null}}",
+      "expectedOutput": "{\"r1\":{\"__type\":\"resultType\",\"success\":true,\"value\":10},\"r2\":{\"__type\":\"resultType\",\"success\":true,\"value\":50},\"r3\":{\"__type\":\"resultType\",\"success\":true,\"value\":60},\"r4\":{\"__type\":\"resultType\",\"success\":false,\"error\":\"nope\",\"checkpoint\":null,\"retryable\":false,\"functionName\":null,\"args\":null}}",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/tests/agency/result/pipe-variadic.test.json
+++ b/tests/agency/result/pipe-variadic.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "{\"r1\":{\"success\":true,\"value\":\"hello\"},\"r2\":{\"success\":true,\"value\":\"world\"}}",
+      "expectedOutput": "{\"r1\":{\"__type\":\"resultType\",\"success\":true,\"value\":\"hello\"},\"r2\":{\"__type\":\"resultType\",\"success\":true,\"value\":\"world\"}}",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/tests/agency/result/result-extended.test.json
+++ b/tests/agency/result/result-extended.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "{\"val\":42,\"err\":\"bad input\",\"r3\":{\"success\":true,\"value\":5},\"r4\":{\"success\":true,\"value\":4},\"r5Success\":false,\"r5Error\":\"division by zero\",\"r5HasCheckpoint\":true}",
+      "expectedOutput": "{\"val\":42,\"err\":\"bad input\",\"r3\":{\"__type\":\"resultType\",\"success\":true,\"value\":5},\"r4\":{\"__type\":\"resultType\",\"success\":true,\"value\":4},\"r5Success\":false,\"r5Error\":\"division by zero\",\"r5HasCheckpoint\":true}",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/tests/agency/validation/bangNodeReturnType.test.json
+++ b/tests/agency/validation/bangNodeReturnType.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "{\"success\":true,\"value\":42}",
+      "expectedOutput": "{\"__type\":\"resultType\",\"success\":true,\"value\":42}",
       "evaluationCriteria": [{ "type": "exact" }],
       "description": "Node return type ! wraps return value in validation Result"
     }


### PR DESCRIPTION
## Summary
- Add `__type: "resultType"` field to `ResultSuccess` and `ResultFailure` types to prevent accidental collisions with user-defined objects that happen to have `{success: true/false}` shapes
- Update all Result detection logic: `isSuccess()`, `isFailure()`, `resultValueSchema`, `__pipeBind` duck-typing, and validation schema generation

## Test plan
- [x] All existing Result unit tests updated with `__type` field (6 tests)
- [x] Schema validation test updated with `__type` in Zod schema
- [x] Execution test fixture updated for new Result shape
- [x] Full vitest suite passes (2037 tests)
- [x] Full execution test suite passes (36 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)