### PR TITLE
typechecker: support ! validation syntax

### DIFF
--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -13,6 +13,7 @@ import type {
 } from "./types/importStatement.js";
 import type { SymbolTable } from "./symbolTable.js";
 import { walkNodes } from "./utils/node.js";
+import { applyValidationFlag } from "./typeChecker/validation.js";
 
 export const GLOBAL_SCOPE_KEY = "global";
 
@@ -171,9 +172,17 @@ export function buildCompilationUnit(
     for (const stmt of unit.importStatements) {
       for (const r of symbolTable.resolveImport(stmt, fromFile)) {
         if (r.symbol.kind === "function" || r.symbol.kind === "node") {
+          // Pre-wrap the imported return type so consumers see the same
+          // caller-visible shape they would for a local def. The runtime
+          // validation lives inside the imported function's body, so by
+          // the time a value crosses the import boundary it really is a
+          // Result<T, string> — the typechecker just needs to agree.
+          const returnType = r.symbol.returnType
+            ? applyValidationFlag(r.symbol.returnType, r.symbol.returnTypeValidated)
+            : r.symbol.returnType;
           unit.importedFunctions[r.localName] = {
             parameters: r.symbol.parameters,
-            returnType: r.symbol.returnType,
+            returnType,
           };
         }
         if (r.symbol.kind === "function" && r.symbol.safe) {

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -13,7 +13,7 @@ import type {
 } from "./types/importStatement.js";
 import type { SymbolTable } from "./symbolTable.js";
 import { walkNodes } from "./utils/node.js";
-import { applyValidationFlag } from "./typeChecker/validation.js";
+import { resultTypeForValidation } from "./typeChecker/validation.js";
 
 export const GLOBAL_SCOPE_KEY = "global";
 
@@ -178,7 +178,10 @@ export function buildCompilationUnit(
           // the time a value crosses the import boundary it really is a
           // Result<T, string> — the typechecker just needs to agree.
           const returnType = r.symbol.returnType
-            ? applyValidationFlag(r.symbol.returnType, r.symbol.returnTypeValidated)
+            ? resultTypeForValidation(
+                r.symbol.returnType,
+                r.symbol.returnTypeValidated,
+              )
             : r.symbol.returnType;
           unit.importedFunctions[r.localName] = {
             parameters: r.symbol.parameters,
@@ -189,7 +192,11 @@ export function buildCompilationUnit(
           unit.safeFunctions[r.localName] = true;
         }
         if (r.symbol.kind === "type") {
-          unit.typeAliases.add(GLOBAL_SCOPE_KEY, r.localName, r.symbol.aliasedType);
+          unit.typeAliases.add(
+            GLOBAL_SCOPE_KEY,
+            r.localName,
+            r.symbol.aliasedType,
+          );
         }
       }
     }

--- a/packages/agency-lang/lib/symbolTable.ts
+++ b/packages/agency-lang/lib/symbolTable.ts
@@ -27,6 +27,7 @@ export type FunctionSymbol = {
   exported: boolean;
   parameters: FunctionParameter[];
   returnType: VariableType | null;
+  returnTypeValidated?: boolean;
 };
 
 export type NodeSymbol = {
@@ -35,6 +36,7 @@ export type NodeSymbol = {
   loc?: SourceLocation;
   parameters: FunctionParameter[];
   returnType: VariableType | null;
+  returnTypeValidated?: boolean;
 };
 
 export type TypeSymbol = {
@@ -208,6 +210,7 @@ export function classifySymbols(program: AgencyProgram): FileSymbols {
           loc: node.loc,
           parameters: node.parameters,
           returnType: node.returnType ?? null,
+          returnTypeValidated: node.returnTypeValidated,
         };
         break;
       case "function":
@@ -219,6 +222,7 @@ export function classifySymbols(program: AgencyProgram): FileSymbols {
           exported: !!node.exported,
           parameters: node.parameters,
           returnType: node.returnType ?? null,
+          returnTypeValidated: node.returnTypeValidated,
         };
         break;
       case "typeAlias":

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -4801,6 +4801,100 @@ describe("TypeChecker", () => {
       expect(typeCheck(program).errors).toHaveLength(0);
     });
 
+    it("accepts a Result failure as input to a validated param", () => {
+      // def greet(name: string!): Result<number, string> { ... }
+      // const f: Result<string, string> = failure("oops")
+      // greet(f)  // should accept — failures pass through unvalidated
+      const resultStrStr: VariableType = {
+        type: "resultType",
+        successType: str,
+        failureType: str,
+      };
+      const resultNum: VariableType = {
+        type: "resultType",
+        successType: num,
+        failureType: { type: "primitiveType", value: "any" },
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "greet",
+            parameters: [
+              { type: "functionParameter", name: "n", typeHint: str, validated: true },
+            ],
+            returnType: resultNum,
+            body: [
+              {
+                type: "returnStatement",
+                value: {
+                  type: "functionCall",
+                  functionName: "success",
+                  arguments: [{ type: "number", value: "5" }],
+                },
+              },
+            ],
+          },
+          {
+            type: "assignment",
+            variableName: "f",
+            typeHint: resultStrStr,
+            value: {
+              type: "functionCall",
+              functionName: "failure",
+              arguments: [{ type: "string", segments: [{ type: "text", value: "oops" }] }],
+            },
+          },
+          {
+            type: "functionCall",
+            functionName: "greet",
+            arguments: [{ type: "variableName", value: "f" }],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toHaveLength(0);
+    });
+
+    it("rejects a wrong-typed value passed to a validated param", () => {
+      // greet(42) — 42 is neither string nor a Result, should error
+      const resultNum: VariableType = {
+        type: "resultType",
+        successType: num,
+        failureType: { type: "primitiveType", value: "any" },
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "greet",
+            parameters: [
+              { type: "functionParameter", name: "n", typeHint: str, validated: true },
+            ],
+            returnType: resultNum,
+            body: [
+              {
+                type: "returnStatement",
+                value: {
+                  type: "functionCall",
+                  functionName: "success",
+                  arguments: [{ type: "number", value: "5" }],
+                },
+              },
+            ],
+          },
+          {
+            type: "functionCall",
+            functionName: "greet",
+            arguments: [{ type: "number", value: "42" }],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /not assignable/i.test(e.message))).toBe(true);
+    });
+
     it("checks the RHS of a validated assignment against the un-bang'd type", () => {
       // const x: number! = "not a number" — RHS is checked against `number`.
       const program: AgencyProgram = {

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -4685,6 +4685,122 @@ describe("TypeChecker", () => {
       expect(typeCheck(program).errors).toHaveLength(0);
     });
 
+    it("errors when a function has validated params and an explicit non-Result return type", () => {
+      // def greet(name: string!): number { return 5 }
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "greet",
+            parameters: [
+              { type: "functionParameter", name: "n", typeHint: str, validated: true },
+            ],
+            returnType: num,
+            body: [{ type: "returnStatement", value: { type: "number", value: "5" } }],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /validated parameters/i.test(e.message))).toBe(true);
+    });
+
+    it("infers Result<T, string> when validated params + no return annotation", () => {
+      // def greet(name: string!) { return 5 }
+      // expectResult(greet("alice"))  // expectResult: Result<number, string>
+      const resultNumStr: VariableType = {
+        type: "resultType",
+        successType: num,
+        failureType: str,
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "greet",
+            parameters: [
+              { type: "functionParameter", name: "n", typeHint: str, validated: true },
+            ],
+            body: [{ type: "returnStatement", value: { type: "number", value: "5" } }],
+          },
+          {
+            type: "function",
+            functionName: "expectResult",
+            parameters: [
+              { type: "functionParameter", name: "r", typeHint: resultNumStr },
+            ],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "expectResult",
+            arguments: [
+              {
+                type: "functionCall",
+                functionName: "greet",
+                arguments: [{ type: "string", segments: [{ type: "text", value: "alice" }] }],
+              },
+            ],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toHaveLength(0);
+    });
+
+    it("accepts a function with validated params and explicit Result return type", () => {
+      const resultNum: VariableType = {
+        type: "resultType",
+        successType: num,
+        failureType: { type: "primitiveType", value: "any" },
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "greet",
+            parameters: [
+              { type: "functionParameter", name: "n", typeHint: str, validated: true },
+            ],
+            returnType: resultNum,
+            body: [
+              {
+                type: "returnStatement",
+                value: {
+                  type: "functionCall",
+                  functionName: "success",
+                  arguments: [{ type: "number", value: "5" }],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toHaveLength(0);
+    });
+
+    it("accepts a function with validated params and bang return type", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "greet",
+            parameters: [
+              { type: "functionParameter", name: "n", typeHint: str, validated: true },
+            ],
+            returnType: str,
+            returnTypeValidated: true,
+            body: [
+              { type: "returnStatement", value: { type: "string", segments: [{ type: "text", value: "hi" }] } },
+            ],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toHaveLength(0);
+    });
+
     it("checks the RHS of a validated assignment against the un-bang'd type", () => {
       // const x: number! = "not a number" — RHS is checked against `number`.
       const program: AgencyProgram = {

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -5005,6 +5005,35 @@ describe("TypeChecker", () => {
       expect(errors.length).toBeGreaterThan(0);
     });
 
+    it("imported function with bang return type is seen as Result at call sites", () => {
+      // Imported `def getPerson(): Person!` — at the import boundary the
+      // return is pre-wrapped to Result<Person, string>, so calling it from
+      // another file types as a Result like a local def would.
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "expectResult",
+            parameters: [
+              { type: "functionParameter", name: "r", typeHint: resultPersonStr },
+            ],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "expectResult",
+            arguments: [{ type: "functionCall", functionName: "getPerson", arguments: [] }],
+          },
+        ],
+      };
+      // Imported sigs are post-wrap by convention (see compilationUnit.ts).
+      const info = withImports(program, {
+        getPerson: { parameters: [], returnType: resultPersonStr },
+      });
+      expect(typeCheck(program, {}, info).errors).toHaveLength(0);
+    });
+
     it("checks the RHS of a validated assignment against the un-bang'd type", () => {
       // const x: number! = "not a number" — RHS is checked against `number`.
       const program: AgencyProgram = {

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -4552,4 +4552,113 @@ describe("TypeChecker", () => {
       expect(errors.some((e) => /Property 'vlaue'/.test(e.message))).toBe(true);
     });
   });
+
+  describe("v2: bang (!) validation", () => {
+    const num: VariableType = { type: "primitiveType", value: "number" };
+    const str: VariableType = { type: "primitiveType", value: "string" };
+    const person: VariableType = {
+      type: "objectType",
+      properties: [{ key: "name", value: str }],
+    };
+    const resultPersonStr: VariableType = {
+      type: "resultType",
+      successType: person,
+      failureType: str,
+    };
+
+    it("declares a validated variable as Result<T, string>", () => {
+      // const x: Person! = { name: "alice" }; expectResult(x)
+      // expectResult takes Result<Person, string>; passing x must typecheck.
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "expectResult",
+            parameters: [
+              { type: "functionParameter", name: "r", typeHint: resultPersonStr },
+            ],
+            body: [],
+          },
+          {
+            type: "assignment",
+            variableName: "x",
+            typeHint: person,
+            validated: true,
+            value: {
+              type: "agencyObject",
+              entries: [
+                { key: "name", value: { type: "string", segments: [{ type: "text", value: "alice" }] } },
+              ],
+            },
+          },
+          {
+            type: "functionCall",
+            functionName: "expectResult",
+            arguments: [{ type: "variableName", value: "x" }],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toHaveLength(0);
+    });
+
+    it("does not rewrap a Result type with bang", () => {
+      // const x: Result<Person, string>! = success({...}); expectResult(x)
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "expectResult",
+            parameters: [
+              { type: "functionParameter", name: "r", typeHint: resultPersonStr },
+            ],
+            body: [],
+          },
+          {
+            type: "assignment",
+            variableName: "x",
+            typeHint: resultPersonStr,
+            validated: true,
+            value: {
+              type: "functionCall",
+              functionName: "success",
+              arguments: [
+                {
+                  type: "agencyObject",
+                  entries: [
+                    { key: "name", value: { type: "string", segments: [{ type: "text", value: "alice" }] } },
+                  ],
+                },
+              ],
+            },
+          },
+          {
+            type: "functionCall",
+            functionName: "expectResult",
+            arguments: [{ type: "variableName", value: "x" }],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toHaveLength(0);
+    });
+
+    it("checks the RHS of a validated assignment against the un-bang'd type", () => {
+      // const x: number! = "not a number" — RHS is checked against `number`.
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "assignment",
+            variableName: "x",
+            typeHint: num,
+            validated: true,
+            value: { type: "string", segments: [{ type: "text", value: "not a number" }] },
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /not assignable/i.test(e.message))).toBe(true);
+    });
+  });
 });

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -4643,6 +4643,48 @@ describe("TypeChecker", () => {
       expect(typeCheck(program).errors).toHaveLength(0);
     });
 
+    it("exposes a function's bang-annotated return as Result at call sites", () => {
+      // def getPerson(): Person! { return { name: "alice" } }
+      // expectResult(getPerson())  // expectResult: Result<Person, string>
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "getPerson",
+            parameters: [],
+            returnType: person,
+            returnTypeValidated: true,
+            body: [
+              {
+                type: "returnStatement",
+                value: {
+                  type: "agencyObject",
+                  entries: [
+                    { key: "name", value: { type: "string", segments: [{ type: "text", value: "alice" }] } },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            type: "function",
+            functionName: "expectResult",
+            parameters: [
+              { type: "functionParameter", name: "r", typeHint: resultPersonStr },
+            ],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "expectResult",
+            arguments: [{ type: "functionCall", functionName: "getPerson", arguments: [] }],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toHaveLength(0);
+    });
+
     it("checks the RHS of a validated assignment against the un-bang'd type", () => {
       // const x: number! = "not a number" — RHS is checked against `number`.
       const program: AgencyProgram = {

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -4932,6 +4932,79 @@ describe("TypeChecker", () => {
       expect(errors.some((e) => /not allowed on handler/i.test(e.message))).toBe(true);
     });
 
+    it("allows .value/.error on a validated Result via RESULT_FIELDS escape", () => {
+      // const r: Person! = {...}; const v = r.value; const e = r.error
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "assignment",
+            variableName: "r",
+            typeHint: person,
+            validated: true,
+            value: {
+              type: "agencyObject",
+              entries: [
+                { key: "name", value: { type: "string", segments: [{ type: "text", value: "alice" }] } },
+              ],
+            },
+          },
+          {
+            type: "assignment",
+            variableName: "v",
+            value: {
+              type: "valueAccess",
+              base: { type: "variableName", value: "r" },
+              chain: [{ kind: "property", name: "value" }],
+            },
+          },
+          {
+            type: "assignment",
+            variableName: "e",
+            value: {
+              type: "valueAccess",
+              base: { type: "variableName", value: "r" },
+              chain: [{ kind: "property", name: "error" }],
+            },
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toHaveLength(0);
+    });
+
+    it("errors on arbitrary property access on a validated Result (the bug class this catches)", () => {
+      // const r: Person! = {...}; const n = r.name
+      // r is Result<Person, string>; r.name is bogus until narrowing (#14).
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "assignment",
+            variableName: "r",
+            typeHint: person,
+            validated: true,
+            value: {
+              type: "agencyObject",
+              entries: [
+                { key: "name", value: { type: "string", segments: [{ type: "text", value: "alice" }] } },
+              ],
+            },
+          },
+          {
+            type: "assignment",
+            variableName: "n",
+            value: {
+              type: "valueAccess",
+              base: { type: "variableName", value: "r" },
+              chain: [{ kind: "property", name: "name" }],
+            },
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
     it("checks the RHS of a validated assignment against the un-bang'd type", () => {
       // const x: number! = "not a number" — RHS is checked against `number`.
       const program: AgencyProgram = {

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -4895,6 +4895,43 @@ describe("TypeChecker", () => {
       expect(errors.some((e) => /not assignable/i.test(e.message))).toBe(true);
     });
 
+    it("rejects bang syntax on inline handler params", () => {
+      // node main() { handle { ... } with (data: Person!) { return approve() } }
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "graphNode",
+            nodeName: "main",
+            parameters: [],
+            body: [
+              {
+                type: "handleBlock",
+                body: [],
+                handler: {
+                  kind: "inline",
+                  param: {
+                    type: "functionParameter",
+                    name: "data",
+                    typeHint: person,
+                    validated: true,
+                  },
+                  body: [
+                    {
+                      type: "returnStatement",
+                      value: { type: "functionCall", functionName: "approve", arguments: [] },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /not allowed on handler/i.test(e.message))).toBe(true);
+    });
+
     it("checks the RHS of a validated assignment against the un-bang'd type", () => {
       // const x: number! = "not a number" — RHS is checked against `number`.
       const program: AgencyProgram = {

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -33,11 +33,15 @@ function variadicElementType(
   return param.typeHint ?? "any";
 }
 
+type ParamSlot = {
+  type: VariableType | "any" | undefined;
+  validated: boolean;
+};
+
 function paramListSignature(params: FunctionParameter[], argCount: number): {
   minArgs: number;
   maxArgs: number;
-  paramTypes: (VariableType | "any" | undefined)[];
-  validatedFlags: boolean[];
+  slots: ParamSlot[];
 } {
   const lastParam = params[params.length - 1];
   const hasRest = lastParam?.variadic === true;
@@ -46,21 +50,23 @@ function paramListSignature(params: FunctionParameter[], argCount: number): {
   ).length;
   const maxArgs = hasRest ? Infinity : params.length;
 
-  const paramTypes: (VariableType | "any" | undefined)[] = params.map((p) =>
-    p.typeHint,
-  );
-  const validatedFlags: boolean[] = params.map((p) => !!p.validated);
+  const slots: ParamSlot[] = params.map((p) => ({
+    type: p.typeHint,
+    validated: !!p.validated,
+  }));
   if (hasRest) {
     // Replace the variadic slot's array type with the element type, so a
     // single arg at that position is checked element-wise. Then extend to
     // cover any extra args.
     const elementType = variadicElementType(lastParam);
-    paramTypes[paramTypes.length - 1] = elementType;
-    const lastValidated = validatedFlags[validatedFlags.length - 1] ?? false;
-    while (paramTypes.length < argCount) paramTypes.push(elementType);
-    while (validatedFlags.length < argCount) validatedFlags.push(lastValidated);
+    const restSlot: ParamSlot = {
+      type: elementType,
+      validated: slots[slots.length - 1]?.validated ?? false,
+    };
+    slots[slots.length - 1] = restSlot;
+    while (slots.length < argCount) slots.push(restSlot);
   }
-  return { minArgs, maxArgs, paramTypes, validatedFlags };
+  return { minArgs, maxArgs, slots };
 }
 
 export function checkScopes(
@@ -106,12 +112,12 @@ function checkSingleFunctionCall(
   const params = def?.parameters ?? importedSig?.parameters;
 
   if (params) {
-    const { minArgs, maxArgs, paramTypes, validatedFlags } = paramListSignature(
+    const { minArgs, maxArgs, slots } = paramListSignature(
       params,
       call.arguments.length,
     );
     if (!checkArity(call, minArgs, maxArgs, hasSplatArg, ctx)) return;
-    checkArgsAgainstParams(call, paramTypes, scope, ctx, validatedFlags);
+    checkArgsAgainstParams(call, slots, scope, ctx);
     return;
   }
 
@@ -121,14 +127,13 @@ function checkSingleFunctionCall(
     const hasRest = sig.restParam !== undefined;
     const maxArgs = hasRest ? Infinity : sig.params.length;
     if (!checkArity(call, minArgs, maxArgs, hasSplatArg, ctx)) return;
-    const paramTypes: (VariableType | "any" | undefined)[] = [...sig.params];
+    const slots: ParamSlot[] = sig.params.map((type) => ({ type, validated: false }));
     if (hasRest) {
-      while (paramTypes.length < call.arguments.length) {
-        paramTypes.push(sig.restParam!);
+      while (slots.length < call.arguments.length) {
+        slots.push({ type: sig.restParam!, validated: false });
       }
     }
-    // Builtins don't have a validated concept; pass empty flags.
-    checkArgsAgainstParams(call, paramTypes, scope, ctx, []);
+    checkArgsAgainstParams(call, slots, scope, ctx);
   }
 }
 
@@ -172,27 +177,27 @@ function formatArity(minArgs: number, maxArgs: number): string {
  */
 function checkArgsAgainstParams(
   call: FunctionCall,
-  paramTypes: (VariableType | "any" | undefined)[],
+  slots: ParamSlot[],
   scope: Scope,
   ctx: TypeCheckerContext,
-  validatedFlags: boolean[],
 ): void {
   const typeAliases = ctx.getTypeAliases();
   for (let argIndex = 0; argIndex < call.arguments.length; argIndex++) {
     const arg = call.arguments[argIndex];
+    const slot = slots[argIndex];
     if (arg.type === "splat") {
-      checkSplatAgainstRemainingParams(call, arg.value, argIndex, paramTypes, scope, ctx);
+      checkSplatAgainstRemainingParams(call, arg.value, argIndex, slots, scope, ctx);
       return;
     }
     const innerArg = arg.type === "namedArgument" ? arg.value : arg;
     const argType = synthType(innerArg, scope, ctx);
-    const paramType = paramTypes[argIndex];
+    const paramType = slot?.type;
     if (paramType === undefined || paramType === "any" || argType === "any") {
       continue;
     }
     // Validated params accept either the un-bang'd type T or any Result —
     // failures pass through unvalidated per docs-new/guide/schemas.md.
-    if (validatedFlags[argIndex] && argType.type === "resultType") {
+    if (slot.validated && argType.type === "resultType") {
       continue;
     }
     if (!isAssignable(argType, paramType, typeAliases)) {
@@ -215,7 +220,7 @@ function checkSplatAgainstRemainingParams(
   call: FunctionCall,
   splatSource: AgencyNode,
   splatIndex: number,
-  paramTypes: (VariableType | "any" | undefined)[],
+  slots: ParamSlot[],
   scope: Scope,
   ctx: TypeCheckerContext,
 ): void {
@@ -233,10 +238,11 @@ function checkSplatAgainstRemainingParams(
   const elementType = splatType.elementType;
   const elementStr = formatTypeHint(elementType);
   const typeAliases = ctx.getTypeAliases();
-  for (const remainingParam of paramTypes.slice(splatIndex)) {
-    if (remainingParam === undefined || remainingParam === "any") continue;
-    if (isAssignable(elementType, remainingParam, typeAliases)) continue;
-    const paramStr = formatTypeHint(remainingParam);
+  for (const slot of slots.slice(splatIndex)) {
+    const paramType = slot.type;
+    if (paramType === undefined || paramType === "any") continue;
+    if (isAssignable(elementType, paramType, typeAliases)) continue;
+    const paramStr = formatTypeHint(paramType);
     ctx.errors.push({
       message: `Splat element type '${elementStr}' is not assignable to parameter type '${paramStr}' in call to '${call.functionName}'.`,
       expectedType: paramStr,

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -37,6 +37,7 @@ function paramListSignature(params: FunctionParameter[], argCount: number): {
   minArgs: number;
   maxArgs: number;
   paramTypes: (VariableType | "any" | undefined)[];
+  validatedFlags: boolean[];
 } {
   const lastParam = params[params.length - 1];
   const hasRest = lastParam?.variadic === true;
@@ -48,15 +49,18 @@ function paramListSignature(params: FunctionParameter[], argCount: number): {
   const paramTypes: (VariableType | "any" | undefined)[] = params.map((p) =>
     p.typeHint,
   );
+  const validatedFlags: boolean[] = params.map((p) => !!p.validated);
   if (hasRest) {
     // Replace the variadic slot's array type with the element type, so a
     // single arg at that position is checked element-wise. Then extend to
     // cover any extra args.
     const elementType = variadicElementType(lastParam);
     paramTypes[paramTypes.length - 1] = elementType;
+    const lastValidated = validatedFlags[validatedFlags.length - 1] ?? false;
     while (paramTypes.length < argCount) paramTypes.push(elementType);
+    while (validatedFlags.length < argCount) validatedFlags.push(lastValidated);
   }
-  return { minArgs, maxArgs, paramTypes };
+  return { minArgs, maxArgs, paramTypes, validatedFlags };
 }
 
 export function checkScopes(
@@ -102,12 +106,12 @@ function checkSingleFunctionCall(
   const params = def?.parameters ?? importedSig?.parameters;
 
   if (params) {
-    const { minArgs, maxArgs, paramTypes } = paramListSignature(
+    const { minArgs, maxArgs, paramTypes, validatedFlags } = paramListSignature(
       params,
       call.arguments.length,
     );
     if (!checkArity(call, minArgs, maxArgs, hasSplatArg, ctx)) return;
-    checkArgsAgainstParams(call, paramTypes, scope, ctx);
+    checkArgsAgainstParams(call, paramTypes, scope, ctx, validatedFlags);
     return;
   }
 
@@ -123,7 +127,8 @@ function checkSingleFunctionCall(
         paramTypes.push(sig.restParam!);
       }
     }
-    checkArgsAgainstParams(call, paramTypes, scope, ctx);
+    // Builtins don't have a validated concept; pass empty flags.
+    checkArgsAgainstParams(call, paramTypes, scope, ctx, []);
   }
 }
 
@@ -170,6 +175,7 @@ function checkArgsAgainstParams(
   paramTypes: (VariableType | "any" | undefined)[],
   scope: Scope,
   ctx: TypeCheckerContext,
+  validatedFlags: boolean[],
 ): void {
   const typeAliases = ctx.getTypeAliases();
   for (let argIndex = 0; argIndex < call.arguments.length; argIndex++) {
@@ -182,6 +188,11 @@ function checkArgsAgainstParams(
     const argType = synthType(innerArg, scope, ctx);
     const paramType = paramTypes[argIndex];
     if (paramType === undefined || paramType === "any" || argType === "any") {
+      continue;
+    }
+    // Validated params accept either the un-bang'd type T or any Result —
+    // failures pass through unvalidated per docs-new/guide/schemas.md.
+    if (validatedFlags[argIndex] && argType.type === "resultType") {
       continue;
     }
     if (!isAssignable(argType, paramType, typeAliases)) {

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -171,8 +171,9 @@ export class TypeChecker {
       if (!def.returnType) return;
       const effective = effectiveReturnType(def);
       if (effective && effective.type !== "resultType") {
+        const kind = def.type === "function" ? "Function" : "Node";
         this.errors.push({
-          message: `Function '${name}' has validated parameters but its return type is not a Result type. Validated parameters can short-circuit with a failure, so the return type must be 'Result<...>'.`,
+          message: `${kind} '${name}' has validated parameters but its return type is not a Result type. Validated parameters can short-circuit with a failure, so the return type must be 'Result<...>'.`,
           loc: def.loc,
         });
       }

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -20,7 +20,6 @@ import { checkScopes } from "./checker.js";
 import { isAssignable as _isAssignable } from "./assignability.js";
 import { inferReturnTypeFor } from "./inference.js";
 import { effectiveReturnType } from "./validation.js";
-import { walkNodes } from "../utils/node.js";
 
 export type { TypeCheckError, TypeCheckResult } from "./types.js";
 
@@ -161,11 +160,9 @@ export class TypeChecker {
       }
     }
 
-    // 1d. A function/node with validated parameters can short-circuit and
-    // return a `failure` before the body runs. If the user explicitly
-    // annotated a non-Result return type, that's a contradiction — the
-    // caller-visible type must admit a failure. Functions without an
-    // explicit return annotation get auto-wrapped during inference instead.
+    // Validated params let a function short-circuit with a failure before
+    // the body runs. An explicit non-Result return type contradicts that.
+    // (Unannotated returns are auto-wrapped during inference instead.)
     const checkValidatedParamReturn = (
       name: string,
       def: FunctionDefinition | GraphNodeDefinition,
@@ -185,21 +182,6 @@ export class TypeChecker {
     }
     for (const [name, def] of Object.entries(this.nodeDefs)) {
       checkValidatedParamReturn(name, def);
-    }
-
-    // 1e. The `!` validation suffix is meaningless on handler params:
-    // handlers don't have a caller-observable return type, so the
-    // "validation failure short-circuits the function" semantics don't apply.
-    // Validate inside the handler body instead.
-    for (const { node } of walkNodes(this.program.nodes)) {
-      if (node.type !== "handleBlock") continue;
-      if (node.handler.kind !== "inline") continue;
-      if (node.handler.param.validated) {
-        this.errors.push({
-          message: "The '!' validation syntax is not allowed on handler parameters. Validate the data inside the handler body if needed.",
-          loc: node.loc,
-        });
-      }
     }
 
     // 2. Infer return types

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -19,6 +19,7 @@ import { buildScopes } from "./scopes.js";
 import { checkScopes } from "./checker.js";
 import { isAssignable as _isAssignable } from "./assignability.js";
 import { inferReturnTypeFor } from "./inference.js";
+import { effectiveReturnType } from "./validation.js";
 
 export type { TypeCheckError, TypeCheckResult } from "./types.js";
 
@@ -157,6 +158,32 @@ export class TypeChecker {
           });
         }
       }
+    }
+
+    // 1d. A function/node with validated parameters can short-circuit and
+    // return a `failure` before the body runs. If the user explicitly
+    // annotated a non-Result return type, that's a contradiction — the
+    // caller-visible type must admit a failure. Functions without an
+    // explicit return annotation get auto-wrapped during inference instead.
+    const checkValidatedParamReturn = (
+      name: string,
+      def: FunctionDefinition | GraphNodeDefinition,
+    ) => {
+      if (!def.parameters.some((p) => p.validated)) return;
+      if (!def.returnType) return;
+      const effective = effectiveReturnType(def);
+      if (effective && effective !== "any" && (effective as VariableType).type !== "resultType") {
+        this.errors.push({
+          message: `Function '${name}' has validated parameters but its return type is not a Result type. Validated parameters can short-circuit with a failure, so the return type must be 'Result<...>'.`,
+          loc: def.loc,
+        });
+      }
+    };
+    for (const [name, def] of Object.entries(this.functionDefs)) {
+      checkValidatedParamReturn(name, def);
+    }
+    for (const [name, def] of Object.entries(this.nodeDefs)) {
+      checkValidatedParamReturn(name, def);
     }
 
     // 2. Infer return types

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -20,6 +20,7 @@ import { checkScopes } from "./checker.js";
 import { isAssignable as _isAssignable } from "./assignability.js";
 import { inferReturnTypeFor } from "./inference.js";
 import { effectiveReturnType } from "./validation.js";
+import { walkNodes } from "../utils/node.js";
 
 export type { TypeCheckError, TypeCheckResult } from "./types.js";
 
@@ -184,6 +185,21 @@ export class TypeChecker {
     }
     for (const [name, def] of Object.entries(this.nodeDefs)) {
       checkValidatedParamReturn(name, def);
+    }
+
+    // 1e. The `!` validation suffix is meaningless on handler params:
+    // handlers don't have a caller-observable return type, so the
+    // "validation failure short-circuits the function" semantics don't apply.
+    // Validate inside the handler body instead.
+    for (const { node } of walkNodes(this.program.nodes)) {
+      if (node.type !== "handleBlock") continue;
+      if (node.handler.kind !== "inline") continue;
+      if (node.handler.param.validated) {
+        this.errors.push({
+          message: "The '!' validation syntax is not allowed on handler parameters. Validate the data inside the handler body if needed.",
+          loc: node.handler.param.loc ?? node.loc,
+        });
+      }
     }
 
     // 2. Infer return types

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -173,7 +173,7 @@ export class TypeChecker {
       if (!def.parameters.some((p) => p.validated)) return;
       if (!def.returnType) return;
       const effective = effectiveReturnType(def);
-      if (effective && effective !== "any" && (effective as VariableType).type !== "resultType") {
+      if (effective && effective.type !== "resultType") {
         this.errors.push({
           message: `Function '${name}' has validated parameters but its return type is not a Result type. Validated parameters can short-circuit with a failure, so the return type must be 'Result<...>'.`,
           loc: def.loc,
@@ -197,7 +197,7 @@ export class TypeChecker {
       if (node.handler.param.validated) {
         this.errors.push({
           message: "The '!' validation syntax is not allowed on handler parameters. Validate the data inside the handler body if needed.",
-          loc: node.handler.param.loc ?? node.loc,
+          loc: node.loc,
         });
       }
     }

--- a/packages/agency-lang/lib/typeChecker/inference.ts
+++ b/packages/agency-lang/lib/typeChecker/inference.ts
@@ -10,7 +10,7 @@ import type { ResultType } from "../types/typeHints.js";
 import { scopeKey } from "../compilationUnit.js";
 import { walkNodes } from "../utils/node.js";
 import { isAssignable, widenType } from "./assignability.js";
-import { applyValidationFlag } from "./validation.js";
+import { resultTypeForValidation } from "./validation.js";
 import { synthType } from "./synthesizer.js";
 import { walkScopeBody } from "./scopes.js";
 import { TypeCheckerContext } from "./types.js";
@@ -47,9 +47,10 @@ export function inferReturnTypeFor(
 
   ctx.inferringReturnType.add(name);
 
-  const defScopeKey = def.type === "function"
-    ? scopeKey(functionScope(def.functionName))
-    : scopeKey(nodeScope(def.nodeName));
+  const defScopeKey =
+    def.type === "function"
+      ? scopeKey(functionScope(def.functionName))
+      : scopeKey(nodeScope(def.nodeName));
 
   return ctx.withScope(defScopeKey, () => {
     const scope = new Scope(defScopeKey);
@@ -108,7 +109,7 @@ export function inferReturnTypeFor(
     // index.ts (section 1d) — this branch only handles unannotated returns.
     const hasValidatedParam = def.parameters.some((p) => p.validated);
     if (hasValidatedParam && inferred !== "any") {
-      inferred = applyValidationFlag(inferred, true);
+      inferred = resultTypeForValidation(inferred, true);
     }
 
     ctx.inferredReturnTypes[name] = widenType(inferred);

--- a/packages/agency-lang/lib/typeChecker/inference.ts
+++ b/packages/agency-lang/lib/typeChecker/inference.ts
@@ -10,6 +10,7 @@ import type { ResultType } from "../types/typeHints.js";
 import { scopeKey } from "../compilationUnit.js";
 import { walkNodes } from "../utils/node.js";
 import { isAssignable, widenType } from "./assignability.js";
+import { applyValidationFlag } from "./validation.js";
 import { synthType } from "./synthesizer.js";
 import { walkScopeBody } from "./scopes.js";
 import { TypeCheckerContext } from "./types.js";
@@ -99,6 +100,15 @@ export function inferReturnTypeFor(
           inferred = allSame ? first : "any";
         }
       }
+    }
+
+    // Validated params can short-circuit the body with a failure, so the
+    // caller-visible inferred type must admit one. Functions whose user
+    // explicitly annotated a non-Result return type are caught earlier in
+    // index.ts (section 1d) — this branch only handles unannotated returns.
+    const hasValidatedParam = def.parameters.some((p) => p.validated);
+    if (hasValidatedParam && inferred !== "any") {
+      inferred = applyValidationFlag(inferred, true);
     }
 
     ctx.inferredReturnTypes[name] = widenType(inferred);

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -208,6 +208,12 @@ export function walkScopeBody(
       case "handleBlock":
         walkScopeBody(node.body, scope, ctx);
         if (node.handler.kind === "inline") {
+          if (node.handler.param.validated) {
+            ctx.errors.push({
+              message: "The '!' validation syntax is not allowed on handler parameters. Validate the data inside the handler body if needed.",
+              loc: node.loc,
+            });
+          }
           scope.declare(node.handler.param.name, node.handler.param.typeHint ?? "any");
           walkScopeBody(node.handler.body, scope, ctx);
         }

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -11,6 +11,7 @@ import { GLOBAL_SCOPE_KEY, scopeKey } from "../compilationUnit.js";
 import { getImportedNames } from "../types/importStatement.js";
 import { isAssignable, widenType } from "./assignability.js";
 import { synthType } from "./synthesizer.js";
+import { applyValidationFlag } from "./validation.js";
 import { validateTypeReferences } from "./validate.js";
 import { ScopeInfo, TypeCheckerContext } from "./types.js";
 import { Scope } from "./scope.js";
@@ -101,7 +102,10 @@ export function declareVariable(
       `assignment to '${node.variableName}'`,
       ctx,
     );
-    scope.declare(node.variableName, newType);
+    // The runtime wraps validated values in Result<T, string>, so the
+    // declared scope type must match — otherwise downstream property accesses
+    // see `T` instead of the actual `Result<T, string>` and silently miscompile.
+    scope.declare(node.variableName, applyValidationFlag(newType, node.validated));
     return;
   }
 

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -11,7 +11,7 @@ import { GLOBAL_SCOPE_KEY, scopeKey } from "../compilationUnit.js";
 import { getImportedNames } from "../types/importStatement.js";
 import { isAssignable, widenType } from "./assignability.js";
 import { synthType } from "./synthesizer.js";
-import { applyValidationFlag } from "./validation.js";
+import { resultTypeForValidation } from "./validation.js";
 import { validateTypeReferences } from "./validate.js";
 import { ScopeInfo, TypeCheckerContext } from "./types.js";
 import { Scope } from "./scope.js";
@@ -93,7 +93,13 @@ export function declareVariable(
       node.loc,
     );
     if (existingType) {
-      reportNotAssignable(ctx, node.variableName, newType, existingType, node.loc);
+      reportNotAssignable(
+        ctx,
+        node.variableName,
+        newType,
+        existingType,
+        node.loc,
+      );
     }
     checkType(
       node.value,
@@ -105,13 +111,22 @@ export function declareVariable(
     // The runtime wraps validated values in Result<T, string>, so the
     // declared scope type must match — otherwise downstream property accesses
     // see `T` instead of the actual `Result<T, string>` and silently miscompile.
-    scope.declare(node.variableName, applyValidationFlag(newType, node.validated));
+    scope.declare(
+      node.variableName,
+      resultTypeForValidation(newType, node.validated),
+    );
     return;
   }
 
   if (existingType) {
     const valueType = synthType(node.value, scope, ctx);
-    reportNotAssignable(ctx, node.variableName, valueType, existingType, node.loc);
+    reportNotAssignable(
+      ctx,
+      node.variableName,
+      valueType,
+      existingType,
+      node.loc,
+    );
     return;
   }
 
@@ -210,11 +225,15 @@ export function walkScopeBody(
         if (node.handler.kind === "inline") {
           if (node.handler.param.validated) {
             ctx.errors.push({
-              message: "The '!' validation syntax is not allowed on handler parameters. Validate the data inside the handler body if needed.",
+              message:
+                "The '!' validation syntax is not allowed on handler parameters. Validate the data inside the handler body if needed.",
               loc: node.loc,
             });
           }
-          scope.declare(node.handler.param.name, node.handler.param.typeHint ?? "any");
+          scope.declare(
+            node.handler.param.name,
+            node.handler.param.typeHint ?? "any",
+          );
           walkScopeBody(node.handler.body, scope, ctx);
         }
         break;

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -1,14 +1,12 @@
-import {
-  AgencyNode,
-  Expression,
-  VariableType,
-  ValueAccess,
-} from "../types.js";
-import type { NamedArgument, SplatExpression } from "../types/dataStructures.js";
+import { AgencyNode, Expression, VariableType, ValueAccess } from "../types.js";
+import type {
+  NamedArgument,
+  SplatExpression,
+} from "../types/dataStructures.js";
 import { formatTypeHint } from "../cli/util.js";
 import { BUILTIN_FUNCTION_TYPES } from "./builtins.js";
 import { isAssignable, resolveType } from "./assignability.js";
-import { applyValidationFlag } from "./validation.js";
+import { resultTypeForValidation } from "./validation.js";
 import { TypeCheckerContext } from "./types.js";
 import { Scope } from "./scope.js";
 
@@ -204,9 +202,11 @@ function synthPipeRhs(
     // Pipes inherit Result wrapping like direct calls — apply the bang at
     // the call-site read so `... |> half` types as `Result<halfReturn>`.
     const fnReturn =
-      (def?.returnType && applyValidationFlag(def.returnType, def.returnTypeValidated)) ??
+      (def?.returnType &&
+        resultTypeForValidation(def.returnType, def.returnTypeValidated)) ??
       ctx.inferredReturnTypes[name] ??
-      (importedSig?.returnType && applyValidationFlag(importedSig.returnType, undefined));
+      (importedSig?.returnType &&
+        resultTypeForValidation(importedSig.returnType, undefined));
     if (fnReturn) return fnReturn;
   }
   return synthType(rhs, scope, ctx);
@@ -221,7 +221,10 @@ function synthFunctionCall(
   // get `Result<T, any>` (success) or `Result<any, T>` (failure). The names
   // are reserved at the typechecker level (see RESERVED_FUNCTION_NAMES in
   // index.ts), so shadowing is impossible — no gating needed here.
-  if (RESULT_CONSTRUCTORS.has(expr.functionName) && expr.arguments.length >= 1) {
+  if (
+    RESULT_CONSTRUCTORS.has(expr.functionName) &&
+    expr.arguments.length >= 1
+  ) {
     const inner = asPositionalArg(expr.arguments[0]);
     if (inner) {
       const innerType = maybeAny(synthType(inner, scope, ctx));
@@ -233,7 +236,8 @@ function synthFunctionCall(
   const fn = ctx.functionDefs[expr.functionName];
   const graphNode = ctx.nodeDefs[expr.functionName];
   const def = fn ?? graphNode;
-  if (def?.returnType) return applyValidationFlag(def.returnType, def.returnTypeValidated);
+  if (def?.returnType)
+    return resultTypeForValidation(def.returnType, def.returnTypeValidated);
   if (expr.functionName in ctx.inferredReturnTypes) {
     return ctx.inferredReturnTypes[expr.functionName];
   }
@@ -299,7 +303,8 @@ function synthObject(
       const splatType = synthType(entry.value, scope, ctx);
       if (splatType === "any") return "any";
       if (splatType.type !== "objectType") return "any";
-      for (const prop of splatType.properties) properties.set(prop.key, prop.value);
+      for (const prop of splatType.properties)
+        properties.set(prop.key, prop.value);
       continue;
     }
     const kv = entry as { key: string; value: AgencyNode };
@@ -326,7 +331,8 @@ export function synthValueAccess(
   for (const element of expr.chain) {
     if (currentType === "any") return "any";
     const resolved = resolveType(currentType, typeAliases);
-    if (resolved.type === "primitiveType" && resolved.value === "any") return "any";
+    if (resolved.type === "primitiveType" && resolved.value === "any")
+      return "any";
 
     switch (element.kind) {
       case "property": {
@@ -365,9 +371,7 @@ export function synthValueAccess(
             return "any";
           }
         } else if (resolved.type === "objectType") {
-          const prop = resolved.properties.find(
-            (p) => p.key === element.name,
-          );
+          const prop = resolved.properties.find((p) => p.key === element.name);
           if (prop) {
             currentType = prop.value;
           } else {
@@ -377,10 +381,7 @@ export function synthValueAccess(
             });
             return "any";
           }
-        } else if (
-          resolved.type === "arrayType" &&
-          element.name === "length"
-        ) {
+        } else if (resolved.type === "arrayType" && element.name === "length") {
           currentType = { type: "primitiveType", value: "number" };
         } else {
           ctx.errors.push({

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -8,7 +8,7 @@ import type { NamedArgument, SplatExpression } from "../types/dataStructures.js"
 import { formatTypeHint } from "../cli/util.js";
 import { BUILTIN_FUNCTION_TYPES } from "./builtins.js";
 import { isAssignable, resolveType } from "./assignability.js";
-import { effectiveReturnType } from "./validation.js";
+import { applyValidationFlag } from "./validation.js";
 import { TypeCheckerContext } from "./types.js";
 import { Scope } from "./scope.js";
 
@@ -201,12 +201,12 @@ function synthPipeRhs(
     const name = rhs.value;
     const def = ctx.functionDefs[name] ?? ctx.nodeDefs[name];
     const importedSig = ctx.importedFunctions[name];
-    // Pull the caller-visible return type (with `!` already applied) so
-    // pipes inherit Result wrapping like direct calls do.
+    // Pipes inherit Result wrapping like direct calls — apply the bang at
+    // the call-site read so `... |> half` types as `Result<halfReturn>`.
     const fnReturn =
-      (def && effectiveReturnType(def)) ??
+      (def?.returnType && applyValidationFlag(def.returnType, def.returnTypeValidated)) ??
       ctx.inferredReturnTypes[name] ??
-      (importedSig && effectiveReturnType(importedSig));
+      (importedSig?.returnType && applyValidationFlag(importedSig.returnType, undefined));
     if (fnReturn) return fnReturn;
   }
   return synthType(rhs, scope, ctx);
@@ -233,7 +233,7 @@ function synthFunctionCall(
   const fn = ctx.functionDefs[expr.functionName];
   const graphNode = ctx.nodeDefs[expr.functionName];
   const def = fn ?? graphNode;
-  if (def?.returnType) return effectiveReturnType(def)!;
+  if (def?.returnType) return applyValidationFlag(def.returnType, def.returnTypeValidated);
   if (expr.functionName in ctx.inferredReturnTypes) {
     return ctx.inferredReturnTypes[expr.functionName];
   }
@@ -242,7 +242,7 @@ function synthFunctionCall(
   }
   if (!def) {
     const imported = ctx.importedFunctions[expr.functionName];
-    if (imported?.returnType) return effectiveReturnType(imported)!;
+    if (imported?.returnType) return imported.returnType;
     if (expr.functionName in BUILTIN_FUNCTION_TYPES) {
       return BUILTIN_FUNCTION_TYPES[expr.functionName].returnType;
     }

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -8,6 +8,7 @@ import type { NamedArgument, SplatExpression } from "../types/dataStructures.js"
 import { formatTypeHint } from "../cli/util.js";
 import { BUILTIN_FUNCTION_TYPES } from "./builtins.js";
 import { isAssignable, resolveType } from "./assignability.js";
+import { effectiveReturnType } from "./validation.js";
 import { TypeCheckerContext } from "./types.js";
 import { Scope } from "./scope.js";
 
@@ -198,11 +199,14 @@ function synthPipeRhs(
 ): VariableType | "any" {
   if (rhs.type === "variableName") {
     const name = rhs.value;
+    const def = ctx.functionDefs[name] ?? ctx.nodeDefs[name];
+    const importedSig = ctx.importedFunctions[name];
+    // Pull the caller-visible return type (with `!` already applied) so
+    // pipes inherit Result wrapping like direct calls do.
     const fnReturn =
-      ctx.functionDefs[name]?.returnType ??
-      ctx.nodeDefs[name]?.returnType ??
+      (def && effectiveReturnType(def)) ??
       ctx.inferredReturnTypes[name] ??
-      ctx.importedFunctions[name]?.returnType;
+      (importedSig && effectiveReturnType(importedSig));
     if (fnReturn) return fnReturn;
   }
   return synthType(rhs, scope, ctx);
@@ -229,7 +233,7 @@ function synthFunctionCall(
   const fn = ctx.functionDefs[expr.functionName];
   const graphNode = ctx.nodeDefs[expr.functionName];
   const def = fn ?? graphNode;
-  if (def?.returnType) return def.returnType;
+  if (def?.returnType) return effectiveReturnType(def)!;
   if (expr.functionName in ctx.inferredReturnTypes) {
     return ctx.inferredReturnTypes[expr.functionName];
   }
@@ -238,7 +242,7 @@ function synthFunctionCall(
   }
   if (!def) {
     const imported = ctx.importedFunctions[expr.functionName];
-    if (imported?.returnType) return imported.returnType;
+    if (imported?.returnType) return effectiveReturnType(imported)!;
     if (expr.functionName in BUILTIN_FUNCTION_TYPES) {
       return BUILTIN_FUNCTION_TYPES[expr.functionName].returnType;
     }

--- a/packages/agency-lang/lib/typeChecker/validation.test.ts
+++ b/packages/agency-lang/lib/typeChecker/validation.test.ts
@@ -3,7 +3,7 @@ import { applyValidationFlag, effectiveReturnType } from "./validation.js";
 import type { VariableType, FunctionDefinition } from "../types.js";
 
 describe("applyValidationFlag", () => {
-  const person: VariableType = { type: "namedType", name: "Person" };
+  const person: VariableType = { type: "typeAliasVariable", aliasName: "Person" };
   const stringT: VariableType = { type: "primitiveType", value: "string" };
 
   it("returns the type unchanged when validated is false/undefined", () => {
@@ -39,7 +39,7 @@ describe("applyValidationFlag", () => {
 });
 
 describe("effectiveReturnType", () => {
-  const person: VariableType = { type: "namedType", name: "Person" };
+  const person: VariableType = { type: "typeAliasVariable", aliasName: "Person" };
   const stringT: VariableType = { type: "primitiveType", value: "string" };
 
   function fn(returnType: VariableType | null | undefined, validated?: boolean): FunctionDefinition {

--- a/packages/agency-lang/lib/typeChecker/validation.test.ts
+++ b/packages/agency-lang/lib/typeChecker/validation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { applyValidationFlag, effectiveReturnType } from "./validation.js";
+import type { VariableType, FunctionDefinition } from "../types.js";
+
+describe("applyValidationFlag", () => {
+  const person: VariableType = { type: "namedType", name: "Person" };
+  const stringT: VariableType = { type: "primitiveType", value: "string" };
+
+  it("returns the type unchanged when validated is false/undefined", () => {
+    expect(applyValidationFlag(person, false)).toEqual(person);
+    expect(applyValidationFlag(person, undefined)).toEqual(person);
+  });
+
+  it("wraps a non-Result type in Result<T, string> when validated", () => {
+    expect(applyValidationFlag(person, true)).toEqual({
+      type: "resultType",
+      successType: person,
+      failureType: stringT,
+    });
+  });
+
+  it("does not rewrap a Result type", () => {
+    const result: VariableType = {
+      type: "resultType",
+      successType: person,
+      failureType: stringT,
+    };
+    expect(applyValidationFlag(result, true)).toEqual(result);
+  });
+
+  it("wraps an array type in Result<T[], string>", () => {
+    const arr: VariableType = { type: "arrayType", elementType: person };
+    expect(applyValidationFlag(arr, true)).toEqual({
+      type: "resultType",
+      successType: arr,
+      failureType: stringT,
+    });
+  });
+});
+
+describe("effectiveReturnType", () => {
+  const person: VariableType = { type: "namedType", name: "Person" };
+  const stringT: VariableType = { type: "primitiveType", value: "string" };
+
+  function fn(returnType: VariableType | null | undefined, validated?: boolean): FunctionDefinition {
+    return {
+      type: "function",
+      functionName: "f",
+      parameters: [],
+      body: [],
+      returnType: returnType,
+      returnTypeValidated: validated,
+    };
+  }
+
+  it("returns undefined / null unchanged", () => {
+    expect(effectiveReturnType(fn(undefined))).toBeUndefined();
+    expect(effectiveReturnType(fn(null))).toBeNull();
+  });
+
+  it("returns the type unchanged when not validated", () => {
+    expect(effectiveReturnType(fn(person))).toEqual(person);
+  });
+
+  it("wraps in Result when returnTypeValidated", () => {
+    expect(effectiveReturnType(fn(person, true))).toEqual({
+      type: "resultType",
+      successType: person,
+      failureType: stringT,
+    });
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/validation.test.ts
+++ b/packages/agency-lang/lib/typeChecker/validation.test.ts
@@ -1,18 +1,21 @@
 import { describe, expect, it } from "vitest";
-import { applyValidationFlag, effectiveReturnType } from "./validation.js";
+import { resultTypeForValidation, effectiveReturnType } from "./validation.js";
 import type { VariableType, FunctionDefinition } from "../types.js";
 
 describe("applyValidationFlag", () => {
-  const person: VariableType = { type: "typeAliasVariable", aliasName: "Person" };
+  const person: VariableType = {
+    type: "typeAliasVariable",
+    aliasName: "Person",
+  };
   const stringT: VariableType = { type: "primitiveType", value: "string" };
 
   it("returns the type unchanged when validated is false/undefined", () => {
-    expect(applyValidationFlag(person, false)).toEqual(person);
-    expect(applyValidationFlag(person, undefined)).toEqual(person);
+    expect(resultTypeForValidation(person, false)).toEqual(person);
+    expect(resultTypeForValidation(person, undefined)).toEqual(person);
   });
 
   it("wraps a non-Result type in Result<T, string> when validated", () => {
-    expect(applyValidationFlag(person, true)).toEqual({
+    expect(resultTypeForValidation(person, true)).toEqual({
       type: "resultType",
       successType: person,
       failureType: stringT,
@@ -25,12 +28,12 @@ describe("applyValidationFlag", () => {
       successType: person,
       failureType: stringT,
     };
-    expect(applyValidationFlag(result, true)).toEqual(result);
+    expect(resultTypeForValidation(result, true)).toEqual(result);
   });
 
   it("wraps an array type in Result<T[], string>", () => {
     const arr: VariableType = { type: "arrayType", elementType: person };
-    expect(applyValidationFlag(arr, true)).toEqual({
+    expect(resultTypeForValidation(arr, true)).toEqual({
       type: "resultType",
       successType: arr,
       failureType: stringT,
@@ -39,10 +42,16 @@ describe("applyValidationFlag", () => {
 });
 
 describe("effectiveReturnType", () => {
-  const person: VariableType = { type: "typeAliasVariable", aliasName: "Person" };
+  const person: VariableType = {
+    type: "typeAliasVariable",
+    aliasName: "Person",
+  };
   const stringT: VariableType = { type: "primitiveType", value: "string" };
 
-  function fn(returnType: VariableType | null | undefined, validated?: boolean): FunctionDefinition {
+  function fn(
+    returnType: VariableType | null | undefined,
+    validated?: boolean,
+  ): FunctionDefinition {
     return {
       type: "function",
       functionName: "f",

--- a/packages/agency-lang/lib/typeChecker/validation.ts
+++ b/packages/agency-lang/lib/typeChecker/validation.ts
@@ -1,0 +1,38 @@
+import type { VariableType, FunctionDefinition, GraphNodeDefinition } from "../types.js";
+import type { ImportedFunctionSignature } from "../compilationUnit.js";
+
+const STRING_T: VariableType = { type: "primitiveType", value: "string" };
+
+/**
+ * Wrap `t` in Result<T, string> when `validated` is true, mirroring the
+ * runtime's __validateType wrapping. Per the no-rewrap rule in
+ * docs-new/guide/schemas.md, an already-Result type passes through.
+ */
+export function applyValidationFlag(
+  t: VariableType,
+  validated: boolean | undefined,
+): VariableType {
+  if (!validated) return t;
+  if (t.type === "resultType") return t;
+  return {
+    type: "resultType",
+    successType: t,
+    failureType: STRING_T,
+  };
+}
+
+/**
+ * The caller-visible return type of a function/node, after applying any `!`
+ * on the declared return type. Does NOT auto-wrap based on validated params —
+ * the auto-wrap for unannotated returns happens during inference.
+ *
+ * Returns undefined for functions with no declared return type and no
+ * inference yet — caller should look up the inferred return type instead.
+ */
+export function effectiveReturnType(
+  def: FunctionDefinition | GraphNodeDefinition | ImportedFunctionSignature,
+): VariableType | null | undefined {
+  if (!def.returnType) return def.returnType;
+  const validated = "returnTypeValidated" in def ? def.returnTypeValidated : undefined;
+  return applyValidationFlag(def.returnType, validated);
+}

--- a/packages/agency-lang/lib/typeChecker/validation.ts
+++ b/packages/agency-lang/lib/typeChecker/validation.ts
@@ -26,8 +26,13 @@ export function applyValidationFlag(
  * on the declared return type. Does NOT auto-wrap based on validated params —
  * the auto-wrap for unannotated returns happens during inference.
  *
- * Returns undefined for functions with no declared return type and no
- * inference yet — caller should look up the inferred return type instead.
+ * Returns the un-set value (`null` for unannotated functions/nodes per the
+ * parser, `undefined` if the field is absent) when there's no declared
+ * return type — caller should look up the inferred return type instead.
+ *
+ * For ImportedFunctionSignature, the bang is already baked into `returnType`
+ * at compilation-unit-build time (see compilationUnit.ts), so passing one
+ * through here is a no-op wrap — the un-bang'd shape isn't reachable.
  */
 export function effectiveReturnType(
   def: FunctionDefinition | GraphNodeDefinition | ImportedFunctionSignature,

--- a/packages/agency-lang/lib/typeChecker/validation.ts
+++ b/packages/agency-lang/lib/typeChecker/validation.ts
@@ -1,14 +1,18 @@
-import type { VariableType, FunctionDefinition, GraphNodeDefinition } from "../types.js";
+import type {
+  VariableType,
+  FunctionDefinition,
+  GraphNodeDefinition,
+} from "../types.js";
 import type { ImportedFunctionSignature } from "../compilationUnit.js";
 
 const STRING_T: VariableType = { type: "primitiveType", value: "string" };
 
 /**
  * Wrap `t` in Result<T, string> when `validated` is true, mirroring the
- * runtime's __validateType wrapping. Per the no-rewrap rule in
- * docs-new/guide/schemas.md, an already-Result type passes through.
+ * runtime's __validateType wrapping. An already-Result type passes through
+ * without re-wrapping.
  */
-export function applyValidationFlag(
+export function resultTypeForValidation(
   t: VariableType,
   validated: boolean | undefined,
 ): VariableType {
@@ -38,6 +42,7 @@ export function effectiveReturnType(
   def: FunctionDefinition | GraphNodeDefinition | ImportedFunctionSignature,
 ): VariableType | null | undefined {
   if (!def.returnType) return def.returnType;
-  const validated = "returnTypeValidated" in def ? def.returnTypeValidated : undefined;
-  return applyValidationFlag(def.returnType, validated);
+  const validated =
+    "returnTypeValidated" in def ? def.returnTypeValidated : undefined;
+  return resultTypeForValidation(def.returnType, validated);
 }


### PR DESCRIPTION
## Summary

Make the typechecker reflect the runtime semantics of the `!` validation suffix on type annotations. Previously, the parser, AST, backend, and runtime all handled `!` (wrapping values in `Result<T, string>` via `__validateType`), but the typechecker silently ignored the `validated` flag — so `const x: Person! = obj; x.name` typechecked at compile time but crashed at runtime.

Spec: `docs/superpowers/specs/2026-05-03-bang-validation-typechecker-design.md`
Plan: `docs/superpowers/plans/2026-05-03-bang-validation-typechecker.md`

Five typechecker sites updated, each backed by a single helper (`applyValidationFlag`):

- **Variable declarations** — `const x: Person!` declares `x: Result<Person, string>`. RHS still checked against the un-bang'd type.
- **Function return types (declared)** — `def foo(): Person!` exposes `Result<Person, string>` to callers; body return statements still checked against `Person`.
- **Function return types (inferred)** — when a function has any validated parameter and no explicit return annotation, the inferred type is auto-wrapped in `Result<inferred, string>` to reflect the failure short-circuit.
- **Function return types (explicit + validated params)** — error if the user annotates a non-Result return type with validated params present (e.g. `def greet(name: string!): number` is rejected; user must write `Result<number>`).
- **Call-site validated params** — accept either the un-bang'd type `T` or any `Result<…>` (failures pass through unvalidated per the schemas docs).
- **Handler params** — `!` is rejected outright with a clear error; handlers don't have caller-observable return types, so the validation-failure semantics don't apply.

The "no rewrap" rule from `docs-new/guide/schemas.md` is honored — `Result<Person>!` stays `Result<Person, …>`.

## Test Plan

- [x] All 2298 tests pass (`pnpm test:run`)
- [x] Clean `make` build
- [x] 13 new tests in `lib/typeChecker.test.ts` (`v2: bang (!) validation` describe block)
- [x] 7 new helper tests in `lib/typeChecker/validation.test.ts`
- [ ] Smoke test: write a small `.agency` file using `Person!` and verify the new errors surface as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
