### PR TITLE
Add @agency-lang/web-fetch package

### DIFF
--- a/packages/brave-search/index.js
+++ b/packages/brave-search/index.js
@@ -1,0 +1,330 @@
+import { print, printJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit } from "agency-lang/stdlib/index.js";
+import { braveSearch as braveSearchImpl } from "./dist/src/braveSearch.js";
+import { fileURLToPath } from "url";
+import __process from "process";
+import { z } from "zod";
+import { nanoid } from "agency-lang";
+import path from "path";
+import {
+  RuntimeContext,
+  Runner,
+  setupFunction,
+  callHook,
+  checkpoint as __checkpoint_impl,
+  getCheckpoint as __getCheckpoint_impl,
+  restore as __restore_impl,
+  interrupt,
+  isInterrupt,
+  hasInterrupts,
+  isDebugger,
+  respondToInterrupts as _respondToInterrupts,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  failure,
+  isFailure,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  AgencyFunction as __AgencyFunction,
+  UNSET as __UNSET,
+  __call,
+  functionRefReviver as __functionRefReviver
+} from "agency-lang/runtime";
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+const getDirname = () => __dirname;
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "agency-lang",
+    debugMode: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  traceConfig: {
+    program: "../brave-search/index.agency",
+    traceDir: "traces"
+  }
+});
+const graph = __globalCtx.graph;
+function readSkill({ filepath }) {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+function approve(value) {
+  return { type: "approve", value };
+}
+function reject(value) {
+  return { type: "reject", value };
+}
+function propagate() {
+  return { type: "propagate" };
+}
+const respondToInterrupts = (interrupts, responses, opts) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+const rewindFrom = (checkpoint2, overrides, opts) => _rewindFrom({ ctx: __globalCtx, checkpoint: checkpoint2, overrides, metadata: opts?.metadata });
+const __setDebugger = (dbg) => {
+  __globalCtx.debuggerState = dbg;
+};
+const __setTraceWriter = (tw) => {
+  __globalCtx.traceWriter = tw;
+};
+const __getCheckpoints = () => __globalCtx.checkpoints;
+const __toolRegistry = {};
+function __registerTool(value, name) {
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[name ?? value.name] = value;
+  }
+}
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: void 0, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: void 0, variadic: false }, { name: "options", hasDefault: false, defaultValue: void 0, variadic: false }], toolDefinition: null }, __toolRegistry);
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+function registerTools(tools) {
+  for (const tool of tools) {
+    if (__AgencyFunction.isAgencyFunction(tool)) {
+      __toolRegistry[tool.name] = tool;
+    }
+  }
+}
+__registerTool(print);
+__registerTool(printJSON);
+__registerTool(input);
+__registerTool(sleep);
+__registerTool(round);
+__registerTool(fetch);
+__registerTool(fetchJSON);
+__registerTool(read);
+__registerTool(write);
+__registerTool(readImage);
+__registerTool(notify);
+__registerTool(range);
+__registerTool(mostCommon);
+__registerTool(keys);
+__registerTool(values);
+__registerTool(entries);
+__registerTool(emit);
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("../brave-search/index.agency");
+}
+__toolRegistry["readSkill"] = __AgencyFunction.create({
+  name: "readSkill",
+  module: "../brave-search/index.agency",
+  fn: readSkill,
+  params: __readSkillToolParams.map((p) => ({ name: p, hasDefault: false, defaultValue: void 0, variadic: false })),
+  toolDefinition: __readSkillTool
+}, __toolRegistry);
+__functionRefReviver.registry = __toolRegistry;
+async function __braveSearch_impl(query, count = __UNSET, apiKey = __UNSET, country = __UNSET, searchLang = __UNSET, safesearch = __UNSET, freshness = __UNSET, __state = void 0) {
+  const __setupData = setupFunction({
+    state: __state
+  });
+  const __stateStack = __setupData.stateStack;
+  const __stack = __setupData.stack;
+  const __step = __setupData.step;
+  const __self = __setupData.self;
+  const __threads = __setupData.threads;
+  const __ctx = __state?.ctx || __globalCtx;
+  const statelogClient = __ctx.statelogClient;
+  const __graph = __ctx.graph;
+  let __forked;
+  let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("../brave-search/index.agency")) {
+    await __initializeGlobals(__ctx);
+  }
+  let __funcStartTime = performance.now();
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onFunctionStart",
+    data: {
+      functionName: "braveSearch",
+      args: {
+        query,
+        count,
+        apiKey,
+        country,
+        searchLang,
+        safesearch,
+        freshness
+      },
+      isBuiltin: false,
+      moduleId: "../brave-search/index.agency"
+    }
+  });
+  __stack.args["query"] = query;
+  __stack.args["count"] = count === __UNSET ? 5 : count;
+  __stack.args["apiKey"] = apiKey === __UNSET ? `` : apiKey;
+  __stack.args["country"] = country === __UNSET ? `` : country;
+  __stack.args["searchLang"] = searchLang === __UNSET ? `` : searchLang;
+  __stack.args["safesearch"] = safesearch === __UNSET ? `` : safesearch;
+  __stack.args["freshness"] = freshness === __UNSET ? `` : freshness;
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "../brave-search/index.agency", scopeName: "braveSearch" });
+  let __resultCheckpointId = -1;
+  if (__ctx.stateStack.currentNodeId()) {
+    __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "../brave-search/index.agency", scopeName: "braveSearch", stepPath: "", label: "result-entry" });
+  }
+  if (__ctx._pendingArgOverrides) {
+    const __overrides = __ctx._pendingArgOverrides;
+    __ctx._pendingArgOverrides = void 0;
+    if ("query" in __overrides) {
+      query = __overrides["query"];
+      __stack.args["query"] = query;
+    }
+    if ("count" in __overrides) {
+      count = __overrides["count"];
+      __stack.args["count"] = count;
+    }
+    if ("apiKey" in __overrides) {
+      apiKey = __overrides["apiKey"];
+      __stack.args["apiKey"] = apiKey;
+    }
+    if ("country" in __overrides) {
+      country = __overrides["country"];
+      __stack.args["country"] = country;
+    }
+    if ("searchLang" in __overrides) {
+      searchLang = __overrides["searchLang"];
+      __stack.args["searchLang"] = searchLang;
+    }
+    if ("safesearch" in __overrides) {
+      safesearch = __overrides["safesearch"];
+      __stack.args["safesearch"] = safesearch;
+    }
+    if ("freshness" in __overrides) {
+      freshness = __overrides["freshness"];
+      __stack.args["freshness"] = freshness;
+    }
+  }
+  try {
+    await runner.step(0, async (runner2) => {
+      __self.__retryable = false;
+      __functionCompleted = true;
+      runner2.halt(await __call(braveSearchImpl, {
+        type: "positional",
+        args: [__stack.args.query, {
+          "count": __stack.args.count,
+          "apiKey": __stack.args.apiKey,
+          "country": __stack.args.country,
+          "searchLang": __stack.args.searchLang,
+          "safesearch": __stack.args.safesearch,
+          "freshness": __stack.args.freshness
+        }]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      }));
+      return;
+    });
+    if (runner.halted) {
+      if (isFailure(runner.haltResult)) {
+        runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable;
+      }
+      return runner.haltResult;
+    }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error;
+    }
+    return failure(
+      __error instanceof Error ? __error.message : String(__error),
+      {
+        checkpoint: __ctx.getResultCheckpoint(),
+        retryable: __self.__retryable,
+        functionName: "braveSearch",
+        args: __stack.args
+      }
+    );
+  } finally {
+    __stateStack.pop();
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "braveSearch",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      });
+    }
+  }
+}
+const braveSearch = __AgencyFunction.create({
+  name: "braveSearch",
+  module: "../brave-search/index.agency",
+  fn: __braveSearch_impl,
+  params: [{
+    name: "query",
+    hasDefault: false,
+    defaultValue: void 0,
+    variadic: false
+  }, {
+    name: "count",
+    hasDefault: true,
+    defaultValue: void 0,
+    variadic: false
+  }, {
+    name: "apiKey",
+    hasDefault: true,
+    defaultValue: void 0,
+    variadic: false
+  }, {
+    name: "country",
+    hasDefault: true,
+    defaultValue: void 0,
+    variadic: false
+  }, {
+    name: "searchLang",
+    hasDefault: true,
+    defaultValue: void 0,
+    variadic: false
+  }, {
+    name: "safesearch",
+    hasDefault: true,
+    defaultValue: void 0,
+    variadic: false
+  }, {
+    name: "freshness",
+    hasDefault: true,
+    defaultValue: void 0,
+    variadic: false
+  }],
+  toolDefinition: {
+    name: "braveSearch",
+    description: `No description provided.`,
+    schema: z.object({ "query": z.string(), "count": z.number().nullable().describe("Default: 5"), "apiKey": z.string().nullable().describe("Default: "), "country": z.string().nullable().describe("Default: "), "searchLang": z.string().nullable().describe("Default: "), "safesearch": z.string().nullable().describe("Default: "), "freshness": z.string().nullable().describe("Default: ") })
+  }
+}, __toolRegistry);
+var stdin_default = graph;
+const __sourceMap = { "../brave-search/index.agency:braveSearch": { "0": { "line": 4, "col": 2 } } };
+export {
+  __getCheckpoints,
+  __setDebugger,
+  __setTraceWriter,
+  __sourceMap,
+  approve,
+  braveSearch,
+  stdin_default as default,
+  hasInterrupts,
+  interrupt,
+  isDebugger,
+  isInterrupt,
+  readSkill,
+  reject,
+  respondToInterrupts,
+  rewindFrom
+};

