### PR TITLE
LLM client abstraction: pluggable LLM clients (phases 1-2)

### DIFF
--- a/docs/superpowers/plans/2026-04-24-llm-client-abstraction.md
+++ b/docs/superpowers/plans/2026-04-24-llm-client-abstraction.md
@@ -1,0 +1,477 @@
+# LLM Client Abstraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the LLM client pluggable so users can swap smoltalk for alternative implementations via `setLLMClient()`.
+
+**Architecture:** Define an `LLMClient` interface with `text` and `textStream` methods using smoltalk's existing types. Refactor `prompt.ts` to call through `ctx.llmClient` instead of `smoltalk` directly. Add a simple fetch-based OpenAI reference client. Wire up `setLLMClient` as a builtin function.
+
+**Tech Stack:** TypeScript, smoltalk (types), Vitest
+
+**Spec:** `docs/superpowers/specs/2026-04-24-llm-client-abstraction-design.md`
+
+---
+
+## Phase 1: Define interface and refactor prompt.ts
+
+### Task 1: Define LLMClient type and default smoltalk client
+
+**Files:**
+- Create: `lib/runtime/llmClient.ts`
+- Modify: `lib/runtime/index.ts`
+
+- [ ] **Step 1: Create the LLMClient type and default client**
+
+Create `lib/runtime/llmClient.ts`:
+
+```typescript
+import * as smoltalk from "smoltalk";
+import type { SmolPromptConfig, PromptResult, StreamChunk, Result } from "smoltalk";
+
+export type LLMClient = {
+  text(config: SmolPromptConfig): Promise<Result<PromptResult>>;
+  textStream(config: SmolPromptConfig): AsyncGenerator<StreamChunk>;
+};
+
+export function createDefaultClient(): LLMClient {
+  return {
+    text: (config) => smoltalk.text(config),
+    textStream: (config) => smoltalk.textStream(config),
+  };
+}
+```
+
+- [ ] **Step 2: Export from runtime index**
+
+In `lib/runtime/index.ts`, add:
+
+```typescript
+export { createDefaultClient } from "./llmClient.js";
+export type { LLMClient } from "./llmClient.js";
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `pnpm test:run`
+
+Expected: All tests pass (no behavioral change).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/runtime/llmClient.ts lib/runtime/index.ts
+git commit -m "feat: define LLMClient type and default smoltalk client"
+```
+
+---
+
+### Task 2: Add llmClient to RuntimeContext
+
+**Files:**
+- Modify: `lib/runtime/state/context.ts`
+
+- [ ] **Step 1: Add llmClient field and import**
+
+In `lib/runtime/state/context.ts`, add import:
+
+```typescript
+import { LLMClient, createDefaultClient } from "../llmClient.js";
+```
+
+Add the field to the class (near the `smoltalkDefaults` field):
+
+```typescript
+llmClient: LLMClient;
+```
+
+- [ ] **Step 2: Set default in constructor**
+
+In the constructor body, after `this.smoltalkDefaults = args.smoltalkDefaults;`, add:
+
+```typescript
+this.llmClient = createDefaultClient();
+```
+
+- [ ] **Step 3: Copy in createExecutionContext**
+
+In `createExecutionContext`, after `execCtx.smoltalkDefaults = this.smoltalkDefaults;`, add:
+
+```typescript
+execCtx.llmClient = this.llmClient;
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test:run`
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/state/context.ts
+git commit -m "feat: add llmClient field to RuntimeContext"
+```
+
+---
+
+### Task 3: Refactor prompt.ts to use ctx.llmClient
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts`
+
+- [ ] **Step 1: Replace smoltalk.text calls with ctx.llmClient**
+
+In `lib/runtime/prompt.ts`, find the call at ~line 74-82:
+
+```typescript
+let _completion: AsyncGenerator<StreamChunk> | Promise<Result<PromptResult>> =
+  await (smoltalk.text as Function)({
+    messages: messages.getMessages(),
+    tools,
+    responseFormat,
+    stream,
+    abortSignal: ctx.abortController.signal,
+    ...clientConfig,
+  });
+```
+
+Replace with:
+
+```typescript
+const llmConfig = {
+  messages: messages.getMessages(),
+  tools,
+  responseFormat,
+  abortSignal: ctx.abortController.signal,
+  ...clientConfig,
+};
+
+let _completion: AsyncGenerator<StreamChunk> | Promise<Result<PromptResult>>;
+if (stream) {
+  _completion = ctx.llmClient.textStream(llmConfig);
+} else {
+  _completion = ctx.llmClient.text(llmConfig);
+}
+```
+
+Note: `stream` is intentionally omitted from `llmConfig` — the caller branches on it and calls the appropriate method. Passing `stream` in the config would confuse custom clients.
+
+This removes the `(smoltalk.text as Function)` type cast and uses the explicit two-method interface.
+
+- [ ] **Step 2: Verify smoltalk is still imported for message construction**
+
+`smoltalk` is still needed for `smoltalk.userMessage()`, `smoltalk.assistantMessage()`, `smoltalk.toolMessage()`, etc. Do NOT remove the `import * as smoltalk from "smoltalk"` line.
+
+- [ ] **Step 3: Run tests**
+
+Run: `pnpm test:run`
+
+Expected: All tests pass — behavior is identical since the default client wraps smoltalk.
+
+- [ ] **Step 4: Run agency tests to verify end-to-end**
+
+Run: `pnpm run agency test tests/agency/imports/typeImport.test.json`
+
+Expected: PASS — LLM calls still work through the default client.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/prompt.ts
+git commit -m "refactor: prompt.ts uses ctx.llmClient instead of smoltalk directly"
+```
+
+---
+
+## Phase 2: Simple reference client
+
+### Task 4: Implement simple OpenAI client
+
+**Files:**
+- Create: `lib/runtime/simpleOpenAIClient.ts`
+- Create: `lib/runtime/simpleOpenAIClient.test.ts`
+- Modify: `lib/runtime/index.ts`
+
+- [ ] **Step 1: Create the simple client**
+
+Create `lib/runtime/simpleOpenAIClient.ts`:
+
+```typescript
+import type { SmolPromptConfig, PromptResult, StreamChunk, ToolCallJSON, Result } from "smoltalk";
+import type { LLMClient } from "./llmClient.js";
+
+export function createSimpleOpenAIClient(opts?: { apiKey?: string; model?: string }): LLMClient {
+  const apiKey = opts?.apiKey ?? process.env.OPENAI_API_KEY;
+  const defaultModel = opts?.model ?? "gpt-4o-mini";
+
+  if (!apiKey) {
+    throw new Error("OPENAI_API_KEY not found. Pass apiKey option or set OPENAI_API_KEY environment variable.");
+  }
+
+  async function text(config: SmolPromptConfig): Promise<Result<PromptResult>> {
+    const model = (config as any).model || defaultModel;
+    const messages = (config.messages || []).map((m: any) => {
+      const json = typeof m.toJSON === "function" ? m.toJSON() : m;
+      return { role: json.role, content: json.content, ...(json.tool_calls ? { tool_calls: json.tool_calls } : {}), ...(json.tool_call_id ? { tool_call_id: json.tool_call_id } : {}) };
+    });
+
+    const body: any = { model, messages };
+
+    if (config.tools && config.tools.length > 0) {
+      body.tools = config.tools.map((t: any) => ({
+        type: "function",
+        function: { name: t.name, description: t.description || "", parameters: t.inputSchema || t.schema },
+      }));
+    }
+
+    if (config.responseFormat) {
+      body.response_format = {
+        type: "json_schema",
+        json_schema: {
+          name: "response",
+          schema: typeof config.responseFormat.jsonSchema === "function"
+            ? config.responseFormat.jsonSchema()
+            : config.responseFormat,
+          strict: true,
+        },
+      };
+    }
+
+    try {
+      const response = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: config.abortSignal as AbortSignal | undefined,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return { success: false, error: `OpenAI API error (${response.status}): ${errorText}` };
+      }
+
+      const data = await response.json();
+      const choice = data.choices?.[0];
+      const output = choice?.message?.content || "";
+      const toolCalls: ToolCallJSON[] = (choice?.message?.tool_calls || []).map((tc: any) => ({
+        id: tc.id,
+        name: tc.function.name,
+        arguments: JSON.parse(tc.function.arguments),
+      }));
+
+      const usage = data.usage ? {
+        inputTokens: data.usage.prompt_tokens || 0,
+        outputTokens: data.usage.completion_tokens || 0,
+        cachedInputTokens: 0,
+        totalTokens: data.usage.total_tokens || 0,
+      } : { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, totalTokens: 0 };
+
+      return {
+        success: true,
+        value: {
+          output,
+          toolCalls,
+          usage,
+          cost: { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" },
+          model,
+        } as PromptResult,
+      };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { success: false, error: message };
+    }
+  }
+
+  async function* textStream(config: SmolPromptConfig): AsyncGenerator<StreamChunk> {
+    const result = await text(config);
+    if (result.success) {
+      yield { type: "done", result: result.value } as StreamChunk;
+    } else {
+      yield { type: "error", error: result.error } as StreamChunk;
+    }
+  }
+
+  return { text, textStream };
+}
+```
+
+- [ ] **Step 2: Export from runtime index**
+
+In `lib/runtime/index.ts`, add:
+
+```typescript
+export { createSimpleOpenAIClient } from "./simpleOpenAIClient.js";
+```
+
+- [ ] **Step 3: Write a unit test**
+
+Create `lib/runtime/simpleOpenAIClient.test.ts`:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { createSimpleOpenAIClient } from "./simpleOpenAIClient.js";
+
+describe("createSimpleOpenAIClient", () => {
+  it("should throw if no API key is available", () => {
+    const origKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      expect(() => createSimpleOpenAIClient()).toThrow("OPENAI_API_KEY not found");
+    } finally {
+      if (origKey) process.env.OPENAI_API_KEY = origKey;
+    }
+  });
+
+  it("should create a client with a provided API key", () => {
+    const client = createSimpleOpenAIClient({ apiKey: "test-key" });
+    expect(client).toHaveProperty("text");
+    expect(client).toHaveProperty("textStream");
+    expect(typeof client.text).toBe("function");
+    expect(typeof client.textStream).toBe("function");
+  });
+
+  it("should return the LLMClient interface", () => {
+    const client = createSimpleOpenAIClient({ apiKey: "test-key" });
+    expect(client.text).toBeDefined();
+    expect(client.textStream).toBeDefined();
+  });
+});
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test:run -- lib/runtime/simpleOpenAIClient.test.ts`
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/simpleOpenAIClient.ts lib/runtime/simpleOpenAIClient.test.ts lib/runtime/index.ts
+git commit -m "feat: add simple OpenAI reference client"
+```
+
+---
+
+## Phase 3: setLLMClient builtin
+
+### Task 5: Add setLLMClient builtin function
+
+**Files:**
+- Create: `lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.mustache`
+- Modify: `lib/backends/typescriptGenerator/builtins.ts`
+- Modify: `lib/backends/typescriptBuilder.ts`
+
+- [ ] **Step 1: Create the mustache template**
+
+Create `lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.mustache`:
+
+```
+function setLLMClient(client) {
+  __globalCtx.llmClient = client;
+}
+```
+
+- [ ] **Step 2: Run templates to generate the .ts file**
+
+Run: `pnpm run templates`
+
+This generates `lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.ts` from the mustache file.
+
+- [ ] **Step 3: Wire into builtins.ts**
+
+In `lib/backends/typescriptGenerator/builtins.ts`, add the import:
+
+```typescript
+import * as builtinFunctionsSetLLMClient from "../../templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.js";
+```
+
+In `generateBuiltinHelpers`, add after the `mcpFunc` line:
+
+```typescript
+const setLLMClientFunc = builtinFunctionsSetLLMClient.default({});
+helpers.push(setLLMClientFunc);
+```
+
+- [ ] **Step 4: Add to DIRECT_CALL_FUNCTIONS**
+
+In `lib/backends/typescriptBuilder.ts`, add `"setLLMClient"` to the `DIRECT_CALL_FUNCTIONS` set (~line 342):
+
+```typescript
+private static DIRECT_CALL_FUNCTIONS = new Set([
+    "approve", "reject", "propagate",
+    "success", "failure",
+    "isInterrupt", "isDebugger", "isRejected", "isApproved",
+    "isSuccess", "isFailure", "mcp", "setLLMClient"
+]);
+```
+
+- [ ] **Step 5: Build and run tests**
+
+Run: `make all && pnpm test:run`
+
+Expected: All tests pass. Generator fixtures may need regeneration since the generated imports template changed.
+
+- [ ] **Step 6: Regenerate fixtures if needed**
+
+Run: `make fixtures`
+
+Then: `pnpm test:run`
+
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.mustache lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.ts lib/backends/typescriptGenerator/builtins.ts lib/backends/typescriptBuilder.ts
+git commit -m "feat: add setLLMClient builtin function"
+```
+
+---
+
+### Task 6: Add end-to-end test for setLLMClient
+
+**Files:**
+- Create: `tests/agency/setLLMClient.agency`
+- Create: `tests/agency/setLLMClient.test.json`
+
+- [ ] **Step 1: Create a generator fixture that verifies setLLMClient compiles**
+
+Create `tests/typescriptGenerator/setLLMClient.agency`:
+
+```
+import { createSimpleOpenAIClient } from "agency-lang/runtime"
+
+const client = createSimpleOpenAIClient()
+setLLMClient(client)
+
+node main() {
+  const result = llm("Hello")
+  print(result)
+}
+```
+
+- [ ] **Step 2: Generate the expected output**
+
+Run: `make fixtures`
+
+- [ ] **Step 3: Verify the output**
+
+Check that the generated `.mjs` contains `setLLMClient(client)` as a direct function call (no AgencyFunction wrapping, no interrupt handling).
+
+- [ ] **Step 4: Run tests**
+
+Run: `pnpm test:run`
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/typescriptGenerator/setLLMClient.agency tests/typescriptGenerator/setLLMClient.mjs
+git commit -m "test: add generator fixture for setLLMClient"
+```

--- a/docs/superpowers/plans/2026-04-24-llm-client-abstraction.md
+++ b/docs/superpowers/plans/2026-04-24-llm-client-abstraction.md
@@ -14,40 +14,103 @@
 
 ## Phase 1: Define interface and refactor prompt.ts
 
-### Task 1: Define LLMClient type and default smoltalk client
+### Task 1: Define PromptConfig, LLMClient types, and default SmoltalkClient
 
 **Files:**
 - Create: `lib/runtime/llmClient.ts`
 - Modify: `lib/runtime/index.ts`
 
-- [ ] **Step 1: Create the LLMClient type and default client**
+- [ ] **Step 1: Create the types and default client**
 
 Create `lib/runtime/llmClient.ts`:
 
 ```typescript
 import * as smoltalk from "smoltalk";
