### PR TITLE
typechecker resolves stdlib auto-imports via SymbolTable

### DIFF
--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -158,7 +158,8 @@ export function compile(
     if (errors.length > 0) {
       if (config.typeCheckStrict) {
         console.error(formatErrors(errors));
-        process.exit(1);
+        const hasFatal = errors.some((e) => (e.severity ?? "error") === "error");
+        if (hasFatal) process.exit(1);
       } else {
         console.warn(formatErrors(errors, "warning"));
       }

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -70,7 +70,10 @@ export type CompilationUnit = {
   importedNodes: ImportNodeStatement[];
   importStatements: ImportStatement[];
   safeFunctions: Record<string, boolean>;
-  importedFunctions: Record<string, { parameters: FunctionParameter[] }>;
+  importedFunctions: Record<
+    string,
+    { parameters: FunctionParameter[]; returnType: VariableType | null }
+  >;
   classDefinitions: Record<string, ClassDefinition>;
 };
 
@@ -137,7 +140,7 @@ export function buildCompilationUnit(
           if (node.isAgencyImport) {
             for (const name of nameType.importedNames) {
               const localName = nameType.aliases[name] ?? name;
-              unit.importedFunctions[localName] = { parameters: [] };
+              unit.importedFunctions[localName] = { parameters: [], returnType: null };
             }
           }
           for (const safeName of nameType.safeNames) {
@@ -168,6 +171,7 @@ export function buildCompilationUnit(
           unit.importedFunctions[r.localName]
         ) {
           unit.importedFunctions[r.localName].parameters = r.symbol.parameters;
+          unit.importedFunctions[r.localName].returnType = r.symbol.returnType;
         }
         if (r.symbol.kind === "function" && r.symbol.safe) {
           unit.safeFunctions[r.localName] = true;

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -145,12 +145,6 @@ export function buildCompilationUnit(
         unit.importStatements.push(node);
         for (const nameType of node.importedNames) {
           if (nameType.type !== "namedImport") continue;
-          if (node.isAgencyImport) {
-            for (const name of nameType.importedNames) {
-              const localName = nameType.aliases[name] ?? name;
-              unit.importedFunctions[localName] = { parameters: [], returnType: null };
-            }
-          }
           for (const safeName of nameType.safeNames) {
             const localSafe = nameType.aliases[safeName] ?? safeName;
             unit.safeFunctions[localSafe] = true;
@@ -168,18 +162,19 @@ export function buildCompilationUnit(
     }
   }
 
-  // Stitch in cross-file information from imports. Both passes use
-  // resolveImport, so the (file, original→local) mapping is computed once
-  // per statement instead of being re-derived from raw symbol-table loops.
+  // Stitch in cross-file information from imports. Entries are only added
+  // to importedFunctions when the SymbolTable actually resolves them — an
+  // unresolved import (no SymbolTable, missing file, etc.) falls through
+  // to the typechecker's builtin/any path instead of being treated as a
+  // bogus 0-arg signature.
   if (symbolTable && fromFile) {
     for (const stmt of unit.importStatements) {
       for (const r of symbolTable.resolveImport(stmt, fromFile)) {
-        if (
-          (r.symbol.kind === "function" || r.symbol.kind === "node") &&
-          unit.importedFunctions[r.localName]
-        ) {
-          unit.importedFunctions[r.localName].parameters = r.symbol.parameters;
-          unit.importedFunctions[r.localName].returnType = r.symbol.returnType;
+        if (r.symbol.kind === "function" || r.symbol.kind === "node") {
+          unit.importedFunctions[r.localName] = {
+            parameters: r.symbol.parameters,
+            returnType: r.symbol.returnType,
+          };
         }
         if (r.symbol.kind === "function" && r.symbol.safe) {
           unit.safeFunctions[r.localName] = true;

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -58,6 +58,17 @@ export class ScopedTypeAliases {
 }
 
 /**
+ * Signature info collected from a SymbolTable for a name brought in via
+ * `import { ... }`. Both fields may be populated lazily — `parameters` is
+ * filled by the stitch loop in `buildCompilationUnit`, and `returnType`
+ * comes from the imported function/node's declaration.
+ */
+export type ImportedFunctionSignature = {
+  parameters: FunctionParameter[];
+  returnType: VariableType | null;
+};
+
+/**
  * Per-compilation aggregate. Holds the rich AST nodes for the entry file's
  * local declarations plus a typechecker-shaped scoped type-alias map. For
  * any cross-file question — what does this name resolve to in another
@@ -70,10 +81,7 @@ export type CompilationUnit = {
   importedNodes: ImportNodeStatement[];
   importStatements: ImportStatement[];
   safeFunctions: Record<string, boolean>;
-  importedFunctions: Record<
-    string,
-    { parameters: FunctionParameter[]; returnType: VariableType | null }
-  >;
+  importedFunctions: Record<string, ImportedFunctionSignature>;
   classDefinitions: Record<string, ClassDefinition>;
 };
 

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -1,6 +1,17 @@
 import { describe, it, expect } from "vitest";
 import { TypeChecker, typeCheck } from "./typeChecker/index.js";
 import { AgencyProgram } from "./types.js";
+import { buildCompilationUnit } from "./compilationUnit.js";
+import type { CompilationUnit } from "./compilationUnit.js";
+
+function withImports(
+  program: AgencyProgram,
+  importedFunctions: CompilationUnit["importedFunctions"],
+): CompilationUnit {
+  const info = buildCompilationUnit(program);
+  info.importedFunctions = importedFunctions;
+  return info;
+}
 
 describe("TypeChecker", () => {
   describe("function call argument type matching", () => {
@@ -3238,6 +3249,212 @@ describe("TypeChecker", () => {
         ],
       };
       expect(typeCheck(program).errors).toHaveLength(0);
+    });
+
+    it("imported function call uses imported signature for return type", () => {
+      // Simulates `import { add } from "..."; add(1, 2)` and verifies the
+      // typechecker pulls the imported signature, not "any".
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "expectStr",
+            parameters: [
+              { type: "functionParameter", name: "s", typeHint: { type: "primitiveType", value: "string" } },
+            ],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "expectStr",
+            arguments: [
+              {
+                type: "functionCall",
+                functionName: "add",
+                arguments: [
+                  { type: "number", value: "1" },
+                  { type: "number", value: "2" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const info = withImports(program, {
+        add: {
+          parameters: [
+            { type: "functionParameter", name: "a", typeHint: { type: "primitiveType", value: "number" } },
+            { type: "functionParameter", name: "b", typeHint: { type: "primitiveType", value: "number" } },
+          ],
+          returnType: { type: "primitiveType", value: "number" },
+        },
+      });
+      const { errors } = typeCheck(program, {}, info);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toMatch(/'number' is not assignable to parameter type 'string'/);
+    });
+
+    it("imported function arity is checked", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "functionCall",
+            functionName: "add",
+            arguments: [{ type: "number", value: "1" }],
+          },
+        ],
+      };
+      const info = withImports(program, {
+        add: {
+          parameters: [
+            { type: "functionParameter", name: "a", typeHint: { type: "primitiveType", value: "number" } },
+            { type: "functionParameter", name: "b", typeHint: { type: "primitiveType", value: "number" } },
+          ],
+          returnType: { type: "primitiveType", value: "number" },
+        },
+      });
+      const errors = typeCheck(program, {}, info).errors;
+      expect(errors.some((e) => /Expected 2 argument\(s\) for 'add'/.test(e.message))).toBe(true);
+    });
+
+    it("imported function with optional default arg accepts fewer args", () => {
+      // def range(start: number, end: number = -1) — calling range(5) is fine.
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "functionCall",
+            functionName: "range",
+            arguments: [{ type: "number", value: "5" }],
+          },
+        ],
+      };
+      const info = withImports(program, {
+        range: {
+          parameters: [
+            { type: "functionParameter", name: "start", typeHint: { type: "primitiveType", value: "number" } },
+            {
+              type: "functionParameter",
+              name: "end",
+              typeHint: { type: "primitiveType", value: "number" },
+              defaultValue: { type: "number", value: "-1" },
+            },
+          ],
+          returnType: {
+            type: "arrayType",
+            elementType: { type: "primitiveType", value: "number" },
+          },
+        },
+      });
+      expect(typeCheck(program, {}, info).errors).toHaveLength(0);
+    });
+
+    it("imported variadic function accepts any number of args (element-typed)", () => {
+      // def join(...parts: string[]): string — element type is string.
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "functionCall",
+            functionName: "join",
+            arguments: [
+              { type: "string", segments: [{ type: "text", value: "a" }] },
+              { type: "string", segments: [{ type: "text", value: "b" }] },
+              { type: "string", segments: [{ type: "text", value: "c" }] },
+            ],
+          },
+          {
+            type: "functionCall",
+            functionName: "join",
+            arguments: [{ type: "number", value: "1" }],
+          },
+        ],
+      };
+      const info = withImports(program, {
+        join: {
+          parameters: [
+            {
+              type: "functionParameter",
+              name: "parts",
+              typeHint: {
+                type: "arrayType",
+                elementType: { type: "primitiveType", value: "string" },
+              },
+              variadic: true,
+            },
+          ],
+          returnType: { type: "primitiveType", value: "string" },
+        },
+      });
+      const errors = typeCheck(program, {}, info).errors;
+      // First call OK; second should fail (number not assignable to string).
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toMatch(/'number' is not assignable to parameter type 'string'/);
+    });
+
+    it("warns when a local def shadows an imported function", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "add",
+            parameters: [],
+            body: [],
+          },
+        ],
+      };
+      const info = withImports(program, {
+        add: {
+          parameters: [],
+          returnType: { type: "primitiveType", value: "number" },
+        },
+      });
+      const errors = typeCheck(program, {}, info).errors;
+      expect(errors.some((e) => /'add' shadows an imported function/.test(e.message))).toBe(true);
+    });
+
+    it("local definition wins over imported function", () => {
+      // Local `add` returns string; if local wins, expectStr(add(...)) is OK.
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "add",
+            parameters: [],
+            body: [],
+            returnType: { type: "primitiveType", value: "string" },
+          },
+          {
+            type: "function",
+            functionName: "expectStr",
+            parameters: [
+              { type: "functionParameter", name: "s", typeHint: { type: "primitiveType", value: "string" } },
+            ],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "expectStr",
+            arguments: [
+              { type: "functionCall", functionName: "add", arguments: [] },
+            ],
+          },
+        ],
+      };
+      const info = withImports(program, {
+        add: {
+          parameters: [],
+          returnType: { type: "primitiveType", value: "number" },
+        },
+      });
+      const errors = typeCheck(program, {}, info).errors;
+      // Only the shadow warning; no type error from the call.
+      expect(errors.some((e) => /'add' shadows/.test(e.message))).toBe(true);
+      expect(errors.some((e) => /not assignable/.test(e.message))).toBe(false);
     });
 
     it("match block case body is type-checked", () => {

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -3413,7 +3413,44 @@ describe("TypeChecker", () => {
         },
       });
       const errors = typeCheck(program, {}, info).errors;
-      expect(errors.some((e) => /'add' shadows an imported function/.test(e.message))).toBe(true);
+      const shadow = errors.find((e) => /'add' shadows an imported function/.test(e.message));
+      expect(shadow).toBeDefined();
+      expect(shadow!.severity).toBe("warning");
+    });
+
+    it("does not register importedFunctions placeholders when no SymbolTable", () => {
+      // Regression: stdin / no-SymbolTable mode used to create placeholder
+      // entries with parameters: [] for every auto-imported stdlib name,
+      // leading to bogus "Expected 0 args" errors on calls like print("x").
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "importStatement",
+            modulePath: "std::index",
+            isAgencyImport: true,
+            importedNames: [
+              {
+                type: "namedImport",
+                importedNames: ["print"],
+                aliases: {},
+                safeNames: [],
+              },
+            ],
+          },
+          {
+            type: "functionCall",
+            functionName: "print",
+            arguments: [
+              { type: "string", segments: [{ type: "text", value: "x" }] },
+            ],
+          },
+        ],
+      };
+      // No SymbolTable passed → typeCheck builds a CompilationUnit with
+      // empty importedFunctions and falls through to the builtin signature.
+      const errors = typeCheck(program).errors;
+      expect(errors.filter((e) => /Expected.*argument\(s\) for 'print'/.test(e.message))).toHaveLength(0);
     });
 
     it("local definition wins over imported function", () => {

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -1,6 +1,7 @@
 import {
   AgencyNode,
   FunctionCall,
+  FunctionParameter,
   VariableType,
 } from "../types.js";
 import { walkNodes } from "../utils/node.js";
@@ -12,6 +13,45 @@ import { ScopeInfo } from "./types.js";
 import type { TypeCheckerContext } from "./types.js";
 import { checkType } from "./utils.js";
 import { Scope } from "./scope.js";
+
+/**
+ * Derive arity bounds and per-position param types from a parameter list,
+ * honoring optional (`defaultValue`) and rest (`variadic`) parameters.
+ *
+ * For a variadic last parameter declared as `...xs: T[]`, every arg at or
+ * past its position is checked against the array's element type `T`.
+ */
+function paramListSignature(params: FunctionParameter[], argCount: number): {
+  minArgs: number;
+  maxArgs: number;
+  paramTypes: (VariableType | "any" | undefined)[];
+} {
+  const lastParam = params[params.length - 1];
+  const hasRest = lastParam?.variadic === true;
+  const requiredCount = params.filter(
+    (p) => p.defaultValue === undefined && !p.variadic,
+  ).length;
+  const minArgs = requiredCount;
+  const maxArgs = hasRest ? Infinity : params.length;
+
+  const restElementType: VariableType | "any" | undefined = hasRest
+    ? lastParam.typeHint?.type === "arrayType"
+      ? lastParam.typeHint.elementType
+      : (lastParam.typeHint ?? "any")
+    : undefined;
+
+  const paramTypes: (VariableType | "any" | undefined)[] = params.map((p) =>
+    p.typeHint,
+  );
+  if (hasRest) {
+    // Replace the variadic slot's array type with the element type, so a
+    // single arg at that position is checked element-wise. Then extend to
+    // cover any extra args.
+    paramTypes[paramTypes.length - 1] = restElementType;
+    while (paramTypes.length < argCount) paramTypes.push(restElementType);
+  }
+  return { minArgs, maxArgs, paramTypes };
+}
 
 export function checkScopes(
   scopes: ScopeInfo[],
@@ -48,24 +88,34 @@ function checkSingleFunctionCall(
   // checking when one is present. The splat element-type check still runs.
   const hasSplatArg = call.arguments.some((a) => a.type === "splat");
 
+  // Resolution order: local definition → imported (cross-file) → builtin
+  // fallback. Importeds take precedence over builtins so a real stdlib
+  // function shadows a hardcoded signature when SymbolTable info is wired in.
+  const def = ctx.functionDefs[call.functionName] ?? ctx.nodeDefs[call.functionName];
+  const importedSig = ctx.importedFunctions[call.functionName];
+  const params = def?.parameters ?? importedSig?.parameters;
+
+  if (params) {
+    const { minArgs, maxArgs, paramTypes } = paramListSignature(
+      params,
+      call.arguments.length,
+    );
+    reportArityIfBad(call, minArgs, maxArgs, hasSplatArg, ctx);
+    if (call.arguments.length < minArgs || call.arguments.length > maxArgs) {
+      if (!hasSplatArg) return;
+    }
+    checkArgsAgainstParams(call, paramTypes, scope, ctx);
+    return;
+  }
+
   if (call.functionName in BUILTIN_FUNCTION_TYPES) {
     const sig = BUILTIN_FUNCTION_TYPES[call.functionName];
     const minArgs = sig.minParams ?? sig.params.length;
     const hasRest = sig.restParam !== undefined;
     const maxArgs = hasRest ? Infinity : sig.params.length;
-    if (
-      !hasSplatArg &&
-      (call.arguments.length < minArgs || call.arguments.length > maxArgs)
-    ) {
-      const expected = hasRest
-        ? `at least ${minArgs}`
-        : minArgs === maxArgs
-          ? `${minArgs}`
-          : `${minArgs}-${maxArgs}`;
-      ctx.errors.push({
-        message: `Expected ${expected} argument(s) for '${call.functionName}', but got ${call.arguments.length}.`,
-      });
-      return;
+    reportArityIfBad(call, minArgs, maxArgs, hasSplatArg, ctx);
+    if (call.arguments.length < minArgs || call.arguments.length > maxArgs) {
+      if (!hasSplatArg) return;
     }
     const paramTypes: (VariableType | "any" | undefined)[] = [...sig.params];
     if (hasRest) {
@@ -74,24 +124,27 @@ function checkSingleFunctionCall(
       }
     }
     checkArgsAgainstParams(call, paramTypes, scope, ctx);
-    return;
   }
+}
 
-  const def = ctx.functionDefs[call.functionName] ?? ctx.nodeDefs[call.functionName];
-  if (!def) return;
-
-  if (!hasSplatArg && call.arguments.length !== def.parameters.length) {
-    ctx.errors.push({
-      message: `Expected ${def.parameters.length} argument(s) for '${call.functionName}', but got ${call.arguments.length}.`,
-    });
-    return;
-  }
-  checkArgsAgainstParams(
-    call,
-    def.parameters.map((p) => p.typeHint),
-    scope,
-    ctx,
-  );
+function reportArityIfBad(
+  call: FunctionCall,
+  minArgs: number,
+  maxArgs: number,
+  hasSplatArg: boolean,
+  ctx: TypeCheckerContext,
+): void {
+  if (hasSplatArg) return;
+  if (call.arguments.length >= minArgs && call.arguments.length <= maxArgs) return;
+  const expected =
+    maxArgs === Infinity
+      ? `at least ${minArgs}`
+      : minArgs === maxArgs
+        ? `${minArgs}`
+        : `${minArgs}-${maxArgs}`;
+  ctx.errors.push({
+    message: `Expected ${expected} argument(s) for '${call.functionName}', but got ${call.arguments.length}.`,
+  });
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -100,10 +100,7 @@ function checkSingleFunctionCall(
       params,
       call.arguments.length,
     );
-    reportArityIfBad(call, minArgs, maxArgs, hasSplatArg, ctx);
-    if (call.arguments.length < minArgs || call.arguments.length > maxArgs) {
-      if (!hasSplatArg) return;
-    }
+    if (!checkArity(call, minArgs, maxArgs, hasSplatArg, ctx)) return;
     checkArgsAgainstParams(call, paramTypes, scope, ctx);
     return;
   }
@@ -113,10 +110,7 @@ function checkSingleFunctionCall(
     const minArgs = sig.minParams ?? sig.params.length;
     const hasRest = sig.restParam !== undefined;
     const maxArgs = hasRest ? Infinity : sig.params.length;
-    reportArityIfBad(call, minArgs, maxArgs, hasSplatArg, ctx);
-    if (call.arguments.length < minArgs || call.arguments.length > maxArgs) {
-      if (!hasSplatArg) return;
-    }
+    if (!checkArity(call, minArgs, maxArgs, hasSplatArg, ctx)) return;
     const paramTypes: (VariableType | "any" | undefined)[] = [...sig.params];
     if (hasRest) {
       while (paramTypes.length < call.arguments.length) {
@@ -127,15 +121,21 @@ function checkSingleFunctionCall(
   }
 }
 
-function reportArityIfBad(
+/**
+ * Validate arg count against [minArgs, maxArgs]. Pushes an error and returns
+ * `false` (caller should bail) when arity is wrong and there's no splat. With
+ * a splat present we can't tell the count statically, so always return `true`
+ * and let the splat element-type check run.
+ */
+function checkArity(
   call: FunctionCall,
   minArgs: number,
   maxArgs: number,
   hasSplatArg: boolean,
   ctx: TypeCheckerContext,
-): void {
-  if (hasSplatArg) return;
-  if (call.arguments.length >= minArgs && call.arguments.length <= maxArgs) return;
+): boolean {
+  if (hasSplatArg) return true;
+  if (call.arguments.length >= minArgs && call.arguments.length <= maxArgs) return true;
   const expected =
     maxArgs === Infinity
       ? `at least ${minArgs}`
@@ -145,6 +145,7 @@ function reportArityIfBad(
   ctx.errors.push({
     message: `Expected ${expected} argument(s) for '${call.functionName}', but got ${call.arguments.length}.`,
   });
+  return false;
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -21,6 +21,18 @@ import { Scope } from "./scope.js";
  * For a variadic last parameter declared as `...xs: T[]`, every arg at or
  * past its position is checked against the array's element type `T`.
  */
+/**
+ * Per-arg type for a variadic param. `...xs: T[]` means each incoming arg
+ * is a `T`; if the typeHint isn't an arrayType (e.g. untyped `...args`),
+ * fall back to its raw hint or "any".
+ */
+function variadicElementType(
+  param: FunctionParameter,
+): VariableType | "any" | undefined {
+  if (param.typeHint?.type === "arrayType") return param.typeHint.elementType;
+  return param.typeHint ?? "any";
+}
+
 function paramListSignature(params: FunctionParameter[], argCount: number): {
   minArgs: number;
   maxArgs: number;
@@ -28,17 +40,10 @@ function paramListSignature(params: FunctionParameter[], argCount: number): {
 } {
   const lastParam = params[params.length - 1];
   const hasRest = lastParam?.variadic === true;
-  const requiredCount = params.filter(
+  const minArgs = params.filter(
     (p) => p.defaultValue === undefined && !p.variadic,
   ).length;
-  const minArgs = requiredCount;
   const maxArgs = hasRest ? Infinity : params.length;
-
-  const restElementType: VariableType | "any" | undefined = hasRest
-    ? lastParam.typeHint?.type === "arrayType"
-      ? lastParam.typeHint.elementType
-      : (lastParam.typeHint ?? "any")
-    : undefined;
 
   const paramTypes: (VariableType | "any" | undefined)[] = params.map((p) =>
     p.typeHint,
@@ -47,8 +52,9 @@ function paramListSignature(params: FunctionParameter[], argCount: number): {
     // Replace the variadic slot's array type with the element type, so a
     // single arg at that position is checked element-wise. Then extend to
     // cover any extra args.
-    paramTypes[paramTypes.length - 1] = restElementType;
-    while (paramTypes.length < argCount) paramTypes.push(restElementType);
+    const elementType = variadicElementType(lastParam);
+    paramTypes[paramTypes.length - 1] = elementType;
+    while (paramTypes.length < argCount) paramTypes.push(elementType);
   }
   return { minArgs, maxArgs, paramTypes };
 }
@@ -136,16 +142,16 @@ function checkArity(
 ): boolean {
   if (hasSplatArg) return true;
   if (call.arguments.length >= minArgs && call.arguments.length <= maxArgs) return true;
-  const expected =
-    maxArgs === Infinity
-      ? `at least ${minArgs}`
-      : minArgs === maxArgs
-        ? `${minArgs}`
-        : `${minArgs}-${maxArgs}`;
   ctx.errors.push({
-    message: `Expected ${expected} argument(s) for '${call.functionName}', but got ${call.arguments.length}.`,
+    message: `Expected ${formatArity(minArgs, maxArgs)} argument(s) for '${call.functionName}', but got ${call.arguments.length}.`,
   });
   return false;
+}
+
+function formatArity(minArgs: number, maxArgs: number): string {
+  if (maxArgs === Infinity) return `at least ${minArgs}`;
+  if (minArgs === maxArgs) return `${minArgs}`;
+  return `${minArgs}-${maxArgs}`;
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -25,6 +25,7 @@ export class TypeChecker {
   private currentScopeKey: string = GLOBAL_SCOPE_KEY;
   private functionDefs: Record<string, FunctionDefinition> = {};
   private nodeDefs: Record<string, GraphNodeDefinition> = {};
+  private importedFunctions: CompilationUnit["importedFunctions"] = {};
   private errors: TypeCheckError[] = [];
   private inferredReturnTypes: Record<string, VariableType | "any"> = {};
   private inferringReturnType = new Set<string>();
@@ -38,6 +39,7 @@ export class TypeChecker {
     this.nodeDefs = Object.fromEntries(
       resolved.graphNodes.map((n) => [n.nodeName, n]),
     );
+    this.importedFunctions = { ...resolved.importedFunctions };
   }
 
   private get typeAliases(): Record<string, VariableType> {
@@ -61,6 +63,7 @@ export class TypeChecker {
       currentScopeKey: this.currentScopeKey,
       functionDefs: this.functionDefs,
       nodeDefs: this.nodeDefs,
+      importedFunctions: this.importedFunctions,
       errors: this.errors,
       inferredReturnTypes: this.inferredReturnTypes,
       inferringReturnType: this.inferringReturnType,
@@ -83,6 +86,21 @@ export class TypeChecker {
           validateTypeReferences(aliasedType, name, this.typeAliases, this.errors);
         }
       });
+    }
+
+    // 1b. Warn on local definitions that shadow imported functions/nodes.
+    for (const localName of [
+      ...Object.keys(this.functionDefs),
+      ...Object.keys(this.nodeDefs),
+    ]) {
+      if (this.importedFunctions[localName]) {
+        const def =
+          this.functionDefs[localName] ?? this.nodeDefs[localName];
+        this.errors.push({
+          message: `'${localName}' shadows an imported function.`,
+          loc: def.loc,
+        });
+      }
     }
 
     // 2. Infer return types

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -11,6 +11,7 @@ import {
   GraphNodeDefinition,
   VariableType,
 } from "../types.js";
+import type { SourceLocation } from "../types/base.js";
 import { TypeCheckError, TypeCheckResult, TypeCheckerContext } from "./types.js";
 import { validateTypeReferences } from "./validate.js";
 import { inferReturnTypes } from "./inference.js";
@@ -94,21 +95,17 @@ export class TypeChecker {
     // 1b. Warn on local definitions that shadow imported functions/nodes.
     // functionDefs and nodeDefs are mutually exclusive by construction
     // (a name is parsed as one or the other, never both).
+    const shadowWarning = (name: string, loc: SourceLocation | undefined) =>
+      this.errors.push({
+        message: `'${name}' shadows an imported function.`,
+        severity: "warning",
+        loc,
+      });
     for (const [name, def] of Object.entries(this.functionDefs)) {
-      if (this.importedFunctions[name]) {
-        this.errors.push({
-          message: `'${name}' shadows an imported function.`,
-          loc: def.loc,
-        });
-      }
+      if (this.importedFunctions[name]) shadowWarning(name, def.loc);
     }
     for (const [name, def] of Object.entries(this.nodeDefs)) {
-      if (this.importedFunctions[name]) {
-        this.errors.push({
-          message: `'${name}' shadows an imported function.`,
-          loc: def.loc,
-        });
-      }
+      if (this.importedFunctions[name]) shadowWarning(name, def.loc);
     }
 
     // 2. Infer return types
@@ -157,8 +154,9 @@ export function formatErrors(
 ): string {
   return errors
     .map((err) => {
-      const colorFunc = errorType === "warning" ? color.yellow : color.red;
-      return `${colorFunc(errorType)}: ${err.message}`;
+      const kind = err.severity ?? errorType;
+      const colorFunc = kind === "warning" ? color.yellow : color.red;
+      return `${colorFunc(kind)}: ${err.message}`;
     })
     .join("\n");
 }

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -1,5 +1,8 @@
 import { color } from "@/utils/termcolors.js";
-import type { CompilationUnit } from "../compilationUnit.js";
+import type {
+  CompilationUnit,
+  ImportedFunctionSignature,
+} from "../compilationUnit.js";
 import { GLOBAL_SCOPE_KEY, ScopedTypeAliases, scopeKey, buildCompilationUnit } from "../compilationUnit.js";
 import { AgencyConfig } from "../config.js";
 import {
@@ -25,7 +28,7 @@ export class TypeChecker {
   private currentScopeKey: string = GLOBAL_SCOPE_KEY;
   private functionDefs: Record<string, FunctionDefinition> = {};
   private nodeDefs: Record<string, GraphNodeDefinition> = {};
-  private importedFunctions: CompilationUnit["importedFunctions"] = {};
+  private importedFunctions: Record<string, ImportedFunctionSignature> = {};
   private errors: TypeCheckError[] = [];
   private inferredReturnTypes: Record<string, VariableType | "any"> = {};
   private inferringReturnType = new Set<string>();
@@ -89,15 +92,20 @@ export class TypeChecker {
     }
 
     // 1b. Warn on local definitions that shadow imported functions/nodes.
-    for (const localName of [
-      ...Object.keys(this.functionDefs),
-      ...Object.keys(this.nodeDefs),
-    ]) {
-      if (this.importedFunctions[localName]) {
-        const def =
-          this.functionDefs[localName] ?? this.nodeDefs[localName];
+    // functionDefs and nodeDefs are mutually exclusive by construction
+    // (a name is parsed as one or the other, never both).
+    for (const [name, def] of Object.entries(this.functionDefs)) {
+      if (this.importedFunctions[name]) {
         this.errors.push({
-          message: `'${localName}' shadows an imported function.`,
+          message: `'${name}' shadows an imported function.`,
+          loc: def.loc,
+        });
+      }
+    }
+    for (const [name, def] of Object.entries(this.nodeDefs)) {
+      if (this.importedFunctions[name]) {
+        this.errors.push({
+          message: `'${name}' shadows an imported function.`,
           loc: def.loc,
         });
       }

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -84,9 +84,6 @@ function synthFunctionCall(
   _scope: Scope,
   ctx: TypeCheckerContext,
 ): VariableType | "any" {
-  // Resolution order: local definition → imported (cross-file) → builtin
-  // fallback. Importeds take precedence over builtins so a real stdlib
-  // function shadows a hardcoded signature when SymbolTable info is wired in.
   const fn = ctx.functionDefs[expr.functionName];
   const graphNode = ctx.nodeDefs[expr.functionName];
   const def = fn ?? graphNode;

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -84,9 +84,9 @@ function synthFunctionCall(
   _scope: Scope,
   ctx: TypeCheckerContext,
 ): VariableType | "any" {
-  if (expr.functionName in BUILTIN_FUNCTION_TYPES) {
-    return BUILTIN_FUNCTION_TYPES[expr.functionName].returnType;
-  }
+  // Resolution order: local definition → imported (cross-file) → builtin
+  // fallback. Importeds take precedence over builtins so a real stdlib
+  // function shadows a hardcoded signature when SymbolTable info is wired in.
   const fn = ctx.functionDefs[expr.functionName];
   const graphNode = ctx.nodeDefs[expr.functionName];
   const def = fn ?? graphNode;
@@ -94,9 +94,15 @@ function synthFunctionCall(
   if (expr.functionName in ctx.inferredReturnTypes) {
     return ctx.inferredReturnTypes[expr.functionName];
   }
-  // Lazily trigger inference if we're in the inference phase
   if (def && !def.returnType && ctx.inferringReturnType.size > 0) {
     return ctx.inferReturnTypeFor(expr.functionName, def);
+  }
+  if (!def) {
+    const imported = ctx.importedFunctions[expr.functionName];
+    if (imported?.returnType) return imported.returnType;
+    if (expr.functionName in BUILTIN_FUNCTION_TYPES) {
+      return BUILTIN_FUNCTION_TYPES[expr.functionName].returnType;
+    }
   }
   return "any";
 }

--- a/packages/agency-lang/lib/typeChecker/types.ts
+++ b/packages/agency-lang/lib/typeChecker/types.ts
@@ -3,17 +3,14 @@ import { AgencyConfig } from "../config.js";
 import {
   AgencyNode,
   FunctionDefinition,
-  FunctionParameter,
   GraphNodeDefinition,
   VariableType,
 } from "../types.js";
 import { SourceLocation } from "../types/base.js";
-import type { ScopedTypeAliases } from "../compilationUnit.js";
-
-export type ImportedFunctionSignature = {
-  parameters: FunctionParameter[];
-  returnType: VariableType | null;
-};
+import type {
+  ImportedFunctionSignature,
+  ScopedTypeAliases,
+} from "../compilationUnit.js";
 
 export type TypeCheckError = {
   message: string;

--- a/packages/agency-lang/lib/typeChecker/types.ts
+++ b/packages/agency-lang/lib/typeChecker/types.ts
@@ -3,11 +3,17 @@ import { AgencyConfig } from "../config.js";
 import {
   AgencyNode,
   FunctionDefinition,
+  FunctionParameter,
   GraphNodeDefinition,
   VariableType,
 } from "../types.js";
 import { SourceLocation } from "../types/base.js";
 import type { ScopedTypeAliases } from "../compilationUnit.js";
+
+export type ImportedFunctionSignature = {
+  parameters: FunctionParameter[];
+  returnType: VariableType | null;
+};
 
 export type TypeCheckError = {
   message: string;
@@ -42,6 +48,7 @@ export type TypeCheckerContext = {
   currentScopeKey: string;
   functionDefs: Record<string, FunctionDefinition>;
   nodeDefs: Record<string, GraphNodeDefinition>;
+  importedFunctions: Record<string, ImportedFunctionSignature>;
   errors: TypeCheckError[];
   inferredReturnTypes: Record<string, VariableType | "any">;
   inferringReturnType: Set<string>;

--- a/packages/agency-lang/lib/typeChecker/types.ts
+++ b/packages/agency-lang/lib/typeChecker/types.ts
@@ -14,6 +14,7 @@ import type {
 
 export type TypeCheckError = {
   message: string;
+  severity?: "error" | "warning"; // defaults to "error" when omitted
   variableName?: string;
   expectedType?: string;
   actualType?: string;

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -18,6 +18,7 @@ import * as path from "path";
 import { _parseAgency } from "@/parser.js";
 import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
 import { buildCompilationUnit } from "@/compilationUnit.js";
+import { SymbolTable } from "@/symbolTable.js";
 import { formatErrors, typeCheck } from "@/typeChecker/index.js";
 import { Command } from "commander";
 import * as fs from "fs";
@@ -412,9 +413,16 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .action(async (inputs: string[], opts: { strict?: boolean }) => {
       const config = getConfig();
       let hasErrors = false;
-      const runTypeCheck = (contents: string) => {
+      const runTypeCheck = (contents: string, filePath?: string) => {
         const parsedProgram = parse(contents, config);
-        const info = buildCompilationUnit(parsedProgram);
+        const symbolTable = filePath
+          ? SymbolTable.build(path.resolve(filePath), config)
+          : undefined;
+        const info = buildCompilationUnit(
+          parsedProgram,
+          symbolTable,
+          filePath ? path.resolve(filePath) : undefined,
+        );
         const { errors } = typeCheck(parsedProgram, config, info);
         if (errors.length > 0) {
           console.error(formatErrors(errors));
@@ -430,7 +438,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
       } else {
         for (const input of inputs) {
           const contents = readFile(input);
-          runTypeCheck(contents);
+          runTypeCheck(contents, input);
         }
       }
       if (hasErrors) process.exit(1);

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -413,16 +413,14 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .action(async (inputs: string[], opts: { strict?: boolean }) => {
       const config = getConfig();
       let hasErrors = false;
-      const runTypeCheck = (contents: string, filePath?: string) => {
+      const runTypeCheck = (
+        contents: string,
+        filePath?: string,
+        symbolTable?: SymbolTable,
+      ) => {
         const parsedProgram = parse(contents, config);
-        const symbolTable = filePath
-          ? SymbolTable.build(path.resolve(filePath), config)
-          : undefined;
-        const info = buildCompilationUnit(
-          parsedProgram,
-          symbolTable,
-          filePath ? path.resolve(filePath) : undefined,
-        );
+        const absPath = filePath ? path.resolve(filePath) : undefined;
+        const info = buildCompilationUnit(parsedProgram, symbolTable, absPath);
         const { errors } = typeCheck(parsedProgram, config, info);
         if (errors.length > 0) {
           console.error(formatErrors(errors));
@@ -436,9 +434,12 @@ export function createProgram(deps: CliDependencies = {}): Command {
         const contents = await readStdin();
         runTypeCheck(contents);
       } else {
+        // Build one SymbolTable seeded from the first input. Reachable files
+        // (including stdlib) are crawled once, not once per input file.
+        const symbolTable = SymbolTable.build(path.resolve(inputs[0]), config);
         for (const input of inputs) {
           const contents = readFile(input);
-          runTypeCheck(contents, input);
+          runTypeCheck(contents, input, symbolTable);
         }
       }
       if (hasErrors) process.exit(1);

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -424,7 +424,9 @@ export function createProgram(deps: CliDependencies = {}): Command {
         const { errors } = typeCheck(parsedProgram, config, info);
         if (errors.length > 0) {
           console.error(formatErrors(errors));
-          hasErrors = true;
+          if (errors.some((e) => (e.severity ?? "error") === "error")) {
+            hasErrors = true;
+          }
         } else {
           console.log("No type errors found.");
         }


### PR DESCRIPTION
## Summary
Wires up cross-file function resolution so the typechecker uses real signatures from imported `.agency` files (including auto-imported stdlib) instead of falling back to `any`. Fixes the v1 hardcoded-builtin overlap noted in PR #77.

- `CompilationUnit.importedFunctions` now carries `returnType` alongside `parameters`; `buildCompilationUnit` fills both from `SymbolTable`.
- `TypeChecker` consults imported signatures. Resolution order: **local def → imported → builtin fallback** — importeds win over builtins so a real stdlib function shadows the hardcoded one.
- New `paramListSignature` helper honors `defaultValue` (optional) and `variadic` (rest) parameters when computing arity bounds and per-position param types. Variadic last params declared as `T[]` are checked element-wise on the caller side.
- Warns on local function/node definitions that shadow an imported name.
- Wires `SymbolTable` into the `tc`/`typecheck` CLI (compile path already had it; only typecheck was missing). Without this, the typechecker never sees stdlib at all.
- Adds 6 new tests covering imported call resolution, arity, optional default args, variadic params, and shadowing semantics.

**Not in this PR:** the duplicate entries (`print`, `read`, etc.) in `BUILTIN_FUNCTION_TYPES` are kept as a fallback for unit tests built without a `SymbolTable`. Once we're confident the import path is solid in real use, a follow-up can delete them and migrate the affected unit tests.

## Test plan
- [x] `pnpm exec vitest run` — 2198/2198 pass
- [x] `make` green
- [x] Manual smoke on a real `.agency` file: `print("a", "b", 42)` accepted (variadic), `keys({a:1})` returns `string[]`, `read()` (missing arg) errors with arity, `const k: number = keys(...)` errors with assignability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)