### PR TITLE
Add review command and args() stdlib function

### DIFF
--- a/packages/agency-lang/lib/agents/review/agent.agency
+++ b/packages/agency-lang/lib/agents/review/agent.agency
@@ -1,4 +1,4 @@
-import { bash } from "std::shell"
+import { exec } from "std::shell"
 import { args } from "std::system"
 systemPrompt = read("./prompts/system.md")
 
@@ -28,7 +28,7 @@ node main() {
   let code = read(filePath)
   print("Reviewing: ${filePath}\n")
   print("Running type checker...")
-  let typeCheckResult = bash("node '${agencyScript}' typecheck '${filePath}'")
+  let typeCheckResult = exec("node", [agencyScript, "typecheck", filePath])
   let typeErrors = ""
   if (typeCheckResult.exitCode != 0) {
     typeErrors = typeCheckResult.stderr + typeCheckResult.stdout

--- a/packages/agency-lang/lib/agents/review/agent.agency
+++ b/packages/agency-lang/lib/agents/review/agent.agency
@@ -1,0 +1,91 @@
+import { bash } from "std::shell"
+import { args } from "std::system"
+systemPrompt = read("./prompts/system.md")
+
+type Severity = "critical" | "warning" | "suggestion"
+
+type Issue = {
+  severity: Severity;
+  line: number | null;
+  message: string;
+  suggestion: string | null
+}
+
+type ReviewResult = {
+  summary: string;
+  issues: Issue[];
+  strengths: string[]
+}
+
+node main() {
+  let cliArgs = args()
+  if (cliArgs.length == 0) {
+    print("Usage: agency review <file.agency>")
+    return end()
+  }
+  let filePath = cliArgs[0]
+  let code = read(filePath)
+  print("Reviewing: ${filePath}\n")
+  // Run the typechecker
+  print("Running type checker...")
+  let typeCheckResult = bash("node dist/scripts/agency.js typecheck ${filePath}")
+  let typeErrors: string | number = ""
+  if (typeCheckResult.exitCode != 0) {
+    typeErrors = typeCheckResult.stderr + typeCheckResult.stdout
+    print("Type checker found issues:\n${typeErrors}\n")
+  } else {
+    print("Type checker passed.\n")
+  }
+  // Have the LLM review the code
+  thread {
+    system(systemPrompt)
+    let typeErrorMessage = "The type checker found no errors."
+    if (typeErrors != "") {
+      typeErrorMessage = "The type checker reported the following errors:\n${typeErrors}"
+    }
+    const reviewPrompt = """
+              Please review the following Agency code.
+
+              File: ${filePath}
+
+              ---CODE START---
+              ${code}
+              ---CODE END---
+
+              ${typeErrorMessage}
+
+              Provide a structured review with a summary, list of issues (with severity, line number if applicable, message, and suggested fix), and a list of strengths.
+            """
+    let review: ReviewResult = llm(reviewPrompt)
+  }
+  // Display the review
+  print("\n--- Review Summary ---")
+  print(review.summary)
+  if (review.strengths.length > 0) {
+    print("\n--- Strengths ---")
+    for (strength in review.strengths) {
+      print("  + ${strength}")
+    }
+  }
+  if (review.issues.length > 0) {
+    print("\n--- Issues ---")
+    for (issue in review.issues) {
+      let prefix = "[${issue.severity}]"
+      let lineInfo = ""
+      if (issue.line != null) {
+        lineInfo = " (line ${issue.line})"
+      }
+      print("  ${prefix}${lineInfo} ${issue.message}")
+      if (issue.suggestion != null) {
+        print("    Fix: ${issue.suggestion}")
+      }
+    }
+  } else {
+    print("\nNo issues found. Code looks good!")
+  }
+  return end()
+}
+
+node end() {
+
+}

--- a/packages/agency-lang/lib/agents/review/agent.agency
+++ b/packages/agency-lang/lib/agents/review/agent.agency
@@ -19,17 +19,17 @@ type ReviewResult = {
 
 node main() {
   let cliArgs = args()
-  if (cliArgs.length == 0) {
+  if (cliArgs.length < 2) {
     print("Usage: agency review <file.agency>")
     return end()
   }
-  let filePath = cliArgs[0]
+  let agencyScript = cliArgs[0]
+  let filePath = cliArgs[1]
   let code = read(filePath)
   print("Reviewing: ${filePath}\n")
-  // Run the typechecker
   print("Running type checker...")
-  let typeCheckResult = bash("node dist/scripts/agency.js typecheck ${filePath}")
-  let typeErrors: string | number = ""
+  let typeCheckResult = bash("node '${agencyScript}' typecheck '${filePath}'")
+  let typeErrors = ""
   if (typeCheckResult.exitCode != 0) {
     typeErrors = typeCheckResult.stderr + typeCheckResult.stdout
     print("Type checker found issues:\n${typeErrors}\n")

--- a/packages/agency-lang/lib/agents/review/prompts/system.md
+++ b/packages/agency-lang/lib/agents/review/prompts/system.md
@@ -1,0 +1,18 @@
+You are an expert code reviewer for the Agency programming language. Agency is a domain-specific language for building AI agent workflows that compiles to TypeScript.
+
+Your job is to review Agency code and provide constructive, actionable feedback. You evaluate code against:
+
+1. **Type safety**: Are types used correctly? Are LLM return types properly annotated?
+2. **Code structure**: Is the code well-organized? Are nodes and functions appropriately scoped?
+3. **Error handling**: Does the code handle failures gracefully? Are `try` and `Result` types used where appropriate?
+4. **LLM usage**: Are LLM calls efficient? Are prompts clear? Is structured output used properly?
+5. **Security**: Are there any potential security issues (e.g., unvalidated user input passed to shell commands)?
+6. **Readability**: Is the code clear and well-documented? Are variable names meaningful?
+7. **Best practices**: Does the code follow Agency idioms and conventions?
+
+When providing feedback:
+- Be specific about what line or section you're referring to
+- Explain WHY something is an issue, not just that it is
+- Suggest concrete fixes when possible
+- Acknowledge what the code does well
+- Prioritize issues by severity (critical > warning > suggestion)

--- a/packages/agency-lang/lib/cli/agent.ts
+++ b/packages/agency-lang/lib/cli/agent.ts
@@ -1,33 +1,6 @@
 import { AgencyConfig } from "@/config.js";
-import { compile } from "./commands.js";
-import { spawn } from "child_process";
-import * as path from "path";
+import { runBundledAgent } from "./runBundledAgent.js";
 
 export function agent(config: AgencyConfig): void {
-  // Resolve the bundled agent directory relative to this file in dist/
-  const currentDir = path.dirname(new URL(import.meta.url).pathname);
-  const agentDir = path.resolve(currentDir, "../agents/agency-agent");
-  const agencyFile = path.join(agentDir, "agent.agency");
-  const runFile = path.join(agentDir, "run.js");
-
-  // Compile the agent's .agency file
-  compile(config, agencyFile);
-
-  // Run the wrapper
-  console.log("---");
-  const nodeProcess = spawn("node", [runFile], {
-    stdio: "inherit",
-    shell: false,
-  });
-
-  nodeProcess.on("error", (error) => {
-    console.error(`Failed to run agent:`, error);
-    process.exit(1);
-  });
-
-  nodeProcess.on("exit", (code) => {
-    if (code !== 0) {
-      process.exit(code || 1);
-    }
-  });
+  runBundledAgent(config, "agency-agent");
 }

--- a/packages/agency-lang/lib/cli/review.ts
+++ b/packages/agency-lang/lib/cli/review.ts
@@ -1,36 +1,7 @@
 import { AgencyConfig } from "@/config.js";
-import { compile } from "./commands.js";
-import { spawn } from "child_process";
+import { runBundledAgent } from "./runBundledAgent.js";
 import * as path from "path";
 
 export function review(config: AgencyConfig, targetFile: string): void {
-  // Resolve the bundled review agent directory relative to this file in dist/
-  const currentDir = path.dirname(new URL(import.meta.url).pathname);
-  const agentDir = path.resolve(currentDir, "../agents/review");
-  const agencyFile = path.join(agentDir, "agent.agency");
-  const runFile = path.join(agentDir, "run.js");
-
-  // Resolve the target file to an absolute path
-  const absoluteTarget = path.resolve(targetFile);
-
-  // Compile the review agent's .agency file
-  compile(config, agencyFile);
-
-  // Run the wrapper, passing the target file as an argument
-  console.log("---");
-  const nodeProcess = spawn("node", [runFile, absoluteTarget], {
-    stdio: "inherit",
-    shell: false,
-  });
-
-  nodeProcess.on("error", (error) => {
-    console.error(`Failed to run review agent:`, error);
-    process.exit(1);
-  });
-
-  nodeProcess.on("exit", (code) => {
-    if (code !== 0) {
-      process.exit(code || 1);
-    }
-  });
+  runBundledAgent(config, "review", [path.resolve(targetFile)]);
 }

--- a/packages/agency-lang/lib/cli/review.ts
+++ b/packages/agency-lang/lib/cli/review.ts
@@ -1,0 +1,36 @@
+import { AgencyConfig } from "@/config.js";
+import { compile } from "./commands.js";
+import { spawn } from "child_process";
+import * as path from "path";
+
+export function review(config: AgencyConfig, targetFile: string): void {
+  // Resolve the bundled review agent directory relative to this file in dist/
+  const currentDir = path.dirname(new URL(import.meta.url).pathname);
+  const agentDir = path.resolve(currentDir, "../agents/review");
+  const agencyFile = path.join(agentDir, "agent.agency");
+  const runFile = path.join(agentDir, "run.js");
+
+  // Resolve the target file to an absolute path
+  const absoluteTarget = path.resolve(targetFile);
+
+  // Compile the review agent's .agency file
+  compile(config, agencyFile);
+
+  // Run the wrapper, passing the target file as an argument
+  console.log("---");
+  const nodeProcess = spawn("node", [runFile, absoluteTarget], {
+    stdio: "inherit",
+    shell: false,
+  });
+
+  nodeProcess.on("error", (error) => {
+    console.error(`Failed to run review agent:`, error);
+    process.exit(1);
+  });
+
+  nodeProcess.on("exit", (code) => {
+    if (code !== 0) {
+      process.exit(code || 1);
+    }
+  });
+}

--- a/packages/agency-lang/lib/cli/review.ts
+++ b/packages/agency-lang/lib/cli/review.ts
@@ -3,5 +3,5 @@ import { runBundledAgent } from "./runBundledAgent.js";
 import * as path from "path";
 
 export function review(config: AgencyConfig, targetFile: string): void {
-  runBundledAgent(config, "review", [path.resolve(targetFile)]);
+  runBundledAgent(config, "review", [process.argv[1], path.resolve(targetFile)]);
 }

--- a/packages/agency-lang/lib/cli/runBundledAgent.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.ts
@@ -1,0 +1,35 @@
+import { AgencyConfig } from "@/config.js";
+import { compile } from "./commands.js";
+import { spawn } from "child_process";
+import * as path from "path";
+
+const currentDir = path.dirname(new URL(import.meta.url).pathname);
+
+export function runBundledAgent(
+  config: AgencyConfig,
+  agentName: string,
+  args: string[] = [],
+): void {
+  const agentDir = path.resolve(currentDir, `../agents/${agentName}`);
+  const agencyFile = path.join(agentDir, "agent.agency");
+  const runFile = path.join(agentDir, "run.js");
+
+  compile(config, agencyFile);
+
+  console.log("---");
+  const nodeProcess = spawn("node", [runFile, ...args], {
+    stdio: "inherit",
+    shell: false,
+  });
+
+  nodeProcess.on("error", (error) => {
+    console.error(`Failed to run ${agentName}:`, error);
+    process.exit(1);
+  });
+
+  nodeProcess.on("exit", (code) => {
+    if (code !== 0) {
+      process.exit(code || 1);
+    }
+  });
+}

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -26,6 +26,7 @@ import { color } from "@/utils/termcolors.js";
 import { TarsecError } from "tarsec";
 import process from "process";
 import { agent } from "@/cli/agent.js";
+import { review } from "@/cli/review.js";
 import { loadEnv } from "@/utils/envfile.js";
 import { debug } from "@/cli/debug.js";
 import { generateDoc } from "@/cli/doc.js";
@@ -538,6 +539,15 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .action(() => {
       const config = getConfig();
       agent(config);
+    });
+
+  program
+    .command("review")
+    .description("Review an Agency file for type errors and code quality")
+    .argument("<file>", "The .agency file to review")
+    .action((file: string) => {
+      const config = getConfig();
+      review(config, file);
     });
 
   const lspCmd = program

--- a/packages/agency-lang/stdlib/lib/shell.ts
+++ b/packages/agency-lang/stdlib/lib/shell.ts
@@ -16,6 +16,36 @@ import {
   str,
 } from "tarsec";
 
+export function _exec(
+  command: string,
+  args: string[],
+  cwd: string,
+  timeout: number,
+  stdin: string,
+): { stdout: string; stderr: string; exitCode: number } {
+  const options: SpawnSyncOptions = {
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+  };
+
+  if (cwd) {
+    options.cwd = cwd;
+  }
+  if (timeout > 0) {
+    options.timeout = timeout * 1000;
+  }
+  if (stdin) {
+    options.input = stdin;
+  }
+
+  const result = spawnSync(command, args, options);
+  return {
+    stdout: (result.stdout as string) ?? "",
+    stderr: (result.stderr as string) ?? "",
+    exitCode: result.status ?? 1,
+  };
+}
+
 export function _bash(
   command: string,
   cwd: string,

--- a/packages/agency-lang/stdlib/lib/system.ts
+++ b/packages/agency-lang/stdlib/lib/system.ts
@@ -6,6 +6,10 @@ import { promisify } from "util";
 
 const execFileAsync = promisify(execFile);
 
+export function _args(): string[] {
+  return process.argv.slice(2);
+}
+
 export function _cwd(): string {
   return process.cwd();
 }

--- a/packages/agency-lang/stdlib/shell.agency
+++ b/packages/agency-lang/stdlib/shell.agency
@@ -1,14 +1,29 @@
-import { _bash, _ls, _grep, _glob, _stat, _exists, _which } from "./lib/shell.js"
+import { _exec, _bash, _ls, _grep, _glob, _stat, _exists, _which } from "./lib/shell.js"
 
-type BashResult = {
+type ExecResult = {
   stdout: string;
   stderr: string;
   exitCode: number
 }
 
-export def bash(command: string, cwd: string = "", timeout: number = 0, stdin: string = ""): BashResult {
+export def exec(command: string, args: string[] = [], cwd: string = "", timeout: number = 0, stdin: string = ""): ExecResult {
   """
-  Run a shell command and return its stdout, stderr, and exit code. Pass cwd to change the working directory, timeout (seconds) to enforce a time limit, and stdin to feed input to the command.
+  Run an executable directly with an array of arguments, bypassing the shell. This is safer than bash() because arguments are passed directly to the process without shell interpretation, preventing command injection. Use this when you have a known command and structured arguments. Pass cwd to change the working directory, timeout (seconds) to enforce a time limit, and stdin to feed input to the command.
+  """
+  return interrupt std::exec("Are you sure you want to run this command?", {
+    command: command,
+    args: args,
+    cwd: cwd,
+    timeout: timeout,
+    stdin: stdin
+  })
+
+  return _exec(command, args, cwd, timeout, stdin)
+}
+
+export def bash(command: string, cwd: string = "", timeout: number = 0, stdin: string = ""): ExecResult {
+  """
+  Run a shell command string via sh -c and return its stdout, stderr, and exit code. The command is interpreted by the shell, so pipes, redirects, globbing, and other shell features work. However, this means interpolated values are subject to shell interpretation -- use exec() instead when passing untrusted or dynamic arguments. Pass cwd to change the working directory, timeout (seconds) to enforce a time limit, and stdin to feed input to the command.
   """
   return interrupt std::bash("Are you sure you want to run this shell command?", {
     command: command,

--- a/packages/agency-lang/stdlib/system.agency
+++ b/packages/agency-lang/stdlib/system.agency
@@ -1,10 +1,17 @@
-import { _screenshot, _cwd, _env, _setEnv, _openUrl } from "./lib/system.js"
+import { _args, _screenshot, _cwd, _env, _setEnv, _openUrl } from "./lib/system.js"
 
 export def screenshot(filepath: string, x: number = -1, y: number = -1, width: number = -1, height: number = -1) {
   """
   A tool for taking a screenshot and saving it to a file. Optionally specify x, y, width, and height to capture a specific region.
   """
   _screenshot(filepath, x, y, width, height)
+}
+
+export safe def args(): string[] {
+  """
+  Return the command-line arguments passed to the Agency program (excluding the node executable and script path).
+  """
+  return _args()
 }
 
 export safe def cwd(): string {


### PR DESCRIPTION
## Summary

- Adds `agency review <file>` CLI command that launches a review agent to analyze Agency code for type errors and code quality
- Adds `args()` function to `std::system` stdlib, giving Agency programs access to command-line arguments
- The review agent runs the typechecker via shell, then uses an LLM to provide structured feedback (severity, line numbers, suggestions, strengths)

## Test plan

- [ ] `pnpm run build` succeeds
- [ ] `node dist/scripts/agency.js --help` shows the `review` command
- [ ] `node dist/scripts/agency.js review <some-file.agency>` compiles and runs the review agent
- [ ] `import { args } from "std::system"` works in Agency programs

🤖 Generated with [Claude Code](https://claude.com/claude-code)