--- a/packages/brave-search/package.json
+++ b/packages/brave-search/package.json
@@ -4,7 +4,7 @@
   "description": "Brave Search integration for Agency",
   "type": "module",
   "agency": "./index.agency",
-  "main": "./dist/src/braveSearch.js",
+  "main": "./index.js",
   "exports": {
     ".": {
       "types": "./dist/src/braveSearch.d.ts",
@@ -14,7 +14,8 @@
   },
   "files": [
     "dist/",
-    "index.agency"
+    "index.agency",
+    "index.js"
   ],
   "author": "Aditya Bhargava",
   "license": "ISC",

--- a/packages/mcp/index.js
+++ b/packages/mcp/index.js
@@ -1,0 +1,268 @@
+import { print, printJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit } from "agency-lang/stdlib/index.js";
+import { mcp as mcpImpl } from "./dist/src/mcp.js";
+import { fileURLToPath } from "url";
+import __process from "process";
+import { z } from "zod";
+import { nanoid } from "agency-lang";
+import path from "path";
+import {
+  RuntimeContext,
+  Runner,
+  setupFunction,
+  callHook,
+  checkpoint as __checkpoint_impl,
+  getCheckpoint as __getCheckpoint_impl,
+  restore as __restore_impl,
+  interrupt,
+  isInterrupt,
+  hasInterrupts,
+  isDebugger,
+  respondToInterrupts as _respondToInterrupts,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  failure,
+  isFailure,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  AgencyFunction as __AgencyFunction,
+  UNSET as __UNSET,
+  __call,
+  functionRefReviver as __functionRefReviver
+} from "agency-lang/runtime";
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+const getDirname = () => __dirname;
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "agency-lang",
+    debugMode: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  traceConfig: {
+    program: "../mcp/index.agency",
+    traceDir: "traces"
+  }
+});
+const graph = __globalCtx.graph;
+function readSkill({ filepath }) {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+function approve(value) {
+  return { type: "approve", value };
+}
+function reject(value) {
+  return { type: "reject", value };
+}
+function propagate() {
+  return { type: "propagate" };
+}
+const respondToInterrupts = (interrupts, responses, opts) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+const rewindFrom = (checkpoint2, overrides, opts) => _rewindFrom({ ctx: __globalCtx, checkpoint: checkpoint2, overrides, metadata: opts?.metadata });
+const __setDebugger = (dbg) => {
+  __globalCtx.debuggerState = dbg;
+};
+const __setTraceWriter = (tw) => {
+  __globalCtx.traceWriter = tw;
+};
+const __getCheckpoints = () => __globalCtx.checkpoints;
+const __toolRegistry = {};
+function __registerTool(value, name) {
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[name ?? value.name] = value;
+  }
+}
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: void 0, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: void 0, variadic: false }, { name: "options", hasDefault: false, defaultValue: void 0, variadic: false }], toolDefinition: null }, __toolRegistry);
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+function registerTools(tools) {
+  for (const tool of tools) {
+    if (__AgencyFunction.isAgencyFunction(tool)) {
+      __toolRegistry[tool.name] = tool;
+    }
+  }
+}
+__registerTool(print);
+__registerTool(printJSON);
+__registerTool(input);
+__registerTool(sleep);
+__registerTool(round);
+__registerTool(fetch);
+__registerTool(fetchJSON);
+__registerTool(read);
+__registerTool(write);
+__registerTool(readImage);
+__registerTool(notify);
+__registerTool(range);
+__registerTool(mostCommon);
+__registerTool(keys);
+__registerTool(values);
+__registerTool(entries);
+__registerTool(emit);
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("../mcp/index.agency");
+}
+__toolRegistry["readSkill"] = __AgencyFunction.create({
+  name: "readSkill",
+  module: "../mcp/index.agency",
+  fn: readSkill,
+  params: __readSkillToolParams.map((p) => ({ name: p, hasDefault: false, defaultValue: void 0, variadic: false })),
+  toolDefinition: __readSkillTool
+}, __toolRegistry);
+__functionRefReviver.registry = __toolRegistry;
+async function __mcp_impl(serverName, onOAuthRequired = __UNSET, __state = void 0) {
+  const __setupData = setupFunction({
+    state: __state
+  });
+  const __stateStack = __setupData.stateStack;
+  const __stack = __setupData.stack;
+  const __step = __setupData.step;
+  const __self = __setupData.self;
+  const __threads = __setupData.threads;
+  const __ctx = __state?.ctx || __globalCtx;
+  const statelogClient = __ctx.statelogClient;
+  const __graph = __ctx.graph;
+  let __forked;
+  let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("../mcp/index.agency")) {
+    await __initializeGlobals(__ctx);
+  }
+  let __funcStartTime = performance.now();
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onFunctionStart",
+    data: {
+      functionName: "mcp",
+      args: {
+        serverName,
+        onOAuthRequired
+      },
+      isBuiltin: false,
+      moduleId: "../mcp/index.agency"
+    }
+  });
+  __stack.args["serverName"] = serverName;
+  __stack.args["onOAuthRequired"] = onOAuthRequired === __UNSET ? null : onOAuthRequired;
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "../mcp/index.agency", scopeName: "mcp" });
+  let __resultCheckpointId = -1;
+  if (__ctx.stateStack.currentNodeId()) {
+    __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "../mcp/index.agency", scopeName: "mcp", stepPath: "", label: "result-entry" });
+  }
+  if (__ctx._pendingArgOverrides) {
+    const __overrides = __ctx._pendingArgOverrides;
+    __ctx._pendingArgOverrides = void 0;
+    if ("serverName" in __overrides) {
+      serverName = __overrides["serverName"];
+      __stack.args["serverName"] = serverName;
+    }
+    if ("onOAuthRequired" in __overrides) {
+      onOAuthRequired = __overrides["onOAuthRequired"];
+      __stack.args["onOAuthRequired"] = onOAuthRequired;
+    }
+  }
+  try {
+    await runner.step(0, async (runner2) => {
+      __self.__retryable = false;
+      __functionCompleted = true;
+      runner2.halt(await __call(mcpImpl, {
+        type: "positional",
+        args: [__stack.args.serverName, __stack.args.onOAuthRequired]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      }));
+      return;
+    });
+    if (runner.halted) {
+      if (isFailure(runner.haltResult)) {
+        runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable;
+      }
+      return runner.haltResult;
+    }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error;
+    }
+    return failure(
+      __error instanceof Error ? __error.message : String(__error),
+      {
+        checkpoint: __ctx.getResultCheckpoint(),
+        retryable: __self.__retryable,
+        functionName: "mcp",
+        args: __stack.args
+      }
+    );
+  } finally {
+    __stateStack.pop();
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "mcp",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      });
+    }
+  }
+}
+const mcp = __AgencyFunction.create({
+  name: "mcp",
+  module: "../mcp/index.agency",
+  fn: __mcp_impl,
+  params: [{
+    name: "serverName",
+    hasDefault: false,
+    defaultValue: void 0,
+    variadic: false
+  }, {
+    name: "onOAuthRequired",
+    hasDefault: true,
+    defaultValue: void 0,
+    variadic: false
+  }],
+  toolDefinition: {
+    name: "mcp",
+    description: `No description provided.`,
+    schema: z.object({ "serverName": z.string(), "onOAuthRequired": z.string().nullable().describe("Default: null") })
+  }
+}, __toolRegistry);
+var stdin_default = graph;
+const __sourceMap = { "../mcp/index.agency:mcp": { "0": { "line": 3, "col": 2 } } };
+export {
+  __getCheckpoints,
+  __setDebugger,
+  __setTraceWriter,
+  __sourceMap,
+  approve,
+  stdin_default as default,
+  hasInterrupts,
+  interrupt,
+  isDebugger,
+  isInterrupt,
+  mcp,
+  readSkill,
+  reject,
+  respondToInterrupts,
+  rewindFrom
+};

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -4,7 +4,7 @@
   "description": "MCP (Model Context Protocol) support for the Agency language",
   "type": "module",
   "agency": "./index.agency",
