### PR TITLE
Add inline block syntax (\x -> expr)

### DIFF
--- a/docs-new/guide/blocks.md
+++ b/docs-new/guide/blocks.md
@@ -33,6 +33,30 @@ Now use it:
   print(greetings)
 ```
 
+## Inline blocks
+
+For simple one-liner blocks, you can use the inline block syntax. Instead of writing the block after the function call, you write it as an argument using `\`:
+
+```typescript
+  const names: string[] = ["Alice", "Bob", "Charlie"]
+  const greetings = map(names, \name -> "Hi, ${name}!")
+  print(greetings)
+```
+
+For multiple parameters, wrap them in parentheses:
+
+```typescript
+  const greetings = mapWithIndex(names, \(name, index) -> "${index}: ${name}")
+```
+
+For no parameters:
+
+```typescript
+  const results = twice(\ -> "hello")
+```
+
+Inline blocks are expression-only — the expression is implicitly returned. For multi-line blocks with multiple statements, use the trailing `as` syntax shown above.
+
 ## Blocks and interrupts
 
 Blocks work correctly with [interrupts](./interrupts). If a block throws an interrupt (or calls a function that throws one), Agency can serialize the execution state, and when the user responds, resume from the exact point the block left off. Blocks can also close over variables from their enclosing scope, and this works correctly across interrupts too.

--- a/docs-new/guide/blocks.md
+++ b/docs-new/guide/blocks.md
@@ -55,7 +55,7 @@ For no parameters:
   const results = twice(\ -> "hello")
 ```
 
-Inline blocks are expression-only — the expression is implicitly returned. For multi-line blocks with multiple statements, use the trailing `as` syntax shown above.
+Inline blocks are single-line only, and the expression is implicitly returned. For multi-line blocks with multiple statements, use the trailing `as` syntax shown above.
 
 ## Blocks and interrupts
 

