### PR TITLE
Add built-in emit() function and onEmit callback

### DIFF
--- a/docs/superpowers/plans/2026-04-23-type-imports.md
+++ b/docs/superpowers/plans/2026-04-23-type-imports.md
@@ -1,0 +1,390 @@
+# Type Imports Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Agency `type` declarations compile to runtime Zod schema values so types can be imported across files.
+
+**Architecture:** Change `processTypeAlias` to emit `const Foo = z.<schema>()` + `type Foo = z.infer<typeof Foo>`, and change `mapTypeToSchema` to reference type alias names directly instead of inlining expanded schemas. No parser, preprocessor, symbol table, or type checker changes needed.
+
+**Tech Stack:** TypeScript, Zod, Vitest
+
+**Spec:** `docs/superpowers/specs/2026-04-23-type-imports-design.md`
+
+---
+
+### Task 1: Change `mapTypeToSchema` to emit type alias names directly
+
+The `typeAliasVariable` case currently looks up the alias in `typeAliases` and recursively expands it into an inline schema. Change it to return the alias name as a direct reference to the Zod schema const.
+
+**Files:**
+- Modify: `lib/backends/typescriptGenerator/typeToZodSchema.ts:70-77`
+
+- [ ] **Step 1: Write unit test for the new behavior**
+
+Create a test file `lib/backends/typescriptGenerator/typeToZodSchema.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { mapTypeToZodSchema, mapTypeToValidationSchema } from "./typeToZodSchema.js";
+import { VariableType } from "../../types.js";
+
+describe("mapTypeToZodSchema", () => {
+  it("should return the alias name directly for typeAliasVariable", () => {
+    const variableType: VariableType = {
+      type: "typeAliasVariable",
+      aliasName: "MathResult",
+    };
+    const typeAliases = {
+      MathResult: {
+        type: "objectType" as const,
+        properties: [{ key: "answer", value: { type: "primitiveType" as const, value: "number" } }],
+      },
+    };
+    const result = mapTypeToZodSchema(variableType, typeAliases);
+    expect(result).toBe("MathResult");
+  });
+
+  it("should return the alias name in nested contexts", () => {
+    const variableType: VariableType = {
+      type: "objectType",
+      properties: [
+        { key: "result", value: { type: "typeAliasVariable" as const, aliasName: "Coords" } },
+      ],
+    };
+    const typeAliases = {
+      Coords: {
+        type: "objectType" as const,
+        properties: [
+          { key: "x", value: { type: "primitiveType" as const, value: "number" } },
+          { key: "y", value: { type: "primitiveType" as const, value: "number" } },
+        ],
+      },
+    };
+    const result = mapTypeToZodSchema(variableType, typeAliases);
+    expect(result).toBe(`z.object({ "result": Coords })`);
+  });
+
+  it("should return the alias name inside an array type", () => {
+    const variableType: VariableType = {
+      type: "arrayType",
+      elementType: { type: "typeAliasVariable" as const, aliasName: "Item" },
+    };
+    const typeAliases = {
+      Item: {
+        type: "objectType" as const,
+        properties: [{ key: "name", value: { type: "primitiveType" as const, value: "string" } }],
+      },
+    };
+    const result = mapTypeToZodSchema(variableType, typeAliases);
+    expect(result).toBe("z.array(Item)");
+  });
+
+  it("should return the alias name inside a union type", () => {
+    const variableType: VariableType = {
+      type: "unionType",
+      types: [
+        { type: "typeAliasVariable" as const, aliasName: "Foo" },
+        { type: "primitiveType" as const, value: "number" },
+      ],
+    };
+    const typeAliases = {
+      Foo: { type: "primitiveType" as const, value: "string" },
+    };
+    const result = mapTypeToZodSchema(variableType, typeAliases);
+    expect(result).toBe("z.union([Foo, z.number()])");
+  });
+});
+
+describe("mapTypeToValidationSchema", () => {
+  it("should return the alias name directly for typeAliasVariable", () => {
+    const variableType: VariableType = {
+      type: "typeAliasVariable",
+      aliasName: "Category",
+    };
+    const typeAliases = {
+      Category: {
+        type: "unionType" as const,
+        types: [
+          { type: "stringLiteralType" as const, value: "bug" },
+          { type: "stringLiteralType" as const, value: "feature" },
+        ],
+      },
+    };
+    const result = mapTypeToValidationSchema(variableType, typeAliases);
+    expect(result).toBe("Category");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm test:run -- lib/backends/typescriptGenerator/typeToZodSchema.test.ts`
+
+Expected: FAIL — the current code expands the alias instead of returning the name.
+
+- [ ] **Step 3: Implement the change**
+
+In `lib/backends/typescriptGenerator/typeToZodSchema.ts`, replace the `typeAliasVariable` case (lines 70-77):
+
+```typescript
+// Before
+} else if (variableType.type === "typeAliasVariable") {
+    if (!typeAliases || !typeAliases[variableType.aliasName]) {
+      throw new Error(
+        `Type alias '${variableType.aliasName}' not found in provided type aliases: ${JSON.stringify(typeAliases)}`,
+      );
+    }
+    return recurse(typeAliases[variableType.aliasName]);
+}
+
+// After
+} else if (variableType.type === "typeAliasVariable") {
+    return variableType.aliasName;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm test:run -- lib/backends/typescriptGenerator/typeToZodSchema.test.ts`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/backends/typescriptGenerator/typeToZodSchema.ts lib/backends/typescriptGenerator/typeToZodSchema.test.ts
+git commit -m "feat: mapTypeToSchema emits type alias name instead of inlining"
+```
+
+---
+
+### Task 2: Change `processTypeAlias` to emit Zod schema const + TS type
+
+Currently `processTypeAlias` emits `type Foo = { ... };`. Change it to emit `const Foo = z.object({ ... }); type Foo = z.infer<typeof Foo>;`.
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder.ts:840-845`
+
+- [ ] **Step 1: Update `processTypeAlias`**
+
+In `lib/backends/typescriptBuilder.ts`, replace the `processTypeAlias` method:
+
+```typescript
+// Before
+private processTypeAlias(node: TypeAlias): TsNode {
+    const exportPrefix = node.exported ? "export " : "";
+    return ts.raw(
+      `${exportPrefix}type ${node.aliasName} = ${formatTypeHint(node.aliasedType)};`,
+    );
+}
+
+// After
+private processTypeAlias(node: TypeAlias): TsNode {
+    const exportPrefix = node.exported ? "export " : "";
+    const zodSchema = mapTypeToZodSchema(node.aliasedType, this.getVisibleTypeAliases());
+    return ts.statements([
+      ts.raw(`${exportPrefix}const ${node.aliasName} = ${zodSchema};`),
+      ts.raw(`${exportPrefix}type ${node.aliasName} = z.infer<typeof ${node.aliasName}>;`),
+    ]);
+}
+```
+
+Note: `mapTypeToZodSchema` and `ts.statements` are already imported/available in this file.
+
+- [ ] **Step 2: Run unit tests to check for breakage**
+
+Run: `pnpm test:run -- lib/backends/typescriptBuilder`
+
+Expected: Some integration fixture tests may fail because the expected output has changed. That's expected — we'll update fixtures in Task 3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/backends/typescriptBuilder.ts
+git commit -m "feat: processTypeAlias emits const Zod schema + z.infer type"
+```
+
+---
+
+### Task 3: Update generator test fixtures
+
+Three fixtures reference type aliases and will have changed output. Regenerate them with `make fixtures` and verify the new output is correct.
+
+**Files:**
+- Update: `tests/typescriptGenerator/types/typeAlias.mjs`
+- Update: `tests/typescriptGenerator/schemaAccess.mjs`
+- Update: `tests/typescriptGenerator/bangValidation.mjs`
+
+- [ ] **Step 1: Regenerate all fixtures**
+
+Run: `make fixtures`
+
+- [ ] **Step 2: Verify `typeAlias.mjs` changes**
+
+Check that:
+- Old: `type Coords = { x: number, y: number };`
+- New: `const Coords = z.object({ "x": z.number(), "y": z.number() });` and `type Coords = z.infer<typeof Coords>;`
+- The LLM call site now uses `Coords` instead of `z.object({ "x": z.number(), "y": z.number() })`
+
+- [ ] **Step 3: Verify `schemaAccess.mjs` changes**
+
+Check that:
+- Old: `type Category = "bug" | "feature" | "docs";`
+- New: `const Category = z.union([...]);` and `type Category = z.infer<typeof Category>;`
+- The `schema()` call site now uses `Category` instead of the inline union
+
+- [ ] **Step 4: Verify `bangValidation.mjs` changes**
+
+Check that:
+- Old: `type Category = "bug" | "feature" | "docs";`
+- New: `const Category = z.union([...]);` and `type Category = z.infer<typeof Category>;`
+- The `__validateType` call site now uses `Category` instead of the inline union
+
+- [ ] **Step 5: Run all integration tests**
+
+Run: `pnpm test:run`
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/typescriptGenerator/
+git commit -m "fix: update generator fixtures for type-as-zod-schema change"
+```
+
+---
+
+### Task 4: Verify the existing type import test passes
+
+The test at `tests/agency/imports/typeImport.agency` currently fails because the compiled JS tries to import a type that doesn't exist as a JS value. With our changes, `MathResult` is now exported as a `const` from the compiled `agencyHelpers.js`, so the import should resolve.
+
+**Files:**
+- Verify: `tests/agency/imports/typeImport.agency`
+- Verify: `tests/agency/imports/agencyHelpers.agency`
+- Update: `tests/agency/imports/typeImport.js` (compiled output — agency execution tests use pre-compiled `.js` files)
+- Update: `tests/agency/imports/agencyHelpers.js` (compiled output for the helper file)
+
+- [ ] **Step 1: Build the compiler**
+
+Run: `make all`
+
+This ensures the compiler itself is up to date with our changes from Tasks 1-2.
+
+- [ ] **Step 2: Recompile both agency files**
+
+Run: `pnpm run compile tests/agency/imports/agencyHelpers.agency`
+Run: `pnpm run compile tests/agency/imports/typeImport.agency`
+
+Both `.js` files will be regenerated. The key changes to verify:
+- `agencyHelpers.js` now has `export const MathResult = z.object({ "answer": z.number() });` instead of `export type MathResult = ...`
+- `typeImport.js` imports `MathResult` and uses it in the response format (not an inline expansion)
+
+- [ ] **Step 3: Run the type import test**
+
+Run: `pnpm run agency test tests/agency/imports/typeImport.test.json`
+
+Expected: PASS — the test should now work end-to-end.
+
+- [ ] **Step 4: Commit the updated compiled output**
+
+```bash
+git add tests/agency/imports/
+git commit -m "fix: type import test now passes with runtime Zod schema values"
+```
+
+---
+
+### Task 5: Add a test for nested type alias references
+
+Verify that a type referencing another type alias emits the correct schema (referencing the other type's const, not inlining it).
+
+**Files:**
+- Create: `tests/typescriptGenerator/types/nestedTypeAlias.agency`
+
+- [ ] **Step 1: Create the test fixture**
+
+Create `tests/typescriptGenerator/types/nestedTypeAlias.agency`:
+
+```
+type Name = string
+
+type User = {
+  name: Name;
+  age: number
+}
+
+node main() {
+  const user: User = llm("give me a user")
+  print(user)
+}
+```
+
+- [ ] **Step 2: Generate the expected output**
+
+Run: `make fixtures`
+
+- [ ] **Step 3: Verify the output**
+
+Check that `nestedTypeAlias.mjs` contains:
+- `const Name = z.string();`
+- `const User = z.object({ "name": Name, "age": z.number() });`
+- The LLM call uses `User` in the response format, not an inline expansion
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test:run`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/typescriptGenerator/types/nestedTypeAlias.agency tests/typescriptGenerator/types/nestedTypeAlias.mjs
+git commit -m "test: add fixture for nested type alias references"
+```
+
+---
+
+### Task 6: Add a test for exported type imports
+
+Add a generator fixture that verifies exported types emit `export const` + `export type`.
+
+**Files:**
+- Create: `tests/typescriptGenerator/types/exportedTypeAlias.agency`
+
+- [ ] **Step 1: Create the test fixture**
+
+Create `tests/typescriptGenerator/types/exportedTypeAlias.agency`:
+
+```
+export type Color = "red" | "green" | "blue"
+
+node main() {
+  const c: Color = llm("pick a color")
+  print(c)
+}
+```
+
+- [ ] **Step 2: Generate the expected output**
+
+Run: `make fixtures`
+
+- [ ] **Step 3: Verify the output**
+
+Check that `exportedTypeAlias.mjs` contains:
+- `export const Color = z.union([z.literal("red"), z.literal("green"), z.literal("blue")]);`
+- `export type Color = z.infer<typeof Color>;`
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test:run`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/typescriptGenerator/types/exportedTypeAlias.agency tests/typescriptGenerator/types/exportedTypeAlias.mjs
+git commit -m "test: add fixture for exported type alias"
+```

--- a/docs/superpowers/specs/2026-04-23-type-imports-design.md
+++ b/docs/superpowers/specs/2026-04-23-type-imports-design.md
@@ -1,0 +1,121 @@
+# Type Imports: Types as Runtime Zod Schema Values
+
+## Problem
+
+Agency type aliases (`type Foo = { ... }`) currently compile to TypeScript type declarations, which are erased at JavaScript runtime. This means:
+
+- Importing a type from another `.agency` file generates a JS import for a value that doesn't exist, crashing at runtime
+- Zod schemas are inlined at every call site by resolving the type's AST at compile time
+- Types can't be passed around as runtime values
+
+## Solution
+
+Every Agency `type` declaration emits both a runtime Zod schema value and a TypeScript type:
+
+```typescript
+// Agency source
+type MathResult = {
+  answer: number
+}
+
+// Generated TypeScript
+const MathResult = z.object({ answer: z.number() });
+type MathResult = z.infer<typeof MathResult>;
+```
+
+For exported types, both get `export`:
+
+```typescript
+export const MathResult = z.object({ answer: z.number() });
+export type MathResult = z.infer<typeof MathResult>;
+```
+
+This is valid TypeScript because a `const` and a `type` can share the same name (they exist in different namespaces).
+
+## Design
+
+### 1. Code Generation for Type Aliases
+
+**File:** `lib/backends/typescriptBuilder.ts` — `processTypeAlias`
+
+Change from emitting `type Foo = ...` to emitting `const Foo = z.<schema>(...)` + `type Foo = z.infer<typeof Foo>`.
+
+Uses `mapTypeToZodSchema` from `lib/backends/typescriptGenerator/typeToZodSchema.ts` to generate the Zod schema string.
+
+### 2. Schema Reference at Call Sites
+
+**File:** `lib/backends/typescriptGenerator/typeToZodSchema.ts`
+
+When `mapTypeToSchema` encounters a `typeAliasVariable`, instead of recursively expanding the type's structure into an inline schema, it emits the variable name directly.
+
+The core change is in the `typeAliasVariable` case in `mapTypeToSchema` (line ~70):
+
+```typescript
+// Before: recursively expands the type
+} else if (variableType.type === "typeAliasVariable") {
+    if (!typeAliases || !typeAliases[variableType.aliasName]) {
+      throw new Error(...);
+    }
+    return recurse(typeAliases[variableType.aliasName]);
+}
+
+// After: emits the variable name as a reference to the Zod schema const
+} else if (variableType.type === "typeAliasVariable") {
+    return variableType.aliasName;
+}
+```
+
+The `typeAliases` map is no longer needed in `mapTypeToZodSchema` for expansion. It is still needed by the type checker (via `collectProgramInfo`).
+
+Before:
+```typescript
+responseFormat: z.object({ response: z.object({ "answer": z.number() }) })
+```
+
+After:
+```typescript
+responseFormat: z.object({ response: MathResult })
+```
+
+This works because `MathResult` is now a real Zod schema value in scope, whether defined locally or imported.
+
+The same applies to all validation sites (`Type!`, `schema(Type)`, function parameter validation) — anywhere that calls `mapTypeToZodSchema` or `mapTypeToValidationSchema`.
+
+**Nested type aliases work transitively.** For example:
+
+```
+type Name = string
+type User = { name: Name; age: number }
+```
+
+Generates:
+
+```typescript
+const Name = z.string();
+const User = z.object({ name: Name, age: z.number() });
+```
+
+`User`'s schema references the `Name` const directly.
+
+### 3. Declaration Ordering
+
+Type alias `const` declarations are emitted at the point in the file where the `type` statement appears, which is at the top level of the module. Graph node callbacks and function definitions are registered (not executed) at module load time, so they execute after all top-level statements have run. This means type schema consts are always initialized before any node or function references them at runtime. No reordering is needed.
+
+### 4. Imports
+
+No changes needed to import handling. The compiler already generates `import { MathResult } from "./agencyHelpers.js"` for types imported from other Agency files. This currently crashes because `MathResult` doesn't exist as a JS value. After this change, the compiled file exports `const MathResult = z.object(...)`, so the import resolves correctly.
+
+`collectProgramInfo` currently copies the full `VariableType` AST from imported types into the local `typeAliases` map. This is no longer needed for code generation (schemas are referenced by name), but is kept because the type checker still needs it for cross-file type checking.
+
+### 5. What Doesn't Change
+
+- **Parser** — no syntax changes
+- **Symbol table** — already tracks types correctly
+- **Type checker** — works from the `VariableType` AST, not generated code
+- **Preprocessor** — no changes
+- **`collectProgramInfo`** — keep the cross-file type copy for the type checker
+
+## Future Work
+
+- **Self-recursive types** — types that reference themselves (e.g., `type Tree = { value: number; children: Tree[] }`) would need `z.lazy()` wrapping for the self-reference and a `z.ZodType<T>` annotation on the const. Deferred for now.
+- **Mutual recursion** — types that reference each other in cycles. Deferred.

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -1810,6 +1810,10 @@ export class TypeScriptBuilder {
       return this.buildInterruptReturn(node.arguments);
     }
 
+    if (node.functionName === "emit") {
+      return this.processFunctionCall(node);
+    }
+
     const callNode = this.processFunctionCall(node);
     const scope = this.getCurrentScope();
 

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -1910,6 +1910,23 @@ export class TypeScriptBuilder {
       return ts.throw(`new Error(${this.str(arg)})`);
     }
 
+    if (node.functionName === "emit") {
+      const argNodes: TsNode[] = node.arguments.map((arg) =>
+        this.processCallArg(arg),
+      );
+      const data = argNodes.length > 0 ? argNodes[0] : ts.id("undefined");
+      return $(ts.id("callHook"))
+        .call([
+          ts.obj({
+            callbacks: $(ts.runtime.ctx).prop("callbacks").done(),
+            name: ts.str("onEmit"),
+            data,
+          }),
+        ])
+        .await()
+        .done();
+    }
+
     if (node.functionName === "llm") {
       // Standalone llm() call (not assigned to variable)
       return this.processLlmCall(

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -1915,16 +1915,7 @@ export class TypeScriptBuilder {
         this.processCallArg(arg),
       );
       const data = argNodes.length > 0 ? argNodes[0] : ts.id("undefined");
-      return $(ts.id("callHook"))
-        .call([
-          ts.obj({
-            callbacks: $(ts.runtime.ctx).prop("callbacks").done(),
-            name: ts.str("onEmit"),
-            data,
-          }),
-        ])
-        .await()
-        .done();
+      return ts.callHook("onEmit", data);
     }
 
     if (node.functionName === "llm") {

--- a/lib/ir/builders.ts
+++ b/lib/ir/builders.ts
@@ -448,13 +448,14 @@ export const ts = {
     return ts.raw(`__process.env[${JSON.stringify(varName)}]`);
   },
 
-  callHook(hookName: string, data: Record<string, TsNode>): TsNode {
+  callHook(hookName: string, data: Record<string, TsNode> | TsNode): TsNode {
+    const dataNode = "kind" in data ? data as TsNode : ts.obj(data as Record<string, TsNode>);
     return $(ts.id("callHook"))
       .call([
         ts.obj({
           callbacks: $(ts.runtime.ctx).prop("callbacks").done(),
           name: ts.str(hookName),
-          data: ts.obj(data),
+          data: dataNode,
         }),
       ])
       .await()

--- a/lib/runtime/hooks.ts
+++ b/lib/runtime/hooks.ts
@@ -57,6 +57,7 @@ export type CallbackMap = {
     complete: Promise<void>;
     cancel: () => void;
   };
+  onEmit: any;
 };
 
 // Compile-time guard: ensures VALID_CALLBACK_NAMES stays in sync with CallbackMap.

--- a/lib/runtime/hooks.ts
+++ b/lib/runtime/hooks.ts
@@ -57,7 +57,7 @@ export type CallbackMap = {
     complete: Promise<void>;
     cancel: () => void;
   };
-  onEmit: any;
+  onEmit: unknown;
 };
 
 // Compile-time guard: ensures VALID_CALLBACK_NAMES stays in sync with CallbackMap.

--- a/lib/types/function.ts
+++ b/lib/types/function.ts
@@ -34,6 +34,7 @@ export const VALID_CALLBACK_NAMES = [
   "onStream",
   "onTrace",
   "onOAuthRequired",
+  "onEmit",
 ] as const;
 
 export type CallbackName = (typeof VALID_CALLBACK_NAMES)[number];

--- a/tests/agency/builtins/emit.agency
+++ b/tests/agency/builtins/emit.agency
@@ -1,0 +1,10 @@
+let emitted = false
+
+callback onEmit(data) {
+  emitted = true
+}
+
+node main() {
+  emit("hello")
+  return emitted
+}

--- a/tests/agency/builtins/emit.agency
+++ b/tests/agency/builtins/emit.agency
@@ -1,10 +1,10 @@
-let emitted = false
+let emittedData = null
 
 callback onEmit(data) {
-  emitted = true
+  emittedData = data
 }
 
 node main() {
   emit("hello")
-  return emitted
+  return emittedData == "hello"
 }

--- a/tests/agency/builtins/emit.test.json
+++ b/tests/agency/builtins/emit.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "emit calls the onEmit callback"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a new built-in `emit(data)` function for sending arbitrary data from Agency code to TypeScript callers
- Adds `onEmit` to the callback system (`CallbackMap` and `VALID_CALLBACK_NAMES`)
- The builder generates inline `callHook` calls using the execution context, so `emit` works correctly with concurrent executions

**Agency side:**
```ts
node main() {
  emit({ step: 3, total: 10 })
}
```

**TypeScript caller side:**
```ts
const result = await main({
  callbacks: {
    onEmit: (data) => console.log("Agent emitted:", data)
  }
});
```

## Test plan
- [x] Integration test verifying `emit` triggers `onEmit` callback (`tests/agency/builtins/emit.test.json`)
- [ ] Verify existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)