-  "main": "./dist/src/mcp.js",
+  "main": "./index.js",
   "keywords": [],
   "author": "Aditya Bhargava",
   "license": "ISC",
@@ -24,7 +24,8 @@
   },
   "files": [
     "dist/",
-    "index.agency"
+    "index.agency",
+    "index.js"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/web-fetch/index.agency
+++ b/packages/web-fetch/index.agency
@@ -1,0 +1,6 @@
+import { fetchPage as fetchPageImpl } from "./dist/src/fetchPage.js"
+
+/// Fetch a web page and extract its readable content as markdown. Returns title, content, excerpt, siteName, and url.
+export def fetchPage(url: string, maxChars: number = 20000, timeout: number = 15000) {
+  return fetchPageImpl(url, { maxChars: maxChars, timeout: timeout })
+}

--- a/packages/web-fetch/index.js
+++ b/packages/web-fetch/index.js
@@ -1,0 +1,282 @@
+import { print, printJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit } from "agency-lang/stdlib/index.js";
+import { fetchPage as fetchPageImpl } from "./dist/src/fetchPage.js";
+import { fileURLToPath } from "url";
+import __process from "process";
+import { z } from "zod";
+import { nanoid } from "agency-lang";
+import path from "path";
+import {
+  RuntimeContext,
+  Runner,
+  setupFunction,
+  callHook,
+  checkpoint as __checkpoint_impl,
+  getCheckpoint as __getCheckpoint_impl,
+  restore as __restore_impl,
+  interrupt,
+  isInterrupt,
+  hasInterrupts,
+  isDebugger,
+  respondToInterrupts as _respondToInterrupts,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  failure,
+  isFailure,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  AgencyFunction as __AgencyFunction,
+  UNSET as __UNSET,
+  __call,
+  functionRefReviver as __functionRefReviver
+} from "agency-lang/runtime";
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+const getDirname = () => __dirname;
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "agency-lang",
+    debugMode: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  traceConfig: {
+    program: "../web-fetch/index.agency",
+    traceDir: "traces"
+  }
+});
+const graph = __globalCtx.graph;
+function readSkill({ filepath }) {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+function approve(value) {
+  return { type: "approve", value };
+}
+function reject(value) {
+  return { type: "reject", value };
+}
+function propagate() {
+  return { type: "propagate" };
+}
+const respondToInterrupts = (interrupts, responses, opts) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+const rewindFrom = (checkpoint2, overrides, opts) => _rewindFrom({ ctx: __globalCtx, checkpoint: checkpoint2, overrides, metadata: opts?.metadata });
+const __setDebugger = (dbg) => {
+  __globalCtx.debuggerState = dbg;
+};
+const __setTraceWriter = (tw) => {
+  __globalCtx.traceWriter = tw;
+};
+const __getCheckpoints = () => __globalCtx.checkpoints;
+const __toolRegistry = {};
+function __registerTool(value, name) {
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[name ?? value.name] = value;
+  }
+}
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: void 0, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: void 0, variadic: false }, { name: "options", hasDefault: false, defaultValue: void 0, variadic: false }], toolDefinition: null }, __toolRegistry);
+function setLLMClient(client) {
+  __globalCtx.setLLMClient(client);
+}
+function registerTools(tools) {
+  for (const tool of tools) {
+    if (__AgencyFunction.isAgencyFunction(tool)) {
+      __toolRegistry[tool.name] = tool;
+    }
+  }
+}
+__registerTool(print);
+__registerTool(printJSON);
+__registerTool(input);
+__registerTool(sleep);
+__registerTool(round);
+__registerTool(fetch);
+__registerTool(fetchJSON);
+__registerTool(read);
+__registerTool(write);
+__registerTool(readImage);
+__registerTool(notify);
+__registerTool(range);
+__registerTool(mostCommon);
+__registerTool(keys);
+__registerTool(values);
+__registerTool(entries);
+__registerTool(emit);
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("../web-fetch/index.agency");
+}
+__toolRegistry["readSkill"] = __AgencyFunction.create({
+  name: "readSkill",
+  module: "../web-fetch/index.agency",
+  fn: readSkill,
+  params: __readSkillToolParams.map((p) => ({ name: p, hasDefault: false, defaultValue: void 0, variadic: false })),
+  toolDefinition: __readSkillTool
+}, __toolRegistry);
+__functionRefReviver.registry = __toolRegistry;
+async function __fetchPage_impl(url, maxChars = __UNSET, timeout = __UNSET, __state = void 0) {
+  const __setupData = setupFunction({
+    state: __state
+  });
+  const __stateStack = __setupData.stateStack;
+  const __stack = __setupData.stack;
+  const __step = __setupData.step;
+  const __self = __setupData.self;
+  const __threads = __setupData.threads;
+  const __ctx = __state?.ctx || __globalCtx;
+  const statelogClient = __ctx.statelogClient;
+  const __graph = __ctx.graph;
+  let __forked;
+  let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("../web-fetch/index.agency")) {
+    await __initializeGlobals(__ctx);
+  }
+  let __funcStartTime = performance.now();
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onFunctionStart",
+    data: {
+      functionName: "fetchPage",
+      args: {
+        url,
+        maxChars,
+        timeout
+      },
+      isBuiltin: false,
+      moduleId: "../web-fetch/index.agency"
+    }
+  });
+  __stack.args["url"] = url;
+  __stack.args["maxChars"] = maxChars === __UNSET ? 2e4 : maxChars;
+  __stack.args["timeout"] = timeout === __UNSET ? 15e3 : timeout;
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "../web-fetch/index.agency", scopeName: "fetchPage" });
+  let __resultCheckpointId = -1;
+  if (__ctx.stateStack.currentNodeId()) {
+    __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "../web-fetch/index.agency", scopeName: "fetchPage", stepPath: "", label: "result-entry" });
+  }
+  if (__ctx._pendingArgOverrides) {
+    const __overrides = __ctx._pendingArgOverrides;
+    __ctx._pendingArgOverrides = void 0;
+    if ("url" in __overrides) {
+      url = __overrides["url"];
+      __stack.args["url"] = url;
+    }
+    if ("maxChars" in __overrides) {
+      maxChars = __overrides["maxChars"];
+      __stack.args["maxChars"] = maxChars;
+    }
+    if ("timeout" in __overrides) {
+      timeout = __overrides["timeout"];
+      __stack.args["timeout"] = timeout;
+    }
+  }
+  try {
+    await runner.step(0, async (runner2) => {
+      __self.__retryable = false;
+      __functionCompleted = true;
+      runner2.halt(await __call(fetchPageImpl, {
+        type: "positional",
+        args: [__stack.args.url, {
+          "maxChars": __stack.args.maxChars,
+          "timeout": __stack.args.timeout
+        }]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      }));
+      return;
+    });
+    if (runner.halted) {
+      if (isFailure(runner.haltResult)) {
+        runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable;
+      }
+      return runner.haltResult;
+    }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error;
+    }
+    return failure(
+      __error instanceof Error ? __error.message : String(__error),
+      {
+        checkpoint: __ctx.getResultCheckpoint(),
+        retryable: __self.__retryable,
+        functionName: "fetchPage",
+        args: __stack.args
+      }
+    );
+  } finally {
+    __stateStack.pop();
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "fetchPage",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      });
+    }
+  }
+}
+const fetchPage = __AgencyFunction.create({
+  name: "fetchPage",
+  module: "../web-fetch/index.agency",
+  fn: __fetchPage_impl,
+  params: [{
+    name: "url",
+    hasDefault: false,
+    defaultValue: void 0,
+    variadic: false
+  }, {
+    name: "maxChars",
+    hasDefault: true,
+    defaultValue: void 0,
+    variadic: false
+  }, {
+    name: "timeout",
+    hasDefault: true,
+    defaultValue: void 0,
+    variadic: false
+  }],
+  toolDefinition: {
+    name: "fetchPage",
+    description: `No description provided.`,
+    schema: z.object({ "url": z.string(), "maxChars": z.number().nullable().describe("Default: 20000"), "timeout": z.number().nullable().describe("Default: 15000") })
+  }
+}, __toolRegistry);
+var stdin_default = graph;
+const __sourceMap = { "../web-fetch/index.agency:fetchPage": { "0": { "line": 4, "col": 2 } } };
+export {
+  __getCheckpoints,
+  __setDebugger,
+  __setTraceWriter,
+  __sourceMap,
+  approve,
+  stdin_default as default,
+  fetchPage,
+  hasInterrupts,
+  interrupt,
+  isDebugger,
+  isInterrupt,
+  readSkill,
+  reject,
+  respondToInterrupts,
+  rewindFrom
+};

