### PR TITLE
Add setLLMClient builtin function (Phase 3)

### DIFF
--- a/docs/dev/llm-clients.md
+++ b/docs/dev/llm-clients.md
@@ -1,0 +1,140 @@
+# Custom LLM Clients
+
+Agency uses [smoltalk](https://www.npmjs.com/package/smoltalk) as its default LLM client, but you can swap it out for any client that implements the `LLMClient` type.
+
+## Using the built-in simple client
+
+Agency ships with `SimpleOpenAIClient`, a lightweight client that hits the OpenAI API directly using `fetch` with no extra dependencies. To use it:
+
+```
+import { SimpleOpenAIClient } from "agency-lang/runtime"
+
+const client = SimpleOpenAIClient()
+setLLMClient(client)
+
+node main() {
+  const result = llm("Hello!")
+  print(result)
+}
+```
+
+`SimpleOpenAIClient` reads `OPENAI_API_KEY` from your environment by default. You can also pass options:
+
+```
+const client = SimpleOpenAIClient({ apiKey: "sk-...", model: "gpt-4o" })
+```
+
+The simple client does not support real streaming — `textStream` falls back to making a non-streaming call and yielding the result as a single chunk. It also does not calculate cost estimates.
+
+## Building your own client
+
+A custom LLM client is a class that implements the `LLMClient` type:
+
+```typescript
+import type { LLMClient, PromptConfig } from "agency-lang/runtime";
+import type { PromptResult, StreamChunk } from "smoltalk";
+import type { Result } from "smoltalk";
+
+class MyClient implements LLMClient {
+  async text(config: PromptConfig): Promise<Result<PromptResult>> {
+    // Make your LLM call here
+    // Return { success: true, value: promptResult } or { success: false, error: "message" }
+  }
+
+  async *textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
+    // Yield StreamChunk objects as the response streams in
+    // If you don't need streaming, fall back to text():
+    const result = await this.text(config);
+    if (result.success) {
+      yield { type: "done", result: result.value } as StreamChunk;
+    } else {
+      yield { type: "error", error: result.error } as StreamChunk;
+    }
+  }
+}
+```
+
+Then in your Agency code:
+
+```
+import { MyClient } from "./myClient.js"
+
+const client = MyClient()
+setLLMClient(client)
+
+node main() {
+  const result = llm("Hello!")
+  print(result)
+}
+```
+
+### PromptConfig
+
+Your `text` and `textStream` methods receive a `PromptConfig` with these fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `messages` | `Message[]` | Conversation history (smoltalk Message objects) |
+| `tools` | `ToolDefinition[]` | Available tools with name, description, and Zod schema |
+| `model` | `string` | Model identifier |
+| `apiKey` | `string` | API key |
+| `maxTokens` | `number` | Max tokens to generate |
+| `temperature` | `number` | Sampling temperature (0-2) |
+| `responseFormat` | `ZodType` | Zod schema for structured output |
+| `thinking` | `{ enabled, budgetTokens? }` | Extended thinking configuration |
+| `reasoningEffort` | `"low" \| "medium" \| "high"` | Reasoning effort level |
+| `provider` | `string` | Provider override |
+| `abortSignal` | `AbortSignal` | Cancellation signal |
+| `metadata` | `Record<string, any>` | Additional client-specific options |
+
+All fields except `messages` are optional. Your client can ignore fields it doesn't support.
+
+### Converting Zod schemas
+
+`tools[].schema` and `responseFormat` are Zod objects. To convert them to JSON Schema for APIs that expect it (like OpenAI), use Zod's built-in conversion:
+
+```typescript
+const jsonSchema = config.responseFormat.toJSONSchema();
+```
+
+### Return types
+
+`text()` must return a `Result<PromptResult>`:
+
+```typescript
+// Success
+{ success: true, value: { output: "Hello!", toolCalls: [], usage: { ... }, model: "gpt-4o" } }
+
+// Failure
+{ success: false, error: "API error message" }
+```
+
+`PromptResult` fields:
+- `output` — the model's text response (string)
+- `toolCalls` — array of tool call objects with `id`, `name`, and `arguments`
+- `usage` — token counts: `{ inputTokens, outputTokens, cachedInputTokens, totalTokens }`
+- `cost` — cost estimate: `{ inputCost, outputCost, totalCost, currency }` (optional)
+- `model` — the model that was used (optional)
+
+### Streaming
+
+`textStream()` must yield `StreamChunk` objects:
+
+- `{ type: "text", text: "partial response..." }` — streamed text
+- `{ type: "tool_call", toolCall: { id, name, arguments } }` — tool invocation
+- `{ type: "done", result: promptResult }` — final result
+- `{ type: "error", error: "message" }` — error
+
+Errors must be signaled as chunks, not thrown exceptions. Agency's streaming handler (`handleStreamingResponse`) relies on this convention.
+
+## How it works
+
+`setLLMClient(client)` sets the client on the global runtime context. All subsequent `llm()` calls in all nodes use that client. If `setLLMClient` is never called, the default `SmoltalkClient` is used.
+
+`setLLMClient` must be called at the top level of your Agency file, before any node runs. The client is not serialized — if execution resumes in a new process (e.g., from a checkpoint), the top-level code re-runs and re-sets the client.
+
+## Source code
+
+- `lib/runtime/llmClient.ts` — `LLMClient` type, `PromptConfig` type, `SmoltalkClient` default
+- `lib/runtime/simpleOpenAIClient.ts` — `SimpleOpenAIClient` reference implementation
+- `lib/runtime/prompt.ts` — where `ctx.llmClient` is called

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -384,6 +384,18 @@ export class TypeScriptBuilder {
     );
   }
 