--- a/docs/superpowers/plans/2026-04-24-inline-block-syntax.md
+++ b/docs/superpowers/plans/2026-04-24-inline-block-syntax.md
@@ -1,0 +1,722 @@
+# Inline Block Syntax Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `\x -> expr` inline block syntax for terse one-liner blocks inside function call parentheses.
+
+**Architecture:** The inline block parser produces the same `BlockArgument` AST node as the existing `as` trailing blocks, with a new `inline: boolean` field. The parser post-processes function call arguments to move inline blocks to `FunctionCall.block`. No builder/runtime changes needed.
+
+**Tech Stack:** TypeScript, tarsec parser combinators, vitest
+
+**Spec:** `docs/superpowers/specs/2026-04-24-inline-block-syntax-design.md`
+
+---
+
+### Task 1: Add `inline` field to `BlockArgument` AST node
+
+**Files:**
+- Modify: `lib/types/blockArgument.ts`
+- Modify: `lib/parsers/parsers.ts` (existing `blockArgumentParser`, around line 1684)
+
+- [ ] **Step 1: Add `inline` field to `BlockArgument` type**
+
+In `lib/types/blockArgument.ts`, add `inline?: boolean` to the type:
+
+```typescript
+export type BlockArgument = BaseNode & {
+  type: "blockArgument";
+  params: FunctionParameter[];
+  body: AgencyNode[];
+  inline?: boolean;
+};
+```
+
+- [ ] **Step 2: Set `inline: false` in existing `blockArgumentParser`**
+
+In `lib/parsers/parsers.ts`, add `set("inline", false)` to the existing `blockArgumentParser` (around line 1687), right after the `set("type", "blockArgument")` line:
+
+```typescript
+export const blockArgumentParser: Parser<BlockArgument> = trace(
+  "blockArgumentParser",
+  seqC(
+    set("type", "blockArgument"),
+    set("inline", false),
+    str("as"),
+    spaces,
+    capture(blockParamsParser, "params"),
+    optionalSpaces,
+    char("{"),
+    optionalSpacesOrNewline,
+    capture(lazy(() => bodyParser), "body"),
+    optionalSpacesOrNewline,
+    char("}"),
+  ),
+);
+```
+
+- [ ] **Step 3: Run existing tests to verify no regressions**
+
+Run: `pnpm test:run -- --reporter=verbose lib/parsers/blockArgument.test.ts`
+Expected: All existing tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/types/blockArgument.ts lib/parsers/parsers.ts
+git commit -m "Add inline field to BlockArgument AST node"
+```
+
+---
+
+### Task 2: Write the `inlineBlockParser`
+
+**Files:**
+- Modify: `lib/parsers/parsers.ts` (add new parser after `blockArgumentParser`, around line 1699)
+- Test: `lib/parsers/blockArgument.test.ts`
+
+The inline block parser parses `\ [params] -> expression`. It reuses the existing `blockParamParser` and `blockParamsParser` for parameter parsing. The expression body is wrapped in a synthetic `ReturnStatement` node.
+
+- [ ] **Step 1: Write failing tests for `inlineBlockParser`**
+
+Add these tests to `lib/parsers/blockArgument.test.ts`. You'll need to import `inlineBlockParser` from `./parsers.js` (it doesn't exist yet, so the import will fail).
+
+```typescript
+import { inlineBlockParser } from "./parsers.js";
+
+describe("inlineBlockParser", () => {
+  it("parses single param with expression body", () => {
+    const input = String.raw`\x -> x + 1`;
+    const result = inlineBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.type).toBe("blockArgument");
+      expect(result.result.inline).toBe(true);
+      expect(result.result.params).toHaveLength(1);
+      expect(result.result.params[0].name).toBe("x");
+      // Body should be a single return statement wrapping the expression
+      expect(result.result.body).toHaveLength(1);
+      expect(result.result.body[0].type).toBe("returnStatement");
+    }
+  });
+
+  it("parses multi param with expression body", () => {
+    const input = String.raw`\(x, i) -> x + i`;
+    const result = inlineBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.inline).toBe(true);
+      expect(result.result.params).toHaveLength(2);
+      expect(result.result.params[0].name).toBe("x");
+      expect(result.result.params[1].name).toBe("i");
+      expect(result.result.body).toHaveLength(1);
+      expect(result.result.body[0].type).toBe("returnStatement");
+    }
+  });
+
+  it("parses no params with expression body", () => {
+    const input = String.raw`\ -> "hello"`;
+    const result = inlineBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.inline).toBe(true);
+      expect(result.result.params).toHaveLength(0);
+      expect(result.result.body).toHaveLength(1);
+      expect(result.result.body[0].type).toBe("returnStatement");
+    }
+  });
+
+  it("stops expression body at comma", () => {
+    const input = String.raw`\x -> x + 1, 42`;
+    const result = inlineBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.body).toHaveLength(1);
+      // The rest should contain ", 42"
+      expect(result.rest.trim()).toBe(", 42");
+    }
+  });
+
+  it("stops expression body at closing paren", () => {
+    const input = String.raw`\x -> x + 1)`;
+    const result = inlineBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.body).toHaveLength(1);
+      expect(result.rest).toBe(")");
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test:run -- --reporter=verbose lib/parsers/blockArgument.test.ts`
+Expected: FAIL — `inlineBlockParser` is not exported from `./parsers.js`.
+
+- [ ] **Step 3: Implement `inlineBlockParser`**
+
+Add this parser to `lib/parsers/parsers.ts`, right after the existing `blockArgumentParser` (after line 1698). The parser:
+1. Matches `\`
+2. Parses params using the existing `blockParamsParser` (handles single, multi, and no params)
+3. Matches `->` with optional surrounding spaces
+4. Parses a single expression using `exprParser`
+5. Wraps the expression in a synthetic `ReturnStatement` node
+6. Returns a `BlockArgument` with `inline: true`
+
+```typescript
+// Parse an inline block argument: \params -> expression
+//   \x -> x + 1           — single param
+//   \(x, i) -> x + i      — multiple params
+//   \ -> "hello"           — no params
+// Expression-only: the expression is wrapped in a synthetic return statement.
+export const inlineBlockParser: Parser<BlockArgument> = trace(
+  "inlineBlockParser",
+  (input: string): ParserResult<BlockArgument> => {
+    const parser = seqC(
+      set("type", "blockArgument"),
+      set("inline", true),
+      char("\\"),
+      optionalSpaces,
+      capture(blockParamsParser, "params"),
+      optionalSpaces,
+      str("->"),
+      optionalSpaces,
+      capture(lazy(() => exprParser), "__expr"),
+    );
+    const result = parser(input);
+    if (!result.success) return result;
+
+    // Wrap the expression in a synthetic return statement
+    const expr = result.result.__expr;
+    const returnNode: ReturnStatement = { type: "returnStatement", value: expr };
+    return success({
+      type: "blockArgument",
+      inline: true,
+      params: result.result.params,
+      body: [returnNode],
+    } as BlockArgument, result.rest);
+  },
+);
+```
+
+You will also need to import `ReturnStatement` at the top of `parsers.ts`. Check whether it's already imported — it likely is since `returnStatement` is parsed elsewhere. If not, add:
+
+```typescript
+import { ReturnStatement } from "../types/returnStatement.js";
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test:run -- --reporter=verbose lib/parsers/blockArgument.test.ts`
+Expected: All tests pass including the new `inlineBlockParser` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/parsers/parsers.ts lib/parsers/blockArgument.test.ts
+git commit -m "Add inlineBlockParser for backslash-arrow block syntax"
+```
+
+---
+
+### Task 3: Wire inline blocks into function call parser
+
+**Files:**
+- Modify: `lib/parsers/parsers.ts` (`_functionCallParser`, around line 1135)
+- Test: `lib/parsers/blockArgument.test.ts`
+
+- [ ] **Step 1: Write failing tests for function calls with inline blocks**
+
+Add these tests to the existing `"function call with block argument"` describe block in `lib/parsers/blockArgument.test.ts`:
+
+```typescript
+  it("parses function call with inline block as last arg", () => {
+    const input = String.raw`map(arr, \x -> x + 1)`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.functionName).toBe("map");
+      expect(result.result.arguments).toHaveLength(1); // just 'arr'
+      expect(result.result.block).toBeDefined();
+      expect(result.result.block!.inline).toBe(true);
+      expect(result.result.block!.params).toHaveLength(1);
+      expect(result.result.block!.params[0].name).toBe("x");
+    }
+  });
+
+  it("parses function call with inline block and multiple regular args", () => {
+    const input = String.raw`foo(1, "bar", \x -> x + 1)`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.functionName).toBe("foo");
+      expect(result.result.arguments).toHaveLength(2); // 1 and "bar"
+      expect(result.result.block).toBeDefined();
+      expect(result.result.block!.inline).toBe(true);
+    }
+  });
+
+  it("parses function call with inline block as non-last arg", () => {
+    const input = String.raw`foo(\x -> x + 1, 42)`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.functionName).toBe("foo");
+      expect(result.result.arguments).toHaveLength(1); // just 42
+      expect(result.result.block).toBeDefined();
+      expect(result.result.block!.inline).toBe(true);
+    }
+  });
+
+  it("parses function call with multi-param inline block", () => {
+    const input = String.raw`mapWithIndex(arr, \(x, i) -> x + i)`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.arguments).toHaveLength(1); // just 'arr'
+      expect(result.result.block).toBeDefined();
+      expect(result.result.block!.params).toHaveLength(2);
+      expect(result.result.block!.params[0].name).toBe("x");
+      expect(result.result.block!.params[1].name).toBe("i");
+    }
+  });
+
+  it("parses function call with no-param inline block", () => {
+    const input = String.raw`sample(5, \ -> "hello")`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.arguments).toHaveLength(1); // just 5
+      expect(result.result.block).toBeDefined();
+      expect(result.result.block!.params).toHaveLength(0);
+    }
+  });
+
+  it("parses nested inline blocks in nested function calls", () => {
+    const input = String.raw`map(arr, \x -> filter(x, \y -> y > 0))`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.functionName).toBe("map");
+      expect(result.result.block).toBeDefined();
+      // The body of the outer block is a return statement containing the inner function call
+      const returnStmt = result.result.block!.body[0];
+      expect(returnStmt.type).toBe("returnStatement");
+    }
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm test:run -- --reporter=verbose lib/parsers/blockArgument.test.ts`
+Expected: FAIL — inline blocks are not yet recognized inside function call arguments.
+
+- [ ] **Step 3: Wire `inlineBlockParser` into `_functionCallParser`**
+
+Modify `_functionCallParser` in `lib/parsers/parsers.ts` (around line 1135). There are two changes:
+
+**Change 1:** Add `inlineBlockParser` as an alternative in the `sepBy` argument list, tried before `exprParser`:
+
+```typescript
+    capture(
+      sepBy(
+        comma,
+        or(
+          namedArgumentParser,
+          splatParser,
+          lazy(() => inlineBlockParser),
+          lazy(() => exprParser),
+        ),
+      ),
+      "arguments",
+    ),
+```
+
+**Change 2:** After the `seqC` parser succeeds, post-process the result to move any `BlockArgument` from `arguments` to `block`. Replace the simple `return parser(input)` with:
+
+```typescript
+  const result = parser(input);
+  if (!result.success) return result;
+
+  // Post-process: move inline block from arguments to block field
+  const args = result.result.arguments as AgencyNode[];
+  const blockIndex = args.findIndex((a: AgencyNode) => a.type === "blockArgument");
+  if (blockIndex !== -1) {
+    const inlineBlock = args[blockIndex] as BlockArgument;
+    args.splice(blockIndex, 1);
+    if (result.result.block) {
+      // Both inline block and trailing block — parse error
+      return failure("A function call cannot have both an inline block and a trailing 'as' block", input);
+    }
+    result.result.block = inlineBlock;
+  }
+
+  // Check for multiple inline blocks (they would have been parsed as args)
+  const secondBlock = args.findIndex((a: AgencyNode) => a.type === "blockArgument");
+  if (secondBlock !== -1) {
+    return failure("A function call cannot have more than one block argument", input);
+  }
+
+  return result;
+```
+
+Note: `failure` is tarsec's function for creating a failure result (already imported in `parsers.ts`). Do not confuse with `fail`, which is a Parser that always fails — you need `failure()` here since you're returning a `ParserResult`, not constructing a parser.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm test:run -- --reporter=verbose lib/parsers/blockArgument.test.ts`
+Expected: All tests pass.
+
+- [ ] **Step 5: Run the full parser test suite to check for regressions**
+
+Run: `pnpm test:run -- --reporter=verbose lib/parsers/`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/parsers/parsers.ts lib/parsers/blockArgument.test.ts
+git commit -m "Wire inline blocks into function call parser with post-processing"
+```
+
+---
+
+### Task 4: Add negative parser tests
+
+**Files:**
+- Test: `lib/parsers/blockArgument.test.ts`
+
+- [ ] **Step 1: Write negative tests**
+
+Add to the `"function call with block argument"` describe block in `lib/parsers/blockArgument.test.ts`:
+
+```typescript
+  it("fails when function call has two inline blocks", () => {
+    const input = String.raw`foo(\x -> x + 1, \y -> y * 2)`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when function call has inline block and trailing as block", () => {
+    const input = `map(arr, \\x -> x + 1) as y {
+  return y
+}`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(false);
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pnpm test:run -- --reporter=verbose lib/parsers/blockArgument.test.ts`
+Expected: All tests pass (the negative tests should fail to parse as expected).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/parsers/blockArgument.test.ts
+git commit -m "Add negative parser tests for multiple blocks in one call"
+```
+
+---
+
+### Task 5: Integration test fixtures (TypeScript generator)
+
+**Files:**
+- Create: `tests/typescriptGenerator/inlineBlockBasic.agency`
+- Create: `tests/typescriptGenerator/inlineBlockParams.agency`
+
+These tests verify the full compilation pipeline: parse → preprocess → build → generate TypeScript. The `.mjs` fixture files will be generated by running `make fixtures`.
+
+- [ ] **Step 1: Create `inlineBlockBasic.agency`**
+
+```
+def twice(block: () => string): string[] {
+  let a: string = block()
+  let b: string = block()
+  return [a, b]
+}
+
+node main() {
+  let results = twice(\ -> "hello")
+  print(results)
+}
+```
+
+- [ ] **Step 2: Create `inlineBlockParams.agency`**
+
+```
+def mapItems(items: any[], block: (any) => any): any[] {
+  let results: any[] = []
+  for (item in items) {
+    let result = block(item)
+    results = results.concat([result])
+  }
+  return results
+}
+
+node main() {
+  let items = [1, 2, 3]
+  let doubled = mapItems(items, \x -> x * 2)
+  return doubled
+}
+```
+
+- [ ] **Step 3: Generate the `.mjs` fixture files**
+
+Run: `make fixtures`
+Expected: `inlineBlockBasic.mjs` and `inlineBlockParams.mjs` are generated in `tests/typescriptGenerator/`.
+
+- [ ] **Step 4: Verify the generated TypeScript looks correct**
+
+Read the generated `.mjs` files. The inline block should compile to the same `AgencyFunction.create(...)` pattern as the trailing `as` blocks — compare with `tests/typescriptGenerator/blockBasic.mjs` for reference. The generated code should be functionally identical.
+
+- [ ] **Step 5: Run the TypeScript generator tests**
+
+Run: `pnpm test:run -- --reporter=verbose tests/typescriptGenerator/`
+Expected: All tests pass including the new fixtures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/typescriptGenerator/inlineBlockBasic.agency tests/typescriptGenerator/inlineBlockBasic.mjs
+git add tests/typescriptGenerator/inlineBlockParams.agency tests/typescriptGenerator/inlineBlockParams.mjs
+git commit -m "Add integration test fixtures for inline block syntax"
+```
+
+---
+
+### Task 6: Agency execution tests
+
+**Files:**
+- Create: `tests/agency/blocks/block-inline-basic.agency`
+- Create: `tests/agency/blocks/block-inline-basic.test.json`
+- Create: `tests/agency/blocks/block-inline-params.agency`
+- Create: `tests/agency/blocks/block-inline-params.test.json`
+
+These tests compile AND execute `.agency` files, verifying the runtime output. They do NOT require LLM calls.
+
+- [ ] **Step 1: Create `block-inline-basic.agency`**
+
+```
+def twice(block: () => string): string[] {
+  let a: string = block()
+  let b: string = block()
+  return [a, b]
+}
+
+node main() {
+  let results = twice(\ -> "hello")
+  return results
+}
+```
+
+- [ ] **Step 2: Create `block-inline-basic.test.json`**
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[\"hello\",\"hello\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "Inline block with no params called twice returns two hello strings"
+    }
+  ]
+}
+```
+
+- [ ] **Step 3: Create `block-inline-params.agency`**
+
+```
+def mapItems(items: any[], block: (any) => any): any[] {
+  let results: any[] = []
+  for (item in items) {
+    let result = block(item)
+    results = results.concat([result])
+  }
+  return results
+}
+
+node main() {
+  let items = [1, 2, 3]
+  let doubled = mapItems(items, \x -> x * 2)
+  return doubled
+}
+```
+
+- [ ] **Step 4: Create `block-inline-params.test.json`**
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[2,4,6]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "Inline block with params maps items by doubling them"
+    }
+  ]
+}
+```
+
+- [ ] **Step 5: Run the execution tests**
+
+Run: `pnpm test:run -- --reporter=verbose tests/agency/blocks/block-inline`
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/agency/blocks/block-inline-basic.agency tests/agency/blocks/block-inline-basic.test.json
+git add tests/agency/blocks/block-inline-params.agency tests/agency/blocks/block-inline-params.test.json
+git commit -m "Add execution tests for inline block syntax"
+```
+
+---
+
+### Task 7: Interrupt execution test
+
+**Files:**
+- Create: `tests/agency/blocks/block-inline-interrupt.agency`
+- Create: `tests/agency/blocks/block-inline-interrupt.test.json`
+
+This test verifies that inline blocks work correctly with the interrupt/resume system — a critical safety feature.
+
+- [ ] **Step 1: Create `block-inline-interrupt.agency`**
+
+Model this after `tests/agency/blocks/block-interrupt.agency` but using inline block syntax. Since inline blocks are expression-only, the block expression itself should be a function call that interrupts. Look at the existing `block-interrupt.agency` test for the pattern:
+
+```
+def withApproval(block: () => string): string {
+  let result = block()
+  return result
+}
+
+def getApproval(): string {
+  interrupt("please approve")
+  return "approved"
+}
+
+node main() {
+  let result = withApproval(\ -> getApproval())
+  return result
+}
+```
+
+- [ ] **Step 2: Create `block-inline-interrupt.test.json`**
+
+Look at `tests/agency/blocks/block-interrupt.test.json` for the pattern used with interrupts. The test should approve the interrupt and verify the result. Here's the general shape (adapt based on what the existing interrupt tests look like):
+
+```json
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"approved\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "Inline block that interrupts resumes correctly after approval",
+      "interruptHandlers": [
+        {
+          "action": "approve"
+        }
+      ]
+    }
+  ]
+}
+```
+
+This matches the existing `block-interrupt.test.json` format: the field is `"interruptHandlers"` (not `"interrupts"`), and string outputs are wrapped in escaped quotes (`"\"approved\""`).
+
+
+- [ ] **Step 3: Run the test**
+
+Run: `pnpm test:run -- --reporter=verbose tests/agency/blocks/block-inline-interrupt`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/agency/blocks/block-inline-interrupt.agency tests/agency/blocks/block-inline-interrupt.test.json
+git commit -m "Add interrupt execution test for inline block syntax"
+```
+
+---
+
+### Task 8: Full regression test
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `pnpm test:run`
+Expected: All tests pass. Pay special attention to:
+- `lib/parsers/` — parser tests
+- `tests/typescriptGenerator/` — code gen tests
+- `tests/agency/blocks/` — block execution tests
+- `tests/agency/substeps/` — checkpoint/nested block tests
+
+- [ ] **Step 2: If any failures, fix them before proceeding**
+
+Any failure at this stage likely means the new parser alternative is matching something it shouldn't, or the post-processing is interfering with existing block handling. Debug by checking which test fails and whether it involves function calls with arguments.
+
+- [ ] **Step 3: Commit any fixes if needed**
+
+---
+
+### Task 9: Update documentation
+
+**Files:**
+- Modify: `docs-new/guide/blocks.md`
+
+- [ ] **Step 1: Add inline block syntax section to blocks.md**
+
+Add a new section after the opening example in `docs-new/guide/blocks.md`. Place it before the "Blocks and interrupts" section. The new section should document the inline syntax as a terse alternative:
+
+```markdown
+## Inline blocks
+
+For simple one-liner blocks, you can use the inline block syntax. Instead of writing the block after the function call, you write it as an argument using `\`:
+
+\```typescript
+  const names: string[] = ["Alice", "Bob", "Charlie"]
+  const greetings = map(names, \name -> "Hi, ${name}!")
+  print(greetings)
+\```
+
+For multiple parameters, wrap them in parentheses:
+
+\```typescript
+  const greetings = mapWithIndex(names, \(name, index) -> "${index}: ${name}")
+\```
+
+For no parameters:
+
+\```typescript
+  const results = twice(\ -> "hello")
+\```
+
+Inline blocks are expression-only — the expression is implicitly returned. For multi-line blocks with multiple statements, use the trailing `as` syntax shown above.
+```
+
+(Remove the backslash escapes on the triple-backtick fences — those are just to prevent breaking this plan's markdown.)
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs-new/guide/blocks.md
+git commit -m "Document inline block syntax in language guide"
+```

--- a/docs/superpowers/specs/2026-04-24-inline-block-syntax-design.md
+++ b/docs/superpowers/specs/2026-04-24-inline-block-syntax-design.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Add a new terse inline block syntax (`\x -> expr`) for passing blocks as function arguments, alongside the existing trailing `as` syntax. The new syntax places the block inside the function call parentheses and supports implicit-return expression bodies.
+Add a new terse inline block syntax (`\x -> expr`) for passing blocks as function arguments, alongside the existing trailing `as` syntax. The new syntax places the block inside the function call parentheses and is expression-only with implicit return. For multi-line blocks, use the existing `as` syntax.
 
 ## Motivation
 
@@ -33,19 +33,9 @@ mapWithIndex(arr, \(x, i) -> x + i)
 
 // No params
 sample(5, \ -> "hello")
-
-// Single param, statement body (explicit return required)
-map(arr, \x -> {
-  const y = x + 1
-  return y
-})
-
-// Multi param, statement body
-mapWithIndex(arr, \(x, i) -> {
-  const y = x + i
-  return y
-})
 ```
+
+Inline blocks are **expression-only**. There is no multi-line or statement body form. For multi-line blocks, use the trailing `as` syntax.
 
 ### Existing trailing syntax (unchanged)
 
@@ -66,7 +56,7 @@ sample(5) as {
 ### Rules
 
 1. **Inline blocks can only appear as function call arguments.** They are parsed only inside function call argument lists. They cannot be assigned to variables or used as standalone expressions.
-2. **Expression bodies implicitly return.** `\x -> x + 1` wraps the expression in a synthetic return node. Statement bodies (with `{ }`) require explicit `return`.
+2. **Expression-only with implicit return.** `\x -> x + 1` wraps the expression in a synthetic return node. There is no statement body form — use the trailing `as` syntax for multi-line blocks.
 3. **Parens required for multiple params.** Single param: `\x -> ...`. Multiple params: `\(x, i) -> ...`. No params: `\ -> ...`.
 4. **Both syntaxes produce the same AST node** (`BlockArgument`), so the builder, type checker, and runtime require no changes.
 
@@ -76,13 +66,12 @@ sample(5) as {
 
 **New parser: `inlineBlockParser`** in `lib/parsers/parsers.ts`
 
-Parses `\ [params] -> expr_or_block`:
+Parses `\ [params] -> expression`:
 - Starts with `\` character (unambiguous prefix, no backtracking). Note: `\` is not currently a valid expression start in Agency (it only appears inside string/regex literals), so this is unambiguous today. This is a deliberate syntax choice inspired by Haskell's lambda syntax.
 - Params: either `(p1, p2, ...)` for multiple, a single identifier, or nothing (for `\ ->`)
 - `->` arrow separator
-- Body disambiguation: the parser tries **statement block first** (looks for `{` followed by statements), then falls back to **expression**. This resolves the `{` ambiguity between object literals and statement blocks — statement block wins. This matches the existing `as` block behavior where `{` always starts a block body.
-- For expression bodies: the expression parser naturally stops at `,` and `)` because these are not binary operators in Agency's `buildExpressionParser`. The expression `x + 1` in `\x -> x + 1, 42)` terminates at the comma because `sepBy` handles the comma as a separator between arguments, not as part of the expression. No special expression-termination logic is needed.
-- Expression bodies are wrapped in a synthetic `return` statement node to produce the same `body: AgencyNode[]` structure as statement blocks.
+- Body: a single expression. The expression parser naturally stops at `,` and `)` because these are not binary operators in Agency's `buildExpressionParser`. The expression `x + 1` in `\x -> x + 1, 42)` terminates at the comma because `sepBy` handles the comma as a separator between arguments, not as part of the expression. No special expression-termination logic is needed.
+- The expression is wrapped in a synthetic `return` statement node to produce the same `body: AgencyNode[]` structure as the trailing `as` blocks.
 - Type annotations on inline block params are not supported (same as existing `as` blocks — types come from the function signature).
 
 **Wire into function call parser:**
@@ -99,7 +88,7 @@ When an inline block is parsed as an argument within `sepBy`, the function call 
 
 ### AST changes
 
-None. `BlockArgument` already has `params: FunctionParameter[]` and `body: AgencyNode[]`. Expression bodies become a single-element `body` array containing a `return` statement node wrapping the parsed expression.
+None. `BlockArgument` already has `params: FunctionParameter[]` and `body: AgencyNode[]`. The expression body becomes a single-element `body` array containing a synthetic `return` statement node wrapping the parsed expression.
 
 ### Builder changes
 
@@ -129,8 +118,6 @@ Add to `lib/parsers/blockArgument.test.ts`:
 - `\x -> x + 1` — single param expression body
 - `\(x, i) -> x + i` — multi param expression body
 - `\ -> "hello"` — no param expression body
-- `\x -> { return x + 1 }` — single param statement body
-- `\(x, i) -> { return x + i }` — multi param statement body
 - Function call with inline block: `map(arr, \x -> x + 1)`
 - Function call with other args and inline block: `foo(1, "bar", \x -> x + 1)`
 - Inline block as non-last argument: `foo(\x -> x + 1, 42)` — allowed, block is moved to `FunctionCall.block` regardless of position
@@ -149,7 +136,6 @@ Add to `tests/typescriptGenerator/`:
 Add to `tests/agency/blocks/`:
 - `block-inline-basic.agency` / `.test.json` — inline block with expression body runs correctly
 - `block-inline-params.agency` / `.test.json` — inline block with multiple params
-- `block-inline-statement.agency` / `.test.json` — inline block with statement body
 - `block-inline-interrupt.agency` / `.test.json` — inline block that interrupts and resumes correctly
 
 ## Edge cases
@@ -158,5 +144,4 @@ Add to `tests/agency/blocks/`:
 - **Nested inline blocks:** `map(arr, \x -> filter(x.items, \y -> y > 0))` — works naturally since the inner block is inside a nested function call's argument list, which is a separate parsing context.
 - **Block as non-last argument:** `foo(\x -> x + 1, 42)` — allowed. The inline block can appear at any argument position. The parser post-processes to move it to `FunctionCall.block`.
 - **Expression body precedence:** In `\x -> x + 1, 42)`, the expression body is `x + 1`. The comma terminates the expression naturally because `,` is not a binary operator in Agency's expression parser. `sepBy` handles the comma as an argument separator. No special termination logic needed.
-- **`{` ambiguity (object literal vs statement block):** After `->`, the parser tries statement block first, then expression. So `\x -> { ... }` is always a statement block. To pass an object literal as the expression body, users would need to wrap it: `\x -> ({ key: value })`. This matches the behavior of JavaScript arrow functions and is unlikely to arise in practice since blocks typically return computed values, not object literals.
 - **Type annotations on params:** Not supported. Types are inferred from the function signature, same as the existing `as` syntax. `\(x: number) -> x + 1` is a parse error.

--- a/docs/superpowers/specs/2026-04-24-inline-block-syntax-design.md
+++ b/docs/superpowers/specs/2026-04-24-inline-block-syntax-design.md
@@ -1,0 +1,162 @@
+# Inline Block Syntax Design
+
+## Summary
+
+Add a new terse inline block syntax (`\x -> expr`) for passing blocks as function arguments, alongside the existing trailing `as` syntax. The new syntax places the block inside the function call parentheses and supports implicit-return expression bodies.
+
+## Motivation
+
+The current `as` syntax is verbose for simple operations like map/filter:
+
+```
+const arr2 = map(arr) as x {
+  return x + 1
+}
+```
+
+The new syntax makes one-liners concise:
+
+```
+const arr2 = map(arr, \x -> x + 1)
+```
+
+## Syntax
+
+### New inline block forms
+
+```
+// Single param, expression body (implicit return)
+map(arr, \x -> x + 1)
+
+// Multi param, expression body (parens required for multiple params)
+mapWithIndex(arr, \(x, i) -> x + i)
+
+// No params
+sample(5, \ -> "hello")
+
+// Single param, statement body (explicit return required)
+map(arr, \x -> {
+  const y = x + 1
+  return y
+})
+
+// Multi param, statement body
+mapWithIndex(arr, \(x, i) -> {
+  const y = x + i
+  return y
+})
+```
+
+### Existing trailing syntax (unchanged)
+
+```
+map(arr) as x {
+  return x + 1
+}
+
+retry(3) as (prev, attempt) {
+  return attempt + 1
+}
+
+sample(5) as {
+  return "hello"
+}
+```
+
+### Rules
+
+1. **Inline blocks can only appear as function call arguments.** They are parsed only inside function call argument lists. They cannot be assigned to variables or used as standalone expressions.
+2. **Expression bodies implicitly return.** `\x -> x + 1` wraps the expression in a synthetic return node. Statement bodies (with `{ }`) require explicit `return`.
+3. **Parens required for multiple params.** Single param: `\x -> ...`. Multiple params: `\(x, i) -> ...`. No params: `\ -> ...`.
+4. **Both syntaxes produce the same AST node** (`BlockArgument`), so the builder, type checker, and runtime require no changes.
+
+## Implementation
+
+### Parser changes
+
+**New parser: `inlineBlockParser`** in `lib/parsers/parsers.ts`
+
+Parses `\ [params] -> expr_or_block`:
+- Starts with `\` character (unambiguous prefix, no backtracking). Note: `\` is not currently a valid expression start in Agency (it only appears inside string/regex literals), so this is unambiguous today. This is a deliberate syntax choice inspired by Haskell's lambda syntax.
+- Params: either `(p1, p2, ...)` for multiple, a single identifier, or nothing (for `\ ->`)
+- `->` arrow separator
+- Body disambiguation: the parser tries **statement block first** (looks for `{` followed by statements), then falls back to **expression**. This resolves the `{` ambiguity between object literals and statement blocks — statement block wins. This matches the existing `as` block behavior where `{` always starts a block body.
+- For expression bodies: the expression parser naturally stops at `,` and `)` because these are not binary operators in Agency's `buildExpressionParser`. The expression `x + 1` in `\x -> x + 1, 42)` terminates at the comma because `sepBy` handles the comma as a separator between arguments, not as part of the expression. No special expression-termination logic is needed.
+- Expression bodies are wrapped in a synthetic `return` statement node to produce the same `body: AgencyNode[]` structure as statement blocks.
+- Type annotations on inline block params are not supported (same as existing `as` blocks — types come from the function signature).
+
+**Wire into function call parser:**
+
+Add `inlineBlockParser` as an alternative in the function call argument list's `sepBy`, alongside `namedArgumentParser`, `splatParser`, and `exprParser`. It must be tried before `exprParser` since `\` is not a valid expression start.
+
+When an inline block is parsed as an argument within `sepBy`, the function call parser post-processes the argument list: it scans for the `BlockArgument` node, removes it from the `arguments` array, and moves it to the `FunctionCall.block` field. This approach lets the inline block participate naturally in `sepBy`'s comma-separated parsing while producing the same `FunctionCall` structure the builder expects.
+
+**Only one block per call.** If the parser finds more than one `BlockArgument` in the argument list (or an inline block plus a trailing `as` block), it should produce a parse error. A function call may have at most one block.
+
+**Inline blocks can appear at any argument position.** Unlike the trailing `as` which is always after the closing `)`, an inline block can be the first, middle, or last argument. Positional information is not lost because the builder always places the block as the last positional arg to the callee regardless of where it appears syntactically.
+
+**Keep existing `blockArgumentParser`** for the trailing `as` syntax — no changes needed.
+
+### AST changes
+
+None. `BlockArgument` already has `params: FunctionParameter[]` and `body: AgencyNode[]`. Expression bodies become a single-element `body` array containing a `return` statement node wrapping the parsed expression.
+
+### Builder changes
+
+None. `processBlockArgument()` in `typescriptBuilder.ts` already converts any `BlockArgument` into an `AgencyFunction` positional argument. Both syntaxes produce the same AST, so the same code path handles both.
+
+### Type checker changes
+
+None expected. The type checker validates block params against the function signature's block type. Since the AST is identical, existing checks apply.
+
+### Symbol table and collectProgramInfo changes
+
+None. These phases operate on `BlockArgument` nodes which are unchanged. The inline block produces the same AST, so no changes are needed in `buildSymbolTable` or `collectProgramInfo`.
+
+### Preprocessor changes
+
+None expected. The preprocessor operates on `BlockArgument` nodes regardless of how they were parsed.
+
+### Formatter changes
+
+Out of scope for the initial implementation. The `AgencyGenerator` formatter will need to be updated to emit the inline block syntax, but this can be done as a follow-up. Initially, formatting an inline block may round-trip it to the trailing `as` form.
+
+## Testing
+
+### Parser unit tests
+
+Add to `lib/parsers/blockArgument.test.ts`:
+- `\x -> x + 1` — single param expression body
+- `\(x, i) -> x + i` — multi param expression body
+- `\ -> "hello"` — no param expression body
+- `\x -> { return x + 1 }` — single param statement body
+- `\(x, i) -> { return x + i }` — multi param statement body
+- Function call with inline block: `map(arr, \x -> x + 1)`
+- Function call with other args and inline block: `foo(1, "bar", \x -> x + 1)`
+- Inline block as non-last argument: `foo(\x -> x + 1, 42)` — allowed, block is moved to `FunctionCall.block` regardless of position
+- **Negative tests:**
+  - Two inline blocks in one call: `foo(\x -> x + 1, \y -> y * 2)` — should produce parse error
+  - Inline block plus trailing `as` block: `map(arr, \x -> x + 1) as y { return y }` — should produce parse error
+
+### Integration test fixtures
+
+Add to `tests/typescriptGenerator/`:
+- `inlineBlockBasic.agency` / `.mjs` — inline block with expression body
+- `inlineBlockParams.agency` / `.mjs` — inline block with multiple params
+
+### Agency execution tests
+
+Add to `tests/agency/blocks/`:
+- `block-inline-basic.agency` / `.test.json` — inline block with expression body runs correctly
+- `block-inline-params.agency` / `.test.json` — inline block with multiple params
+- `block-inline-statement.agency` / `.test.json` — inline block with statement body
+- `block-inline-interrupt.agency` / `.test.json` — inline block that interrupts and resumes correctly
+
+## Edge cases
+
+- **Multiple blocks in one call:** A function call may have at most one block (whether inline or trailing). Two inline blocks or an inline block plus a trailing `as` block produce a parse error.
+- **Nested inline blocks:** `map(arr, \x -> filter(x.items, \y -> y > 0))` — works naturally since the inner block is inside a nested function call's argument list, which is a separate parsing context.
+- **Block as non-last argument:** `foo(\x -> x + 1, 42)` — allowed. The inline block can appear at any argument position. The parser post-processes to move it to `FunctionCall.block`.
+- **Expression body precedence:** In `\x -> x + 1, 42)`, the expression body is `x + 1`. The comma terminates the expression naturally because `,` is not a binary operator in Agency's expression parser. `sepBy` handles the comma as an argument separator. No special termination logic needed.
+- **`{` ambiguity (object literal vs statement block):** After `->`, the parser tries statement block first, then expression. So `\x -> { ... }` is always a statement block. To pass an object literal as the expression body, users would need to wrap it: `\x -> ({ key: value })`. This matches the behavior of JavaScript arrow functions and is unlikely to arise in practice since blocks typically return computed values, not object literals.
+- **Type annotations on params:** Not supported. Types are inferred from the function signature, same as the existing `as` syntax. `\(x: number) -> x + 1` is a parse error.

--- a/docs/superpowers/specs/2026-04-24-inline-block-syntax-design.md
+++ b/docs/superpowers/specs/2026-04-24-inline-block-syntax-design.md
@@ -58,7 +58,7 @@ sample(5) as {
 1. **Inline blocks can only appear as function call arguments.** They are parsed only inside function call argument lists. They cannot be assigned to variables or used as standalone expressions.
 2. **Expression-only with implicit return.** `\x -> x + 1` wraps the expression in a synthetic return node. There is no statement body form — use the trailing `as` syntax for multi-line blocks.
 3. **Parens required for multiple params.** Single param: `\x -> ...`. Multiple params: `\(x, i) -> ...`. No params: `\ -> ...`.
-4. **Both syntaxes produce the same AST node** (`BlockArgument`), so the builder, type checker, and runtime require no changes.
+4. **Both syntaxes produce the same AST node** (`BlockArgument`), with a new `inline: boolean` field to distinguish them. The builder, type checker, and runtime don't need changes (they don't care about the distinction), but the formatter (`AgencyGenerator`) will use `inline` to know which syntax to emit.
 
 ## Implementation
 
@@ -88,7 +88,7 @@ When an inline block is parsed as an argument within `sepBy`, the function call 
 
 ### AST changes
 
-None. `BlockArgument` already has `params: FunctionParameter[]` and `body: AgencyNode[]`. The expression body becomes a single-element `body` array containing a synthetic `return` statement node wrapping the parsed expression.
+Add an `inline: boolean` field to `BlockArgument` in `lib/types/blockArgument.ts`. Set to `true` for inline blocks (`\x -> expr`), `false` for trailing `as` blocks. The body representation is unchanged — `params: FunctionParameter[]` and `body: AgencyNode[]`. The expression body becomes a single-element `body` array containing a synthetic `return` statement node wrapping the parsed expression.
 
 ### Builder changes
 

--- a/foo.agency
+++ b/foo.agency
@@ -1,3 +1,5 @@
-import { add } from "std::math"
-import { greet } from "./bar.agency"
-import * as bar from "./bar.agency"
+node main() {
+  const arr = range(5)
+  const doubles = map(arr, \x -> x * 2)
+  print( doubles)
+}

--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -556,26 +556,41 @@ export class AgencyGenerator {
 
     if (node.block) {
       const block = node.block;
-      let asClause = "as ";
-      if (block.params.length === 1) {
-        asClause = `as ${block.params[0].name} `;
-      } else if (block.params.length > 1) {
-        asClause = `as (${block.params.map((p) => p.name).join(", ")}) `;
-      }
 
-      this.increaseIndent();
-      const bodyLines: string[] = [];
-      for (const stmt of block.body) {
-        bodyLines.push(this.processNode(stmt));
-      }
-      this.decreaseIndent();
-      const bodyStr =
-        bodyLines
-          .filter((s) => s !== "")
-          .join("\n")
-          .trimEnd() + "\n";
+      if (block.inline) {
+        // Inline block: \params -> expr
+        const returnStmt = block.body[0] as ReturnStatement;
+        const exprStr = this.processNode(returnStmt.value!).trim();
+        let params = "";
+        if (block.params.length === 1) {
+          params = block.params[0].name;
+        } else if (block.params.length > 1) {
+          params = `(${block.params.map((p) => p.name).join(", ")})`;
+        }
+        // Rewrite result to include inline block as an argument
+        result = `${asyncPrefix}${node.functionName}(${[...args, `\\${params} -> ${exprStr}`].join(", ")})`;
+      } else {
+        let asClause = "as ";
+        if (block.params.length === 1) {
+          asClause = `as ${block.params[0].name} `;
+        } else if (block.params.length > 1) {
+          asClause = `as (${block.params.map((p) => p.name).join(", ")}) `;
+        }
 
-      result += ` ${asClause}{\n${bodyStr}${this.indentStr("}")}`;
+        this.increaseIndent();
+        const bodyLines: string[] = [];
+        for (const stmt of block.body) {
+          bodyLines.push(this.processNode(stmt));
+        }
+        this.decreaseIndent();
+        const bodyStr =
+          bodyLines
+            .filter((s) => s !== "")
+            .join("\n")
+            .trimEnd() + "\n";
+
+        result += ` ${asClause}{\n${bodyStr}${this.indentStr("}")}`;
+      }
     }
 
     return result;

--- a/lib/parsers/blockArgument.test.ts
+++ b/lib/parsers/blockArgument.test.ts
@@ -243,6 +243,20 @@ describe("function call with block argument", () => {
     }
   });
 
+  it("fails when function call has two inline blocks", () => {
+    const input = String.raw`foo(\x -> x + 1, \y -> y * 2)`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(false);
+  });
+
+  it("fails when function call has inline block and trailing as block", () => {
+    const input = `map(arr, \\x -> x + 1) as y {
+  return y
+}`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(false);
+  });
+
   it("parses function call without block (no block field)", () => {
     const result = functionCallParser("foo(1, 2)");
     expect(result.success).toBe(true);

--- a/lib/parsers/blockArgument.test.ts
+++ b/lib/parsers/blockArgument.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { blockArgumentParser } from "./parsers.js";
+import { blockArgumentParser, inlineBlockParser } from "./parsers.js";
 import { functionCallParser } from "./parsers.js";
 
 describe("blockArgumentParser", () => {
@@ -59,6 +59,70 @@ describe("blockArgumentParser", () => {
 }`;
     const result = blockArgumentParser(input);
     expect(result.success).toBe(false);
+  });
+});
+
+describe("inlineBlockParser", () => {
+  it("parses single param with expression body", () => {
+    const input = String.raw`\x -> x + 1`;
+    const result = inlineBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.type).toBe("blockArgument");
+      expect(result.result.inline).toBe(true);
+      expect(result.result.params).toHaveLength(1);
+      expect(result.result.params[0].name).toBe("x");
+      // Body should be a single return statement wrapping the expression
+      expect(result.result.body).toHaveLength(1);
+      expect(result.result.body[0].type).toBe("returnStatement");
+    }
+  });
+
+  it("parses multi param with expression body", () => {
+    const input = String.raw`\(x, i) -> x + i`;
+    const result = inlineBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.inline).toBe(true);
+      expect(result.result.params).toHaveLength(2);
+      expect(result.result.params[0].name).toBe("x");
+      expect(result.result.params[1].name).toBe("i");
+      expect(result.result.body).toHaveLength(1);
+      expect(result.result.body[0].type).toBe("returnStatement");
+    }
+  });
+
+  it("parses no params with expression body", () => {
+    const input = String.raw`\ -> "hello"`;
+    const result = inlineBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.inline).toBe(true);
+      expect(result.result.params).toHaveLength(0);
+      expect(result.result.body).toHaveLength(1);
+      expect(result.result.body[0].type).toBe("returnStatement");
+    }
+  });
+
+  it("stops expression body at comma", () => {
+    const input = String.raw`\x -> x + 1, 42`;
+    const result = inlineBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.body).toHaveLength(1);
+      // The rest should contain ", 42"
+      expect(result.rest.trim()).toBe(", 42");
+    }
+  });
+
+  it("stops expression body at closing paren", () => {
+    const input = String.raw`\x -> x + 1)`;
+    const result = inlineBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.body).toHaveLength(1);
+      expect(result.rest).toBe(")");
+    }
   });
 });
 