--- a/packages/web-fetch/package.json
+++ b/packages/web-fetch/package.json
@@ -18,10 +18,13 @@
   ],
   "author": "Aditya Bhargava",
   "license": "ISC",
-  "bugs": { "url": "https://github.com/egonSchiele/agency-lang/issues" },
+  "bugs": {
+    "url": "https://github.com/egonSchiele/agency-lang/issues"
+  },
   "homepage": "https://github.com/egonSchiele/agency-lang",
   "scripts": {
     "build": "tsc",
+    "agency": "agency",
     "test": "vitest",
     "test:run": "vitest run",
     "test:agency": "agency tests/agency"
@@ -36,6 +39,7 @@
   "devDependencies": {
     "@types/node": "^25.0.0",
     "typescript": "^5.0.0",
-    "vitest": "^3.0.0"
+    "vitest": "^3.0.0",
+    "zod": "^4.3.5"
   }
 }

--- a/packages/web-fetch/package.json
+++ b/packages/web-fetch/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@agency-lang/web-fetch",
+  "version": "0.0.1",
+  "description": "Web page fetching and content extraction for Agency",
+  "type": "module",
+  "agency": "./index.agency",
+  "main": "./dist/src/fetchPage.js",
+  "exports": {
+    ".": {
+      "types": "./dist/src/fetchPage.d.ts",
+      "import": "./dist/src/fetchPage.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist/",
+    "index.agency"
+  ],
+  "author": "Aditya Bhargava",
+  "license": "ISC",
+  "bugs": { "url": "https://github.com/egonSchiele/agency-lang/issues" },
+  "homepage": "https://github.com/egonSchiele/agency-lang",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:run": "vitest run",
+    "test:agency": "agency tests/agency"
+  },
+  "dependencies": {
+    "@mozilla/readability": "^0.5.0",
+    "linkedom": "^0.18.0"
+  },
+  "peerDependencies": {
+    "agency-lang": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/web-fetch/package.json
+++ b/packages/web-fetch/package.json
@@ -4,7 +4,7 @@
   "description": "Web page fetching and content extraction for Agency",
   "type": "module",
   "agency": "./index.agency",
-  "main": "./dist/src/fetchPage.js",
+  "main": "./index.js",
   "exports": {
     ".": {
       "types": "./dist/src/fetchPage.d.ts",
@@ -14,7 +14,8 @@
   },
   "files": [
     "dist/",
-    "index.agency"
+    "index.agency",
+    "index.js"
   ],
   "author": "Aditya Bhargava",
   "license": "ISC",

--- a/packages/web-fetch/src/fetchPage.test.ts
+++ b/packages/web-fetch/src/fetchPage.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { fetchPage } from "./fetchPage.js";
+
+const SAMPLE_ARTICLE_HTML = `
+<!DOCTYPE html>
+<html>
+<head><title>Test Article</title></head>
+<body>
+  <nav><a href="/">Home</a></nav>
+  <article>
+    <h1>Test Article Title</h1>
+    <p>This is the first paragraph of the article with enough text to be considered content by readability. It needs to be reasonably long so the algorithm picks it up as the main article body.</p>
+    <p>This is the second paragraph with more content. Readability needs a substantial amount of text to determine that this is indeed an article worth extracting from the page.</p>
+    <p>Here is a third paragraph. The more content we add, the more confident Readability will be that this is the main content of the page and not just some sidebar or navigation element.</p>
+    <h2>A Subheading</h2>
+    <p>More content under the subheading. This paragraph provides additional depth to the article, covering more details about the topic at hand.</p>
+    <ul>
+      <li>First item in a list</li>
+      <li>Second item in a list</li>
+    </ul>
+    <p>A paragraph with <strong>bold text</strong> and <em>italic text</em> and <code>inline code</code>.</p>
+    <p>A paragraph with a <a href="https://example.com">link to example</a>.</p>
+  </article>
+  <footer><p>Copyright 2026</p></footer>
+</body>
+</html>
+`;
+
+const MINIMAL_HTML = `
+<!DOCTYPE html>
+<html><head><title>Minimal</title></head>
+<body></body>
+</html>
+`;
+
+function mockFetchResponse(body: string, options: { status?: number; contentType?: string; url?: string } = {}) {
+  const { status = 200, contentType = "text/html", url = "https://example.com" } = options;
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? "OK" : "Error",
+    url,
+    headers: new Headers({ "content-type": contentType }),
+    text: async () => body,
+  });
+}
+
+describe("fetchPage", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("extracts title, content, and excerpt from article HTML", async () => {
+    globalThis.fetch = mockFetchResponse(SAMPLE_ARTICLE_HTML);
+
+    const result = await fetchPage("https://example.com/article");
+
+    expect(result.title).toBe("Test Article");
+    expect(result.content).toContain("first paragraph");
+    expect(result.content).toContain("second paragraph");
+    expect(result.excerpt).toBeTruthy();
+    expect(result.url).toBe("https://example.com");
+  });
+
+  it("converts extracted HTML to markdown", async () => {
+    globalThis.fetch = mockFetchResponse(SAMPLE_ARTICLE_HTML);
+
+    const result = await fetchPage("https://example.com/article");
+
+    expect(result.content).toContain("## A Subheading");
+    expect(result.content).toContain("**bold text**");
+    expect(result.content).toContain("*italic text*");
+    expect(result.content).toContain("`inline code`");
+    expect(result.content).toContain("[link to example](https://example.com)");
+    expect(result.content).toContain("- First item in a list");
+  });
+
+  it("truncates content to maxChars", async () => {
+    globalThis.fetch = mockFetchResponse(SAMPLE_ARTICLE_HTML);
+
+    const result = await fetchPage("https://example.com/article", { maxChars: 50 });
+
+    expect(result.content.length).toBeLessThanOrEqual(50);
+  });
+
+  it("returns full content when under maxChars", async () => {
+    globalThis.fetch = mockFetchResponse(SAMPLE_ARTICLE_HTML);
+
+    const result = await fetchPage("https://example.com/article", { maxChars: 100000 });
+
+    expect(result.content).toContain("first paragraph");
+    expect(result.content).toContain("A Subheading");
+  });
+
+  it("throws on non-200 HTTP response", async () => {
+    globalThis.fetch = mockFetchResponse("Not Found", { status: 404 });
+
+    await expect(fetchPage("https://example.com/missing")).rejects.toThrow(
+      "Fetch error (404)"
+    );
+  });
+
+  it("throws on non-HTML content type", async () => {
+    globalThis.fetch = mockFetchResponse("%PDF-1.4", { contentType: "application/pdf" });
+
+    await expect(fetchPage("https://example.com/file.pdf")).rejects.toThrow(
+      "Expected HTML but got application/pdf"
+    );
+  });
+
+  it("throws when Readability cannot extract content", async () => {
+    globalThis.fetch = mockFetchResponse(MINIMAL_HTML);
+
+    await expect(fetchPage("https://example.com/empty")).rejects.toThrow(
+      "no extractable content"
+    );
+  });
+
+  it("passes through the final URL from response.url", async () => {
+    globalThis.fetch = mockFetchResponse(SAMPLE_ARTICLE_HTML, {
+      url: "https://example.com/redirected",
+    });
+
+    const result = await fetchPage("https://example.com/original");
+
+    expect(result.url).toBe("https://example.com/redirected");
+  });
+
+  it("handles pages with missing title/excerpt gracefully", async () => {
+    const htmlNoTitle = `
+      <!DOCTYPE html>
+      <html><head></head>
+      <body><article>
+        <p>This is a long enough article body that readability should pick it up as the main content. We need several sentences to ensure detection works properly.</p>
+        <p>Adding another paragraph to make sure readability has enough content to work with. This should be sufficient for extraction.</p>
+        <p>And one more paragraph for good measure. Readability typically needs a fair amount of text before it considers something article-worthy.</p>
+      </article></body>
+      </html>
+    `;
+    globalThis.fetch = mockFetchResponse(htmlNoTitle);
+
+    const result = await fetchPage("https://example.com/no-title");
+
+    expect(typeof result.title).toBe("string");
+    expect(typeof result.excerpt).toBe("string");
+  });
+
+  it("sends a browser-like User-Agent header", async () => {
+    const mockFetch = mockFetchResponse(SAMPLE_ARTICLE_HTML);
+    globalThis.fetch = mockFetch;
+
+    await fetchPage("https://example.com");
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.headers["User-Agent"]).toContain("Mozilla/5.0");
+  });
+
+  it("uses AbortSignal.timeout for fetch timeout", async () => {
+    const mockFetch = mockFetchResponse(SAMPLE_ARTICLE_HTML);
+    globalThis.fetch = mockFetch;
+
+    await fetchPage("https://example.com", { timeout: 5000 });
+
+    const [, init] = mockFetch.mock.calls[0];
+    expect(init.signal).toBeDefined();
+  });
+
+  it("throws on fetch timeout", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(
+      new DOMException("The operation was aborted", "TimeoutError")
+    );
+
+    await expect(fetchPage("https://example.com")).rejects.toThrow("aborted");
+  });
+});

