### PR TITLE
add parallel and seq blocks (v1)

### DIFF
--- a/.claude/commands/check-tests.md
+++ b/.claude/commands/check-tests.md
@@ -1,1 +1,2 @@
 Please review the tests you have written. Do they actually test the functionality they're supposed to? If the functionality breaks, will the test fail?
+What test cases do you not have tests for yet?

--- a/.claude/commands/postmortem.md
+++ b/.claude/commands/postmortem.md
@@ -1,0 +1,1 @@
+Let's do a little post-mortem. As you were working on this, what surprised you? What didn't go how you expected? What are some tasks that you decided to defer for later? What are some places where you realized that you needed to deviate from the spec? What are some test failures that surprised you? What are some issues that you spent the most time on?

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@ make                    # build everything
 pnpm test               # Run vitest in watch mode
 pnpm test:run           # Run vitest once
 pnpm run agency <file>  # Compile and run an .agency file
+pnpm run agency test <file>  # Run a single Agency test
+pnpm run agency test js <file>  # Run a single Agency js test
 pnpm run compile <file> # Compile .agency to .ts
 pnpm run ast <file>     # Parse .agency and print AST as JSON
 pnpm run preprocess <file>     # Parse .agency, run preprocessor, and print the resulting AST as JSON
@@ -217,3 +219,6 @@ There are plenty of files that dive into implementation details on specific feat
 - `docs/dev/trace.md` — execution traces capturing checkpoints at every step
 - `docs/dev/typechecker.md` — bidirectional type checking to catch errors before compilation
 - `docs/dev/typescript-ir.md` — structured TsNode tree representation of generated TypeScript
+
+## Guidance on writing commit messages and PR descriptions
+If you try to write commit messages with apostrophes right on the command line, you will get an error. I'm telling you this now because you do this every time. Same with PR descriptions. Instead you need to write the commit message or PR description in a file, and then pass that in to the git command.

--- a/TODO.md
+++ b/TODO.md
@@ -126,3 +126,5 @@ Tool call "unsafeMethodTool" crashed: Unknown named argument 'action' in call to
 ```
 
 import * from std::array into every file
+
+nested fork blocks, inner block can't access the variables of the outer block (the arg vars at least)

--- a/packages/agency-lang/docs/dev/parallel-blocks-v2-dataflow.md
+++ b/packages/agency-lang/docs/dev/parallel-blocks-v2-dataflow.md
@@ -1,0 +1,199 @@
+# Parallel Blocks v2: Dataflow Auto-Grouping
+
+Status: planned fast-follow to v1 (`parallel-blocks.md`). Not yet designed in detail; this doc captures the intent and key questions.
+
+## Motivation
+
+v1 requires explicit `seq { }` for any data dependency between sibling statements in a `parallel` block:
+
+```agency
+// v1 — must wrap dependent chain in seq
+parallel {
+  seq {
+    let posts = fetchPosts(id)
+    let summary = summarize(posts)
+  }
+  let user = fetchUser(id)
+}
+```
+
+For obvious linear chains, this is verbose. v2 lets the compiler infer arm grouping from data dependencies, so users write:
+
+```agency
+// v2 — compiler auto-groups posts and summary into one arm
+parallel {
+  let posts = fetchPosts(id)
+  let summary = summarize(posts)
+  let user = fetchUser(id)
+}
+```
+
+The compiler analyzes free-variable references between sibling statements, builds a dep graph, and partitions statements into arms via union-find. Statements with no inter-dependencies run in their own arm; chains collapse into a single sequential arm.
+
+## Backwards compatibility
+
+v2 is a **strict relaxation** of v1. Any program that compiled under v1 compiles under v2 and behaves identically. v2 only allows additional programs (those with cross-arm references that v1 rejects).
+
+## Behavior
+
+For each direct child of a `parallel` block:
+
+1. Compute `(binds, frees)` per child.
+2. Build dep graph: edge from `S2` to `S1` if `frees(S2) ∩ binds(S1) ≠ ∅`.
+3. Union-find to partition children into connected components. Each component becomes an arm.
+4. Within each arm, preserve original textual order (already a topological order since deps go backwards).
+5. Lower each arm to a single closure containing its statements, exactly like v1's `seq` arm lowering.
+
+Cross-arm references no longer error; instead, they merge statements into the same arm.
+
+`seq { }` blocks remain a single child for the analysis: bindings inside a `seq` are scoped to that arm and not visible to siblings. `seq` is still useful for forcing a sequential chain when the dataflow rule wouldn't have grouped (e.g., bare side-effecting calls with no var deps).
+
+## Examples
+
+These mirror the cases discussed during design. Same examples, different grouping outcomes vs v1.
+
+### A. Independent — two parallel arms
+
+```agency
+parallel {
+  let user = fetchUser(id)
+  let posts = fetchPosts(id)
+}
+```
+
+Arms: `[{user}, {posts}]`. Same as v1.
+
+### B. Linear chain — collapses to one arm
+
+```agency
+parallel {
+  let posts = fetchPosts(id)
+  let summary = summarize(posts)
+}
+```
+
+`summary` references `posts` → merged. Arms: `[{posts, summary}]`. **No actual parallelism.** Compiler should emit a warning: "parallel block has no concurrency; consider removing or restructuring."
+
+### C. Fan-in — collapses to one arm
+
+```agency
+parallel {
+  let a = foo()
+  let b = bar()
+  let c = baz(a, b)
+}
+```
+
+`c` depends on both → all merged. Arms: `[{a, b, c}]`. Same warning as B.
+
+### D. Multiple chains
+
+```agency
+parallel {
+  let user = fetchUser(id)
+  let bio = formatBio(user)
+  let posts = fetchPosts(id)
+  let count = countPosts(posts)
+}
+```
+
+Two independent chains. Arms: `[{user, bio}, {posts, count}]`. Two arms run concurrently, each internally sequential.
+
+### E. Outer-scope captures don't create deps
+
+```agency
+def main() {
+  let id = "user-123"
+  parallel {
+    let user = fetchUser(id)
+    let posts = fetchPosts(id)
+  }
+}
+```
+
+`id` is bound outside the parallel block, so neither arm depends on the other. Arms: `[{user}, {posts}]`.
+
+### F. Bare side-effecting calls — each is its own arm
+
+```agency
+parallel {
+  logStart()
+  let user = fetchUser(id)
+  let posts = fetchPosts(id)
+  logEnd()
+}
+```
+
+Arms: `[{logStart}, {user}, {posts}, {logEnd}]`. **Footgun:** `logStart` and `logEnd` may run in any order — there is no implicit textual-order ordering for statements without var deps. Users wanting ordering must wrap in `seq`. Document this prominently; consider lint warning.
+
+### G. Explicit `seq` forces a chain
+
+```agency
+parallel {
+  let user = fetchUser(id)
+  seq {
+    fireMetricStart()
+    fireMetricEnd()
+  }
+  let summary = fetchSummary(id)
+}
+```
+
+Three arms: `[{user}, {seq block}, {summary}]`. The `seq` block is one arm regardless of whether its internal statements have deps — it's how users force a sequential lane.
+
+## Diagnostic CLI
+
+v2 introduces a debugging command:
+
+```
+pnpm run agency plan <file>
+```
+
+For each `parallel` block in the file, print the inferred arm grouping:
+
+```
+foo.agency:12 — parallel block
+  arm_0:
+    line 13: let user = fetchUser(id)
+    line 14: let bio = formatBio(user)
+  arm_1:
+    line 15: let posts = fetchPosts(id)
+    line 16: let count = countPosts(posts)
+```
+
+This is essential because v2's grouping is implicit. Without it, users debugging "why isn't this running in parallel?" have no visibility into the compiler's analysis. Common diagnostic uses:
+
+- "Why is this entire block one arm?" — usually a fan-in case the user didn't notice (example C).
+- "Why are these two side-effecting calls reordered?" — they have no var deps so the analyzer treats them as independent (example F).
+
+The output should be machine-readable (also support `--json`) so it can be consumed by an editor extension later.
+
+## Edge cases and warnings
+
+- **Linear chain (B) / fan-in (C) collapse to one arm**: warning. The user wrote `parallel` but got no parallelism. Probably a mistake.
+- **Bare side-effecting calls without var deps (F)**: footgun. Document; consider lint.
+- **Conditional binding inside `seq`**: a `seq` arm may bind a name conditionally (e.g., inside an `if`). For the cross-arm analysis, treat the `seq` block as binding the union of names it could bind.
+- **Type errors in arm-internal sequencing**: if `summary = summarize(posts)` and `summarize` expects `Post[]` but `posts` is `Failure | Post[]`, that's a normal type error inside the arm — no v2-specific concern.
+
+## Implementation sketch
+
+1. Preprocessor: identify `parallel` blocks, walk children, compute `(binds, frees)` per child via a small AST visitor.
+2. Build dep graph + union-find. Implementation cost: O(N²) over child count, fine for realistic parallel blocks (N is small).
+3. Annotate the AST with arm-grouping metadata.
+4. Builder consumes metadata; emits one `runParallel` arm per group, with the group's statements concatenated as the arm body (same shape as v1's `seq` arm lowering).
+5. Add `agency plan` CLI command that runs the preprocessor and pretty-prints the grouping. Implementation: parse + preprocess only, don't build/run.
+6. Warning emission: after grouping, if a parallel block has < 2 arms, emit a warning unless the user opts out (e.g., `// allow-no-concurrency` pragma comment, or just suppress when N == 1 since they may have intentionally degenerated).
+
+## Testing
+
+- Unit tests on the partitioning algorithm. Table-driven: input snippet, expected arm groups. Cover all the examples above plus edge cases.
+- New fixtures under `tests/agency/parallel/dataflow/` exercising the same runtime behavior as v1 fixtures but written without explicit `seq`.
+- Snapshot tests for the `agency plan` CLI output across a representative set of `parallel` blocks.
+- Regression: re-run the v1 fixture suite as-is. All tests must continue to pass (since v2 is a strict relaxation).
+
+## Open questions
+
+- **Warning vs error for "no concurrency in parallel block"?** Lean: warning. Power users may want to use `parallel` for the scoping behavior even when there's no parallelism.
+- **`seq` outside `parallel` in v2?** Same as v1: a no-op block. No reason to change.
+- **Should the analyzer reorder statements within an arm?** No. Preserve textual order for predictability and to match user mental model. Even if `let a = foo(); let b = bar();` are independent within a single arm, run them in source order.
+- **Type-system-level dataflow?** If a function returns `{user, posts}` and an arm destructures one field, does the rest count as "used"? For v2, treat any reference to the destructured object as a dep on the producing statement. Don't try to be field-precise.

