### PR TITLE
Add @agency-lang/brave-search package

### DIFF
--- a/docs/superpowers/plans/2026-05-01-brave-search.md
+++ b/docs/superpowers/plans/2026-05-01-brave-search.md
@@ -1,0 +1,481 @@
+# @agency-lang/brave-search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create an Agency package that wraps the Brave Search REST API, exposing a `braveSearch` function usable as an LLM tool.
+
+**Architecture:** A TypeScript core module (`src/braveSearch.ts`) calls the Brave Search API directly via native `fetch`. A thin Agency wrapper (`index.agency`) re-exports it as an Agency function with named parameters and defaults.
+
+**Tech Stack:** TypeScript, native `fetch`, vitest for unit tests, Agency for integration test.
+
+**Spec:** `docs/superpowers/specs/2026-05-01-brave-search-design.md`
+
+---
+
+### Task 1: Scaffold the package
+
+**Files:**
+- Create: `packages/brave-search/package.json`
+- Create: `packages/brave-search/tsconfig.json`
+
+- [ ] **Step 1: Create `packages/brave-search/package.json`**
+
+```json
+{
+  "name": "@agency-lang/brave-search",
+  "version": "0.0.1",
+  "description": "Brave Search integration for Agency",
+  "type": "module",
+  "agency": "./index.agency",
+  "main": "./dist/src/braveSearch.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/braveSearch.d.ts",
+      "import": "./dist/src/braveSearch.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/",
+    "index.agency"
+  ],
+  "author": "Aditya Bhargava",
+  "license": "ISC",
+  "bugs": { "url": "https://github.com/egonSchiele/agency-lang/issues" },
+  "homepage": "https://github.com/egonSchiele/agency-lang",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:agency": "agency tests/agency"
+  },
+  "peerDependencies": {
+    "agency-lang": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create `packages/brave-search/tsconfig.json`**
+
+Copy from `packages/mcp/tsconfig.json` — identical settings:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}
+```
+
+- [ ] **Step 3: Install dependencies**
+
+Run: `cd packages/brave-search && pnpm install`
+
+Verify the package is recognized by the workspace.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/brave-search/package.json packages/brave-search/tsconfig.json
+git commit -m "scaffold @agency-lang/brave-search package"
+```
+
+---
+
+### Task 2: Write unit tests for the TS core
+
+**Files:**
+- Create: `packages/brave-search/src/braveSearch.test.ts`
+
+All tests mock `global.fetch`. No real API calls.
+
+- [ ] **Step 1: Write the tests**
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { braveSearch } from "./braveSearch.js";
+
+const FAKE_KEY = "test-brave-api-key";
+
+function mockFetchResponse(body: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  });
+}
+
+describe("braveSearch", () => {
+  const originalFetch = globalThis.fetch;
+  const originalEnv = process.env.BRAVE_API_KEY;
+
+  beforeEach(() => {
+    process.env.BRAVE_API_KEY = FAKE_KEY;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv !== undefined) {
+      process.env.BRAVE_API_KEY = originalEnv;
+    } else {
+      delete process.env.BRAVE_API_KEY;
+    }
+  });
+
+  it("builds correct URL with query and default params", async () => {
+    const mockFetch = mockFetchResponse({ web: { results: [] } });
+    globalThis.fetch = mockFetch;
+
+    await braveSearch("test query");
+
+    const [url] = mockFetch.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.origin + parsed.pathname).toBe(
+      "https://api.search.brave.com/res/v1/web/search"
+    );
+    expect(parsed.searchParams.get("q")).toBe("test query");
+    expect(parsed.searchParams.get("count")).toBe("5");
+  });
+
+  it("sends API key in X-Subscription-Token header", async () => {
+    const mockFetch = mockFetchResponse({ web: { results: [] } });
+    globalThis.fetch = mockFetch;
+
+    await braveSearch("test");
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers["X-Subscription-Token"]).toBe(FAKE_KEY);
+  });
+
+  it("uses apiKey option over env var", async () => {
+    const mockFetch = mockFetchResponse({ web: { results: [] } });
+    globalThis.fetch = mockFetch;
+
+    await braveSearch("test", { apiKey: "override-key" });
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers["X-Subscription-Token"]).toBe("override-key");
+  });
+
+  it("maps response to BraveSearchResult array", async () => {
+    globalThis.fetch = mockFetchResponse({
+      web: {
+        results: [
+          {
+            title: "Example",
+            url: "https://example.com",
+            description: "An example site",
+            extra_field: "ignored",
+          },
+        ],
+      },
+    });
+
+    const results = await braveSearch("test");
+
+    expect(results).toEqual([
+      {
+        title: "Example",
+        url: "https://example.com",
+        description: "An example site",
+      },
+    ]);
+  });
+
+  it("returns empty array when no web results", async () => {
+    globalThis.fetch = mockFetchResponse({ web: { results: [] } });
+    const results = await braveSearch("test");
+    expect(results).toEqual([]);
+  });
+
+  it("returns empty array when web field is missing", async () => {
+    globalThis.fetch = mockFetchResponse({});
+    const results = await braveSearch("test");
+    expect(results).toEqual([]);
+  });
+
+  it("throws when no API key is available", async () => {
+    delete process.env.BRAVE_API_KEY;
+    await expect(braveSearch("test")).rejects.toThrow(
+      "BRAVE_API_KEY"
+    );
+  });
+
+  it("throws on non-200 response with status and body", async () => {
+    globalThis.fetch = mockFetchResponse(
+      { message: "Rate limit exceeded" },
+      429
+    );
+
+    await expect(braveSearch("test")).rejects.toThrow(
+      "Brave Search API error (429)"
+    );
+  });
+
+  it("includes optional params in URL when provided", async () => {
+    const mockFetch = mockFetchResponse({ web: { results: [] } });
+    globalThis.fetch = mockFetch;
+
+    await braveSearch("test", {
+      count: 10,
+      country: "US",
+      searchLang: "en",
+      safesearch: "strict",
+      freshness: "pw",
+    });
+
+    const [url] = mockFetch.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("count")).toBe("10");
+    expect(parsed.searchParams.get("country")).toBe("US");
+    expect(parsed.searchParams.get("search_lang")).toBe("en");
+    expect(parsed.searchParams.get("safesearch")).toBe("strict");
+    expect(parsed.searchParams.get("freshness")).toBe("pw");
+  });
+
+  it("omits empty-string options from URL", async () => {
+    const mockFetch = mockFetchResponse({ web: { results: [] } });
+    globalThis.fetch = mockFetch;
+
+    await braveSearch("test", { country: "", freshness: "" });
+
+    const [url] = mockFetch.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has("country")).toBe(false);
+    expect(parsed.searchParams.has("freshness")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/brave-search && pnpm test:run 2>&1 | tee /tmp/brave-search-test-1.txt`
+
+Expected: All tests FAIL because `braveSearch` doesn't exist yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/brave-search/src/braveSearch.test.ts
+git commit -m "add unit tests for braveSearch"
+```
+
+---
+
+### Task 3: Implement the TS core
+
+**Files:**
+- Create: `packages/brave-search/src/braveSearch.ts`
+
+- [ ] **Step 1: Write the implementation**
+
+```typescript
+const BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search";
+
+export type BraveSearchResult = {
+  title: string;
+  url: string;
+  description: string;
+};
+
+export type BraveSearchOptions = {
+  apiKey?: string;
+  count?: number;
+  country?: string;
+  searchLang?: string;
+  safesearch?: string;
+  freshness?: string;
+};
+
+export async function braveSearch(
+  query: string,
+  options?: BraveSearchOptions
+): Promise<BraveSearchResult[]> {
+  // Note: using || (not ??) so empty strings from Agency defaults fall through to env var
+  const apiKey = options?.apiKey || process.env.BRAVE_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "Missing Brave Search API key. Set BRAVE_API_KEY env var or pass apiKey option."
+    );
+  }
+
+  const url = new URL(BRAVE_SEARCH_URL);
+  url.searchParams.set("q", query);
+  url.searchParams.set("count", String(options?.count ?? 5));
+
+  if (options?.country) url.searchParams.set("country", options.country);
+  if (options?.searchLang) url.searchParams.set("search_lang", options.searchLang);
+  if (options?.safesearch) url.searchParams.set("safesearch", options.safesearch);
+  if (options?.freshness) url.searchParams.set("freshness", options.freshness);
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      "Accept": "application/json",
+      "X-Subscription-Token": apiKey,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Brave Search API error (${response.status}): ${body}`);
+  }
+
+  const data = await response.json();
+  const results = data?.web?.results ?? [];
+
+  return results.map((r: Record<string, unknown>) => ({
+    title: r.title as string,
+    url: r.url as string,
+    description: r.description as string,
+  }));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `cd packages/brave-search && pnpm test:run 2>&1 | tee /tmp/brave-search-test-2.txt`
+
+Expected: All 9 tests PASS.
+
+- [ ] **Step 3: Verify the TypeScript compiles**
+
+Run: `cd packages/brave-search && pnpm build`
+
+Expected: Clean compilation, `dist/src/braveSearch.js` and `dist/src/braveSearch.d.ts` are generated.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/brave-search/src/braveSearch.ts
+git commit -m "implement braveSearch TypeScript core"
+```
+
+---
+
+### Task 4: Write the Agency wrapper
+
+**Files:**
+- Create: `packages/brave-search/index.agency`
+
+- [ ] **Step 1: Create `packages/brave-search/index.agency`**
+
+```
+import { braveSearch as braveSearchImpl } from "./dist/src/braveSearch.js"
+
+/// Search the web using Brave Search. Returns titles, URLs, and descriptions.
+export def braveSearch(query: string, count: number = 5, apiKey: string = "", country: string = "", searchLang: string = "", safesearch: string = "moderate", freshness: string = "") {
+  return braveSearchImpl(query, {
+    count: count,
+    apiKey: apiKey,
+    country: country,
+    searchLang: searchLang,
+    safesearch: safesearch,
+    freshness: freshness
+  })
+}
+```
+
+- [ ] **Step 2: Verify it parses**
+
+Run: `cd packages/brave-search && pnpm run --filter agency-lang ast index.agency`
+
+If pnpm filtering doesn't work, run from the agency-lang package: `cd packages/agency-lang && pnpm run ast ../../packages/brave-search/index.agency`
+
+Expected: Valid AST output (no parse errors).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/brave-search/index.agency
+git commit -m "add Agency wrapper for braveSearch"
+```
+
+---
+
+### Task 5: Write integration test
+
+**Files:**
+- Create: `packages/brave-search/tests/agency/brave-search.agency`
+
+- [ ] **Step 1: Create the integration test**
+
+This test calls `braveSearch` directly (no LLM) and checks the result shape. It requires a real `BRAVE_API_KEY`.
+
+```
+import { braveSearch } from "../../index.agency"
+
+node main() {
+  let results = braveSearch("TypeScript programming language")
+  let first = results[0]
+  print(first.title)
+  print(first.url)
+  print(first.description)
+  print(results)
+}
+```
+
+- [ ] **Step 2: Run the integration test (manual, requires API key)**
+
+Run: `cd packages/brave-search && BRAVE_API_KEY=<your-key> pnpm run test:agency 2>&1 | tee /tmp/brave-search-integration.txt`
+
+Expected: Prints an array of search results with title, url, and description fields. Verify the output looks correct.
+
+Note: Skip this step if no API key is available. The unit tests in Task 2/3 cover the logic without needing a key.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/brave-search/tests/agency/brave-search.agency
+git commit -m "add integration test for braveSearch"
+```
+
+---
+
+### Task 6: Wire into workspace and verify end-to-end build
+
+- [ ] **Step 1: Install workspace dependencies**
+
+Run: `pnpm install` (from repo root)
+
+Expected: `@agency-lang/brave-search` appears in the workspace packages.
+
+- [ ] **Step 2: Build the package**
+
+Run: `cd packages/brave-search && pnpm build`
+
+Expected: Clean compilation.
+
+- [ ] **Step 3: Run all unit tests**
+
+Run: `cd packages/brave-search && pnpm test:run 2>&1 | tee /tmp/brave-search-test-final.txt`
+
+Expected: All tests pass.
+
+- [ ] **Step 4: Verify nothing is broken in the rest of the repo**
+
+Run: `cd packages/agency-lang && pnpm test:run 2>&1 | tee /tmp/agency-lang-test.txt`
+
+Expected: Existing tests still pass. The new package should have no effect on existing code.
+
+- [ ] **Step 5: Commit any remaining changes (lockfile, etc.)**
+
+```bash
+git add -A
+git commit -m "wire @agency-lang/brave-search into workspace"
+```