--- a/packages/web-fetch/src/fetchPage.ts
+++ b/packages/web-fetch/src/fetchPage.ts
@@ -1,0 +1,117 @@
+import { Readability } from "@mozilla/readability";
+import { parseHTML } from "linkedom";
+
+const DEFAULT_MAX_CHARS = 20_000;
+const DEFAULT_TIMEOUT_MS = 15_000;
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+
+export type FetchPageResult = {
+  title: string;
+  content: string;
+  excerpt: string;
+  siteName: string;
+  url: string;
+};
+
+export type FetchPageOptions = {
+  maxChars?: number;
+  timeout?: number;
+};
+
+export async function fetchPage(
+  url: string,
+  options?: FetchPageOptions,
+): Promise<FetchPageResult> {
+  const maxChars = options?.maxChars ?? DEFAULT_MAX_CHARS;
+  const timeout = options?.timeout ?? DEFAULT_TIMEOUT_MS;
+
+  const response = await fetch(url, {
+    headers: {
+      "User-Agent": USER_AGENT,
+      "Accept": "text/html",
+    },
+    signal: AbortSignal.timeout(timeout),
+  });
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => response.statusText);
+    throw new Error(`Fetch error (${response.status}): ${body}`);
+  }
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!contentType.includes("text/html") && !contentType.includes("application/xhtml+xml")) {
+    throw new Error(`Expected HTML but got ${contentType.split(";")[0].trim()}`);
+  }
+
+  const html = await response.text();
+  const { document } = parseHTML(html);
+
+  const reader = new Readability(document as unknown as Document);
+  const article = reader.parse();
+
+  if (!article) {
+    throw new Error(`Could not extract content from ${url}: no extractable content`);
+  }
+
+  let content = htmlToMarkdown(article.content);
+  if (content.length > maxChars) {
+    content = content.slice(0, maxChars);
+  }
+
+  return {
+    title: article.title ?? "",
+    content,
+    excerpt: article.excerpt ?? "",
+    siteName: article.siteName ?? "",
+    url: response.url,
+  };
+}
+
+function htmlToMarkdown(html: string): string {
+  let s = html;
+
+  s = s.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, (_m, n, inner) => {
+    const hashes = "#".repeat(parseInt(n, 10));
+    return `\n\n${hashes} ${stripTags(inner).trim()}\n\n`;
+  });
+
+  s = s.replace(/<br\s*\/?>/gi, "\n");
+  s = s.replace(/<\/p>/gi, "\n\n");
+  s = s.replace(/<p[^>]*>/gi, "");
+  s = s.replace(/<\/div>/gi, "\n");
+  s = s.replace(/<div[^>]*>/gi, "");
+  s = s.replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, (_m, inner) => {
+    return `- ${stripTags(inner).trim()}\n`;
+  });
+
+  s = s.replace(
+    /<a[^>]*href="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi,
+    (_m, href, inner) => {
+      const text = stripTags(inner).trim();
+      return text ? `[${text}](${href})` : href;
+    },
+  );
+
+  s = s.replace(/<(strong|b)[^>]*>([\s\S]*?)<\/\1>/gi, "**$2**");
+  s = s.replace(/<(em|i)[^>]*>([\s\S]*?)<\/\1>/gi, "*$2*");
+  s = s.replace(/<code[^>]*>([\s\S]*?)<\/code>/gi, "`$1`");
+
+  s = stripTags(s);
+  s = s.replace(/&nbsp;|&amp;|&lt;|&gt;|&quot;|&#39;/g, (m) => ENTITIES[m] ?? m);
+  s = s.replace(/\n{3,}/g, "\n\n");
+  return s.trim();
+}
+
+const ENTITIES: Record<string, string> = {
+  "&nbsp;": " ",
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+};
+
+function stripTags(s: string): string {
+  return s.replace(/<[^>]+>/g, "");
+}