+  private static TOP_LEVEL_DECLARATION_TYPES = new Set([
+    "graphNode", "function", "typeAlias", "classDefinition",
+    "importStatement", "importNodeStatement",
+    "comment", "multiLineComment", "newLine",
+  ]);
+
+  private isTopLevelDeclaration(node: AgencyNode): boolean {
+    if (TypeScriptBuilder.TOP_LEVEL_DECLARATION_TYPES.has(node.type)) return true;
+    if (node.type === "assignment" && (node as any).scope === "shared") return true;
+    return false;
+  }
+
   private isImpureImportedFunction(functionName: string): boolean {
     if (!this._plainTsImportNames) {
       this._buildImportNameSets();
@@ -511,9 +523,14 @@ export class TypeScriptBuilder {
         const handler = this.buildHandlerArrow(node.handlerName);
 
         globalInitStatements.push(ts.withHandler(handler, setNode));
-      } else {
+      } else if (this.isTopLevelDeclaration(node)) {
         const result = this.processNode(node);
         this.generatedStatements.push(result);
+      } else {
+        // Top-level statements (function calls, etc.) go into __initializeGlobals
+        // so they can access the execution context and global variables.
+        const result = this.processNodeInGlobalInit(node);
+        globalInitStatements.push(result);
       }
     }
 

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -339,7 +339,7 @@ export class TypeScriptBuilder {
     "approve", "reject", "propagate",
     "success", "failure",
     "isInterrupt", "isDebugger", "isRejected", "isApproved",
-    "isSuccess", "isFailure", "mcp"
+    "isSuccess", "isFailure", "mcp", "setLLMClient"
   ]);
 
   /**

--- a/lib/backends/typescriptGenerator/builtins.ts
+++ b/lib/backends/typescriptGenerator/builtins.ts
@@ -6,6 +6,7 @@ import * as builtinFunctionsFetch from "../../templates/backends/typescriptGener
 import * as builtinFunctionsSleep from "../../templates/backends/typescriptGenerator/builtinFunctions/sleep.js";
 import * as builtinFunctionsSystem from "../../templates/backends/typescriptGenerator/builtinFunctions/system.js";
 import * as builtinFunctionsMcp from "../../templates/backends/typescriptGenerator/builtinFunctions/mcp.js";
+import * as builtinFunctionsSetLLMClient from "../../templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.js";
 import { BUILTIN_FUNCTIONS } from "@/config.js";
 
 /**
@@ -57,6 +58,9 @@ export function generateBuiltinHelpers(functionsUsed: Set<string>): string {
    */
   const mcpFunc = builtinFunctionsMcp.default({});
   helpers.push(mcpFunc);
+
+  const setLLMClientFunc = builtinFunctionsSetLLMClient.default({});
+  helpers.push(setLLMClientFunc);
 
   return helpers.join("\n\n");
 }

--- a/lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.mustache
+++ b/lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.mustache
@@ -1,3 +1,3 @@
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }

--- a/lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.mustache
+++ b/lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.mustache
@@ -1,0 +1,3 @@
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}

--- a/lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.ts
+++ b/lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.ts
@@ -1,0 +1,19 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+`;
+
+export type TemplateType = {
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.ts
+++ b/lib/templates/backends/typescriptGenerator/builtinFunctions/setLLMClient.ts
@@ -3,7 +3,7 @@
 // Any manual changes will be lost.
 import { apply } from "typestache";
 
-export const template = `function setLLMClient(client) {
+export const template = `function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 `;

--- a/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,

--- a/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/lib/templates/backends/typescriptGenerator/imports.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,

--- a/tests/agency/setLLMClient.agency
+++ b/tests/agency/setLLMClient.agency
@@ -1,0 +1,9 @@
+import { SimpleOpenAIClient } from "agency-lang/runtime"
+
+const client = new SimpleOpenAIClient()
+setLLMClient(client)
+
+node testSetLLMClient() {
+  const result = llm("What is 2 + 2? Reply with just the number.")
+  return result
+}

--- a/tests/agency/setLLMClient.test.json
+++ b/tests/agency/setLLMClient.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "testSetLLMClient",
+      "input": "",
+      "expectedOutput": "",
+      "evaluationCriteria": [
+        {
+          "type": "llmJudge",
+          "judgePrompt": "Does the output contain the number 4?",
+          "desiredAccuracy": 80
+        }
+      ],
+      "description": "setLLMClient with SimpleOpenAIClient makes a real LLM call"
+    }
+  ]
+}