--- a/packages/agency-lang/docs/dev/parallel-blocks.md
+++ b/packages/agency-lang/docs/dev/parallel-blocks.md
@@ -1,0 +1,353 @@
+# Parallel and Sequential Blocks (v1)
+
+Status: design draft, not yet implemented.
+
+## Summary
+
+Two new block constructs:
+
+- `parallel { ... }` — top-level statements run concurrently.
+- `seq { ... }` — top-level statements run sequentially. Used inside `parallel` to carve out a dependent chain. Outside `parallel`, it's a no-op.
+
+```agency
+parallel {
+  let user = fetchUser(id)
+  let posts = fetchPosts(id)
+  seq {
+    let raw = fetchProfile(id)
+    let parsed = parse(raw)
+    store(parsed)
+  }
+}
+```
+
+This block runs three arms concurrently: fetching the user, fetching the posts, and the three-step profile chain. After the block, `user`, `posts`, `raw`, `parsed` are all in scope.
+
+## Goals
+
+- Heterogeneous, fixed-N parallel function calls — the common case for "do these specific things at the same time."
+- Reuse `fork` wholesale. `parallel` and `seq` are pure compile-time sugar that desugars to `fork` in the preprocessor; no new runtime helpers, no new branching primitives.
+- Surface syntax that makes parallelism predictable: a reader can tell what runs concurrently from a single read of the source.
+
+## Non-goals (v1)
+
+- **Dataflow auto-grouping** — v1 requires explicit `seq` for data dependencies between sibling statements. See `parallel-blocks-v2-dataflow.md` for the planned relaxation.
+- **Dynamic N** — for parallelism over a runtime list, use `fork(items) as item { ... }`.
+- **First-class concurrent values** — `parallel` is a compile-time block, not a runtime value. You can't store, pass, or compose it. (Same constraint as `fork`; rooted in checkpoint serialization.)
+- **Auto-cancellation on failure** — failures are values. A failing arm does not cancel siblings. (`race` is the only construct that cancels.)
+
+## Surface syntax
+
+### parallel block
+
+```
+parallel { <stmt>* }
+```
+
+Each top-level statement is one **arm**. Arms run concurrently.
+
+### seq block
+
+```
+seq { <stmt>* }
+```
+
+Inside a `parallel` block: one arm whose body runs sequentially. Used to express data dependencies between calls that would otherwise be siblings.
+
+Outside a `parallel` block: a normal block. The `seq` keyword has no runtime effect; it only serves as documentation and as a way to write code that's portable into a `parallel` context.
+
+## Statement allowlist (top level of `parallel { }`)
+
+The grammar of statements *directly* inside a `parallel` block is restricted to keep compile-time analysis simple and the runtime semantics obvious.
+
+**Allowed:**
+
+- `let X = <expr>` — binding form.
+- `<expr>` — bare expression statement (typically a function call).
+- `seq { ... }` — sequential block.
+- `parallel { ... }` — nested parallel block.
+
+**Banned at the top level:**
+
+- Control flow: `if`, `for`, `while`. Wrap in `seq`.
+- Reassignment to outer-scope variables (`x = expr`). Wrap in `seq`.
+- `return`, `break`, `continue`, `throw`.
+- Function or type declarations.
+
+The `seq` block has **no** grammar restrictions — it accepts the full Agency statement grammar. So users who want control flow inside a parallel block just put it inside `seq`:
+
+```agency
+// ❌ Error: `if` not allowed at top level of parallel block.
+parallel {
+  if (cond) { fetchA() }
+  fetchB()
+}
+
+// ✅ OK
+parallel {
+  seq {
+    if (cond) { fetchA() }
+  }
+  fetchB()
+}
+```
+
+## Compile-time checks
+
+Two checks run during the preprocessor pass:
+
+1. **Allowlist enforcement.** Walk the direct children of each `parallel` block. Reject any statement type not in the allowlist with a clear error pointing to the offending line and suggesting `seq { }`.
+
+2. **Cross-arm reference check.** For each direct child of a `parallel` block, compute the pair `(binds, frees)`:
+   - `binds`: the set of names this statement introduces into the parallel-block scope.
+   - `frees`: the set of names this statement references that are not bound within itself.
+
+   For every pair of children `(i, j)` with `i ≠ j`: error if `frees(j) ∩ binds(i) ≠ ∅`.
+
+   Error message format:
+   > Parallel arm at `foo.agency:13` references `posts`, which is declared by sibling arm at `foo.agency:12`. Wrap both arms in a single `seq { }` block to make the dependency explicit, or move them into the same existing `seq` block.
+
+   `seq { }` blocks are treated as a single child for this check; the bindings declared inside a `seq` block are NOT visible to sibling arms (they're scoped to the `seq`'s arm).
+
+   References to names declared *outside* the parallel block (enclosing function scope, globals, imports) are always fine.
+
+## Runtime semantics
+
+`parallel` and `seq` are pure compile-time constructs. They have no dedicated runtime helper. The preprocessor desugars `parallel { ... }` into a `fork` over an array of compile-time arm name strings, with a control-flow dispatch in the body that runs the matching arm's statements. Each arm therefore becomes one branch in the existing `BranchState` machinery, indexed by its position in the desugared item list.
+
+All arms run concurrently via the existing `fork` execution path (`runForkAll`), which already uses `Promise.all` to drive branches in parallel.
+
+### Bindings
+
+Names bound inside a parallel arm are visible *after* the parallel block in the enclosing scope. The compiler hoists them out and assigns them from the runtime result map after the block completes.
+
+```agency
+parallel {
+  let user = fetchUser(id)
+  let posts = fetchPosts(id)
+}
+log(user.name)   // user and posts are in scope here
+log(posts.length)
+```
+
+### Failures
+
+Failures are values. An arm returning a failure object behaves exactly like a normal return — the arm completes with a failure value, the binding receives the failure, and sibling arms continue running. The parallel block as a whole completes when all arms complete (or are interrupted).
+
+This matches Agency's existing failure-as-values model: every function body is wrapped in try/catch and uncaught exceptions are converted to failure objects, so there is no separate "exception" path that would justify cross-arm cancellation.
+
+### Interrupts
+
+Each arm has its own substack. Interrupts work via the existing concurrent-interrupts machinery:
+
+- A single arm interrupting → `Interrupt` propagates out of the parallel block → caller sees one `Interrupt` to respond to.
+- Multiple arms interrupting concurrently → aggregated into `Interrupt[]` via `hasInterrupts()`. Caller responds to all via `respondToInterrupts(interrupts, responses)`, matched by `interruptId`.
+- On resume: completed arms read their cached `BranchState.result` (no re-execution); only still-interrupted arms re-execute from their checkpoint slice.
+
+### Cancellation
+
+`parallel` never auto-cancels arms. Each arm receives an `AbortSignal` composed with the enclosing scope's signal via `AbortSignal.any`, so cancellation initiated *outside* the parallel block (e.g., a `race` loser branch containing a parallel) propagates in. But the parallel block itself does not initiate cancellation under any condition.
+
+## Lowering
+
+`parallel { ... }` desugars at the preprocessor level into a `fork` over compile-time arm name strings, with an `if`-chain in the body that dispatches each branch to its arm's statements. There is **no new runtime helper**: the existing `fork` machinery (branch state, slice-only checkpoints, interrupt aggregation, abort signals, resume protocol) handles everything.
+
+For:
+
+```agency
+parallel {
+  let a = foo()
+  let b = bar()
+  seq {
+    let raw = fetchRaw()
+    let p = parse(raw)
+  }
+}
+```
+
+The desugared AST (still in Agency, before TypeScript codegen):
+
+```agency
+let __arms = fork(["arm_0", "arm_1", "arm_2"]) as __arm {
+  if (__arm == "arm_0") {
+    let a = foo()
+    return { a }
+  }
+  if (__arm == "arm_1") {
+    let b = bar()
+    return { b }
+  }
+  if (__arm == "arm_2") {
+    let raw = fetchRaw()
+    let p = parse(raw)
+    return { raw, p }
+  }
+}
+let a = __arms[0].a
+let b = __arms[1].b
+let raw = __arms[2].raw
+let p = __arms[2].p
+```
+
+The compiler:
+
+1. Assigns arm names: `arm_0`, `arm_1`, `arm_2` in source order.
+2. Hoists every binding (`a`, `b`, `raw`, `p`) out to the parallel-block scope.
+3. Generates the `fork(items) as __arm { if-chain }` desugaring above.
+4. Emits a destructuring sequence after the fork to assign the hoisted names from each arm's returned object.
+
+From there the standard pipeline runs: the desugared `fork` flows through the existing builder, IR, and templates that already produce TypeScript for `fork` blocks. No new templates or lowering code paths.
+
+### `seq` lowering
+
+Inside `parallel`: a `seq { ... }` block at the parallel top level is treated as a single arm during desugaring — its body becomes the body of one `if (__arm == "arm_X")` branch in the generated `fork`. The `seq` keyword has no runtime representation.
+
+Outside `parallel`: emit as a regular block. The braces scope variables; otherwise no special code.
+
+### What this assumes about `fork`
+
+This desugaring relies on `fork` correctly handling bodies that take different control-flow paths per branch. Specifically:
+
+- Each branch's checkpoint slice must capture only the statements that actually executed in that branch (the matched `if`-arm), not all the unmatched ones.
+- On resume, the same dispatch must reproduce — branch `i` re-evaluates `if (__arm == "arm_i")`, follows the same path, and resumes inside it.
+
+This should already be true of the current `fork` substep / checkpoint logic — branch state is per-branch and captures the executed code path — but it's worth verifying with a targeted test before relying on it across the parallel test suite. See "Implementation order" below.
+
+## Examples
+
+### Two independent calls
+
+```agency
+parallel {
+  let user = fetchUser(id)
+  let posts = fetchPosts(id)
+}
+```
+
+Two arms. Both run concurrently. After the block, `user` and `posts` are in scope.
+
+### Mixed: two parallel arms, one of them a chain
+
+```agency
+parallel {
+  let posts = fetchPosts(id)
+  seq {
+    let raw = fetchProfile(id)
+    let parsed = parse(raw)
+    store(parsed)
+  }
+}
+```
+
+Two arms. Arm 0 fetches posts. Arm 1 runs the three-step profile chain. They run concurrently.
+
+### Cross-arm reference is a compile error
+
+```agency
+parallel {
+  let posts = fetchPosts(id)
+  let summary = summarize(posts)   // ❌ references `posts` from sibling arm
+}
+
+// Fix: use seq.
+parallel {
+  seq {
+    let posts = fetchPosts(id)
+    let summary = summarize(posts)
+  }
+}
+```
+
+(In v2 this will compile and auto-group; in v1 it errors.)
+
+### Bare side-effecting calls
+
+```agency
+parallel {
+  notifySlack("starting")
+  let result = doWork()
+  notifyMetrics("started")
+}
+```
+
+Three arms run concurrently. **Note:** there is no implicit ordering between bare side-effecting calls — `notifySlack` and `notifyMetrics` may run in any order, and may overlap with `doWork`. If you need ordering, use `seq`.
+
+### Nested parallel
+
+```agency
+parallel {
+  let x = fetchX()
+  parallel {
+    let p = fetchP()
+    let q = fetchQ()
+  }
+}
+```
+
+Outer block has two arms. The second arm is itself a parallel block with two sub-arms. After desugaring, this is `fork`-inside-`fork`, which already works.
+
+### Reading from outer scope
+
+```agency
+def main() {
+  let id = "user-123"
+  parallel {
+    let user = fetchUser(id)    // reading `id` from outer scope is fine
+    let posts = fetchPosts(id)  // ditto
+  }
+}
+```
+
+`id` is bound *outside* the parallel block, so neither arm depends on the other. Two arms run in parallel.
+
+### Single-arm (degenerate)
+
+```agency
+parallel {
+  let x = foo()
+}
+```
+
+Allowed. One arm. No actual parallelism. Avoids parser/preprocessor special cases for the empty/singleton edges; not worth a warning.
+
+## Testing
+
+Test fixtures live under `tests/agency/parallel/`, mirroring the `tests/agency/fork/` layout.
+
+### Compile-time error tests (unit tests)
+
+Per-snippet table-driven tests. Categories:
+
+- Cross-arm reference: each combination of (binding form, free-ref form), confirm error.
+- Banned statements at top level: `if`, `for`, `while`, reassignment, `return`, `break`, `continue`, `throw`.
+- Confirm allowlist passes: `let`, bare expr, `seq`, nested `parallel`.
+
+### Runtime tests (fixture tests under `tests/agency/parallel/`)
+
+- `basic/` — two-arm, three-arm, single-arm, empty (if allowed).
+- `with-seq/` — `seq` inside `parallel`, `seq` outside `parallel` (no-op behavior).
+- `nested/` — parallel-in-parallel, parallel-in-seq, parallel-in-fork, fork-in-parallel.
+- `interrupts/` — single arm interrupts; multiple arms interrupt simultaneously; resume completes only the still-interrupted arms; `Interrupt[]` aggregation.
+- `failures/` — one arm returns failure, siblings continue; multiple arms fail; failures inside a `seq` arm.
+- `outer-scope/` — reading outer scope; mutating outer scope (race caveat).
+- `stress/` — N arms with mix of LLM tools, interrupts, failures (analog of `fork-stress`).
+
+### Desugaring snapshots
+
+A small fixture that runs only through the preprocessor and snapshots the desugared Agency AST (the `fork`-with-if-chain shape). Catches preprocessor regressions cheaply. Separately, a snapshot of the final generated TypeScript catches downstream regressions in the existing `fork` lowering path.
+
+### Verifying the `fork`-with-dispatch assumption
+
+Before building out the full parallel test suite, add one focused fixture that exercises a hand-written `fork(items) as item { if (item == "a") { ... } else if (item == "b") { ... } }` to confirm: per-branch checkpoint slicing, interrupt-on-one-branch-only, resume-only-the-interrupted-branch. If any of these don't behave correctly with branch-divergent bodies, fix `fork` first; the rest of parallel depends on it.
+
+## Implementation order
+
+1. Verify `fork` handles branch-divergent bodies correctly (focused fixture, no parser/preprocessor work).
+2. Parser: add `parallel` and `seq` keywords + block parsers.
+3. Preprocessor: allowlist check; cross-arm reference check; desugaring transform that rewrites `parallel { ... }` to `fork(["arm_0", ...]) as __arm { if-chain }` and emits the post-fork destructuring assignments.
+4. Builder/codegen: nothing new — desugared output flows through the existing `fork` pipeline.
+5. Tests: compile-time errors first, then fixture suite.
+
+## Future work
+
+See `parallel-blocks-v2-dataflow.md` for the planned dataflow auto-grouping relaxation.