--- a/packages/web-fetch/src/fetchPage.ts
+++ b/packages/web-fetch/src/fetchPage.ts
@@ -3,6 +3,7 @@ import { parseHTML } from "linkedom";
 
 const DEFAULT_MAX_CHARS = 20_000;
 const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_HTML_BYTES = 5_000_000;
 const USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
 
@@ -36,7 +37,7 @@ export async function fetchPage(
 
   if (!response.ok) {
     const body = await response.text().catch(() => response.statusText);
-    throw new Error(`Fetch error (${response.status}): ${body}`);
+    throw new Error(`Fetch error (${response.status}): ${body.slice(0, 500)}`);
   }
 
   const contentType = response.headers.get("content-type") ?? "";
@@ -45,6 +46,9 @@ export async function fetchPage(
   }
 
   const html = await response.text();
+  if (html.length > MAX_HTML_BYTES) {
+    throw new Error(`Page too large (${html.length} bytes, max ${MAX_HTML_BYTES})`);
+  }
   const { document } = parseHTML(html);
 
   const reader = new Readability(document as unknown as Document);

--- a/packages/web-fetch/src/fetchPage.ts
+++ b/packages/web-fetch/src/fetchPage.ts
@@ -75,6 +75,11 @@ export async function fetchPage(
 function htmlToMarkdown(html: string): string {
   let s = html;
 
+  s = s.replace(/<script[\s\S]*?<\/script>/gi, "");
+  s = s.replace(/<style[\s\S]*?<\/style>/gi, "");
+  s = s.replace(/<noscript[\s\S]*?<\/noscript>/gi, "");
+  s = s.replace(/<!--[\s\S]*?-->/g, "");
+
   s = s.replace(/<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi, (_m, n, inner) => {
     const hashes = "#".repeat(parseInt(n, 10));
     return `\n\n${hashes} ${stripTags(inner).trim()}\n\n`;

--- a/packages/web-fetch/tests/agency/web-fetch.agency
+++ b/packages/web-fetch/tests/agency/web-fetch.agency
@@ -1,0 +1,12 @@
+import { fetchPage } from "../../index.agency"
+
+node main() {
+  let result = fetchPage("https://example.com")
+  if (length(result.content) > 0) {
+    print(result.title)
+    print(result.url)
+    print(result.excerpt)
+    print(result.siteName)
+  }
+  print(result)
+}

--- a/packages/web-fetch/tests/agency/web-fetch.agency
+++ b/packages/web-fetch/tests/agency/web-fetch.agency
@@ -2,11 +2,5 @@ import { fetchPage } from "../../index.agency"
 
 node main() {
   let result = fetchPage("https://s.adit.io/agency-webfetch-test.html")
-  if (length(result.content) > 0) {
-    print(result.title)
-    print(result.url)
-    print(result.excerpt)
-    print(result.siteName)
-  }
-  print(result)
+  return result
 }

--- a/packages/web-fetch/tests/agency/web-fetch.agency
+++ b/packages/web-fetch/tests/agency/web-fetch.agency
@@ -1,7 +1,7 @@
 import { fetchPage } from "../../index.agency"
 
 node main() {
-  let result = fetchPage("https://example.com")
+  let result = fetchPage("https://s.adit.io/agency-webfetch-test.html")
   if (length(result.content) > 0) {
     print(result.title)
     print(result.url)

--- a/packages/web-fetch/tests/agency/web-fetch.test.json
+++ b/packages/web-fetch/tests/agency/web-fetch.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"title\":\"A Calvin and Hobbes fan site\",\"content\":\"## Welcome to the Calvin and Hobbes Fan Site\\n\\n    \\n        Calvin and Hobbes are two beloved comic strip characters created by Bill\\n        Watterson.\",\"excerpt\":\"Calvin and Hobbes are two beloved comic strip characters created by Bill\\n        Watterson.\",\"siteName\":\"Site name is a Calvin and Hobbes fan site\",\"url\":\"https://s.adit.io/agency-webfetch-test.html\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/web-fetch/tsconfig.json
+++ b/packages/web-fetch/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests", "src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.0.6)
+      zod:
+        specifier: ^4.3.5
+        version: 4.3.6
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,28 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.0.6)
 
+  packages/web-fetch:
+    dependencies:
+      '@mozilla/readability':
+        specifier: ^0.5.0
+        version: 0.5.0
+      agency-lang:
+        specifier: workspace:*
+        version: link:../agency-lang
+      linkedom:
+        specifier: ^0.18.0
+        version: 0.18.12
+    devDependencies:
+      '@types/node':
+        specifier: ^25.0.0
+        version: 25.0.6
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.0.6)
+
 packages:
 
   '@algolia/abtesting@1.17.0':
@@ -619,6 +641,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@mozilla/readability@0.5.0':
+    resolution: {integrity: sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==}
+    engines: {node: '>=14.0.0'}
 
   '@node-llama-cpp/linux-arm64@3.18.1':
     resolution: {integrity: sha512-rXMgZxUay78FOJV/fJ67apYP9eElH5jd4df5YRKPlLhLHHchuOSyDn+qtyW/L/EnPzpogoLkmULqCkdXU39XsQ==}
@@ -1269,6 +1295,9 @@ packages:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -1419,6 +1448,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -1461,6 +1500,19 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
@@ -1486,6 +1538,10 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
@@ -1712,8 +1768,14 @@ packages:
   hookable@5.5.3:
     resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -1837,6 +1899,15 @@ packages:
 
   lifecycle-utils@3.1.1:
     resolution: {integrity: sha512-gNd3OvhFNjHykJE3uGntz7UuPzWlK9phrIdXxU9Adis0+ExkwnZibfxCJWiWWZ+a6VbKiZrb+9D9hCQWd4vjTg==}
+
+  linkedom@0.18.12:
+    resolution: {integrity: sha512-jalJsOwIKuQJSeTvsgzPe9iJzyfVaEJiEXl+25EkKevsULHvMJzpNqwvj1jOESWdmgKDiXObyjOYwlUqG7wo1Q==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -1981,6 +2052,9 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2466,6 +2540,9 @@ packages:
   typestache@0.5.0:
     resolution: {integrity: sha512-ZIiZUau3wKHM3KQ64zhpkcvZ9G1mbnWBOM4fxYJlCI+IQel4/Xl4nS6ARWhryOmOh58v0JiefnZSlkGon5Si7A==}
     hasBin: true
+
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -3135,6 +3212,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mozilla/readability@0.5.0': {}
+
   '@node-llama-cpp/linux-arm64@3.18.1':
     optional: true
 
@@ -3732,6 +3811,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  boolbase@1.0.0: {}
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -3879,6 +3960,18 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-what@6.2.2: {}
+
+  cssom@0.5.0: {}
+
   csstype@3.2.3: {}
 
   data-uri-to-buffer@4.0.1: {}
@@ -3905,6 +3998,24 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3928,6 +4039,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  entities@4.5.0: {}
 
   entities@7.0.1: {}
 
@@ -4233,7 +4346,16 @@ snapshots:
 
   hookable@5.5.3: {}
 
+  html-escaper@3.0.3: {}
+
   html-void-elements@3.0.0: {}
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
 
   http-errors@2.0.1:
     dependencies:
@@ -4359,6 +4481,14 @@ snapshots:
   lifecycle-utils@2.1.0: {}
 
   lifecycle-utils@3.1.1: {}
+
+  linkedom@0.18.12:
+    dependencies:
+      css-select: 5.2.2
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
 
   lodash.debounce@4.0.8: {}
 
@@ -4520,6 +4650,10 @@ snapshots:
       - supports-color
 
   normalize-path@3.0.0: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
 
   object-assign@4.1.1: {}
 
@@ -5062,6 +5196,8 @@ snapshots:
       commander: 14.0.3
       tarsec: 0.0.18
       typescript: 5.9.3
+
+  uhyphen@0.2.0: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
## Summary

- Adds a new `@agency-lang/web-fetch` package that fetches web pages and extracts readable content as markdown
- Uses `@mozilla/readability` for article extraction and `linkedom` for DOM parsing
- Returns structured results: `{ title, content, excerpt, siteName, url }`
- Default 20,000 character cap to prevent overwhelming LLM context windows
- 15-second fetch timeout with `AbortSignal.timeout`
- Content-Type validation (rejects non-HTML responses)
- No API keys needed — works out of the box

### Usage

```
import { fetchPage } from "pkg::@agency-lang/web-fetch"

node main() {
  let page = fetchPage("https://example.com/article")
  print(page.title)
  print(page.content)
}
```

Pairs with brave-search for search + read workflows:

```
import { braveSearch } from "pkg::@agency-lang/brave-search"
import { fetchPage } from "pkg::@agency-lang/web-fetch"

node main() {
  let answer = llm("Research climate change policy") uses braveSearch, fetchPage
}
```

## Test plan

- [x] 12 unit tests with mocked fetch + real Readability/linkedom parsing
- [x] All 2105 existing agency-lang tests still pass
- [ ] Integration test with network: `cd packages/web-fetch && pnpm run test:agency`