--- a/tests/typescriptBuilder/assignment.mjs
+++ b/tests/typescriptBuilder/assignment.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client: LLMClient) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("assignment.agency")
 }

--- a/tests/typescriptBuilder/safe-function.mjs
+++ b/tests/typescriptBuilder/safe-function.mjs
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,6 +101,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client: LLMClient) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("safe-function.agency")
 }

--- a/tests/typescriptBuilder/simple.mjs
+++ b/tests/typescriptBuilder/simple.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client: LLMClient) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("simple.agency")
 }

--- a/tests/typescriptGenerator/array.mjs
+++ b/tests/typescriptGenerator/array.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("array.agency")
 }

--- a/tests/typescriptGenerator/array.mjs
+++ b/tests/typescriptGenerator/array.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/tests/typescriptGenerator/arrayAndObject.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/tests/typescriptGenerator/arrayAndObject.mjs
@@ -100,23 +100,64 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("arrayAndObject.agency")
   __ctx.globals.set("arrayAndObject.agency", "nums", [1, 2, 3, 4, 5])
+  await __call(print, {
+    type: "positional",
+    args: [__ctx.globals.get("arrayAndObject.agency", "nums")]
+  }, {
+    ctx: __ctx
+  })
   __ctx.globals.set("arrayAndObject.agency", "names", [`Alice`, `Bob`, `Charlie`])
+  await __call(print, {
+    type: "positional",
+    args: [__ctx.globals.get("arrayAndObject.agency", "names")]
+  }, {
+    ctx: __ctx
+  })
   __ctx.globals.set("arrayAndObject.agency", "matrix", [[1, 2], [3, 4], [5, 6]])
+  await __call(print, {
+    type: "positional",
+    args: [__ctx.globals.get("arrayAndObject.agency", "matrix")]
+  }, {
+    ctx: __ctx
+  })
   __ctx.globals.set("arrayAndObject.agency", "person", {
     "name": `Alice`,
     "age": 30
+  })
+  await __call(print, {
+    type: "positional",
+    args: [__ctx.globals.get("arrayAndObject.agency", "person")]
+  }, {
+    ctx: __ctx
   })
   __ctx.globals.set("arrayAndObject.agency", "address", {
     "street": `123 Main St`,
     "city": `NYC`,
     "zip": `10001`
   })