--- a/lib/parsers/blockArgument.test.ts
+++ b/lib/parsers/blockArgument.test.ts
@@ -169,6 +169,80 @@ describe("function call with block argument", () => {
     }
   });
 
+  it("parses function call with inline block as last arg", () => {
+    const input = String.raw`map(arr, \x -> x + 1)`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.functionName).toBe("map");
+      expect(result.result.arguments).toHaveLength(1); // just 'arr'
+      expect(result.result.block).toBeDefined();
+      expect(result.result.block!.inline).toBe(true);
+      expect(result.result.block!.params).toHaveLength(1);
+      expect(result.result.block!.params[0].name).toBe("x");
+    }
+  });
+
+  it("parses function call with inline block and multiple regular args", () => {
+    const input = String.raw`foo(1, "bar", \x -> x + 1)`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.functionName).toBe("foo");
+      expect(result.result.arguments).toHaveLength(2); // 1 and "bar"
+      expect(result.result.block).toBeDefined();
+      expect(result.result.block!.inline).toBe(true);
+    }
+  });
+
+  it("parses function call with inline block as non-last arg", () => {
+    const input = String.raw`foo(\x -> x + 1, 42)`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.functionName).toBe("foo");
+      expect(result.result.arguments).toHaveLength(1); // just 42
+      expect(result.result.block).toBeDefined();
+      expect(result.result.block!.inline).toBe(true);
+    }
+  });
+
+  it("parses function call with multi-param inline block", () => {
+    const input = String.raw`mapWithIndex(arr, \(x, i) -> x + i)`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.arguments).toHaveLength(1); // just 'arr'
+      expect(result.result.block).toBeDefined();
+      expect(result.result.block!.params).toHaveLength(2);
+      expect(result.result.block!.params[0].name).toBe("x");
+      expect(result.result.block!.params[1].name).toBe("i");
+    }
+  });
+
+  it("parses function call with no-param inline block", () => {
+    const input = String.raw`sample(5, \ -> "hello")`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.arguments).toHaveLength(1); // just 5
+      expect(result.result.block).toBeDefined();
+      expect(result.result.block!.params).toHaveLength(0);
+    }
+  });
+
+  it("parses nested inline blocks in nested function calls", () => {
+    const input = String.raw`map(arr, \x -> filter(x, \y -> y > 0))`;
+    const result = functionCallParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.functionName).toBe("map");
+      expect(result.result.block).toBeDefined();
+      const returnStmt = result.result.block!.body[0];
+      expect(returnStmt.type).toBe("returnStatement");
+    }
+  });
+
   it("parses function call without block (no block field)", () => {
     const result = functionCallParser("foo(1, 2)");
     expect(result.success).toBe(true);

--- a/lib/parsers/blockArgument.test.ts
+++ b/lib/parsers/blockArgument.test.ts
@@ -110,6 +110,9 @@ describe("inlineBlockParser", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.result.body).toHaveLength(1);
+      // Verify the expression is x + 1 (a binop), not just x
+      const returnStmt = result.result.body[0] as any;
+      expect(returnStmt.value.type).toBe("binOpExpression");
       // The rest should contain ", 42"
       expect(result.rest.trim()).toBe(", 42");
     }
@@ -121,6 +124,9 @@ describe("inlineBlockParser", () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.result.body).toHaveLength(1);
+      // Verify the expression is x + 1 (a binop), not just x
+      const returnStmt = result.result.body[0] as any;
+      expect(returnStmt.value.type).toBe("binOpExpression");
       expect(result.rest).toBe(")");
     }
   });