--- a/docs/superpowers/specs/2026-05-01-brave-search-design.md
+++ b/docs/superpowers/specs/2026-05-01-brave-search-design.md
@@ -4,18 +4,24 @@
 
 An Agency package that provides web search via the [Brave Search API](https://brave.com/search/api/). Exposes a single `braveSearch` function that agents can use as an LLM tool to search the web and get back structured results.
 
-No third-party wrapper libraries — calls the Brave REST API directly (~40 lines of TypeScript). Requires a `BRAVE_API_KEY` environment variable (free tier: 1,000 searches/month).
+No third-party wrapper libraries — calls the Brave REST API directly (~40 lines of TypeScript). Uses the `BRAVE_API_KEY` environment variable by default, or accepts the key directly via the `apiKey` parameter (free tier: 1,000 searches/month).
 
 ## Configuration
 
-Set the `BRAVE_API_KEY` environment variable. You can do this in a `.env` file in your project root or in your shell environment:
+Get a free API key at https://api.search.brave.com/app/keys. No `agency.json` configuration is needed.
+
+**Option 1: Environment variable** (recommended). Set `BRAVE_API_KEY` in a `.env` file or your shell:
 
 ```
 # .env
 BRAVE_API_KEY=your-key-here
 ```
 
-Get a free API key at https://api.search.brave.com/app/keys. No `agency.json` configuration is needed.
+**Option 2: Pass directly.** Use the `apiKey` named parameter if you can't set an env var:
+
+```
+braveSearch("my query", apiKey: myApiKey)
+```
 
 ## Usage
 
@@ -27,7 +33,7 @@ node main() {
 }
 ```
 
-The LLM calls `braveSearch(query, count)` as a tool. Results come back as an array of `{ title, url, description }` objects.
+The LLM calls `braveSearch(query)` as a tool. Results come back as an array of `{ title, url, description }` objects.
 
 ## Package Structure
 
@@ -63,9 +69,10 @@ type BraveSearchResult = {
 }
 
 type BraveSearchOptions = {
+  apiKey?: string             // override BRAVE_API_KEY env var
   count?: number              // 1-20, default 5
   country?: string            // 2-char code, e.g. "US"
-  search_lang?: string        // ISO 639-1, e.g. "en"
+  searchLang?: string         // ISO 639-1, e.g. "en"
   safesearch?: "off" | "moderate" | "strict"  // default "moderate"
   freshness?: string          // "pd" (24h), "pw" (7d), "pm" (31d), "py" (1y)
 }
@@ -77,8 +84,8 @@ export async function braveSearch(
 ```
 
 **Behavior:**
-- Reads `BRAVE_API_KEY` from `process.env`
-- Throws if key is missing
+- Uses `options.apiKey` if provided, otherwise reads `BRAVE_API_KEY` from `process.env`
+- Throws if neither is set
 - Builds URL with query params, makes GET request with auth header
 - Extracts `response.web.results`, maps each to `{ title, url, description }`
 - Throws on non-200 HTTP responses with status code and response body (e.g., "Brave Search API error (429): Rate limit exceeded")
@@ -89,12 +96,29 @@ export async function braveSearch(
 import { braveSearch as braveSearchImpl } from "./dist/src/braveSearch.js"
 
 /// Search the web using Brave Search. Returns titles, URLs, and descriptions.
-export def braveSearch(query: string, count: number = 5) {
-  return braveSearchImpl(query, { count })
+export def braveSearch(query: string, count: number = 5, apiKey: string = "", country: string = "", searchLang: string = "", safesearch: string = "moderate", freshness: string = "") {
+  return braveSearchImpl(query, {
+    count: count,
+    apiKey: apiKey,
+    country: country,
+    searchLang: searchLang,
+    safesearch: safesearch,
+    freshness: freshness
+  })
 }
 ```
 
-The Agency wrapper keeps the tool interface simple for the LLM: just `query` and `count`. The docstring becomes the tool description. Advanced options (country, language, freshness) are available in the TypeScript API for programmatic use but not exposed as tool parameters.
+All options are exposed with sensible defaults. Users can pass them positionally or with named parameters:
+
+```
+// Simple — LLM will typically call it this way
+braveSearch("climate change")
+
+// With named parameters for advanced use
+braveSearch("climate change", count: 10, country: "US", apiKey: myKey)
+```
+
+The TS core ignores empty-string options (treats them as unset), so the defaults work cleanly.
 
 ## Testing
 
@@ -158,6 +182,6 @@ No runtime dependencies — uses native `fetch`.
 ## Decisions
 
 - **No wrapper library:** The Brave API is a single GET endpoint. Calling it directly avoids dependency risk, license issues (the existing `brave-search` npm package is GPL v3), and keeps the package minimal.
-- **Simple tool interface:** The LLM only sees `query` and `count`. Advanced options are available in the TS API for programmatic use.
+- **All options exposed with defaults:** All Brave API options are available via named parameters with sensible defaults. The TS core treats empty strings as unset, so default values don't generate unnecessary query params.
 - **No caching:** Kept out of v1 for simplicity. Users can add their own caching layer.
 - **No Result types in the TS core:** The core throws on errors. The Agency wrapper can use try/catch to convert to Result types if needed, but for a tool function, throwing is fine — Agency's tool execution catches errors and reports them to the LLM.

--- a/docs/superpowers/specs/2026-05-01-brave-search-design.md
+++ b/docs/superpowers/specs/2026-05-01-brave-search-design.md
@@ -73,7 +73,7 @@ type BraveSearchOptions = {
   count?: number              // 1-20, default 5
   country?: string            // 2-char code, e.g. "US"
   searchLang?: string         // ISO 639-1, e.g. "en"
-  safesearch?: "off" | "moderate" | "strict"  // default "moderate"
+  safesearch?: string              // "off", "moderate", or "strict"; default "moderate"
   freshness?: string          // "pd" (24h), "pw" (7d), "pm" (31d), "py" (1y)
 }
 

--- a/docs/superpowers/specs/2026-05-01-brave-search-design.md
+++ b/docs/superpowers/specs/2026-05-01-brave-search-design.md
@@ -1,0 +1,147 @@
+# @agency-lang/brave-search Design Spec
+
+## Overview
+
+An Agency package that provides web search via the [Brave Search API](https://brave.com/search/api/). Exposes a single `braveSearch` function that agents can use as an LLM tool to search the web and get back structured results.
+
+No third-party wrapper libraries — calls the Brave REST API directly (~40 lines of TypeScript). Requires a `BRAVE_API_KEY` environment variable (free tier: 1,000 searches/month).
+
+## Usage
+
+```
+import { braveSearch } from "pkg::brave-search"
+
+node main() {
+  let answer = llm("What's the latest news on AI regulation?") uses braveSearch
+}
+```
+
+The LLM calls `braveSearch(query, count)` as a tool. Results come back as an array of `{ title, url, description }` objects.
+
+## Package Structure
+
+```
+packages/brave-search/
+├── package.json            # @agency-lang/brave-search
+├── tsconfig.json
+├── index.agency            # Agency wrapper exporting braveSearch
+├── src/
+│   ├── braveSearch.ts      # Core: fetch Brave API + map results
+│   └── braveSearch.test.ts # Unit tests (mocked fetch)
+└── tests/
+    └── agency/
+        └── brave-search.agency  # Integration test
+```
+
+## API Design
+
+### Brave Search API
+
+- **Endpoint:** `GET https://api.search.brave.com/res/v1/web/search`
+- **Auth:** `X-Subscription-Token: <BRAVE_API_KEY>` header
+- **Key params:** `q` (query), `count` (1-20), `country`, `search_lang`, `safesearch`, `freshness`
+- **Response:** `{ web: { results: [{ title, url, description, ... }] } }`
+
+### TypeScript Core (`src/braveSearch.ts`)
+
+```typescript
+type BraveSearchResult = {
+  title: string
+  url: string
+  description: string
+}
+
+type BraveSearchOptions = {
+  count?: number              // 1-20, default 5
+  country?: string            // 2-char code, e.g. "US"
+  search_lang?: string        // ISO 639-1, e.g. "en"
+  safesearch?: "off" | "moderate" | "strict"  // default "moderate"
+  freshness?: string          // "pd" (24h), "pw" (7d), "pm" (31d), "py" (1y)
+}
+
+export async function braveSearch(
+  query: string,
+  options?: BraveSearchOptions
+): Promise<BraveSearchResult[]>
+```
+
+**Behavior:**
+- Reads `BRAVE_API_KEY` from `process.env`
+- Throws if key is missing
+- Builds URL with query params, makes GET request with auth header
+- Extracts `response.web.results`, maps each to `{ title, url, description }`
+- Throws on non-200 HTTP responses
+
+### Agency Wrapper (`index.agency`)
+
+```
+import { braveSearch as braveSearchImpl } from "./dist/src/braveSearch.js"
+
+/// Search the web using Brave Search. Returns titles, URLs, and descriptions.
+export def braveSearch(query: string, count: number = 5) {
+  return braveSearchImpl(query, { count })
+}
+```
+
+The Agency wrapper keeps the tool interface simple for the LLM: just `query` and `count`. The docstring becomes the tool description. Advanced options (country, language, freshness) are available in the TypeScript API for programmatic use but not exposed as tool parameters.
+
+## Testing
+
+### Unit Tests (`src/braveSearch.test.ts`)
+
+Mock `global.fetch` and test:
+- Correct URL construction with query params
+- Auth header is set correctly
+- Response mapping: extracts title, url, description from Brave API response
+- Error: missing BRAVE_API_KEY throws
+- Error: non-200 HTTP response throws with status/message
+- Empty results: returns empty array
+
+### Integration Test (`tests/agency/brave-search.agency`)
+
+A simple Agency program that uses `braveSearch` as a tool to verify end-to-end wiring.
+
+## package.json
+
+```json
+{
+  "name": "@agency-lang/brave-search",
+  "version": "0.0.1",
+  "description": "Brave Search integration for Agency",
+  "type": "module",
+  "agency": "./index.agency",
+  "main": "./dist/src/braveSearch.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/braveSearch.d.ts",
+      "import": "./dist/src/braveSearch.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/",
+    "index.agency"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "peerDependencies": {
+    "agency-lang": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}
+```
+
+No runtime dependencies — uses native `fetch`.
+
+## Decisions
+
+- **No wrapper library:** The Brave API is a single GET endpoint. Calling it directly avoids dependency risk, license issues (the existing `brave-search` npm package is GPL v3), and keeps the package minimal.
+- **Simple tool interface:** The LLM only sees `query` and `count`. Advanced options are available in the TS API for programmatic use.
+- **No caching:** Kept out of v1 for simplicity. Users can add their own caching layer.
+- **No Result types in the TS core:** The core throws on errors. The Agency wrapper can use try/catch to convert to Result types if needed, but for a tool function, throwing is fine — Agency's tool execution catches errors and reports them to the LLM.

--- a/docs/superpowers/specs/2026-05-01-brave-search-design.md
+++ b/docs/superpowers/specs/2026-05-01-brave-search-design.md
@@ -6,10 +6,21 @@ An Agency package that provides web search via the [Brave Search API](https://br
 
 No third-party wrapper libraries — calls the Brave REST API directly (~40 lines of TypeScript). Requires a `BRAVE_API_KEY` environment variable (free tier: 1,000 searches/month).
 
+## Configuration
+
+Set the `BRAVE_API_KEY` environment variable. You can do this in a `.env` file in your project root or in your shell environment:
+
+```
+# .env
+BRAVE_API_KEY=your-key-here
+```
+
+Get a free API key at https://api.search.brave.com/app/keys. No `agency.json` configuration is needed.
+
 ## Usage
 
 ```
-import { braveSearch } from "pkg::brave-search"
+import { braveSearch } from "pkg::@agency-lang/brave-search"
 
 node main() {
   let answer = llm("What's the latest news on AI regulation?") uses braveSearch
@@ -70,7 +81,7 @@ export async function braveSearch(
 - Throws if key is missing
 - Builds URL with query params, makes GET request with auth header
 - Extracts `response.web.results`, maps each to `{ title, url, description }`
-- Throws on non-200 HTTP responses
+- Throws on non-200 HTTP responses with status code and response body (e.g., "Brave Search API error (429): Rate limit exceeded")
 
 ### Agency Wrapper (`index.agency`)
 
@@ -99,7 +110,7 @@ Mock `global.fetch` and test:
 
 ### Integration Test (`tests/agency/brave-search.agency`)
 
-A simple Agency program that uses `braveSearch` as a tool to verify end-to-end wiring.
+An Agency program that calls `braveSearch` directly (not via LLM) to verify the wiring works. The test requires a real `BRAVE_API_KEY` env var and makes a live API call. It should be skipped in CI unless secrets are configured. The test verifies that calling `braveSearch("test query")` returns an array of results with `title`, `url`, and `description` fields.
 
 ## package.json
 
@@ -122,10 +133,15 @@ A simple Agency program that uses `braveSearch` as a tool to verify end-to-end w
     "dist/",
     "index.agency"
   ],
+  "author": "Aditya Bhargava",
+  "license": "ISC",
+  "bugs": { "url": "https://github.com/egonSchiele/agency-lang/issues" },
+  "homepage": "https://github.com/egonSchiele/agency-lang",
   "scripts": {
     "build": "tsc",
     "test": "vitest",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "test:agency": "agency tests/agency"
   },
   "peerDependencies": {
     "agency-lang": "workspace:*"

--- a/packages/brave-search/index.agency
+++ b/packages/brave-search/index.agency
@@ -1,7 +1,7 @@
 import { braveSearch as braveSearchImpl } from "./dist/src/braveSearch.js"
 
 /// Search the web using Brave Search. Returns titles, URLs, and descriptions.
-export def braveSearch(query: string, count: number = 5, apiKey: string = "", country: string = "", searchLang: string = "", safesearch: string = "moderate", freshness: string = "") {
+export def braveSearch(query: string, count: number = 5, apiKey: string = "", country: string = "", searchLang: string = "", safesearch: string = "", freshness: string = "") {
   return braveSearchImpl(query, {
     count: count,
     apiKey: apiKey,

--- a/packages/brave-search/index.agency
+++ b/packages/brave-search/index.agency
@@ -1,0 +1,13 @@
+import { braveSearch as braveSearchImpl } from "./dist/src/braveSearch.js"
+
+/// Search the web using Brave Search. Returns titles, URLs, and descriptions.
+export def braveSearch(query: string, count: number = 5, apiKey: string = "", country: string = "", searchLang: string = "", safesearch: string = "moderate", freshness: string = "") {
+  return braveSearchImpl(query, {
+    count: count,
+    apiKey: apiKey,
+    country: country,
+    searchLang: searchLang,
+    safesearch: safesearch,
+    freshness: freshness
+  })
+}

--- a/packages/brave-search/package.json
+++ b/packages/brave-search/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@agency-lang/brave-search",
+  "version": "0.0.1",
+  "description": "Brave Search integration for Agency",
+  "type": "module",
+  "agency": "./index.agency",
+  "main": "./dist/src/braveSearch.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/braveSearch.d.ts",
+      "import": "./dist/src/braveSearch.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/",
+    "index.agency"
+  ],
+  "author": "Aditya Bhargava",
+  "license": "ISC",
+  "bugs": { "url": "https://github.com/egonSchiele/agency-lang/issues" },
+  "homepage": "https://github.com/egonSchiele/agency-lang",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:agency": "agency tests/agency"
+  },
+  "peerDependencies": {
+    "agency-lang": "workspace:*"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/brave-search/package.json
+++ b/packages/brave-search/package.json
@@ -30,6 +30,7 @@
     "agency-lang": "workspace:*"
   },
   "devDependencies": {
+    "@types/node": "^25.0.0",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0"
   }

--- a/packages/brave-search/src/braveSearch.test.ts
+++ b/packages/brave-search/src/braveSearch.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { braveSearch } from "./braveSearch.js";
+
+const FAKE_KEY = "test-brave-api-key";
+
+function mockFetchResponse(body: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  });
+}
+
+describe("braveSearch", () => {
+  const originalFetch = globalThis.fetch;
+  const originalEnv = process.env.BRAVE_API_KEY;
+
+  beforeEach(() => {
+    process.env.BRAVE_API_KEY = FAKE_KEY;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalEnv !== undefined) {
+      process.env.BRAVE_API_KEY = originalEnv;
+    } else {
+      delete process.env.BRAVE_API_KEY;
+    }
+  });
+
+  it("builds correct URL with query and default params", async () => {
+    const mockFetch = mockFetchResponse({ web: { results: [] } });
+    globalThis.fetch = mockFetch;
+
+    await braveSearch("test query");
+
+    const [url] = mockFetch.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.origin + parsed.pathname).toBe(
+      "https://api.search.brave.com/res/v1/web/search"
+    );
+    expect(parsed.searchParams.get("q")).toBe("test query");
+    expect(parsed.searchParams.get("count")).toBe("5");
+  });
+
+  it("sends API key in X-Subscription-Token header", async () => {
+    const mockFetch = mockFetchResponse({ web: { results: [] } });
+    globalThis.fetch = mockFetch;
+
+    await braveSearch("test");
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers["X-Subscription-Token"]).toBe(FAKE_KEY);
+  });
+
+  it("uses apiKey option over env var", async () => {
+    const mockFetch = mockFetchResponse({ web: { results: [] } });
+    globalThis.fetch = mockFetch;
+
+    await braveSearch("test", { apiKey: "override-key" });
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers["X-Subscription-Token"]).toBe("override-key");
+  });
+
+  it("maps response to BraveSearchResult array", async () => {
+    globalThis.fetch = mockFetchResponse({
+      web: {
+        results: [
+          {
+            title: "Example",
+            url: "https://example.com",
+            description: "An example site",
+            extra_field: "ignored",
+          },
+        ],
+      },
+    });
+
+    const results = await braveSearch("test");
+
+    expect(results).toEqual([
+      {
+        title: "Example",
+        url: "https://example.com",
+        description: "An example site",
+      },
+    ]);
+  });
+
+  it("returns empty array when no web results", async () => {
+    globalThis.fetch = mockFetchResponse({ web: { results: [] } });
+    const results = await braveSearch("test");
+    expect(results).toEqual([]);
+  });
+
+  it("returns empty array when web field is missing", async () => {
+    globalThis.fetch = mockFetchResponse({});
+    const results = await braveSearch("test");
+    expect(results).toEqual([]);
+  });
+
+  it("throws when no API key is available", async () => {
+    delete process.env.BRAVE_API_KEY;
+    await expect(braveSearch("test")).rejects.toThrow(
+      "BRAVE_API_KEY"
+    );
+  });
+
+  it("throws on non-200 response with status and body", async () => {
+    globalThis.fetch = mockFetchResponse(
+      { message: "Rate limit exceeded" },
+      429
+    );
+
+    await expect(braveSearch("test")).rejects.toThrow(
+      "Brave Search API error (429)"
+    );
+  });
+
+  it("includes optional params in URL when provided", async () => {
+    const mockFetch = mockFetchResponse({ web: { results: [] } });
+    globalThis.fetch = mockFetch;
+
+    await braveSearch("test", {
+      count: 10,
+      country: "US",
+      searchLang: "en",
+      safesearch: "strict",
+      freshness: "pw",
+    });
+
+    const [url] = mockFetch.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.searchParams.get("count")).toBe("10");
+    expect(parsed.searchParams.get("country")).toBe("US");
+    expect(parsed.searchParams.get("search_lang")).toBe("en");
+    expect(parsed.searchParams.get("safesearch")).toBe("strict");
+    expect(parsed.searchParams.get("freshness")).toBe("pw");
+  });
+
+  it("omits empty-string options from URL", async () => {
+    const mockFetch = mockFetchResponse({ web: { results: [] } });
+    globalThis.fetch = mockFetch;
+
+    await braveSearch("test", { country: "", freshness: "" });
+
+    const [url] = mockFetch.mock.calls[0];
+    const parsed = new URL(url);
+    expect(parsed.searchParams.has("country")).toBe(false);
+    expect(parsed.searchParams.has("freshness")).toBe(false);
+  });
+});

--- a/packages/brave-search/src/braveSearch.ts
+++ b/packages/brave-search/src/braveSearch.ts
@@ -1,0 +1,59 @@
+const BRAVE_SEARCH_URL = "https://api.search.brave.com/res/v1/web/search";
+
+export type BraveSearchResult = {
+  title: string;
+  url: string;
+  description: string;
+};
+
+export type BraveSearchOptions = {
+  apiKey?: string;
+  count?: number;
+  country?: string;
+  searchLang?: string;
+  safesearch?: string;
+  freshness?: string;
+};
+
+export async function braveSearch(
+  query: string,
+  options?: BraveSearchOptions
+): Promise<BraveSearchResult[]> {
+  // Note: using || (not ??) so empty strings from Agency defaults fall through to env var
+  const apiKey = options?.apiKey || process.env.BRAVE_API_KEY;
+  if (!apiKey) {
+    throw new Error(
+      "Missing Brave Search API key. Set BRAVE_API_KEY env var or pass apiKey option."
+    );
+  }
+
+  const url = new URL(BRAVE_SEARCH_URL);
+  url.searchParams.set("q", query);
+  url.searchParams.set("count", String(options?.count ?? 5));
+
+  if (options?.country) url.searchParams.set("country", options.country);
+  if (options?.searchLang) url.searchParams.set("search_lang", options.searchLang);
+  if (options?.safesearch) url.searchParams.set("safesearch", options.safesearch);
+  if (options?.freshness) url.searchParams.set("freshness", options.freshness);
+
+  const response = await fetch(url.toString(), {
+    headers: {
+      "Accept": "application/json",
+      "X-Subscription-Token": apiKey,
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Brave Search API error (${response.status}): ${body}`);
+  }
+
+  const data = await response.json();
+  const results = data?.web?.results ?? [];
+
+  return results.map((r: Record<string, unknown>) => ({
+    title: r.title as string,
+    url: r.url as string,
+    description: r.description as string,
+  }));
+}

--- a/packages/brave-search/src/braveSearch.ts
+++ b/packages/brave-search/src/braveSearch.ts
@@ -36,7 +36,7 @@ export async function braveSearch(
   if (options?.safesearch) url.searchParams.set("safesearch", options.safesearch);
   if (options?.freshness) url.searchParams.set("freshness", options.freshness);
 
-  const response = await fetch(url.toString(), {
+  const response = await fetch(url, {
     headers: {
       "Accept": "application/json",
       "X-Subscription-Token": apiKey,
@@ -52,8 +52,8 @@ export async function braveSearch(
   const results = data?.web?.results ?? [];
 
   return results.map((r: Record<string, unknown>) => ({
-    title: r.title as string,
-    url: r.url as string,
-    description: r.description as string,
+    title: (r.title as string) ?? "",
+    url: (r.url as string) ?? "",
+    description: (r.description as string) ?? "",
   }));
 }

--- a/packages/brave-search/tests/agency/brave-search.agency
+++ b/packages/brave-search/tests/agency/brave-search.agency
@@ -1,0 +1,10 @@
+import { braveSearch } from "../../index.agency"
+
+node main() {
+  let results = braveSearch("TypeScript programming language")
+  let first = results[0]
+  print(first.title)
+  print(first.url)
+  print(first.description)
+  print(results)
+}

--- a/packages/brave-search/tests/agency/brave-search.agency
+++ b/packages/brave-search/tests/agency/brave-search.agency
@@ -2,9 +2,11 @@ import { braveSearch } from "../../index.agency"
 
 node main() {
   let results = braveSearch("TypeScript programming language")
-  let first = results[0]
-  print(first.title)
-  print(first.url)
-  print(first.description)
+  if (length(results) > 0) {
+    let first = results[0]
+    print(first.title)
+    print(first.url)
+    print(first.description)
+  }
   print(results)
 }

--- a/packages/brave-search/tsconfig.json
+++ b/packages/brave-search/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/brave-search/tsconfig.json
+++ b/packages/brave-search/tsconfig.json
@@ -12,5 +12,5 @@
     "skipLibCheck": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "tests"]
+  "exclude": ["node_modules", "dist", "tests", "src/**/*.test.ts"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,9 @@ importers:
         specifier: workspace:*
         version: link:../agency-lang
     devDependencies:
+      '@types/node':
+        specifier: ^25.0.0
+        version: 25.0.6
       typescript:
         specifier: ^5.0.0
         version: 5.9.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,19 @@ importers:
         specifier: ^3.5.13
         version: 3.5.33(typescript@5.9.3)
 
+  packages/brave-search:
+    dependencies:
+      agency-lang:
+        specifier: workspace:*
+        version: link:../agency-lang
+    devDependencies:
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.0.6)
+
   packages/examples:
     dependencies:
       '@agency-lang/mcp':


### PR DESCRIPTION
## Summary

- Adds a new `@agency-lang/brave-search` package that wraps the Brave Search REST API
- Exposes a `braveSearch` Agency function usable as an LLM tool via `uses`
- No third-party dependencies — calls the Brave API directly with native `fetch`
- Supports API key via env var (`BRAVE_API_KEY`) or named parameter (`apiKey`)
- All Brave API options exposed via named parameters with sensible defaults

### Usage

```
import { braveSearch } from "pkg::@agency-lang/brave-search"

node main() {
  let answer = llm("What's the latest news on AI?") uses braveSearch
}
```

## Test plan

- [x] 10 unit tests with mocked fetch (URL construction, auth, response mapping, error handling)
- [x] All 2105 existing agency-lang tests still pass
- [ ] Integration test with live API key: `cd packages/brave-search && BRAVE_API_KEY=<key> pnpm run test:agency`