### PR TITLE
more typechecker tests for recent additions

### DIFF
--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -5965,11 +5965,11 @@ describe("TypeChecker", () => {
     });
 
     // Known typechecker gap: a pipe RHS with no `?` placeholder is currently
-    // delegated to the backend (see pipeRhsSlotType in checker.ts:468 — "No
-    // placeholder = backend will reject"). The typechecker emits no error
-    // even when the resulting arity is bogus (here: LHS + 2 explicit args
-    // for a 2-param fn). Pinned as `.skip` so we have a target to flip when
-    // the typechecker grows pipe arity-checking.
+    // delegated to the backend (`pipeRhsSlotType` early-returns when no
+    // placeholder is found — "backend will reject"). The typechecker emits
+    // no error even when the resulting arity is bogus (here: LHS + 2 explicit
+    // args for a 2-param fn). Pinned as `.skip` so we have a target to flip
+    // when the typechecker grows pipe arity-checking.
     it.skip("pipe RHS arity mismatch errors when no placeholder is given", () => {
       // 5 |> add(10, 20)  ← LHS + 2 explicit args ≠ 2 params.
       const program: AgencyProgram = {
@@ -6062,9 +6062,11 @@ describe("TypeChecker", () => {
     });
 
     it("variable as llm() second argument typechecks without excess-property errors", () => {
-      // const cfg = { model: "gpt-4" }; llm("...", cfg)
-      // The excess-property check only fires on object literals — passing a
-      // variable should pass through assignability (structural) cleanly.
+      // const cfg = { model: "gpt-4", modle: "x" }; llm("...", cfg)
+      // The excess-property check only fires on object literals at the call
+      // site — assigning the typo'd object to a variable first launders it
+      // past the check, exactly as TypeScript behaves. Confirms that passing
+      // a *variable* with an extra key produces no excess-property error.
       const program: AgencyProgram = {
         type: "agencyProgram",
         nodes: [
@@ -6075,6 +6077,7 @@ describe("TypeChecker", () => {
               type: "agencyObject",
               entries: [
                 { key: "model", value: { type: "string", segments: [{ type: "text", value: "gpt-4" }] } },
+                { key: "modle", value: { type: "string", segments: [{ type: "text", value: "x" }] } },
               ],
             },
           },
@@ -6088,7 +6091,8 @@ describe("TypeChecker", () => {
           },
         ],
       };
-      expect(typeCheck(program).errors).toEqual([]);
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /unknown property/i.test(e.message))).toBe(false);
     });
   });
 });

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -5798,5 +5798,298 @@ describe("TypeChecker", () => {
       const errors = typeCheck(program).errors;
       expect(errors.some((e) => /not assignable/i.test(e.message))).toBe(true);
     });