--- a/packages/agency-lang/lib/parsers/parallelBlock.test.ts
+++ b/packages/agency-lang/lib/parsers/parallelBlock.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import { parallelBlockParser, seqBlockParser, bodyParser } from "./parsers.js";
+
+describe("parallelBlockParser", () => {
+  it("parses an empty parallel block", () => {
+    const input = `parallel {
+}`;
+    const result = parallelBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.type).toBe("parallelBlock");
+      expect(result.result.body).toEqual([]);
+    }
+  });
+
+  it("parses a parallel block with two let bindings", () => {
+    const input = `parallel {
+  let a = foo()
+  let b = bar()
+}`;
+    const result = parallelBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.type).toBe("parallelBlock");
+      expect(result.result.body).toHaveLength(2);
+      expect(result.result.body[0].type).toBe("assignment");
+      expect(result.result.body[1].type).toBe("assignment");
+    }
+  });
+
+  it("parses a parallel block containing a seq block", () => {
+    const input = `parallel {
+  let a = foo()
+  seq {
+    let b = bar()
+    let c = baz(b)
+  }
+}`;
+    const result = parallelBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.body).toHaveLength(2);
+      expect(result.result.body[0].type).toBe("assignment");
+      expect(result.result.body[1].type).toBe("seqBlock");
+      const inner = result.result.body[1] as any;
+      expect(inner.body).toHaveLength(2);
+    }
+  });
+
+  it("parses nested parallel blocks", () => {
+    const input = `parallel {
+  let x = foo()
+  parallel {
+    let p = a()
+    let q = b()
+  }
+}`;
+    const result = parallelBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.body).toHaveLength(2);
+      expect(result.result.body[1].type).toBe("parallelBlock");
+    }
+  });
+
+  it("throws a clear error if the opening brace is missing", () => {
+    // After matching `parallel`, the parser expects `{` and throws via parseError if absent.
+    const input = `parallel oops`;
+    expect(() => parallelBlockParser(input)).toThrow(
+      /expected `\{` to open parallel block body/,
+    );
+  });
+});
+
+describe("seqBlockParser", () => {
+  it("parses an empty seq block", () => {
+    const input = `seq {
+}`;
+    const result = seqBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.type).toBe("seqBlock");
+      expect(result.result.body).toEqual([]);
+    }
+  });
+
+  it("parses a seq block with multiple statements", () => {
+    const input = `seq {
+  let a = foo()
+  let b = bar(a)
+  baz(b)
+}`;
+    const result = seqBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.body).toHaveLength(3);
+    }
+  });
+
+  it("allows control flow inside seq", () => {
+    const input = `seq {
+  if (cond) {
+    foo()
+  }
+  for (x in xs) {
+    bar(x)
+  }
+}`;
+    const result = seqBlockParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.body).toHaveLength(2);
+      expect(result.result.body[0].type).toBe("ifElse");
+      expect(result.result.body[1].type).toBe("forLoop");
+    }
+  });
+});
+
+describe("parallel/seq via bodyParser integration", () => {
+  it("parses a parallel block as a top-level statement in a function body", () => {
+    const input = `let z = 1
+parallel {
+  let a = foo()
+  let b = bar()
+}
+let w = 2
+`;
+    const result = bodyParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toHaveLength(3);
+      expect(result.result[0].type).toBe("assignment");
+      expect(result.result[1].type).toBe("parallelBlock");
+      expect(result.result[2].type).toBe("assignment");
+    }
+  });
+
+  it("does not confuse identifiers that start with `parallel` or `seq`", () => {
+    // `parallelism` and `sequence` should parse as plain assignments, not blocks.
+    const input = `let parallelism = 1
+let sequence = 2
+`;
+    const result = bodyParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result).toHaveLength(2);
+      expect(result.result[0].type).toBe("assignment");
+      expect(result.result[1].type).toBe("assignment");
+    }
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -97,6 +97,7 @@ import {
 import { GraphNodeDefinition, Visibility } from "../types/graphNode.js";
 import { ForLoop } from "../types/forLoop.js";
 import { WhileLoop } from "../types/whileLoop.js";
+import { ParallelBlock, SeqBlock } from "../types/parallelBlock.js";
 import { IfElse } from "../types/ifElse.js";
 import { ValueAccess } from "../types/access.js";
 import { BlockArgument } from "../types/blockArgument.js";
@@ -2103,6 +2104,8 @@ export const bodyParser = (input: string): ParserResult<AgencyNode[]> => {
     gotoStatementParser,
     forLoopParser,
     whileLoopParser,
+    parallelBlockParser,
+    seqBlockParser,
     matchBlockParser,
     ifParser,
     messageThreadParser,
@@ -2348,6 +2351,44 @@ export const whileLoopParser: Parser<WhileLoop> = label("a while loop", withLoc(
         optionalSpacesOrNewline,
         char("}"),
         optionalSpacesOrNewline,
+      ),
+    ),
+  ),
+)));
+
+export const parallelBlockParser: Parser<ParallelBlock> = label("a parallel block", withLoc(trace(
+  "parallelBlockParser",
+  seqC(
+    set("type", "parallelBlock"),
+    str("parallel"),
+    optionalSpaces,
+    captureCaptures(
+      parseError(
+        "expected `{` to open parallel block body",
+        char("{"),
+        optionalSpacesOrNewline,
+        capture(bodyParser, "body"),
+        optionalSpacesOrNewline,
+        char("}"),
+      ),
+    ),
+  ),
+)));
+
+export const seqBlockParser: Parser<SeqBlock> = label("a seq block", withLoc(trace(
+  "seqBlockParser",
+  seqC(
+    set("type", "seqBlock"),
+    str("seq"),
+    optionalSpaces,
+    captureCaptures(
+      parseError(
+        "expected `{` to open seq block body",
+        char("{"),
+        optionalSpacesOrNewline,
+        capture(bodyParser, "body"),
+        optionalSpacesOrNewline,
+        char("}"),
       ),
     ),
   ),

--- a/packages/agency-lang/lib/preprocessors/parallelDesugar.test.ts
+++ b/packages/agency-lang/lib/preprocessors/parallelDesugar.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { parseAgency } from "../parser.js";
+import { generateTypeScript } from "../backends/typescriptGenerator.js";
 import { TypescriptPreprocessor } from "./typescriptPreprocessor.js";
 import {
   desugarParallelInBody,
@@ -173,6 +174,79 @@ describe("validateParallelBlock", () => {
       /not allowed at the top level of a `parallel` block/,
     );
   });
+
+  it("rejects `while` at the top level of a parallel block", () => {
+    const body = getMainBody(`
+      node main() {
+        parallel {
+          while (cond) {
+            foo()
+          }
+          bar()
+        }
+      }
+    `);
+    expect(() => validateParallelBlock(findParallelBlock(body))).toThrow(
+      /not allowed at the top level of a `parallel` block/,
+    );
+  });
+
+  it("rejects reassignment (no declKind) at the top level", () => {
+    const body = getMainBody(`
+      node main() {
+        let x = 0
+        parallel {
+          x = 1
+          let y = bar()
+        }
+      }
+    `);
+    expect(() => validateParallelBlock(findParallelBlock(body))).toThrow(
+      /Reassignment to `x` is not allowed at the top level of a `parallel` block/,
+    );
+  });
+
+  it("rejects `return` at the top level of a parallel block", () => {
+    const body = getMainBody(`
+      node main() {
+        parallel {
+          return 1
+          let y = bar()
+        }
+      }
+    `);
+    expect(() => validateParallelBlock(findParallelBlock(body))).toThrow(
+      /not allowed at the top level of a `parallel` block/,
+    );
+  });
+
+  it("rejects `break` at the top level of a parallel block", () => {
+    const body = getMainBody(`
+      node main() {
+        parallel {
+          break
+          let y = bar()
+        }
+      }
+    `);
+    expect(() => validateParallelBlock(findParallelBlock(body))).toThrow(
+      /not allowed at the top level of a `parallel` block/,
+    );
+  });
+
+  it("rejects `continue` at the top level of a parallel block", () => {
+    const body = getMainBody(`
+      node main() {
+        parallel {
+          continue
+          let y = bar()
+        }
+      }
+    `);
+    expect(() => validateParallelBlock(findParallelBlock(body))).toThrow(
+      /not allowed at the top level of a `parallel` block/,
+    );
+  });
 });
 
 describe("desugarParallelInBody", () => {
@@ -325,5 +399,57 @@ describe("end-to-end through TypescriptPreprocessor", () => {
     expect(() => pp.preprocess()).toThrow(
       /Parallel arm references `x`, which is declared by a sibling arm/,
     );
+  });
+});
+
+describe("desugar → codegen snapshot", () => {
+  beforeEach(() => resetParallelCounter());
+
+  // This snapshot captures the contract of the preprocessor + codegen pipeline
+  // for parallel/seq blocks. It exists to catch unintended regressions in:
+  //   - the desugar shape (fork over arm name strings, if-chain dispatch,
+  //     binding return objects, post-fork destructuring),
+  //   - the existing fork lowering's handling of branch-divergent bodies,
+  //   - upstream codegen changes that affect how let/fork/return are emitted.
+  // If the assertions below fail, that means one of those layers changed
+  // shape — either intentionally (update the snapshot) or accidentally.
+  it("emits fork+if-chain shape for a parallel block with seq arm", () => {
+    const src = `
+      def foo(): string { return "f" }
+      def bar(): string { return "b" }
+      def baz(s: string): string { return s }
+      node main() {
+        parallel {
+          let a = foo()
+          seq {
+            let b = bar()
+            let c = baz(b)
+          }
+        }
+        return "done"
+      }
+    `;
+    const result = parseAgency(src, {}, false);
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const ts = generateTypeScript(result.result, undefined, undefined, "snapshot.agency");
+
+    // Structural assertions — looser than a full snapshot file but specific
+    // enough to catch regressions in any layer. Codegen uses backtick
+    // template literals for string args, so arm names show up as `arm_N`.
+    // 1. The preprocessor introduced an __arms_0 binding fed by a fork call
+    //    over the arm name strings.
+    expect(ts).toMatch(/runner\d*\.fork\(\s*\d+\s*,\s*\[\s*`arm_0`\s*,\s*`arm_1`\s*\]/);
+    // 2. Each arm is dispatched by a string-equality check on the arm param.
+    expect(ts).toMatch(/__arm_0\s*===?\s*`arm_0`/);
+    expect(ts).toMatch(/__arm_0\s*===?\s*`arm_1`/);
+    // 3. Bindings (a from arm 0, b and c from the seq arm) are hoisted and
+    //    assigned from __arms_0 indexed access.
+    expect(ts).toMatch(/__arms_0\[0\]\.a/);
+    expect(ts).toMatch(/__arms_0\[1\]\.b/);
+    expect(ts).toMatch(/__arms_0\[1\]\.c/);
+    // 4. parallelBlock and seqBlock should have no representation in the
+    //    generated TS — they're pure preprocessor sugar.
+    expect(ts).not.toMatch(/parallelBlock|seqBlock/);
   });
 });

--- a/packages/agency-lang/lib/preprocessors/parallelDesugar.test.ts
+++ b/packages/agency-lang/lib/preprocessors/parallelDesugar.test.ts
@@ -1,0 +1,329 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { parseAgency } from "../parser.js";
+import { TypescriptPreprocessor } from "./typescriptPreprocessor.js";
+import {
+  desugarParallelInBody,
+  validateParallelBlock,
+  collectBindings,
+  collectReferences,
+  resetParallelCounter,
+} from "./parallelDesugar.js";
+import { ParallelBlock } from "@/types/parallelBlock.js";
+import { AgencyNode, AgencyProgram, GraphNodeDefinition } from "@/types.js";
+
+function parse(src: string): AgencyProgram {
+  const result = parseAgency(src);
+  if (!result.success) {
+    throw new Error(
+      `parse failed: ${result.message ?? "unknown"}\n${result.rest}`,
+    );
+  }
+  return result.result;
+}
+
+function getMainBody(src: string): AgencyNode[] {
+  const program = parse(src);
+  const main = program.nodes.find(
+    (n): n is GraphNodeDefinition =>
+      n.type === "graphNode" && n.nodeName === "main",
+  );
+  if (!main) throw new Error("no `main` node found in test source");
+  return main.body;
+}
+
+function findParallelBlock(body: AgencyNode[]): ParallelBlock {
+  const pb = body.find((n) => n.type === "parallelBlock") as
+    | ParallelBlock
+    | undefined;
+  if (!pb) throw new Error("no parallel block found in body");
+  return pb;
+}
+
+describe("collectBindings", () => {
+  it("collects let/const declarations in a flat body", () => {
+    const body = getMainBody(`
+      node main() {
+        let a = 1
+        let b = 2
+      }
+    `);
+    const binds = new Set<string>();
+    for (const n of body) {
+      for (const name of collectBindings(n)) binds.add(name);
+    }
+    expect(binds).toEqual(new Set(["a", "b"]));
+  });
+
+  it("descends into seq and parallel blocks", () => {
+    const body = getMainBody(`
+      node main() {
+        parallel {
+          let a = foo()
+          seq {
+            let b = bar()
+            let c = baz(b)
+          }
+        }
+      }
+    `);
+    const pb = findParallelBlock(body);
+    const binds = collectBindings(pb);
+    expect(binds).toEqual(new Set(["a", "b", "c"]));
+  });
+});
+
+describe("collectReferences", () => {
+  it("collects variable refs and function-name refs", () => {
+    const body = getMainBody(`
+      node main() {
+        let r = foo(x)
+      }
+    `);
+    const refs = collectReferences(body[0]);
+    expect(refs.has("foo")).toBe(true);
+    expect(refs.has("x")).toBe(true);
+    expect(refs.has("r")).toBe(false); // r is a binding, not a ref
+  });
+});
+
+describe("validateParallelBlock", () => {
+  it("accepts a valid two-arm parallel block", () => {
+    const body = getMainBody(`
+      node main() {
+        parallel {
+          let a = foo()
+          let b = bar()
+        }
+      }
+    `);
+    expect(() => validateParallelBlock(findParallelBlock(body))).not.toThrow();
+  });
+
+  it("rejects cross-arm references", () => {
+    const body = getMainBody(`
+      node main() {
+        parallel {
+          let x = foo()
+          let y = bar(x)
+        }
+      }
+    `);
+    expect(() => validateParallelBlock(findParallelBlock(body))).toThrow(
+      /Parallel arm references `x`, which is declared by a sibling arm/,
+    );
+  });
+
+  it("does NOT flag references to outer-scope bindings", () => {
+    const body = getMainBody(`
+      node main() {
+        let id = "abc"
+        parallel {
+          let a = fetchA(id)
+          let b = fetchB(id)
+        }
+      }
+    `);
+    const pb = findParallelBlock(body);
+    expect(() => validateParallelBlock(pb)).not.toThrow();
+  });
+
+  it("does NOT flag refs within a single seq arm", () => {
+    const body = getMainBody(`
+      node main() {
+        parallel {
+          let a = foo()
+          seq {
+            let b = bar()
+            let c = baz(b)
+          }
+        }
+      }
+    `);
+    expect(() => validateParallelBlock(findParallelBlock(body))).not.toThrow();
+  });
+
+  it("rejects `if` at the top level of a parallel block", () => {
+    const body = getMainBody(`
+      node main() {
+        parallel {
+          if (cond) {
+            foo()
+          }
+          bar()
+        }
+      }
+    `);
+    expect(() => validateParallelBlock(findParallelBlock(body))).toThrow(
+      /not allowed at the top level of a `parallel` block/,
+    );
+  });
+
+  it("rejects `for` at the top level of a parallel block", () => {
+    const body = getMainBody(`
+      node main() {
+        parallel {
+          for (x in xs) {
+            foo(x)
+          }
+          bar()
+        }
+      }
+    `);
+    expect(() => validateParallelBlock(findParallelBlock(body))).toThrow(
+      /not allowed at the top level of a `parallel` block/,
+    );
+  });
+});
+
+describe("desugarParallelInBody", () => {
+  beforeEach(() => resetParallelCounter());
+
+  it("rewrites a parallel block into a fork-let plus destructuring lets", () => {
+    const src = `
+      def foo(): string { return "f" }
+      def bar(): string { return "b" }
+      node main() {
+        parallel {
+          let a = foo()
+          let b = bar()
+        }
+        return "${"${a},${b}"}"
+      }
+    `;
+    const program = parse(src);
+    // Run only the parallel desugar (skip other preprocessor passes for unit-test focus).
+    const main = program.nodes.find(
+      (n) => n.type === "graphNode" && n.nodeName === "main",
+    ) as GraphNodeDefinition;
+    main.body = desugarParallelInBody(main.body);
+
+    // First statement should be `let __arms_0 = fork(...)`.
+    const first = main.body[0] as any;
+    expect(first.type).toBe("assignment");
+    expect(first.declKind).toBe("let");
+    expect(first.variableName).toBe("__arms_0");
+    expect(first.value.type).toBe("functionCall");
+    expect(first.value.functionName).toBe("fork");
+
+    // Two destructuring lets follow.
+    const second = main.body[1] as any;
+    expect(second.type).toBe("assignment");
+    expect(second.variableName).toBe("a");
+    expect(second.value.type).toBe("valueAccess");
+
+    const third = main.body[2] as any;
+    expect(third.variableName).toBe("b");
+  });
+
+  it("inlines a seq block at the top level of a body", () => {
+    const src = `
+      def foo(): string { return "f" }
+      node main() {
+        seq {
+          let a = foo()
+          let b = a
+        }
+      }
+    `;
+    const program = parse(src);
+    const main = program.nodes.find(
+      (n) => n.type === "graphNode" && n.nodeName === "main",
+    ) as GraphNodeDefinition;
+    main.body = desugarParallelInBody(main.body);
+
+    // The seq's body (two assignments) should be present at the top level
+    // — no seqBlock node remaining.
+    expect(main.body.find((n) => n.type === "seqBlock")).toBeUndefined();
+    const lets = main.body.filter((n) => n.type === "assignment") as any[];
+    expect(lets).toHaveLength(2);
+    expect(lets[0].variableName).toBe("a");
+    expect(lets[1].variableName).toBe("b");
+  });
+
+  it("uses fresh suffixes for nested parallel blocks", () => {
+    const src = `
+      def f(): string { return "x" }
+      node main() {
+        parallel {
+          let a = f()
+          parallel {
+            let b = f()
+            let c = f()
+          }
+        }
+      }
+    `;
+    const program = parse(src);
+    const main = program.nodes.find(
+      (n) => n.type === "graphNode" && n.nodeName === "main",
+    ) as GraphNodeDefinition;
+    main.body = desugarParallelInBody(main.body);
+
+    // Outer __arms variable is at index 0 of main.body.
+    const outer = main.body[0] as any;
+    expect(outer.variableName).toBe("__arms_0");
+
+    // Inner __arms variable is somewhere inside the outer fork's if-chain.
+    // Walk to find a `__arms_1` declaration.
+    function findArmsVar(node: any, depth = 0): string[] {
+      if (!node || depth > 20) return [];
+      const results: string[] = [];
+      if (
+        node.type === "assignment" &&
+        typeof node.variableName === "string" &&
+        node.variableName.startsWith("__arms_")
+      ) {
+        results.push(node.variableName);
+      }
+      for (const key of Object.keys(node)) {
+        const v = (node as any)[key];
+        if (Array.isArray(v)) for (const item of v) results.push(...findArmsVar(item, depth + 1));
+        else if (v && typeof v === "object") results.push(...findArmsVar(v, depth + 1));
+      }
+      return results;
+    }
+    const allArmsVars = findArmsVar(outer);
+    // Should include both "__arms_0" (the outer) and "__arms_1" (the inner).
+    expect(allArmsVars).toContain("__arms_0");
+    expect(allArmsVars).toContain("__arms_1");
+  });
+});
+
+describe("end-to-end through TypescriptPreprocessor", () => {
+  beforeEach(() => resetParallelCounter());
+
+  it("preprocesses a parallel block without throwing", () => {
+    const src = `
+      def foo(): string { return "f" }
+      def bar(): string { return "b" }
+      node main() {
+        parallel {
+          let a = foo()
+          let b = bar()
+        }
+        return "${"${a},${b}"}"
+      }
+    `;
+    const program = parse(src);
+    const pp = new TypescriptPreprocessor(program);
+    expect(() => pp.preprocess()).not.toThrow();
+  });
+
+  it("propagates the cross-arm error through the full pipeline", () => {
+    const src = `
+      def foo(): string { return "f" }
+      def bar(s: string): string { return "b-${"${s}"}" }
+      node main() {
+        parallel {
+          let x = foo()
+          let y = bar(x)
+        }
+      }
+    `;
+    const program = parse(src);
+    const pp = new TypescriptPreprocessor(program);
+    expect(() => pp.preprocess()).toThrow(
+      /Parallel arm references `x`, which is declared by a sibling arm/,
+    );
+  });
+});

--- a/packages/agency-lang/lib/preprocessors/parallelDesugar.ts
+++ b/packages/agency-lang/lib/preprocessors/parallelDesugar.ts
@@ -1,0 +1,516 @@
+import {
+  AgencyNode,
+  Assignment,
+  Expression,
+  FunctionCall,
+  ParallelBlock,
+  AgencyArray,
+  AgencyObject,
+  IfElse,
+  ReturnStatement,
+  StringLiteral,
+  VariableNameLiteral,
+  ValueAccess,
+  NumberLiteral,
+} from "@/types.js";
+import { BinOpExpression } from "@/types/binop.js";
+import { BlockArgument } from "@/types/blockArgument.js";
+
+/**
+ * Statement allowlist enforcement and cross-arm reference checks for `parallel`
+ * blocks, plus desugaring of `parallel`/`seq` blocks into the existing `fork`
+ * primitive. See docs/dev/parallel-blocks.md for the v1 spec.
+ *
+ * Outline:
+ *   parallel { stmt0; stmt1; seq { ... } }
+ * desugars to:
+ *   let __arms_<n> = fork(["arm_0", "arm_1", "arm_2"]) as __arm_<n> {
+ *     if (__arm_<n> == "arm_0") { <stmt0>; return { ...bindings } }
+ *     if (__arm_<n> == "arm_1") { <stmt1>; return { ...bindings } }
+ *     if (__arm_<n> == "arm_2") { <seq.body>; return { ...bindings } }
+ *   }
+ *   let X = __arms_<n>[i].X    // for each hoisted binding
+ *
+ * `seq { ... }` outside a `parallel` block is inlined: its body replaces the
+ * seq node in the enclosing body. Variables declared inside leak to the
+ * enclosing scope, matching the spec's "no runtime effect outside parallel".
+ */
+
+// Sentinel names. The suffix is appended at desugar time so nested parallel
+// blocks don't collide.
+const ARMS_VAR_PREFIX = "__arms";
+const ARM_PARAM_PREFIX = "__arm";
+
+let parallelCounter = 0;
+
+function nextSuffix(): string {
+  return String(parallelCounter++);
+}
+
+// Reset the counter — used in tests to make output deterministic.
+export function resetParallelCounter(): void {
+  parallelCounter = 0;
+}
+
+const ALLOWED_ARM_TYPES = new Set([
+  "assignment",
+  "functionCall",
+  "valueAccess",
+  "seqBlock",
+  "parallelBlock",
+  "comment",
+  "multiLineComment",
+  "newLine",
+]);
+
+const COMMENT_TYPES = new Set(["comment", "multiLineComment", "newLine"]);
+
+function isAssignmentDecl(node: AgencyNode): node is Assignment {
+  return (
+    node.type === "assignment" &&
+    (node.declKind === "let" || node.declKind === "const")
+  );
+}
+
+/**
+ * Validate a parallel block: enforce statement allowlist at the top level,
+ * then check cross-arm references. Throws on violation.
+ */
+export function validateParallelBlock(pb: ParallelBlock): void {
+  // 1. Allowlist check.
+  for (const child of pb.body) {
+    if (!ALLOWED_ARM_TYPES.has(child.type)) {
+      throw new Error(
+        `Statement type \`${child.type}\` is not allowed at the top level of a \`parallel\` block. Wrap it in \`seq { ... }\` to use it.`,
+      );
+    }
+    if (child.type === "assignment") {
+      // Reassignment to outer-scope variables is banned at the top level.
+      // Treat any assignment without a declKind as reassignment.
+      const a = child as Assignment;
+      if (!a.declKind) {
+        throw new Error(
+          `Reassignment to \`${a.variableName}\` is not allowed at the top level of a \`parallel\` block. Wrap it in \`seq { ... }\` to use it.`,
+        );
+      }
+    }
+  }
+
+  // 2. Cross-arm reference check. For each arm, compute the set of names it
+  // binds (deep walk: every let/const at any depth within the arm's subtree)
+  // and the set of names it references but doesn't bind locally. For each
+  // pair (i, j): error if frees(j) ∩ binds(i) is non-empty.
+  const arms = pb.body.filter((n) => !COMMENT_TYPES.has(n.type));
+  const armBinds: Set<string>[] = arms.map((arm) => collectBindings(arm));
+  const armFrees: Set<string>[] = arms.map((arm, i) =>
+    setMinus(collectReferences(arm), armBinds[i]),
+  );
+
+  for (let i = 0; i < arms.length; i++) {
+    for (let j = 0; j < arms.length; j++) {
+      if (i === j) continue;
+      for (const name of armFrees[j]) {
+        if (armBinds[i].has(name)) {
+          throw new Error(
+            `Parallel arm references \`${name}\`, which is declared by a sibling arm. Wrap both arms in a single \`seq { ... }\` block to make the dependency explicit.`,
+          );
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Collect every let/const variable name introduced anywhere in the subtree of
+ * the given node. Crosses into seqBlock, parallelBlock, ifElse branches, loop
+ * bodies — but NOT into nested function/graphNode definitions (those
+ * introduce their own scope). For nested parallel/seq, all bindings declared
+ * inside are still considered bindings of the outer arm because they're
+ * hoisted out.
+ */
+export function collectBindings(node: AgencyNode): Set<string> {
+  const binds = new Set<string>();
+  walkForBindings(node, binds);
+  return binds;
+}
+
+function walkForBindings(node: AgencyNode, binds: Set<string>): void {
+  if (isAssignmentDecl(node)) {
+    binds.add(node.variableName);
+    return;
+  }
+  // Don't descend into nested function/graphNode definitions — they have their
+  // own scope and their lets don't leak.
+  if (node.type === "function" || node.type === "graphNode") return;
+
+  // Descend into child bodies.
+  if (node.type === "ifElse") {
+    for (const n of node.thenBody) walkForBindings(n, binds);
+    if (node.elseBody) for (const n of node.elseBody) walkForBindings(n, binds);
+    return;
+  }
+  if (
+    node.type === "forLoop" ||
+    node.type === "whileLoop" ||
+    node.type === "messageThread" ||
+    node.type === "handleBlock"
+  ) {
+    for (const n of node.body) walkForBindings(n, binds);
+    return;
+  }
+  if (node.type === "seqBlock" || node.type === "parallelBlock") {
+    for (const n of node.body) walkForBindings(n, binds);
+    return;
+  }
+  if (node.type === "matchBlock") {
+    for (const c of node.cases) {
+      if (c.type === "comment") continue;
+      walkForBindings(c.body as any, binds);
+    }
+    return;
+  }
+}
+
+/**
+ * Collect every variable name referenced (read) anywhere in the subtree.
+ * "Referenced" means a `variableName` literal — i.e., a use of the name as a
+ * value. Excludes the LHS of declarations (those are bindings, not refs).
+ */
+export function collectReferences(node: AgencyNode): Set<string> {
+  const refs = new Set<string>();
+  walkForReferences(node, refs);
+  return refs;
+}
+
+function walkForReferences(node: AgencyNode, refs: Set<string>): void {
+  if (!node) return;
+  switch (node.type) {
+    case "variableName":
+      refs.add(node.value);
+      return;
+    case "assignment": {
+      // The LHS variableName is a binding, NOT a reference. The RHS value
+      // is the only source of references here. (Compound forms like x.y = z
+      // would also produce a reference to x via accessChain, but the v1
+      // allowlist bans plain reassignment in parallel arms.)
+      walkForReferences(node.value as AgencyNode, refs);
+      return;
+    }
+    case "functionCall": {
+      // Function names ARE references — they could collide with bindings
+      // declared by sibling arms (e.g., `let foo = ...; let r = foo()`).
+      refs.add(node.functionName);
+      for (const arg of node.arguments) {
+        if (arg.type === "splat") {
+          walkForReferences(arg.value as AgencyNode, refs);
+        } else if (arg.type === "namedArgument") {
+          walkForReferences(arg.value as AgencyNode, refs);
+        } else {
+          walkForReferences(arg as AgencyNode, refs);
+        }
+      }
+      if (node.block) {
+        for (const n of node.block.body) walkForReferences(n, refs);
+      }
+      return;
+    }
+    case "binOpExpression":
+      walkForReferences(node.left as AgencyNode, refs);
+      walkForReferences(node.right as AgencyNode, refs);
+      return;
+    case "valueAccess":
+      walkForReferences(node.base, refs);
+      for (const el of node.chain) {
+        if (el.kind === "index") walkForReferences(el.index as AgencyNode, refs);
+        else if (el.kind === "slice") {
+          if (el.start) walkForReferences(el.start as AgencyNode, refs);
+          if (el.end) walkForReferences(el.end as AgencyNode, refs);
+        } else if (el.kind === "methodCall") {
+          for (const arg of el.functionCall.arguments) {
+            if (arg.type === "splat" || arg.type === "namedArgument") {
+              walkForReferences(arg.value as AgencyNode, refs);
+            } else {
+              walkForReferences(arg as AgencyNode, refs);
+            }
+          }
+        } else if (el.kind === "call") {
+          for (const arg of el.arguments) {
+            if (arg.type === "splat" || arg.type === "namedArgument") {
+              walkForReferences(arg.value as AgencyNode, refs);
+            } else {
+              walkForReferences(arg as AgencyNode, refs);
+            }
+          }
+        }
+      }
+      return;
+    case "agencyArray":
+      for (const item of node.items) {
+        if (item.type === "splat") walkForReferences(item.value as AgencyNode, refs);
+        else walkForReferences(item as AgencyNode, refs);
+      }
+      return;
+    case "agencyObject":
+      for (const e of node.entries) {
+        if ("type" in e && e.type === "splat") {
+          walkForReferences(e.value as AgencyNode, refs);
+        } else {
+          walkForReferences((e as any).value as AgencyNode, refs);
+        }
+      }
+      return;
+    case "string":
+    case "multiLineString":
+      for (const seg of node.segments) {
+        if (seg.type === "interpolation") {
+          walkForReferences(seg.expression as AgencyNode, refs);
+        }
+      }
+      return;
+    case "ifElse": {
+      walkForReferences(node.condition as AgencyNode, refs);
+      // References inside thenBody/elseBody might bind their own locals —
+      // shadowing is handled at outer-arm level since we collect refs and
+      // binds independently and subtract. Simpler: just collect all refs,
+      // subtract all binds. Same outcome.
+      for (const n of node.thenBody) walkForReferences(n, refs);
+      if (node.elseBody) for (const n of node.elseBody) walkForReferences(n, refs);
+      return;
+    }
+    case "forLoop": {
+      walkForReferences(node.iterable as AgencyNode, refs);
+      for (const n of node.body) walkForReferences(n, refs);
+      return;
+    }
+    case "whileLoop": {
+      walkForReferences(node.condition as AgencyNode, refs);
+      for (const n of node.body) walkForReferences(n, refs);
+      return;
+    }
+    case "returnStatement":
+      if (node.value) walkForReferences(node.value as AgencyNode, refs);
+      return;
+    case "seqBlock":
+    case "parallelBlock":
+      for (const n of node.body) walkForReferences(n, refs);
+      return;
+    case "messageThread":
+      for (const n of node.body) walkForReferences(n, refs);
+      return;
+    case "handleBlock":
+      for (const n of node.body) walkForReferences(n, refs);
+      if (node.handler.kind === "inline") {
+        for (const n of node.handler.body) walkForReferences(n, refs);
+      }
+      return;
+    default:
+      return;
+  }
+}
+
+function setMinus(a: Set<string>, b: Set<string>): Set<string> {
+  const result = new Set<string>();
+  for (const x of a) if (!b.has(x)) result.add(x);
+  return result;
+}
+
+/* ------------------------------------------------------------------ */
+/* AST node builders                                                  */
+/* ------------------------------------------------------------------ */
+
+function strLit(value: string): StringLiteral {
+  return { type: "string", segments: [{ type: "text", value }] };
+}
+
+function numLit(value: number): NumberLiteral {
+  return { type: "number", value: String(value) };
+}
+
+function varRef(name: string): VariableNameLiteral {
+  return { type: "variableName", value: name };
+}
+
+function eqExpr(left: Expression, right: Expression): BinOpExpression {
+  return { type: "binOpExpression", operator: "==", left, right };
+}
+
+function letAssign(name: string, value: Expression): Assignment {
+  return {
+    type: "assignment",
+    declKind: "let",
+    variableName: name,
+    value,
+  };
+}
+
+function ret(value: Expression): ReturnStatement {
+  return { type: "returnStatement", value } as any;
+}
+
+function objectLit(keys: string[]): AgencyObject {
+  return {
+    type: "agencyObject",
+    entries: keys.map((k) => ({ key: k, value: varRef(k) })),
+  };
+}
+
+function arrayLit(items: Expression[]): AgencyArray {
+  return { type: "agencyArray", items };
+}
+
+function indexAccess(baseName: string, idx: number, prop: string): ValueAccess {
+  return {
+    type: "valueAccess",
+    base: varRef(baseName),
+    chain: [
+      { kind: "index", index: numLit(idx) },
+      { kind: "property", name: prop },
+    ],
+  };
+}
+
+function ifStmt(cond: Expression, body: AgencyNode[]): IfElse {
+  return { type: "ifElse", condition: cond, thenBody: body };
+}
+
+function forkCall(items: Expression[], block: BlockArgument): FunctionCall {
+  return {
+    type: "functionCall",
+    functionName: "fork",
+    arguments: [arrayLit(items)],
+    block,
+  };
+}
+
+/* ------------------------------------------------------------------ */
+/* Desugar transform                                                   */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Recursively desugar `parallel { ... }` and `seq { ... }` blocks within an
+ * AgencyNode array. Replaces each top-level `parallelBlock` with the desugared
+ * fork+destructuring sequence. Replaces each top-level `seqBlock` with its
+ * body inlined (recursively desugared). Recurses into nested control-flow
+ * bodies for any other node types so deeply-nested parallel/seq blocks
+ * inside if/for/while/etc. also get processed.
+ *
+ * Note: `seqBlock` nodes that appear directly as arms of a `parallelBlock`
+ * are NOT inlined here — they're handled by `desugarOneParallel`, which
+ * treats each arm (including a `seqBlock` arm) as a single arm whose body is
+ * the seq's body. Inlining at this level would flatten arm boundaries and
+ * confuse the cross-arm reference check.
+ */
+export function desugarParallelInBody(body: AgencyNode[]): AgencyNode[] {
+  const result: AgencyNode[] = [];
+  for (const node of body) {
+    if (node.type === "parallelBlock") {
+      // desugarOneParallel handles arm-aware recursion into its children.
+      result.push(...desugarOneParallel(node));
+    } else if (node.type === "seqBlock") {
+      // Outside a parallel context, a seq block has no runtime effect; inline
+      // its body after recursively desugaring.
+      result.push(...desugarParallelInBody(node.body));
+    } else {
+      // Recurse into nested control-flow bodies, then keep the node.
+      descendIntoSubstructures(node);
+      result.push(node);
+    }
+  }
+  return result;
+}
+
+function descendIntoSubstructures(node: AgencyNode): void {
+  switch (node.type) {
+    case "ifElse":
+      node.thenBody = desugarParallelInBody(node.thenBody);
+      if (node.elseBody) node.elseBody = desugarParallelInBody(node.elseBody);
+      return;
+    case "forLoop":
+    case "whileLoop":
+    case "messageThread":
+      node.body = desugarParallelInBody(node.body);
+      return;
+    case "handleBlock":
+      node.body = desugarParallelInBody(node.body);
+      if (node.handler.kind === "inline") {
+        node.handler.body = desugarParallelInBody(node.handler.body);
+      }
+      return;
+    case "matchBlock":
+      for (const c of node.cases) {
+        if (c.type === "comment") continue;
+        c.body = desugarParallelInBody([c.body as any])[0] as any;
+      }
+      return;
+    case "withModifier":
+      node.statement = desugarParallelInBody([node.statement as any])[0];
+      return;
+    case "functionCall":
+      if (node.block) {
+        node.block.body = desugarParallelInBody(node.block.body);
+      }
+      return;
+    case "classDefinition":
+      for (const m of node.methods) m.body = desugarParallelInBody(m.body);
+      return;
+    default:
+      return;
+  }
+}
+
+function desugarOneParallel(pb: ParallelBlock): AgencyNode[] {
+  validateParallelBlock(pb);
+
+  const arms = pb.body.filter((n) => !COMMENT_TYPES.has(n.type));
+  const suffix = nextSuffix();
+  const armsVar = `${ARMS_VAR_PREFIX}_${suffix}`;
+  const armParam = `${ARM_PARAM_PREFIX}_${suffix}`;
+
+  // Build the if-chain body for the fork.
+  const ifChainBody: AgencyNode[] = [];
+  const armBindingsList: string[][] = [];
+
+  for (let i = 0; i < arms.length; i++) {
+    const arm = arms[i];
+    const armName = `arm_${i}`;
+    const bindings = Array.from(collectBindings(arm));
+    armBindingsList.push(bindings);
+
+    // The arm's stmts: for seqBlock, use its body (the seq is the arm wrapper,
+    // not a separate stmt). Recursively desugar so any nested parallel/seq
+    // inside the arm gets rewritten before we splice it into the if-chain.
+    let armStmts: AgencyNode[];
+    if (arm.type === "seqBlock") {
+      armStmts = desugarParallelInBody([...arm.body]);
+    } else {
+      armStmts = desugarParallelInBody([arm]);
+    }
+
+    // Append `return { binding1: binding1, binding2: binding2, ... }`.
+    armStmts.push(ret(objectLit(bindings)));
+
+    ifChainBody.push(
+      ifStmt(eqExpr(varRef(armParam), strLit(armName)), armStmts),
+    );
+  }
+
+  // Build the fork call.
+  const armNames = arms.map((_, i) => strLit(`arm_${i}`));
+  const fork = forkCall(armNames, {
+    type: "blockArgument",
+    inline: false,
+    params: [{ type: "functionParameter", name: armParam }],
+    body: ifChainBody,
+  });
+
+  const out: AgencyNode[] = [letAssign(armsVar, fork)];
+
+  // Hoist bindings out: `let X = __arms_<n>[i].X` for each arm's bindings.
+  for (let i = 0; i < arms.length; i++) {
+    for (const name of armBindingsList[i]) {
+      out.push(letAssign(name, indexAccess(armsVar, i, name)));
+    }
+  }
+
+  return out;
+}

--- a/packages/agency-lang/lib/preprocessors/parallelDesugar.ts
+++ b/packages/agency-lang/lib/preprocessors/parallelDesugar.ts
@@ -445,6 +445,14 @@ function descendIntoSubstructures(node: AgencyNode): void {
     case "withModifier":
       node.statement = desugarParallelInBody([node.statement as any])[0];
       return;
+    case "assignment":
+      // The RHS may be a function call that has a block (e.g. fork) whose
+      // body might contain a parallel block.
+      descendIntoSubstructures(node.value as AgencyNode);
+      return;
+    case "returnStatement":
+      if (node.value) descendIntoSubstructures(node.value as AgencyNode);
+      return;
     case "functionCall":
       if (node.block) {
         node.block.body = desugarParallelInBody(node.block.body);

--- a/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
+++ b/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
@@ -26,6 +26,7 @@ import {
   getAllVariablesInBodyArray,
   walkNodesArray,
 } from "@/utils/node.js";
+import { desugarParallelInBody } from "./parallelDesugar.js";
 
 /**
  * Recursively apply a transform function to all body arrays in a node tree.
@@ -65,6 +66,8 @@ function walkBody(
       node.statement = walkBody([node.statement], fn)[0];
     } else if (node.type === "functionCall" && node.block) {
       node.block.body = walkBody(node.block.body, fn);
+    } else if (node.type === "parallelBlock" || node.type === "seqBlock") {
+      node.body = walkBody(node.body, fn);
     }
     return node;
   });
@@ -232,6 +235,7 @@ export class TypescriptPreprocessor {
   preprocess(): AgencyProgram {
     this.attachDocComments();
     this.program.nodes = collectTags(this.program.nodes);
+    this.desugarParallelBlocks();
     if (Object.keys(this.functionDefinitions).length === 0) {
       this.getFunctionDefinitions();
     }
@@ -277,6 +281,24 @@ export class TypescriptPreprocessor {
 
     this.resolveVariableScopes();
     return this.program;
+  }
+
+  /**
+   * Walk every function and graph-node body and desugar `parallel { ... }`
+   * blocks into the existing `fork` primitive. Also inlines any `seq { ... }`
+   * blocks that appear outside a parallel block (where they have no runtime
+   * effect). See lib/preprocessors/parallelDesugar.ts.
+   */
+  protected desugarParallelBlocks(): void {
+    for (const node of this.program.nodes) {
+      if (node.type === "function" || node.type === "graphNode") {
+        node.body = desugarParallelInBody(node.body);
+      } else if (node.type === "classDefinition") {
+        for (const m of node.methods) {
+          m.body = desugarParallelInBody(m.body);
+        }
+      }
+    }
   }
 
   protected removeUnusedLlmCalls(): void {

--- a/packages/agency-lang/lib/types.ts
+++ b/packages/agency-lang/lib/types.ts
@@ -23,6 +23,7 @@ import { GotoStatement } from "./types/gotoStatement.js";
 import { Skill } from "./types/skill.js";
 import { TypeAlias, VariableType } from "./types/typeHints.js";
 import { WhileLoop } from "./types/whileLoop.js";
+import { ParallelBlock, SeqBlock } from "./types/parallelBlock.js";
 import { AwaitPending } from "./types/awaitPending.js";
 import { HandleBlock } from "./types/handleBlock.js";
 import { DebuggerStatement } from "./types/debuggerStatement.js";
@@ -45,6 +46,7 @@ export * from "./types/returnStatement.js";
 export * from "./types/gotoStatement.js";
 export * from "./types/typeHints.js";
 export * from "./types/whileLoop.js";
+export * from "./types/parallelBlock.js";
 export * from "./types/forLoop.js";
 export * from "./types/handleBlock.js";
 export * from "./types/keyword.js";
@@ -223,6 +225,8 @@ export type AgencyNode =
   | ImportStatement
   | ImportNodeStatement
   | WhileLoop
+  | ParallelBlock
+  | SeqBlock
   | IfElse
   | NewLine
   | RawCode

--- a/packages/agency-lang/lib/types/parallelBlock.ts
+++ b/packages/agency-lang/lib/types/parallelBlock.ts
@@ -1,0 +1,12 @@
+import { AgencyNode } from "../types.js";
+import { BaseNode } from "./base.js";
+
+export type ParallelBlock = BaseNode & {
+  type: "parallelBlock";
+  body: AgencyNode[];
+};
+
+export type SeqBlock = BaseNode & {
+  type: "seqBlock";
+  body: AgencyNode[];
+};

--- a/packages/agency-lang/stdlib/index.agency
+++ b/packages/agency-lang/stdlib/index.agency
@@ -1,3 +1,5 @@
+/** 
+The imports from this file get auto-imported into every .agency file, so you can use these tools without needing to import them manually. */
 import { _print, _printJSON, _input, _sleep, _round, _fetch, _fetchJSON, _read, _write, _readImage, _notify, _range, _mostCommon, _keys, _values, _entries } from "./lib/builtins.js"
 export safe def print(...messages) {
   """

--- a/packages/agency-lang/tests/agency/fork/fork-divergent-body.agency
+++ b/packages/agency-lang/tests/agency/fork/fork-divergent-body.agency
@@ -1,0 +1,34 @@
+def fetchA(): string {
+  let x = interrupt("approve a?")
+  return "a-result"
+}
+
+def fetchB(): string {
+  return "b-result"
+}
+
+def fetchC(): string {
+  let x = interrupt("approve c?")
+  return "c-result"
+}
+
+node main() {
+  let results = fork(["arm_0", "arm_1", "arm_2"]) as __arm {
+    if (__arm == "arm_0") {
+      let a = fetchA()
+      return { a: a }
+    }
+    if (__arm == "arm_1") {
+      let b = fetchB()
+      return { b: b }
+    }
+    if (__arm == "arm_2") {
+      let c = fetchC()
+      return { c: c }
+    }
+  }
+  let a = results[0].a
+  let b = results[1].b
+  let c = results[2].c
+  return "${a},${b},${c}"
+}

--- a/packages/agency-lang/tests/agency/fork/fork-divergent-body.test.json
+++ b/packages/agency-lang/tests/agency/fork/fork-divergent-body.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Fork body with top-level if-chain dispatching on the iteration item — each branch executes a different code path. Exercises the shape the parallel/seq desugar produces. Two of three arms interrupt; on resume, the non-interrupting arm's result must be cached and only the interrupted arms re-execute. Final output exact-matches a comma-joined string built from each arm's distinct return-shape ({a:...}, {b:...}, {c:...}), confirming per-arm bindings round-trip correctly through the fork result aggregation.",
+      "input": "",
+      "expectedOutput": "\"a-result,b-result,c-result\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [
+        { "action": "approve" },
+        { "action": "approve" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/basic/parallel-with-seq.agency
+++ b/packages/agency-lang/tests/agency/parallel/basic/parallel-with-seq.agency
@@ -1,0 +1,14 @@
+def foo(): string { return "foo-result" }
+def bar(): string { return "bar-result" }
+def baz(s: string): string { return "baz-${s}" }
+
+node main() {
+  parallel {
+    let a = foo()
+    seq {
+      let b = bar()
+      let c = baz(b)
+    }
+  }
+  return "${a},${b},${c}"
+}

--- a/packages/agency-lang/tests/agency/parallel/basic/parallel-with-seq.test.json
+++ b/packages/agency-lang/tests/agency/parallel/basic/parallel-with-seq.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Basic parallel block with two arms: a bare let-binding and a seq block. Verifies that (1) parallel desugars correctly through the preprocessor; (2) seq-as-arm acts as one arm whose body is the seq's contents (so b and c stay in the same arm and the data dependency is allowed); (3) bindings (a, b, c) hoist out of the parallel block and are visible in the enclosing scope. The exact-match output proves all three bindings round-trip correctly through the desugared fork's per-arm result objects.",
+      "input": "",
+      "expectedOutput": "\"foo-result,bar-result,baz-bar-result\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/basic/seq-outside-parallel.agency
+++ b/packages/agency-lang/tests/agency/parallel/basic/seq-outside-parallel.agency
@@ -1,0 +1,10 @@
+def foo(): string { return "F" }
+def bar(s: string): string { return "B-${s}" }
+
+node main() {
+  seq {
+    let a = foo()
+    let b = bar(a)
+  }
+  return "${a},${b}"
+}

--- a/packages/agency-lang/tests/agency/parallel/basic/seq-outside-parallel.test.json
+++ b/packages/agency-lang/tests/agency/parallel/basic/seq-outside-parallel.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "A `seq { ... }` block at the top level of a node body (no enclosing `parallel`). Per the v1 spec, seq has no runtime effect outside parallel — its body is inlined into the enclosing scope, and bindings declared inside leak out. Exact-match output proves both `a` and `b` are visible after the seq block.",
+      "input": "",
+      "expectedOutput": "\"F,B-F\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/basic/single-arm.agency
+++ b/packages/agency-lang/tests/agency/parallel/basic/single-arm.agency
@@ -1,0 +1,10 @@
+def f(): string {
+  return "only-arm"
+}
+
+node main() {
+  parallel {
+    let a = f()
+  }
+  return a
+}

--- a/packages/agency-lang/tests/agency/parallel/basic/single-arm.test.json
+++ b/packages/agency-lang/tests/agency/parallel/basic/single-arm.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Degenerate single-arm parallel block. The desugar still produces a fork with one arm — no actual concurrency, but no special-case path either. The single binding hoists out normally. Per the v1 spec, this is allowed without warning to keep the parser/preprocessor edges simple.",
+      "input": "",
+      "expectedOutput": "\"only-arm\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/basic/three-arm.agency
+++ b/packages/agency-lang/tests/agency/parallel/basic/three-arm.agency
@@ -1,0 +1,12 @@
+def f(label: string): string {
+  return "v-${label}"
+}
+
+node main() {
+  parallel {
+    let a = f("a")
+    let b = f("b")
+    let c = f("c")
+  }
+  return "${a},${b},${c}"
+}

--- a/packages/agency-lang/tests/agency/parallel/basic/three-arm.test.json
+++ b/packages/agency-lang/tests/agency/parallel/basic/three-arm.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Three independent let-binding arms in a parallel block. Confirms the desugar handles N>2 cleanly: arm names arm_0/arm_1/arm_2, all three bindings hoist out, all three run concurrently and produce their values.",
+      "input": "",
+      "expectedOutput": "\"v-a,v-b,v-c\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/failures/one-arm-fails.agency
+++ b/packages/agency-lang/tests/agency/parallel/failures/one-arm-fails.agency
@@ -1,0 +1,19 @@
+def maybeFails(label: string): string {
+  if (label == "fail") {
+    return failure("boom")
+  }
+  return "ok-${label}"
+}
+
+node main() {
+  parallel {
+    let a = maybeFails("ok1")
+    let b = maybeFails("fail")
+    let c = maybeFails("ok2")
+  }
+  let bMsg = "no-error"
+  if (isFailure(b)) {
+    bMsg = b.error
+  }
+  return "${a},${bMsg},${c}"
+}

--- a/packages/agency-lang/tests/agency/parallel/failures/one-arm-fails.test.json
+++ b/packages/agency-lang/tests/agency/parallel/failures/one-arm-fails.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Failures-as-values invariant: one parallel arm returns a failure value, siblings continue and produce their normal results. The block does NOT auto-cancel on the first failure (per spec — that behavior is reserved for `race`). After the block, the failing arm's binding holds the failure object and `isFailure()` resolves it.",
+      "input": "",
+      "expectedOutput": "\"ok-ok1,boom,ok-ok2\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/interrupts/interrupt-response-values.agency
+++ b/packages/agency-lang/tests/agency/parallel/interrupts/interrupt-response-values.agency
@@ -1,0 +1,24 @@
+// Verifies that interrupt response values are routed to the correct arm.
+// Two arms each interrupt with a distinct prompt; the test harness resolves
+// each interrupt with a distinct value matched by `expectedMessage`. If the
+// desugar broke routing — e.g., responseMap matching by interruptId got
+// scrambled across arms — arm A would receive arm B's value (and vice
+// versa), and the exact-match would fail.
+
+def armA(): string {
+  const v = interrupt("approve a?")
+  return "a-got-${v}"
+}
+
+def armB(): string {
+  const v = interrupt("approve b?")
+  return "b-got-${v}"
+}
+
+node main() {
+  parallel {
+    let a = armA()
+    let b = armB()
+  }
+  return "${a},${b}"
+}

--- a/packages/agency-lang/tests/agency/parallel/interrupts/interrupt-response-values.test.json
+++ b/packages/agency-lang/tests/agency/parallel/interrupts/interrupt-response-values.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Two arms interrupt simultaneously, each gets resolved with a distinct value. The test asserts each arm received the value addressed to its prompt — this catches a bug where the desugar's responseMap (matching by interruptId) routed arm B's resolved value to arm A or vice versa.",
+      "input": "",
+      "expectedOutput": "\"a-got-vA,b-got-vB\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [
+        { "action": "resolve", "expectedMessage": "approve a?", "resolvedValue": "vA" },
+        { "action": "resolve", "expectedMessage": "approve b?", "resolvedValue": "vB" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/interrupts/multi-arm-simultaneous.agency
+++ b/packages/agency-lang/tests/agency/parallel/interrupts/multi-arm-simultaneous.agency
@@ -1,0 +1,23 @@
+def fetchA(): string {
+  let approved = interrupt("approve a?")
+  return "a-result"
+}
+
+def fetchB(): string {
+  let approved = interrupt("approve b?")
+  return "b-result"
+}
+
+def fetchC(): string {
+  let approved = interrupt("approve c?")
+  return "c-result"
+}
+
+node main() {
+  parallel {
+    let a = fetchA()
+    let b = fetchB()
+    let c = fetchC()
+  }
+  return "${a},${b},${c}"
+}

--- a/packages/agency-lang/tests/agency/parallel/interrupts/multi-arm-simultaneous.test.json
+++ b/packages/agency-lang/tests/agency/parallel/interrupts/multi-arm-simultaneous.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Three-arm parallel where every arm interrupts simultaneously. Exercises Interrupt[] aggregation through the desugared fork: the test harness sees an array of three pending interrupts and responds to each. Confirms the parallel block's interrupt path uses the same `hasInterrupts` aggregation machinery as fork.",
+      "input": "",
+      "expectedOutput": "\"a-result,b-result,c-result\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [
+        { "action": "approve" },
+        { "action": "approve" },
+        { "action": "approve" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/interrupts/seq-arm-interrupts.agency
+++ b/packages/agency-lang/tests/agency/parallel/interrupts/seq-arm-interrupts.agency
@@ -1,0 +1,23 @@
+def fetchA(): string {
+  return "a-result"
+}
+
+def fetchPart1(): string {
+  let approved = interrupt("approve part 1?")
+  return "p1"
+}
+
+def fetchPart2(s: string): string {
+  return "p2-${s}"
+}
+
+node main() {
+  parallel {
+    let a = fetchA()
+    seq {
+      let p1 = fetchPart1()
+      let p2 = fetchPart2(p1)
+    }
+  }
+  return "${a},${p1},${p2}"
+}

--- a/packages/agency-lang/tests/agency/parallel/interrupts/seq-arm-interrupts.test.json
+++ b/packages/agency-lang/tests/agency/parallel/interrupts/seq-arm-interrupts.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "An interrupt that fires inside a `seq` arm's body must pause that arm and resume from the right point inside the seq. The seq has two sequential calls, the first of which interrupts. After resume, both p1 and p2 must be in scope along with the sibling arm's `a`. Exercises the case where an interrupt fires deeper than the parallel arm boundary.",
+      "input": "",
+      "expectedOutput": "\"a-result,p1,p2-p1\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [
+        { "action": "approve" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/interrupts/single-arm-interrupts.agency
+++ b/packages/agency-lang/tests/agency/parallel/interrupts/single-arm-interrupts.agency
@@ -1,0 +1,16 @@
+def fetchA(): string {
+  let approved = interrupt("approve a?")
+  return "a-result"
+}
+
+def fetchB(): string {
+  return "b-result"
+}
+
+node main() {
+  parallel {
+    let a = fetchA()
+    let b = fetchB()
+  }
+  return "${a},${b}"
+}

--- a/packages/agency-lang/tests/agency/parallel/interrupts/single-arm-interrupts.test.json
+++ b/packages/agency-lang/tests/agency/parallel/interrupts/single-arm-interrupts.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Two-arm parallel where one arm interrupts and the other completes immediately. On resume, the completed arm's result must be cached (not re-executed) and only the interrupted arm continues. Verifies that the desugar's per-arm BranchState resume protocol — inherited from fork's existing machinery — works for parallel-shaped concurrent calls.",
+      "input": "",
+      "expectedOutput": "\"a-result,b-result\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [
+        { "action": "approve" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/multi-cycle/cached-arm-not-rerun.agency
+++ b/packages/agency-lang/tests/agency/parallel/multi-cycle/cached-arm-not-rerun.agency
@@ -1,0 +1,29 @@
+// Detects a bug where a non-interrupting arm gets re-executed on resume.
+// The "cached" arm increments a global counter and produces its return
+// value from that counter. The "interrupting" arm interrupts once. After
+// the resume cycle, the counter must be exactly 1 — if the cached arm
+// ran again, the counter would be 2 and the test fails.
+//
+// This is the gap noted in tests/agency/fork/multi-cycle/partial-cycle-cached:
+// re-execution of a non-interrupting branch is invisible if the branch
+// is pure. Adding a side effect (counter increment) lets us see it.
+
+let counter = 0
+
+def cachedArm(): string {
+  counter = counter + 1
+  return "n${counter}"
+}
+
+def interruptingArm(): string {
+  const v = interrupt("approve?")
+  return "ok"
+}
+
+node main() {
+  parallel {
+    let a = cachedArm()
+    let b = interruptingArm()
+  }
+  return "${a},${b},counter:${counter}"
+}

--- a/packages/agency-lang/tests/agency/parallel/multi-cycle/cached-arm-not-rerun.test.json
+++ b/packages/agency-lang/tests/agency/parallel/multi-cycle/cached-arm-not-rerun.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Two-arm parallel where one arm interrupts and one runs to completion. The completed arm increments a module-level `counter` global as a side effect. After resume, the test asserts counter is exactly 1 — if the BranchState.result caching is broken and the completed arm re-executes on resume, counter would be 2 (or more) and the exact-match would fail. This addresses the gap described in fork/multi-cycle/partial-cycle-cached: pure non-interrupting branches don't reveal re-execution, but a side-effecting branch does.",
+      "input": "",
+      "expectedOutput": "\"n1,ok,counter:1\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [
+        { "action": "approve" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/nested/fork-in-parallel.agency
+++ b/packages/agency-lang/tests/agency/parallel/nested/fork-in-parallel.agency
@@ -1,0 +1,15 @@
+def f(label: string): string {
+  return "v-${label}"
+}
+
+node main() {
+  parallel {
+    let outerA = f("oa")
+    seq {
+      let forked = fork(["x", "y", "z"]) as item {
+        return f(item)
+      }
+    }
+  }
+  return "${outerA}|${forked[0]},${forked[1]},${forked[2]}"
+}

--- a/packages/agency-lang/tests/agency/parallel/nested/fork-in-parallel.test.json
+++ b/packages/agency-lang/tests/agency/parallel/nested/fork-in-parallel.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "A `fork(...) as item { ... }` call inside a `seq` arm of a parallel block. After desugar, this is a fork (the parallel's outer fork) whose second arm body contains another fork (the inner one). Confirms the existing fork-inside-fork pathway handles parallel-introduced forks correctly. The inner fork's `forked` binding is hoisted out via the seq-arm's return shape.",
+      "input": "",
+      "expectedOutput": "\"v-oa|v-x,v-y,v-z\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/nested/parallel-in-fork.agency
+++ b/packages/agency-lang/tests/agency/parallel/nested/parallel-in-fork.agency
@@ -1,0 +1,13 @@
+def fa(): string { return "pa" }
+def fb(): string { return "pb" }
+
+node main() {
+  let results = fork(["x", "y"]) as item {
+    parallel {
+      let p = fa()
+      let q = fb()
+    }
+    return "${p}+${q}"
+  }
+  return "${results[0]}|${results[1]}"
+}

--- a/packages/agency-lang/tests/agency/parallel/nested/parallel-in-fork.test.json
+++ b/packages/agency-lang/tests/agency/parallel/nested/parallel-in-fork.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "A `parallel` block inside a `fork(...) as item { ... }` body. Each fork branch independently desugars its own parallel block. Confirms suffix uniqueness across nested fork iterations and that the parallel's bindings hoist into the fork-body scope correctly so the trailing `return` sees them. The arms do not reference the outer fork's `item` because that is an unrelated pre-existing fork limitation (outer block args don't capture into inner fork closures).",
+      "input": "",
+      "expectedOutput": "\"pa+pb|pa+pb\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/nested/parallel-in-parallel.agency
+++ b/packages/agency-lang/tests/agency/parallel/nested/parallel-in-parallel.agency
@@ -1,0 +1,14 @@
+def f(label: string): string {
+  return "v-${label}"
+}
+
+node main() {
+  parallel {
+    let outerA = f("oa")
+    parallel {
+      let innerP = f("ip")
+      let innerQ = f("iq")
+    }
+  }
+  return "${outerA}|${innerP},${innerQ}"
+}

--- a/packages/agency-lang/tests/agency/parallel/nested/parallel-in-parallel.test.json
+++ b/packages/agency-lang/tests/agency/parallel/nested/parallel-in-parallel.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "A parallel block whose second arm is itself a parallel block. After both desugars, this becomes fork-inside-fork, which the existing fork machinery handles. Verifies that bindings declared in the inner parallel (innerP, innerQ) hoist all the way out — first to the outer arm's scope, then out of the outer parallel — and are visible in the enclosing node body.",
+      "input": "",
+      "expectedOutput": "\"v-oa|v-ip,v-iq\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/outer-scope/reads-outer-scope.agency
+++ b/packages/agency-lang/tests/agency/parallel/outer-scope/reads-outer-scope.agency
@@ -1,0 +1,16 @@
+def fetchA(prefix: string): string {
+  return "${prefix}-a"
+}
+
+def fetchB(prefix: string): string {
+  return "${prefix}-b"
+}
+
+node main() {
+  let prefix = "outer"
+  parallel {
+    let a = fetchA(prefix)
+    let b = fetchB(prefix)
+  }
+  return "${a},${b}"
+}

--- a/packages/agency-lang/tests/agency/parallel/outer-scope/reads-outer-scope.test.json
+++ b/packages/agency-lang/tests/agency/parallel/outer-scope/reads-outer-scope.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Both parallel arms read a variable bound in the enclosing node scope. Per the cross-arm rule, references to outer-scope bindings do NOT count as cross-arm refs (the binding is not declared by a sibling arm), so the validation passes and both arms see the same `prefix`.",
+      "input": "",
+      "expectedOutput": "\"outer-a,outer-b\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/parallel/parallel-stress.agency
+++ b/packages/agency-lang/tests/agency/parallel/parallel-stress.agency
@@ -1,0 +1,46 @@
+// Stress test for parallel/seq blocks. Mirrors the spirit of fork-stress
+// but exercises parallel-specific surface: heterogeneous arms with mixed
+// interrupt counts (0, 1, 2), a seq arm that interrupts twice and is
+// followed by a non-interrupting call, and per-arm response routing
+// across three distinct resolved values.
+//
+// Across three resume cycles, this fixture verifies:
+//   - Multi-cycle resume works for parallel arms (cycles 1, 2, 3).
+//   - Cached non-interrupting arms (a, e) are NOT re-executed on resume.
+//   - A seq arm with two sequential interrupts in one call advances its
+//     internal substep counter correctly across cycles.
+//   - The non-interrupting call AFTER a multi-interrupt call inside a
+//     seq arm fires exactly once, in the final cycle.
+//   - Per-arm responseMap correctly routes each distinct resolvedValue
+//     to the right interrupt site.
+//
+// The fixture uses pure functions throughout — no shared mutable state —
+// so the output is fully deterministic.
+
+def neverInterrupts(label: string): string {
+  return "n${label}"
+}
+
+def interruptsOnce(label: string): string {
+  const v = interrupt("i1${label}?")
+  return "i1${label}-${v}"
+}
+
+def interruptsTwice(label: string): string {
+  const v1 = interrupt("i2${label}-1?")
+  const v2 = interrupt("i2${label}-2?")
+  return "i2${label}-${v1}-${v2}"
+}
+
+node main() {
+  parallel {
+    let a = neverInterrupts("a")
+    let b = interruptsOnce("b")
+    seq {
+      let c = interruptsTwice("c")
+      let d = neverInterrupts("d-after-c")
+    }
+    let e = neverInterrupts("e")
+  }
+  return "${a}|${b}|${c}|${d}|${e}"
+}

--- a/packages/agency-lang/tests/agency/parallel/parallel-stress.test.json
+++ b/packages/agency-lang/tests/agency/parallel/parallel-stress.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Parallel-blocks stress test: 4 arms (a, b, seq{c, d}, e) running concurrently with mixed interrupt patterns. Arm a runs to completion (cycle 1), arm b interrupts once (cycle 1) and finishes after one resume (cycle 2), the seq arm's first call interrupts twice (cycles 1 and 2) before its second call fires (cycle 3), arm e runs to completion (cycle 1). Three resume cycles total, three distinct interrupts (i1b, i2c-1, i2c-2) with three distinct resolved values, exact-match output proves all arms produce the right value with the right resolved data routed to the right site. If caching is broken, arms a/d/e re-execute and the test does NOT directly catch that for these pure arms — but cached-arm-not-rerun.{agency,test.json} provides side-effect-tracked coverage of that case. This fixture covers the combinatorial surface (multi-cycle × mixed-arm-types × seq-internal-multi-interrupt × distinct-response-routing) that simpler fixtures don't.",
+      "input": "",
+      "expectedOutput": "\"na|i1b-vB|i2c-vC1-vC2|nd-after-c|ne\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "interruptHandlers": [
+        { "action": "resolve", "expectedMessage": "i1b?", "resolvedValue": "vB" },
+        { "action": "resolve", "expectedMessage": "i2c-1?", "resolvedValue": "vC1" },
+        { "action": "resolve", "expectedMessage": "i2c-2?", "resolvedValue": "vC2" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Introduces `parallel { ... }` for fixed-N heterogeneous concurrent calls and `seq { ... }` for sequential carve-outs (or a no-op block outside `parallel`).
- Implemented as preprocessor sugar that desugars to the existing `fork` primitive — no new runtime helpers, no new branching code paths.
- Includes parser, AST types, allowlist enforcement and cross-arm reference checks at the preprocessor level, the desugaring transform, unit tests, and runtime fixtures.

## Design docs

- `docs/dev/parallel-blocks.md` — v1 spec (this PR)
- `docs/dev/parallel-blocks-v2-dataflow.md` — planned fast-follow that relaxes the cross-arm rule via dataflow auto-grouping

## How the desugar works

```agency
parallel {
  let a = foo()
  seq {
    let b = bar()
    let c = baz(b)
  }
}
```

becomes (conceptually):

```agency
let __arms_0 = fork(["arm_0", "arm_1"]) as __arm_0 {
  if (__arm_0 == "arm_0") {
    let a = foo()
    return { a: a }
  }
  if (__arm_0 == "arm_1") {
    let b = bar()
    let c = baz(b)
    return { b: b, c: c }
  }
}
let a = __arms_0[0].a
let b = __arms_0[1].b
let c = __arms_0[1].c
```

Each top-level statement of a `parallel` block becomes one arm; arms run concurrently via the existing fork machinery. A `seq` arm collapses the seq body into one arm. Bindings hoist out of the parallel block via the post-fork destructuring lets, so they are visible in the enclosing scope. Cross-arm references (a sibling arm referencing another arm binding) are a compile error in v1 — wrap both in `seq` to express the dependency.

Failures are values: a failing arm does not cancel siblings, matching the existing fork behavior.

## Statement allowlist (top of `parallel { }`)

Allowed: `let X = expr`, bare `expr`, `seq { ... }`, nested `parallel { ... }`. Banned: `if`/`for`/`while`, reassignment, `return`/`break`/`continue`/`throw`, decls. Wrap any of these in `seq { ... }` if needed — `seq` has no grammar restrictions.

## Tests

- New: `tests/agency/fork/fork-divergent-body.{agency,test.json}` — verifies fork handles a body with top-level `if`-chain dispatch on the iteration item, the load-bearing assumption for the desugar.
- New: `tests/agency/parallel/basic/parallel-with-seq.{agency,test.json}` and `tests/agency/parallel/basic/seq-outside-parallel.{agency,test.json}` — runtime fixtures for the v1 spec.
- New: `lib/parsers/parallelBlock.test.ts` — 10 parser tests.
- New: `lib/preprocessors/parallelDesugar.test.ts` — 14 unit tests for binding/reference collection, allowlist + cross-arm validation, desugar shape, and end-to-end through the preprocessor.

## Test plan

- [ ] Run `pnpm run test:run lib/parsers/parallelBlock.test.ts` — 10/10 pass.
- [ ] Run `pnpm run test:run lib/preprocessors/parallelDesugar.test.ts` — 14/14 pass.
- [ ] Run `pnpm run a test tests/agency/fork/fork-divergent-body.test.json` — passes.
- [ ] Run `pnpm run a test tests/agency/parallel/basic/` — both fixtures pass.
- [ ] Run `pnpm run typecheck` — clean.

## Out of scope

- Dataflow auto-grouping (v2 fast-follow, doc'd separately).
- `agency plan` CLI for visualizing arm grouping (also v2).
- Broader runtime fixture coverage (interrupts in arms, race-with-parallel, deeper nesting). v1 desugars to fork so the existing fork test suite covers most of it indirectly, but explicit parallel-shaped fixtures are worth adding incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