@@ -238,8 +244,17 @@ describe("function call with block argument", () => {
     if (result.success) {
       expect(result.result.functionName).toBe("map");
       expect(result.result.block).toBeDefined();
-      const returnStmt = result.result.block!.body[0];
+      const returnStmt = result.result.block!.body[0] as any;
       expect(returnStmt.type).toBe("returnStatement");
+      // The return value should be the inner function call to filter
+      const innerCall = returnStmt.value;
+      expect(innerCall.type).toBe("functionCall");
+      expect(innerCall.functionName).toBe("filter");
+      // filter should have its own inline block
+      expect(innerCall.block).toBeDefined();
+      expect(innerCall.block.inline).toBe(true);
+      expect(innerCall.block.params).toHaveLength(1);
+      expect(innerCall.block.params[0].name).toBe("y");
     }
   });
 

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1685,6 +1685,7 @@ export const blockArgumentParser: Parser<BlockArgument> = trace(
   "blockArgumentParser",
   seqC(
     set("type", "blockArgument"),
+    set("inline", false),
     str("as"),
     spaces,
     capture(blockParamsParser, "params"),

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1132,8 +1132,12 @@ const namedArgumentParser: Parser<NamedArgument> = trace(
   ),
 );
 
+type FunctionCallWithBlock = Omit<FunctionCall, "arguments"> & {
+  arguments: (Expression | SplatExpression | NamedArgument | BlockArgument)[]
+}
+
 export const _functionCallParser: Parser<FunctionCall> = (input: string) => {
-  const parser = seqC(
+  const parser: Parser<FunctionCallWithBlock> = seqC(
     set("type", "functionCall"),
     capture(many1WithJoin(varNameChar), "functionName"),
     char("("),
@@ -1144,6 +1148,7 @@ export const _functionCallParser: Parser<FunctionCall> = (input: string) => {
         or(
           namedArgumentParser,
           splatParser,
+          lazy(() => inlineBlockParser),
           lazy(() => exprParser),
         ),
       ),
@@ -1162,7 +1167,30 @@ export const _functionCallParser: Parser<FunctionCall> = (input: string) => {
     optionalSemicolon,
     optionalSpacesOrNewline
   );
-  return parser(input);
+  const result = parser(input);
+  if (!result.success) return result;
+
+  // Post-process: move inline block from arguments to block field
+  const funcCall = result.result;
+  const args = funcCall.arguments;
+  const blockIndex = args.findIndex((a) => a.type === "blockArgument");
+  if (blockIndex !== -1) {
+    if (funcCall.block) {
+      return failure("A function call cannot have both an inline block and a trailing 'as' block", input);
+    }
+
+    const inlineBlock = args[blockIndex] as BlockArgument;
+    args.splice(blockIndex, 1);
+    funcCall.block = inlineBlock;
+
+    // Check for multiple inline blocks
+    const secondBlock = args.findIndex((a: any) => a.type === "blockArgument");
+    if (secondBlock !== -1) {
+      return failure("A function call cannot have more than one block argument", input);
+    }
+  }
+
+  return result as ParserResult<FunctionCall>;
 };
 
 // functionCallParser is now just _functionCallParser (no async/sync wrappers - handled by valueAccessParser)

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1725,30 +1725,25 @@ export const blockArgumentParser: Parser<BlockArgument> = trace(
 //   \(x, i) -> x + i      — multiple params
 //   \ -> "hello"           — no params
 // Expression-only: the expression is wrapped in a synthetic return statement.
-const _inlineBlockInner = seqC(
-  char("\\"),
-  optionalSpaces,
-  capture(blockParamsParser, "params"),
-  optionalSpaces,
-  str("->"),
-  optionalSpaces,
-  capture(lazy(() => exprParser), "expr"),
-);
-
 export const inlineBlockParser: Parser<BlockArgument> = trace(
   "inlineBlockParser",
-  (input: string): ParserResult<BlockArgument> => {
-    const result = _inlineBlockInner(input);
-    if (!result.success) return result;
-
-    const returnNode: ReturnStatement = { type: "returnStatement", value: result.result.expr };
-    return success({
-      type: "blockArgument",
+  map(
+    seqC(
+      char("\\"),
+      optionalSpaces,
+      capture(blockParamsParser, "params"),
+      optionalSpaces,
+      str("->"),
+      optionalSpaces,
+      capture(lazy(() => exprParser), "expr"),
+    ),
+    (result) => ({
+      type: "blockArgument" as const,
       inline: true,
-      params: result.result.params,
-      body: [returnNode],
-    } as BlockArgument, result.rest);
-  },
+      params: result.params,
+      body: [{ type: "returnStatement", value: result.expr } as ReturnStatement],
+    }),
+  ),
 );
 
 // =============================================================================

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1698,6 +1698,40 @@ export const blockArgumentParser: Parser<BlockArgument> = trace(
   ),
 );
 
+// Parse an inline block argument: \params -> expression
+//   \x -> x + 1           — single param
+//   \(x, i) -> x + i      — multiple params
+//   \ -> "hello"           — no params
+// Expression-only: the expression is wrapped in a synthetic return statement.
+export const inlineBlockParser: Parser<BlockArgument> = trace(
+  "inlineBlockParser",
+  (input: string): ParserResult<BlockArgument> => {
+    const parser = seqC(
+      set("type", "blockArgument"),
+      set("inline", true),
+      char("\\"),
+      optionalSpaces,
+      capture(blockParamsParser, "params"),
+      optionalSpaces,
+      str("->"),
+      optionalSpaces,
+      capture(lazy(() => exprParser), "__expr"),
+    );
+    const result = parser(input);
+    if (!result.success) return result;
+
+    // Wrap the expression in a synthetic return statement
+    const expr = result.result.__expr;
+    const returnNode: ReturnStatement = { type: "returnStatement", value: expr };
+    return success({
+      type: "blockArgument",
+      inline: true,
+      params: result.result.params,
+      body: [returnNode],
+    } as BlockArgument, result.rest);
+  },
+);
+
 // =============================================================================
 // matchBlock.ts
 // =============================================================================

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1172,22 +1172,16 @@ export const _functionCallParser: Parser<FunctionCall> = (input: string) => {
 
   // Post-process: move inline block from arguments to block field
   const funcCall = result.result;
-  const args = funcCall.arguments;
-  const blockIndex = args.findIndex((a) => a.type === "blockArgument");
-  if (blockIndex !== -1) {
+  const inlineBlocks = funcCall.arguments.filter((a) => a.type === "blockArgument") as BlockArgument[];
+  if (inlineBlocks.length > 1) {
+    return failure("A function call cannot have more than one block argument", input);
+  }
+  if (inlineBlocks.length === 1) {
     if (funcCall.block) {
       return failure("A function call cannot have both an inline block and a trailing 'as' block", input);
     }
-
-    const inlineBlock = args[blockIndex] as BlockArgument;
-    args.splice(blockIndex, 1);
-    funcCall.block = inlineBlock;
-
-    // Check for multiple inline blocks
-    const secondBlock = args.findIndex((a: any) => a.type === "blockArgument");
-    if (secondBlock !== -1) {
-      return failure("A function call cannot have more than one block argument", input);
-    }
+    funcCall.block = inlineBlocks[0];
+    funcCall.arguments = funcCall.arguments.filter((a) => a.type !== "blockArgument");
   }
 
   return result as ParserResult<FunctionCall>;
@@ -1731,26 +1725,23 @@ export const blockArgumentParser: Parser<BlockArgument> = trace(
 //   \(x, i) -> x + i      — multiple params
 //   \ -> "hello"           — no params
 // Expression-only: the expression is wrapped in a synthetic return statement.
+const _inlineBlockInner = seqC(
+  char("\\"),
+  optionalSpaces,
+  capture(blockParamsParser, "params"),
+  optionalSpaces,
+  str("->"),
+  optionalSpaces,
+  capture(lazy(() => exprParser), "expr"),
+);
+
 export const inlineBlockParser: Parser<BlockArgument> = trace(
   "inlineBlockParser",
   (input: string): ParserResult<BlockArgument> => {
-    const parser = seqC(
-      set("type", "blockArgument"),
-      set("inline", true),
-      char("\\"),
-      optionalSpaces,
-      capture(blockParamsParser, "params"),
-      optionalSpaces,
-      str("->"),
-      optionalSpaces,
-      capture(lazy(() => exprParser), "__expr"),
-    );
-    const result = parser(input);
+    const result = _inlineBlockInner(input);
     if (!result.success) return result;
 
-    // Wrap the expression in a synthetic return statement
-    const expr = result.result.__expr;
-    const returnNode: ReturnStatement = { type: "returnStatement", value: expr };
+    const returnNode: ReturnStatement = { type: "returnStatement", value: result.result.expr };
     return success({
       type: "blockArgument",
       inline: true,

--- a/lib/types/blockArgument.ts
+++ b/lib/types/blockArgument.ts
@@ -6,4 +6,5 @@ export type BlockArgument = BaseNode & {
   type: "blockArgument";
   params: FunctionParameter[];
   body: AgencyNode[];
+  inline?: boolean;
 };

--- a/tests/agency/blocks/block-inline-basic.agency
+++ b/tests/agency/blocks/block-inline-basic.agency
@@ -1,0 +1,10 @@
+def twice(block: () => string): string[] {
+  let a: string = block()
+  let b: string = block()
+  return [a, b]
+}
+
+node main() {
+  let results = twice(\ -> "hello")
+  return results
+}

--- a/tests/agency/blocks/block-inline-basic.test.json
+++ b/tests/agency/blocks/block-inline-basic.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[\"hello\",\"hello\"]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "Inline block with no params called twice returns two hello strings"
+    }
+  ]
+}

--- a/tests/agency/blocks/block-inline-interrupt.agency
+++ b/tests/agency/blocks/block-inline-interrupt.agency
@@ -1,0 +1,14 @@
+def withApproval(block: () => string): string {
+  let result = block()
+  return result
+}
+
+def getApproval(): string {
+  interrupt("please approve")
+  return "approved"
+}
+
+node main() {
+  let result = withApproval(\ -> getApproval())
+  return result
+}

--- a/tests/agency/blocks/block-inline-interrupt.test.json
+++ b/tests/agency/blocks/block-inline-interrupt.test.json
@@ -1,0 +1,20 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"approved\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "Inline block that interrupts resumes correctly after approval",
+      "interruptHandlers": [
+        {
+          "action": "approve"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/agency/blocks/block-inline-params.agency
+++ b/tests/agency/blocks/block-inline-params.agency
@@ -1,0 +1,14 @@
+def mapItems(items: any[], block: (any) => any): any[] {
+  let results: any[] = []
+  for (item in items) {
+    let result = block(item)
+    results = results.concat([result])
+  }
+  return results
+}
+
+node main() {
+  let items = [1, 2, 3]
+  let doubled = mapItems(items, \x -> x * 2)
+  return doubled
+}

--- a/tests/agency/blocks/block-inline-params.test.json
+++ b/tests/agency/blocks/block-inline-params.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[2,4,6]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "Inline block with params maps items by doubling them"
+    }
+  ]
+}

--- a/tests/typescriptGenerator/inlineBlockBasic.agency
+++ b/tests/typescriptGenerator/inlineBlockBasic.agency
@@ -1,0 +1,10 @@
+def twice(block: () => string): string[] {
+  let a: string = block()
+  let b: string = block()
+  return [a, b]
+}
+
+node main() {
+  let results = twice(\ -> "hello")
+  print(results)
+}

--- a/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -1,0 +1,363 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl,
+  interrupt, isInterrupt, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupt as _respondToInterrupt,
+  approveInterrupt as _approveInterrupt,
+  rejectInterrupt as _rejectInterrupt,
+  resolveInterrupt as _resolveInterrupt,
+  modifyInterrupt as _modifyInterrupt,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  deepClone as __deepClone,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  AgencyFunction as __AgencyFunction, UNSET as __UNSET,
+  __call, __callMethod,
+  functionRefReviver as __functionRefReviver,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  traceConfig: {
+    program: "inlineBlockBasic.agency"
+  }
+});
+const graph = __globalCtx.graph;
+
+// Path-dependent builtin wrappers
+export function readSkill({filepath}: {filepath: string}): string {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+
+// Handler result builtins
+function approve(value?: any) { return { type: "approved" as const, value }; }
+function reject(value?: any) { return { type: "rejected" as const, value }; }
+function propagate() { return { type: "propagated" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, isDebugger };
+export const respondToInterrupt = (interrupt: Interrupt, response: InterruptResponse, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupt({ ctx: __globalCtx, interrupt, interruptResponse: response, overrides: opts?.overrides, metadata: opts?.metadata });
+export const approveInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _approveInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rejectInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _rejectInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const modifyInterrupt = (interrupt: Interrupt, newArguments: Record<string, any>, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _modifyInterrupt({ ctx: __globalCtx, interrupt, newArguments, overrides: opts?.overrides, metadata: opts?.metadata });
+export const resolveInterrupt = (interrupt: Interrupt, value: any, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _resolveInterrupt({ ctx: __globalCtx, interrupt, value, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+
+const __toolRegistry: Record<string, any> = {};
+
+function __registerTool(value: unknown, name?: string) {
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[name ?? value.name] = value;
+  }
+}
+
+// Wrap stateful runtime functions as AgencyFunction instances
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "options", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+async function mcp(serverName: string) {
+  return __globalCtx.mcpManager.getTools(serverName);
+}
+
+function setLLMClient(client: LLMClient) {
+  __globalCtx.setLLMClient(client);
+}
+
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("inlineBlockBasic.agency")
+}
+__toolRegistry["readSkill"] = __AgencyFunction.create({
+  name: "readSkill",
+  module: "inlineBlockBasic.agency",
+  fn: readSkill,
+  params: __readSkillToolParams.map(p => ({ name: p, hasDefault: false, defaultValue: undefined, variadic: false })),
+  toolDefinition: __readSkillTool,
+}, __toolRegistry);
+__functionRefReviver.registry = __toolRegistry;
+async function __twice_impl(block: () => string, __state: InternalFunctionState | undefined = undefined) {
+  const __setupData = setupFunction({
+    state: __state
+  });
+  // __state will be undefined if this function is being called as a tool by an llm
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state?.ctx || __globalCtx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("inlineBlockBasic.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onFunctionStart",
+    data: {
+      functionName: "twice",
+      args: {
+        block: block
+      },
+      isBuiltin: false,
+      moduleId: "inlineBlockBasic.agency"
+    }
+  })
+  __stack.args["block"] = block;
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "inlineBlockBasic.agency", scopeName: "twice" });
+  let __resultCheckpointId = -1;
+if (__ctx.stateStack.currentNodeId()) {
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__ctx, { moduleId: "inlineBlockBasic.agency", scopeName: "twice", stepPath: "", label: "result-entry" });
+}
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+  if ("block" in __overrides) {
+    block = __overrides["block"];
+    __stack.args["block"] = block;
+  }
+
+}
+
+  try {
+    await runner.step(0, async (runner) => {
+__stack.locals.a = await __call(__stack.args.block, {
+        type: "positional",
+        args: []
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        interruptData: __state?.interruptData
+      });
+if (isInterrupt(__stack.locals.a)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt(__stack.locals.a)
+        return;
+      }
+    });
+    await runner.step(1, async (runner) => {
+__stack.locals.b = await __call(__stack.args.block, {
+        type: "positional",
+        args: []
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        interruptData: __state?.interruptData
+      });
+if (isInterrupt(__stack.locals.b)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt(__stack.locals.b)
+        return;
+      }
+    });
+    await runner.step(2, async (runner) => {
+__functionCompleted = true;
+runner.halt([__stack.locals.a, __stack.locals.b])
+return;
+    });
+    if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: __ctx.getResultCheckpoint(),
+    retryable: __self.__retryable,
+    functionName: "twice",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    if (!__state?.isForked) { __ctx.stateStack.pop() }
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "twice",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
+const twice = __AgencyFunction.create({
+  name: "twice",
+  module: "inlineBlockBasic.agency",
+  fn: __twice_impl,
+  params: [],
+  toolDefinition: {
+    name: "twice",
+    description: `No description provided.`,
+    schema: z.object({})
+  }
+}, __toolRegistry);
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state.ctx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onNodeStart",
+    data: {
+      nodeName: "main"
+    }
+  })
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "inlineBlockBasic.agency", scopeName: "main" });
+  try {
+    await runner.step(0, async (runner) => {
+__stack.locals.results = await __call(twice, {
+        type: "positional",
+        args: [__AgencyFunction.create({ name: "__block_0", module: "inlineBlockBasic.agency", fn: async () => {
+          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads } });
+const __bstack = __bsetup.stack;
+const __self = __bstack.locals;
+
+const runner = new Runner(__ctx, __bstack, { state: __bstack, moduleId: "inlineBlockBasic.agency", scopeName: "__block_0" });
+try {
+await runner.step(0, async (runner) => {
+runner.halt(`hello`)
+return;
+  });
+return runner.halted ? runner.haltResult : undefined;
+} finally {
+__ctx.stateStack.pop();
+}
+        }, params: [], toolDefinition: null }, __toolRegistry)]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        interruptData: __state?.interruptData
+      });
+if (isInterrupt(__stack.locals.results)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __stack.locals.results
+        })
+        return;
+      }
+    });
+    await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+        type: "positional",
+        args: [__stack.locals.results]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        interruptData: __state?.interruptData
+      });
+if (isInterrupt(__funcResult)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __funcResult
+        })
+        return;
+      }
+    });
+    if (runner.halted) return runner.haltResult;
+    await callHook({
+      callbacks: __ctx.callbacks,
+      name: "onNodeEnd",
+      data: {
+        nodeName: "main",
+        data: undefined
+      }
+    })
+    return {
+      messages: __threads,
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    console.error(`\nAgent crashed: ${__error.message}`)
+    return {
+      messages: __threads,
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}): Promise<RunNodeResult<any>> {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    await main(initialState)
+  } catch (__error: any) {
+    console.error(`\nAgent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"inlineBlockBasic.agency:twice":{"0":{"line":-1,"col":2},"1":{"line":0,"col":2},"2":{"line":1,"col":2}},"inlineBlockBasic.agency:main":{"0":{"line":5,"col":2},"1":{"line":6,"col":2}},"inlineBlockBasic.agency:__block_0":{}};

--- a/tests/typescriptGenerator/inlineBlockParams.agency
+++ b/tests/typescriptGenerator/inlineBlockParams.agency
@@ -1,0 +1,14 @@
+def mapItems(items: any[], block: (any) => any): any[] {
+  let results: any[] = []
+  for (item in items) {
+    let result = block(item)
+    results = results.concat([result])
+  }
+  return results
+}
+
+node main() {
+  let items = [1, 2, 3]
+  let doubled = mapItems(items, \x -> x * 2)
+  return doubled
+}

--- a/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -1,0 +1,368 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, RewindCheckpoint, LLMClient } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl,
+  interrupt, isInterrupt, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupt as _respondToInterrupt,
+  approveInterrupt as _approveInterrupt,
+  rejectInterrupt as _rejectInterrupt,
+  resolveInterrupt as _resolveInterrupt,
+  modifyInterrupt as _modifyInterrupt,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  deepClone as __deepClone,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  AgencyFunction as __AgencyFunction, UNSET as __UNSET,
+  __call, __callMethod,
+  functionRefReviver as __functionRefReviver,
+} from "agency-lang/runtime";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  traceConfig: {
+    program: "inlineBlockParams.agency"
+  }
+});
+const graph = __globalCtx.graph;
+
+// Path-dependent builtin wrappers
+export function readSkill({filepath}: {filepath: string}): string {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+
+// Handler result builtins
+function approve(value?: any) { return { type: "approved" as const, value }; }
+function reject(value?: any) { return { type: "rejected" as const, value }; }
+function propagate() { return { type: "propagated" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, isDebugger };
+export const respondToInterrupt = (interrupt: Interrupt, response: InterruptResponse, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupt({ ctx: __globalCtx, interrupt, interruptResponse: response, overrides: opts?.overrides, metadata: opts?.metadata });
+export const approveInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _approveInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rejectInterrupt = (interrupt: Interrupt, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _rejectInterrupt({ ctx: __globalCtx, interrupt, overrides: opts?.overrides, metadata: opts?.metadata });
+export const modifyInterrupt = (interrupt: Interrupt, newArguments: Record<string, any>, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _modifyInterrupt({ ctx: __globalCtx, interrupt, newArguments, overrides: opts?.overrides, metadata: opts?.metadata });
+export const resolveInterrupt = (interrupt: Interrupt, value: any, opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _resolveInterrupt({ ctx: __globalCtx, interrupt, value, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rewindFrom = (checkpoint: RewindCheckpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+
+const __toolRegistry: Record<string, any> = {};
+
+function __registerTool(value: unknown, name?: string) {
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[name ?? value.name] = value;
+  }
+}
+
+// Wrap stateful runtime functions as AgencyFunction instances
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "options", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+async function mcp(serverName: string) {
+  return __globalCtx.mcpManager.getTools(serverName);
+}
+
+function setLLMClient(client: LLMClient) {
+  __globalCtx.setLLMClient(client);
+}
+
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("inlineBlockParams.agency")
+}
+__toolRegistry["readSkill"] = __AgencyFunction.create({
+  name: "readSkill",
+  module: "inlineBlockParams.agency",
+  fn: readSkill,
+  params: __readSkillToolParams.map(p => ({ name: p, hasDefault: false, defaultValue: undefined, variadic: false })),
+  toolDefinition: __readSkillTool,
+}, __toolRegistry);
+__functionRefReviver.registry = __toolRegistry;
+async function __mapItems_impl(items: any[], block: (any) => any, __state: InternalFunctionState | undefined = undefined) {
+  const __setupData = setupFunction({
+    state: __state
+  });
+  // __state will be undefined if this function is being called as a tool by an llm
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state?.ctx || __globalCtx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("inlineBlockParams.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onFunctionStart",
+    data: {
+      functionName: "mapItems",
+      args: {
+        items: items,
+        block: block
+      },
+      isBuiltin: false,
+      moduleId: "inlineBlockParams.agency"
+    }
+  })
+  __stack.args["items"] = items;
+  __stack.args["block"] = block;
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "inlineBlockParams.agency", scopeName: "mapItems" });
+  let __resultCheckpointId = -1;
+if (__ctx.stateStack.currentNodeId()) {
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__ctx, { moduleId: "inlineBlockParams.agency", scopeName: "mapItems", stepPath: "", label: "result-entry" });
+}
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+  if ("items" in __overrides) {
+    items = __overrides["items"];
+    __stack.args["items"] = items;
+  }
+  if ("block" in __overrides) {
+    block = __overrides["block"];
+    __stack.args["block"] = block;
+  }
+
+}
+
+  try {
+    await runner.step(0, async (runner) => {
+__stack.locals.results = [];
+    });
+    await runner.loop(1, __stack.args.items, async (item, _, runner) => {
+await runner.step(0, async (runner) => {
+__stack.locals.result = await __call(__stack.args.block, {
+          type: "positional",
+          args: [item]
+        }, {
+          ctx: __ctx,
+          threads: __threads,
+          interruptData: __state?.interruptData
+        });
+if (isInterrupt(__stack.locals.result)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.result)
+          return;
+        }
+      });
+await runner.step(1, async (runner) => {
+__stack.locals.results = await __callMethod(__stack.locals.results, "concat", {
+          type: "positional",
+          args: [[__stack.locals.result]]
+        }, {
+          ctx: __ctx,
+          threads: __threads,
+          interruptData: __state?.interruptData
+        });
+      });
+    });
+    await runner.step(2, async (runner) => {
+__functionCompleted = true;
+runner.halt(__stack.locals.results)
+return;
+    });
+    if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: __ctx.getResultCheckpoint(),
+    retryable: __self.__retryable,
+    functionName: "mapItems",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    if (!__state?.isForked) { __ctx.stateStack.pop() }
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "mapItems",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
+const mapItems = __AgencyFunction.create({
+  name: "mapItems",
+  module: "inlineBlockParams.agency",
+  fn: __mapItems_impl,
+  params: [{
+    name: "items",
+    hasDefault: false,
+    defaultValue: undefined,
+    variadic: false
+  }],
+  toolDefinition: {
+    name: "mapItems",
+    description: `No description provided.`,
+    schema: z.object({"items": z.array(z.any()), })
+  }
+}, __toolRegistry);
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state.ctx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onNodeStart",
+    data: {
+      nodeName: "main"
+    }
+  })
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "inlineBlockParams.agency", scopeName: "main" });
+  try {
+    await runner.step(0, async (runner) => {
+__stack.locals.items = [1, 2, 3];
+    });
+    await runner.step(1, async (runner) => {
+__stack.locals.doubled = await __call(mapItems, {
+        type: "positional",
+        args: [__stack.locals.items, __AgencyFunction.create({ name: "__block_0", module: "inlineBlockParams.agency", fn: async (x: any) => {
+          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads } });
+const __bstack = __bsetup.stack;
+const __self = __bstack.locals;
+
+__bstack.args["x"] = x;
+
+const runner = new Runner(__ctx, __bstack, { state: __bstack, moduleId: "inlineBlockParams.agency", scopeName: "__block_0" });
+try {
+await runner.step(0, async (runner) => {
+runner.halt(__bstack.args.x * 2)
+return;
+  });
+return runner.halted ? runner.haltResult : undefined;
+} finally {
+__ctx.stateStack.pop();
+}
+        }, params: [{ name: "x", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry)]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        interruptData: __state?.interruptData
+      });
+if (isInterrupt(__stack.locals.doubled)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __stack.locals.doubled
+        })
+        return;
+      }
+    });
+    await runner.step(2, async (runner) => {
+runner.halt({
+        messages: __threads,
+        data: __stack.locals.doubled
+      })
+return;
+    });
+    if (runner.halted) return runner.haltResult;
+    await callHook({
+      callbacks: __ctx.callbacks,
+      name: "onNodeEnd",
+      data: {
+        nodeName: "main",
+        data: undefined
+      }
+    })
+    return {
+      messages: __threads,
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    console.error(`\nAgent crashed: ${__error.message}`)
+    return {
+      messages: __threads,
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}): Promise<RunNodeResult<any>> {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    await main(initialState)
+  } catch (__error: any) {
+    console.error(`\nAgent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"inlineBlockParams.agency:mapItems":{"0":{"line":-1,"col":2},"1":{"line":0,"col":2},"2":{"line":4,"col":2},"1.0":{"line":1,"col":4},"1.1":{"line":2,"col":4}},"inlineBlockParams.agency:main":{"0":{"line":8,"col":2},"1":{"line":9,"col":2},"2":{"line":10,"col":2}},"inlineBlockParams.agency:__block_0":{}};


### PR DESCRIPTION
## Summary

- Add new terse inline block syntax `\x -> expr` for passing blocks as function call arguments, alongside existing trailing `as` syntax
- Inline blocks are expression-only with implicit return; multi-param requires parens: `\(x, i) -> x + i`
- New `inline` boolean field on `BlockArgument` AST node to distinguish inline from trailing blocks
- Parser post-processes function call arguments to move inline blocks to `FunctionCall.block` field

## Test Plan

- [x] Parser unit tests: single param, multi param, no param, expression termination, nested inline blocks
- [x] Negative parser tests: two inline blocks in one call, inline + trailing block
- [x] Integration test fixtures: inlineBlockBasic, inlineBlockParams
- [x] Agency execution tests: block-inline-basic, block-inline-params
- [x] Interrupt execution test: block-inline-interrupt (interrupt/resume works correctly)
- [x] Full regression suite: 2136 tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)