+  await __call(print, {
+    type: "positional",
+    args: [__ctx.globals.get("arrayAndObject.agency", "address")]
+  }, {
+    ctx: __ctx
+  })
   __ctx.globals.set("arrayAndObject.agency", "user", {
     "name": `Bob`,
     "tags": [`admin`, `developer`]
+  })
+  await __call(print, {
+    type: "positional",
+    args: [__ctx.globals.get("arrayAndObject.agency", "user")]
+  }, {
+    ctx: __ctx
   })
   __ctx.globals.set("arrayAndObject.agency", "users", [{
     "name": `Alice`,
@@ -125,6 +166,12 @@ async function __initializeGlobals(__ctx) {
     "name": `Bob`,
     "age": 25
   }])
+  await __call(print, {
+    type: "positional",
+    args: [__ctx.globals.get("arrayAndObject.agency", "users")]
+  }, {
+    ctx: __ctx
+  })
   __ctx.globals.set("arrayAndObject.agency", "config", {
     "server": {
       "host": `localhost`,
@@ -132,8 +179,26 @@ async function __initializeGlobals(__ctx) {
     },
     "debug": true
   })
+  await __call(print, {
+    type: "positional",
+    args: [__ctx.globals.get("arrayAndObject.agency", "config")]
+  }, {
+    ctx: __ctx
+  })
   __ctx.globals.set("arrayAndObject.agency", "firstNum", __ctx.globals.get("arrayAndObject.agency", "nums")[0])
+  await __call(print, {
+    type: "positional",
+    args: [__ctx.globals.get("arrayAndObject.agency", "firstNum")]
+  }, {
+    ctx: __ctx
+  })
   __ctx.globals.set("arrayAndObject.agency", "personName", __ctx.globals.get("arrayAndObject.agency", "person").name)
+  await __call(print, {
+    type: "positional",
+    args: [__ctx.globals.get("arrayAndObject.agency", "personName")]
+  }, {
+    ctx: __ctx
+  })
 }
 __toolRegistry["readSkill"] = __AgencyFunction.create({
   name: "readSkill",
@@ -145,94 +210,14 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
 __functionRefReviver.registry = __toolRegistry;
 //  Test arrays and objects
 //  Simple array
-await __call(print, {
-  type: "positional",
-  args: [__ctx.globals.get("arrayAndObject.agency", "nums")]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 //  Array with strings
-await __call(print, {
-  type: "positional",
-  args: [__ctx.globals.get("arrayAndObject.agency", "names")]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 //  Nested arrays
-await __call(print, {
-  type: "positional",
-  args: [__ctx.globals.get("arrayAndObject.agency", "matrix")]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 //  Simple object
-await __call(print, {
-  type: "positional",
-  args: [__ctx.globals.get("arrayAndObject.agency", "person")]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 //  Object with nested structure
-await __call(print, {
-  type: "positional",
-  args: [__ctx.globals.get("arrayAndObject.agency", "address")]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 //  Object with array property
-await __call(print, {
-  type: "positional",
-  args: [__ctx.globals.get("arrayAndObject.agency", "user")]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 //  Array of objects
-await __call(print, {
-  type: "positional",
-  args: [__ctx.globals.get("arrayAndObject.agency", "users")]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 //  Nested object
-await __call(print, {
-  type: "positional",
-  args: [__ctx.globals.get("arrayAndObject.agency", "config")]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 //  Array access
-await __call(print, {
-  type: "positional",
-  args: [__ctx.globals.get("arrayAndObject.agency", "firstNum")]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 //  Object property access
-await __call(print, {
-  type: "positional",
-  args: [__ctx.globals.get("arrayAndObject.agency", "personName")]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 export default graph
 export const __sourceMap = {};

--- a/tests/typescriptGenerator/assignment.mjs
+++ b/tests/typescriptGenerator/assignment.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("assignment.agency")
 }

--- a/tests/typescriptGenerator/assignment.mjs
+++ b/tests/typescriptGenerator/assignment.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/tests/typescriptGenerator/asyncAssigned.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("asyncAssigned.agency")
 }

--- a/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/tests/typescriptGenerator/asyncAssigned.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/asyncLlm.mjs
+++ b/tests/typescriptGenerator/asyncLlm.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/asyncLlm.mjs
+++ b/tests/typescriptGenerator/asyncLlm.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("asyncLlm.agency")
 }

--- a/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("asyncUnassigned.agency")
 }

--- a/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/bangParams.mjs
+++ b/tests/typescriptGenerator/bangParams.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/bangParams.mjs
+++ b/tests/typescriptGenerator/bangParams.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("bangParams.agency")
 }

--- a/tests/typescriptGenerator/bangReturnType.mjs
+++ b/tests/typescriptGenerator/bangReturnType.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("bangReturnType.agency")
 }

--- a/tests/typescriptGenerator/bangReturnType.mjs
+++ b/tests/typescriptGenerator/bangReturnType.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/bangValidation.mjs
+++ b/tests/typescriptGenerator/bangValidation.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("bangValidation.agency")
 }

--- a/tests/typescriptGenerator/bangValidation.mjs
+++ b/tests/typescriptGenerator/bangValidation.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/blockBasic.mjs
+++ b/tests/typescriptGenerator/blockBasic.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/blockBasic.mjs
+++ b/tests/typescriptGenerator/blockBasic.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("blockBasic.agency")
 }

--- a/tests/typescriptGenerator/blockParams.mjs
+++ b/tests/typescriptGenerator/blockParams.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/blockParams.mjs
+++ b/tests/typescriptGenerator/blockParams.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("blockParams.agency")
 }

--- a/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("checkpoint-restore.agency")
 }

--- a/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/class-basic.mjs
+++ b/tests/typescriptGenerator/class-basic.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/class-basic.mjs
+++ b/tests/typescriptGenerator/class-basic.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("class-basic.agency")
 }

--- a/tests/typescriptGenerator/class-inheritance.mjs
+++ b/tests/typescriptGenerator/class-inheritance.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/class-inheritance.mjs
+++ b/tests/typescriptGenerator/class-inheritance.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("class-inheritance.agency")
 }

--- a/tests/typescriptGenerator/comments.mjs
+++ b/tests/typescriptGenerator/comments.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/comments.mjs
+++ b/tests/typescriptGenerator/comments.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("comments.agency")
   __ctx.globals.set("comments.agency", "x", 42)

--- a/tests/typescriptGenerator/defaultValues.mjs
+++ b/tests/typescriptGenerator/defaultValues.mjs
@@ -100,8 +100,25 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("defaultValues.agency")
+  await __call(greet, {
+    type: "positional",
+    args: [`world`]
+  }, {
+    ctx: __ctx
+  })
+  await __call(greet, {
+    type: "positional",
+    args: [`world`, `Hi`]
+  }, {
+    ctx: __ctx
+  })
 }
 __toolRegistry["readSkill"] = __AgencyFunction.create({
   name: "readSkill",
@@ -230,21 +247,5 @@ const greet = __AgencyFunction.create({
     schema: z.object({"name": z.string(), "greeting": z.string().nullable().describe("Default: Hello"), })
   }
 }, __toolRegistry);
-await __call(greet, {
-  type: "positional",
-  args: [`world`]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
-await __call(greet, {
-  type: "positional",
-  args: [`world`, `Hi`]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 export default graph
 export const __sourceMap = {"defaultValues.agency:greet":{"0":{"line":-1,"col":2}}};

--- a/tests/typescriptGenerator/defaultValues.mjs
+++ b/tests/typescriptGenerator/defaultValues.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/docstrings.mjs
+++ b/tests/typescriptGenerator/docstrings.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("docstrings.agency")
 }

--- a/tests/typescriptGenerator/docstrings.mjs
+++ b/tests/typescriptGenerator/docstrings.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/forLoop.mjs
+++ b/tests/typescriptGenerator/forLoop.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("forLoop.agency")
 }

--- a/tests/typescriptGenerator/forLoop.mjs
+++ b/tests/typescriptGenerator/forLoop.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/function-with-types.mjs
+++ b/tests/typescriptGenerator/function-with-types.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("function-with-types.agency")
 }

--- a/tests/typescriptGenerator/function-with-types.mjs
+++ b/tests/typescriptGenerator/function-with-types.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/function.mjs
+++ b/tests/typescriptGenerator/function.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/function.mjs
+++ b/tests/typescriptGenerator/function.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("function.agency")
 }

--- a/tests/typescriptGenerator/functionRef.mjs
+++ b/tests/typescriptGenerator/functionRef.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("functionRef.agency")
 }

--- a/tests/typescriptGenerator/functionRef.mjs
+++ b/tests/typescriptGenerator/functionRef.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/goto.mjs
+++ b/tests/typescriptGenerator/goto.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/goto.mjs
+++ b/tests/typescriptGenerator/goto.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("goto.agency")
 }

--- a/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("gotoWithArgs.agency")
 }

--- a/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("graph-node-with-types.agency")
 }

--- a/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/ifElse.mjs
+++ b/tests/typescriptGenerator/ifElse.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("ifElse.agency")
 }

--- a/tests/typescriptGenerator/ifElse.mjs
+++ b/tests/typescriptGenerator/ifElse.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/imports.mjs
+++ b/tests/typescriptGenerator/imports.mjs
@@ -115,6 +115,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 __registerTool(foo);
 __registerTool(foo);
 async function __initializeGlobals(__ctx) {

--- a/tests/typescriptGenerator/imports.mjs
+++ b/tests/typescriptGenerator/imports.mjs
@@ -20,7 +20,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -116,7 +116,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/input.mjs
+++ b/tests/typescriptGenerator/input.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("input.agency")
 }

--- a/tests/typescriptGenerator/input.mjs
+++ b/tests/typescriptGenerator/input.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/interpolation.mjs
+++ b/tests/typescriptGenerator/interpolation.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/interpolation.mjs
+++ b/tests/typescriptGenerator/interpolation.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("interpolation.agency")
 }

--- a/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("interrupt-2-deep-in-function.agency")
 }

--- a/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("interrupt-assignment.agency")
 }

--- a/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("interrupt-in-node.agency")
 }

--- a/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/tests/typescriptGenerator/llmConfigParam.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("llmConfigParam.agency")
   __ctx.globals.set("llmConfigParam.agency", "config", {

--- a/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/tests/typescriptGenerator/llmConfigParam.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/matchBlock.mjs
+++ b/tests/typescriptGenerator/matchBlock.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/matchBlock.mjs
+++ b/tests/typescriptGenerator/matchBlock.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("matchBlock.agency")
 }

--- a/tests/typescriptGenerator/multiLineComment.mjs
+++ b/tests/typescriptGenerator/multiLineComment.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("multiLineComment.agency")
   __ctx.globals.set("multiLineComment.agency", "x", 42)

--- a/tests/typescriptGenerator/multiLineComment.mjs
+++ b/tests/typescriptGenerator/multiLineComment.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/multipleNodes.mjs
+++ b/tests/typescriptGenerator/multipleNodes.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/multipleNodes.mjs
+++ b/tests/typescriptGenerator/multipleNodes.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("multipleNodes.agency")
 }

--- a/tests/typescriptGenerator/namedArgs.mjs
+++ b/tests/typescriptGenerator/namedArgs.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/namedArgs.mjs
+++ b/tests/typescriptGenerator/namedArgs.mjs
@@ -100,8 +100,32 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("namedArgs.agency")
+  await __call(greet, {
+    type: "named",
+    positionalArgs: [],
+    namedArgs: {
+      name: `world`
+    }
+  }, {
+    ctx: __ctx
+  })
+  await __call(greet, {
+    type: "named",
+    positionalArgs: [],
+    namedArgs: {
+      name: `world`,
+      greeting: `Hi`
+    }
+  }, {
+    ctx: __ctx
+  })
 }
 __toolRegistry["readSkill"] = __AgencyFunction.create({
   name: "readSkill",
@@ -230,28 +254,5 @@ const greet = __AgencyFunction.create({
     schema: z.object({"name": z.string(), "greeting": z.string().nullable().describe("Default: Hello"), })
   }
 }, __toolRegistry);
-await __call(greet, {
-  type: "named",
-  positionalArgs: [],
-  namedArgs: {
-    name: `world`
-  }
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
-await __call(greet, {
-  type: "named",
-  positionalArgs: [],
-  namedArgs: {
-    name: `world`,
-    greeting: `Hi`
-  }
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 export default graph
 export const __sourceMap = {"namedArgs.agency:greet":{"0":{"line":-1,"col":2}}};

--- a/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("namedArgsReorder.agency")
 }

--- a/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/tests/typescriptGenerator/noResponseFormat.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("noResponseFormat.agency")
 }

--- a/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/tests/typescriptGenerator/noResponseFormat.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/objectDescription.mjs
+++ b/tests/typescriptGenerator/objectDescription.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/objectDescription.mjs
+++ b/tests/typescriptGenerator/objectDescription.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("objectDescription.agency")
 }

--- a/tests/typescriptGenerator/optionalParams.mjs
+++ b/tests/typescriptGenerator/optionalParams.mjs
@@ -100,8 +100,25 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("optionalParams.agency")
+  await __call(greet, {
+    type: "positional",
+    args: [`world`]
+  }, {
+    ctx: __ctx
+  })
+  await __call(greet, {
+    type: "positional",
+    args: [`world`, `Hi`]
+  }, {
+    ctx: __ctx
+  })
 }
 __toolRegistry["readSkill"] = __AgencyFunction.create({
   name: "readSkill",
@@ -230,21 +247,5 @@ const greet = __AgencyFunction.create({
     schema: z.object({"name": z.string(), "greeting": z.string().nullable().describe("Default: null"), })
   }
 }, __toolRegistry);
-await __call(greet, {
-  type: "positional",
-  args: [`world`]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
-await __call(greet, {
-  type: "positional",
-  args: [`world`, `Hi`]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 export default graph
 export const __sourceMap = {"optionalParams.agency:greet":{"0":{"line":-1,"col":2}}};

--- a/tests/typescriptGenerator/optionalParams.mjs
+++ b/tests/typescriptGenerator/optionalParams.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/pipe-operator.mjs
+++ b/tests/typescriptGenerator/pipe-operator.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/pipe-operator.mjs
+++ b/tests/typescriptGenerator/pipe-operator.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("pipe-operator.agency")
 }

--- a/tests/typescriptGenerator/result-basic.mjs
+++ b/tests/typescriptGenerator/result-basic.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/result-basic.mjs
+++ b/tests/typescriptGenerator/result-basic.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("result-basic.agency")
 }

--- a/tests/typescriptGenerator/result-guards.mjs
+++ b/tests/typescriptGenerator/result-guards.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("result-guards.agency")
 }

--- a/tests/typescriptGenerator/result-guards.mjs
+++ b/tests/typescriptGenerator/result-guards.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/returnValue.mjs
+++ b/tests/typescriptGenerator/returnValue.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("returnValue.agency")
 }

--- a/tests/typescriptGenerator/returnValue.mjs
+++ b/tests/typescriptGenerator/returnValue.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("rewindCheckpoint.agency")
 }

--- a/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/safe.mjs
+++ b/tests/typescriptGenerator/safe.mjs
@@ -101,6 +101,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("safe.agency")
 }

--- a/tests/typescriptGenerator/safe.mjs
+++ b/tests/typescriptGenerator/safe.mjs
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -102,7 +102,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/schemaAccess.mjs
+++ b/tests/typescriptGenerator/schemaAccess.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("schemaAccess.agency")
 }