+
+    it("rejects a wrong-typed value inside a nested llm() option", () => {
+      // llm("...", { thinking: { enabled: "yes" } })  ← enabled must be boolean
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "functionCall",
+            functionName: "llm",
+            arguments: [
+              { type: "string", segments: [{ type: "text", value: "hi" }] },
+              {
+                type: "agencyObject",
+                entries: [
+                  {
+                    key: "thinking",
+                    value: {
+                      type: "agencyObject",
+                      entries: [
+                        { key: "enabled", value: { type: "string", segments: [{ type: "text", value: "yes" }] } },
+                      ],
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /not assignable/i.test(e.message))).toBe(true);
+    });
+
+    it("rejects an invalid string literal in llm()'s reasoningEffort", () => {
+      // llm("...", { reasoningEffort: "ultra" })  ← only "low" | "medium" | "high"
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "functionCall",
+            functionName: "llm",
+            arguments: [
+              { type: "string", segments: [{ type: "text", value: "hi" }] },
+              {
+                type: "agencyObject",
+                entries: [
+                  { key: "reasoningEffort", value: { type: "string", segments: [{ type: "text", value: "ultra" }] } },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /not assignable/i.test(e.message))).toBe(true);
+    });
+
+    it("still type-checks the value of an optional property when present", () => {
+      // type Opts = { model?: string }; use({ model: 123 })  ← number, not string
+      const undef: VariableType = { type: "primitiveType", value: "undefined" };
+      const opts: VariableType = {
+        type: "objectType",
+        properties: [
+          { key: "model", value: { type: "unionType", types: [str, undef] } },
+        ],
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "use",
+            parameters: [{ type: "functionParameter", name: "o", typeHint: opts }],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "use",
+            arguments: [
+              {
+                type: "agencyObject",
+                entries: [{ key: "model", value: { type: "number", value: "123" } }],
+              },
+            ],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /not assignable/i.test(e.message))).toBe(true);
+    });
+
+    it("resolves type aliases when checking optional-property omission", () => {
+      // type Opts = { a?: string }; def use(o: Opts) {}; use({})  ← target is alias, not inline
+      const undef: VariableType = { type: "primitiveType", value: "undefined" };
+      const optsAlias: VariableType = { type: "typeAliasVariable", aliasName: "Opts" };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "typeAlias",
+            aliasName: "Opts",
+            aliasedType: {
+              type: "objectType",
+              properties: [
+                { key: "a", value: { type: "unionType", types: [str, undef] } },
+              ],
+            },
+          },
+          {
+            type: "function",
+            functionName: "use",
+            parameters: [{ type: "functionParameter", name: "o", typeHint: optsAlias }],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "use",
+            arguments: [{ type: "agencyObject", entries: [] }],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toEqual([]);
+    });
+
+    it("excess-property check still catches typos when a splat is mixed in", () => {
+      // type Opts = { model: string }; const base: Opts = ...; use({ ...base, modle: "x" })
+      const opts: VariableType = {
+        type: "objectType",
+        properties: [{ key: "model", value: str }],
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "assignment",
+            variableName: "base",
+            typeHint: opts,
+            value: {
+              type: "agencyObject",
+              entries: [{ key: "model", value: { type: "string", segments: [{ type: "text", value: "gpt-4" }] } }],
+            },
+          },
+          {
+            type: "function",
+            functionName: "use",
+            parameters: [{ type: "functionParameter", name: "o", typeHint: opts }],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "use",
+            arguments: [
+              {
+                type: "agencyObject",
+                entries: [
+                  { type: "splat", value: { type: "variableName", value: "base" } },
+                  { key: "modle", value: { type: "string", segments: [{ type: "text", value: "x" }] } },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /unknown property 'modle'/i.test(e.message))).toBe(true);
+    });
+
+    // Known typechecker gap: a pipe RHS with no `?` placeholder is currently
+    // delegated to the backend (see pipeRhsSlotType in checker.ts:468 — "No
+    // placeholder = backend will reject"). The typechecker emits no error
+    // even when the resulting arity is bogus (here: LHS + 2 explicit args
+    // for a 2-param fn). Pinned as `.skip` so we have a target to flip when
+    // the typechecker grows pipe arity-checking.
+    it.skip("pipe RHS arity mismatch errors when no placeholder is given", () => {
+      // 5 |> add(10, 20)  ← LHS + 2 explicit args ≠ 2 params.
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "add",
+            parameters: [
+              { type: "functionParameter", name: "a", typeHint: num },
+              { type: "functionParameter", name: "b", typeHint: num },
+            ],
+            returnType: num,
+            body: [{ type: "returnStatement", value: { type: "number", value: "0" } }],
+          },
+          {
+            type: "binOpExpression",
+            operator: "|>",
+            left: { type: "number", value: "5" },
+            right: {
+              type: "functionCall",
+              functionName: "add",
+              arguments: [{ type: "number", value: "10" }, { type: "number", value: "20" }],
+            },
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it("named-arg call may omit a default-valued param", () => {
+      // def f(a: string, b: string = "x") {}; f(a: "y")  ← b has a default, omittable
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "f",
+            parameters: [
+              { type: "functionParameter", name: "a", typeHint: str },
+              {
+                type: "functionParameter",
+                name: "b",
+                typeHint: str,
+                defaultValue: { type: "string", segments: [{ type: "text", value: "x" }] },
+              },
+            ],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "f",
+            arguments: [
+              { type: "namedArgument", name: "a", value: { type: "string", segments: [{ type: "text", value: "y" }] } },
+            ],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toEqual([]);
+    });
+
+    it("named arg targeting a block-typed param is rejected as unknown", () => {
+      // def f(cb: () => void) {}; f(cb: ...)  ← block-typed params can't be named
+      const blockT: VariableType = {
+        type: "blockType",
+        params: [],
+        returnType: { type: "primitiveType", value: "void" },
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "f",
+            parameters: [{ type: "functionParameter", name: "cb", typeHint: blockT }],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "f",
+            arguments: [
+              { type: "namedArgument", name: "cb", value: { type: "string", segments: [{ type: "text", value: "x" }] } },
+            ],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /Unknown named argument 'cb'/.test(e.message))).toBe(true);
+    });
+
+    it("variable as llm() second argument typechecks without excess-property errors", () => {
+      // const cfg = { model: "gpt-4" }; llm("...", cfg)
+      // The excess-property check only fires on object literals — passing a
+      // variable should pass through assignability (structural) cleanly.
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "assignment",
+            variableName: "cfg",
+            value: {
+              type: "agencyObject",
+              entries: [
+                { key: "model", value: { type: "string", segments: [{ type: "text", value: "gpt-4" }] } },
+              ],
+            },
+          },
+          {
+            type: "functionCall",
+            functionName: "llm",
+            arguments: [
+              { type: "string", segments: [{ type: "text", value: "hi" }] },
+              { type: "variableName", value: "cfg" },
+            ],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toEqual([]);
+    });
   });
 });

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -4556,6 +4556,7 @@ describe("TypeChecker", () => {
   describe("v2: bang (!) validation", () => {
     const num: VariableType = { type: "primitiveType", value: "number" };
     const str: VariableType = { type: "primitiveType", value: "string" };
+    const undef: VariableType = { type: "primitiveType", value: "undefined" };
     const person: VariableType = {
       type: "objectType",
       properties: [{ key: "name", value: str }],
@@ -5857,7 +5858,6 @@ describe("TypeChecker", () => {
 
     it("still type-checks the value of an optional property when present", () => {
       // type Opts = { model?: string }; use({ model: 123 })  ← number, not string
-      const undef: VariableType = { type: "primitiveType", value: "undefined" };
       const opts: VariableType = {
         type: "objectType",
         properties: [
@@ -5891,7 +5891,6 @@ describe("TypeChecker", () => {
 
     it("resolves type aliases when checking optional-property omission", () => {
       // type Opts = { a?: string }; def use(o: Opts) {}; use({})  ← target is alias, not inline
-      const undef: VariableType = { type: "primitiveType", value: "undefined" };
       const optsAlias: VariableType = { type: "typeAliasVariable", aliasName: "Opts" };
       const program: AgencyProgram = {
         type: "agencyProgram",


### PR DESCRIPTION
## Summary

Backfills test coverage across recent typechecker additions (pipe slot validation, named-args, regex types, optional properties, excess-property checks, llm() options).

New passing tests:
- Nested llm() option validation — `{ thinking: { enabled: "yes" } }` errors
- Invalid string-literal in `reasoningEffort` union (e.g. `"ultra"`) errors
- Optional property's value type is still checked when the key is present
- Type-alias resolution path through optional-property omission
- Excess-property check still catches typos when a splat is mixed in
- Named arg may omit a default-valued param
- Named arg targeting a block-typed param is rejected as unknown
- Variable (not object literal) passed as llm()'s 2nd arg typechecks cleanly

One `.skip` documents an existing typechecker gap: a pipe RHS with no `?` placeholder isn't arity-checked at typecheck time — `pipeRhsSlotType` in `checker.ts` deliberately defers to the backend. Pinned with a comment so we have a target to flip when this gets addressed.

## Test plan
- [x] `pnpm test:run` — 2339 passing, 1 skipped (intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