-import type { SmolPromptConfig, PromptResult, StreamChunk, Result } from "smoltalk";
+import type { SmolPromptConfig, PromptResult, StreamChunk, Result, Message } from "smoltalk";
+import type { ZodType } from "zod";
 
-export type LLMClient = {
-  text(config: SmolPromptConfig): Promise<Result<PromptResult>>;
-  textStream(config: SmolPromptConfig): AsyncGenerator<StreamChunk>;
+export type ToolDefinition = {
+  name: string;
+  description?: string;
+  schema: ZodType;
 };
 
-export function createDefaultClient(): LLMClient {
-  return {
-    text: (config) => smoltalk.text(config),
-    textStream: (config) => smoltalk.textStream(config),
+export type ToolCall = {
+  id: string;
+  name: string;
+  arguments: Record<string, any>;
+};
+
+export type PromptConfig = {
+  messages: Message[];
+  tools?: ToolDefinition[];
+  maxTokens?: number;
+  temperature?: number;
+  responseFormat?: ZodType;
+  thinking?: {
+    enabled: boolean;
+    budgetTokens?: number;
   };
+  reasoningEffort?: "low" | "medium" | "high";
+  apiKey?: string;
+  model?: string;
+  provider?: string;
+  metadata?: Record<string, any>;
+  abortSignal?: AbortSignal;
+  hooks?: Partial<{
+    onStart: (config: PromptConfig) => void;
+    onToolCall: (toolCall: ToolCall) => void;
+    onEnd: (result: PromptResult) => void;
+    onError: (error: Error) => void;
+  }>;
+};
+
+export type LLMClient = {
+  text(config: PromptConfig): Promise<Result<PromptResult>>;
+  textStream(config: PromptConfig): AsyncGenerator<StreamChunk>;
+};
+
+export class SmoltalkClient implements LLMClient {
+  async text(config: PromptConfig): Promise<Result<PromptResult>> {
+    const smolConfig = this.toSmolConfig(config);
+    return smoltalk.text(smolConfig);
+  }
+
+  async *textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
+    const smolConfig = this.toSmolConfig(config);
+    yield* smoltalk.textStream(smolConfig);
+  }
+
+  private toSmolConfig(config: PromptConfig): SmolPromptConfig {
+    const smolConfig: any = {
+      messages: config.messages,
+      tools: config.tools,
+      responseFormat: config.responseFormat,
+      abortSignal: config.abortSignal,
+    };
+    if (config.model) smolConfig.model = config.model;
+    if (config.apiKey) smolConfig.openAiApiKey = config.apiKey;
+    if (config.maxTokens) smolConfig.maxTokens = config.maxTokens;
+    if (config.temperature !== undefined) smolConfig.temperature = config.temperature;
+    if (config.provider) smolConfig.provider = config.provider;
+    if (config.thinking) smolConfig.thinking = config.thinking;
+    if (config.reasoningEffort) smolConfig.reasoningEffort = config.reasoningEffort;
+    // Pass through client-specific options from metadata
+    if (config.metadata) Object.assign(smolConfig, config.metadata);
+    return smolConfig as SmolPromptConfig;
+  }
 }
 ```
+
+Note: The `toSmolConfig` mapping may need adjustment based on exact `SmolPromptConfig` field names. Verify during implementation by checking smoltalk's types.
 
 - [ ] **Step 2: Export from runtime index**
 
 In `lib/runtime/index.ts`, add:
 
 ```typescript
-export { createDefaultClient } from "./llmClient.js";
-export type { LLMClient } from "./llmClient.js";
+export { SmoltalkClient } from "./llmClient.js";
+export type { LLMClient, PromptConfig, ToolDefinition, ToolCall } from "./llmClient.js";
 ```
 
 - [ ] **Step 3: Run tests**
@@ -60,7 +123,7 @@ Expected: All tests pass (no behavioral change).
 
 ```bash
 git add lib/runtime/llmClient.ts lib/runtime/index.ts
-git commit -m "feat: define LLMClient type and default smoltalk client"
+git commit -m "feat: define PromptConfig, LLMClient types, and SmoltalkClient"
 ```
 
 ---
@@ -75,7 +138,7 @@ git commit -m "feat: define LLMClient type and default smoltalk client"
 In `lib/runtime/state/context.ts`, add import:
 
 ```typescript
-import { LLMClient, createDefaultClient } from "../llmClient.js";
+import { LLMClient, SmoltalkClient } from "../llmClient.js";
 ```
 
 Add the field to the class (near the `smoltalkDefaults` field):
@@ -89,7 +152,7 @@ llmClient: LLMClient;
 In the constructor body, after `this.smoltalkDefaults = args.smoltalkDefaults;`, add:
 
 ```typescript
-this.llmClient = createDefaultClient();
+this.llmClient = new SmoltalkClient();
 ```
 
 - [ ] **Step 3: Copy in createExecutionContext**
@@ -139,23 +202,30 @@ let _completion: AsyncGenerator<StreamChunk> | Promise<Result<PromptResult>> =
 Replace with:
 
 ```typescript
-const llmConfig = {
+import type { PromptConfig } from "./llmClient.js";
+
+// ... in the function body:
+const promptConfig: PromptConfig = {
   messages: messages.getMessages(),
   tools,
   responseFormat,
   abortSignal: ctx.abortController.signal,
-  ...clientConfig,
+  model: (clientConfig as any)?.model,
+  apiKey: (clientConfig as any)?.openAiApiKey,
+  maxTokens: (clientConfig as any)?.maxTokens,
+  temperature: (clientConfig as any)?.temperature,
+  metadata: clientConfig,
 };
 
 let _completion: AsyncGenerator<StreamChunk> | Promise<Result<PromptResult>>;
 if (stream) {
-  _completion = ctx.llmClient.textStream(llmConfig);
+  _completion = ctx.llmClient.textStream(promptConfig);
 } else {
-  _completion = ctx.llmClient.text(llmConfig);
+  _completion = ctx.llmClient.text(promptConfig);
 }
 ```
 
-Note: `stream` is intentionally omitted from `llmConfig` — the caller branches on it and calls the appropriate method. Passing `stream` in the config would confuse custom clients.
+Note: `stream` is intentionally omitted from `promptConfig` — the caller branches on it and calls the appropriate method. The full `clientConfig` is passed as `metadata` so the default SmoltalkClient can forward smoltalk-specific options. The explicit fields (`model`, `apiKey`, etc.) are extracted so that alternative clients can use them without parsing metadata.
 
 This removes the `(smoltalk.text as Function)` type cast and uses the explicit two-method interface.
 
@@ -198,8 +268,8 @@ git commit -m "refactor: prompt.ts uses ctx.llmClient instead of smoltalk direct
 Create `lib/runtime/simpleOpenAIClient.ts`:
 
 ```typescript
-import type { SmolPromptConfig, PromptResult, StreamChunk, ToolCallJSON, Result, TokenUsage, CostEstimate } from "smoltalk";
-import type { LLMClient } from "./llmClient.js";
+import type { PromptResult, StreamChunk, TokenUsage, CostEstimate, Result } from "smoltalk";
+import type { LLMClient, PromptConfig, ToolCall } from "./llmClient.js";
 
 export class SimpleOpenAIClient implements LLMClient {
   private apiKey: string;
@@ -214,8 +284,8 @@ export class SimpleOpenAIClient implements LLMClient {
     this.defaultModel = opts?.model ?? "gpt-4o-mini";
   }
 
-  async text(config: SmolPromptConfig): Promise<Result<PromptResult>> {
-    const model = (config as any).model || this.defaultModel;
+  async text(config: PromptConfig): Promise<Result<PromptResult>> {
+    const model = config.model || this.defaultModel;
     const body = this.buildRequestBody(config, model);
 
     try {
@@ -226,7 +296,7 @@ export class SimpleOpenAIClient implements LLMClient {
           "Authorization": `Bearer ${this.apiKey}`,
         },
         body: JSON.stringify(body),
-        signal: config.abortSignal as AbortSignal | undefined,
+        signal: config.abortSignal,
       });
 
       if (!response.ok) {
@@ -254,7 +324,7 @@ export class SimpleOpenAIClient implements LLMClient {
     }
   }
 
-  async *textStream(config: SmolPromptConfig): AsyncGenerator<StreamChunk> {
+  async *textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
     const result = await this.text(config);
     if (result.success) {
       yield { type: "done", result: result.value } as StreamChunk;
@@ -263,7 +333,7 @@ export class SimpleOpenAIClient implements LLMClient {
     }
   }
 
-  private buildRequestBody(config: SmolPromptConfig, model: string): any {
+  private buildRequestBody(config: PromptConfig, model: string): any {
     const messages = (config.messages || []).map((m: any) => {
       const json = typeof m.toJSON === "function" ? m.toJSON() : m;
       return {
@@ -303,7 +373,7 @@ export class SimpleOpenAIClient implements LLMClient {
     return body;
   }
 
-  private extractToolCalls(choice: any): ToolCallJSON[] {
+  private extractToolCalls(choice: any): ToolCall[] {
     return (choice?.message?.tool_calls || []).map((tc: any) => ({
       id: tc.id,
       name: tc.function.name,

--- a/docs/superpowers/plans/2026-04-24-llm-client-abstraction.md
+++ b/docs/superpowers/plans/2026-04-24-llm-client-abstraction.md
@@ -198,22 +198,80 @@ git commit -m "refactor: prompt.ts uses ctx.llmClient instead of smoltalk direct
 Create `lib/runtime/simpleOpenAIClient.ts`:
 
 ```typescript
-import type { SmolPromptConfig, PromptResult, StreamChunk, ToolCallJSON, Result } from "smoltalk";
+import type { SmolPromptConfig, PromptResult, StreamChunk, ToolCallJSON, Result, TokenUsage, CostEstimate } from "smoltalk";
 import type { LLMClient } from "./llmClient.js";
 
-export function createSimpleOpenAIClient(opts?: { apiKey?: string; model?: string }): LLMClient {
-  const apiKey = opts?.apiKey ?? process.env.OPENAI_API_KEY;
-  const defaultModel = opts?.model ?? "gpt-4o-mini";
+export class SimpleOpenAIClient implements LLMClient {
+  private apiKey: string;
+  private defaultModel: string;
 
-  if (!apiKey) {
-    throw new Error("OPENAI_API_KEY not found. Pass apiKey option or set OPENAI_API_KEY environment variable.");
+  constructor(opts?: { apiKey?: string; model?: string }) {
+    const apiKey = opts?.apiKey ?? process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error("OPENAI_API_KEY not found. Pass apiKey option or set OPENAI_API_KEY environment variable.");
+    }
+    this.apiKey = apiKey;
+    this.defaultModel = opts?.model ?? "gpt-4o-mini";
   }
 
-  async function text(config: SmolPromptConfig): Promise<Result<PromptResult>> {
-    const model = (config as any).model || defaultModel;
+  async text(config: SmolPromptConfig): Promise<Result<PromptResult>> {
+    const model = (config as any).model || this.defaultModel;
+    const body = this.buildRequestBody(config, model);
+
+    try {
+      const response = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: config.abortSignal as AbortSignal | undefined,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return { success: false, error: `OpenAI API error (${response.status}): ${errorText}` };
+      }
+
+      const data = await response.json();
+      const choice = data.choices?.[0];
+      const output = choice?.message?.content || "";
+
+      return {
+        success: true,
+        value: {
+          output,
+          toolCalls: this.extractToolCalls(choice),
+          usage: this.extractUsage(data),
+          cost: { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" } as CostEstimate,
+          model,
+        } as PromptResult,
+      };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { success: false, error: message };
+    }
+  }
+
+  async *textStream(config: SmolPromptConfig): AsyncGenerator<StreamChunk> {
+    const result = await this.text(config);
+    if (result.success) {
+      yield { type: "done", result: result.value } as StreamChunk;
+    } else {
+      yield { type: "error", error: result.error } as StreamChunk;
+    }
+  }
+
+  private buildRequestBody(config: SmolPromptConfig, model: string): any {
     const messages = (config.messages || []).map((m: any) => {
       const json = typeof m.toJSON === "function" ? m.toJSON() : m;
-      return { role: json.role, content: json.content, ...(json.tool_calls ? { tool_calls: json.tool_calls } : {}), ...(json.tool_call_id ? { tool_call_id: json.tool_call_id } : {}) };
+      return {
+        role: json.role,
+        content: json.content,
+        ...(json.tool_calls ? { tool_calls: json.tool_calls } : {}),
+        ...(json.tool_call_id ? { tool_call_id: json.tool_call_id } : {}),
+      };
     });
 
     const body: any = { model, messages };
@@ -221,7 +279,11 @@ export function createSimpleOpenAIClient(opts?: { apiKey?: string; model?: strin
     if (config.tools && config.tools.length > 0) {
       body.tools = config.tools.map((t: any) => ({
         type: "function",
-        function: { name: t.name, description: t.description || "", parameters: t.inputSchema || t.schema },
+        function: {
+          name: t.name,
+          description: t.description || "",
+          parameters: t.inputSchema || t.schema,
+        },
       }));
     }
 
@@ -238,64 +300,28 @@ export function createSimpleOpenAIClient(opts?: { apiKey?: string; model?: strin
       };
     }
 
-    try {
-      const response = await fetch("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Authorization": `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify(body),
-        signal: config.abortSignal as AbortSignal | undefined,
-      });
+    return body;
+  }
 
-      if (!response.ok) {
-        const errorText = await response.text();
-        return { success: false, error: `OpenAI API error (${response.status}): ${errorText}` };
-      }
+  private extractToolCalls(choice: any): ToolCallJSON[] {
+    return (choice?.message?.tool_calls || []).map((tc: any) => ({
+      id: tc.id,
+      name: tc.function.name,
+      arguments: JSON.parse(tc.function.arguments),
+    }));
+  }
 
-      const data = await response.json();
-      const choice = data.choices?.[0];
-      const output = choice?.message?.content || "";
-      const toolCalls: ToolCallJSON[] = (choice?.message?.tool_calls || []).map((tc: any) => ({
-        id: tc.id,
-        name: tc.function.name,
-        arguments: JSON.parse(tc.function.arguments),
-      }));
-
-      const usage = data.usage ? {
+  private extractUsage(data: any): TokenUsage {
+    if (data.usage) {
+      return {
         inputTokens: data.usage.prompt_tokens || 0,
         outputTokens: data.usage.completion_tokens || 0,
         cachedInputTokens: 0,
         totalTokens: data.usage.total_tokens || 0,
-      } : { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, totalTokens: 0 };
-
-      return {
-        success: true,
-        value: {
-          output,
-          toolCalls,
-          usage,
-          cost: { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" },
-          model,
-        } as PromptResult,
       };
-    } catch (error: unknown) {
-      const message = error instanceof Error ? error.message : String(error);
-      return { success: false, error: message };
     }
+    return { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, totalTokens: 0 };
   }
-
-  async function* textStream(config: SmolPromptConfig): AsyncGenerator<StreamChunk> {
-    const result = await text(config);
-    if (result.success) {
-      yield { type: "done", result: result.value } as StreamChunk;
-    } else {
-      yield { type: "error", error: result.error } as StreamChunk;
-    }
-  }
-
-  return { text, textStream };
 }
 ```
 
@@ -304,7 +330,7 @@ export function createSimpleOpenAIClient(opts?: { apiKey?: string; model?: strin
 In `lib/runtime/index.ts`, add:
 
 ```typescript
-export { createSimpleOpenAIClient } from "./simpleOpenAIClient.js";
+export { SimpleOpenAIClient } from "./simpleOpenAIClient.js";
 ```
 
 - [ ] **Step 3: Write a unit test**
@@ -313,29 +339,29 @@ Create `lib/runtime/simpleOpenAIClient.test.ts`:
 
 ```typescript
 import { describe, it, expect } from "vitest";
-import { createSimpleOpenAIClient } from "./simpleOpenAIClient.js";
+import { SimpleOpenAIClient } from "./simpleOpenAIClient.js";
 
-describe("createSimpleOpenAIClient", () => {
+describe("SimpleOpenAIClient", () => {
   it("should throw if no API key is available", () => {
     const origKey = process.env.OPENAI_API_KEY;
     delete process.env.OPENAI_API_KEY;
     try {
-      expect(() => createSimpleOpenAIClient()).toThrow("OPENAI_API_KEY not found");
+      expect(() => new SimpleOpenAIClient()).toThrow("OPENAI_API_KEY not found");
     } finally {
       if (origKey) process.env.OPENAI_API_KEY = origKey;
     }
   });
 
   it("should create a client with a provided API key", () => {
-    const client = createSimpleOpenAIClient({ apiKey: "test-key" });
+    const client = new SimpleOpenAIClient({ apiKey: "test-key" });
     expect(client).toHaveProperty("text");
     expect(client).toHaveProperty("textStream");
     expect(typeof client.text).toBe("function");
     expect(typeof client.textStream).toBe("function");
   });
 
-  it("should return the LLMClient interface", () => {
-    const client = createSimpleOpenAIClient({ apiKey: "test-key" });
+  it("should satisfy the LLMClient type", () => {
+    const client = new SimpleOpenAIClient({ apiKey: "test-key" });
     expect(client.text).toBeDefined();
     expect(client.textStream).toBeDefined();
   });
@@ -444,9 +470,9 @@ git commit -m "feat: add setLLMClient builtin function"
 Create `tests/typescriptGenerator/setLLMClient.agency`:
 
 ```
-import { createSimpleOpenAIClient } from "agency-lang/runtime"
+import { SimpleOpenAIClient } from "agency-lang/runtime"
 
-const client = createSimpleOpenAIClient()
+const client = SimpleOpenAIClient()
 setLLMClient(client)
 
 node main() {

--- a/docs/superpowers/plans/2026-04-24-llm-client-abstraction.md
+++ b/docs/superpowers/plans/2026-04-24-llm-client-abstraction.md
@@ -82,22 +82,16 @@ export class SmoltalkClient implements LLMClient {
   }
 
   private toSmolConfig(config: PromptConfig): SmolPromptConfig {
-    const smolConfig: any = {
-      messages: config.messages,
-      tools: config.tools,
-      responseFormat: config.responseFormat,
-      abortSignal: config.abortSignal,
-    };
-    if (config.model) smolConfig.model = config.model;
-    if (config.apiKey) smolConfig.openAiApiKey = config.apiKey;
-    if (config.maxTokens) smolConfig.maxTokens = config.maxTokens;
-    if (config.temperature !== undefined) smolConfig.temperature = config.temperature;
-    if (config.provider) smolConfig.provider = config.provider;
-    if (config.thinking) smolConfig.thinking = config.thinking;
-    if (config.reasoningEffort) smolConfig.reasoningEffort = config.reasoningEffort;
-    // Pass through client-specific options from metadata
-    if (config.metadata) Object.assign(smolConfig, config.metadata);
-    return smolConfig as SmolPromptConfig;
+    const { messages, tools, responseFormat, abortSignal,
+            model, apiKey, maxTokens, temperature, provider,
+            thinking, reasoningEffort, metadata } = config;
+
+    return {
+      messages, tools, responseFormat, abortSignal,
+      model, maxTokens, temperature, provider, thinking, reasoningEffort,
+      openAiApiKey: apiKey,
+      ...metadata,
+    } as SmolPromptConfig;
   }
 }
 ```
@@ -141,10 +135,14 @@ In `lib/runtime/state/context.ts`, add import:
 import { LLMClient, SmoltalkClient } from "../llmClient.js";
 ```
 
-Add the field to the class (near the `smoltalkDefaults` field):
+Add the private field, getter, and setter to the class (near the `smoltalkDefaults` field):
 
 ```typescript
-llmClient: LLMClient;
+private _llmClient: LLMClient;
+
+get llmClient(): LLMClient { return this._llmClient; }
+
+setLLMClient(client: LLMClient): void { this._llmClient = client; }
 ```
 
 - [ ] **Step 2: Set default in constructor**
@@ -152,7 +150,7 @@ llmClient: LLMClient;
 In the constructor body, after `this.smoltalkDefaults = args.smoltalkDefaults;`, add:
 
 ```typescript
-this.llmClient = new SmoltalkClient();
+this._llmClient = new SmoltalkClient();
 ```
 
 - [ ] **Step 3: Copy in createExecutionContext**
@@ -160,8 +158,10 @@ this.llmClient = new SmoltalkClient();
 In `createExecutionContext`, after `execCtx.smoltalkDefaults = this.smoltalkDefaults;`, add:
 
 ```typescript
-execCtx.llmClient = this.llmClient;
+execCtx._llmClient = this._llmClient;
 ```
+
+Note: `createExecutionContext` uses `Object.create` and sets fields directly, so it accesses the private field. This is an existing pattern in the codebase (e.g., `execCtx._mcpManager`).
 
 - [ ] **Step 4: Run tests**
 
@@ -468,7 +468,7 @@ Create `lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient
 
 ```
 function setLLMClient(client) {
-  __globalCtx.llmClient = client;
+  __globalCtx.setLLMClient(client);
 }
 ```
 

--- a/docs/superpowers/specs/2026-04-24-llm-client-abstraction-design.md
+++ b/docs/superpowers/specs/2026-04-24-llm-client-abstraction-design.md
@@ -105,12 +105,10 @@ A thin wrapper that converts `PromptConfig` to `SmolPromptConfig` and delegates 
 ```typescript
 class SmoltalkClient implements LLMClient {
   text(config: PromptConfig): Promise<Result<PromptResult>> {
-    const smolConfig = this.toSmolConfig(config);
-    return smoltalk.text(smolConfig);
+    return smoltalk.text({ ...this.toSmolConfig(config), stream: false });
   }
   textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
-    const smolConfig = this.toSmolConfig(config);
-    return smoltalk.textStream(smolConfig);
+    return smoltalk.text({ ...this.toSmolConfig(config), stream: true });
   }
   private toSmolConfig(config: PromptConfig): SmolPromptConfig {
     // Map PromptConfig fields to SmolPromptConfig fields

--- a/docs/superpowers/specs/2026-04-24-llm-client-abstraction-design.md
+++ b/docs/superpowers/specs/2026-04-24-llm-client-abstraction-design.md
@@ -48,7 +48,21 @@ Created automatically. Zero-config backward compatibility — if a user never ca
 
 Everything else in `prompt.ts` stays the same — tool call loop, message construction, interrupt handling, token tracking, abort signals. The client only handles the actual LLM request/response.
 
-### 4. `setLLMClient` Builtin Function
+### 4. Simple Reference Client
+
+A minimal `LLMClient` implementation that hits the OpenAI API directly using `fetch` — no additional packages. Serves as a reference implementation for client authors, a test target for the abstraction, and a lightweight alternative to smoltalk for users who don't need its features.
+
+Lives in `lib/runtime/` alongside the interface definition. Reads `OPENAI_API_KEY` from `process.env`.
+
+Key properties:
+- **`text`:** Makes a `fetch` call to `https://api.openai.com/v1/chat/completions` with the messages, tools, and response format from the config. Parses the response into a `PromptResult` (extracting `output`, `toolCalls`, `usage`, `cost`, `model`).
+- **`textStream`:** Falls back to calling `text` and yields a single `"done"` chunk with the result. No actual streaming — keeps the implementation simple.
+- **Model:** Uses `config.model` if provided, otherwise defaults to `"gpt-4o-mini"`.
+- **Structured output:** Passes `response_format` with the Zod schema's JSON schema representation when `responseFormat` is provided in the config.
+
+This client intentionally does not support every feature smoltalk supports (e.g., multiple providers, retries, caching). It is a minimal working implementation.
+
+### 5. `setLLMClient` Builtin Function
 
 A new builtin function available in Agency code:
 
@@ -68,7 +82,7 @@ node main() {
 
 Applies globally — all `llm()` calls in all nodes use the set client.
 
-### 5. Implementation Phases
+### 6. Implementation Phases
 
 **Phase 1: Define the interface and refactor `prompt.ts`**
 - Define `LLMClient` type in `lib/runtime/`
@@ -77,12 +91,16 @@ Applies globally — all `llm()` calls in all nodes use the set client.
 - Change `prompt.ts` to use `ctx.llmClient` instead of `smoltalk` directly
 - Zero user-facing behavior change
 
-**Phase 2: Add `setLLMClient` builtin**
+**Phase 2: Simple reference client**
+- Implement the simple OpenAI-only client using `fetch`
+- Add tests that use the simple client to verify the abstraction works end-to-end
+
+**Phase 3: Add `setLLMClient` builtin**
 - Add `setLLMClient` as a builtin function (similar to `checkpoint`, `restore`)
 - Generated code wires it to set `__globalCtx.llmClient`
 - Users can now swap in alternative clients
 
-### 6. What Doesn't Change
+### 7. What Doesn't Change
 
 - **Parser** — no new syntax
 - **Message format** — still smoltalk types everywhere

--- a/docs/superpowers/specs/2026-04-24-llm-client-abstraction-design.md
+++ b/docs/superpowers/specs/2026-04-24-llm-client-abstraction-design.md
@@ -1,0 +1,94 @@
+# LLM Client Abstraction
+
+## Problem
+
+Agency currently hardcodes smoltalk as the LLM client. All `llm()` calls go through `smoltalk.text()` in `lib/runtime/prompt.ts`. Users who want to use a different LLM package (e.g., for a different provider, custom retry logic, or a proprietary API) have no way to swap it out.
+
+## Solution
+
+Define a minimal `LLMClient` interface using smoltalk's existing types. Users can provide an alternative client via a `setLLMClient()` builtin function. Smoltalk remains the default when no client is set.
+
+## Design
+
+### 1. LLM Client Interface
+
+```typescript
+type LLMClient = {
+  text(config: SmolPromptConfig): Promise<Result<PromptResult>>
+  textStream(config: SmolPromptConfig): AsyncGenerator<StreamChunk>
+}
+```
+
+Uses smoltalk's types (`SmolPromptConfig`, `Result`, `PromptResult`, `StreamChunk`) as the shared format. Alternative clients import these types from smoltalk. This avoids defining Agency-owned types that mirror smoltalk — the message/tool/config format is essentially the OpenAI API format and unlikely to change.
+
+**Trade-off:** `SmolPromptConfig` includes smoltalk-specific fields (`logLevel`, `provider`, `baseURL`, etc.) that alternative clients won't use. This is acceptable — clients can ignore fields they don't understand. The alternative (defining a minimal config subset) would lose configuration that `getSmoltalkConfig` merges in and would require mapping at the boundary.
+
+Message construction (`smoltalk.userMessage()`, `assistantMessage()`, etc.) is NOT part of the interface — all clients use smoltalk's message format directly, so there's no reason for clients to provide their own message factories.
+
+**Streaming vs non-streaming:** Currently `prompt.ts` calls `smoltalk.text()` with a `stream` flag — one function with overloads. The `LLMClient` interface splits this into two explicit methods (`text` and `textStream`) to avoid overload ambiguity. `prompt.ts` branches on the `stream` flag in the config and calls the appropriate method. The `(smoltalk.text as Function)` type cast in prompt.ts (currently used to bypass TypeScript overload resolution) is removed as part of Phase 1.
+
+**Error contract for streaming:** `textStream` returns a bare `AsyncGenerator<StreamChunk>`. Errors are signaled as `StreamChunk` items with `type: "error"`, not thrown exceptions. Alternative clients must follow this convention — `handleStreamingResponse` in `streaming.ts` relies on it.
+
+### 2. Default Smoltalk Client
+
+A thin wrapper around the existing `smoltalk.*` calls:
+
+```typescript
+const defaultClient: LLMClient = {
+  text: (config) => smoltalk.text(config),
+  textStream: (config) => smoltalk.textStream(config),
+}
+```
+
+Created automatically. Zero-config backward compatibility — if a user never calls `setLLMClient`, everything works exactly as before.
+
+### 3. RuntimeContext Integration
+
+`RuntimeContext` gets a new `llmClient: LLMClient` field, defaulting to the smoltalk wrapper. `runPrompt` in `prompt.ts` uses `ctx.llmClient.text()` / `ctx.llmClient.textStream()` instead of calling `smoltalk.text()` directly.
+
+Everything else in `prompt.ts` stays the same — tool call loop, message construction, interrupt handling, token tracking, abort signals. The client only handles the actual LLM request/response.
+
+### 4. `setLLMClient` Builtin Function
+
+A new builtin function available in Agency code:
+
+```
+import { MyClient } from "my-client-package"
+
+const client = MyClient({ apiKey: "sk-..." })
+setLLMClient(client)
+
+node main() {
+  const result = llm("Hello!")
+  print(result)
+}
+```
+
+`setLLMClient` must be called at the top level (before any node runs). It sets `__globalCtx.llmClient = client`.
+
+Applies globally — all `llm()` calls in all nodes use the set client.
+
+### 5. Implementation Phases
+
+**Phase 1: Define the interface and refactor `prompt.ts`**
+- Define `LLMClient` type in `lib/runtime/`
+- Create default smoltalk wrapper
+- Add `llmClient` field to `RuntimeContext` (constructor + `createExecutionContext` — must explicitly copy the field since `createExecutionContext` manually copies each property)
+- Change `prompt.ts` to use `ctx.llmClient` instead of `smoltalk` directly
+- Zero user-facing behavior change
+
+**Phase 2: Add `setLLMClient` builtin**
+- Add `setLLMClient` as a builtin function (similar to `checkpoint`, `restore`)
+- Generated code wires it to set `__globalCtx.llmClient`
+- Users can now swap in alternative clients
+
+### 6. What Doesn't Change
+
+- **Parser** — no new syntax
+- **Message format** — still smoltalk types everywhere
+- **Tool calling** — still handled by `prompt.ts`
+- **Streaming callbacks** — still handled by `prompt.ts`
+- **Token tracking** — still extracted from `PromptResult`
+- **Generated code for `llm()` calls** — still calls `runPrompt`
+- **Interrupts, checkpoints, message threads** — untouched
+- **CLI optimizer** — `optimizerIO.ts` calls `smoltalk.textSync()` directly. This is CLI tooling, not user-facing runtime code, and is intentionally excluded from the abstraction

--- a/docs/superpowers/specs/2026-04-24-llm-client-abstraction-design.md
+++ b/docs/superpowers/specs/2026-04-24-llm-client-abstraction-design.md
@@ -6,63 +6,150 @@ Agency currently hardcodes smoltalk as the LLM client. All `llm()` calls go thro
 
 ## Solution
 
-Define a minimal `LLMClient` interface using smoltalk's existing types. Users can provide an alternative client via a `setLLMClient()` builtin function. Smoltalk remains the default when no client is set.
+Define a minimal `LLMClient` interface with an Agency-owned `PromptConfig` type. Users can provide an alternative client via a `setLLMClient()` builtin function. Smoltalk remains the default when no client is set.
 
 ## Design
 
-### 1. LLM Client Interface
+### 1. Agency-Owned PromptConfig
+
+Agency defines its own config type rather than using smoltalk's `SmolPromptConfig`. This gives Agency control over the interface stability and keeps the contract clean for alternative client authors.
+
+```typescript
+type ToolDefinition = {
+  name: string;
+  description?: string;
+  schema: ZodType;
+};
+
+type ToolCall = {
+  id: string;
+  name: string;
+  arguments: Record<string, any>;
+};
+
+type PromptConfig = {
+  /** The conversation messages to send to the model. */
+  messages: Message[];
+
+  /** Tools (functions) the model can call. */
+  tools?: ToolDefinition[];
+
+  /** Maximum number of tokens the model can generate. */
+  maxTokens?: number;
+
+  /** Sampling temperature (0-2). */
+  temperature?: number;
+
+  /** A Zod schema to constrain the model's output to structured JSON. */
+  responseFormat?: ZodType;
+
+  /** Enable extended thinking / reasoning. */
+  thinking?: {
+    enabled: boolean;
+    /** Token budget for thinking. (Anthropic only) */
+    budgetTokens?: number;
+  };
+
+  /** Provider-agnostic reasoning effort level. */
+  reasoningEffort?: "low" | "medium" | "high";
+
+  /** API key for the provider. */
+  apiKey?: string;
+
+  /** Model identifier. */
+  model?: string;
+
+  /** Override the provider. */
+  provider?: string;
+
+  /** Client-specific options — escape hatch for features not in the standard config. */
+  metadata?: Record<string, any>;
+
+  /** Abort signal for cancellation. */
+  abortSignal?: AbortSignal;
+
+  /** Lifecycle hooks. Called by client implementations at the appropriate points. */
+  hooks?: Partial<{
+    onStart: (config: PromptConfig) => void;
+    onToolCall: (toolCall: ToolCall) => void;
+    onEnd: (result: PromptResult) => void;
+    onError: (error: Error) => void;
+  }>;
+};
+```
+
+**Two audiences for this config:**
+
+- **Users** see a subset when passing the second arg to `llm()` (model, temperature, maxTokens, etc.). They never see hooks or messages — Agency fills those in.
+- **Client authors** implement against the full `PromptConfig`. They must call the lifecycle hooks at the appropriate points in their implementation. `metadata` is the escape hatch for client-specific options.
+
+`Message`, `PromptResult`, and `StreamChunk` types still come from smoltalk — they represent the message/response format and are used throughout the runtime for serialization, interrupts, and threads. Only the config type is Agency-owned.
+
+### 2. LLM Client Interface
 
 ```typescript
 type LLMClient = {
-  text(config: SmolPromptConfig): Promise<Result<PromptResult>>
-  textStream(config: SmolPromptConfig): AsyncGenerator<StreamChunk>
+  text(config: PromptConfig): Promise<Result<PromptResult>>
+  textStream(config: PromptConfig): AsyncGenerator<StreamChunk>
 }
 ```
 
-Uses smoltalk's types (`SmolPromptConfig`, `Result`, `PromptResult`, `StreamChunk`) as the shared format. Alternative clients import these types from smoltalk. This avoids defining Agency-owned types that mirror smoltalk — the message/tool/config format is essentially the OpenAI API format and unlikely to change.
-
-**Trade-off:** `SmolPromptConfig` includes smoltalk-specific fields (`logLevel`, `provider`, `baseURL`, etc.) that alternative clients won't use. This is acceptable — clients can ignore fields they don't understand. The alternative (defining a minimal config subset) would lose configuration that `getSmoltalkConfig` merges in and would require mapping at the boundary.
-
-Message construction (`smoltalk.userMessage()`, `assistantMessage()`, etc.) is NOT part of the interface — all clients use smoltalk's message format directly, so there's no reason for clients to provide their own message factories.
-
-**Streaming vs non-streaming:** Currently `prompt.ts` calls `smoltalk.text()` with a `stream` flag — one function with overloads. The `LLMClient` interface splits this into two explicit methods (`text` and `textStream`) to avoid overload ambiguity. `prompt.ts` branches on the `stream` flag in the config and calls the appropriate method. The `(smoltalk.text as Function)` type cast in prompt.ts (currently used to bypass TypeScript overload resolution) is removed as part of Phase 1.
+**Streaming vs non-streaming:** Currently `prompt.ts` calls `smoltalk.text()` with a `stream` flag — one function with overloads. The `LLMClient` interface splits this into two explicit methods (`text` and `textStream`) to avoid overload ambiguity. `prompt.ts` branches on the stream flag and calls the appropriate method. The `(smoltalk.text as Function)` type cast in prompt.ts is removed as part of Phase 1.
 
 **Error contract for streaming:** `textStream` returns a bare `AsyncGenerator<StreamChunk>`. Errors are signaled as `StreamChunk` items with `type: "error"`, not thrown exceptions. Alternative clients must follow this convention — `handleStreamingResponse` in `streaming.ts` relies on it.
 
-### 2. Default Smoltalk Client
+### 3. Default Smoltalk Client
 
-A thin wrapper around the existing `smoltalk.*` calls:
+A thin wrapper that converts `PromptConfig` to `SmolPromptConfig` and delegates to smoltalk:
 
 ```typescript
-const defaultClient: LLMClient = {
-  text: (config) => smoltalk.text(config),
-  textStream: (config) => smoltalk.textStream(config),
+class SmoltalkClient implements LLMClient {
+  text(config: PromptConfig): Promise<Result<PromptResult>> {
+    const smolConfig = this.toSmolConfig(config);
+    return smoltalk.text(smolConfig);
+  }
+  textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
+    const smolConfig = this.toSmolConfig(config);
+    return smoltalk.textStream(smolConfig);
+  }
+  private toSmolConfig(config: PromptConfig): SmolPromptConfig {
+    // Map PromptConfig fields to SmolPromptConfig fields
+    // Pass metadata fields through as extra config
+  }
 }
 ```
 
 Created automatically. Zero-config backward compatibility — if a user never calls `setLLMClient`, everything works exactly as before.
 
-### 3. RuntimeContext Integration
+### 4. RuntimeContext Integration
 
-`RuntimeContext` gets a new `llmClient: LLMClient` field, defaulting to the smoltalk wrapper. `runPrompt` in `prompt.ts` uses `ctx.llmClient.text()` / `ctx.llmClient.textStream()` instead of calling `smoltalk.text()` directly.
+`RuntimeContext` gets a new `llmClient: LLMClient` field, defaulting to the smoltalk wrapper. `runPrompt` in `prompt.ts` builds a `PromptConfig` from the prompt, messages, tools, and user-provided options, then calls `ctx.llmClient.text()` / `ctx.llmClient.textStream()`.
 
-Everything else in `prompt.ts` stays the same — tool call loop, message construction, interrupt handling, token tracking, abort signals. The client only handles the actual LLM request/response.
+Everything else in `prompt.ts` stays the same — tool call loop, message construction, interrupt handling, token tracking. The client only handles the actual LLM request/response.
 
-### 4. Simple Reference Client
+`createExecutionContext` must explicitly copy `llmClient` since it manually copies each property.
 
-A minimal `LLMClient` implementation that hits the OpenAI API directly using `fetch` — no additional packages. Serves as a reference implementation for client authors, a test target for the abstraction, and a lightweight alternative to smoltalk for users who don't need its features.
+### 5. Simple Reference Client
+
+A minimal `LLMClient` class that hits the OpenAI API directly using `fetch` — no additional packages. Serves as a reference implementation for client authors, a test target for the abstraction, and a lightweight alternative to smoltalk.
+
+```typescript
+class SimpleOpenAIClient implements LLMClient {
+  // ...private helpers: buildRequestBody, extractToolCalls, extractUsage
+}
+```
 
 Lives in `lib/runtime/` alongside the interface definition. Reads `OPENAI_API_KEY` from `process.env`.
 
 Key properties:
-- **`text`:** Makes a `fetch` call to `https://api.openai.com/v1/chat/completions` with the messages, tools, and response format from the config. Parses the response into a `PromptResult` (extracting `output`, `toolCalls`, `usage`, `cost`, `model`).
-- **`textStream`:** Falls back to calling `text` and yields a single `"done"` chunk with the result. No actual streaming — keeps the implementation simple.
+- **`text`:** Makes a `fetch` call to `https://api.openai.com/v1/chat/completions`. Parses the response into a `PromptResult`.
+- **`textStream`:** Falls back to calling `text` and yields a single `"done"` chunk. No actual streaming.
 - **Model:** Uses `config.model` if provided, otherwise defaults to `"gpt-4o-mini"`.
-- **Structured output:** Passes `response_format` with the Zod schema's JSON schema representation when `responseFormat` is provided in the config.
+- **Structured output:** Passes `response_format` with the Zod schema's JSON schema representation when `responseFormat` is provided.
 
-This client intentionally does not support every feature smoltalk supports (e.g., multiple providers, retries, caching). It is a minimal working implementation.
+This client intentionally does not support every feature smoltalk supports. It is a minimal working implementation.
 
-### 5. `setLLMClient` Builtin Function
+### 6. `setLLMClient` Builtin Function
 
 A new builtin function available in Agency code:
 
@@ -82,28 +169,28 @@ node main() {
 
 Applies globally — all `llm()` calls in all nodes use the set client.
 
-### 6. Implementation Phases
+### 7. Implementation Phases
 
 **Phase 1: Define the interface and refactor `prompt.ts`**
-- Define `LLMClient` type in `lib/runtime/`
-- Create default smoltalk wrapper
-- Add `llmClient` field to `RuntimeContext` (constructor + `createExecutionContext` — must explicitly copy the field since `createExecutionContext` manually copies each property)
-- Change `prompt.ts` to use `ctx.llmClient` instead of `smoltalk` directly
+- Define `PromptConfig` and `LLMClient` types in `lib/runtime/`
+- Create default `SmoltalkClient` wrapper with `PromptConfig` → `SmolPromptConfig` conversion
+- Add `llmClient` field to `RuntimeContext` (constructor + `createExecutionContext`)
+- Change `prompt.ts` to build a `PromptConfig` and use `ctx.llmClient` instead of `smoltalk` directly
 - Zero user-facing behavior change
 
 **Phase 2: Simple reference client**
-- Implement the simple OpenAI-only client using `fetch`
+- Implement `SimpleOpenAIClient` class using `fetch`
 - Add tests that use the simple client to verify the abstraction works end-to-end
 
 **Phase 3: Add `setLLMClient` builtin**
-- Add `setLLMClient` as a builtin function (similar to `checkpoint`, `restore`)
+- Add `setLLMClient` as a builtin function (similar to `mcp`)
 - Generated code wires it to set `__globalCtx.llmClient`
 - Users can now swap in alternative clients
 
-### 7. What Doesn't Change
+### 8. What Doesn't Change
 
 - **Parser** — no new syntax
-- **Message format** — still smoltalk types everywhere
+- **Message format** — still smoltalk `Message`/`MessageJSON` types for serialization
 - **Tool calling** — still handled by `prompt.ts`
 - **Streaming callbacks** — still handled by `prompt.ts`
 - **Token tracking** — still extracted from `PromptResult`

--- a/lib/runtime/index.ts
+++ b/lib/runtime/index.ts
@@ -63,6 +63,7 @@ export { isGenerator, handleStreamingResponse } from "./streaming.js";
 export { runPrompt } from "./prompt.js";
 
 export { SmoltalkClient } from "./llmClient.js";
+export { SimpleOpenAIClient } from "./simpleOpenAIClient.js";
 export type { LLMClient, PromptConfig, ToolCall } from "./llmClient.js";
 
 export {

--- a/lib/runtime/index.ts
+++ b/lib/runtime/index.ts
@@ -62,6 +62,9 @@ export { isGenerator, handleStreamingResponse } from "./streaming.js";
 
 export { runPrompt } from "./prompt.js";
 
+export { SmoltalkClient } from "./llmClient.js";
+export type { LLMClient, PromptConfig, ToolDefinition, ToolCall } from "./llmClient.js";
+
 export {
   ConcurrentInterruptError,
   CheckpointError,

--- a/lib/runtime/index.ts
+++ b/lib/runtime/index.ts
@@ -63,7 +63,7 @@ export { isGenerator, handleStreamingResponse } from "./streaming.js";
 export { runPrompt } from "./prompt.js";
 
 export { SmoltalkClient } from "./llmClient.js";
-export type { LLMClient, PromptConfig, ToolDefinition, ToolCall } from "./llmClient.js";
+export type { LLMClient, PromptConfig, ToolCall } from "./llmClient.js";
 
 export {
   ConcurrentInterruptError,

--- a/lib/runtime/llmClient.ts
+++ b/lib/runtime/llmClient.ts
@@ -1,0 +1,77 @@
+import * as smoltalk from "smoltalk";
+import type {
+  SmolPromptConfig,
+  PromptResult,
+  StreamChunk,
+  Message,
+} from "smoltalk";
+import type { Result } from "smoltalk";
+import type { ZodType } from "zod";
+
+export type ToolDefinition = {
+  name: string;
+  description?: string;
+  schema: ZodType;
+};
+
+export type ToolCall = {
+  id: string;
+  name: string;
+  arguments: Record<string, any>;
+};
+
+export type PromptConfig = {
+  messages: Message[];
+  tools?: ToolDefinition[];
+  maxTokens?: number;
+  temperature?: number;
+  responseFormat?: ZodType;
+  thinking?: {
+    enabled: boolean;
+    budgetTokens?: number;
+  };
+  reasoningEffort?: "low" | "medium" | "high";
+  apiKey?: string;
+  model?: string;
+  provider?: string;
+  metadata?: Record<string, any>;
+  abortSignal?: AbortSignal;
+  hooks?: Partial<{
+    onStart: (config: PromptConfig) => void;
+    onToolCall: (toolCall: ToolCall) => void;
+    onEnd: (result: PromptResult) => void;
+    onError: (error: Error) => void;
+  }>;
+};
+
+export type LLMClient = {
+  text(config: PromptConfig): Promise<Result<PromptResult>>;
+  textStream(config: PromptConfig): AsyncGenerator<StreamChunk>;
+};
+
+export class SmoltalkClient implements LLMClient {
+  async text(config: PromptConfig): Promise<Result<PromptResult>> {
+    const smolConfig = this.toSmolConfig(config);
+    return smoltalk.text(smolConfig);
+  }
+
+  async *textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
+    const smolConfig = this.toSmolConfig(config);
+    yield* smoltalk.textStream(smolConfig);
+  }
+
+  private toSmolConfig(config: PromptConfig): SmolPromptConfig {
+    const {
+      messages, tools, responseFormat, abortSignal,
+      model, apiKey, maxTokens, temperature, provider,
+      thinking, reasoningEffort, metadata,
+    } = config;
+
+    return {
+      messages, tools, responseFormat, abortSignal,
+      model, maxTokens, temperature, provider, thinking, reasoningEffort,
+      openAiApiKey: apiKey,
+      ...metadata,
+    } as SmolPromptConfig;
+  }
+}

--- a/lib/runtime/llmClient.ts
+++ b/lib/runtime/llmClient.ts
@@ -52,12 +52,12 @@ export type LLMClient = {
 export class SmoltalkClient implements LLMClient {
   async text(config: PromptConfig): Promise<Result<PromptResult>> {
     const smolConfig = this.toSmolConfig(config);
-    return smoltalk.text(smolConfig);
+    return smoltalk.text({ ...smolConfig, stream: false });
   }
 
   async *textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
     const smolConfig = this.toSmolConfig(config);
-    yield* smoltalk.textStream(smolConfig);
+    yield* smoltalk.text({ ...smolConfig, stream: true });
   }
 
   private toSmolConfig(config: PromptConfig): SmolPromptConfig {
@@ -68,10 +68,10 @@ export class SmoltalkClient implements LLMClient {
     } = config;
 
     return {
+      ...metadata,
       messages, tools, responseFormat, abortSignal,
       model, maxTokens, temperature, provider, thinking, reasoningEffort,
       openAiApiKey: apiKey,
-      ...metadata,
     } as SmolPromptConfig;
   }
 }

--- a/lib/runtime/llmClient.ts
+++ b/lib/runtime/llmClient.ts
@@ -51,16 +51,14 @@ export type LLMClient = {
 
 export class SmoltalkClient implements LLMClient {
   async text(config: PromptConfig): Promise<Result<PromptResult>> {
-    const smolConfig = this.toSmolConfig(config);
-    return smoltalk.text({ ...smolConfig, stream: false });
+    return smoltalk.text({ ...this.toSmolConfig(config), stream: false });
   }
 
   async *textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
-    const smolConfig = this.toSmolConfig(config);
-    yield* smoltalk.text({ ...smolConfig, stream: true });
+    yield* smoltalk.text({ ...this.toSmolConfig(config), stream: true });
   }
 
-  private toSmolConfig(config: PromptConfig): SmolPromptConfig {
+  private toSmolConfig(config: PromptConfig): Omit<SmolPromptConfig, "stream"> {
     const {
       messages, tools, responseFormat, abortSignal,
       model, apiKey, maxTokens, temperature, provider,
@@ -72,6 +70,6 @@ export class SmoltalkClient implements LLMClient {
       messages, tools, responseFormat, abortSignal,
       model, maxTokens, temperature, provider, thinking, reasoningEffort,
       openAiApiKey: apiKey,
-    } as SmolPromptConfig;
+    } as Omit<SmolPromptConfig, "stream">;
   }
 }

--- a/lib/runtime/prompt.ts
+++ b/lib/runtime/prompt.ts
@@ -12,6 +12,7 @@ import { updateTokenStats, extractResponse } from "./utils.js";
 import { callHook } from "./hooks.js";
 import { handleStreamingResponse, isGenerator } from "./streaming.js";
 import type { RuntimeContext } from "./state/context.js";
+import type { PromptConfig } from "./llmClient.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import { color } from "@/utils/termcolors.js";
 import { GraphState } from "./types.js";
@@ -71,15 +72,24 @@ async function _runPrompt({
     throw new AgencyCancelledError();
   }
 
-  let _completion: AsyncGenerator<StreamChunk> | Promise<Result<PromptResult>> =
-    await (smoltalk.text as Function)({
-      messages: messages.getMessages(),
-      tools,
-      responseFormat,
-      stream,
-      abortSignal: ctx.abortController.signal,
-      ...clientConfig,
-    });
+  const promptConfig: PromptConfig = {
+    messages: messages.getMessages(),
+    tools,
+    responseFormat,
+    abortSignal: ctx.abortController.signal,
+    model: (clientConfig as any)?.model,
+    apiKey: (clientConfig as any)?.openAiApiKey,
+    maxTokens: (clientConfig as any)?.maxTokens,
+    temperature: (clientConfig as any)?.temperature,
+    metadata: clientConfig,
+  };
+
+  let _completion: AsyncGenerator<StreamChunk> | Promise<Result<PromptResult>>;
+  if (stream) {
+    _completion = ctx.llmClient.textStream(promptConfig);
+  } else {
+    _completion = ctx.llmClient.text(promptConfig);
+  }
 
   const endTime = performance.now();
   let completion: PromptResult;

--- a/lib/runtime/prompt.ts
+++ b/lib/runtime/prompt.ts
@@ -73,16 +73,13 @@ async function _runPrompt({
   }
 
   const promptConfig: PromptConfig = {
+    ...clientConfig,
     messages: messages.getMessages(),
     tools,
     responseFormat,
     abortSignal: ctx.abortController.signal,
-    model: (clientConfig as any)?.model,
-    apiKey: (clientConfig as any)?.openAiApiKey,
-    maxTokens: (clientConfig as any)?.maxTokens,
-    temperature: (clientConfig as any)?.temperature,
     metadata: clientConfig,
-  };
+  } as any;
 
   let _completion: AsyncGenerator<StreamChunk> | Promise<Result<PromptResult>>;
   if (stream) {

--- a/lib/runtime/simpleOpenAIClient.test.ts
+++ b/lib/runtime/simpleOpenAIClient.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { SimpleOpenAIClient } from "./simpleOpenAIClient.js";
+
+describe("SimpleOpenAIClient", () => {
+  it("should throw if no API key is available", () => {
+    const origKey = process.env.OPENAI_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    try {
+      expect(() => new SimpleOpenAIClient()).toThrow("OPENAI_API_KEY not found");
+    } finally {
+      if (origKey) process.env.OPENAI_API_KEY = origKey;
+    }
+  });
+
+  it("should create a client with a provided API key", () => {
+    const client = new SimpleOpenAIClient({ apiKey: "test-key" });
+    expect(typeof client.text).toBe("function");
+    expect(typeof client.textStream).toBe("function");
+  });
+
+  it("should accept a custom model", () => {
+    const client = new SimpleOpenAIClient({ apiKey: "test-key", model: "gpt-4o" });
+    expect(client).toBeDefined();
+  });
+});

--- a/lib/runtime/simpleOpenAIClient.ts
+++ b/lib/runtime/simpleOpenAIClient.ts
@@ -1,0 +1,126 @@
+import type { PromptResult, StreamChunk, TokenUsage, CostEstimate } from "smoltalk";
+import type { Result } from "smoltalk";
+import type { LLMClient, PromptConfig, ToolCall } from "./llmClient.js";
+
+export class SimpleOpenAIClient implements LLMClient {
+  private apiKey: string;
+  private defaultModel: string;
+
+  constructor(opts?: { apiKey?: string; model?: string }) {
+    const apiKey = opts?.apiKey ?? process.env.OPENAI_API_KEY;
+    if (!apiKey) {
+      throw new Error("OPENAI_API_KEY not found. Pass apiKey option or set OPENAI_API_KEY environment variable.");
+    }
+    this.apiKey = apiKey;
+    this.defaultModel = opts?.model ?? "gpt-4o-mini";
+  }
+
+  async text(config: PromptConfig): Promise<Result<PromptResult>> {
+    const model = config.model || this.defaultModel;
+    const body = this.buildRequestBody(config, model);
+
+    try {
+      const response = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${this.apiKey}`,
+        },
+        body: JSON.stringify(body),
+        signal: config.abortSignal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        return { success: false, error: `OpenAI API error (${response.status}): ${errorText}` };
+      }
+
+      const data = await response.json();
+      const choice = data.choices?.[0];
+      const output = choice?.message?.content || "";
+
+      return {
+        success: true,
+        value: {
+          output,
+          toolCalls: this.extractToolCalls(choice),
+          usage: this.extractUsage(data),
+          cost: { inputCost: 0, outputCost: 0, totalCost: 0, currency: "USD" } as CostEstimate,
+          model,
+        } as PromptResult,
+      };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      return { success: false, error: message };
+    }
+  }
+
+  async *textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
+    const result = await this.text(config);
+    if (result.success) {
+      yield { type: "done", result: result.value } as StreamChunk;
+    } else {
+      yield { type: "error", error: result.error } as StreamChunk;
+    }
+  }
+
+  private buildRequestBody(config: PromptConfig, model: string): any {
+    const messages = (config.messages || []).map((m: any) => {
+      const json = typeof m.toJSON === "function" ? m.toJSON() : m;
+      return {
+        role: json.role,
+        content: json.content,
+        ...(json.tool_calls ? { tool_calls: json.tool_calls } : {}),
+        ...(json.tool_call_id ? { tool_call_id: json.tool_call_id } : {}),
+      };
+    });
+
+    const body: any = { model, messages };
+
+    if (config.tools && config.tools.length > 0) {
+      body.tools = config.tools.map((t: any) => ({
+        type: "function",
+        function: {
+          name: t.name,
+          description: t.description || "",
+          parameters: t.inputSchema || t.schema,
+        },
+      }));
+    }
+
+    if (config.responseFormat) {
+      body.response_format = {
+        type: "json_schema",
+        json_schema: {
+          name: "response",
+          schema: typeof config.responseFormat.jsonSchema === "function"
+            ? config.responseFormat.jsonSchema()
+            : config.responseFormat,
+          strict: true,
+        },
+      };
+    }
+
+    return body;
+  }
+
+  private extractToolCalls(choice: any): ToolCall[] {
+    return (choice?.message?.tool_calls || []).map((tc: any) => ({
+      id: tc.id,
+      name: tc.function.name,
+      arguments: JSON.parse(tc.function.arguments),
+    }));
+  }
+
+  private extractUsage(data: any): TokenUsage {
+    if (data.usage) {
+      return {
+        inputTokens: data.usage.prompt_tokens || 0,
+        outputTokens: data.usage.completion_tokens || 0,
+        cachedInputTokens: 0,
+        totalTokens: data.usage.total_tokens || 0,
+      };
+    }
+    return { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, totalTokens: 0 };
+  }
+}

--- a/lib/runtime/simpleOpenAIClient.ts
+++ b/lib/runtime/simpleOpenAIClient.ts
@@ -77,13 +77,16 @@ export class SimpleOpenAIClient implements LLMClient {
 
     const body: any = { model, messages };
 
+    if (config.maxTokens) body.max_tokens = config.maxTokens;
+    if (config.temperature !== undefined) body.temperature = config.temperature;
+
     if (config.tools && config.tools.length > 0) {
       body.tools = config.tools.map((t: any) => ({
         type: "function",
         function: {
           name: t.name,
           description: t.description || "",
-          parameters: t.inputSchema || t.schema,
+          parameters: t.schema.toJSONSchema(),
         },
       }));
     }
@@ -93,9 +96,7 @@ export class SimpleOpenAIClient implements LLMClient {
         type: "json_schema",
         json_schema: {
           name: "response",
-          schema: typeof config.responseFormat.jsonSchema === "function"
-            ? config.responseFormat.jsonSchema()
-            : config.responseFormat,
+          schema: config.responseFormat.toJSONSchema(),
           strict: true,
         },
       };

--- a/lib/runtime/simpleOpenAIClient.ts
+++ b/lib/runtime/simpleOpenAIClient.ts
@@ -105,11 +105,13 @@ export class SimpleOpenAIClient implements LLMClient {
   }
 
   private extractToolCalls(choice: any): ToolCall[] {
-    return (choice?.message?.tool_calls || []).map((tc: any) => ({
-      id: tc.id,
-      name: tc.function.name,
-      arguments: JSON.parse(tc.function.arguments),
-    }));
+    return (choice?.message?.tool_calls || []).map((tc: any) => {
+      let args: Record<string, any> = {};
+      try {
+        args = JSON.parse(tc.function.arguments);
+      } catch {}
+      return { id: tc.id, name: tc.function.name, arguments: args };
+    });
   }
 
   private extractUsage(data: any): TokenUsage {

--- a/lib/runtime/state/context.ts
+++ b/lib/runtime/state/context.ts
@@ -17,6 +17,7 @@ import type { TraceConfig } from "../trace/types.js";
 import { reviveWithClasses, type ClassRegistry } from "../classReviver.js";
 import { AgencyCancelledError } from "../errors.js";
 import { McpManager } from "../mcp/mcpManager.js";
+import { LLMClient, SmoltalkClient } from "../llmClient.js";
 
 /* bunch of stuff that every node/function in the runtime needs access to,
 that we don't want to pass as individual arguments everywhere */
@@ -53,6 +54,10 @@ export class RuntimeContext<T> {
   // so that all the logs share the same traceId, so they all show up in the same trace in the Statelog dashboard.
   statelogClient: StatelogClient;
   smoltalkDefaults: Partial<SmolPromptConfig>;
+  private _llmClient: LLMClient;
+
+  get llmClient(): LLMClient { return this._llmClient; }
+  setLLMClient(client: LLMClient): void { this._llmClient = client; }
 
   // this is the directory that the runtime is running in. We need this to be able to read files relative to the runtime.
   dirname: string;
@@ -128,6 +133,7 @@ export class RuntimeContext<T> {
     this.graph = new SimpleMachine<T>(graphConfig);
 
     this.smoltalkDefaults = args.smoltalkDefaults;
+    this._llmClient = new SmoltalkClient();
     this.classRegistry = {};
     this.abortController = new AbortController();
     this._mcpManager = new McpManager({});
@@ -146,6 +152,7 @@ export class RuntimeContext<T> {
     ) as RuntimeContext<T>;
     execCtx.graph = this.graph;
     execCtx.smoltalkDefaults = this.smoltalkDefaults;
+    execCtx._llmClient = this._llmClient;
     execCtx.dirname = this.dirname;
     execCtx.statelogConfig = this.statelogConfig;
     execCtx.stateStack = new StateStack();


### PR DESCRIPTION
## Summary

- Defines an Agency-owned `PromptConfig` type and `LLMClient` interface with `text()` and `textStream()` methods
- Refactors `prompt.ts` to call through `ctx.llmClient` instead of `smoltalk.text()` directly
- Adds `SmoltalkClient` as the default wrapper (zero behavior change)
- Adds `SimpleOpenAIClient` reference implementation using raw `fetch` — no extra dependencies

## LLMClient interface

```typescript
type LLMClient = {
  text(config: PromptConfig): Promise<Result<PromptResult>>
  textStream(config: PromptConfig): AsyncGenerator<StreamChunk>
}
```

## What this enables (Phase 3, not in this PR)

`setLLMClient()` builtin function so Agency users can swap in alternative LLM clients.

## Test plan

- [x] All 2122 tests pass
- [x] End-to-end LLM call verified through SmoltalkClient wrapper
- [x] SimpleOpenAIClient unit tests (construction, API key validation)
- [x] Build succeeds with no type errors