### PR TITLE
Support calling functions from index access: arr[0](args)

### DIFF
--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -17,6 +17,7 @@ import {
 } from "../types.js";
 
 import { AccessChainElement, ValueAccess } from "../types/access.js";
+import { BlockArgument } from "../types/blockArgument.js";
 import {
   AgencyArray,
   AgencyObject,
@@ -532,11 +533,9 @@ export class AgencyGenerator {
     return tags + this.indentStr(`${expr}`);
   }
 
-  protected generateFunctionCallExpression(
-    node: FunctionCall,
-    context: "valueAccess" | "functionArg" | "topLevelStatement",
-  ): string {
-    const args = node.arguments.map((arg) => {
+  // Render arguments (and optional inline block) into a parenthesized string: (arg1, arg2, \x -> expr)
+  protected renderArgList(args: FunctionCall["arguments"], block?: BlockArgument): string {
+    const rendered = args.map((arg) => {
       if (arg.type === "namedArgument") {
         return `${arg.name}: ${this.processNode(arg.value).trim()}`;
       }
@@ -545,6 +544,24 @@ export class AgencyGenerator {
       }
       return this.processNode(arg).trim();
     });
+    if (block?.inline) {
+      const returnStmt = block.body[0] as ReturnStatement;
+      const exprStr = this.processNode(returnStmt.value!).trim();
+      let params = "";
+      if (block.params.length === 1) {
+        params = block.params[0].name;
+      } else if (block.params.length > 1) {
+        params = `(${block.params.map((p) => p.name).join(", ")})`;
+      }
+      rendered.push(`\\${params} -> ${exprStr}`);
+    }
+    return `(${rendered.join(", ")})`;
+  }
+
+  protected generateFunctionCallExpression(
+    node: FunctionCall,
+    context: "valueAccess" | "functionArg" | "topLevelStatement",
+  ): string {
     let asyncPrefix = "";
     if (node.async === true) {
       asyncPrefix = "async ";
@@ -552,45 +569,30 @@ export class AgencyGenerator {
       asyncPrefix = "await ";
     }
 
-    let result = `${asyncPrefix}${node.functionName}(${args.join(", ")})`;
+    const block = node.block;
+    let result = `${asyncPrefix}${node.functionName}${this.renderArgList(node.arguments, block?.inline ? block : undefined)}`;
 
-    if (node.block) {
-      const block = node.block;
-
-      if (block.inline) {
-        // Inline block: \params -> expr
-        const returnStmt = block.body[0] as ReturnStatement;
-        const exprStr = this.processNode(returnStmt.value!).trim();
-        let params = "";
-        if (block.params.length === 1) {
-          params = block.params[0].name;
-        } else if (block.params.length > 1) {
-          params = `(${block.params.map((p) => p.name).join(", ")})`;
-        }
-        // Rewrite result to include inline block as an argument
-        result = `${asyncPrefix}${node.functionName}(${[...args, `\\${params} -> ${exprStr}`].join(", ")})`;
-      } else {
-        let asClause = "as ";
-        if (block.params.length === 1) {
-          asClause = `as ${block.params[0].name} `;
-        } else if (block.params.length > 1) {
-          asClause = `as (${block.params.map((p) => p.name).join(", ")}) `;
-        }
-
-        this.increaseIndent();
-        const bodyLines: string[] = [];
-        for (const stmt of block.body) {
-          bodyLines.push(this.processNode(stmt));
-        }
-        this.decreaseIndent();
-        const bodyStr =
-          bodyLines
-            .filter((s) => s !== "")
-            .join("\n")
-            .trimEnd() + "\n";
-
-        result += ` ${asClause}{\n${bodyStr}${this.indentStr("}")}`;
+    if (block && !block.inline) {
+      let asClause = "as ";
+      if (block.params.length === 1) {
+        asClause = `as ${block.params[0].name} `;
+      } else if (block.params.length > 1) {
+        asClause = `as (${block.params.map((p) => p.name).join(", ")}) `;
       }
+
+      this.increaseIndent();
+      const bodyLines: string[] = [];
+      for (const stmt of block.body) {
+        bodyLines.push(this.processNode(stmt));
+      }
+      this.decreaseIndent();
+      const bodyStr =
+        bodyLines
+          .filter((s) => s !== "")
+          .join("\n")
+          .trimEnd() + "\n";
+
+      result += ` ${asClause}{\n${bodyStr}${this.indentStr("}")}`;
     }
 
     return result;
@@ -1066,6 +1068,8 @@ export class AgencyGenerator {
       }
       case "methodCall":
         return `${dot}${this.generateFunctionCallExpression(node.functionCall, "valueAccess")}`;
+      case "call":
+        return this.renderArgList(node.arguments, node.block);
       default:
         throw new Error(
           `Unknown access chain element kind: ${(node as any).kind}`,

--- a/lib/backends/agencyGenerator.ts
+++ b/lib/backends/agencyGenerator.ts
@@ -1069,7 +1069,7 @@ export class AgencyGenerator {
       case "methodCall":
         return `${dot}${this.generateFunctionCallExpression(node.functionCall, "valueAccess")}`;
       case "call":
-        return this.renderArgList(node.arguments, node.block);
+        return `${node.optional ? "?." : ""}${this.renderArgList(node.arguments, node.block)}`;
       default:
         throw new Error(
           `Unknown access chain element kind: ${(node as any).kind}`,

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -1002,7 +1002,11 @@ export class TypeScriptBuilder {
           const isLastInChain = element === node.chain[node.chain.length - 1];
           const descriptor = this.buildCallDescriptor(element as unknown as FunctionCall);
           const configObj = this.buildStateConfig();
-          const callExpr = ts.call(ts.id("__call"), [result, descriptor, configObj]);
+          const callArgs: TsNode[] = [result, descriptor, configObj];
+          if (element.optional) {
+            callArgs.push(ts.bool(true));
+          }
+          const callExpr = ts.call(ts.id("__call"), callArgs);
           result = isLastInChain
             ? ts.await(callExpr)
             : ts.raw(`(${this.str(ts.await(callExpr))})`);

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -998,6 +998,16 @@ export class TypeScriptBuilder {
             : ts.raw(`(${this.str(ts.await(callExpr))})`);
           break;
         }
+        case "call": {
+          const isLastInChain = element === node.chain[node.chain.length - 1];
+          const descriptor = this.buildCallDescriptor(element as unknown as FunctionCall);
+          const configObj = this.buildStateConfig();
+          const callExpr = ts.call(ts.id("__call"), [result, descriptor, configObj]);
+          result = isLastInChain
+            ? ts.await(callExpr)
+            : ts.raw(`(${this.str(ts.await(callExpr))})`);
+          break;
+        }
       }
     }
     return result;

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -1000,7 +1000,7 @@ export class TypeScriptBuilder {
         }
         case "call": {
           const isLastInChain = element === node.chain[node.chain.length - 1];
-          const descriptor = this.buildCallDescriptor(element as unknown as FunctionCall);
+          const descriptor = this.buildCallDescriptor(element);
           const configObj = this.buildStateConfig();
           const callArgs: TsNode[] = [result, descriptor, configObj];
           if (element.optional) {
@@ -1431,10 +1431,10 @@ export class TypeScriptBuilder {
    * Process a block argument into a wrapped AgencyFunction TsNode.
    * Shared by generateFunctionCallExpression and buildCallDescriptor.
    */
-  private processBlockArgument(node: FunctionCall): TsNode {
+  private processBlockArgument(node: Pick<FunctionCall, "block"> & { functionName?: string }): TsNode {
     const block = node.block!;
-    const fnDef = this.programInfo.functionDefinitions[node.functionName];
-    const imported = this.programInfo.importedFunctions[node.functionName];
+    const fnDef = node.functionName ? this.programInfo.functionDefinitions[node.functionName] : undefined;
+    const imported = node.functionName ? this.programInfo.importedFunctions[node.functionName] : undefined;
     const paramList = fnDef?.parameters ?? imported?.parameters;
     const blockType = paramList
       ?.map((p) => p.typeHint)
@@ -2072,7 +2072,7 @@ export class TypeScriptBuilder {
    * Build a CallType descriptor TsNode for an Agency function call.
    * Determines whether to emit positional or named call type based on arguments.
    */
-  private buildCallDescriptor(node: FunctionCall): TsNode {
+  private buildCallDescriptor(node: Pick<FunctionCall, "arguments" | "block">): TsNode {
     const args = node.arguments;
     const hasNamedArgs = args.some((a) => a.type === "namedArgument");
 

--- a/lib/backends/typescriptBuilder.ts
+++ b/lib/backends/typescriptBuilder.ts
@@ -979,42 +979,29 @@ export class TypeScriptBuilder {
           break;
         }
         case "methodCall": {
-          const isLastInChain = element === node.chain[node.chain.length - 1];
           const fnCall = element.functionCall;
-
-          // Build descriptor from the method call's arguments
           const descriptor = this.buildCallDescriptor(fnCall);
           const configObj = this.buildStateConfig();
-
-          const propArg = ts.str(fnCall.functionName);
-          const callArgs: TsNode[] = [result, propArg, descriptor, configObj];
-          if (element.optional) {
-            callArgs.push(ts.bool(true));
-          }
-          const callExpr = ts.call(ts.id("__callMethod"), callArgs);
-
-          result = isLastInChain
-            ? ts.await(callExpr)
-            : ts.raw(`(${this.str(ts.await(callExpr))})`);
+          const callArgs: TsNode[] = [result, ts.str(fnCall.functionName), descriptor, configObj];
+          if (element.optional) callArgs.push(ts.bool(true));
+          result = this.awaitChainCall(ts.call(ts.id("__callMethod"), callArgs), element === node.chain[node.chain.length - 1]);
           break;
         }
         case "call": {
-          const isLastInChain = element === node.chain[node.chain.length - 1];
           const descriptor = this.buildCallDescriptor(element);
           const configObj = this.buildStateConfig();
           const callArgs: TsNode[] = [result, descriptor, configObj];
-          if (element.optional) {
-            callArgs.push(ts.bool(true));
-          }
-          const callExpr = ts.call(ts.id("__call"), callArgs);
-          result = isLastInChain
-            ? ts.await(callExpr)
-            : ts.raw(`(${this.str(ts.await(callExpr))})`);
+          if (element.optional) callArgs.push(ts.bool(true));
+          result = this.awaitChainCall(ts.call(ts.id("__call"), callArgs), element === node.chain[node.chain.length - 1]);
           break;
         }
       }
     }
     return result;
+  }
+
+  private awaitChainCall(callExpr: TsNode, isLast: boolean): TsNode {
+    return isLast ? ts.await(callExpr) : ts.raw(`(${this.str(ts.await(callExpr))})`);
   }
 
   private processBinOpExpression(node: BinOpExpression): TsNode {

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1296,17 +1296,20 @@ const indexChainParser: Parser<AccessChainElement> = (input: string) => {
   );
 };
 
-// Parse a call chain element: (args) — calling the result of a previous chain element
-// e.g. arr[0](arg1, arg2), getHandlers()[0]()
+// Parse a call chain element: (args) or ?.(args) — calling the result of a previous chain element
+// e.g. arr[0](arg1, arg2), getHandlers()[0](), fns[0]?.(5)
 const callChainParser: Parser<AccessChainElement> = (input: string) => {
-  const result = argumentListParser(input);
-  if (!result.success) return result;
+  const optResult = str("?.")(input);
+  const isOptional = optResult.success;
+
+  const result = argumentListParser(isOptional ? optResult.rest : input);
+  if (!result.success) return failure("expected call arguments", input);
 
   const extracted = extractInlineBlock(result.result.arguments, undefined, input);
   if (!extracted.success) return extracted.error;
 
   return success(
-    { kind: "call" as const, arguments: extracted.arguments, ...(extracted.block && { block: extracted.block }) },
+    { kind: "call" as const, arguments: extracted.arguments, ...(extracted.block && { block: extracted.block }), ...(isOptional && { optional: true }) },
     result.rest,
   );
 };

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1157,11 +1157,11 @@ const argumentListParser = seqC(
 // Returns { arguments, block } or a failure if there are multiple inline blocks,
 // or if an inline block conflicts with an existing trailing block.
 function extractInlineBlock(
-  args: any[],
+  args: ArgWithBlock[],
   existingBlock: BlockArgument | undefined,
   input: string,
-): { success: true; arguments: any[]; block?: BlockArgument } | { success: false; error: ParserResult<any> } {
-  const inlineBlocks = args.filter((a) => a.type === "blockArgument") as BlockArgument[];
+): { success: true; arguments: FunctionCall["arguments"]; block?: BlockArgument } | { success: false; error: ParserResult<any> } {
+  const inlineBlocks = args.filter((a): a is BlockArgument => a.type === "blockArgument");
   if (inlineBlocks.length > 1) {
     return { success: false, error: failure("A function call cannot have more than one block argument", input) };
   }
@@ -1171,15 +1171,17 @@ function extractInlineBlock(
     }
     return {
       success: true,
-      arguments: args.filter((a) => a.type !== "blockArgument"),
+      arguments: args.filter((a): a is Exclude<ArgWithBlock, BlockArgument> => a.type !== "blockArgument"),
       block: inlineBlocks[0],
     };
   }
-  return { success: true, arguments: args, block: existingBlock };
+  return { success: true, arguments: args as FunctionCall["arguments"], block: existingBlock };
 }
 
+type ArgWithBlock = Expression | SplatExpression | NamedArgument | BlockArgument;
+
 type FunctionCallWithBlock = Omit<FunctionCall, "arguments"> & {
-  arguments: (Expression | SplatExpression | NamedArgument | BlockArgument)[]
+  arguments: ArgWithBlock[]
 }
 
 export const _functionCallParser: Parser<FunctionCall> = (input: string) => {

--- a/lib/parsers/parsers.ts
+++ b/lib/parsers/parsers.ts
@@ -1132,6 +1132,52 @@ const namedArgumentParser: Parser<NamedArgument> = trace(
   ),
 );
 
+// Shared argument list parser: (arg1, arg2, \x -> expr, ...)
+// Used by both _functionCallParser and callChainParser.
+const argumentListParser = seqC(
+  char("("),
+  optionalSpaces,
+  capture(
+    sepBy(
+      comma,
+      or(
+        namedArgumentParser,
+        splatParser,
+        lazy(() => inlineBlockParser),
+        lazy(() => exprParser),
+      ),
+    ),
+    "arguments",
+  ),
+  optionalSpaces,
+  char(")"),
+);
+
+// Extract inline block from parsed arguments into a separate block field.
+// Returns { arguments, block } or a failure if there are multiple inline blocks,
+// or if an inline block conflicts with an existing trailing block.
+function extractInlineBlock(
+  args: any[],
+  existingBlock: BlockArgument | undefined,
+  input: string,
+): { success: true; arguments: any[]; block?: BlockArgument } | { success: false; error: ParserResult<any> } {
+  const inlineBlocks = args.filter((a) => a.type === "blockArgument") as BlockArgument[];
+  if (inlineBlocks.length > 1) {
+    return { success: false, error: failure("A function call cannot have more than one block argument", input) };
+  }
+  if (inlineBlocks.length === 1) {
+    if (existingBlock) {
+      return { success: false, error: failure("A function call cannot have both an inline block and a trailing 'as' block", input) };
+    }
+    return {
+      success: true,
+      arguments: args.filter((a) => a.type !== "blockArgument"),
+      block: inlineBlocks[0],
+    };
+  }
+  return { success: true, arguments: args, block: existingBlock };
+}
+
 type FunctionCallWithBlock = Omit<FunctionCall, "arguments"> & {
   arguments: (Expression | SplatExpression | NamedArgument | BlockArgument)[]
 }
@@ -1140,22 +1186,7 @@ export const _functionCallParser: Parser<FunctionCall> = (input: string) => {
   const parser: Parser<FunctionCallWithBlock> = seqC(
     set("type", "functionCall"),
     capture(many1WithJoin(varNameChar), "functionName"),
-    char("("),
-    optionalSpaces,
-    capture(
-      sepBy(
-        comma,
-        or(
-          namedArgumentParser,
-          splatParser,
-          lazy(() => inlineBlockParser),
-          lazy(() => exprParser),
-        ),
-      ),
-      "arguments",
-    ),
-    optionalSpaces,
-    char(")"),
+    captureCaptures(argumentListParser),
     optionalSpaces,
     optional(
       captureCaptures(
@@ -1170,19 +1201,11 @@ export const _functionCallParser: Parser<FunctionCall> = (input: string) => {
   const result = parser(input);
   if (!result.success) return result;
 
-  // Post-process: move inline block from arguments to block field
   const funcCall = result.result;
-  const inlineBlocks = funcCall.arguments.filter((a) => a.type === "blockArgument") as BlockArgument[];
-  if (inlineBlocks.length > 1) {
-    return failure("A function call cannot have more than one block argument", input);
-  }
-  if (inlineBlocks.length === 1) {
-    if (funcCall.block) {
-      return failure("A function call cannot have both an inline block and a trailing 'as' block", input);
-    }
-    funcCall.block = inlineBlocks[0];
-    funcCall.arguments = funcCall.arguments.filter((a) => a.type !== "blockArgument");
-  }
+  const extracted = extractInlineBlock(funcCall.arguments, funcCall.block, input);
+  if (!extracted.success) return extracted.error;
+  funcCall.arguments = extracted.arguments;
+  funcCall.block = extracted.block;
 
   return result as ParserResult<FunctionCall>;
 };
@@ -1273,8 +1296,24 @@ const indexChainParser: Parser<AccessChainElement> = (input: string) => {
   );
 };
 
+// Parse a call chain element: (args) — calling the result of a previous chain element
+// e.g. arr[0](arg1, arg2), getHandlers()[0]()
+const callChainParser: Parser<AccessChainElement> = (input: string) => {
+  const result = argumentListParser(input);
+  if (!result.success) return result;
+
+  const extracted = extractInlineBlock(result.result.arguments, undefined, input);
+  if (!extracted.success) return extracted.error;
+
+  return success(
+    { kind: "call" as const, arguments: extracted.arguments, ...(extracted.block && { block: extracted.block }) },
+    result.rest,
+  );
+};
+
 const chainElementParser: Parser<AccessChainElement> = or(
   dotMethodCallParser,
+  callChainParser,
   sliceChainParser,
   indexChainParser,
 );

--- a/lib/runtime/call.ts
+++ b/lib/runtime/call.ts
@@ -5,7 +5,11 @@ export async function __call(
   target: unknown,
   descriptor: CallType,
   state?: unknown,
+  optional?: boolean,
 ): Promise<unknown> {
+  if (optional && (target === null || target === undefined)) {
+    return undefined;
+  }
   if (AgencyFunction.isAgencyFunction(target)) {
     return target.invoke(descriptor, state);
   }

--- a/lib/types/access.ts
+++ b/lib/types/access.ts
@@ -5,7 +5,8 @@ export type AccessChainElement =
   | { kind: "property"; name: string; optional?: boolean }
   | { kind: "index"; index: Expression; optional?: boolean }
   | { kind: "slice"; start?: Expression; end?: Expression; optional?: boolean }
-  | { kind: "methodCall"; functionCall: FunctionCall; optional?: boolean };
+  | { kind: "methodCall"; functionCall: FunctionCall; optional?: boolean }
+  | { kind: "call"; optional?: boolean } & Pick<FunctionCall, "arguments" | "block">;
 
 export type ValueAccess = BaseNode & {
   type: "valueAccess";

--- a/tests/agency/dynamic-functions/direct-array-access-call.test.json
+++ b/tests/agency/dynamic-functions/direct-array-access-call.test.json
@@ -2,7 +2,6 @@
   "tests": [
     {
       "nodeName": "main",
-      "skip": true,
       "description": "Agency functions called directly from array index without extracting to variable",
       "input": "",
       "expectedOutput": "{\"r1\":10,\"r2\":15}",

--- a/tests/agency/dynamic-functions/optional-call-chain.agency
+++ b/tests/agency/dynamic-functions/optional-call-chain.agency
@@ -1,0 +1,15 @@
+def double(x: number): number {
+  return x * 2
+}
+
+node main() {
+  const fns: any[] = [double, null]
+
+  // optional call on non-null — should call the function
+  const r1 = fns[0]?.(5)
+
+  // optional call on null — should return undefined (not crash)
+  const r2 = fns[1]?.(5)
+
+  return { r1: r1, r2: r2 }
+}

--- a/tests/agency/dynamic-functions/optional-call-chain.test.json
+++ b/tests/agency/dynamic-functions/optional-call-chain.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Optional call chain — calls function on non-null, returns undefined on null",
+      "input": "",
+      "expectedOutput": "{\"r1\":10}",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add call chain element to value access parser for invoking the result of a previous chain element as a function: arr[0](args), getHandlers()[0]()
- Support optional call chaining: fns[0]?.(5) returns undefined if callee is nullish
- Extract shared argumentListParser and extractInlineBlock helper to avoid duplicating function call argument parsing logic
- Add optional parameter to __call runtime function, matching __callMethod existing pattern

## Test Plan

- [x] Unskipped existing direct-array-access-call agency test - passes
- [x] New optional-call-chain agency test - calls on non-null, returns undefined on null
- [x] Full regression suite: 2189 tests pass, no regressions