### PR TITLE
typecheck llm() options, optional properties, excess properties

### DIFF
--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -5587,6 +5587,142 @@ describe("TypeChecker", () => {
       expect(errors.some((e) => /regex.*cannot appear in an llm/i.test(e.message))).toBe(true);
     });
 
+    it("allows omitting an optional object property when calling a function", () => {
+      // type Opts = { model?: string, temperature?: number }
+      // def use(o: Opts) {}; use({ model: "gpt-4" })
+      const undef: VariableType = { type: "primitiveType", value: "undefined" };
+      const opts: VariableType = {
+        type: "objectType",
+        properties: [
+          { key: "model", value: { type: "unionType", types: [str, undef] } },
+          { key: "temperature", value: { type: "unionType", types: [num, undef] } },
+        ],
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "use",
+            parameters: [{ type: "functionParameter", name: "o", typeHint: opts }],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "use",
+            arguments: [
+              {
+                type: "agencyObject",
+                entries: [
+                  { key: "model", value: { type: "string", segments: [{ type: "text", value: "gpt-4" }] } },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toEqual([]);
+    });
+
+    it("still rejects omitting a required object property", () => {
+      // type Opts = { model: string, temperature?: number }; use({}) — model required.
+      const undef: VariableType = { type: "primitiveType", value: "undefined" };
+      const opts: VariableType = {
+        type: "objectType",
+        properties: [
+          { key: "model", value: str },
+          { key: "temperature", value: { type: "unionType", types: [num, undef] } },
+        ],
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "use",
+            parameters: [{ type: "functionParameter", name: "o", typeHint: opts }],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "use",
+            arguments: [{ type: "agencyObject", entries: [] }],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /not assignable/i.test(e.message))).toBe(true);
+    });
+
+    it("accepts llm() with a known option of the right type", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "functionCall",
+            functionName: "llm",
+            arguments: [
+              { type: "string", segments: [{ type: "text", value: "hi" }] },
+              {
+                type: "agencyObject",
+                entries: [
+                  { key: "model", value: { type: "string", segments: [{ type: "text", value: "gpt-4" }] } },
+                  { key: "temperature", value: { type: "number", value: "0.5" } },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toEqual([]);
+    });
+
+    it("rejects an unknown option in llm()", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "functionCall",
+            functionName: "llm",
+            arguments: [
+              { type: "string", segments: [{ type: "text", value: "hi" }] },
+              {
+                type: "agencyObject",
+                entries: [
+                  { key: "modle", value: { type: "string", segments: [{ type: "text", value: "gpt-4" }] } },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /unknown property 'modle'/i.test(e.message))).toBe(true);
+    });
+
+    it("rejects an option with the wrong type in llm()", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "functionCall",
+            functionName: "llm",
+            arguments: [
+              { type: "string", segments: [{ type: "text", value: "hi" }] },
+              {
+                type: "agencyObject",
+                entries: [
+                  { key: "temperature", value: { type: "string", segments: [{ type: "text", value: "hot" }] } },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /not assignable/i.test(e.message))).toBe(true);
+    });
+
     it("checks the RHS of a validated assignment against the un-bang'd type", () => {
       // const x: number! = "not a number" — RHS is checked against `number`.
       const program: AgencyProgram = {

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -50,6 +50,23 @@ export function widenType(vt: VariableType | "any"): VariableType | "any" {
   }
 }
 
+/**
+ * A type that includes `undefined` — i.e. the desugared form of an optional
+ * property (`key?: T` parses as `key: T | undefined`). Used to decide whether
+ * a target object property may be absent from the source.
+ */
+function isOptionalType(
+  vt: VariableType,
+  typeAliases: Record<string, VariableType>,
+): boolean {
+  const resolved = resolveType(vt, typeAliases);
+  if (resolved.type === "primitiveType" && resolved.value === "undefined")
+    return true;
+  if (resolved.type === "unionType")
+    return resolved.types.some((t) => isOptionalType(t, typeAliases));
+  return false;
+}
+
 export function isAssignable(
   source: VariableType | "any",
   target: VariableType | "any",
@@ -175,12 +192,17 @@ export function isAssignable(
     resolvedSource.type === "objectType" &&
     resolvedTarget.type === "objectType"
   ) {
-    // Structural: source must have all properties of target with compatible types
+    // Structural: source must have all properties of target with compatible
+    // types. A target property whose type permits `undefined` (the desugaring
+    // of `key?:`) may be omitted from the source.
     for (const targetProp of resolvedTarget.properties) {
       const sourceProp = resolvedSource.properties.find(
         (p) => p.key === targetProp.key,
       );
-      if (!sourceProp) return false;
+      if (!sourceProp) {
+        if (isOptionalType(targetProp.value, typeAliases)) continue;
+        return false;
+      }
       if (!isAssignable(sourceProp.value, targetProp.value, typeAliases))
         return false;
     }

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -51,17 +51,17 @@ export function widenType(vt: VariableType | "any"): VariableType | "any" {
 }
 
 /**
- * A type that includes `undefined` — i.e. the desugared form of an optional
- * property (`key?: T` parses as `key: T | undefined`). Used to decide whether
- * a target object property may be absent from the source.
+ * A type that admits `undefined` as a value, so the corresponding object
+ * property may be absent from the source. Covers the `key?: T` desugaring
+ * (parsed as `T | undefined`) plus `any`, which subsumes undefined.
  */
 function isOptionalType(
   vt: VariableType,
   typeAliases: Record<string, VariableType>,
 ): boolean {
   const resolved = resolveType(vt, typeAliases);
-  if (resolved.type === "primitiveType" && resolved.value === "undefined")
-    return true;
+  if (resolved.type === "primitiveType")
+    return resolved.value === "undefined" || resolved.value === "any";
   if (resolved.type === "unionType")
     return resolved.types.some((t) => isOptionalType(t, typeAliases));
   return false;

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -54,7 +54,8 @@ const llmOptions: VariableType = {
       }),
     },
     { key: "tools", value: optional(anyArray) },
-    { key: "metadata", value: optional({ type: "primitiveType", value: "any" }) },
+    // `any` already accepts undefined, so no need to wrap in optional.
+    { key: "metadata", value: { type: "primitiveType", value: "any" } },
   ],
 };
 

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -1,14 +1,62 @@
+import { VariableType } from "../types.js";
 import { BuiltinSignature } from "./types.js";
 
 const string = { type: "primitiveType", value: "string" } as const;
 const number = { type: "primitiveType", value: "number" } as const;
 const boolean = { type: "primitiveType", value: "boolean" } as const;
 const voidT = { type: "primitiveType", value: "void" } as const;
+const undef = { type: "primitiveType", value: "undefined" } as const;
 const stringArray = { type: "arrayType", elementType: string } as const;
 const anyArray = {
   type: "arrayType",
   elementType: { type: "primitiveType", value: "any" },
 } as const;
+
+const optional = (t: VariableType): VariableType => ({
+  type: "unionType",
+  types: [t, undef],
+});
+
+/**
+ * Options accepted by `llm()`'s second argument. Mirrors the user-facing
+ * fields of smoltalk's PromptConfig (lib/runtime/llmClient.ts) — the runtime
+ * forwards everything to smoltalk. `metadata` accepts arbitrary shape, so
+ * we type it as optional `any` and skip structural checking.
+ */
+const llmOptions: VariableType = {
+  type: "objectType",
+  properties: [
+    { key: "model", value: optional(string) },
+    { key: "provider", value: optional(string) },
+    { key: "apiKey", value: optional(string) },
+    { key: "maxTokens", value: optional(number) },
+    { key: "temperature", value: optional(number) },
+    { key: "stream", value: optional(boolean) },
+    {
+      key: "reasoningEffort",
+      value: optional({
+        type: "unionType",
+        types: [
+          { type: "stringLiteralType", value: "low" },
+          { type: "stringLiteralType", value: "medium" },
+          { type: "stringLiteralType", value: "high" },
+        ],
+      }),
+    },
+    {
+      key: "thinking",
+      value: optional({
+        type: "objectType",
+        properties: [
+          { key: "enabled", value: boolean },
+          { key: "budgetTokens", value: optional(number) },
+        ],
+      }),
+    },
+    { key: "tools", value: optional(anyArray) },
+    { key: "metadata", value: optional({ type: "primitiveType", value: "any" }) },
+  ],
+};
 
 /**
  * Signatures for builtin / auto-imported functions that the typechecker
@@ -33,7 +81,7 @@ export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
   notify: { params: [string, string], returnType: boolean },
   sleep: { params: [number], returnType: voidT },
   round: { params: [number, number], returnType: number },
-  llm: { params: ["any", "any"], minParams: 1, returnType: string },
+  llm: { params: ["any", llmOptions], minParams: 1, returnType: string },
   emit: { params: [], restParam: "any", returnType: voidT },
 
   // --- Object / array helpers (auto-imported from stdlib/index.agency) ---

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -341,11 +341,10 @@ function checkExcessObjectProperties(
   if (resolved.type !== "objectType") return;
   const known = new Set(resolved.properties.map((p) => p.key));
   for (const entry of literal.entries) {
-    if ("type" in entry && entry.type === "splat") continue;
-    const kv = entry as { key: string };
-    if (!known.has(kv.key)) {
+    if ("type" in entry) continue; // splat
+    if (!known.has(entry.key)) {
       ctx.errors.push({
-        message: `Unknown property '${kv.key}' on type '${formatTypeHint(paramType)}' in call to '${call.functionName}'.`,
+        message: `Unknown property '${entry.key}' on type '${formatTypeHint(paramType)}' in call to '${call.functionName}'.`,
         loc: call.loc,
       });
     }

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -345,7 +345,7 @@ function checkExcessObjectProperties(
     if (!known.has(entry.key)) {
       ctx.errors.push({
         message: `Unknown property '${entry.key}' on type '${formatTypeHint(paramType)}' in call to '${call.functionName}'.`,
-        loc: call.loc,
+        loc: literal.loc ?? call.loc,
       });
     }
   }

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -12,6 +12,7 @@ import { synthType } from "./synthesizer.js";
 import { ScopeInfo } from "./types.js";
 import type { TypeCheckerContext } from "./types.js";
 import { checkType, isAnyType, getParamsForNodeOrFunc } from "./utils.js";
+import { resolveType } from "./assignability.js";
 import { Scope } from "./scope.js";
 
 /**
@@ -309,6 +310,42 @@ function checkArgsAgainstParams(
         message: `Argument type '${formatTypeHint(argType)}' is not assignable to parameter type '${formatTypeHint(paramType)}' in call to '${call.functionName}'.`,
         expectedType: formatTypeHint(paramType),
         actualType: formatTypeHint(argType),
+        loc: call.loc,
+      });
+      continue;
+    }
+    // Excess-property check for object literals: a typo'd or unknown key
+    // would otherwise pass since assignability is purely structural in the
+    // target → source direction.
+    if (innerArg.type === "agencyObject") {
+      checkExcessObjectProperties(innerArg, paramType, call, ctx);
+    }
+  }
+}
+
+/**
+ * When an object literal is assigned to an object-typed slot, every key in
+ * the literal must correspond to a property declared on the target. Mirrors
+ * TypeScript's excess-property check; without it, typos like `modle:` slip
+ * through structural assignability.
+ *
+ * Only literal keys are checked — splats are dynamic and skipped.
+ */
+function checkExcessObjectProperties(
+  literal: AgencyNode & { type: "agencyObject" },
+  paramType: VariableType,
+  call: FunctionCall,
+  ctx: TypeCheckerContext,
+): void {
+  const resolved = resolveType(paramType, ctx.getTypeAliases());
+  if (resolved.type !== "objectType") return;
+  const known = new Set(resolved.properties.map((p) => p.key));
+  for (const entry of literal.entries) {
+    if ("type" in entry && entry.type === "splat") continue;
+    const kv = entry as { key: string };
+    if (!known.has(kv.key)) {
+      ctx.errors.push({
+        message: `Unknown property '${kv.key}' on type '${formatTypeHint(paramType)}' in call to '${call.functionName}'.`,
         loc: call.loc,
       });
     }


### PR DESCRIPTION
## Summary

Three related typechecker improvements that together let `llm()`'s second argument be properly type-checked without any llm-specific code in the checker.

- **Optional properties in assignability** — the parser already desugars `key?: T` into `key: T | undefined`, but `isAssignable` still required every target key to be present on the source. Now a target property whose type permits `undefined` may be omitted. Fixes the latent bug where `?:` syntax existed but wasn't actually honored.
- **Excess-property check for object literals** — when an object literal is passed to an object-typed slot, every key must correspond to a declared property. Catches typos (`modle:` instead of `model:`) that previously slipped through purely-structural assignability. Mirrors TypeScript's excess-property check.
- **`llm()` options typed generically** — the second arg of `llm` is now an `LlmOptions` object type with all-optional fields (`model`, `provider`, `apiKey`, `maxTokens`, `temperature`, `stream`, `reasoningEffort`, `thinking`, `tools`, `metadata`). The existing arg-checker handles validation; no special-case `checkLlmOptions` function.

## Test plan

- [x] `pnpm test:run` — 2329 passing
- [x] New tests in `lib/typeChecker.test.ts`: optional-property allow/reject pair, llm() valid options, llm() unknown option, llm() wrong-type option

🤖 Generated with [Claude Code](https://claude.com/claude-code)
