### PR TITLE
Add MCP OAuth and static header support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Apr 21 2026 — v0.0.102
+- Add mcp support with auth, docs
+## Apr 21 2026 — v0.0.101
+- Add mcp support
+## Apr 20 2026 — v0.0.100
+- Fix various import-related issues
 ## Apr 19 2026 — v0.0.93
 - Added `schema()` function and made validation work with Result types
 - Added `__type: "resultType"` tag to result types to avoid misdetecting user return values

--- a/docs-new/guide/mcp.md
+++ b/docs-new/guide/mcp.md
@@ -1,0 +1,251 @@
+# MCP Servers
+
+Agency supports the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), a standard protocol for connecting to external tool servers. This lets your agents use tools provided by MCP servers — filesystem access, databases, GitHub, and more — without reimplementing them as Agency functions.
+
+## Quick start
+
+1. Configure an MCP server in `agency.json`:
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    }
+  }
+}
+```
+
+2. Use its tools in your agent:
+
+```ts
+node main() {
+  const tools = mcp("filesystem") catch []
+  const result = llm("List the files in /tmp", { tools: [...tools] })
+  print(result)
+}
+```
+
+That's it. The `mcp()` function connects to the server, fetches its tools, and returns them as an array. You pass them to `llm()` via the `tools` option.
+
+## How it works
+
+`mcp()` returns a `Result` type. If the connection fails, it returns a `failure`. Use `catch` to provide a default:
+
+```ts
+// If the server is down, use an empty tool list instead of crashing
+const tools = mcp("filesystem") catch []
+```
+
+Each tool in the array is a plain object with a `name`, `description`, and `inputSchema`. Tool names are prefixed with the server name to avoid collisions: a `read_file` tool from a server named `filesystem` becomes `filesystem__read_file`.
+
+You can filter tools before passing them to the LLM:
+
+```ts
+const allTools = mcp("filesystem") catch []
+const safeTools = filter(allTools) as tool {
+  return tool.name != "filesystem__delete_file"
+}
+const result = llm("Summarize my files", { tools: [...safeTools] })
+```
+
+You can also combine tools from multiple servers and your own Agency functions:
+
+```ts
+def summarize(text: string): string {
+  return llm("Summarize this: ${text}")
+}
+
+node main() {
+  const fsTools = mcp("filesystem") catch []
+  const dbTools = mcp("database") catch []
+
+  uses summarize
+  const result = llm("Read my files, query the database, and summarize everything", {
+    tools: [summarize, ...fsTools, ...dbTools]
+  })
+  print(result)
+}
+```
+
+## Configuration
+
+MCP servers are configured in `agency.json` under the `mcpServers` key. There are two transport types.
+
+### Stdio servers
+
+Stdio servers run as local subprocesses. Agency spawns the process and communicates over stdin/stdout.
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      "env": {
+        "SOME_VAR": "value"
+      }
+    }
+  }
+}
+```
+
+- `command` (required): the command to run
+- `args` (optional): arguments to pass
+- `env` (optional): environment variables for the subprocess
+
+### HTTP servers
+
+HTTP servers run remotely and communicate over Streamable HTTP.
+
+```json
+{
+  "mcpServers": {
+    "weather": {
+      "type": "http",
+      "url": "https://weather-mcp.example.com/mcp"
+    }
+  }
+}
+```
+
+- `type` (required): must be `"http"`
+- `url` (required): the server's MCP endpoint URL
+
+### HTTP servers with static headers
+
+If the server requires an API key or token, you can pass static headers:
+
+```json
+{
+  "mcpServers": {
+    "weather": {
+      "type": "http",
+      "url": "https://weather-mcp.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer your-api-key-here"
+      }
+    }
+  }
+}
+```
+
+## Authentication (OAuth)
+
+Many MCP servers (like GitHub) require OAuth authentication. Agency handles the full OAuth 2.1 flow — opening your browser, receiving the callback, and storing tokens for reuse.
+
+### Setup
+
+1. Register an OAuth App with the provider (e.g., [GitHub OAuth Apps](https://github.com/settings/developers)).
+   - Set the callback URL to `http://127.0.0.1:19876/oauth/callback`
+   - Note your Client ID and Client Secret.
+
+2. Add the server to `agency.json`:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "auth": "oauth",
+      "clientId": "your-client-id",
+      "clientSecret": "your-client-secret"
+    }
+  }
+}
+```
+
+Alternatively, you can set credentials as environment variables instead of putting them in the config file. Agency checks for `MCP_<SERVER>_CLIENT_ID` and `MCP_<SERVER>_CLIENT_SECRET` (server name uppercased) as a fallback:
+
+```bash
+export MCP_GITHUB_CLIENT_ID=your-client-id
+export MCP_GITHUB_CLIENT_SECRET=your-client-secret
+```
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "auth": "oauth"
+    }
+  }
+}
+```
+
+3. The first time your agent connects, Agency opens your browser for authorization. After you approve, the token is stored at `~/.agency/tokens/<server-name>.json` and reused automatically on future runs.
+
+### OAuth config options
+
+- `auth` (required): must be `"oauth"`
+- `clientId` (optional): the OAuth client ID. Falls back to `MCP_<SERVER>_CLIENT_ID` env var.
+- `clientSecret` (optional): the OAuth client secret. Falls back to `MCP_<SERVER>_CLIENT_SECRET` env var.
+- `authTimeout` (optional): milliseconds to wait for the user to authorize in the browser. Defaults to 5 minutes.
+
+Note: `auth` and `headers` are mutually exclusive — use one or the other.
+
+### Using OAuth in Agency code
+
+No special code is needed. The OAuth flow is handled automatically by the runtime when you call `mcp()`:
+
+```ts
+node main() {
+  const tools = mcp("github") catch []
+  const result = llm("List my GitHub repositories", { tools: [...tools] })
+  print(result)
+}
+```
+
+On the first run, your browser opens for authorization. On subsequent runs, the stored token is used.
+
+### Using OAuth from TypeScript
+
+When you import and call an Agency node from TypeScript, the OAuth flow works the same way — it opens a browser. If you need to customize this (e.g., in a web app where you can't open a local browser), provide an `onOAuthRequired` callback:
+
+```ts
+import { main } from "./agent.js";
+
+const result = await main({
+  callbacks: {
+    onOAuthRequired: async ({ serverName, authUrl, complete }) => {
+      // Show the URL to the user however you want
+      console.log(`Please authorize at: ${authUrl}`);
+      // Wait for the auth to complete
+      await complete;
+    }
+  }
+});
+```
+
+The callback receives:
+- `serverName` — which MCP server needs authorization
+- `authUrl` — the URL to send the user to
+- `complete` — a promise that resolves when the user completes authorization
+- `cancel` — a function to abort the OAuth flow
+
+If you don't provide `onOAuthRequired`, Agency opens the browser automatically (the default behavior).
+
+### Managing tokens with the CLI
+
+You can manage OAuth tokens from the command line:
+
+```bash
+# Authorize a server (opens browser)
+agency auth github
+
+# List all stored tokens
+agency auth --list
+
+# Remove a stored token (forces re-authorization on next use)
+agency auth --revoke github
+```
+
+## Interrupts and handlers
+
+MCP tools are external and cannot throw Agency interrupts. If you want safety checks on MCP tool usage, you can:
+
+- Filter out dangerous tools before passing them to `llm()`
+- Wrap the `llm()` call in a `handle` block to intercept any interrupts from your own tools

--- a/docs-new/guide/mcp.md
+++ b/docs-new/guide/mcp.md
@@ -141,28 +141,16 @@ Many MCP servers (like GitHub) require OAuth authentication. Agency handles the 
    - Set the callback URL to `http://127.0.0.1:19876/oauth/callback`
    - Note your Client ID and Client Secret.
 
-2. Add the server to `agency.json`:
-
-```json
-{
-  "mcpServers": {
-    "github": {
-      "type": "http",
-      "url": "https://api.githubcopilot.com/mcp/",
-      "auth": "oauth",
-      "clientId": "your-client-id",
-      "clientSecret": "your-client-secret"
-    }
-  }
-}
-```
-
-Alternatively, you can set credentials as environment variables instead of putting them in the config file. Agency checks for `MCP_<SERVER>_CLIENT_ID` and `MCP_<SERVER>_CLIENT_SECRET` (server name uppercased) as a fallback:
+2. Set your credentials as environment variables. Agency looks for `MCP_<SERVER>_CLIENT_ID` and `MCP_<SERVER>_CLIENT_SECRET`, where the server name is uppercased and any hyphens are replaced with underscores:
 
 ```bash
 export MCP_GITHUB_CLIENT_ID=your-client-id
 export MCP_GITHUB_CLIENT_SECRET=your-client-secret
 ```
+
+For a server named `my-api`, the env vars would be `MCP_MY_API_CLIENT_ID` and `MCP_MY_API_CLIENT_SECRET`.
+
+3. Add the server to `agency.json`:
 
 ```json
 {
@@ -176,16 +164,31 @@ export MCP_GITHUB_CLIENT_SECRET=your-client-secret
 }
 ```
 
-3. The first time your agent connects, Agency opens your browser for authorization. After you approve, the token is stored at `~/.agency/tokens/<server-name>.json` and reused automatically on future runs.
+You can also put `clientId` directly in the config file if you prefer (it's not a secret). But never put `clientSecret` in `agency.json` — it gets stripped from compiled output for security, so it won't work, and you'd be putting a secret in a file that may be checked into version control. Always use environment variables for the client secret.
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "auth": "oauth",
+      "clientId": "your-client-id"
+    }
+  }
+}
+```
+
+4. The first time your agent connects, Agency opens your browser for authorization. After you approve, the token is stored at `~/.agency/tokens/<server-name>.json` and reused automatically on future runs.
 
 ### OAuth config options
 
 - `auth` (required): must be `"oauth"`
 - `clientId` (optional): the OAuth client ID. Falls back to `MCP_<SERVER>_CLIENT_ID` env var.
-- `clientSecret` (optional): the OAuth client secret. Falls back to `MCP_<SERVER>_CLIENT_SECRET` env var.
+- `clientSecret` (optional): the OAuth client secret. Falls back to `MCP_<SERVER>_CLIENT_SECRET` env var. **Use env vars for this — secrets are stripped from compiled output.**
 - `authTimeout` (optional): milliseconds to wait for the user to authorize in the browser. Defaults to 5 minutes.
 
-Note: `auth` and `headers` are mutually exclusive — use one or the other.
+Note: `auth` and `headers` are mutually exclusive — use one or the other. OAuth requires HTTPS (localhost is exempt for development).
 
 ### Using OAuth in Agency code
 

--- a/docs-new/stdlib/system.md
+++ b/docs-new/stdlib/system.md
@@ -70,3 +70,21 @@ Set an environment variable in the current process. Fails if the name is empty o
 **Returns:** Result
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L23))
+
+### openUrl
+
+```ts
+openUrl(url: string): Result
+```
+
+Open a URL in the user's default browser. Currently macOS-only.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| url | string |  |
+
+**Returns:** Result
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L36))

--- a/docs/superpowers/plans/2026-04-21-mcp-oauth-support.md
+++ b/docs/superpowers/plans/2026-04-21-mcp-oauth-support.md
@@ -1,0 +1,1880 @@
+# MCP OAuth Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add OAuth 2.1 authentication and static header support for HTTP-based MCP servers, so users can connect to OAuth-protected MCP servers (GitHub, Google, etc.) with a single config change.
+
+**Architecture:** OAuth logic is strictly encapsulated behind two classes: `AgencyOAuthProvider` (implements the MCP SDK's `OAuthClientProvider` — owns tokens, PKCE, browser, callback server) and `OAuthConnector` (owns the two-phase connect/retry flow). `McpConnection` does not know OAuth exists — it receives a pre-connected `{client, transport}` pair from `OAuthConnector`, or builds its own transport for non-OAuth paths. `McpManager` uses a factory function to create connectors and never touches `AgencyOAuthProvider` directly. All instance variables are private; functionality is exposed via methods.
+
+**Tech Stack:** `@modelcontextprotocol/sdk` (already installed — provides `OAuthClientProvider` interface, `UnauthorizedError`, `StreamableHTTPClientTransport.finishAuth()`), macOS `open` command (no npm dep), Zod (config validation), vitest (testing)
+
+**Spec:** `docs/superpowers/specs/2026-04-20-mcp-oauth-design.md`
+
+**Key MCP SDK auth types (from `@modelcontextprotocol/sdk`):**
+- `OAuthClientProvider` interface (`sdk/client/auth.js`) — provider passed to `StreamableHTTPClientTransport`
+- `UnauthorizedError` (`sdk/client/auth.js`) — thrown by `connect()` when auth is needed
+- `StreamableHTTPClientTransport.finishAuth(code)` — called after user authorizes in browser
+- `OAuthTokens` — `{ access_token, token_type, expires_in?, refresh_token?, scope? }`
+- `OAuthClientMetadata` — `{ redirect_uris, client_name?, scope?, ... }`
+- `OAuthClientInformationMixed` — client registration info (client_id, etc.)
+
+**Encapsulation boundaries:**
+
+```
+McpManager (orchestrator — creates connections, caches tools)
+  → createOAuthConnector() factory (one place that knows how to build OAuth)
+  → McpConnection (NO OAuth knowledge — connects via transport or connector)
+
+OAuthConnector (owns the two-phase connect/retry flow)
+  → connect(): Promise<{client, transport}> — the ONE public method
+  → AgencyOAuthProvider (implements OAuthClientProvider)
+  → StreamableHTTPClientTransport, Client
+
+AgencyOAuthProvider (owns tokens, browser, callback)
+  → TokenStore (disk persistence)
+  → CallbackServer (localhost redirect handler)
+```
+
+**What each class does NOT know:**
+- `McpConnection`: does not import `UnauthorizedError`, `AgencyOAuthProvider`, `OAuthConnector` types, `TokenStore`, or `CallbackServer`
+- `McpManager`: does not import `AgencyOAuthProvider`, `TokenStore`, or `CallbackServer`
+- `OAuthConnector`: does not know about `McpConnection` or `McpManager`
+- `AgencyOAuthProvider`: does not know about `McpConnection`, `McpManager`, or `OAuthConnector`
+
+---
+
+### Task 1: Add `openUrl` to the stdlib (already done)
+
+The `_openUrl` function has been added to `stdlib/lib/system.ts` and exposed as `openUrl` in `stdlib/system.agency`. It uses the macOS `open` command (no npm dependency). Cross-platform support can be added later. The OAuth provider inlines the same `execFile("open", [url])` call to avoid cross-tsconfig imports.
+
+**Files (already modified):**
+- `stdlib/lib/system.ts` — added `_openUrl(url: string): Promise<void>`
+- `stdlib/system.agency` — added `export def openUrl(url: string): Result`
+- `stdlib/lib/__tests__/system-openUrl.test.ts` — tests
+
+This task is complete. Run `make stdlib` if needed, then proceed.
+
+---
+
+### Task 2: Token store
+
+Handles reading, writing, and deleting OAuth tokens and client registration info on disk. Uses atomic writes and restrictive file permissions. All fields are private.
+
+**Files:**
+- Create: `lib/runtime/mcp/tokenStore.ts`
+- Create: `lib/runtime/mcp/tokenStore.test.ts`
+
+- [ ] **Step 1: Write the tests**
+
+Create `lib/runtime/mcp/tokenStore.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { TokenStore } from "./tokenStore.js";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+describe("TokenStore", () => {
+  let store: TokenStore;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-token-test-"));
+    store = new TokenStore(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should return undefined when no tokens exist", async () => {
+    const tokens = await store.loadTokens("github");
+    expect(tokens).toBeUndefined();
+  });
+
+  it("should save and load tokens", async () => {
+    const tokens = { access_token: "abc", token_type: "bearer" };
+    await store.saveTokens("github", tokens);
+    const loaded = await store.loadTokens("github");
+    expect(loaded).toEqual(tokens);
+  });
+
+  it("should overwrite existing tokens", async () => {
+    await store.saveTokens("github", { access_token: "old", token_type: "bearer" });
+    await store.saveTokens("github", { access_token: "new", token_type: "bearer" });
+    const loaded = await store.loadTokens("github");
+    expect(loaded?.access_token).toBe("new");
+  });
+
+  it("should delete tokens", async () => {
+    await store.saveTokens("github", { access_token: "abc", token_type: "bearer" });
+    await store.deleteTokens("github");
+    const loaded = await store.loadTokens("github");
+    expect(loaded).toBeUndefined();
+  });
+
+  it("should save and load PKCE code verifier", async () => {
+    await store.saveCodeVerifier("github", "verifier123");
+    const loaded = await store.loadCodeVerifier("github");
+    expect(loaded).toBe("verifier123");
+  });
+
+  it("should delete PKCE code verifier", async () => {
+    await store.saveCodeVerifier("github", "verifier123");
+    await store.deleteCodeVerifier("github");
+    const loaded = await store.loadCodeVerifier("github");
+    expect(loaded).toBeUndefined();
+  });
+
+  it("should save and load client info", async () => {
+    const info = { client_id: "my-client", client_secret: "secret" };
+    await store.saveClientInfo("github", info);
+    const loaded = await store.loadClientInfo("github");
+    expect(loaded).toEqual(info);
+  });
+
+  it("should list stored server names", async () => {
+    await store.saveTokens("github", { access_token: "a", token_type: "bearer" });
+    await store.saveTokens("slack", { access_token: "b", token_type: "bearer" });
+    const names = await store.listServers();
+    expect(names.sort()).toEqual(["github", "slack"]);
+  });
+
+  it("should set file permissions to 0600", async () => {
+    await store.saveTokens("github", { access_token: "abc", token_type: "bearer" });
+    const filePath = path.join(tmpDir, "github.json");
+    const stat = fs.statSync(filePath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run lib/runtime/mcp/tokenStore.test.ts`
+Expected: FAIL — `tokenStore.js` doesn't exist
+
+- [ ] **Step 3: Implement TokenStore**
+
+Create `lib/runtime/mcp/tokenStore.ts`:
+
+```ts
+import fs from "fs";
+import path from "path";
+import os from "os";
+import type { OAuthTokens, OAuthClientInformationMixed } from "@modelcontextprotocol/sdk/shared/auth.js";
+
+const DEFAULT_TOKEN_DIR = path.join(os.homedir(), ".agency", "tokens");
+
+export class TokenStore {
+  private dir: string;
+
+  constructor(dir: string = DEFAULT_TOKEN_DIR) {
+    this.dir = dir;
+  }
+
+  private ensureDir(): void {
+    if (!fs.existsSync(this.dir)) {
+      fs.mkdirSync(this.dir, { recursive: true, mode: 0o700 });
+    }
+  }
+
+  private tokenPath(serverName: string): string {
+    return path.join(this.dir, `${serverName}.json`);
+  }
+
+  private verifierPath(serverName: string): string {
+    return path.join(this.dir, `${serverName}.verifier`);
+  }
+
+  private clientInfoPath(serverName: string): string {
+    return path.join(this.dir, `${serverName}.client.json`);
+  }
+
+  private atomicWrite(filePath: string, data: string): void {
+    this.ensureDir();
+    const tmpPath = filePath + ".tmp";
+    fs.writeFileSync(tmpPath, data, { mode: 0o600 });
+    fs.renameSync(tmpPath, filePath);
+  }
+
+  private readJson(filePath: string): any | undefined {
+    try {
+      const data = fs.readFileSync(filePath, "utf-8");
+      return JSON.parse(data);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async saveTokens(serverName: string, tokens: OAuthTokens): Promise<void> {
+    this.atomicWrite(this.tokenPath(serverName), JSON.stringify(tokens));
+  }
+
+  async loadTokens(serverName: string): Promise<OAuthTokens | undefined> {
+    return this.readJson(this.tokenPath(serverName));
+  }
+
+  async deleteTokens(serverName: string): Promise<void> {
+    const p = this.tokenPath(serverName);
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+    await this.deleteCodeVerifier(serverName);
+    await this.deleteClientInfo(serverName);
+  }
+
+  async saveCodeVerifier(serverName: string, verifier: string): Promise<void> {
+    this.atomicWrite(this.verifierPath(serverName), verifier);
+  }
+
+  async loadCodeVerifier(serverName: string): Promise<string | undefined> {
+    try {
+      return fs.readFileSync(this.verifierPath(serverName), "utf-8");
+    } catch {
+      return undefined;
+    }
+  }
+
+  async deleteCodeVerifier(serverName: string): Promise<void> {
+    const p = this.verifierPath(serverName);
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+  }
+
+  async saveClientInfo(serverName: string, info: OAuthClientInformationMixed): Promise<void> {
+    this.atomicWrite(this.clientInfoPath(serverName), JSON.stringify(info));
+  }
+
+  async loadClientInfo(serverName: string): Promise<OAuthClientInformationMixed | undefined> {
+    return this.readJson(this.clientInfoPath(serverName));
+  }
+
+  async deleteClientInfo(serverName: string): Promise<void> {
+    const p = this.clientInfoPath(serverName);
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+  }
+
+  async listServers(): Promise<string[]> {
+    try {
+      const files = fs.readdirSync(this.dir);
+      return files
+        .filter((f) => f.endsWith(".json") && !f.endsWith(".client.json"))
+        .map((f) => f.replace(/\.json$/, ""));
+    } catch {
+      return [];
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `pnpm vitest run lib/runtime/mcp/tokenStore.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/mcp/tokenStore.ts lib/runtime/mcp/tokenStore.test.ts
+git commit -m "feat: add TokenStore for MCP OAuth token persistence"
+```
+
+---
+
+### Task 3: Callback server
+
+A temporary localhost HTTP server that listens for the OAuth redirect callback. All fields are private. The only public methods are `start()`, `waitForCode()`, and `stop()`. The `state` getter is read-only.
+
+**Files:**
+- Create: `lib/runtime/mcp/callbackServer.ts`
+- Create: `lib/runtime/mcp/callbackServer.test.ts`
+
+- [ ] **Step 1: Write the tests**
+
+Create `lib/runtime/mcp/callbackServer.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { CallbackServer } from "./callbackServer.js";
+
+describe("CallbackServer", () => {
+  it("should start on an available port and return a URL", async () => {
+    const server = new CallbackServer();
+    const url = await server.start();
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/oauth\/callback$/);
+    await server.stop();
+  });
+
+  it("should resolve with the authorization code when callback is received", async () => {
+    const server = new CallbackServer();
+    const url = await server.start();
+    const state = server.state;
+
+    const callbackUrl = `${url}?code=auth-code-123&state=${state}`;
+    const response = await fetch(callbackUrl);
+    expect(response.ok).toBe(true);
+
+    const code = await server.waitForCode();
+    expect(code).toBe("auth-code-123");
+
+    await server.stop();
+  });
+
+  it("should reject when state parameter doesn't match", async () => {
+    const server = new CallbackServer();
+    const url = await server.start();
+
+    const callbackUrl = `${url}?code=auth-code-123&state=wrong-state`;
+    const response = await fetch(callbackUrl);
+    expect(response.status).toBe(403);
+
+    await server.stop();
+  });
+
+  it("should reject when code is missing", async () => {
+    const server = new CallbackServer();
+    const url = await server.start();
+    const state = server.state;
+
+    const callbackUrl = `${url}?state=${state}`;
+    const response = await fetch(callbackUrl);
+    expect(response.status).toBe(400);
+
+    await server.stop();
+  });
+
+  it("should time out if no callback is received", async () => {
+    const server = new CallbackServer({ timeoutMs: 200 });
+    await server.start();
+
+    await expect(server.waitForCode()).rejects.toThrow(/timed out/i);
+
+    await server.stop();
+  });
+
+  it("should stop cleanly even if no callback was received", async () => {
+    const server = new CallbackServer();
+    await server.start();
+    await server.stop();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run lib/runtime/mcp/callbackServer.test.ts`
+Expected: FAIL — `callbackServer.js` doesn't exist
+
+- [ ] **Step 3: Implement CallbackServer**
+
+Create `lib/runtime/mcp/callbackServer.ts`:
+
+```ts
+import http from "http";
+import { randomBytes } from "crypto";
+
+const SUCCESS_HTML = `<!DOCTYPE html><html><body><h1>Authorization successful</h1><p>You can close this tab and return to your terminal.</p></body></html>`;
+const ERROR_HTML = `<!DOCTYPE html><html><body><h1>Authorization failed</h1><p>Please try again.</p></body></html>`;
+
+export type CallbackServerOptions = {
+  timeoutMs?: number; // default 300000 (5 minutes)
+};
+
+export class CallbackServer {
+  private server: http.Server | null = null;
+  private port = 0;
+  private _state: string;
+  private timeoutMs: number;
+  private codePromise: Promise<string>;
+  private resolveCode!: (code: string) => void;
+  private rejectCode!: (err: Error) => void;
+  private timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(opts: CallbackServerOptions = {}) {
+    this.timeoutMs = opts.timeoutMs ?? 300_000;
+    this._state = randomBytes(32).toString("hex");
+    this.codePromise = new Promise<string>((resolve, reject) => {
+      this.resolveCode = resolve;
+      this.rejectCode = reject;
+    });
+  }
+
+  get state(): string {
+    return this._state;
+  }
+
+  get callbackUrl(): string {
+    return `http://127.0.0.1:${this.port}/oauth/callback`;
+  }
+
+  async start(): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      this.server = http.createServer((req, res) => {
+        const url = new URL(req.url || "/", `http://127.0.0.1:${this.port}`);
+
+        if (url.pathname !== "/oauth/callback") {
+          res.writeHead(404);
+          res.end("Not found");
+          return;
+        }
+
+        const code = url.searchParams.get("code");
+        const state = url.searchParams.get("state");
+
+        if (state !== this._state) {
+          res.writeHead(403, { "Content-Type": "text/html" });
+          res.end(ERROR_HTML);
+          return;
+        }
+
+        if (!code) {
+          res.writeHead(400, { "Content-Type": "text/html" });
+          res.end(ERROR_HTML);
+          return;
+        }
+
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(SUCCESS_HTML);
+        this.resolveCode(code);
+      });
+
+      this.server.listen(0, "127.0.0.1", () => {
+        const addr = this.server!.address();
+        if (addr && typeof addr === "object") {
+          this.port = addr.port;
+        }
+        resolve(this.callbackUrl);
+      });
+
+      this.server.on("error", reject);
+
+      this.timeoutHandle = setTimeout(() => {
+        this.rejectCode(new Error("OAuth callback timed out"));
+      }, this.timeoutMs);
+    });
+  }
+
+  async waitForCode(): Promise<string> {
+    return this.codePromise;
+  }
+
+  async stop(): Promise<void> {
+    if (this.timeoutHandle) {
+      clearTimeout(this.timeoutHandle);
+      this.timeoutHandle = null;
+    }
+    if (this.server) {
+      return new Promise<void>((resolve) => {
+        this.server!.close(() => resolve());
+        this.server = null;
+      });
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `pnpm vitest run lib/runtime/mcp/callbackServer.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/mcp/callbackServer.ts lib/runtime/mcp/callbackServer.test.ts
+git commit -m "feat: add CallbackServer for MCP OAuth redirect handling"
+```
+
+---
+
+### Task 4: OAuth provider
+
+Implements the MCP SDK's `OAuthClientProvider` interface. All fields are private. The only public surface is what `OAuthClientProvider` requires, plus `prepare()`, `waitForAuthCode()`, and `cleanup()`.
+
+**Files:**
+- Create: `lib/runtime/mcp/oauthProvider.ts`
+- Create: `lib/runtime/mcp/oauthProvider.test.ts`
+
+**Context:** The MCP SDK's `StreamableHTTPClientTransport` constructor accepts `{ authProvider?: OAuthClientProvider }`. When the server requires auth:
+1. The SDK calls `authProvider.tokens()` to check for existing tokens
+2. If no tokens / expired, the SDK calls `authProvider.redirectToAuthorization(url)` — our implementation opens the browser
+3. The SDK throws `UnauthorizedError` from `connect()`
+4. The caller catches it, waits for the callback code via `provider.waitForAuthCode()`, and calls `transport.finishAuth(code)`
+5. The SDK calls `authProvider.saveTokens()` with the new tokens
+6. The caller retries `connect()`
+
+- [ ] **Step 1: Write the tests**
+
+Create `lib/runtime/mcp/oauthProvider.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { AgencyOAuthProvider } from "./oauthProvider.js";
+import { TokenStore } from "./tokenStore.js";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+describe("AgencyOAuthProvider", () => {
+  let tmpDir: string;
+  let store: TokenStore;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-oauth-test-"));
+    store = new TokenStore(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should return undefined tokens when none are stored", async () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const tokens = await provider.tokens();
+    expect(tokens).toBeUndefined();
+  });
+
+  it("should return stored tokens", async () => {
+    const savedTokens = { access_token: "abc", token_type: "bearer" };
+    await store.saveTokens("github", savedTokens);
+
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const tokens = await provider.tokens();
+    expect(tokens).toEqual(savedTokens);
+  });
+
+  it("should save tokens via saveTokens", async () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const tokens = { access_token: "new-token", token_type: "bearer" };
+    await provider.saveTokens(tokens);
+
+    const loaded = await store.loadTokens("github");
+    expect(loaded).toEqual(tokens);
+  });
+
+  it("should save and load code verifier", async () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    await provider.saveCodeVerifier("verifier-abc");
+    const loaded = await provider.codeVerifier();
+    expect(loaded).toBe("verifier-abc");
+  });
+
+  it("should save and load client info", async () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const info = { client_id: "my-id", client_secret: "secret" };
+    await provider.saveClientInformation(info);
+    const loaded = await provider.clientInformation();
+    expect(loaded).toEqual(info);
+  });
+
+  it("should have correct client metadata", () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const meta = provider.clientMetadata;
+    expect(meta.client_name).toBe("agency-github");
+    expect(meta.redirect_uris).toBeDefined();
+  });
+
+  it("should have a real redirectUrl after prepare()", async () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    await provider.prepare();
+    expect(provider.redirectUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/oauth\/callback$/);
+    expect(provider.redirectUrl).not.toContain(":0/");
+    await provider.cleanup();
+  });
+
+  it("should call onOAuthRequired callback instead of opening browser when provided", async () => {
+    const onOAuthRequired = vi.fn();
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store, {
+      onOAuthRequired,
+    });
+
+    const authUrl = new URL("https://example.com/authorize?code=123");
+    await provider.redirectToAuthorization(authUrl);
+
+    expect(onOAuthRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverName: "github",
+        authUrl: authUrl.toString(),
+      }),
+    );
+  });
+
+  it("should expose waitForAuthCode() that resolves when callback arrives", async () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    await provider.prepare();
+
+    // Simulate callback arriving
+    const callbackUrl = provider.redirectUrl;
+    const state = provider.state;
+    // Fire the callback in the background
+    const codePromise = provider.waitForAuthCode();
+    await fetch(`${callbackUrl}?code=test-code&state=${state}`);
+    const code = await codePromise;
+    expect(code).toBe("test-code");
+
+    await provider.cleanup();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run lib/runtime/mcp/oauthProvider.test.ts`
+Expected: FAIL — `oauthProvider.js` doesn't exist
+
+- [ ] **Step 3: Implement AgencyOAuthProvider**
+
+Create `lib/runtime/mcp/oauthProvider.ts`:
+
+```ts
+import type {
+  OAuthClientProvider,
+} from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthTokens,
+  OAuthClientMetadata,
+  OAuthClientInformationMixed,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { CallbackServer } from "./callbackServer.js";
+import { TokenStore } from "./tokenStore.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Open a URL in the default browser. macOS-only for now. */
+async function openInBrowser(url: string): Promise<void> {
+  await execFileAsync("open", [url]);
+}
+
+export type OAuthRequiredData = {
+  serverName: string;
+  authUrl: string;
+  /** Promise that resolves when the OAuth flow completes (callback received) */
+  complete: Promise<void>;
+  /** Cancel the OAuth flow */
+  cancel: () => void;
+};
+
+export type OAuthProviderOptions = {
+  onOAuthRequired?: (data: OAuthRequiredData) => void | Promise<void>;
+  timeoutMs?: number;
+};
+
+export class AgencyOAuthProvider implements OAuthClientProvider {
+  private serverName: string;
+  private serverUrl: string;
+  private store: TokenStore;
+  private options: OAuthProviderOptions;
+  private callbackServer: CallbackServer | null = null;
+  private _callbackUrl: string | null = null;
+
+  constructor(
+    serverName: string,
+    serverUrl: string,
+    store: TokenStore,
+    options: OAuthProviderOptions = {},
+  ) {
+    this.serverName = serverName;
+    this.serverUrl = serverUrl;
+    this.store = store;
+    this.options = options;
+  }
+
+  /**
+   * Start the callback server before connect() so the redirect URL is
+   * known when the SDK reads clientMetadata for dynamic registration.
+   * Called by OAuthConnector before client.connect().
+   */
+  async prepare(): Promise<void> {
+    this.callbackServer = new CallbackServer({
+      timeoutMs: this.options.timeoutMs,
+    });
+    this._callbackUrl = await this.callbackServer.start();
+  }
+
+  /**
+   * Wait for the authorization code from the callback server.
+   * Returns the code string. Rejects on timeout or cancellation.
+   */
+  async waitForAuthCode(): Promise<string> {
+    if (!this.callbackServer) {
+      throw new Error(`OAuth flow for "${this.serverName}" not started — call prepare() first`);
+    }
+    return this.callbackServer.waitForCode();
+  }
+
+  get state(): string {
+    if (!this.callbackServer) {
+      throw new Error(`OAuth flow for "${this.serverName}" not started — call prepare() first`);
+    }
+    return this.callbackServer.state;
+  }
+
+  get redirectUrl(): string {
+    // After prepare(), this is the real localhost URL with actual port.
+    return this._callbackUrl ?? "http://127.0.0.1:0/oauth/callback";
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      redirect_uris: [new URL(this.redirectUrl)],
+      client_name: `agency-${this.serverName}`,
+    };
+  }
+
+  async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+    return this.store.loadClientInfo(this.serverName);
+  }
+
+  async saveClientInformation(info: OAuthClientInformationMixed): Promise<void> {
+    await this.store.saveClientInfo(this.serverName, info);
+  }
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    return this.store.loadTokens(this.serverName);
+  }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    await this.store.saveTokens(this.serverName, tokens);
+  }
+
+  async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    // Set up a completion promise for the onOAuthRequired callback
+    let resolveComplete: () => void;
+    let rejectComplete: (err: Error) => void;
+    const completePromise = new Promise<void>((resolve, reject) => {
+      resolveComplete = resolve;
+      rejectComplete = reject;
+    });
+
+    // Wire callback server completion to the complete promise
+    if (this.callbackServer) {
+      this.callbackServer.waitForCode()
+        .then(() => resolveComplete())
+        .catch((err) => rejectComplete(err));
+    }
+
+    if (this.options.onOAuthRequired) {
+      await this.options.onOAuthRequired({
+        serverName: this.serverName,
+        authUrl: authorizationUrl.toString(),
+        complete: completePromise,
+        cancel: () => {
+          this.cleanup();
+          rejectComplete!(new Error("OAuth flow cancelled"));
+        },
+      });
+    } else {
+      try {
+        await openInBrowser(authorizationUrl.toString());
+        console.log(
+          `Waiting for authorization for "${this.serverName}"... (press Ctrl+C to cancel)`,
+        );
+      } catch {
+        console.log(
+          `Please open this URL to authorize "${this.serverName}":\n${authorizationUrl.toString()}`,
+        );
+      }
+    }
+  }
+
+  async saveCodeVerifier(verifier: string): Promise<void> {
+    await this.store.saveCodeVerifier(this.serverName, verifier);
+  }
+
+  async codeVerifier(): Promise<string> {
+    const verifier = await this.store.loadCodeVerifier(this.serverName);
+    if (!verifier) {
+      throw new Error(`No PKCE code verifier found for "${this.serverName}"`);
+    }
+    return verifier;
+  }
+
+  async cleanup(): Promise<void> {
+    if (this.callbackServer) {
+      await this.callbackServer.stop();
+      this.callbackServer = null;
+    }
+    this._callbackUrl = null;
+    await this.store.deleteCodeVerifier(this.serverName);
+  }
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `pnpm vitest run lib/runtime/mcp/oauthProvider.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/mcp/oauthProvider.ts lib/runtime/mcp/oauthProvider.test.ts
+git commit -m "feat: add AgencyOAuthProvider implementing MCP SDK OAuthClientProvider"
+```
+
+---
+
+### Task 5: OAuthConnector
+
+Encapsulates the entire two-phase OAuth connect flow. This is the ONLY class that knows about `UnauthorizedError`, `finishAuth()`, and the retry logic. All fields are private. The only public method is `connect()`, which returns a connected `{client, transport}` pair.
+
+**Files:**
+- Create: `lib/runtime/mcp/oauthConnector.ts`
+- Create: `lib/runtime/mcp/oauthConnector.test.ts`
+
+- [ ] **Step 1: Write the tests**
+
+Create `lib/runtime/mcp/oauthConnector.test.ts`:
+
+```ts
+import { describe, it, expect, afterEach } from "vitest";
+import { OAuthConnector } from "./oauthConnector.js";
+import { TokenStore } from "./tokenStore.js";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+describe("OAuthConnector", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should construct with server name, url, and token store", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-connector-test-"));
+    const store = new TokenStore(tmpDir);
+    const connector = new OAuthConnector("github", "https://example.com/mcp", store);
+    expect(connector).toBeDefined();
+  });
+
+  it("should return a failure-path error when server is unreachable", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-connector-test-"));
+    const store = new TokenStore(tmpDir);
+    const connector = new OAuthConnector("test", "http://127.0.0.1:1/nonexistent", store);
+
+    // connect() should throw since the server is unreachable
+    await expect(connector.connect()).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run lib/runtime/mcp/oauthConnector.test.ts`
+Expected: FAIL — `oauthConnector.js` doesn't exist
+
+- [ ] **Step 3: Implement OAuthConnector**
+
+Create `lib/runtime/mcp/oauthConnector.ts`:
+
+```ts
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { AgencyOAuthProvider, type OAuthProviderOptions } from "./oauthProvider.js";
+import { TokenStore } from "./tokenStore.js";
+
+export type OAuthConnectResult = {
+  client: Client;
+  transport: StreamableHTTPClientTransport;
+};
+
+/**
+ * Encapsulates the two-phase OAuth connect flow for an MCP HTTP server.
+ *
+ * This is the ONLY class that knows about UnauthorizedError, finishAuth(),
+ * and the retry logic. McpConnection and McpManager do not import any
+ * OAuth-related types.
+ *
+ * Usage:
+ *   const connector = new OAuthConnector(serverName, url, tokenStore, options);
+ *   const { client, transport } = await connector.connect();
+ */
+export class OAuthConnector {
+  private serverName: string;
+  private url: string;
+  private provider: AgencyOAuthProvider;
+
+  constructor(
+    serverName: string,
+    url: string,
+    tokenStore: TokenStore,
+    options: OAuthProviderOptions = {},
+  ) {
+    this.serverName = serverName;
+    this.url = url;
+    this.provider = new AgencyOAuthProvider(serverName, url, tokenStore, options);
+  }
+
+  private createTransport(): StreamableHTTPClientTransport {
+    return new StreamableHTTPClientTransport(new URL(this.url), {
+      authProvider: this.provider,
+    });
+  }
+
+  private createClient(): Client {
+    return new Client({ name: "agency-lang", version: "1.0.0" });
+  }
+
+  /**
+   * Connect to the MCP server, handling OAuth if required.
+   *
+   * 1. Starts the callback server (so redirect URL is known for registration)
+   * 2. Attempts to connect
+   * 3. If the server requires auth, the SDK calls redirectToAuthorization
+   *    and throws UnauthorizedError
+   * 4. Waits for the user to authorize in the browser
+   * 5. Calls finishAuth(code) to exchange the code for tokens
+   * 6. Retries with a fresh client/transport (SDK may not support reuse)
+   *
+   * Returns a connected {client, transport} pair.
+   */
+  async connect(): Promise<OAuthConnectResult> {
+    // Start callback server BEFORE connect so the redirect URL has a real port
+    // when the SDK reads clientMetadata for dynamic client registration.
+    await this.provider.prepare();
+
+    const client = this.createClient();
+    const transport = this.createTransport();
+
+    try {
+      await client.connect(transport);
+      // No auth needed (or had valid stored tokens) — clean up callback server
+      await this.provider.cleanup();
+      return { client, transport };
+    } catch (error) {
+      if (!(error instanceof UnauthorizedError)) {
+        await this.provider.cleanup();
+        throw error;
+      }
+
+      // Two-phase OAuth: the SDK has called redirectToAuthorization and thrown.
+      // Wait for the user to complete auth in the browser.
+      try {
+        const code = await this.provider.waitForAuthCode();
+        await transport.finishAuth(code);
+
+        // Create fresh client/transport for retry — the SDK may not support
+        // reusing a Client/transport after an UnauthorizedError.
+        const retryClient = this.createClient();
+        const retryTransport = this.createTransport();
+        await retryClient.connect(retryTransport);
+        return { client: retryClient, transport: retryTransport };
+      } finally {
+        await this.provider.cleanup();
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `pnpm vitest run lib/runtime/mcp/oauthConnector.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/mcp/oauthConnector.ts lib/runtime/mcp/oauthConnector.test.ts
+git commit -m "feat: add OAuthConnector encapsulating two-phase MCP OAuth flow"
+```
+
+---
+
+### Task 6: Extend config types and validation
+
+Add `auth`, `authTimeout`, and `headers` fields to HTTP server config, with mutual exclusion validation.
+
+**Files:**
+- Modify: `lib/runtime/mcp/types.ts`
+- Modify: `lib/config.ts`
+- Modify: `lib/config.test.ts`
+
+- [ ] **Step 1: Write the new config validation tests**
+
+Add to `lib/config.test.ts` (inside the existing `describe("AgencyConfigSchema")` block):
+
+```ts
+it("should accept HTTP server with auth: oauth", () => {
+  const result = AgencyConfigSchema.safeParse({
+    mcpServers: {
+      github: { type: "http", url: "https://github-mcp.example.com/mcp", auth: "oauth" },
+    },
+  });
+  expect(result.success).toBe(true);
+});
+
+it("should accept HTTP server with headers", () => {
+  const result = AgencyConfigSchema.safeParse({
+    mcpServers: {
+      weather: {
+        type: "http",
+        url: "https://weather.example.com/mcp",
+        headers: { "Authorization": "Bearer ${WEATHER_KEY}" },
+      },
+    },
+  });
+  expect(result.success).toBe(true);
+});
+
+it("should accept HTTP server with authTimeout", () => {
+  const result = AgencyConfigSchema.safeParse({
+    mcpServers: {
+      github: {
+        type: "http",
+        url: "https://github-mcp.example.com/mcp",
+        auth: "oauth",
+        authTimeout: 120000,
+      },
+    },
+  });
+  expect(result.success).toBe(true);
+});
+
+it("should reject HTTP server with both auth and headers", () => {
+  const result = AgencyConfigSchema.safeParse({
+    mcpServers: {
+      github: {
+        type: "http",
+        url: "https://example.com/mcp",
+        auth: "oauth",
+        headers: { "Authorization": "Bearer token" },
+      },
+    },
+  });
+  expect(result.success).toBe(false);
+});
+
+it("should reject authTimeout without auth: oauth", () => {
+  const result = AgencyConfigSchema.safeParse({
+    mcpServers: {
+      github: {
+        type: "http",
+        url: "https://example.com/mcp",
+        authTimeout: 120000,
+      },
+    },
+  });
+  expect(result.success).toBe(false);
+});
+
+it("should reject auth on stdio server", () => {
+  const result = AgencyConfigSchema.safeParse({
+    mcpServers: {
+      local: {
+        command: "npx",
+        args: ["some-server"],
+        auth: "oauth",
+      },
+    },
+  });
+  expect(result.success).toBe(false);
+});
+```
+
+- [ ] **Step 2: Run test to verify the new tests fail**
+
+Run: `pnpm vitest run lib/config.test.ts`
+Expected: New tests FAIL (existing tests still pass)
+
+- [ ] **Step 3: Update the types**
+
+In `lib/runtime/mcp/types.ts`, update `McpHttpServerConfig`:
+
+```ts
+export type McpHttpServerConfig = {
+  type: "http";
+  url: string;
+  auth?: "oauth";
+  authTimeout?: number;
+  headers?: Record<string, string>;
+};
+```
+
+- [ ] **Step 4: Update the Zod schema**
+
+In `lib/config.ts`, replace `McpHttpServerSchema`:
+
+```ts
+const McpHttpServerSchema = z.object({
+  type: z.literal("http"),
+  url: z.string(),
+  auth: z.literal("oauth").optional(),
+  authTimeout: z.number().optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+}).strict();
+
+const McpServerSchema = z.union([MccStdioServerSchema, McpHttpServerSchema]);
+```
+
+Then chain `.superRefine()` on `AgencyConfigSchema` for cross-field validation. The existing schema chains `.partial().passthrough()`. Preserve that and append `.superRefine(...)`:
+
+```ts
+export const AgencyConfigSchema = z.object({
+  // ... existing fields ...
+  mcpServers: z.record(z.string(), McpServerSchema).optional(),
+  // ... existing fields ...
+}).partial().passthrough().superRefine((data, ctx) => {
+  if (!data.mcpServers) return;
+  for (const [name, server] of Object.entries(data.mcpServers)) {
+    if ("type" in server && server.type === "http") {
+      const httpServer = server as z.infer<typeof McpHttpServerSchema>;
+      if (httpServer.auth && httpServer.headers) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `MCP server "${name}": cannot specify both 'auth' and 'headers'`,
+          path: ["mcpServers", name],
+        });
+      }
+      if (httpServer.authTimeout && httpServer.auth !== "oauth") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `MCP server "${name}": 'authTimeout' requires 'auth: "oauth"'`,
+          path: ["mcpServers", name],
+        });
+      }
+    }
+  }
+});
+```
+
+This keeps `McpHttpServerSchema` as a plain `ZodObject` (no `ZodEffects`), so `z.union` works.
+
+- [ ] **Step 5: Run tests and verify they pass**
+
+Run: `pnpm vitest run lib/config.test.ts`
+Expected: All tests PASS (both old and new)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/runtime/mcp/types.ts lib/config.ts lib/config.test.ts
+git commit -m "feat: add auth, headers, authTimeout to MCP HTTP server config"
+```
+
+---
+
+### Task 7: Static headers and OAuth connector in McpConnection
+
+Add env var interpolation for `headers` config. Add support for receiving a pre-connected `{client, transport}` from `OAuthConnector`. **McpConnection does NOT import any OAuth types.**
+
+**Files:**
+- Modify: `lib/runtime/mcp/mcpConnection.ts`
+- Modify: `lib/runtime/mcp/mcpConnection.test.ts`
+
+- [ ] **Step 1: Write the tests**
+
+Add to `lib/runtime/mcp/mcpConnection.test.ts`:
+
+```ts
+import { interpolateEnvVars } from "./mcpConnection.js";
+
+describe("interpolateEnvVars", () => {
+  it("should replace ${VAR} with env values", () => {
+    const original = process.env.TEST_VAR_ABC;
+    process.env.TEST_VAR_ABC = "hello";
+    try {
+      const result = interpolateEnvVars({ "Authorization": "Bearer ${TEST_VAR_ABC}" });
+      expect(result["Authorization"]).toBe("Bearer hello");
+    } finally {
+      if (original === undefined) delete process.env.TEST_VAR_ABC;
+      else process.env.TEST_VAR_ABC = original;
+    }
+  });
+
+  it("should throw if env var is not set", () => {
+    delete process.env.NONEXISTENT_VAR_XYZ;
+    expect(() =>
+      interpolateEnvVars({ "Authorization": "Bearer ${NONEXISTENT_VAR_XYZ}" }),
+    ).toThrow(/NONEXISTENT_VAR_XYZ/);
+  });
+
+  it("should pass through headers without env vars unchanged", () => {
+    const result = interpolateEnvVars({ "X-Custom": "static-value" });
+    expect(result["X-Custom"]).toBe("static-value");
+  });
+
+  it("should reject values containing newlines (CRLF injection)", () => {
+    const original = process.env.TEST_CRLF_VAR;
+    process.env.TEST_CRLF_VAR = "token\r\nX-Injected: evil";
+    try {
+      expect(() =>
+        interpolateEnvVars({ "Authorization": "Bearer ${TEST_CRLF_VAR}" }),
+      ).toThrow(/newline/i);
+    } finally {
+      if (original === undefined) delete process.env.TEST_CRLF_VAR;
+      else process.env.TEST_CRLF_VAR = original;
+    }
+  });
+
+  it("should reject values containing bare \\n (LF injection)", () => {
+    const original = process.env.TEST_LF_VAR;
+    process.env.TEST_LF_VAR = "token\nX-Injected: evil";
+    try {
+      expect(() =>
+        interpolateEnvVars({ "Authorization": "Bearer ${TEST_LF_VAR}" }),
+      ).toThrow(/newline/i);
+    } finally {
+      if (original === undefined) delete process.env.TEST_LF_VAR;
+      else process.env.TEST_LF_VAR = original;
+    }
+  });
+});
+
+describe("McpConnection with connector", () => {
+  it("should accept a connector function option", () => {
+    const conn = new McpConnection("test", {
+      type: "http",
+      url: "https://example.com/mcp",
+      auth: "oauth",
+    }, {
+      connector: async () => {
+        throw new Error("mock connector");
+      },
+    });
+    expect(conn).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run lib/runtime/mcp/mcpConnection.test.ts`
+Expected: FAIL — `interpolateEnvVars` not exported, connector not accepted
+
+- [ ] **Step 3: Implement**
+
+Replace the full contents of `lib/runtime/mcp/mcpConnection.ts`:
+
+```ts
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { McpServerConfig, McpStdioServerConfig, McpHttpServerConfig, McpTool } from "./types.js";
+
+export function interpolateEnvVars(headers: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    result[key] = value.replace(/\$\{(\w+)\}/g, (_, varName) => {
+      const envValue = process.env[varName];
+      if (envValue === undefined) {
+        throw new Error(
+          `Environment variable "${varName}" is not set (referenced in MCP server headers)`,
+        );
+      }
+      return envValue;
+    });
+    // Guard against CRLF injection: env var values containing \r or \n
+    // could inject additional HTTP headers.
+    if (/[\r\n]/.test(result[key])) {
+      throw new Error(
+        `Header "${key}" contains illegal newline characters after environment variable interpolation (possible CRLF injection)`,
+      );
+    }
+  }
+  return result;
+}
+
+/**
+ * A function that returns a connected {client, transport} pair.
+ * Used by OAuthConnector to provide pre-authenticated connections.
+ * McpConnection does NOT know what this function does internally.
+ */
+export type ConnectorFn = () => Promise<{ client: Client; transport: any }>;
+
+export type McpConnectionOptions = {
+  /** Opaque connector function that returns a connected client+transport. */
+  connector?: ConnectorFn;
+};
+
+export class McpConnection {
+  private client: Client;
+  private serverName: string;
+  private config: McpServerConfig;
+  private tools: McpTool[] = [];
+  private connected = false;
+  private connector: ConnectorFn | undefined;
+
+  constructor(serverName: string, config: McpServerConfig, options: McpConnectionOptions = {}) {
+    this.serverName = serverName;
+    this.config = config;
+    this.connector = options.connector;
+    this.client = new Client({
+      name: "agency-lang",
+      version: "1.0.0",
+    });
+  }
+
+  async connect(): Promise<void> {
+    if (this.connector) {
+      // Delegate entirely to the connector (e.g. OAuthConnector).
+      // McpConnection doesn't know what happens inside.
+      const result = await this.connector();
+      this.client = result.client;
+    } else {
+      // Build transport directly (stdio or plain HTTP with optional headers)
+      let transport;
+      if ("type" in this.config && this.config.type === "http") {
+        const httpConfig = this.config as McpHttpServerConfig;
+        const opts: Record<string, any> = {};
+        if (httpConfig.headers) {
+          const headers = interpolateEnvVars(httpConfig.headers);
+          opts.requestInit = { headers };
+        }
+        transport = new StreamableHTTPClientTransport(new URL(httpConfig.url), opts);
+      } else {
+        const stdio = this.config as McpStdioServerConfig;
+        transport = new StdioClientTransport({
+          command: stdio.command,
+          args: stdio.args,
+          env: stdio.env,
+        });
+      }
+      await this.client.connect(transport);
+    }
+
+    this.connected = true;
+
+    const result = await this.client.listTools();
+    this.tools = (result.tools || []).map((tool) => ({
+      name: `${this.serverName}__${tool.name}`,
+      description: tool.description || "",
+      serverName: this.serverName,
+      inputSchema: (tool.inputSchema as Record<string, unknown>) || {},
+      __mcpTool: true as const,
+    }));
+  }
+
+  getTools(): McpTool[] {
+    return this.tools;
+  }
+
+  async callTool(
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<string> {
+    const result = await this.client.callTool({ name: toolName, arguments: args });
+    const textParts = (result.content as any[])
+      .filter((c: any) => c.type === "text")
+      .map((c: any) => c.text);
+    return textParts.join("\n");
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.connected) {
+      await this.client.close();
+      this.connected = false;
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+}
+```
+
+Note: `McpConnection` imports **zero** OAuth-related modules. It takes an opaque `ConnectorFn` that returns `{client, transport}`. It doesn't know or care whether OAuth happened.
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `pnpm vitest run lib/runtime/mcp/mcpConnection.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/mcp/mcpConnection.ts lib/runtime/mcp/mcpConnection.test.ts
+git commit -m "feat: add static headers and connector support to McpConnection"
+```
+
+---
+
+### Task 8: Wire OAuth into McpManager via factory
+
+`McpManager` creates `OAuthConnector` instances for OAuth servers and passes their `connect()` method as the `ConnectorFn` to `McpConnection`. `McpManager` never touches `AgencyOAuthProvider`, `TokenStore`, or `CallbackServer` directly — it only imports `OAuthConnector`.
+
+**Files:**
+- Modify: `lib/runtime/mcp/mcpManager.ts`
+- Modify: `lib/runtime/mcp/mcpManager.test.ts`
+
+- [ ] **Step 1: Write the tests**
+
+Add `fs` and `os` to the existing imports at the top of `lib/runtime/mcp/mcpManager.test.ts` (the file already imports `path`):
+
+```ts
+import fs from "fs";
+import os from "os";
+```
+
+Then add a new describe block:
+
+```ts
+describe("McpManager OAuth config", () => {
+  it("should accept onOAuthRequired callback", () => {
+    const manager = new McpManager(
+      {
+        github: { type: "http" as const, url: "https://example.com/mcp", auth: "oauth" as const },
+      },
+      { onOAuthRequired: () => {} },
+    );
+    expect(manager).toBeDefined();
+  });
+
+  it("should accept a custom tokenStoreDir", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-mgr-test-"));
+    try {
+      const manager = new McpManager(
+        { github: { type: "http" as const, url: "https://example.com/mcp", auth: "oauth" as const } },
+        { tokenStoreDir: tmpDir },
+      );
+      expect(manager).toBeDefined();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should return a failure when OAuth server is unreachable", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-mgr-test-"));
+    try {
+      const manager = new McpManager(
+        {
+          test: {
+            type: "http" as const,
+            url: "http://127.0.0.1:1/nonexistent",
+            auth: "oauth" as const,
+          },
+        },
+        { tokenStoreDir: tmpDir },
+      );
+      const result = await manager.getTools("test");
+      expect(result.success).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should deduplicate concurrent getTools calls for the same server", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-mgr-test-"));
+    try {
+      const manager = new McpManager(
+        {
+          test: {
+            type: "http" as const,
+            url: "http://127.0.0.1:1/nonexistent",
+            auth: "oauth" as const,
+          },
+        },
+        { tokenStoreDir: tmpDir },
+      );
+      const [result1, result2] = await Promise.all([
+        manager.getTools("test"),
+        manager.getTools("test"),
+      ]);
+      expect(result1.success).toBe(false);
+      expect(result2.success).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run lib/runtime/mcp/mcpManager.test.ts`
+Expected: FAIL — `McpManager` doesn't accept a second argument
+
+- [ ] **Step 3: Update McpManager**
+
+Replace the full contents of `lib/runtime/mcp/mcpManager.ts`:
+
+```ts
+import { McpConnection } from "./mcpConnection.js";
+import { OAuthConnector } from "./oauthConnector.js";
+import { TokenStore } from "./tokenStore.js";
+import type { ServerName, McpServerConfig, McpHttpServerConfig, McpTool } from "./types.js";
+import { success, failure, type ResultValue } from "../result.js";
+import type { OAuthRequiredData } from "./oauthProvider.js";
+
+export type McpManagerOptions = {
+  onOAuthRequired?: (data: OAuthRequiredData) => void | Promise<void>;
+  tokenStoreDir?: string;
+};
+
+export class McpManager {
+  private config: Record<ServerName, McpServerConfig>;
+  private connections: Record<ServerName, McpConnection> = {};
+  private toolCache: Record<ServerName, McpTool[]> = {};
+  private connectPromises: Record<ServerName, Promise<ResultValue>> = {};
+  private tokenStore: TokenStore;
+  private onOAuthRequired?: (data: OAuthRequiredData) => void | Promise<void>;
+
+  constructor(
+    config: Record<ServerName, McpServerConfig>,
+    options: McpManagerOptions = {},
+  ) {
+    this.config = config;
+    this.tokenStore = new TokenStore(options.tokenStoreDir);
+    this.onOAuthRequired = options.onOAuthRequired;
+  }
+
+  private createConnection(serverName: string): McpConnection {
+    const serverConfig = this.config[serverName];
+    const isOAuth =
+      "type" in serverConfig &&
+      serverConfig.type === "http" &&
+      (serverConfig as McpHttpServerConfig).auth === "oauth";
+
+    if (isOAuth) {
+      const httpConfig = serverConfig as McpHttpServerConfig;
+      const connector = new OAuthConnector(serverName, httpConfig.url, this.tokenStore, {
+        onOAuthRequired: this.onOAuthRequired,
+        timeoutMs: httpConfig.authTimeout,
+      });
+      // Pass connector.connect() as the opaque ConnectorFn.
+      // McpConnection doesn't know what happens inside.
+      return new McpConnection(serverName, serverConfig, {
+        connector: () => connector.connect(),
+      });
+    }
+
+    return new McpConnection(serverName, serverConfig);
+  }
+
+  async getTools(serverName: string): Promise<ResultValue> {
+    if (!this.config[serverName]) {
+      throw new Error(
+        `MCP server "${serverName}" not found in agency.json mcpServers config`,
+      );
+    }
+
+    if (this.toolCache[serverName]) {
+      return success(this.toolCache[serverName]);
+    }
+
+    // Prevent concurrent connection attempts for the same server.
+    // Only one OAuth flow should fire per server.
+    if (this.connectPromises[serverName]) {
+      return this.connectPromises[serverName];
+    }
+
+    const connectPromise = (async () => {
+      try {
+        const conn = this.createConnection(serverName);
+        await conn.connect();
+        this.connections[serverName] = conn;
+        this.toolCache[serverName] = conn.getTools();
+        return success(this.toolCache[serverName]);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return failure(
+          `Failed to connect to MCP server "${serverName}": ${message}`,
+        );
+      } finally {
+        delete this.connectPromises[serverName];
+      }
+    })();
+
+    this.connectPromises[serverName] = connectPromise;
+    return connectPromise;
+  }
+
+  async callTool(
+    serverName: string,
+    toolName: string,
+    args: Record<string, unknown>,
+  ): Promise<string> {
+    const conn = this.connections[serverName];
+    if (!conn) {
+      if (this.config[serverName]) {
+        const reconnConn = this.createConnection(serverName);
+        await reconnConn.connect();
+        this.connections[serverName] = reconnConn;
+        return reconnConn.callTool(toolName, args);
+      }
+      throw new Error(
+        `No MCP connection for server "${serverName}" and no config to reconnect`,
+      );
+    }
+    return conn.callTool(toolName, args);
+  }
+
+  async disconnectAll(): Promise<void> {
+    const conns = Object.values(this.connections);
+    if (conns.length === 0) return;
+    await Promise.all(conns.map((conn) => conn.disconnect().catch(() => {})));
+    this.connections = {};
+    this.toolCache = {};
+  }
+}
+```
+
+Note: `McpManager` imports `OAuthConnector` and `TokenStore` but does NOT import `AgencyOAuthProvider`, `CallbackServer`, or any MCP SDK auth types. It passes `connector.connect()` as an opaque function.
+
+- [ ] **Step 4: Run tests and verify they pass**
+
+Run: `pnpm vitest run lib/runtime/mcp/mcpManager.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/mcp/mcpManager.ts lib/runtime/mcp/mcpManager.test.ts
+git commit -m "feat: wire OAuthConnector into McpManager via factory pattern"
+```
+
+---
+
+### Task 9: Thread onOAuthRequired callback from RuntimeContext
+
+`McpManager` is created in `RuntimeContext.createMcpManager()`, which is called from generated code. The lifecycle callbacks need to flow from the caller through to `McpManager`.
+
+**Files:**
+- Modify: `lib/runtime/state/context.ts`
+- Modify: `lib/runtime/hooks.ts`
+- Modify: `lib/types/function.ts`
+
+- [ ] **Step 1: Add `onOAuthRequired` to the callback types**
+
+In `lib/types/function.ts`, add to `VALID_CALLBACK_NAMES`:
+
+```ts
+export const VALID_CALLBACK_NAMES = [
+  "onAgentStart",
+  "onAgentEnd",
+  "onNodeStart",
+  "onNodeEnd",
+  "onLLMCallStart",
+  "onLLMCallEnd",
+  "onFunctionStart",
+  "onFunctionEnd",
+  "onToolCallStart",
+  "onToolCallEnd",
+  "onStream",
+  "onTrace",
+  "onOAuthRequired",
+] as const;
+```
+
+In `lib/runtime/hooks.ts`, add the new callback type to `CallbackMap`:
+
+```ts
+onOAuthRequired: {
+  serverName: string;
+  authUrl: string;
+  complete: Promise<void>;
+  cancel: () => void;
+};
+```
+
+- [ ] **Step 2: Update `createMcpManager` to pass the callback**
+
+In `lib/runtime/state/context.ts`, update `createMcpManager`:
+
+```ts
+createMcpManager(config: Record<string, any>): void {
+  const onOAuthRequired = this._registeredCallbacks.onOAuthRequired as
+    | ((data: any) => void | Promise<void>)
+    | undefined;
+  this._mcpManager = new McpManager(config, { onOAuthRequired });
+}
+```
+
+- [ ] **Step 3: Run existing tests to make sure nothing broke**
+
+Run: `pnpm vitest run lib/runtime/mcp/`
+Expected: All existing MCP tests PASS
+
+Run: `pnpm vitest run lib/config.test.ts`
+Expected: All PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/types/function.ts lib/runtime/hooks.ts lib/runtime/state/context.ts
+git commit -m "feat: thread onOAuthRequired lifecycle callback to McpManager"
+```
+
+---
+
+### Task 10: CLI `agency auth` command
+
+Adds `agency auth <server>`, `agency auth --list`, and `agency auth --revoke <server>` commands for managing OAuth tokens.
+
+**Files:**
+- Create: `lib/cli/auth.ts`
+- Modify: `scripts/agency.ts`
+
+- [ ] **Step 1: Implement the auth CLI module**
+
+Create `lib/cli/auth.ts`:
+
+```ts
+import { TokenStore } from "../runtime/mcp/tokenStore.js";
+import { OAuthConnector } from "../runtime/mcp/oauthConnector.js";
+import type { AgencyConfig } from "../config.js";
+import type { McpHttpServerConfig } from "../runtime/mcp/types.js";
+
+const store = new TokenStore();
+
+export async function authServer(
+  serverName: string,
+  config: AgencyConfig,
+): Promise<void> {
+  const mcpServers = config.mcpServers;
+  if (!mcpServers || !mcpServers[serverName]) {
+    console.error(
+      `MCP server "${serverName}" not found in agency.json. Available servers: ${
+        mcpServers ? Object.keys(mcpServers).join(", ") : "(none)"
+      }`,
+    );
+    process.exit(1);
+  }
+
+  const serverConfig = mcpServers[serverName];
+  if (!("type" in serverConfig) || serverConfig.type !== "http") {
+    console.error(`MCP server "${serverName}" is not an HTTP server — OAuth is only for HTTP servers.`);
+    process.exit(1);
+  }
+
+  const httpConfig = serverConfig as McpHttpServerConfig;
+  if (httpConfig.auth !== "oauth") {
+    console.error(`MCP server "${serverName}" does not have auth: "oauth" in its config.`);
+    process.exit(1);
+  }
+
+  const existing = await store.loadTokens(serverName);
+  if (existing) {
+    console.log(`Token already exists for "${serverName}". Use --revoke to remove it first.`);
+    return;
+  }
+
+  console.log(`Starting OAuth authorization for "${serverName}"...`);
+
+  const connector = new OAuthConnector(serverName, httpConfig.url, store, {
+    timeoutMs: httpConfig.authTimeout,
+  });
+
+  try {
+    const { client } = await connector.connect();
+    console.log(`Successfully authorized "${serverName}". Token stored.`);
+    await client.close();
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`Authorization failed for "${serverName}": ${msg}`);
+    process.exit(1);
+  }
+}
+
+export async function listAuth(): Promise<void> {
+  const servers = await store.listServers();
+  if (servers.length === 0) {
+    console.log("No stored OAuth tokens.");
+    return;
+  }
+  console.log("Stored OAuth tokens:");
+  for (const name of servers) {
+    const tokens = await store.loadTokens(name);
+    const hasRefresh = tokens?.refresh_token ? "yes" : "no";
+    console.log(`  ${name} (refresh token: ${hasRefresh})`);
+  }
+}
+
+export async function revokeAuth(serverName: string): Promise<void> {
+  const tokens = await store.loadTokens(serverName);
+  if (!tokens) {
+    console.log(`No stored token for "${serverName}".`);
+    return;
+  }
+  await store.deleteTokens(serverName);
+  console.log(`Removed stored token for "${serverName}".`);
+}
+```
+
+Note: `auth.ts` only imports `OAuthConnector` and `TokenStore`. It does not import `AgencyOAuthProvider` or `CallbackServer`.
+
+- [ ] **Step 2: Register the CLI command**
+
+In `scripts/agency.ts`, add the import:
+
+```ts
+import { authServer, listAuth, revokeAuth } from "@/cli/auth.js";
+```
+
+Then add the command:
+
+```ts
+program
+  .command("auth [server-name]")
+  .description("Manage OAuth tokens for MCP servers")
+  .option("--list", "List all stored OAuth tokens")
+  .option("--revoke <server>", "Remove stored OAuth token for a server")
+  .action(async (serverName: string | undefined, opts: { list?: boolean; revoke?: string }) => {
+    if (opts.list) {
+      await listAuth();
+    } else if (opts.revoke) {
+      await revokeAuth(opts.revoke);
+    } else if (serverName) {
+      const config = loadConfig();
+      await authServer(serverName, config);
+    } else {
+      console.error("Usage: agency auth <server-name> | --list | --revoke <server-name>");
+      process.exit(1);
+    }
+  });
+```
+
+- [ ] **Step 3: Build and verify the command registers**
+
+Run: `make all && pnpm run agency auth --help`
+Expected: Shows the auth command help
+
+- [ ] **Step 4: Test the `--list` command with no tokens**
+
+Run: `pnpm run agency auth --list`
+Expected: `No stored OAuth tokens.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/cli/auth.ts scripts/agency.ts
+git commit -m "feat: add agency auth CLI command for managing MCP OAuth tokens"
+```
+
+---
+
+### Task 11: Run full test suite and rebuild fixtures
+
+Verify nothing is broken across the entire test suite, rebuild fixtures if needed.
+
+**Files:**
+- Potentially modify: binary fixture files in `tests/typescriptGenerator/` and `tests/typescriptBuilder/`
+
+- [ ] **Step 1: Build the project**
+
+Run: `make all`
+Expected: Clean build, no errors
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `pnpm test:run`
+Expected: All tests PASS. If any fixture tests fail due to the config changes, proceed to step 3.
+
+- [ ] **Step 3: Rebuild fixtures if needed**
+
+If fixture tests fail:
+Run: `make fixtures`
+Then verify: `pnpm test:run`
+
+- [ ] **Step 4: Commit if fixtures changed**
+
+```bash
+git add -A tests/
+git commit -m "chore: rebuild test fixtures after MCP OAuth changes"
+```

--- a/docs/superpowers/specs/2026-04-20-mcp-oauth-design.md
+++ b/docs/superpowers/specs/2026-04-20-mcp-oauth-design.md
@@ -1,0 +1,330 @@
+# MCP OAuth Support Design
+
+## Overview
+
+This spec adds OAuth 2.1 authentication support for HTTP-based MCP servers in Agency. It builds on the MCP support spec and provides a batteries-included OAuth flow that works out of the box for CLI usage and is customizable for TypeScript-import usage.
+
+## Motivation
+
+Many useful MCP servers (GitHub, Google Drive, Slack, etc.) require user-level OAuth authorization. Without OAuth support, Agency users are limited to:
+- Stdio servers (local tools, no auth needed)
+- HTTP servers with static API keys (manually obtained, no refresh)
+
+This cuts off a large portion of the MCP ecosystem. The MCP spec defines OAuth 2.1 as the standard auth mechanism for HTTP servers, and most remote MCP servers will require it.
+
+### Design goals
+
+- **Zero-config for common cases.** Setting `"auth": "oauth"` in `agency.json` should just work for CLI usage — no TypeScript code required.
+- **Batteries included.** Token storage, browser opening, callback server, PKCE, and refresh are all handled by the stdlib.
+- **Customizable for non-CLI environments.** TypeScript users importing nodes can provide their own auth behavior via a lifecycle callback.
+- **Secure by default.** Tokens stored with restrictive permissions, PKCE enforced, state parameter validated, tokens never serialized into checkpoints.
+
+## Design
+
+### User-facing configuration
+
+MCP servers in `agency.json` gain an optional `auth` field:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://github-mcp.example.com/mcp",
+      "auth": "oauth"
+    },
+    "weather": {
+      "type": "http",
+      "url": "https://weather-api.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${WEATHER_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+Three auth modes for HTTP servers:
+- **No auth** (default) — no `auth` or `headers` field
+- **Static headers** — `headers` object with env var interpolation (`${VAR_NAME}`)
+- **OAuth** — `"auth": "oauth"`
+
+Static headers and OAuth are mutually exclusive. Specifying both is a config validation error.
+
+### Static headers (quick path)
+
+The `headers` field is an object of string key-value pairs. Values support `${ENV_VAR}` interpolation (resolved at connection time from `process.env` and the Agency `.env` file). Headers are sent on every HTTP request to the MCP server.
+
+```json
+{
+  "headers": {
+    "Authorization": "Bearer ${GITHUB_TOKEN}",
+    "X-Custom-Header": "some-value"
+  }
+}
+```
+
+If an env var is referenced but not set, the runtime throws at connection time with a clear error message.
+
+### OAuth flow
+
+When `"auth": "oauth"` is set, the runtime uses a built-in `OAuthClientProvider` that implements the full MCP OAuth 2.1 flow:
+
+#### Step by step (CLI)
+
+1. User runs `agency run myagent.agency`
+2. Agent calls `mcp("github")` → `McpConnection` connects to the server
+3. If no valid stored token exists, the MCP SDK triggers the OAuth flow
+4. The stdlib provider:
+   a. Starts a temporary localhost HTTP server on an available port
+   b. Opens the user's default browser to the authorization URL
+   c. Prints a message: `Waiting for authorization for "github"... (press Ctrl+C to cancel)`
+   d. Waits for the callback (with a timeout)
+5. User authorizes in the browser → redirected to `http://localhost:PORT/oauth/callback`
+6. Callback server receives the authorization code, validates the `state` parameter, shuts down
+7. MCP SDK exchanges code for tokens (with PKCE verifier)
+8. Stdlib provider stores tokens to disk
+9. `mcp("github")` returns tools — execution continues
+
+#### Subsequent runs
+
+On subsequent runs, the stored token is loaded from disk. If expired, the refresh token is used automatically (handled by the MCP SDK). The user sees no browser popup unless the refresh token has also expired or been revoked.
+
+### Token storage
+
+Tokens are stored at `~/.agency/tokens/<server-name>.json`:
+
+```json
+{
+  "accessToken": "...",
+  "refreshToken": "...",
+  "expiresAt": 1713600000,
+  "scope": "repo read:user"
+}
+```
+
+File permissions are set to `0600` (user-read-write only) on creation. The directory `~/.agency/tokens/` is created with `0700` permissions.
+
+PKCE code verifiers are stored temporarily in `~/.agency/tokens/<server-name>.verifier` during the auth flow and deleted after the token exchange completes.
+
+### Token refresh and re-authentication
+
+The MCP SDK handles token refresh transparently. However, there are edge cases:
+
+**Refresh succeeds:** No user interaction needed. New tokens are stored.
+
+**Refresh fails (token revoked or expired):** The full OAuth flow is triggered again (browser opens). This is signaled to the user:
+```
+Token for "github" expired. Re-authorizing... (opening browser)
+```
+
+**Step-up authorization (403 insufficient_scope):** If the server returns a 403 with `insufficient_scope`, the runtime re-triggers the OAuth flow with the expanded scope. The user sees:
+```
+"github" requires additional permissions. Authorizing... (opening browser)
+```
+
+### Concurrency handling
+
+**Multiple `fork` threads hitting the same server:**
+`McpManager` already caches connections per server name. The OAuth flow is triggered during `McpConnection.connect()`, which is called once per server (subsequent calls reuse the connection). If two threads race to connect, the underlying connection promise is shared — only one OAuth flow fires.
+
+Concretely: `McpManager.getTools(serverName)` checks if a connection (or connection attempt) already exists. If it does, it awaits the existing promise rather than starting a new connection.
+
+**Multiple agent runs on the same machine:**
+Token files are shared on disk. If one run stores a token, the next run picks it up. File locking is not needed because writes are atomic (write to temp file, rename).
+
+**Refresh token rotation:**
+Some servers rotate refresh tokens on each use. To prevent race conditions where two concurrent refreshes invalidate each other, the `saveTokens()` implementation uses atomic file writes (write to `<name>.json.tmp`, then `rename()`). The MCP SDK serializes refresh requests per-connection, so concurrent refreshes on the same connection won't happen. Across separate agent runs, the last writer wins — acceptable since the latest refresh token is always the valid one.
+
+### TypeScript-import usage
+
+When a node is imported and called from TypeScript, the default behavior is the same (open browser, callback server). This works fine when the TypeScript code is running on a developer's machine.
+
+For server/headless environments, a lifecycle callback overrides the default:
+
+```typescript
+import { main } from "./myagent.js";
+
+const result = await main("query", {
+  callbacks: {
+    onOAuthRequired: async ({ serverName, authUrl, complete }) => {
+      // Option 1: Send the URL to the user (web app, Slack, etc.)
+      await sendToUser(`Please authorize: ${authUrl}`);
+      // The callback server still handles the redirect — just don't open a browser
+      // `complete` is a promise that resolves when auth finishes
+      await complete;
+    }
+  }
+});
+```
+
+The `onOAuthRequired` callback receives:
+- `serverName` — which MCP server needs auth
+- `authUrl` — the full authorization URL to present to the user
+- `complete` — a promise that resolves when the auth flow finishes (callback received)
+- `cancel` — a function to abort the auth flow
+
+If `onOAuthRequired` is provided, the runtime does NOT open a browser — it calls the hook instead. The localhost callback server still runs to receive the redirect.
+
+If the environment truly can't receive a localhost redirect (e.g., a remote server with no port access), the user must pre-authorize. This can be done by:
+1. Running `agency auth github` from a machine with a browser (stores token to disk)
+2. Copying `~/.agency/tokens/github.json` to the server
+3. Or providing a token directly via the `headers` config approach
+
+### CLI auth command
+
+A new CLI command for pre-authorizing or managing tokens:
+
+```bash
+# Trigger OAuth flow for a server (stores token)
+agency auth <server-name>
+
+# List stored tokens and their status
+agency auth --list
+
+# Remove a stored token
+agency auth --revoke <server-name>
+```
+
+This is useful for:
+- Pre-authorizing before running an agent
+- CI/CD setup (auth on a dev machine, copy token to CI)
+- Debugging token issues
+
+### Cancellation and cleanup
+
+**User cancels during OAuth (Ctrl+C):**
+- The callback server is shut down
+- No tokens are stored
+- `mcp()` returns a `failure("OAuth flow cancelled for \"github\"")`
+- The agent can handle this via `catch`:
+  ```
+  const tools = mcp("github") catch []
+  ```
+
+**Agent cancelled (`AgencyCancelledError`) during OAuth:**
+- Same as above — callback server shut down, failure propagated
+
+**Timeout:**
+The OAuth flow has a configurable timeout (default: 5 minutes). If the user doesn't complete auth in time:
+- Callback server shuts down
+- `mcp()` returns a `failure("OAuth flow timed out for \"github\"")`
+- A message is printed: `Authorization timed out for "github".`
+
+The timeout is configurable per-server:
+```json
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://...",
+      "auth": "oauth",
+      "authTimeout": 120000
+    }
+  }
+}
+```
+
+### Serialization and checkpoints
+
+**Tokens are NEVER serialized into checkpoints.** This is critical for security — checkpoints may be stored, shared, or logged.
+
+On restore after a checkpoint:
+1. MCP tool objects deserialize as plain data (they contain `serverName`, `name`, etc. — no tokens)
+2. When the tool is actually called post-restore, `McpManager` reconnects to the server
+3. The OAuth provider loads tokens from disk (not from the checkpoint)
+4. If tokens are still valid, the call proceeds. If not, re-auth is triggered.
+
+This matches the existing design in the MCP support spec where `McpManager` reconnects lazily after restore.
+
+### Error handling
+
+| Scenario | Behavior |
+|----------|----------|
+| `auth: "oauth"` on a stdio server | Config validation error (thrown at load time) |
+| Both `auth` and `headers` specified | Config validation error |
+| Server doesn't support OAuth (no 401) | Connection proceeds without auth (server may not need it) |
+| Browser fails to open (headless, no display) | Falls back to printing the URL: `Please open this URL to authorize: <url>` |
+| Callback port in use | Try up to 10 random ports in the 49152-65535 range. If all fail, return failure. |
+| Network error during token exchange | `mcp()` returns failure with error details |
+| Invalid state parameter on callback | Reject the callback, return failure (possible CSRF) |
+| User denies authorization | `mcp()` returns failure |
+
+### Interaction with interrupts
+
+OAuth flows are NOT interrupt-based. They are handled entirely within the `mcp()` call. The reasoning:
+- OAuth is infrastructure, not a user-facing decision about agent behavior
+- Interrupts are for "should the agent do this?" — OAuth is "the agent needs credentials to function"
+- Making OAuth an interrupt would complicate restore semantics (you'd serialize mid-auth state)
+
+However, if the user wraps `mcp()` in a handler, a failure from OAuth (timeout, cancelled, denied) is just a regular `failure` Result that they can handle:
+
+```ts
+const tools = mcp("github") catch []
+if (len(tools) == 0) {
+  print("Couldn't connect to GitHub. Continuing without GitHub tools.")
+}
+```
+
+### Config schema additions
+
+```typescript
+const McpHttpServerSchema = z.object({
+  type: z.literal("http"),
+  url: z.string(),
+  auth: z.literal("oauth").optional(),
+  authTimeout: z.number().optional(), // milliseconds, default 300000
+  headers: z.record(z.string()).optional(),
+}).refine(
+  (data) => !(data.auth && data.headers),
+  { message: "Cannot specify both 'auth' and 'headers'" }
+);
+```
+
+## Implementation
+
+### New files
+
+- `lib/runtime/mcp/oauthProvider.ts` — The `OAuthClientProvider` implementation (token storage, browser opening, callback server)
+- `lib/runtime/mcp/callbackServer.ts` — Temporary localhost HTTP server for receiving OAuth redirects
+- `lib/runtime/mcp/tokenStore.ts` — Read/write/delete token files with atomic writes and correct permissions
+- `lib/cli/auth.ts` — CLI command for `agency auth`
+- `tests/mcp/oauth.test.ts` — Unit tests for the OAuth provider (mocked browser/callback)
+- `tests/mcp/tokenStore.test.ts` — Token storage tests
+- `tests/mcp/callbackServer.test.ts` — Callback server tests
+
+### Modified files
+
+- `lib/runtime/mcp/mcpConnection.ts` — Pass auth provider (or headers) to the MCP SDK client based on config
+- `lib/runtime/mcp/types.ts` — Add auth-related config types
+- `lib/config.ts` — Extend `McpHttpServerSchema` with `auth`, `authTimeout`, `headers` fields and the mutual exclusion validation
+- `lib/runtime/state/context.ts` — Thread `onOAuthRequired` callback from lifecycle hooks to `McpManager`
+- `scripts/agency.ts` — Register the `agency auth` CLI command
+
+### Dependencies
+
+**New:**
+- `open` — for opening the browser (small, well-maintained, already commonly used)
+
+**Already present (from MCP support spec):**
+- `@modelcontextprotocol/sdk` — includes `OAuthClientProvider` interface and OAuth utilities
+
+### Testing approach
+
+OAuth is hard to test end-to-end. The strategy:
+
+1. **Unit test `tokenStore.ts`** — file read/write, permissions, atomic writes, env var interpolation for headers
+2. **Unit test `callbackServer.ts`** — starts server, receives callback with code + state, validates state, rejects bad state, shuts down on timeout
+3. **Unit test `oauthProvider.ts`** — mock the callback server and browser opener, verify the provider calls them correctly, verify tokens are stored/loaded
+4. **Integration test with mock OAuth server** — a test HTTP server that implements the MCP OAuth discovery flow (returns 401, serves metadata, issues tokens). Verify the full flow works without a real browser (by calling the callback URL directly in the test).
+
+The integration test does NOT open a real browser — it simulates the callback by making an HTTP request to the callback server directly.
+
+## Out of scope
+
+- Custom OAuth providers defined in Agency code (always uses the built-in provider; TypeScript users can override via callback)
+- OAuth for stdio servers (not applicable per MCP spec)
+- Token encryption at rest (file permissions are the security boundary; users who need more can use OS keychain integrations)
+- Multi-user token management (e.g., a web app with many users — this requires a custom `onOAuthRequired` implementation)
+- Dynamic client registration UI (the MCP SDK handles this via Client ID Metadata Documents)
+- Refresh token storage across machines (users must manually copy `~/.agency/tokens/` or use `agency auth` on each machine)

--- a/examples/mcp/filesystem/agency.json
+++ b/examples/mcp/filesystem/agency.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+    }
+  }
+}

--- a/examples/mcp/filesystem/agent.agency
+++ b/examples/mcp/filesystem/agent.agency
@@ -1,0 +1,29 @@
+// Example: Using an MCP server (no authentication required)
+//
+// This example connects to the filesystem MCP server and uses its tools
+// to interact with files. No authentication is needed — the server runs
+// as a local subprocess.
+//
+// To run:
+//   cd examples/mcp/filesystem
+//   pnpm run agency agent.agency
+
+node main() {
+  const tools = mcp("filesystem") catch []
+
+  if (len(tools) == 0) {
+    print("Could not connect to the filesystem MCP server.")
+    return null
+  }
+
+  print("Connected to filesystem MCP server.")
+  print("Available tools:")
+  for (tool in tools) {
+    print("  - ${tool.name}")
+  }
+
+  const result = llm("List the files in /tmp and tell me how many there are.", {
+    tools: [...tools]
+  })
+  print(result)
+}

--- a/examples/mcp/filesystem/agent.agency
+++ b/examples/mcp/filesystem/agent.agency
@@ -5,13 +5,13 @@
 // as a local subprocess.
 //
 // To run:
-//   cd examples/mcp/filesystem
-//   pnpm run agency agent.agency
+//   Make sure the "mcpServers" config in agency.json includes the filesystem server.
+//   pnpm run agency examples/mcp/filesystem/agent.agency
 
 node main() {
   const tools = mcp("filesystem") catch []
 
-  if (len(tools) == 0) {
+  if (tools.length == 0) {
     print("Could not connect to the filesystem MCP server.")
     return null
   }

--- a/examples/mcp/github-oauth-ts/agency.json
+++ b/examples/mcp/github-oauth-ts/agency.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "auth": "oauth"
+    }
+  }
+}

--- a/examples/mcp/github-oauth-ts/agent.agency
+++ b/examples/mcp/github-oauth-ts/agent.agency
@@ -1,0 +1,16 @@
+// The Agency agent — same as the regular OAuth example.
+// The TypeScript wrapper in run.ts shows how to customize the OAuth flow.
+
+node main() {
+  const tools = mcp("github") catch []
+
+  if (len(tools) == 0) {
+    print("Could not connect to GitHub MCP server.")
+    return null
+  }
+
+  const result = llm("What are my 5 most recently updated GitHub repositories?", {
+    tools: [...tools]
+  })
+  return result
+}

--- a/examples/mcp/github-oauth-ts/agent.agency
+++ b/examples/mcp/github-oauth-ts/agent.agency
@@ -1,10 +1,15 @@
 // The Agency agent — same as the regular OAuth example.
 // The TypeScript wrapper in run.ts shows how to customize the OAuth flow.
+//
+// To run:
+//   Make sure the "mcpServers" config in agency.json includes the github server.
+//   pnpm run agency compile examples/mcp/github-oauth-ts/agent.agency
+//   npx tsx examples/mcp/github-oauth-ts/run.ts
 
 node main() {
   const tools = mcp("github") catch []
 
-  if (len(tools) == 0) {
+  if (tools.length == 0) {
     print("Could not connect to GitHub MCP server.")
     return null
   }

--- a/examples/mcp/github-oauth-ts/run.ts
+++ b/examples/mcp/github-oauth-ts/run.ts
@@ -1,0 +1,43 @@
+/**
+ * Example: Calling an Agency agent from TypeScript with custom OAuth handling.
+ *
+ * By default, Agency opens a browser for OAuth. If you're running in an
+ * environment where that doesn't work (a web server, CI, etc.), you can
+ * provide an onOAuthRequired callback to handle it yourself.
+ *
+ * Setup:
+ *   1. Create a GitHub OAuth App at https://github.com/settings/developers
+ *      Set callback URL to: http://127.0.0.1:19876/oauth/callback
+ *   2. Set environment variables:
+ *      export MCP_GITHUB_CLIENT_ID=your-client-id
+ *      export MCP_GITHUB_CLIENT_SECRET=your-client-secret
+ *   3. Compile the agent:
+ *      pnpm run agency compile agent.agency
+ *   4. Run this file:
+ *      npx tsx run.ts
+ */
+
+// Import the compiled agent (note: .js, not .agency)
+import { main } from "./agent.js";
+
+async function run() {
+  const result = await main({
+    callbacks: {
+      // Custom OAuth handler — instead of opening a browser automatically,
+      // this prints the URL and waits for the user to complete auth.
+      // In a web app, you'd redirect the user to authUrl instead.
+      onOAuthRequired: async ({ serverName, authUrl, complete }) => {
+        console.log(`\nAuthorization required for "${serverName}".`);
+        console.log(`Please open this URL in your browser:\n`);
+        console.log(`  ${authUrl}\n`);
+        console.log(`Waiting for authorization...`);
+        await complete;
+        console.log(`Authorization complete!\n`);
+      },
+    },
+  });
+
+  console.log("Agent result:", result);
+}
+
+run().catch(console.error);

--- a/examples/mcp/github-oauth/agency.json
+++ b/examples/mcp/github-oauth/agency.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "github": {
+      "type": "http",
+      "url": "https://api.githubcopilot.com/mcp/",
+      "auth": "oauth"
+    }
+  }
+}

--- a/examples/mcp/github-oauth/agent.agency
+++ b/examples/mcp/github-oauth/agent.agency
@@ -1,0 +1,33 @@
+// Example: Using an MCP server with OAuth authentication
+//
+// This example connects to GitHub's MCP server, which requires OAuth.
+// On the first run, your browser opens for GitHub authorization.
+// After that, the token is stored and reused automatically.
+//
+// Setup:
+//   1. Create a GitHub OAuth App at https://github.com/settings/developers
+//      Set callback URL to: http://127.0.0.1:19876/oauth/callback
+//   2. Set environment variables:
+//      export MCP_GITHUB_CLIENT_ID=your-client-id
+//      export MCP_GITHUB_CLIENT_SECRET=your-client-secret
+//
+// To run:
+//   cd examples/mcp/github-oauth
+//   pnpm run agency agent.agency
+
+node main() {
+  const tools = mcp("github") catch []
+
+  if (len(tools) == 0) {
+    print("Could not connect to GitHub MCP server.")
+    print("Make sure MCP_GITHUB_CLIENT_ID and MCP_GITHUB_CLIENT_SECRET are set.")
+    return null
+  }
+
+  print("Connected to GitHub. Found ${len(tools)} tools.")
+
+  const result = llm("What are my 5 most recently updated GitHub repositories?", {
+    tools: [...tools]
+  })
+  print(result)
+}

--- a/examples/mcp/github-oauth/agent.agency
+++ b/examples/mcp/github-oauth/agent.agency
@@ -12,20 +12,16 @@
 //      export MCP_GITHUB_CLIENT_SECRET=your-client-secret
 //
 // To run:
-//   cd examples/mcp/github-oauth
-//   pnpm run agency agent.agency
+//   copy agency.json from the root of the repo to this directory, or add the "mcpServers" config to your existing agency.json
+//   pnpm run agency examples/mcp/github-oauth/agent.agency
 node main() {
   print("Connecting to GitHub MCP server with OAuth...")
   const tools = try mcp("github") catch []
   print("Tools from GitHub MCP:", tools)
-  if (len(tools) == 0) {
+  if (tools.length == 0) {
     print("Could not connect to GitHub MCP server.")
     print("Make sure MCP_GITHUB_CLIENT_ID and MCP_GITHUB_CLIENT_SECRET are set.")
     return null
   }
-  print("Connected to GitHub. Found ${len(tools)} tools.")
-  const result = llm("What are my 5 most recently updated GitHub repositories?", { 
-    tools: [...tools]
-  })
-  print(result)
+  print("Connected to GitHub. Found ${tools.length} tools.")
 }

--- a/examples/mcp/github-oauth/agent.agency
+++ b/examples/mcp/github-oauth/agent.agency
@@ -14,19 +14,17 @@
 // To run:
 //   cd examples/mcp/github-oauth
 //   pnpm run agency agent.agency
-
 node main() {
-  const tools = mcp("github") catch []
-
+  print("Connecting to GitHub MCP server with OAuth...")
+  const tools = try mcp("github") catch []
+  print("Tools from GitHub MCP:", tools)
   if (len(tools) == 0) {
     print("Could not connect to GitHub MCP server.")
     print("Make sure MCP_GITHUB_CLIENT_ID and MCP_GITHUB_CLIENT_SECRET are set.")
     return null
   }
-
   print("Connected to GitHub. Found ${len(tools)} tools.")
-
-  const result = llm("What are my 5 most recently updated GitHub repositories?", {
+  const result = llm("What are my 5 most recently updated GitHub repositories?", { 
     tools: [...tools]
   })
   print(result)

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -2203,6 +2203,14 @@ export class TypeScriptBuilder {
             ts.raw("__error instanceof RestoreSignal"),
             ts.statements([ts.throw("__error")]),
           ),
+          ts.consoleError(
+            ts.template([
+              {
+                text: "\\nAgent crashed: ",
+                expr: $(ts.id("__error")).prop("message").done(),
+              },
+            ]),
+          ),
           ts.return(
             ts.obj({
               messages: ts.runtime.threads,

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -3312,8 +3312,19 @@ export class TypeScriptBuilder {
     ];
 
     if (this.agencyConfig.mcpServers) {
+      // Strip secrets from the config before embedding in generated code.
+      // clientId and clientSecret are resolved at runtime from env vars.
+      const sanitizedServers = Object.fromEntries(
+        Object.entries(this.agencyConfig.mcpServers).map(([name, cfg]) => {
+          if ("type" in cfg && cfg.type === "http") {
+            const { clientSecret, clientId, ...rest } = cfg as Record<string, any>;
+            return [name, rest];
+          }
+          return [name, cfg];
+        }),
+      );
       runtimeCtxStatements.push(
-        ts.raw(`__globalCtx.createMcpManager(${JSON.stringify(this.agencyConfig.mcpServers)});`),
+        ts.raw(`__globalCtx.createMcpManager(${JSON.stringify(sanitizedServers)});`),
       );
     }
 

--- a/lib/cli/auth.ts
+++ b/lib/cli/auth.ts
@@ -1,0 +1,81 @@
+import { TokenStore } from "../runtime/mcp/tokenStore.js";
+import { OAuthConnector } from "../runtime/mcp/oauthConnector.js";
+import type { AgencyConfig } from "../config.js";
+import type { McpHttpServerConfig } from "../runtime/mcp/types.js";
+
+const store = new TokenStore();
+
+export async function authServer(
+  serverName: string,
+  config: AgencyConfig,
+): Promise<void> {
+  const mcpServers = config.mcpServers;
+  if (!mcpServers || !mcpServers[serverName]) {
+    console.error(
+      `MCP server "${serverName}" not found in agency.json. Available servers: ${
+        mcpServers ? Object.keys(mcpServers).join(", ") : "(none)"
+      }`,
+    );
+    process.exit(1);
+  }
+
+  const serverConfig = mcpServers[serverName];
+  if (!("type" in serverConfig) || serverConfig.type !== "http") {
+    console.error(`MCP server "${serverName}" is not an HTTP server — OAuth is only for HTTP servers.`);
+    process.exit(1);
+  }
+
+  const httpConfig = serverConfig as McpHttpServerConfig;
+  if (httpConfig.auth !== "oauth") {
+    console.error(`MCP server "${serverName}" does not have auth: "oauth" in its config.`);
+    process.exit(1);
+  }
+
+  const existing = await store.loadTokens(serverName);
+  if (existing) {
+    console.log(`Token already exists for "${serverName}". Use --revoke to remove it first.`);
+    return;
+  }
+
+  console.log(`Starting OAuth authorization for "${serverName}"...`);
+
+  const connector = new OAuthConnector(serverName, httpConfig.url, store, {
+    timeoutMs: httpConfig.authTimeout,
+    clientId: httpConfig.clientId,
+    clientSecret: httpConfig.clientSecret,
+  });
+
+  try {
+    const { client } = await connector.connect();
+    console.log(`Successfully authorized "${serverName}". Token stored.`);
+    await client.close();
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`Authorization failed for "${serverName}": ${msg}`);
+    process.exit(1);
+  }
+}
+
+export async function listAuth(): Promise<void> {
+  const servers = await store.listServers();
+  if (servers.length === 0) {
+    console.log("No stored OAuth tokens.");
+    return;
+  }
+  console.log("Stored OAuth tokens:");
+  for (const name of servers) {
+    const tokens = await store.loadTokens(name);
+    const hasRefresh = tokens?.refresh_token ? "yes" : "no";
+    console.log(`  ${name} (refresh token: ${hasRefresh})`);
+  }
+}
+
+export async function revokeAuth(serverName: string): Promise<void> {
+  const tokens = await store.loadTokens(serverName);
+  if (!tokens) {
+    console.log(`No stored token for "${serverName}".`);
+    return;
+  }
+  await store.deleteTokens(serverName);
+  console.log(`Removed stored token for "${serverName}".`);
+}

--- a/lib/cli/auth.ts
+++ b/lib/cli/auth.ts
@@ -1,5 +1,6 @@
 import { TokenStore } from "../runtime/mcp/tokenStore.js";
 import { OAuthConnector } from "../runtime/mcp/oauthConnector.js";
+import { isOAuthServer } from "../runtime/mcp/types.js";
 import type { AgencyConfig } from "../config.js";
 import type { McpHttpServerConfig } from "../runtime/mcp/types.js";
 
@@ -20,16 +21,12 @@ export async function authServer(
   }
 
   const serverConfig = mcpServers[serverName];
-  if (!("type" in serverConfig) || serverConfig.type !== "http") {
-    console.error(`MCP server "${serverName}" is not an HTTP server — OAuth is only for HTTP servers.`);
+  if (!isOAuthServer(serverConfig)) {
+    console.error(`MCP server "${serverName}" is not configured with auth: "oauth".`);
     process.exit(1);
   }
 
   const httpConfig = serverConfig as McpHttpServerConfig;
-  if (httpConfig.auth !== "oauth") {
-    console.error(`MCP server "${serverName}" does not have auth: "oauth" in its config.`);
-    process.exit(1);
-  }
 
   const existing = await store.loadTokens(serverName);
   if (existing) {

--- a/lib/cli/commands.ts
+++ b/lib/cli/commands.ts
@@ -123,6 +123,12 @@ export function compile(
   _outputFile?: string,
   options?: { ts?: boolean; symbolTable?: SymbolTable; importStrategy?: ImportStrategy },
 ): string | null {
+
+  if (!fs.existsSync(inputFile)) {
+    console.error(`Error: Input file '${inputFile}' not found`);
+    process.exit(1);
+  }
+
   // Check if the input is a directory
   const stats = fs.statSync(inputFile);
   const verbose = config.verbose ?? false;

--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -132,6 +132,54 @@ describe("AgencyConfigSchema", () => {
     expect(result.success).toBe(false);
   });
 
+  it("should reject clientSecret without auth: oauth", () => {
+    const result = AgencyConfigSchema.safeParse({
+      mcpServers: {
+        github: {
+          type: "http",
+          url: "https://example.com/mcp",
+          clientSecret: "secret",
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject OAuth over plain HTTP (non-localhost)", () => {
+    const result = AgencyConfigSchema.safeParse({
+      mcpServers: {
+        github: {
+          type: "http",
+          url: "http://evil.com/mcp",
+          auth: "oauth",
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should allow OAuth over HTTP on localhost", () => {
+    const result = AgencyConfigSchema.safeParse({
+      mcpServers: {
+        local: {
+          type: "http",
+          url: "http://localhost:3000/mcp",
+          auth: "oauth",
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject server names with invalid characters", () => {
+    const result = AgencyConfigSchema.safeParse({
+      mcpServers: {
+        "../evil": { command: "npx", args: ["server"] },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
   it("should reject auth on stdio server", () => {
     const result = AgencyConfigSchema.safeParse({
       mcpServers: {

--- a/lib/config.test.ts
+++ b/lib/config.test.ts
@@ -68,4 +68,80 @@ describe("AgencyConfigSchema", () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it("should accept HTTP server with auth: oauth", () => {
+    const result = AgencyConfigSchema.safeParse({
+      mcpServers: {
+        github: { type: "http", url: "https://github-mcp.example.com/mcp", auth: "oauth" },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept HTTP server with headers", () => {
+    const result = AgencyConfigSchema.safeParse({
+      mcpServers: {
+        weather: {
+          type: "http",
+          url: "https://weather.example.com/mcp",
+          headers: { "Authorization": "Bearer ${WEATHER_KEY}" },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should accept HTTP server with authTimeout", () => {
+    const result = AgencyConfigSchema.safeParse({
+      mcpServers: {
+        github: {
+          type: "http",
+          url: "https://github-mcp.example.com/mcp",
+          auth: "oauth",
+          authTimeout: 120000,
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("should reject HTTP server with both auth and headers", () => {
+    const result = AgencyConfigSchema.safeParse({
+      mcpServers: {
+        github: {
+          type: "http",
+          url: "https://example.com/mcp",
+          auth: "oauth",
+          headers: { "Authorization": "Bearer token" },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject authTimeout without auth: oauth", () => {
+    const result = AgencyConfigSchema.safeParse({
+      mcpServers: {
+        github: {
+          type: "http",
+          url: "https://example.com/mcp",
+          authTimeout: 120000,
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("should reject auth on stdio server", () => {
+    const result = AgencyConfigSchema.safeParse({
+      mcpServers: {
+        local: {
+          command: "npx",
+          args: ["some-server"],
+          auth: "oauth",
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
 });

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -213,7 +213,10 @@ export const AgencyConfigSchema = z.object({
   distDir: z.string(),
   test: z.object({ parallel: z.number() }).partial(),
   doc: z.object({ outDir: z.string(), baseUrl: z.string() }).partial(),
-  mcpServers: z.record(z.string(), McpServerSchema),
+  mcpServers: z.record(
+    z.string().regex(/^[A-Za-z0-9_-]+$/, "MCP server names must contain only letters, numbers, hyphens, and underscores"),
+    McpServerSchema,
+  ),
 }).partial().passthrough().superRefine((data, ctx) => {
   if (!data.mcpServers) return;
   for (const [name, server] of Object.entries(data.mcpServers)) {
@@ -246,6 +249,25 @@ export const AgencyConfigSchema = z.object({
           message: `MCP server "${name}": 'clientSecret' requires 'auth: "oauth"'`,
           path: ["mcpServers", name],
         });
+      }
+      if (httpServer.auth === "oauth") {
+        try {
+          const parsed = new URL(httpServer.url);
+          const isLocalhost = ["127.0.0.1", "localhost"].includes(parsed.hostname);
+          if (parsed.protocol !== "https:" && !isLocalhost) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `MCP server "${name}": OAuth requires HTTPS (or localhost for development)`,
+              path: ["mcpServers", name, "url"],
+            });
+          }
+        } catch {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `MCP server "${name}": invalid URL "${httpServer.url}"`,
+            path: ["mcpServers", name, "url"],
+          });
+        }
       }
     }
   }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -240,6 +240,13 @@ export const AgencyConfigSchema = z.object({
           path: ["mcpServers", name],
         });
       }
+      if (httpServer.clientSecret && httpServer.auth !== "oauth") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `MCP server "${name}": 'clientSecret' requires 'auth: "oauth"'`,
+          path: ["mcpServers", name],
+        });
+      }
     }
   }
 });

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -174,6 +174,10 @@ const McpStdioServerSchema = z.object({
 const McpHttpServerSchema = z.object({
   type: z.literal("http"),
   url: z.string(),
+  auth: z.literal("oauth").optional(),
+  authTimeout: z.number().optional(),
+  clientId: z.string().optional(),
+  headers: z.record(z.string(), z.string()).optional(),
 }).strict();
 
 const McpServerSchema = z.union([McpStdioServerSchema, McpHttpServerSchema]);
@@ -209,4 +213,32 @@ export const AgencyConfigSchema = z.object({
   test: z.object({ parallel: z.number() }).partial(),
   doc: z.object({ outDir: z.string(), baseUrl: z.string() }).partial(),
   mcpServers: z.record(z.string(), McpServerSchema),
-}).partial().passthrough();
+}).partial().passthrough().superRefine((data, ctx) => {
+  if (!data.mcpServers) return;
+  for (const [name, server] of Object.entries(data.mcpServers)) {
+    if ("type" in server && server.type === "http") {
+      const httpServer = server as z.infer<typeof McpHttpServerSchema>;
+      if (httpServer.auth && httpServer.headers) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `MCP server "${name}": cannot specify both 'auth' and 'headers'`,
+          path: ["mcpServers", name],
+        });
+      }
+      if (httpServer.authTimeout && httpServer.auth !== "oauth") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `MCP server "${name}": 'authTimeout' requires 'auth: "oauth"'`,
+          path: ["mcpServers", name],
+        });
+      }
+      if (httpServer.clientId && httpServer.auth !== "oauth") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `MCP server "${name}": 'clientId' requires 'auth: "oauth"'`,
+          path: ["mcpServers", name],
+        });
+      }
+    }
+  }
+});

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -177,6 +177,7 @@ const McpHttpServerSchema = z.object({
   auth: z.literal("oauth").optional(),
   authTimeout: z.number().optional(),
   clientId: z.string().optional(),
+  clientSecret: z.string().optional(),
   headers: z.record(z.string(), z.string()).optional(),
 }).strict();
 

--- a/lib/runtime/hooks.ts
+++ b/lib/runtime/hooks.ts
@@ -51,6 +51,12 @@ export type CallbackMap = {
     | { type: "done"; result: PromptResult }
     | { type: "error"; error: any };
   onTrace: TraceEvent;
+  onOAuthRequired: {
+    serverName: string;
+    authUrl: string;
+    complete: Promise<void>;
+    cancel: () => void;
+  };
 };
 
 // Compile-time guard: ensures VALID_CALLBACK_NAMES stays in sync with CallbackMap.

--- a/lib/runtime/mcp/callbackServer.test.ts
+++ b/lib/runtime/mcp/callbackServer.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { CallbackServer } from "./callbackServer.js";
+
+// Use port 0 in tests so the OS assigns a random available port,
+// avoiding collisions with other tests or the default port.
+const testOpts = { port: 0 };
+
+describe("CallbackServer", () => {
+  it("should start and return a URL with the correct port", async () => {
+    const server = new CallbackServer(testOpts);
+    const url = await server.start();
+    expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/oauth\/callback$/);
+    await server.stop();
+  });
+
+  it("should use the default fixed port when no port is specified", () => {
+    const server = new CallbackServer();
+    // Before start(), callbackUrl reflects the configured port
+    expect(server.callbackUrl).toBe("http://127.0.0.1:19876/oauth/callback");
+  });
+
+  it("should resolve with the authorization code when callback is received", async () => {
+    const server = new CallbackServer(testOpts);
+    const url = await server.start();
+    const state = server.state;
+
+    const callbackUrl = `${url}?code=auth-code-123&state=${state}`;
+    const response = await fetch(callbackUrl);
+    expect(response.ok).toBe(true);
+
+    const code = await server.waitForCode();
+    expect(code).toBe("auth-code-123");
+
+    await server.stop();
+  });
+
+  it("should reject when state parameter doesn't match", async () => {
+    const server = new CallbackServer(testOpts);
+    const url = await server.start();
+
+    const callbackUrl = `${url}?code=auth-code-123&state=wrong-state`;
+    const response = await fetch(callbackUrl);
+    expect(response.status).toBe(403);
+
+    await server.stop();
+  });
+
+  it("should reject when code is missing", async () => {
+    const server = new CallbackServer(testOpts);
+    const url = await server.start();
+    const state = server.state;
+
+    const callbackUrl = `${url}?state=${state}`;
+    const response = await fetch(callbackUrl);
+    expect(response.status).toBe(400);
+
+    await server.stop();
+  });
+
+  it("should time out if no callback is received", async () => {
+    const server = new CallbackServer({ ...testOpts, timeoutMs: 200 });
+    await server.start();
+
+    await expect(server.waitForCode()).rejects.toThrow(/timed out/i);
+
+    await server.stop();
+  });
+
+  it("should stop cleanly even if no callback was received", async () => {
+    const server = new CallbackServer(testOpts);
+    await server.start();
+    await server.stop();
+  });
+});

--- a/lib/runtime/mcp/callbackServer.ts
+++ b/lib/runtime/mcp/callbackServer.ts
@@ -68,6 +68,7 @@ export class CallbackServer {
         res.writeHead(200, { "Content-Type": "text/html" });
         res.end(SUCCESS_HTML);
         this.resolveCode(code);
+        this.stop();
       });
 
       this.server.listen(this.port, "127.0.0.1", () => {

--- a/lib/runtime/mcp/callbackServer.ts
+++ b/lib/runtime/mcp/callbackServer.ts
@@ -1,0 +1,106 @@
+import http from "http";
+import { randomBytes } from "crypto";
+
+const SUCCESS_HTML = `<!DOCTYPE html><html><body><h1>Authorization successful</h1><p>You can close this tab and return to your terminal.</p></body></html>`;
+const ERROR_HTML = `<!DOCTYPE html><html><body><h1>Authorization failed</h1><p>Please try again.</p></body></html>`;
+
+const DEFAULT_PORT = 19876;
+
+export type CallbackServerOptions = {
+  port?: number; // default 19876
+  timeoutMs?: number; // default 300000 (5 minutes)
+};
+
+export class CallbackServer {
+  private server: http.Server | null = null;
+  private port: number;
+  private _state: string;
+  private timeoutMs: number;
+  private codePromise: Promise<string>;
+  private resolveCode!: (code: string) => void;
+  private rejectCode!: (err: Error) => void;
+  private timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(opts: CallbackServerOptions = {}) {
+    this.port = opts.port ?? DEFAULT_PORT;
+    this.timeoutMs = opts.timeoutMs ?? 300_000;
+    this._state = randomBytes(32).toString("hex");
+    this.codePromise = new Promise<string>((resolve, reject) => {
+      this.resolveCode = resolve;
+      this.rejectCode = reject;
+    });
+  }
+
+  get state(): string {
+    return this._state;
+  }
+
+  get callbackUrl(): string {
+    return `http://127.0.0.1:${this.port}/oauth/callback`;
+  }
+
+  async start(): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+      this.server = http.createServer((req, res) => {
+        const url = new URL(req.url || "/", `http://127.0.0.1:${this.port}`);
+
+        if (url.pathname !== "/oauth/callback") {
+          res.writeHead(404);
+          res.end("Not found");
+          return;
+        }
+
+        const code = url.searchParams.get("code");
+        const state = url.searchParams.get("state");
+
+        if (state !== this._state) {
+          res.writeHead(403, { "Content-Type": "text/html" });
+          res.end(ERROR_HTML);
+          return;
+        }
+
+        if (!code) {
+          res.writeHead(400, { "Content-Type": "text/html" });
+          res.end(ERROR_HTML);
+          return;
+        }
+
+        res.writeHead(200, { "Content-Type": "text/html" });
+        res.end(SUCCESS_HTML);
+        this.resolveCode(code);
+      });
+
+      this.server.listen(this.port, "127.0.0.1", () => {
+        // When port is 0, the OS assigns a random port — read it back.
+        const addr = this.server!.address();
+        if (addr && typeof addr === "object") {
+          this.port = addr.port;
+        }
+        resolve(this.callbackUrl);
+      });
+
+      this.server.on("error", reject);
+
+      this.timeoutHandle = setTimeout(() => {
+        this.rejectCode(new Error("OAuth callback timed out"));
+      }, this.timeoutMs);
+    });
+  }
+
+  async waitForCode(): Promise<string> {
+    return this.codePromise;
+  }
+
+  async stop(): Promise<void> {
+    if (this.timeoutHandle) {
+      clearTimeout(this.timeoutHandle);
+      this.timeoutHandle = null;
+    }
+    if (this.server) {
+      return new Promise<void>((resolve) => {
+        this.server!.close(() => resolve());
+        this.server = null;
+      });
+    }
+  }
+}

--- a/lib/runtime/mcp/callbackServer.ts
+++ b/lib/runtime/mcp/callbackServer.ts
@@ -83,6 +83,7 @@ export class CallbackServer {
 
       this.timeoutHandle = setTimeout(() => {
         this.rejectCode(new Error("OAuth callback timed out"));
+        this.stop();
       }, this.timeoutMs);
     });
   }

--- a/lib/runtime/mcp/mcpConnection.test.ts
+++ b/lib/runtime/mcp/mcpConnection.test.ts
@@ -97,16 +97,29 @@ describe("interpolateEnvVars", () => {
 });
 
 describe("McpConnection with connector", () => {
-  it("should accept a connector function option", () => {
+  it("should call the connector function when connecting", async () => {
+    let connectorCalled = false;
     const conn = new McpConnection("test", {
       type: "http",
       url: "https://example.com/mcp",
       auth: "oauth",
     }, {
       connector: async () => {
+        connectorCalled = true;
         throw new Error("mock connector");
       },
     });
-    expect(conn).toBeDefined();
+
+    await expect(conn.connect()).rejects.toThrow("mock connector");
+    expect(connectorCalled).toBe(true);
+  });
+
+  it("should not use connector for stdio servers without one", async () => {
+    // This just verifies the non-connector path still works
+    // (the existing stdio test covers this, but this confirms the branching)
+    const conn = new McpConnection("bad", {
+      command: "nonexistent-command",
+    });
+    await expect(conn.connect()).rejects.toThrow();
   });
 });

--- a/lib/runtime/mcp/mcpConnection.test.ts
+++ b/lib/runtime/mcp/mcpConnection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { McpConnection, interpolateEnvVars } from "./mcpConnection.js";
+import { McpConnection } from "./mcpConnection.js";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -44,58 +44,6 @@ describe("McpConnection", () => {
   });
 });
 
-describe("interpolateEnvVars", () => {
-  it("should replace ${VAR} with env values", () => {
-    const original = process.env.TEST_VAR_ABC;
-    process.env.TEST_VAR_ABC = "hello";
-    try {
-      const result = interpolateEnvVars({ "Authorization": "Bearer ${TEST_VAR_ABC}" });
-      expect(result["Authorization"]).toBe("Bearer hello");
-    } finally {
-      if (original === undefined) delete process.env.TEST_VAR_ABC;
-      else process.env.TEST_VAR_ABC = original;
-    }
-  });
-
-  it("should throw if env var is not set", () => {
-    delete process.env.NONEXISTENT_VAR_XYZ;
-    expect(() =>
-      interpolateEnvVars({ "Authorization": "Bearer ${NONEXISTENT_VAR_XYZ}" }),
-    ).toThrow(/NONEXISTENT_VAR_XYZ/);
-  });
-
-  it("should pass through headers without env vars unchanged", () => {
-    const result = interpolateEnvVars({ "X-Custom": "static-value" });
-    expect(result["X-Custom"]).toBe("static-value");
-  });
-
-  it("should reject values containing CRLF (CRLF injection)", () => {
-    const original = process.env.TEST_CRLF_VAR;
-    process.env.TEST_CRLF_VAR = "token\r\nX-Injected: evil";
-    try {
-      expect(() =>
-        interpolateEnvVars({ "Authorization": "Bearer ${TEST_CRLF_VAR}" }),
-      ).toThrow(/newline/i);
-    } finally {
-      if (original === undefined) delete process.env.TEST_CRLF_VAR;
-      else process.env.TEST_CRLF_VAR = original;
-    }
-  });
-
-  it("should reject values containing bare LF (LF injection)", () => {
-    const original = process.env.TEST_LF_VAR;
-    process.env.TEST_LF_VAR = "token\nX-Injected: evil";
-    try {
-      expect(() =>
-        interpolateEnvVars({ "Authorization": "Bearer ${TEST_LF_VAR}" }),
-      ).toThrow(/newline/i);
-    } finally {
-      if (original === undefined) delete process.env.TEST_LF_VAR;
-      else process.env.TEST_LF_VAR = original;
-    }
-  });
-});
-
 describe("McpConnection with connector", () => {
   it("should call the connector function when connecting", async () => {
     let connectorCalled = false;
@@ -115,8 +63,6 @@ describe("McpConnection with connector", () => {
   });
 
   it("should not use connector for stdio servers without one", async () => {
-    // This just verifies the non-connector path still works
-    // (the existing stdio test covers this, but this confirms the branching)
     const conn = new McpConnection("bad", {
       command: "nonexistent-command",
     });

--- a/lib/runtime/mcp/mcpConnection.test.ts
+++ b/lib/runtime/mcp/mcpConnection.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { McpConnection } from "./mcpConnection.js";
+import { McpConnection, interpolateEnvVars } from "./mcpConnection.js";
 import path from "path";
 import { fileURLToPath } from "url";
 
@@ -41,5 +41,72 @@ describe("McpConnection", () => {
     });
 
     await expect(conn.connect()).rejects.toThrow();
+  });
+});
+
+describe("interpolateEnvVars", () => {
+  it("should replace ${VAR} with env values", () => {
+    const original = process.env.TEST_VAR_ABC;
+    process.env.TEST_VAR_ABC = "hello";
+    try {
+      const result = interpolateEnvVars({ "Authorization": "Bearer ${TEST_VAR_ABC}" });
+      expect(result["Authorization"]).toBe("Bearer hello");
+    } finally {
+      if (original === undefined) delete process.env.TEST_VAR_ABC;
+      else process.env.TEST_VAR_ABC = original;
+    }
+  });
+
+  it("should throw if env var is not set", () => {
+    delete process.env.NONEXISTENT_VAR_XYZ;
+    expect(() =>
+      interpolateEnvVars({ "Authorization": "Bearer ${NONEXISTENT_VAR_XYZ}" }),
+    ).toThrow(/NONEXISTENT_VAR_XYZ/);
+  });
+
+  it("should pass through headers without env vars unchanged", () => {
+    const result = interpolateEnvVars({ "X-Custom": "static-value" });
+    expect(result["X-Custom"]).toBe("static-value");
+  });
+
+  it("should reject values containing CRLF (CRLF injection)", () => {
+    const original = process.env.TEST_CRLF_VAR;
+    process.env.TEST_CRLF_VAR = "token\r\nX-Injected: evil";
+    try {
+      expect(() =>
+        interpolateEnvVars({ "Authorization": "Bearer ${TEST_CRLF_VAR}" }),
+      ).toThrow(/newline/i);
+    } finally {
+      if (original === undefined) delete process.env.TEST_CRLF_VAR;
+      else process.env.TEST_CRLF_VAR = original;
+    }
+  });
+
+  it("should reject values containing bare LF (LF injection)", () => {
+    const original = process.env.TEST_LF_VAR;
+    process.env.TEST_LF_VAR = "token\nX-Injected: evil";
+    try {
+      expect(() =>
+        interpolateEnvVars({ "Authorization": "Bearer ${TEST_LF_VAR}" }),
+      ).toThrow(/newline/i);
+    } finally {
+      if (original === undefined) delete process.env.TEST_LF_VAR;
+      else process.env.TEST_LF_VAR = original;
+    }
+  });
+});
+
+describe("McpConnection with connector", () => {
+  it("should accept a connector function option", () => {
+    const conn = new McpConnection("test", {
+      type: "http",
+      url: "https://example.com/mcp",
+      auth: "oauth",
+    }, {
+      connector: async () => {
+        throw new Error("mock connector");
+      },
+    });
+    expect(conn).toBeDefined();
   });
 });

--- a/lib/runtime/mcp/mcpConnection.ts
+++ b/lib/runtime/mcp/mcpConnection.ts
@@ -1,36 +1,13 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { isHttpServer, isStdioServer } from "./types.js";
 import type { McpServerConfig, McpStdioServerConfig, McpHttpServerConfig, McpTool } from "./types.js";
-
-export function interpolateEnvVars(headers: Record<string, string>): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (const [key, value] of Object.entries(headers)) {
-    result[key] = value.replace(/\$\{(\w+)\}/g, (_, varName) => {
-      const envValue = process.env[varName];
-      if (envValue === undefined) {
-        throw new Error(
-          `Environment variable "${varName}" is not set (referenced in MCP server headers)`,
-        );
-      }
-      return envValue;
-    });
-    // Guard against CRLF injection: env var values containing \r or \n
-    // could inject additional HTTP headers.
-    if (/[\r\n]/.test(result[key])) {
-      throw new Error(
-        `Header "${key}" contains illegal newline characters after environment variable interpolation (possible CRLF injection)`,
-      );
-    }
-  }
-  return result;
-}
 
 /** Returns a connected MCP Client. Used by OAuthConnector. */
 export type ConnectorFn = () => Promise<{ client: Client }>;
 
 export type McpConnectionOptions = {
-  /** Opaque connector function that returns a connected client+transport. */
   connector?: ConnectorFn;
 };
 
@@ -54,29 +31,21 @@ export class McpConnection {
 
   async connect(): Promise<void> {
     if (this.connector) {
-      // Delegate entirely to the connector (e.g. OAuthConnector).
-      // McpConnection doesn't know what happens inside.
       const result = await this.connector();
       this.client = result.client;
-    } else {
-      // Build transport directly (stdio or plain HTTP with optional headers)
-      let transport;
-      if ("type" in this.config && this.config.type === "http") {
-        const httpConfig = this.config as McpHttpServerConfig;
-        const opts: Record<string, any> = {};
-        if (httpConfig.headers) {
-          const headers = interpolateEnvVars(httpConfig.headers);
-          opts.requestInit = { headers };
-        }
-        transport = new StreamableHTTPClientTransport(new URL(httpConfig.url), opts);
-      } else {
-        const stdio = this.config as McpStdioServerConfig;
-        transport = new StdioClientTransport({
-          command: stdio.command,
-          args: stdio.args,
-          env: stdio.env,
-        });
+    } else if (isHttpServer(this.config)) {
+      const opts: Record<string, any> = {};
+      if (this.config.headers) {
+        opts.requestInit = { headers: this.config.headers };
       }
+      const transport = new StreamableHTTPClientTransport(new URL(this.config.url), opts);
+      await this.client.connect(transport);
+    } else if (isStdioServer(this.config)) {
+      const transport = new StdioClientTransport({
+        command: this.config.command,
+        args: this.config.args,
+        env: this.config.env,
+      });
       await this.client.connect(transport);
     }
 

--- a/lib/runtime/mcp/mcpConnection.ts
+++ b/lib/runtime/mcp/mcpConnection.ts
@@ -26,12 +26,8 @@ export function interpolateEnvVars(headers: Record<string, string>): Record<stri
   return result;
 }
 
-/**
- * A function that returns a connected {client, transport} pair.
- * Used by OAuthConnector to provide pre-authenticated connections.
- * McpConnection does NOT know what this function does internally.
- */
-export type ConnectorFn = () => Promise<{ client: Client; transport: any }>;
+/** Returns a connected MCP Client. Used by OAuthConnector. */
+export type ConnectorFn = () => Promise<{ client: Client }>;
 
 export type McpConnectionOptions = {
   /** Opaque connector function that returns a connected client+transport. */

--- a/lib/runtime/mcp/mcpConnection.ts
+++ b/lib/runtime/mcp/mcpConnection.ts
@@ -1,7 +1,42 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { McpServerConfig, McpStdioServerConfig, McpTool } from "./types.js";
+import type { McpServerConfig, McpStdioServerConfig, McpHttpServerConfig, McpTool } from "./types.js";
+
+export function interpolateEnvVars(headers: Record<string, string>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    result[key] = value.replace(/\$\{(\w+)\}/g, (_, varName) => {
+      const envValue = process.env[varName];
+      if (envValue === undefined) {
+        throw new Error(
+          `Environment variable "${varName}" is not set (referenced in MCP server headers)`,
+        );
+      }
+      return envValue;
+    });
+    // Guard against CRLF injection: env var values containing \r or \n
+    // could inject additional HTTP headers.
+    if (/[\r\n]/.test(result[key])) {
+      throw new Error(
+        `Header "${key}" contains illegal newline characters after environment variable interpolation (possible CRLF injection)`,
+      );
+    }
+  }
+  return result;
+}
+
+/**
+ * A function that returns a connected {client, transport} pair.
+ * Used by OAuthConnector to provide pre-authenticated connections.
+ * McpConnection does NOT know what this function does internally.
+ */
+export type ConnectorFn = () => Promise<{ client: Client; transport: any }>;
+
+export type McpConnectionOptions = {
+  /** Opaque connector function that returns a connected client+transport. */
+  connector?: ConnectorFn;
+};
 
 export class McpConnection {
   private client: Client;
@@ -9,10 +44,12 @@ export class McpConnection {
   private config: McpServerConfig;
   private tools: McpTool[] = [];
   private connected = false;
+  private connector: ConnectorFn | undefined;
 
-  constructor(serverName: string, config: McpServerConfig) {
+  constructor(serverName: string, config: McpServerConfig, options: McpConnectionOptions = {}) {
     this.serverName = serverName;
     this.config = config;
+    this.connector = options.connector;
     this.client = new Client({
       name: "agency-lang",
       version: "1.0.0",
@@ -20,19 +57,33 @@ export class McpConnection {
   }
 
   async connect(): Promise<void> {
-    let transport;
-    if ("type" in this.config && this.config.type === "http") {
-      transport = new StreamableHTTPClientTransport(new URL(this.config.url));
+    if (this.connector) {
+      // Delegate entirely to the connector (e.g. OAuthConnector).
+      // McpConnection doesn't know what happens inside.
+      const result = await this.connector();
+      this.client = result.client;
     } else {
-      const stdio = this.config as McpStdioServerConfig;
-      transport = new StdioClientTransport({
-        command: stdio.command,
-        args: stdio.args,
-        env: stdio.env,
-      });
+      // Build transport directly (stdio or plain HTTP with optional headers)
+      let transport;
+      if ("type" in this.config && this.config.type === "http") {
+        const httpConfig = this.config as McpHttpServerConfig;
+        const opts: Record<string, any> = {};
+        if (httpConfig.headers) {
+          const headers = interpolateEnvVars(httpConfig.headers);
+          opts.requestInit = { headers };
+        }
+        transport = new StreamableHTTPClientTransport(new URL(httpConfig.url), opts);
+      } else {
+        const stdio = this.config as McpStdioServerConfig;
+        transport = new StdioClientTransport({
+          command: stdio.command,
+          args: stdio.args,
+          env: stdio.env,
+        });
+      }
+      await this.client.connect(transport);
     }
 
-    await this.client.connect(transport);
     this.connected = true;
 
     const result = await this.client.listTools();

--- a/lib/runtime/mcp/mcpManager.test.ts
+++ b/lib/runtime/mcp/mcpManager.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { McpManager } from "./mcpManager.js";
 import path from "path";
+import fs from "fs";
+import os from "os";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -82,5 +84,74 @@ describe("McpManager", () => {
     // callTool should lazily reconnect and succeed
     const result = await manager.callTool("test", "add", { a: 10, b: 20 });
     expect(result).toContain("30");
+  });
+});
+
+describe("McpManager OAuth config", () => {
+  it("should accept onOAuthRequired callback", () => {
+    const manager = new McpManager(
+      {
+        github: { type: "http" as const, url: "https://example.com/mcp", auth: "oauth" as const },
+      },
+      { onOAuthRequired: () => {} },
+    );
+    expect(manager).toBeDefined();
+  });
+
+  it("should accept a custom tokenStoreDir", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-mgr-test-"));
+    try {
+      const manager = new McpManager(
+        { github: { type: "http" as const, url: "https://example.com/mcp", auth: "oauth" as const } },
+        { tokenStoreDir: tmpDir },
+      );
+      expect(manager).toBeDefined();
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should return a failure when OAuth server is unreachable", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-mgr-test-"));
+    try {
+      const manager = new McpManager(
+        {
+          test: {
+            type: "http" as const,
+            url: "http://127.0.0.1:1/nonexistent",
+            auth: "oauth" as const,
+          },
+        },
+        { tokenStoreDir: tmpDir },
+      );
+      const result = await manager.getTools("test");
+      expect(result.success).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should deduplicate concurrent getTools calls for the same server", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-mgr-test-"));
+    try {
+      const manager = new McpManager(
+        {
+          test: {
+            type: "http" as const,
+            url: "http://127.0.0.1:1/nonexistent",
+            auth: "oauth" as const,
+          },
+        },
+        { tokenStoreDir: tmpDir },
+      );
+      const [result1, result2] = await Promise.all([
+        manager.getTools("test"),
+        manager.getTools("test"),
+      ]);
+      expect(result1.success).toBe(false);
+      expect(result2.success).toBe(false);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/lib/runtime/mcp/mcpManager.ts
+++ b/lib/runtime/mcp/mcpManager.ts
@@ -79,6 +79,7 @@ export class McpManager {
       } catch (error) {
         const message =
           error instanceof Error ? error.message : String(error);
+        console.error(`[mcp] Failed to connect to server "${serverName}": ${message}`);
         return failure(
           `Failed to connect to MCP server "${serverName}": ${message}`,
         );

--- a/lib/runtime/mcp/mcpManager.ts
+++ b/lib/runtime/mcp/mcpManager.ts
@@ -1,14 +1,55 @@
 import { McpConnection } from "./mcpConnection.js";
-import type { ServerName, McpServerConfig, McpTool } from "./types.js";
+import { OAuthConnector } from "./oauthConnector.js";
+import { TokenStore } from "./tokenStore.js";
+import type { ServerName, McpServerConfig, McpHttpServerConfig, McpTool } from "./types.js";
 import { success, failure, type ResultValue } from "../result.js";
+import type { OAuthRequiredData } from "./oauthProvider.js";
+
+export type McpManagerOptions = {
+  onOAuthRequired?: (data: OAuthRequiredData) => void | Promise<void>;
+  tokenStoreDir?: string;
+};
 
 export class McpManager {
   private config: Record<ServerName, McpServerConfig>;
   private connections: Record<ServerName, McpConnection> = {};
   private toolCache: Record<ServerName, McpTool[]> = {};
+  private connectPromises: Record<ServerName, Promise<ResultValue>> = {};
+  private tokenStore: TokenStore;
+  private onOAuthRequired?: (data: OAuthRequiredData) => void | Promise<void>;
 
-  constructor(config: Record<ServerName, McpServerConfig>) {
+  constructor(
+    config: Record<ServerName, McpServerConfig>,
+    options: McpManagerOptions = {},
+  ) {
     this.config = config;
+    this.tokenStore = new TokenStore(options.tokenStoreDir);
+    this.onOAuthRequired = options.onOAuthRequired;
+  }
+
+  private createConnection(serverName: string): McpConnection {
+    const serverConfig = this.config[serverName];
+    const isOAuth =
+      "type" in serverConfig &&
+      serverConfig.type === "http" &&
+      (serverConfig as McpHttpServerConfig).auth === "oauth";
+
+    if (isOAuth) {
+      const httpConfig = serverConfig as McpHttpServerConfig;
+      const connector = new OAuthConnector(serverName, httpConfig.url, this.tokenStore, {
+        onOAuthRequired: this.onOAuthRequired,
+        timeoutMs: httpConfig.authTimeout,
+        clientId: httpConfig.clientId,
+        clientSecret: httpConfig.clientSecret,
+      });
+      // Pass connector.connect() as the opaque ConnectorFn.
+      // McpConnection doesn't know what happens inside.
+      return new McpConnection(serverName, serverConfig, {
+        connector: () => connector.connect(),
+      });
+    }
+
+    return new McpConnection(serverName, serverConfig);
   }
 
   async getTools(serverName: string): Promise<ResultValue> {
@@ -22,19 +63,32 @@ export class McpManager {
       return success(this.toolCache[serverName]);
     }
 
-    try {
-      const conn = new McpConnection(serverName, this.config[serverName]);
-      await conn.connect();
-      this.connections[serverName] = conn;
-      this.toolCache[serverName] = conn.getTools();
-      return success(this.toolCache[serverName]);
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : String(error);
-      return failure(
-        `Failed to connect to MCP server "${serverName}": ${message}`,
-      );
+    // Prevent concurrent connection attempts for the same server.
+    // Only one OAuth flow should fire per server.
+    if (serverName in this.connectPromises) {
+      return this.connectPromises[serverName];
     }
+
+    const connectPromise = (async () => {
+      try {
+        const conn = this.createConnection(serverName);
+        await conn.connect();
+        this.connections[serverName] = conn;
+        this.toolCache[serverName] = conn.getTools();
+        return success(this.toolCache[serverName]);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return failure(
+          `Failed to connect to MCP server "${serverName}": ${message}`,
+        );
+      } finally {
+        delete this.connectPromises[serverName];
+      }
+    })();
+
+    this.connectPromises[serverName] = connectPromise;
+    return connectPromise;
   }
 
   async callTool(
@@ -45,7 +99,7 @@ export class McpManager {
     const conn = this.connections[serverName];
     if (!conn) {
       if (this.config[serverName]) {
-        const reconnConn = new McpConnection(serverName, this.config[serverName]);
+        const reconnConn = this.createConnection(serverName);
         await reconnConn.connect();
         this.connections[serverName] = reconnConn;
         return reconnConn.callTool(toolName, args);
@@ -60,7 +114,6 @@ export class McpManager {
   async disconnectAll(): Promise<void> {
     const conns = Object.values(this.connections);
     if (conns.length === 0) return;
-    // Swallow individual disconnect errors to ensure all servers get cleaned up
     await Promise.all(conns.map((conn) => conn.disconnect().catch(() => {})));
     this.connections = {};
     this.toolCache = {};

--- a/lib/runtime/mcp/mcpManager.ts
+++ b/lib/runtime/mcp/mcpManager.ts
@@ -1,6 +1,7 @@
 import { McpConnection } from "./mcpConnection.js";
 import { OAuthConnector } from "./oauthConnector.js";
 import { TokenStore } from "./tokenStore.js";
+import { isOAuthServer } from "./types.js";
 import type { ServerName, McpServerConfig, McpHttpServerConfig, McpTool } from "./types.js";
 import { success, failure, type ResultValue } from "../result.js";
 import type { OAuthRequiredData } from "./oauthProvider.js";
@@ -29,12 +30,7 @@ export class McpManager {
 
   private createConnection(serverName: string): McpConnection {
     const serverConfig = this.config[serverName];
-    const isOAuth =
-      "type" in serverConfig &&
-      serverConfig.type === "http" &&
-      (serverConfig as McpHttpServerConfig).auth === "oauth";
-
-    if (isOAuth) {
+    if (isOAuthServer(serverConfig)) {
       const httpConfig = serverConfig as McpHttpServerConfig;
       const connector = new OAuthConnector(serverName, httpConfig.url, this.tokenStore, {
         onOAuthRequired: this.onOAuthRequired,
@@ -113,8 +109,12 @@ export class McpManager {
   }
 
   async disconnectAll(): Promise<void> {
+    // Clear pending connect promises so in-flight connections don't write
+    // back to this.connections after we've cleaned up.
+    this.connectPromises = {};
+
     const conns = Object.values(this.connections);
-    if (conns.length === 0) return;
+    // Swallow individual disconnect errors to ensure all servers get cleaned up
     await Promise.all(conns.map((conn) => conn.disconnect().catch(() => {})));
     this.connections = {};
     this.toolCache = {};

--- a/lib/runtime/mcp/mcpManager.ts
+++ b/lib/runtime/mcp/mcpManager.ts
@@ -61,7 +61,7 @@ export class McpManager {
 
     // Prevent concurrent connection attempts for the same server.
     // Only one OAuth flow should fire per server.
-    if (serverName in this.connectPromises) {
+    if (Object.hasOwn(this.connectPromises, serverName)) {
       return this.connectPromises[serverName];
     }
 

--- a/lib/runtime/mcp/oauthConnector.test.ts
+++ b/lib/runtime/mcp/oauthConnector.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { OAuthConnector } from "./oauthConnector.js";
+import { TokenStore } from "./tokenStore.js";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+describe("OAuthConnector", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("should construct with server name, url, and token store", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-connector-test-"));
+    const store = new TokenStore(tmpDir);
+    const connector = new OAuthConnector("github", "https://example.com/mcp", store, { port: 0 });
+    expect(connector).toBeDefined();
+  });
+
+  it("should throw when server is unreachable", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-connector-test-"));
+    const store = new TokenStore(tmpDir);
+    const connector = new OAuthConnector("test", "http://127.0.0.1:1/nonexistent", store, { port: 0 });
+
+    await expect(connector.connect()).rejects.toThrow();
+  });
+});

--- a/lib/runtime/mcp/oauthConnector.ts
+++ b/lib/runtime/mcp/oauthConnector.ts
@@ -1,0 +1,112 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { AgencyOAuthProvider, type OAuthProviderOptions } from "./oauthProvider.js";
+import { TokenStore } from "./tokenStore.js";
+
+export type OAuthConnectResult = {
+  client: Client;
+  transport: StreamableHTTPClientTransport;
+};
+
+/**
+ * Encapsulates the two-phase OAuth connect flow for an MCP HTTP server.
+ *
+ * This is the ONLY class that knows about UnauthorizedError, finishAuth(),
+ * and the retry logic. McpConnection and McpManager do not import any
+ * OAuth-related types.
+ *
+ * Usage:
+ *   const connector = new OAuthConnector(serverName, url, tokenStore, options);
+ *   const { client, transport } = await connector.connect();
+ */
+export class OAuthConnector {
+  private serverName: string;
+  private url: string;
+  private provider: AgencyOAuthProvider;
+
+  constructor(
+    serverName: string,
+    url: string,
+    tokenStore: TokenStore,
+    options: OAuthProviderOptions = {},
+  ) {
+    this.serverName = serverName;
+    this.url = url;
+    this.provider = new AgencyOAuthProvider(serverName, url, tokenStore, options);
+  }
+
+  private createTransport(): StreamableHTTPClientTransport {
+    const debugFetch: typeof globalThis.fetch = async (input, init) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      const response = await globalThis.fetch(input, init);
+      // Log token endpoint responses for debugging
+      if (url.includes("access_token") || url.includes("/token") || (init?.body && String(init.body).includes("grant_type"))) {
+        const cloned = response.clone();
+        const text = await cloned.text();
+        console.log(`[oauth-debug] Token endpoint ${url}`);
+        console.log(`[oauth-debug] Status: ${response.status}`);
+        console.log(`[oauth-debug] Response: ${text}`);
+      }
+      return response;
+    };
+    return new StreamableHTTPClientTransport(new URL(this.url), {
+      authProvider: this.provider,
+      fetch: debugFetch,
+    });
+  }
+
+  private createClient(): Client {
+    return new Client({ name: "agency-lang", version: "1.0.0" });
+  }
+
+  /**
+   * Connect to the MCP server, handling OAuth if required.
+   *
+   * 1. Starts the callback server (so redirect URL is known for registration)
+   * 2. Attempts to connect
+   * 3. If the server requires auth, the SDK calls redirectToAuthorization
+   *    and throws UnauthorizedError
+   * 4. Waits for the user to authorize in the browser
+   * 5. Calls finishAuth(code) to exchange the code for tokens
+   * 6. Retries with a fresh client/transport (SDK may not support reuse)
+   *
+   * Returns a connected {client, transport} pair.
+   */
+  async connect(): Promise<OAuthConnectResult> {
+    // Start callback server BEFORE connect so the redirect URL has a real port
+    // when the SDK reads clientMetadata for dynamic client registration.
+    await this.provider.prepare();
+
+    const client = this.createClient();
+    const transport = this.createTransport();
+
+    try {
+      await client.connect(transport);
+      // No auth needed (or had valid stored tokens) — clean up callback server
+      await this.provider.cleanup();
+      return { client, transport };
+    } catch (error) {
+      if (!(error instanceof UnauthorizedError)) {
+        await this.provider.cleanup();
+        throw error;
+      }
+
+      // Two-phase OAuth: the SDK has called redirectToAuthorization and thrown.
+      // Wait for the user to complete auth in the browser.
+      try {
+        const code = await this.provider.waitForAuthCode();
+        await transport.finishAuth(code);
+
+        // Create fresh client/transport for retry — the SDK may not support
+        // reusing a Client/transport after an UnauthorizedError.
+        const retryClient = this.createClient();
+        const retryTransport = this.createTransport();
+        await retryClient.connect(retryTransport);
+        return { client: retryClient, transport: retryTransport };
+      } finally {
+        await this.provider.cleanup();
+      }
+    }
+  }
+}

--- a/lib/runtime/mcp/oauthConnector.ts
+++ b/lib/runtime/mcp/oauthConnector.ts
@@ -33,7 +33,7 @@ export class OAuthConnector {
   ) {
     this.serverName = serverName;
     this.url = url;
-    this.provider = new AgencyOAuthProvider(serverName, url, tokenStore, options);
+    this.provider = new AgencyOAuthProvider(serverName, tokenStore, options);
   }
 
   private createTransport(): StreamableHTTPClientTransport {

--- a/lib/runtime/mcp/oauthConnector.ts
+++ b/lib/runtime/mcp/oauthConnector.ts
@@ -84,8 +84,10 @@ export class OAuthConnector {
         const code = await this.provider.waitForAuthCode();
         await transport.finishAuth(code);
 
-        // Create fresh client/transport for retry — the SDK may not support
-        // reusing a Client/transport after an UnauthorizedError.
+        // Close the original client/transport — they can't be reused after
+        // UnauthorizedError and would leak otherwise.
+        await client.close().catch(() => {});
+
         const retryClient = this.createClient();
         const retryTransport = this.createTransport();
         await retryClient.connect(retryTransport);

--- a/lib/runtime/mcp/oauthConnector.ts
+++ b/lib/runtime/mcp/oauthConnector.ts
@@ -37,22 +37,8 @@ export class OAuthConnector {
   }
 
   private createTransport(): StreamableHTTPClientTransport {
-    const debugFetch: typeof globalThis.fetch = async (input, init) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
-      const response = await globalThis.fetch(input, init);
-      // Log token endpoint responses for debugging
-      if (url.includes("access_token") || url.includes("/token") || (init?.body && String(init.body).includes("grant_type"))) {
-        const cloned = response.clone();
-        const text = await cloned.text();
-        console.log(`[oauth-debug] Token endpoint ${url}`);
-        console.log(`[oauth-debug] Status: ${response.status}`);
-        console.log(`[oauth-debug] Response: ${text}`);
-      }
-      return response;
-    };
     return new StreamableHTTPClientTransport(new URL(this.url), {
       authProvider: this.provider,
-      fetch: debugFetch,
     });
   }
 

--- a/lib/runtime/mcp/oauthProvider.test.ts
+++ b/lib/runtime/mcp/oauthProvider.test.ts
@@ -110,11 +110,19 @@ describe("AgencyOAuthProvider", () => {
     await expect(provider.codeVerifier()).rejects.toThrow(/No PKCE code verifier/);
   });
 
-  it("should have correct client metadata", () => {
-    const provider = new AgencyOAuthProvider("github", store);
+  it("should have correct client metadata after prepare()", async () => {
+    const provider = new AgencyOAuthProvider("github", store, { port: 0 });
+    await provider.prepare();
     const meta = provider.clientMetadata;
     expect(meta.client_name).toBe("agency-github");
     expect(meta.redirect_uris).toBeDefined();
+    expect(meta.redirect_uris.length).toBe(1);
+    await provider.cleanup();
+  });
+
+  it("should throw from redirectUrl before prepare()", () => {
+    const provider = new AgencyOAuthProvider("github", store);
+    expect(() => provider.redirectUrl).toThrow(/call prepare/);
   });
 
   it("should have a real redirectUrl after prepare()", async () => {

--- a/lib/runtime/mcp/oauthProvider.test.ts
+++ b/lib/runtime/mcp/oauthProvider.test.ts
@@ -57,6 +57,41 @@ describe("AgencyOAuthProvider", () => {
     expect(loaded).toEqual(info);
   });
 
+  it("should fall back to env vars for clientId and clientSecret", async () => {
+    const origId = process.env.MCP_GITHUB_CLIENT_ID;
+    const origSecret = process.env.MCP_GITHUB_CLIENT_SECRET;
+    process.env.MCP_GITHUB_CLIENT_ID = "env-client-id";
+    process.env.MCP_GITHUB_CLIENT_SECRET = "env-client-secret";
+    try {
+      // No clientId/clientSecret in options — should pick up env vars
+      const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+      const info = await provider.clientInformation();
+      expect(info).toBeDefined();
+      expect((info as any).client_id).toBe("env-client-id");
+      expect((info as any).client_secret).toBe("env-client-secret");
+    } finally {
+      if (origId === undefined) delete process.env.MCP_GITHUB_CLIENT_ID;
+      else process.env.MCP_GITHUB_CLIENT_ID = origId;
+      if (origSecret === undefined) delete process.env.MCP_GITHUB_CLIENT_SECRET;
+      else process.env.MCP_GITHUB_CLIENT_SECRET = origSecret;
+    }
+  });
+
+  it("should prefer config values over env vars", async () => {
+    const origId = process.env.MCP_GITHUB_CLIENT_ID;
+    process.env.MCP_GITHUB_CLIENT_ID = "env-id";
+    try {
+      const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store, {
+        clientId: "config-id",
+      });
+      const info = await provider.clientInformation();
+      expect((info as any).client_id).toBe("config-id");
+    } finally {
+      if (origId === undefined) delete process.env.MCP_GITHUB_CLIENT_ID;
+      else process.env.MCP_GITHUB_CLIENT_ID = origId;
+    }
+  });
+
   it("should have correct client metadata", () => {
     const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
     const meta = provider.clientMetadata;

--- a/lib/runtime/mcp/oauthProvider.test.ts
+++ b/lib/runtime/mcp/oauthProvider.test.ts
@@ -92,6 +92,24 @@ describe("AgencyOAuthProvider", () => {
     }
   });
 
+  it("should return undefined from clientInformation when no config or env vars", async () => {
+    // Make sure the env vars are not set
+    const origId = process.env.MCP_GITHUB_CLIENT_ID;
+    delete process.env.MCP_GITHUB_CLIENT_ID;
+    try {
+      const provider = new AgencyOAuthProvider("github", store);
+      const info = await provider.clientInformation();
+      expect(info).toBeUndefined();
+    } finally {
+      if (origId !== undefined) process.env.MCP_GITHUB_CLIENT_ID = origId;
+    }
+  });
+
+  it("should throw from codeVerifier when no verifier is saved", async () => {
+    const provider = new AgencyOAuthProvider("github", store);
+    await expect(provider.codeVerifier()).rejects.toThrow(/No PKCE code verifier/);
+  });
+
   it("should have correct client metadata", () => {
     const provider = new AgencyOAuthProvider("github", store);
     const meta = provider.clientMetadata;

--- a/lib/runtime/mcp/oauthProvider.test.ts
+++ b/lib/runtime/mcp/oauthProvider.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { AgencyOAuthProvider } from "./oauthProvider.js";
+import { TokenStore } from "./tokenStore.js";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+describe("AgencyOAuthProvider", () => {
+  let tmpDir: string;
+  let store: TokenStore;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-oauth-test-"));
+    store = new TokenStore(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should return undefined tokens when none are stored", async () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const tokens = await provider.tokens();
+    expect(tokens).toBeUndefined();
+  });
+
+  it("should return stored tokens", async () => {
+    const savedTokens = { access_token: "abc", token_type: "bearer" };
+    await store.saveTokens("github", savedTokens);
+
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const tokens = await provider.tokens();
+    expect(tokens).toEqual(savedTokens);
+  });
+
+  it("should save tokens via saveTokens", async () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const tokens = { access_token: "new-token", token_type: "bearer" };
+    await provider.saveTokens(tokens);
+
+    const loaded = await store.loadTokens("github");
+    expect(loaded).toEqual(tokens);
+  });
+
+  it("should save and load code verifier", async () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    await provider.saveCodeVerifier("verifier-abc");
+    const loaded = await provider.codeVerifier();
+    expect(loaded).toBe("verifier-abc");
+  });
+
+  it("should save and load client info", async () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const info = { client_id: "my-id", client_secret: "secret" };
+    await provider.saveClientInformation(info);
+    const loaded = await provider.clientInformation();
+    expect(loaded).toEqual(info);
+  });
+
+  it("should have correct client metadata", () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const meta = provider.clientMetadata;
+    expect(meta.client_name).toBe("agency-github");
+    expect(meta.redirect_uris).toBeDefined();
+  });
+
+  it("should have a real redirectUrl after prepare()", async () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store, { port: 0 });
+    await provider.prepare();
+    expect(provider.redirectUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/oauth\/callback$/);
+    expect(provider.redirectUrl).not.toContain(":0/");
+    await provider.cleanup();
+  });
+
+  it("should call onOAuthRequired callback instead of opening browser when provided", async () => {
+    const onOAuthRequired = vi.fn();
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store, {
+      onOAuthRequired,
+    });
+
+    const authUrl = new URL("https://example.com/authorize?code=123");
+    await provider.redirectToAuthorization(authUrl);
+
+    expect(onOAuthRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverName: "github",
+        authUrl: authUrl.toString(),
+      }),
+    );
+  });
+
+  it("should expose waitForAuthCode() that resolves when callback arrives", async () => {
+    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store, { port: 0 });
+    await provider.prepare();
+
+    const callbackUrl = provider.redirectUrl;
+    const state = provider.state();
+    const codePromise = provider.waitForAuthCode();
+    await fetch(`${callbackUrl}?code=test-code&state=${state}`);
+    const code = await codePromise;
+    expect(code).toBe("test-code");
+
+    await provider.cleanup();
+  });
+});

--- a/lib/runtime/mcp/oauthProvider.test.ts
+++ b/lib/runtime/mcp/oauthProvider.test.ts
@@ -19,7 +19,7 @@ describe("AgencyOAuthProvider", () => {
   });
 
   it("should return undefined tokens when none are stored", async () => {
-    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const provider = new AgencyOAuthProvider("github", store);
     const tokens = await provider.tokens();
     expect(tokens).toBeUndefined();
   });
@@ -28,13 +28,13 @@ describe("AgencyOAuthProvider", () => {
     const savedTokens = { access_token: "abc", token_type: "bearer" };
     await store.saveTokens("github", savedTokens);
 
-    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const provider = new AgencyOAuthProvider("github", store);
     const tokens = await provider.tokens();
     expect(tokens).toEqual(savedTokens);
   });
 
   it("should save tokens via saveTokens", async () => {
-    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const provider = new AgencyOAuthProvider("github", store);
     const tokens = { access_token: "new-token", token_type: "bearer" };
     await provider.saveTokens(tokens);
 
@@ -43,14 +43,14 @@ describe("AgencyOAuthProvider", () => {
   });
 
   it("should save and load code verifier", async () => {
-    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const provider = new AgencyOAuthProvider("github", store);
     await provider.saveCodeVerifier("verifier-abc");
     const loaded = await provider.codeVerifier();
     expect(loaded).toBe("verifier-abc");
   });
 
   it("should save and load client info", async () => {
-    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const provider = new AgencyOAuthProvider("github", store);
     const info = { client_id: "my-id", client_secret: "secret" };
     await provider.saveClientInformation(info);
     const loaded = await provider.clientInformation();
@@ -64,7 +64,7 @@ describe("AgencyOAuthProvider", () => {
     process.env.MCP_GITHUB_CLIENT_SECRET = "env-client-secret";
     try {
       // No clientId/clientSecret in options — should pick up env vars
-      const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+      const provider = new AgencyOAuthProvider("github", store);
       const info = await provider.clientInformation();
       expect(info).toBeDefined();
       expect((info as any).client_id).toBe("env-client-id");
@@ -81,7 +81,7 @@ describe("AgencyOAuthProvider", () => {
     const origId = process.env.MCP_GITHUB_CLIENT_ID;
     process.env.MCP_GITHUB_CLIENT_ID = "env-id";
     try {
-      const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store, {
+      const provider = new AgencyOAuthProvider("github", store, {
         clientId: "config-id",
       });
       const info = await provider.clientInformation();
@@ -93,14 +93,14 @@ describe("AgencyOAuthProvider", () => {
   });
 
   it("should have correct client metadata", () => {
-    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store);
+    const provider = new AgencyOAuthProvider("github", store);
     const meta = provider.clientMetadata;
     expect(meta.client_name).toBe("agency-github");
     expect(meta.redirect_uris).toBeDefined();
   });
 
   it("should have a real redirectUrl after prepare()", async () => {
-    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store, { port: 0 });
+    const provider = new AgencyOAuthProvider("github", store, { port: 0 });
     await provider.prepare();
     expect(provider.redirectUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/oauth\/callback$/);
     expect(provider.redirectUrl).not.toContain(":0/");
@@ -109,7 +109,7 @@ describe("AgencyOAuthProvider", () => {
 
   it("should call onOAuthRequired callback instead of opening browser when provided", async () => {
     const onOAuthRequired = vi.fn();
-    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store, {
+    const provider = new AgencyOAuthProvider("github", store, {
       onOAuthRequired,
     });
 
@@ -125,7 +125,7 @@ describe("AgencyOAuthProvider", () => {
   });
 
   it("should expose waitForAuthCode() that resolves when callback arrives", async () => {
-    const provider = new AgencyOAuthProvider("github", "https://example.com/mcp", store, { port: 0 });
+    const provider = new AgencyOAuthProvider("github", store, { port: 0 });
     await provider.prepare();
 
     const callbackUrl = provider.redirectUrl;

--- a/lib/runtime/mcp/oauthProvider.ts
+++ b/lib/runtime/mcp/oauthProvider.ts
@@ -47,7 +47,6 @@ export type OAuthProviderOptions = {
 
 export class AgencyOAuthProvider implements OAuthClientProvider {
   private serverName: string;
-  private serverUrl: string;
   private store: TokenStore;
   private options: OAuthProviderOptions;
   private callbackServer: CallbackServer | null = null;
@@ -55,12 +54,10 @@ export class AgencyOAuthProvider implements OAuthClientProvider {
 
   constructor(
     serverName: string,
-    serverUrl: string,
     store: TokenStore,
     options: OAuthProviderOptions = {},
   ) {
     this.serverName = serverName;
-    this.serverUrl = serverUrl;
     this.store = store;
     this.options = options;
   }
@@ -103,20 +100,22 @@ export class AgencyOAuthProvider implements OAuthClientProvider {
 
   get clientMetadata(): OAuthClientMetadata {
     return {
-      redirect_uris: [this.redirectUrl as any],
+      redirect_uris: [this.redirectUrl],
       client_name: `agency-${this.serverName}`,
     };
   }
 
+  private envVarName(suffix: string): string {
+    const normalized = this.serverName.toUpperCase().replace(/[^A-Z0-9_]/g, "_");
+    return `MCP_${normalized}_${suffix}`;
+  }
+
   private resolveClientId(): string | undefined {
-    // Config value first, then env var fallback
-    return this.options.clientId
-      ?? process.env[`MCP_${this.serverName.toUpperCase()}_CLIENT_ID`];
+    return this.options.clientId ?? process.env[this.envVarName("CLIENT_ID")];
   }
 
   private resolveClientSecret(): string | undefined {
-    return this.options.clientSecret
-      ?? process.env[`MCP_${this.serverName.toUpperCase()}_CLIENT_SECRET`];
+    return this.options.clientSecret ?? process.env[this.envVarName("CLIENT_SECRET")];
   }
 
   async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
@@ -171,7 +170,7 @@ export class AgencyOAuthProvider implements OAuthClientProvider {
         authUrl: authorizationUrl.toString(),
         complete: completePromise,
         cancel: () => {
-          this.cleanup();
+          void this.cleanup().catch(() => {});
           rejectComplete!(new Error("OAuth flow cancelled"));
         },
       });

--- a/lib/runtime/mcp/oauthProvider.ts
+++ b/lib/runtime/mcp/oauthProvider.ts
@@ -99,16 +99,29 @@ export class AgencyOAuthProvider implements OAuthClientProvider {
     };
   }
 
+  private resolveClientId(): string | undefined {
+    // Config value first, then env var fallback
+    return this.options.clientId
+      ?? process.env[`MCP_${this.serverName.toUpperCase()}_CLIENT_ID`];
+  }
+
+  private resolveClientSecret(): string | undefined {
+    return this.options.clientSecret
+      ?? process.env[`MCP_${this.serverName.toUpperCase()}_CLIENT_SECRET`];
+  }
+
   async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
     const stored = await this.store.loadClientInfo(this.serverName);
     if (stored) return stored;
-    // If a pre-registered clientId was provided in config, use it.
+    // If a pre-registered clientId was provided (config or env var), use it.
     // This skips Dynamic Client Registration (DCR), which many servers
     // (like GitHub) don't support.
-    if (this.options.clientId) {
-      const info: Record<string, string> = { client_id: this.options.clientId };
-      if (this.options.clientSecret) {
-        info.client_secret = this.options.clientSecret;
+    const clientId = this.resolveClientId();
+    if (clientId) {
+      const info: Record<string, string> = { client_id: clientId };
+      const clientSecret = this.resolveClientSecret();
+      if (clientSecret) {
+        info.client_secret = clientSecret;
       }
       return info as unknown as OAuthClientInformationMixed;
     }
@@ -128,8 +141,6 @@ export class AgencyOAuthProvider implements OAuthClientProvider {
   }
 
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
-    console.log(`[oauth] redirectUrl: ${this.redirectUrl}`);
-    console.log(`[oauth] authorizationUrl: ${authorizationUrl.toString()}`);
     // Set up a completion promise for the onOAuthRequired callback
     let resolveComplete: () => void;
     let rejectComplete: (err: Error) => void;

--- a/lib/runtime/mcp/oauthProvider.ts
+++ b/lib/runtime/mcp/oauthProvider.ts
@@ -24,7 +24,7 @@ async function openInBrowser(url: string): Promise<void> {
       `Cross-platform support will be added in a future release.`,
     );
   }
-  await execFileAsync("open", [url]);
+  await execFileAsync("open", ["--", url]);
 }
 
 export type OAuthRequiredData = {

--- a/lib/runtime/mcp/oauthProvider.ts
+++ b/lib/runtime/mcp/oauthProvider.ts
@@ -13,8 +13,17 @@ import { TokenStore } from "./tokenStore.js";
 
 const execFileAsync = promisify(execFile);
 
-/** Open a URL in the default browser. macOS-only for now. */
+/**
+ * Open a URL in the default browser. macOS-only for now.
+ * Mirrors stdlib _openUrl() — duplicated here to avoid cross-tsconfig imports.
+ */
 async function openInBrowser(url: string): Promise<void> {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      `Opening a browser is currently only supported on macOS (detected: ${process.platform}). ` +
+      `Cross-platform support will be added in a future release.`,
+    );
+  }
   await execFileAsync("open", [url]);
 }
 

--- a/lib/runtime/mcp/oauthProvider.ts
+++ b/lib/runtime/mcp/oauthProvider.ts
@@ -1,0 +1,192 @@
+import type {
+  OAuthClientProvider,
+} from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthTokens,
+  OAuthClientMetadata,
+  OAuthClientInformationMixed,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { CallbackServer } from "./callbackServer.js";
+import { TokenStore } from "./tokenStore.js";
+
+const execFileAsync = promisify(execFile);
+
+/** Open a URL in the default browser. macOS-only for now. */
+async function openInBrowser(url: string): Promise<void> {
+  await execFileAsync("open", [url]);
+}
+
+export type OAuthRequiredData = {
+  serverName: string;
+  authUrl: string;
+  /** Promise that resolves when the OAuth flow completes (callback received) */
+  complete: Promise<void>;
+  /** Cancel the OAuth flow */
+  cancel: () => void;
+};
+
+export type OAuthProviderOptions = {
+  onOAuthRequired?: (data: OAuthRequiredData) => void | Promise<void>;
+  timeoutMs?: number;
+  clientId?: string;
+  clientSecret?: string;
+  /** Override the callback server port (default 19876). Use 0 for random port in tests. */
+  port?: number;
+};
+
+export class AgencyOAuthProvider implements OAuthClientProvider {
+  private serverName: string;
+  private serverUrl: string;
+  private store: TokenStore;
+  private options: OAuthProviderOptions;
+  private callbackServer: CallbackServer | null = null;
+  private _callbackUrl: string | null = null;
+
+  constructor(
+    serverName: string,
+    serverUrl: string,
+    store: TokenStore,
+    options: OAuthProviderOptions = {},
+  ) {
+    this.serverName = serverName;
+    this.serverUrl = serverUrl;
+    this.store = store;
+    this.options = options;
+  }
+
+  /**
+   * Start the callback server before connect() so the redirect URL is
+   * known when the SDK reads clientMetadata for dynamic registration.
+   * Called by OAuthConnector before client.connect().
+   */
+  async prepare(): Promise<void> {
+    this.callbackServer = new CallbackServer({
+      port: this.options.port,
+      timeoutMs: this.options.timeoutMs,
+    });
+    this._callbackUrl = await this.callbackServer.start();
+  }
+
+  /**
+   * Wait for the authorization code from the callback server.
+   * Returns the code string. Rejects on timeout or cancellation.
+   */
+  async waitForAuthCode(): Promise<string> {
+    if (!this.callbackServer) {
+      throw new Error(`OAuth flow for "${this.serverName}" not started — call prepare() first`);
+    }
+    return this.callbackServer.waitForCode();
+  }
+
+  state(): string {
+    if (!this.callbackServer) {
+      throw new Error(`OAuth flow for "${this.serverName}" not started — call prepare() first`);
+    }
+    return this.callbackServer.state;
+  }
+
+  get redirectUrl(): string {
+    // After prepare(), this is the real localhost URL with actual port.
+    return this._callbackUrl ?? "http://127.0.0.1:0/oauth/callback";
+  }
+
+  get clientMetadata(): OAuthClientMetadata {
+    return {
+      redirect_uris: [this.redirectUrl as any],
+      client_name: `agency-${this.serverName}`,
+    };
+  }
+
+  async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
+    const stored = await this.store.loadClientInfo(this.serverName);
+    if (stored) return stored;
+    // If a pre-registered clientId was provided in config, use it.
+    // This skips Dynamic Client Registration (DCR), which many servers
+    // (like GitHub) don't support.
+    if (this.options.clientId) {
+      const info: Record<string, string> = { client_id: this.options.clientId };
+      if (this.options.clientSecret) {
+        info.client_secret = this.options.clientSecret;
+      }
+      return info as unknown as OAuthClientInformationMixed;
+    }
+    return undefined;
+  }
+
+  async saveClientInformation(info: OAuthClientInformationMixed): Promise<void> {
+    await this.store.saveClientInfo(this.serverName, info);
+  }
+
+  async tokens(): Promise<OAuthTokens | undefined> {
+    return this.store.loadTokens(this.serverName);
+  }
+
+  async saveTokens(tokens: OAuthTokens): Promise<void> {
+    await this.store.saveTokens(this.serverName, tokens);
+  }
+
+  async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    console.log(`[oauth] redirectUrl: ${this.redirectUrl}`);
+    console.log(`[oauth] authorizationUrl: ${authorizationUrl.toString()}`);
+    // Set up a completion promise for the onOAuthRequired callback
+    let resolveComplete: () => void;
+    let rejectComplete: (err: Error) => void;
+    const completePromise = new Promise<void>((resolve, reject) => {
+      resolveComplete = resolve;
+      rejectComplete = reject;
+    });
+
+    // Wire callback server completion to the complete promise
+    if (this.callbackServer) {
+      this.callbackServer.waitForCode()
+        .then(() => resolveComplete())
+        .catch((err) => rejectComplete(err));
+    }
+
+    if (this.options.onOAuthRequired) {
+      await this.options.onOAuthRequired({
+        serverName: this.serverName,
+        authUrl: authorizationUrl.toString(),
+        complete: completePromise,
+        cancel: () => {
+          this.cleanup();
+          rejectComplete!(new Error("OAuth flow cancelled"));
+        },
+      });
+    } else {
+      try {
+        await openInBrowser(authorizationUrl.toString());
+        console.log(
+          `Waiting for authorization for "${this.serverName}"... (press Ctrl+C to cancel)`,
+        );
+      } catch {
+        console.log(
+          `Please open this URL to authorize "${this.serverName}":\n${authorizationUrl.toString()}`,
+        );
+      }
+    }
+  }
+
+  async saveCodeVerifier(verifier: string): Promise<void> {
+    await this.store.saveCodeVerifier(this.serverName, verifier);
+  }
+
+  async codeVerifier(): Promise<string> {
+    const verifier = await this.store.loadCodeVerifier(this.serverName);
+    if (!verifier) {
+      throw new Error(`No PKCE code verifier found for "${this.serverName}"`);
+    }
+    return verifier;
+  }
+
+  async cleanup(): Promise<void> {
+    if (this.callbackServer) {
+      await this.callbackServer.stop();
+      this.callbackServer = null;
+    }
+    this._callbackUrl = null;
+    await this.store.deleteCodeVerifier(this.serverName);
+  }
+}

--- a/lib/runtime/mcp/oauthProvider.ts
+++ b/lib/runtime/mcp/oauthProvider.ts
@@ -94,8 +94,10 @@ export class AgencyOAuthProvider implements OAuthClientProvider {
   }
 
   get redirectUrl(): string {
-    // After prepare(), this is the real localhost URL with actual port.
-    return this._callbackUrl ?? "http://127.0.0.1:0/oauth/callback";
+    if (!this._callbackUrl) {
+      throw new Error(`OAuth flow for "${this.serverName}" not started — call prepare() first`);
+    }
+    return this._callbackUrl;
   }
 
   get clientMetadata(): OAuthClientMetadata {

--- a/lib/runtime/mcp/tokenStore.test.ts
+++ b/lib/runtime/mcp/tokenStore.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { TokenStore } from "./tokenStore.js";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+describe("TokenStore", () => {
+  let store: TokenStore;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-token-test-"));
+    store = new TokenStore(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should return undefined when no tokens exist", async () => {
+    const tokens = await store.loadTokens("github");
+    expect(tokens).toBeUndefined();
+  });
+
+  it("should save and load tokens", async () => {
+    const tokens = { access_token: "abc", token_type: "bearer" };
+    await store.saveTokens("github", tokens);
+    const loaded = await store.loadTokens("github");
+    expect(loaded).toEqual(tokens);
+  });
+
+  it("should overwrite existing tokens", async () => {
+    await store.saveTokens("github", { access_token: "old", token_type: "bearer" });
+    await store.saveTokens("github", { access_token: "new", token_type: "bearer" });
+    const loaded = await store.loadTokens("github");
+    expect(loaded?.access_token).toBe("new");
+  });
+
+  it("should delete tokens", async () => {
+    await store.saveTokens("github", { access_token: "abc", token_type: "bearer" });
+    await store.deleteTokens("github");
+    const loaded = await store.loadTokens("github");
+    expect(loaded).toBeUndefined();
+  });
+
+  it("should save and load PKCE code verifier", async () => {
+    await store.saveCodeVerifier("github", "verifier123");
+    const loaded = await store.loadCodeVerifier("github");
+    expect(loaded).toBe("verifier123");
+  });
+
+  it("should delete PKCE code verifier", async () => {
+    await store.saveCodeVerifier("github", "verifier123");
+    await store.deleteCodeVerifier("github");
+    const loaded = await store.loadCodeVerifier("github");
+    expect(loaded).toBeUndefined();
+  });
+
+  it("should save and load client info", async () => {
+    const info = { client_id: "my-client", client_secret: "secret" };
+    await store.saveClientInfo("github", info);
+    const loaded = await store.loadClientInfo("github");
+    expect(loaded).toEqual(info);
+  });
+
+  it("should list stored server names", async () => {
+    await store.saveTokens("github", { access_token: "a", token_type: "bearer" });
+    await store.saveTokens("slack", { access_token: "b", token_type: "bearer" });
+    const names = await store.listServers();
+    expect(names.sort()).toEqual(["github", "slack"]);
+  });
+
+  it("should set file permissions to 0600", async () => {
+    await store.saveTokens("github", { access_token: "abc", token_type: "bearer" });
+    const filePath = path.join(tmpDir, "github.json");
+    const stat = fs.statSync(filePath);
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+});

--- a/lib/runtime/mcp/tokenStore.test.ts
+++ b/lib/runtime/mcp/tokenStore.test.ts
@@ -70,6 +70,21 @@ describe("TokenStore", () => {
     expect(names.sort()).toEqual(["github", "slack"]);
   });
 
+  it("should reject server names with path traversal characters", async () => {
+    await expect(store.saveTokens("../evil", { access_token: "x", token_type: "bearer" }))
+      .rejects.toThrow(/Invalid MCP server name/);
+    await expect(store.saveTokens("foo/bar", { access_token: "x", token_type: "bearer" }))
+      .rejects.toThrow(/Invalid MCP server name/);
+    await expect(store.saveTokens("foo bar", { access_token: "x", token_type: "bearer" }))
+      .rejects.toThrow(/Invalid MCP server name/);
+  });
+
+  it("should allow valid server names with hyphens and underscores", async () => {
+    await store.saveTokens("my-server_1", { access_token: "x", token_type: "bearer" });
+    const loaded = await store.loadTokens("my-server_1");
+    expect(loaded?.access_token).toBe("x");
+  });
+
   it("should set file permissions to 0600", async () => {
     await store.saveTokens("github", { access_token: "abc", token_type: "bearer" });
     const filePath = path.join(tmpDir, "github.json");

--- a/lib/runtime/mcp/tokenStore.ts
+++ b/lib/runtime/mcp/tokenStore.ts
@@ -18,16 +18,25 @@ export class TokenStore {
     }
   }
 
+  private validateServerName(serverName: string): string {
+    if (!/^[A-Za-z0-9_-]+$/.test(serverName)) {
+      throw new Error(
+        `Invalid MCP server name "${serverName}": must contain only letters, numbers, hyphens, and underscores`,
+      );
+    }
+    return serverName;
+  }
+
   private tokenPath(serverName: string): string {
-    return path.join(this.dir, `${serverName}.json`);
+    return path.join(this.dir, `${this.validateServerName(serverName)}.json`);
   }
 
   private verifierPath(serverName: string): string {
-    return path.join(this.dir, `${serverName}.verifier`);
+    return path.join(this.dir, `${this.validateServerName(serverName)}.verifier`);
   }
 
   private clientInfoPath(serverName: string): string {
-    return path.join(this.dir, `${serverName}.client.json`);
+    return path.join(this.dir, `${this.validateServerName(serverName)}.client.json`);
   }
 
   private atomicWrite(filePath: string, data: string): void {

--- a/lib/runtime/mcp/tokenStore.ts
+++ b/lib/runtime/mcp/tokenStore.ts
@@ -15,6 +15,12 @@ export class TokenStore {
   private ensureDir(): void {
     if (!fs.existsSync(this.dir)) {
       fs.mkdirSync(this.dir, { recursive: true, mode: 0o700 });
+    } else {
+      // Fix permissions if the directory was created with overly permissive mode
+      const stat = fs.statSync(this.dir);
+      if ((stat.mode & 0o077) !== 0) {
+        fs.chmodSync(this.dir, 0o700);
+      }
     }
   }
 

--- a/lib/runtime/mcp/tokenStore.ts
+++ b/lib/runtime/mcp/tokenStore.ts
@@ -1,0 +1,104 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import type { OAuthTokens, OAuthClientInformationMixed } from "@modelcontextprotocol/sdk/shared/auth.js";
+
+const DEFAULT_TOKEN_DIR = path.join(os.homedir(), ".agency", "tokens");
+
+export class TokenStore {
+  private dir: string;
+
+  constructor(dir: string = DEFAULT_TOKEN_DIR) {
+    this.dir = dir;
+  }
+
+  private ensureDir(): void {
+    if (!fs.existsSync(this.dir)) {
+      fs.mkdirSync(this.dir, { recursive: true, mode: 0o700 });
+    }
+  }
+
+  private tokenPath(serverName: string): string {
+    return path.join(this.dir, `${serverName}.json`);
+  }
+
+  private verifierPath(serverName: string): string {
+    return path.join(this.dir, `${serverName}.verifier`);
+  }
+
+  private clientInfoPath(serverName: string): string {
+    return path.join(this.dir, `${serverName}.client.json`);
+  }
+
+  private atomicWrite(filePath: string, data: string): void {
+    this.ensureDir();
+    const tmpPath = filePath + ".tmp";
+    fs.writeFileSync(tmpPath, data, { mode: 0o600 });
+    fs.renameSync(tmpPath, filePath);
+  }
+
+  private readJson(filePath: string): any | undefined {
+    try {
+      const data = fs.readFileSync(filePath, "utf-8");
+      return JSON.parse(data);
+    } catch {
+      return undefined;
+    }
+  }
+
+  async saveTokens(serverName: string, tokens: OAuthTokens): Promise<void> {
+    this.atomicWrite(this.tokenPath(serverName), JSON.stringify(tokens));
+  }
+
+  async loadTokens(serverName: string): Promise<OAuthTokens | undefined> {
+    return this.readJson(this.tokenPath(serverName));
+  }
+
+  async deleteTokens(serverName: string): Promise<void> {
+    const p = this.tokenPath(serverName);
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+    await this.deleteCodeVerifier(serverName);
+    await this.deleteClientInfo(serverName);
+  }
+
+  async saveCodeVerifier(serverName: string, verifier: string): Promise<void> {
+    this.atomicWrite(this.verifierPath(serverName), verifier);
+  }
+
+  async loadCodeVerifier(serverName: string): Promise<string | undefined> {
+    try {
+      return fs.readFileSync(this.verifierPath(serverName), "utf-8");
+    } catch {
+      return undefined;
+    }
+  }
+
+  async deleteCodeVerifier(serverName: string): Promise<void> {
+    const p = this.verifierPath(serverName);
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+  }
+
+  async saveClientInfo(serverName: string, info: OAuthClientInformationMixed): Promise<void> {
+    this.atomicWrite(this.clientInfoPath(serverName), JSON.stringify(info));
+  }
+
+  async loadClientInfo(serverName: string): Promise<OAuthClientInformationMixed | undefined> {
+    return this.readJson(this.clientInfoPath(serverName));
+  }
+
+  async deleteClientInfo(serverName: string): Promise<void> {
+    const p = this.clientInfoPath(serverName);
+    if (fs.existsSync(p)) fs.unlinkSync(p);
+  }
+
+  async listServers(): Promise<string[]> {
+    try {
+      const files = fs.readdirSync(this.dir);
+      return files
+        .filter((f) => f.endsWith(".json") && !f.endsWith(".client.json"))
+        .map((f) => f.replace(/\.json$/, ""));
+    } catch {
+      return [];
+    }
+  }
+}

--- a/lib/runtime/mcp/types.ts
+++ b/lib/runtime/mcp/types.ts
@@ -18,6 +18,10 @@ export type McpHttpServerConfig = {
 
 export type McpServerConfig = McpStdioServerConfig | McpHttpServerConfig;
 
+export function isOAuthServer(config: McpServerConfig): config is McpHttpServerConfig {
+  return "type" in config && config.type === "http" && config.auth === "oauth";
+}
+
 export type McpTool = {
   name: string;
   description: string;

--- a/lib/runtime/mcp/types.ts
+++ b/lib/runtime/mcp/types.ts
@@ -18,8 +18,16 @@ export type McpHttpServerConfig = {
 
 export type McpServerConfig = McpStdioServerConfig | McpHttpServerConfig;
 
+export function isHttpServer(config: McpServerConfig): config is McpHttpServerConfig {
+  return "type" in config && config.type === "http";
+}
+
+export function isStdioServer(config: McpServerConfig): config is McpStdioServerConfig {
+  return !("type" in config);
+}
+
 export function isOAuthServer(config: McpServerConfig): config is McpHttpServerConfig {
-  return "type" in config && config.type === "http" && config.auth === "oauth";
+  return isHttpServer(config) && config.auth === "oauth";
 }
 
 export type McpTool = {

--- a/lib/runtime/mcp/types.ts
+++ b/lib/runtime/mcp/types.ts
@@ -9,6 +9,11 @@ export type McpStdioServerConfig = {
 export type McpHttpServerConfig = {
   type: "http";
   url: string;
+  auth?: "oauth";
+  authTimeout?: number;
+  clientId?: string;
+  clientSecret?: string;
+  headers?: Record<string, string>;
 };
 
 export type McpServerConfig = McpStdioServerConfig | McpHttpServerConfig;

--- a/lib/runtime/state/context.ts
+++ b/lib/runtime/state/context.ts
@@ -351,7 +351,10 @@ export class RuntimeContext<T> {
   }
 
   createMcpManager(config: Record<string, any>): void {
-    this._mcpManager = new McpManager(config);
+    const onOAuthRequired = this._registeredCallbacks.onOAuthRequired as
+      | ((data: any) => void | Promise<void>)
+      | undefined;
+    this._mcpManager = new McpManager(config, { onOAuthRequired });
   }
 
   get mcpManager(): McpManager {

--- a/lib/types/function.ts
+++ b/lib/types/function.ts
@@ -33,6 +33,7 @@ export const VALID_CALLBACK_NAMES = [
   "onToolCallEnd",
   "onStream",
   "onTrace",
+  "onOAuthRequired",
 ] as const;
 
 export type CallbackName = (typeof VALID_CALLBACK_NAMES)[number];

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,1 +1,1 @@
-export const VERSION = "0.0.100";
+export const VERSION = "0.0.102";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agency-lang",
-  "version": "0.0.100",
+  "version": "0.0.102",
   "description": "The Agency language",
   "main": "lib/index.js",
   "scripts": {

--- a/scripts/agency.ts
+++ b/scripts/agency.ts
@@ -30,6 +30,7 @@ import { debug } from "@/cli/debug.js";
 import { generateDoc } from "@/cli/doc.js";
 import { optimize } from "@/cli/optimize.js";
 import { watchAndCompile } from "@/cli/watch.js";
+import { authServer, listAuth, revokeAuth } from "@/cli/auth.js";
 
 loadEnv();
 const program = new Command();
@@ -489,5 +490,24 @@ addRunOptions(
     process.exit(1);
   }
 });
+
+program
+  .command("auth [server-name]")
+  .description("Manage OAuth tokens for MCP servers")
+  .option("--list", "List all stored OAuth tokens")
+  .option("--revoke <server>", "Remove stored OAuth token for a server")
+  .action(async (serverName: string | undefined, opts: { list?: boolean; revoke?: string }) => {
+    if (opts.list) {
+      await listAuth();
+    } else if (opts.revoke) {
+      await revokeAuth(opts.revoke);
+    } else if (serverName) {
+      const config = getConfig();
+      await authServer(serverName, config);
+    } else {
+      console.error("Usage: agency auth <server-name> | --list | --revoke <server-name>");
+      process.exit(1);
+    }
+  });
 
 program.parse();

--- a/stdlib/lib/__tests__/system-openUrl.test.ts
+++ b/stdlib/lib/__tests__/system-openUrl.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { _openUrl } from "../system.js";
+import { detectPlatform } from "../utils.js";
+
+describe("_openUrl", () => {
+  it("should be an async function that returns a promise", () => {
+    expect(typeof _openUrl).toBe("function");
+    // Calling with empty string returns a promise (don't await — avoid side effects)
+    const result = _openUrl("").catch(() => {});
+    expect(result).toBeInstanceOf(Promise);
+  });
+
+  it("should reject with a nonexistent scheme on macOS (verifies open is called)", async () => {
+    if (detectPlatform() !== "macos") return;
+
+    // A completely bogus scheme that macOS `open` can't handle
+    await expect(_openUrl("x-agency-nonexistent://test")).rejects.toThrow();
+  });
+
+  it("should throw on unsupported platforms", async () => {
+    if (detectPlatform() === "macos") return;
+
+    await expect(_openUrl("https://example.com")).rejects.toThrow(
+      /currently only supported on macOS/,
+    );
+  });
+});

--- a/stdlib/lib/system.ts
+++ b/stdlib/lib/system.ts
@@ -1,7 +1,10 @@
-import { execFileSync } from "child_process";
+import { execFileSync, execFile } from "child_process";
 import path from "path";
 import process from "process";
 import { detectPlatform } from "./utils.js";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
 
 export function _cwd(): string {
   return process.cwd();
@@ -25,6 +28,23 @@ export function _setEnv(name: string, value: string): void {
     throw new Error("setEnv: value must not contain NUL bytes");
   }
   process.env[name] = value;
+}
+
+/**
+ * Open a URL in the user's default browser.
+ * Currently macOS-only (uses the `open` command). Throws on other platforms.
+ */
+export async function _openUrl(url: string): Promise<void> {
+  const platform = detectPlatform();
+
+  if (platform === "macos") {
+    await execFileAsync("open", [url]);
+  } else {
+    throw new Error(
+      `openUrl is currently only supported on macOS (detected: ${platform}). ` +
+      `Cross-platform support will be added in a future release.`,
+    );
+  }
 }
 
 export function _screenshot(

--- a/stdlib/lib/system.ts
+++ b/stdlib/lib/system.ts
@@ -38,7 +38,7 @@ export async function _openUrl(url: string): Promise<void> {
   const platform = detectPlatform();
 
   if (platform === "macos") {
-    await execFileAsync("open", [url]);
+    await execFileAsync("open", ["--", url]);
   } else {
     throw new Error(
       `openUrl is currently only supported on macOS (detected: ${platform}). ` +

--- a/stdlib/system.agency
+++ b/stdlib/system.agency
@@ -1,4 +1,4 @@
-import { _screenshot, _cwd, _env, _setEnv } from "./lib/system.js"
+import { _screenshot, _cwd, _env, _setEnv, _openUrl } from "./lib/system.js"
 
 export def screenshot(filepath: string, x: number = -1, y: number = -1, width: number = -1, height: number = -1) {
   """
@@ -32,4 +32,11 @@ export def setEnv(name: string, value: string): Result {
     value: value
   })
   return try _setEnv(name, value)
+}
+
+export def openUrl(url: string): Result {
+  """
+  Open a URL in the user's default browser. Currently macOS-only.
+  """
+  return try _openUrl(url)
 }


### PR DESCRIPTION
## Summary

- Add OAuth 2.1 authentication for HTTP-based MCP servers (browser-based flow with token storage)
- Add static header support with env var interpolation and CRLF injection protection
- Add `agency auth` CLI command for managing OAuth tokens
- Add `onOAuthRequired` lifecycle callback for TypeScript integration
- Add `openUrl` to the stdlib (macOS)

## Architecture

OAuth logic is strictly encapsulated behind two classes:
- **`AgencyOAuthProvider`** — implements the MCP SDK OAuthClientProvider (owns tokens, PKCE, browser opening, callback server)
- **`OAuthConnector`** — encapsulates the two-phase connect/retry flow (the ONLY class that knows about UnauthorizedError and finishAuth)

`McpConnection` receives an opaque connector function and has zero OAuth imports. `McpManager` creates connectors via a factory and never touches the provider directly.

## Config

```json
{
  "mcpServers": {
    "github": {
      "type": "http",
      "url": "https://api.githubcopilot.com/mcp/",
      "auth": "oauth",
      "clientId": "...",
      "clientSecret": "..."
    }
  }
}
```

Credentials fall back to env vars: `MCP_<SERVER>_CLIENT_ID` and `MCP_<SERVER>_CLIENT_SECRET`.

## Test plan

- [x] TokenStore: 9 tests (save/load/delete tokens, verifiers, client info, permissions)
- [x] CallbackServer: 7 tests (start, code receipt, state validation, timeout)
- [x] AgencyOAuthProvider: 11 tests (tokens, verifiers, prepare, env var fallback, callback)
- [x] OAuthConnector: 2 tests (construction, unreachable server)
- [x] Config validation: 6 new tests (auth/headers mutual exclusion, authTimeout, clientId)
- [x] McpConnection: 5 new tests (interpolateEnvVars, CRLF injection, connector)
- [x] McpManager: 4 new tests (OAuth config, deduplication, unreachable server)
- [x] Full test suite: 2125 tests pass
- [x] Manual end-to-end test with GitHub MCP server (OAuth flow, tool listing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)