--- a/tests/typescriptGenerator/schemaAccess.mjs
+++ b/tests/typescriptGenerator/schemaAccess.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/setLLMClient.agency
+++ b/tests/typescriptGenerator/setLLMClient.agency
@@ -1,0 +1,9 @@
+import { SimpleOpenAIClient } from "agency-lang/runtime"
+
+const client = SimpleOpenAIClient()
+setLLMClient(client)
+
+node main() {
+  const result = llm("Hello")
+  print(result)
+}

--- a/tests/typescriptGenerator/setLLMClient.mjs
+++ b/tests/typescriptGenerator/setLLMClient.mjs
@@ -114,6 +114,7 @@ async function __initializeGlobals(__ctx) {
   }, {
     ctx: __ctx
   }))
+  await setLLMClient(__ctx.globals.get("setLLMClient.agency", "client"))
 }
 __toolRegistry["readSkill"] = __AgencyFunction.create({
   name: "readSkill",
@@ -124,7 +125,6 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
 
-await setLLMClient(__ctx.globals.get("setLLMClient.agency", "client"))
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state

--- a/tests/typescriptGenerator/setLLMClient.mjs
+++ b/tests/typescriptGenerator/setLLMClient.mjs
@@ -1,0 +1,238 @@
+import { SimpleOpenAIClient } from "agency-lang/runtime";
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl,
+  interrupt, isInterrupt, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupt as _respondToInterrupt,
+  approveInterrupt as _approveInterrupt,
+  rejectInterrupt as _rejectInterrupt,
+  resolveInterrupt as _resolveInterrupt,
+  modifyInterrupt as _modifyInterrupt,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  deepClone as __deepClone,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  AgencyFunction as __AgencyFunction, UNSET as __UNSET,
+  __call, __callMethod,
+  functionRefReviver as __functionRefReviver,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  traceConfig: {
+    program: "setLLMClient.agency"
+  }
+});
+const graph = __globalCtx.graph;
+
+// Path-dependent builtin wrappers
+export function readSkill({filepath}: {filepath: string}): string {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+
+// Handler result builtins
+function approve(value?: any) { return { type: "approved" as const, value }; }
+function reject(value?: any) { return { type: "rejected" as const, value }; }
+function propagate() { return { type: "propagated" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, isDebugger };
+export const respondToInterrupt = (interrupt: Interrupt, response: InterruptResponse, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupt({ ctx: __globalCtx, interrupt, interruptResponse: response, overrides: opts?.overrides, metadata: opts?.metadata });
+export const approveInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _approveInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rejectInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _rejectInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const modifyInterrupt = (interrupt: Interrupt, newArguments: Record<string, any>, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _modifyInterrupt({ ctx: __globalCtx, interrupt, newArguments, overrides: opts?.overrides, metadata: opts?.metadata });
+export const resolveInterrupt = (interrupt: Interrupt, value: any, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _resolveInterrupt({ ctx: __globalCtx, interrupt, value, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+
+const __toolRegistry: Record<string, any> = {};
+
+function __registerTool(value: unknown, name?: string) {
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[name ?? value.name] = value;
+  }
+}
+
+// Wrap stateful runtime functions as AgencyFunction instances
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "options", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+async function mcp(serverName: string) {
+  return __globalCtx.mcpManager.getTools(serverName);
+}
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("setLLMClient.agency")
+  __ctx.globals.set("setLLMClient.agency", "client", await __call(SimpleOpenAIClient, {
+    type: "positional",
+    args: []
+  }, {
+    ctx: __ctx
+  }))
+}
+__toolRegistry["readSkill"] = __AgencyFunction.create({
+  name: "readSkill",
+  module: "setLLMClient.agency",
+  fn: readSkill,
+  params: __readSkillToolParams.map(p => ({ name: p, hasDefault: false, defaultValue: undefined, variadic: false })),
+  toolDefinition: __readSkillTool,
+}, __toolRegistry);
+__functionRefReviver.registry = __toolRegistry;
+
+await setLLMClient(__ctx.globals.get("setLLMClient.agency", "client"))
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state.ctx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onNodeStart",
+    data: {
+      nodeName: "main"
+    }
+  })
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "setLLMClient.agency", scopeName: "main" });
+  try {
+    await runner.step(0, async (runner) => {
+__self.__removedTools = __self.__removedTools || [];
+__stack.locals.result = await runPrompt({
+        ctx: __ctx,
+        prompt: `Hello`,
+        messages: __threads.getOrCreateActive(),
+        clientConfig: {},
+        maxToolCallRounds: 10,
+        interruptData: __state?.interruptData,
+        removedTools: __self.__removedTools,
+        checkpointInfo: runner.getCheckpointInfo()
+      });
+// halt if this is an interrupt
+if (isInterrupt(__stack.locals.result)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          messages: __threads,
+          data: __stack.locals.result
+        })
+        return;
+      }
+    });
+    await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+        type: "positional",
+        args: [__stack.locals.result]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        interruptData: __state?.interruptData
+      });
+if (isInterrupt(__funcResult)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __funcResult
+        })
+        return;
+      }
+    });
+    if (runner.halted) return runner.haltResult;
+    await callHook({
+      callbacks: __ctx.callbacks,
+      name: "onNodeEnd",
+      data: {
+        nodeName: "main",
+        data: undefined
+      }
+    })
+    return {
+      messages: __threads,
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    console.error(`\nAgent crashed: ${__error.message}`)
+    return {
+      messages: __threads,
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}): Promise<RunNodeResult<any>> {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    await main(initialState)
+  } catch (__error: any) {
+    console.error(`\nAgent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"setLLMClient.agency:main":{"0":{"line":4,"col":2},"1":{"line":5,"col":2}}};

--- a/tests/typescriptGenerator/setLLMClient.mjs
+++ b/tests/typescriptGenerator/setLLMClient.mjs
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -102,7 +102,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/shared.mjs
+++ b/tests/typescriptGenerator/shared.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 let foo;
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("shared.agency")

--- a/tests/typescriptGenerator/shared.mjs
+++ b/tests/typescriptGenerator/shared.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/simple.mjs
+++ b/tests/typescriptGenerator/simple.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/simple.mjs
+++ b/tests/typescriptGenerator/simple.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("simple.agency")
 }

--- a/tests/typescriptGenerator/skill.mjs
+++ b/tests/typescriptGenerator/skill.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("skill.agency")
 }

--- a/tests/typescriptGenerator/skill.mjs
+++ b/tests/typescriptGenerator/skill.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/slice.mjs
+++ b/tests/typescriptGenerator/slice.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("slice.agency")
 }

--- a/tests/typescriptGenerator/slice.mjs
+++ b/tests/typescriptGenerator/slice.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/sliceAssign.mjs
+++ b/tests/typescriptGenerator/sliceAssign.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("sliceAssign.agency")
 }

--- a/tests/typescriptGenerator/sliceAssign.mjs
+++ b/tests/typescriptGenerator/sliceAssign.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/sourceMap.mjs
+++ b/tests/typescriptGenerator/sourceMap.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("sourceMap.agency")
 }

--- a/tests/typescriptGenerator/sourceMap.mjs
+++ b/tests/typescriptGenerator/sourceMap.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/splat.mjs
+++ b/tests/typescriptGenerator/splat.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/splat.mjs
+++ b/tests/typescriptGenerator/splat.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("splat.agency")
   __ctx.globals.set("splat.agency", "arr1", [1, 2])

--- a/tests/typescriptGenerator/streaming.mjs
+++ b/tests/typescriptGenerator/streaming.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("streaming.agency")
 }

--- a/tests/typescriptGenerator/streaming.mjs
+++ b/tests/typescriptGenerator/streaming.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/string-interpolation.mjs
+++ b/tests/typescriptGenerator/string-interpolation.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("string-interpolation.agency")
 }

--- a/tests/typescriptGenerator/string-interpolation.mjs
+++ b/tests/typescriptGenerator/string-interpolation.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/stringConcat.mjs
+++ b/tests/typescriptGenerator/stringConcat.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("stringConcat.agency")
 }

--- a/tests/typescriptGenerator/stringConcat.mjs
+++ b/tests/typescriptGenerator/stringConcat.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("threadsAndSubthreads.agency")
 }

--- a/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/typeHints.mjs
+++ b/tests/typescriptGenerator/typeHints.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/typeHints.mjs
+++ b/tests/typescriptGenerator/typeHints.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("typeHints.agency")
 }

--- a/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("exportedTypeAlias.agency")
 }

--- a/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/types/literal.mjs
+++ b/tests/typescriptGenerator/types/literal.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("literal.agency")
 }

--- a/tests/typescriptGenerator/types/literal.mjs
+++ b/tests/typescriptGenerator/types/literal.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("nestedTypeAlias.agency")
 }

--- a/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/tests/typescriptGenerator/types/typeAlias.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/tests/typescriptGenerator/types/typeAlias.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("typeAlias.agency")
 }

--- a/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("valueAccessInterpolation.agency")
 }

--- a/tests/typescriptGenerator/varTypes.mjs
+++ b/tests/typescriptGenerator/varTypes.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("varTypes.agency")
 }

--- a/tests/typescriptGenerator/varTypes.mjs
+++ b/tests/typescriptGenerator/varTypes.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/variadic.mjs
+++ b/tests/typescriptGenerator/variadic.mjs
@@ -100,8 +100,19 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("variadic.agency")
+  await __call(log, {
+    type: "positional",
+    args: [`INFO`, `hello`, `world`]
+  }, {
+    ctx: __ctx
+  })
 }
 __toolRegistry["readSkill"] = __AgencyFunction.create({
   name: "readSkill",
@@ -230,13 +241,5 @@ const log = __AgencyFunction.create({
     schema: z.object({"prefix": z.string(), "messages": z.array(z.string()), })
   }
 }, __toolRegistry);
-await __call(log, {
-  type: "positional",
-  args: [`INFO`, `hello`, `world`]
-}, {
-  ctx: __ctx,
-  threads: __threads,
-  interruptData: __state?.interruptData
-})
 export default graph
 export const __sourceMap = {"variadic.agency:log":{"0":{"line":-1,"col":2}}};

--- a/tests/typescriptGenerator/variadic.mjs
+++ b/tests/typescriptGenerator/variadic.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/withModifier.mjs
+++ b/tests/typescriptGenerator/withModifier.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 

--- a/tests/typescriptGenerator/withModifier.mjs
+++ b/tests/typescriptGenerator/withModifier.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("withModifier.agency")
 }

--- a/tests/typescriptGenerator/withParam.mjs
+++ b/tests/typescriptGenerator/withParam.mjs
@@ -100,6 +100,11 @@ const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", 
 async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
+
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("withParam.agency")
 }

--- a/tests/typescriptGenerator/withParam.mjs
+++ b/tests/typescriptGenerator/withParam.mjs
@@ -5,7 +5,7 @@ import { z } from "zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint } from "agency-lang/runtime";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -101,7 +101,7 @@ async function mcp(serverName: string) {
   return __globalCtx.mcpManager.getTools(serverName);
 }
 
-function setLLMClient(client) {
+function setLLMClient(client: LLMClient) {
   __globalCtx.setLLMClient(client);
 }
 


### PR DESCRIPTION
## Summary

- Adds `setLLMClient()` as a builtin function so Agency users can swap in alternative LLM clients
- Follows the same pattern as the `mcp()` builtin: mustache template, wired into builtins.ts, added to DIRECT_CALL_FUNCTIONS

## Usage

```
import { SimpleOpenAIClient } from "agency-lang/runtime"

const client = SimpleOpenAIClient()
setLLMClient(client)

node main() {
  const result = llm("Hello!")
  print(result)
}
```

## Test plan

- [x] All 2123 tests pass
- [x] Generator fixture verifies setLLMClient compiles as a direct function call
- [x] Generated code calls `__globalCtx.setLLMClient(client)`