### PR TITLE
more typechecker fixes: pipe arity, block types, suppression directives, cross-file aliases

### DIFF
--- a/packages/agency-lang/docs-new/guide/llm.md
+++ b/packages/agency-lang/docs-new/guide/llm.md
@@ -51,7 +51,24 @@ const result = await main("some-param", { callbacks })
 
 ## Other options to llm()
 
-Agency uses the [Smoltalk library](https://github.com/egonSchiele/smoltalk) behind the scenes so any options you can pass into Smoltalk ([SmolConfig](https://github.com/egonSchiele/smoltalk#client-options-smolconfig) or [PromptConfig](https://github.com/egonSchiele/smoltalk#request-options-promptconfig)) you can pass in as part of the config object, which is the optional second parameter to the `llm` call.
+Agency uses the [Smoltalk library](https://github.com/egonSchiele/smoltalk) behind the scenes, and the optional second argument to `llm()` forwards through to it. The typechecker recognizes these options:
+
+| Option | Type |
+|---|---|
+| `model` | `string` |
+| `provider` | `string` |
+| `apiKey` | `string` |
+| `maxTokens` | `number` |
+| `temperature` | `number` |
+| `stream` | `boolean` |
+| `reasoningEffort` | `"low" \| "medium" \| "high"` |
+| `thinking` | `{ enabled: boolean, budgetTokens?: number }` |
+| `tools` | `any[]` |
+| `metadata` | `any` |
+
+All optional.
+
+For the full list of fields Smoltalk accepts, see the [SmolConfig](https://github.com/egonSchiele/smoltalk#client-options-smolconfig) and [PromptConfig](https://github.com/egonSchiele/smoltalk#request-options-promptconfig) docs.
 
 ## Interrupts
 Any [interrupts](./interrupts) thrown in tools will just work with no extra work required.

--- a/packages/agency-lang/docs-new/guide/types.md
+++ b/packages/agency-lang/docs-new/guide/types.md
@@ -19,6 +19,7 @@ Primitive types:
 - `null`
 - `undefined` (treated as null)
 - `object` (equivalent to `Record<string, any>`)
+- `regex` (matches a `RegExp` literal — note that LLMs can't return regex values through structured output, so `regex` cannot appear in an `llm()` return type)
 
 Union types. Example:
 
@@ -56,6 +57,67 @@ type User = {
 }
 ```
 
+## Optional properties
 
+Suffix a property's name with `?` to make it optional:
 
-*Note that the agency typechecker is still a work in progress.*
+```ts
+type Options = {
+  model?: string
+  temperature?: number
+}
+```
+
+This is shorthand for `key: T | undefined` — when the property is missing from a value, that's still type-correct. For example:
+
+```ts
+def configure(opts: Options): void { ... }
+configure({ model: "gpt-4" })  // ok — temperature omitted
+configure({})                  // ok — both omitted
+```
+
+## Excess properties
+
+When you write an object *literal*, every key in the literal must correspond to its declared type. This helps catch typos like `modle:` instead of `model:`:
+
+```ts
+const cfg: Options = { modle: "gpt-4" }  // error: Unknown property 'modle'
+```
+
+This check fires only on object literals at the argument site. Assigning the same object to a variable first skips the excess property check, matching the behavior of TypeScript.
+
+```ts
+const badCfg = { modle: "gpt-4" }
+const cfg: Options = badCfg  // ok — excess property check doesn't apply here
+```
+
+## Suppressing typecheck errors
+
+Two directives let you opt out of typechecking:
+
+**`// @tc-nocheck`** — silences every typecheck error in the file. Must appear at the top of the file:
+
+```ts
+// @tc-nocheck
+
+// the rest of this file is not typechecked
+def foo(x: number) {
+  print(x + "oops")
+}
+```
+
+**`// @tc-ignore`** — silences typecheck errors on the *next* line only. Must be on its own line; trailing comments don't count.
+
+```ts
+def take(x: number): void { print(x) }
+
+node main() {
+  // @tc-ignore
+  take("not a number")
+  take(42)
+}
+```
+
+## See also
+
+- **[Schemas and validated types](./schemas)** — the `T!` shorthand for `Result<T, string>`, used for validation at runtime.

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -151,7 +151,13 @@ export function compile(
     symbolTable,
     absoluteInputFile,
   );
-  const info = buildCompilationUnit(resolvedProgram, symbolTable, absoluteInputFile, contents);
+  const info = buildCompilationUnit(
+    resolvedProgram,
+    symbolTable,
+    absoluteInputFile,
+    contents,
+    !isStdlibIndex,
+  );
 
   if (config.typeCheck || config.typeCheckStrict) {
     const { errors } = typeCheck(resolvedProgram, config, info);

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -151,7 +151,7 @@ export function compile(
     symbolTable,
     absoluteInputFile,
   );
-  const info = buildCompilationUnit(resolvedProgram, symbolTable, absoluteInputFile);
+  const info = buildCompilationUnit(resolvedProgram, symbolTable, absoluteInputFile, contents);
 
   if (config.typeCheck || config.typeCheckStrict) {
     const { errors } = typeCheck(resolvedProgram, config, info);

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -261,31 +261,42 @@ function pullTransitiveAliases(
   while (queue.length > 0) {
     const { name, preferFile } = queue.shift()!;
     if (globalAliases[name] !== undefined) continue; // already known
-    const sym = resolveTypeFromFile(symbolTable, name, preferFile);
-    if (!sym) continue;
-    unit.typeAliases.add(GLOBAL_SCOPE_KEY, name, sym.aliasedType);
+    const found = resolveTypeFromFile(symbolTable, name, preferFile);
+    if (!found) continue;
+    unit.typeAliases.add(GLOBAL_SCOPE_KEY, name, found.aliasedType);
+    // Nested aliases referenced by this type should resolve in the file
+    // the type was actually found in (not the original preferFile) — the
+    // body's references are scoped to that module.
     const nested: string[] = [];
-    collectAliasNames(sym.aliasedType, nested);
-    for (const n of nested) queue.push({ name: n, preferFile });
+    collectAliasNames(found.aliasedType, nested);
+    for (const n of nested) queue.push({ name: n, preferFile: found.file });
   }
 }
 
 /**
  * Look up a type alias by name. Prefers the originating module's symbols
  * (so cross-file name collisions pick the file the import actually came
- * from), then falls back to the global cross-file search.
+ * from), then falls back to the global cross-file search. Returns the
+ * file the type was found in alongside its body, so callers can resolve
+ * nested alias references in that same module.
  */
 function resolveTypeFromFile(
   symbolTable: SymbolTable,
   name: string,
   preferFile: string | undefined,
-): { aliasedType: VariableType } | undefined {
+): { aliasedType: VariableType; file: string } | undefined {
   if (preferFile) {
     const fileSym = symbolTable.getFile(preferFile)?.[name];
-    if (fileSym?.kind === "type") return fileSym;
+    if (fileSym?.kind === "type") {
+      return { aliasedType: fileSym.aliasedType, file: preferFile };
+    }
   }
-  const sym = symbolTable.findTypeAcrossFiles(name);
-  if (sym?.kind === "type") return sym;
+  for (const file of symbolTable.filePaths()) {
+    const sym = symbolTable.getFile(file)?.[name];
+    if (sym?.kind === "type") {
+      return { aliasedType: sym.aliasedType, file };
+    }
+  }
   return undefined;
 }
 

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -84,6 +84,10 @@ export type CompilationUnit = {
   safeFunctions: Record<string, boolean>;
   importedFunctions: Record<string, ImportedFunctionSignature>;
   classDefinitions: Record<string, ClassDefinition>;
+  /** Original source text. Used by the typechecker to locate
+   * `// @tc-nocheck` / `// @tc-ignore` directives. Optional because
+   * many callers (including most tests) construct the AST directly. */
+  sourceText?: string;
 };
 
 export function scopeKey(scope: Scope): string {
@@ -109,6 +113,7 @@ export function buildCompilationUnit(
   program: AgencyProgram,
   symbolTable?: SymbolTable,
   fromFile?: string,
+  sourceText?: string,
 ): CompilationUnit {
   const unit: CompilationUnit = {
     functionDefinitions: {},
@@ -119,6 +124,7 @@ export function buildCompilationUnit(
     importedFunctions: {},
     classDefinitions: {},
     safeFunctions: {},
+    sourceText,
   };
 
   // Top-level pass: collect functions, graph nodes, imports.
@@ -200,7 +206,71 @@ export function buildCompilationUnit(
         }
       }
     }
+    // Pull in any type aliases referenced by imported function/node
+    // signatures so property access on those return values resolves
+    // correctly. Without this, `let r = exec(...); r.exitCode` errors with
+    // "Property 'exitCode' does not exist on type 'ExecResult'" because
+    // the alias body lives in the source module and was never imported.
+    pullTransitiveAliases(unit, symbolTable);
   }
 
   return unit;
+}
+
+/**
+ * Walk every imported function/node signature and recursively pull any
+ * type aliases its parameters or return type reference into the unit's
+ * global scope, so the typechecker can resolve property access through
+ * them. Walks transitively (an alias whose body references another alias
+ * pulls that one too) and tracks visited names to terminate on cycles.
+ */
+function pullTransitiveAliases(
+  unit: CompilationUnit,
+  symbolTable: SymbolTable,
+): void {
+  const globalAliases = unit.typeAliases.get(GLOBAL_SCOPE_KEY) ?? {};
+  const queue: string[] = [];
+
+  for (const sig of Object.values(unit.importedFunctions)) {
+    for (const p of sig.parameters) {
+      if (p.typeHint) collectAliasNames(p.typeHint, queue);
+    }
+    if (sig.returnType) collectAliasNames(sig.returnType, queue);
+  }
+
+  while (queue.length > 0) {
+    const name = queue.shift()!;
+    if (globalAliases[name] !== undefined) continue; // already known
+    const sym = symbolTable.findTypeAcrossFiles(name);
+    if (!sym || sym.kind !== "type") continue;
+    unit.typeAliases.add(GLOBAL_SCOPE_KEY, name, sym.aliasedType);
+    collectAliasNames(sym.aliasedType, queue);
+  }
+}
+
+function collectAliasNames(t: VariableType, out: string[]): void {
+  switch (t.type) {
+    case "typeAliasVariable":
+      out.push(t.aliasName);
+      return;
+    case "arrayType":
+      collectAliasNames(t.elementType, out);
+      return;
+    case "unionType":
+      for (const m of t.types) collectAliasNames(m, out);
+      return;
+    case "objectType":
+      for (const p of t.properties) collectAliasNames(p.value, out);
+      return;
+    case "resultType":
+      collectAliasNames(t.successType, out);
+      collectAliasNames(t.failureType, out);
+      return;
+    case "blockType":
+      for (const p of t.params) collectAliasNames(p.typeAnnotation, out);
+      collectAliasNames(t.returnType, out);
+      return;
+    default:
+      return;
+  }
 }

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -189,6 +189,12 @@ export function buildCompilationUnit(
   // to the typechecker's builtin/any path instead of being treated as a
   // bogus 0-arg signature.
   if (symbolTable && fromFile) {
+    // Type-alias seeds gathered from imports — both directly imported
+    // aliases and the types referenced by imported function/node
+    // signatures. Each seed remembers the file it came from so transitive
+    // resolution can prefer that module on name collisions.
+    type AliasSeed = { type: VariableType; preferFile: string };
+    const aliasSeeds: AliasSeed[] = [];
     for (const stmt of unit.importStatements) {
       for (const r of symbolTable.resolveImport(stmt, fromFile)) {
         if (r.symbol.kind === "function" || r.symbol.kind === "node") {
@@ -208,6 +214,10 @@ export function buildCompilationUnit(
             returnType,
             originFile: r.file,
           };
+          for (const p of r.symbol.parameters) {
+            if (p.typeHint) aliasSeeds.push({ type: p.typeHint, preferFile: r.file });
+          }
+          if (returnType) aliasSeeds.push({ type: returnType, preferFile: r.file });
         }
         if (r.symbol.kind === "function" && r.symbol.safe) {
           unit.safeFunctions[r.localName] = true;
@@ -218,30 +228,35 @@ export function buildCompilationUnit(
             r.localName,
             r.symbol.aliasedType,
           );
+          // Imported type's body may reference other aliases from its
+          // module — pull those transitively too.
+          aliasSeeds.push({ type: r.symbol.aliasedType, preferFile: r.file });
         }
       }
     }
-    // Pull in any type aliases referenced by imported function/node
-    // signatures so property access on those return values resolves
-    // correctly. Without this, `let r = exec(...); r.exitCode` errors with
-    // "Property 'exitCode' does not exist on type 'ExecResult'" because
-    // the alias body lives in the source module and was never imported.
-    pullTransitiveAliases(unit, symbolTable);
+    // Pull in any type aliases referenced by imports so property access
+    // on those values resolves correctly. Without this, `let r = exec(...);
+    // r.exitCode` errors with "Property 'exitCode' does not exist on type
+    // 'ExecResult'" because the alias body lives in the source module and
+    // was never imported.
+    pullTransitiveAliases(unit, symbolTable, aliasSeeds);
   }
 
   return unit;
 }
 
 /**
- * Walk every imported function/node signature and recursively pull any
- * type aliases its parameters or return type reference into the unit's
- * global scope, so the typechecker can resolve property access through
- * them. Walks transitively (an alias whose body references another alias
- * pulls that one too) and tracks visited names to terminate on cycles.
+ * Walk every alias-seed type (from imported function/node signatures and
+ * directly imported type aliases) and recursively pull any referenced
+ * aliases into the unit's global scope, so the typechecker can resolve
+ * property access through them. Walks transitively (an alias whose body
+ * references another alias pulls that one too) and tracks visited names
+ * to terminate on cycles.
  */
 function pullTransitiveAliases(
   unit: CompilationUnit,
   symbolTable: SymbolTable,
+  seeds: { type: VariableType; preferFile: string }[],
 ): void {
   const globalAliases = unit.typeAliases.get(GLOBAL_SCOPE_KEY) ?? {};
   // Each pending alias remembers the file it was referenced from, so
@@ -249,13 +264,10 @@ function pullTransitiveAliases(
   // collides across files.
   const queue: { name: string; preferFile?: string }[] = [];
 
-  for (const sig of Object.values(unit.importedFunctions)) {
+  for (const seed of seeds) {
     const names: string[] = [];
-    for (const p of sig.parameters) {
-      if (p.typeHint) collectAliasNames(p.typeHint, names);
-    }
-    if (sig.returnType) collectAliasNames(sig.returnType, names);
-    for (const name of names) queue.push({ name, preferFile: sig.originFile });
+    collectAliasNames(seed.type, names);
+    for (const name of names) queue.push({ name, preferFile: seed.preferFile });
   }
 
   while (queue.length > 0) {

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -67,6 +67,10 @@ export class ScopedTypeAliases {
 export type ImportedFunctionSignature = {
   parameters: FunctionParameter[];
   returnType: VariableType | null;
+  /** Absolute path of the file the symbol was imported from. Used to
+   * resolve type aliases referenced by the signature in the right module
+   * (so a type-name collision across files picks the right one). */
+  originFile?: string;
 };
 
 /**
@@ -88,6 +92,14 @@ export type CompilationUnit = {
    * `// @tc-nocheck` / `// @tc-ignore` directives. Optional because
    * many callers (including most tests) construct the AST directly. */
   sourceText?: string;
+  /** True iff `parseAgency` was called with the template wrapper applied
+   * (the CLI default). The parser unconditionally subtracts
+   * `AGENCY_TEMPLATE_OFFSET` from every span's line, so when the wrapper
+   * was *not* applied (LSP path), error `loc.line` values are off by
+   * `-AGENCY_TEMPLATE_OFFSET` from raw-source 0-indexed lines. The
+   * typechecker uses this flag to align suppression-directive line
+   * numbers with error locations. */
+  templateApplied?: boolean;
 };
 
 export function scopeKey(scope: Scope): string {
@@ -114,6 +126,7 @@ export function buildCompilationUnit(
   symbolTable?: SymbolTable,
   fromFile?: string,
   sourceText?: string,
+  templateApplied: boolean = true,
 ): CompilationUnit {
   const unit: CompilationUnit = {
     functionDefinitions: {},
@@ -125,6 +138,7 @@ export function buildCompilationUnit(
     classDefinitions: {},
     safeFunctions: {},
     sourceText,
+    templateApplied,
   };
 
   // Top-level pass: collect functions, graph nodes, imports.
@@ -192,6 +206,7 @@ export function buildCompilationUnit(
           unit.importedFunctions[r.localName] = {
             parameters: r.symbol.parameters,
             returnType,
+            originFile: r.file,
           };
         }
         if (r.symbol.kind === "function" && r.symbol.safe) {
@@ -229,23 +244,49 @@ function pullTransitiveAliases(
   symbolTable: SymbolTable,
 ): void {
   const globalAliases = unit.typeAliases.get(GLOBAL_SCOPE_KEY) ?? {};
-  const queue: string[] = [];
+  // Each pending alias remembers the file it was referenced from, so
+  // resolution prefers the originating module's symbols when a name
+  // collides across files.
+  const queue: { name: string; preferFile?: string }[] = [];
 
   for (const sig of Object.values(unit.importedFunctions)) {
+    const names: string[] = [];
     for (const p of sig.parameters) {
-      if (p.typeHint) collectAliasNames(p.typeHint, queue);
+      if (p.typeHint) collectAliasNames(p.typeHint, names);
     }
-    if (sig.returnType) collectAliasNames(sig.returnType, queue);
+    if (sig.returnType) collectAliasNames(sig.returnType, names);
+    for (const name of names) queue.push({ name, preferFile: sig.originFile });
   }
 
   while (queue.length > 0) {
-    const name = queue.shift()!;
+    const { name, preferFile } = queue.shift()!;
     if (globalAliases[name] !== undefined) continue; // already known
-    const sym = symbolTable.findTypeAcrossFiles(name);
-    if (!sym || sym.kind !== "type") continue;
+    const sym = resolveTypeFromFile(symbolTable, name, preferFile);
+    if (!sym) continue;
     unit.typeAliases.add(GLOBAL_SCOPE_KEY, name, sym.aliasedType);
-    collectAliasNames(sym.aliasedType, queue);
+    const nested: string[] = [];
+    collectAliasNames(sym.aliasedType, nested);
+    for (const n of nested) queue.push({ name: n, preferFile });
   }
+}
+
+/**
+ * Look up a type alias by name. Prefers the originating module's symbols
+ * (so cross-file name collisions pick the file the import actually came
+ * from), then falls back to the global cross-file search.
+ */
+function resolveTypeFromFile(
+  symbolTable: SymbolTable,
+  name: string,
+  preferFile: string | undefined,
+): { aliasedType: VariableType } | undefined {
+  if (preferFile) {
+    const fileSym = symbolTable.getFile(preferFile)?.[name];
+    if (fileSym?.kind === "type") return fileSym;
+  }
+  const sym = symbolTable.findTypeAcrossFiles(name);
+  if (sym?.kind === "type") return sym;
+  return undefined;
 }
 
 function collectAliasNames(t: VariableType, out: string[]): void {

--- a/packages/agency-lang/lib/lsp/diagnostics.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.ts
@@ -70,7 +70,7 @@ export function runDiagnostics(
     return { diagnostics, program: null, info: null, semanticIndex: {}, scopes: [] };
   }
 
-  const info = buildCompilationUnit(program, symbolTable, fsPath);
+  const info = buildCompilationUnit(program, symbolTable, fsPath, source);
   const { errors, scopes } = typeCheck(program, config, info);
 
   for (const err of errors) {

--- a/packages/agency-lang/lib/lsp/diagnostics.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.ts
@@ -70,7 +70,10 @@ export function runDiagnostics(
     return { diagnostics, program: null, info: null, semanticIndex: {}, scopes: [] };
   }
 
-  const info = buildCompilationUnit(program, symbolTable, fsPath, source);
+  // applyTemplate=false above, so `loc.line` is shifted by -TEMPLATE_OFFSET
+  // from raw source lines. Pass templateApplied=false so the typechecker can
+  // align suppression directives with error locations.
+  const info = buildCompilationUnit(program, symbolTable, fsPath, source, false);
   const { errors, scopes } = typeCheck(program, config, info);
 
   for (const err of errors) {

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -3,6 +3,7 @@ import { TypeChecker, typeCheck } from "./typeChecker/index.js";
 import { AgencyProgram, VariableType } from "./types.js";
 import { buildCompilationUnit } from "./compilationUnit.js";
 import type { CompilationUnit } from "./compilationUnit.js";
+import { SymbolTable } from "./symbolTable.js";
 
 function withImports(
   program: AgencyProgram,
@@ -6118,6 +6119,254 @@ describe("TypeChecker", () => {
       };
       const errors = typeCheck(program).errors;
       expect(errors.some((e) => /unknown property/i.test(e.message))).toBe(false);
+    });
+
+    it("counts a trailing 'as' block toward arity", () => {
+      // def f(x: number, b: (number) => string): void { ... }
+      // f(1) as y { return "ok" }  ← block fills slot 1; arity must check out.
+      const blockT: VariableType = {
+        type: "blockType",
+        params: [{ name: "y", typeAnnotation: num }],
+        returnType: str,
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "f",
+            parameters: [
+              { type: "functionParameter", name: "x", typeHint: num },
+              { type: "functionParameter", name: "b", typeHint: blockT },
+            ],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "f",
+            arguments: [{ type: "number", value: "1" }],
+            block: {
+              type: "blockArgument",
+              params: [{ type: "functionParameter", name: "y" }],
+              body: [
+                { type: "returnStatement", value: { type: "string", segments: [{ type: "text", value: "ok" }] } },
+              ],
+            },
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toEqual([]);
+    });
+
+    it("rejects a block argument passed to a function with no block-typed param", () => {
+      // def noBlock(x: number) {}; noBlock(1) as y { ... }  ← extra block
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "noBlock",
+            parameters: [{ type: "functionParameter", name: "x", typeHint: num }],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "noBlock",
+            arguments: [{ type: "number", value: "1" }],
+            block: {
+              type: "blockArgument",
+              params: [{ type: "functionParameter", name: "y" }],
+              body: [{ type: "returnStatement", value: { type: "number", value: "0" } }],
+            },
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /does not accept a block argument/.test(e.message))).toBe(true);
+    });
+
+    it("accepts identical block types via assignability", () => {
+      // def passThrough(b: (number) => string): string { return takes(b) }
+      // (number)=>string → (number)=>string should typecheck.
+      const blockT: VariableType = {
+        type: "blockType",
+        params: [{ name: "x", typeAnnotation: num }],
+        returnType: str,
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "takes",
+            parameters: [{ type: "functionParameter", name: "b", typeHint: blockT }],
+            returnType: str,
+            body: [{ type: "returnStatement", value: { type: "string", segments: [{ type: "text", value: "ok" }] } }],
+          },
+          {
+            type: "function",
+            functionName: "passThrough",
+            parameters: [{ type: "functionParameter", name: "b", typeHint: blockT }],
+            returnType: str,
+            body: [
+              {
+                type: "returnStatement",
+                value: {
+                  type: "functionCall",
+                  functionName: "takes",
+                  arguments: [{ type: "variableName", value: "b" }],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toEqual([]);
+    });
+
+    it("rejects block-type assignment with mismatched param types", () => {
+      // (number) => string is not assignable to (string) => string.
+      const numToStr: VariableType = {
+        type: "blockType",
+        params: [{ name: "x", typeAnnotation: num }],
+        returnType: str,
+      };
+      const strToStr: VariableType = {
+        type: "blockType",
+        params: [{ name: "x", typeAnnotation: str }],
+        returnType: str,
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "takes",
+            parameters: [{ type: "functionParameter", name: "b", typeHint: strToStr }],
+            returnType: str,
+            body: [{ type: "returnStatement", value: { type: "string", segments: [{ type: "text", value: "ok" }] } }],
+          },
+          {
+            type: "function",
+            functionName: "passWrong",
+            parameters: [{ type: "functionParameter", name: "b", typeHint: numToStr }],
+            returnType: str,
+            body: [
+              {
+                type: "returnStatement",
+                value: {
+                  type: "functionCall",
+                  functionName: "takes",
+                  arguments: [{ type: "variableName", value: "b" }],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /not assignable/i.test(e.message))).toBe(true);
+    });
+
+    it("rejects block-type assignment with mismatched arity", () => {
+      // (number) => string vs (number, number) => string — arity differs.
+      const oneArg: VariableType = {
+        type: "blockType",
+        params: [{ name: "x", typeAnnotation: num }],
+        returnType: str,
+      };
+      const twoArgs: VariableType = {
+        type: "blockType",
+        params: [
+          { name: "x", typeAnnotation: num },
+          { name: "y", typeAnnotation: num },
+        ],
+        returnType: str,
+      };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "takes",
+            parameters: [{ type: "functionParameter", name: "b", typeHint: twoArgs }],
+            returnType: str,
+            body: [{ type: "returnStatement", value: { type: "string", segments: [{ type: "text", value: "ok" }] } }],
+          },
+          {
+            type: "function",
+            functionName: "passWrong",
+            parameters: [{ type: "functionParameter", name: "b", typeHint: oneArg }],
+            returnType: str,
+            body: [
+              {
+                type: "returnStatement",
+                value: {
+                  type: "functionCall",
+                  functionName: "takes",
+                  arguments: [{ type: "variableName", value: "b" }],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /not assignable/i.test(e.message))).toBe(true);
+    });
+
+    it("resolves type aliases referenced by imported function signatures", () => {
+      // Mirror of the real-world bug: imported `exec` returns `ExecResult`,
+      // but `ExecResult` lives in the imported module. Without alias pull-in,
+      // `r.exitCode` errors with "Property 'exitCode' does not exist on type
+      // 'ExecResult'" because resolveType can't find ExecResult in scope.
+      const execResult: VariableType = {
+        type: "objectType",
+        properties: [
+          { key: "stdout", value: str },
+          { key: "stderr", value: str },
+          { key: "exitCode", value: num },
+        ],
+      };
+      const symbolTable = new SymbolTable({
+        "/project/shell.agency": {
+          ExecResult: { kind: "type", name: "ExecResult", aliasedType: execResult, exported: true },
+          exec: {
+            kind: "function",
+            name: "exec",
+            exported: true,
+            safe: false,
+            parameters: [],
+            returnType: { type: "typeAliasVariable", aliasName: "ExecResult" },
+          },
+        },
+      });
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "importStatement",
+            modulePath: "./shell.agency",
+            isAgencyImport: true,
+            importedNames: [
+              { type: "namedImport", importedNames: ["exec"], aliases: {}, safeNames: [] },
+            ],
+          },
+          {
+            type: "assignment",
+            variableName: "r",
+            value: { type: "functionCall", functionName: "exec", arguments: [] },
+          },
+          {
+            type: "valueAccess",
+            base: { type: "variableName", value: "r" },
+            chain: [{ kind: "property", name: "exitCode" }],
+          },
+        ],
+      };
+      const info = buildCompilationUnit(program, symbolTable, "/project/main.agency");
+      const errors = typeCheck(program, {}, info).errors;
+      expect(errors.filter((e) => /does not exist/.test(e.message))).toEqual([]);
     });
   });
 });

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -6368,5 +6368,147 @@ describe("TypeChecker", () => {
       const errors = typeCheck(program, {}, info).errors;
       expect(errors.filter((e) => /does not exist/.test(e.message))).toEqual([]);
     });
+
+    it("alias resolution prefers the originating module on name collision", () => {
+      // Two imported modules both define `Result2` (collision avoided with
+      // the reserved `Result` name). Imported `getA` came from a.agency.
+      // Property access should resolve through a.agency's definition.
+      const aResult: VariableType = {
+        type: "objectType",
+        properties: [{ key: "fromA", value: str }],
+      };
+      const bResult: VariableType = {
+        type: "objectType",
+        properties: [{ key: "fromB", value: str }],
+      };
+      const symbolTable = new SymbolTable({
+        "/project/a.agency": {
+          Result2: { kind: "type", name: "Result2", aliasedType: aResult, exported: true },
+          getA: {
+            kind: "function", name: "getA", exported: true, safe: false,
+            parameters: [],
+            returnType: { type: "typeAliasVariable", aliasName: "Result2" },
+          },
+        },
+        "/project/b.agency": {
+          Result2: { kind: "type", name: "Result2", aliasedType: bResult, exported: true },
+        },
+      });
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "importStatement",
+            modulePath: "./a.agency",
+            isAgencyImport: true,
+            importedNames: [
+              { type: "namedImport", importedNames: ["getA"], aliases: {}, safeNames: [] },
+            ],
+          },
+          {
+            type: "assignment",
+            variableName: "r",
+            value: { type: "functionCall", functionName: "getA", arguments: [] },
+          },
+          {
+            type: "valueAccess",
+            base: { type: "variableName", value: "r" },
+            chain: [{ kind: "property", name: "fromA" }],
+          },
+          {
+            type: "valueAccess",
+            base: { type: "variableName", value: "r" },
+            chain: [{ kind: "property", name: "fromB" }],
+          },
+        ],
+      };
+      const info = buildCompilationUnit(program, symbolTable, "/project/main.agency");
+      const errors = typeCheck(program, {}, info).errors;
+      // fromA exists on a.agency's Result2 → no error.
+      expect(errors.filter((e) => /Property 'fromA'/.test(e.message))).toEqual([]);
+      // fromB only exists on b.agency's Result2; resolution should NOT pick
+      // that file since the import came from a.agency.
+      expect(errors.some((e) => /Property 'fromB' does not exist/.test(e.message))).toBe(true);
+    });
+
+    it("a builtin call is rejected when given a block argument", () => {
+      // print(1) as x { return 2 }  ← `print` is a builtin, not a block-taker.
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "functionCall",
+            functionName: "print",
+            arguments: [{ type: "number", value: "1" }],
+            block: {
+              type: "blockArgument",
+              params: [{ type: "functionParameter", name: "x" }],
+              body: [{ type: "returnStatement", value: { type: "number", value: "2" } }],
+            },
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /'print' does not accept a block/.test(e.message))).toBe(true);
+    });
+
+    it("accepts a block argument when the last param is untyped", () => {
+      // def f(a: number, b) {}; f(1) as y { return 2 }
+      // ← `b` has no typeHint; the block fills slot `b`. Effective arity: 2.
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "f",
+            parameters: [
+              { type: "functionParameter", name: "a", typeHint: num },
+              { type: "functionParameter", name: "b" },
+            ],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "f",
+            arguments: [{ type: "number", value: "1" }],
+            block: {
+              type: "blockArgument",
+              params: [{ type: "functionParameter", name: "y" }],
+              body: [{ type: "returnStatement", value: { type: "number", value: "2" } }],
+            },
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toEqual([]);
+    });
+
+    it("accepts a block argument when the last param is typed `any`", () => {
+      const anyT: VariableType = { type: "primitiveType", value: "any" };
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "f",
+            parameters: [
+              { type: "functionParameter", name: "a", typeHint: num },
+              { type: "functionParameter", name: "b", typeHint: anyT },
+            ],
+            body: [],
+          },
+          {
+            type: "functionCall",
+            functionName: "f",
+            arguments: [{ type: "number", value: "1" }],
+            block: {
+              type: "blockArgument",
+              params: [{ type: "functionParameter", name: "y" }],
+              body: [{ type: "returnStatement", value: { type: "number", value: "2" } }],
+            },
+          },
+        ],
+      };
+      expect(typeCheck(program).errors).toEqual([]);
+    });
   });
 });

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -6516,6 +6516,61 @@ describe("TypeChecker", () => {
       expect(errors.some((e) => /Property 'wrong' does not exist/.test(e.message))).toBe(true);
     });
 
+    it("pulls transitive aliases from a directly imported type alias's body", () => {
+      // main imports `Outer` from types.agency. Outer = { inner: Inner },
+      // where Inner is also defined in types.agency. Property access on
+      // r.inner.x must resolve through Inner without explicit import.
+      const inner: VariableType = {
+        type: "objectType",
+        properties: [{ key: "x", value: num }],
+      };
+      const outer: VariableType = {
+        type: "objectType",
+        properties: [
+          { key: "inner", value: { type: "typeAliasVariable", aliasName: "Inner" } },
+        ],
+      };
+      const symbolTable = new SymbolTable({
+        "/project/types.agency": {
+          Inner: { kind: "type", name: "Inner", aliasedType: inner, exported: true },
+          Outer: { kind: "type", name: "Outer", aliasedType: outer, exported: true },
+        },
+      });
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "importStatement",
+            modulePath: "./types.agency",
+            isAgencyImport: true,
+            importedNames: [
+              { type: "namedImport", importedNames: ["Outer"], aliases: {}, safeNames: [] },
+            ],
+          },
+          {
+            type: "function",
+            functionName: "consume",
+            parameters: [
+              { type: "functionParameter", name: "o", typeHint: { type: "typeAliasVariable", aliasName: "Outer" } },
+            ],
+            body: [
+              {
+                type: "valueAccess",
+                base: { type: "variableName", value: "o" },
+                chain: [
+                  { kind: "property", name: "inner" },
+                  { kind: "property", name: "x" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const info = buildCompilationUnit(program, symbolTable, "/project/main.agency");
+      const errors = typeCheck(program, {}, info).errors;
+      expect(errors.filter((e) => /does not exist/.test(e.message))).toEqual([]);
+    });
+
     it("a builtin call is rejected when given a block argument", () => {
       // print(1) as x { return 2 }  ← `print` is a builtin, not a block-taker.
       const program: AgencyProgram = {

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -5964,14 +5964,8 @@ describe("TypeChecker", () => {
       expect(errors.some((e) => /unknown property 'modle'/i.test(e.message))).toBe(true);
     });
 
-    // Known typechecker gap: a pipe RHS with no `?` placeholder is currently
-    // delegated to the backend (`pipeRhsSlotType` early-returns when no
-    // placeholder is found — "backend will reject"). The typechecker emits
-    // no error even when the resulting arity is bogus (here: LHS + 2 explicit
-    // args for a 2-param fn). Pinned as `.skip` so we have a target to flip
-    // when the typechecker grows pipe arity-checking.
-    it.skip("pipe RHS arity mismatch errors when no placeholder is given", () => {
-      // 5 |> add(10, 20)  ← LHS + 2 explicit args ≠ 2 params.
+    it("rejects a pipe RHS functionCall with no '?' placeholder", () => {
+      // 5 |> add(10, 20)  ← needs exactly one '?'
       const program: AgencyProgram = {
         type: "agencyProgram",
         nodes: [
@@ -5998,7 +5992,38 @@ describe("TypeChecker", () => {
         ],
       };
       const errors = typeCheck(program).errors;
-      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some((e) => /exactly one '\?' placeholder, got 0/.test(e.message))).toBe(true);
+    });
+
+    it("rejects a pipe RHS functionCall with multiple '?' placeholders", () => {
+      // 5 |> add(?, ?)  ← only one '?' allowed
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "add",
+            parameters: [
+              { type: "functionParameter", name: "a", typeHint: num },
+              { type: "functionParameter", name: "b", typeHint: num },
+            ],
+            returnType: num,
+            body: [{ type: "returnStatement", value: { type: "number", value: "0" } }],
+          },
+          {
+            type: "binOpExpression",
+            operator: "|>",
+            left: { type: "number", value: "5" },
+            right: {
+              type: "functionCall",
+              functionName: "add",
+              arguments: [{ type: "placeholder" }, { type: "placeholder" }],
+            },
+          },
+        ],
+      };
+      const errors = typeCheck(program).errors;
+      expect(errors.some((e) => /exactly one '\?' placeholder, got 2/.test(e.message))).toBe(true);
     });
 
     it("named-arg call may omit a default-valued param", () => {

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -6381,7 +6381,13 @@ describe("TypeChecker", () => {
         type: "objectType",
         properties: [{ key: "fromB", value: str }],
       };
+      // b.agency declared FIRST so the fallback (findTypeAcrossFiles)
+      // returns b's Result2 by default. The fix must use originFile to
+      // prefer a.agency, otherwise this test would fail.
       const symbolTable = new SymbolTable({
+        "/project/b.agency": {
+          Result2: { kind: "type", name: "Result2", aliasedType: bResult, exported: true },
+        },
         "/project/a.agency": {
           Result2: { kind: "type", name: "Result2", aliasedType: aResult, exported: true },
           getA: {
@@ -6389,9 +6395,6 @@ describe("TypeChecker", () => {
             parameters: [],
             returnType: { type: "typeAliasVariable", aliasName: "Result2" },
           },
-        },
-        "/project/b.agency": {
-          Result2: { kind: "type", name: "Result2", aliasedType: bResult, exported: true },
         },
       });
       const program: AgencyProgram = {
@@ -6429,6 +6432,88 @@ describe("TypeChecker", () => {
       // fromB only exists on b.agency's Result2; resolution should NOT pick
       // that file since the import came from a.agency.
       expect(errors.some((e) => /Property 'fromB' does not exist/.test(e.message))).toBe(true);
+    });
+
+    it("alias resolution recurses into the host file of the resolved type", () => {
+      // F1 imports `getThing` from origin.agency. origin.agency does NOT
+      // define `Outer` — `Outer` lives in real.agency, where its body
+      // references `Inner`. There's a *different* `Inner` in decoy.agency
+      // declared before real.agency. Without per-file nested resolution,
+      // the recursion would re-acquire decoy's `Inner` for `Outer`.
+      const realInner: VariableType = {
+        type: "objectType",
+        properties: [{ key: "id", value: num }],
+      };
+      const decoyInner: VariableType = {
+        type: "objectType",
+        properties: [{ key: "wrong", value: str }],
+      };
+      const symbolTable = new SymbolTable({
+        // decoy declared first → findTypeAcrossFiles for "Inner" returns it.
+        "/project/decoy.agency": {
+          Inner: { kind: "type", name: "Inner", aliasedType: decoyInner, exported: true },
+        },
+        "/project/real.agency": {
+          Inner: { kind: "type", name: "Inner", aliasedType: realInner, exported: true },
+          Outer: {
+            kind: "type",
+            name: "Outer",
+            aliasedType: {
+              type: "objectType",
+              properties: [
+                { key: "inner", value: { type: "typeAliasVariable", aliasName: "Inner" } },
+              ],
+            },
+            exported: true,
+          },
+        },
+        "/project/origin.agency": {
+          getThing: {
+            kind: "function", name: "getThing", exported: true, safe: false,
+            parameters: [],
+            returnType: { type: "typeAliasVariable", aliasName: "Outer" },
+          },
+        },
+      });
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "importStatement",
+            modulePath: "./origin.agency",
+            isAgencyImport: true,
+            importedNames: [
+              { type: "namedImport", importedNames: ["getThing"], aliases: {}, safeNames: [] },
+            ],
+          },
+          {
+            type: "assignment",
+            variableName: "r",
+            value: { type: "functionCall", functionName: "getThing", arguments: [] },
+          },
+          {
+            type: "valueAccess",
+            base: { type: "variableName", value: "r" },
+            chain: [
+              { kind: "property", name: "inner" },
+              { kind: "property", name: "id" },
+            ],
+          },
+          {
+            type: "valueAccess",
+            base: { type: "variableName", value: "r" },
+            chain: [
+              { kind: "property", name: "inner" },
+              { kind: "property", name: "wrong" },
+            ],
+          },
+        ],
+      };
+      const info = buildCompilationUnit(program, symbolTable, "/project/main.agency");
+      const errors = typeCheck(program, {}, info).errors;
+      // Real Inner has 'id', not 'wrong' — recursion must have picked real.agency.
+      expect(errors.filter((e) => /Property 'id'/.test(e.message))).toEqual([]);
+      expect(errors.some((e) => /Property 'wrong' does not exist/.test(e.message))).toBe(true);
     });
 
     it("a builtin call is rejected when given a block argument", () => {

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -177,6 +177,31 @@ export function isAssignable(
     );
   }
 
+  // Block types: contravariant in parameters, covariant in return — standard
+  // function compatibility. Arity must match exactly (no auto-extension).
+  if (
+    resolvedSource.type === "blockType" &&
+    resolvedTarget.type === "blockType"
+  ) {
+    if (resolvedSource.params.length !== resolvedTarget.params.length)
+      return false;
+    for (let i = 0; i < resolvedSource.params.length; i++) {
+      if (
+        !isAssignable(
+          resolvedTarget.params[i].typeAnnotation,
+          resolvedSource.params[i].typeAnnotation,
+          typeAliases,
+        )
+      )
+        return false;
+    }
+    return isAssignable(
+      resolvedSource.returnType,
+      resolvedTarget.returnType,
+      typeAliases,
+    );
+  }
+
   // Result<T, E>: covariant in both type parameters.
   if (
     resolvedSource.type === "resultType" &&

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -130,17 +130,11 @@ function checkSingleFunctionCall(
   if (params) {
     if (!checkNamedArgStructure(call, params, ctx)) return;
     if (!checkBlockArgShape(call, params, ctx)) return;
-    // A block argument (trailing `as` block or inline `\... -> ...`) fills the
-    // block-typed param slot but lives at `call.block`, not `call.arguments`.
-    // Count it for arity so `f() as x { }` doesn't look like a 0-arg call.
-    const effectiveArgCount =
-      call.arguments.length + (call.block ? 1 : 0);
     const { minArgs, maxArgs, slots } = paramListSignature(
       params,
-      effectiveArgCount,
+      call.arguments.length,
     );
-    if (!checkArity(call, minArgs, maxArgs, hasSplatArg, effectiveArgCount, ctx))
-      return;
+    if (!checkArity(call, minArgs, maxArgs, hasSplatArg, ctx)) return;
     checkArgsAgainstParams(call, slots, scope, ctx);
     return;
   }
@@ -160,8 +154,7 @@ function checkSingleFunctionCall(
     const minArgs = sig.minParams ?? sig.params.length;
     const hasRest = sig.restParam !== undefined;
     const maxArgs = hasRest ? Infinity : sig.params.length;
-    if (!checkArity(call, minArgs, maxArgs, hasSplatArg, call.arguments.length, ctx))
-      return;
+    if (!checkArity(call, minArgs, maxArgs, hasSplatArg, ctx)) return;
     const slots: ParamSlot[] = sig.params.map((type) => ({
       type,
       validated: false,
@@ -270,13 +263,16 @@ function checkArity(
   minArgs: number,
   maxArgs: number,
   hasSplatArg: boolean,
-  effectiveArgCount: number,
   ctx: TypeCheckerContext,
 ): boolean {
   if (hasSplatArg) return true;
-  if (effectiveArgCount >= minArgs && effectiveArgCount <= maxArgs) return true;
+  // A block argument (trailing `as` block or inline `\... -> ...`) fills the
+  // block-typed param slot but lives at `call.block`, not `call.arguments`.
+  // Count it so `f() as x { }` doesn't look like a 0-arg call.
+  const argCount = call.arguments.length + (call.block ? 1 : 0);
+  if (argCount >= minArgs && argCount <= maxArgs) return true;
   ctx.errors.push({
-    message: `Expected ${formatArity(minArgs, maxArgs)} argument(s) for '${call.functionName}', but got ${effectiveArgCount}.`,
+    message: `Expected ${formatArity(minArgs, maxArgs)} argument(s) for '${call.functionName}', but got ${argCount}.`,
     loc: call.loc,
   });
   return false;

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -129,11 +129,18 @@ function checkSingleFunctionCall(
 
   if (params) {
     if (!checkNamedArgStructure(call, params, ctx)) return;
+    if (!checkBlockArgShape(call, params, ctx)) return;
+    // A block argument (trailing `as` block or inline `\... -> ...`) fills the
+    // block-typed param slot but lives at `call.block`, not `call.arguments`.
+    // Count it for arity so `f() as x { }` doesn't look like a 0-arg call.
+    const effectiveArgCount =
+      call.arguments.length + (call.block ? 1 : 0);
     const { minArgs, maxArgs, slots } = paramListSignature(
       params,
-      call.arguments.length,
+      effectiveArgCount,
     );
-    if (!checkArity(call, minArgs, maxArgs, hasSplatArg, ctx)) return;
+    if (!checkArity(call, minArgs, maxArgs, hasSplatArg, effectiveArgCount, ctx))
+      return;
     checkArgsAgainstParams(call, slots, scope, ctx);
     return;
   }
@@ -153,7 +160,8 @@ function checkSingleFunctionCall(
     const minArgs = sig.minParams ?? sig.params.length;
     const hasRest = sig.restParam !== undefined;
     const maxArgs = hasRest ? Infinity : sig.params.length;
-    if (!checkArity(call, minArgs, maxArgs, hasSplatArg, ctx)) return;
+    if (!checkArity(call, minArgs, maxArgs, hasSplatArg, call.arguments.length, ctx))
+      return;
     const slots: ParamSlot[] = sig.params.map((type) => ({
       type,
       validated: false,
@@ -165,6 +173,28 @@ function checkSingleFunctionCall(
     }
     checkArgsAgainstParams(call, slots, scope, ctx);
   }
+}
+
+/**
+ * If the call passes a block (trailing `as` or inline `\... -> ...`), the
+ * function must declare a `blockType` parameter to receive it. Reject calls
+ * that pass a block to a function with no block-typed param.
+ *
+ * Returns false to bail before downstream checks emit confusing diagnostics.
+ */
+function checkBlockArgShape(
+  call: FunctionCall,
+  params: FunctionParameter[],
+  ctx: TypeCheckerContext,
+): boolean {
+  if (!call.block) return true;
+  const hasBlockParam = params.some((p) => p.typeHint?.type === "blockType");
+  if (hasBlockParam) return true;
+  ctx.errors.push({
+    message: `'${call.functionName}' does not accept a block argument.`,
+    loc: call.block.loc ?? call.loc,
+  });
+  return false;
 }
 
 /**
@@ -240,13 +270,13 @@ function checkArity(
   minArgs: number,
   maxArgs: number,
   hasSplatArg: boolean,
+  effectiveArgCount: number,
   ctx: TypeCheckerContext,
 ): boolean {
   if (hasSplatArg) return true;
-  if (call.arguments.length >= minArgs && call.arguments.length <= maxArgs)
-    return true;
+  if (effectiveArgCount >= minArgs && effectiveArgCount <= maxArgs) return true;
   ctx.errors.push({
-    message: `Expected ${formatArity(minArgs, maxArgs)} argument(s) for '${call.functionName}', but got ${call.arguments.length}.`,
+    message: `Expected ${formatArity(minArgs, maxArgs)} argument(s) for '${call.functionName}', but got ${effectiveArgCount}.`,
     loc: call.loc,
   });
   return false;

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -431,6 +431,22 @@ function validatePipeArg(
   scope: Scope,
   ctx: TypeCheckerContext,
 ): void {
+  // Pipe semantics require exactly one `?` placeholder on a functionCall RHS
+  // (the LHS fills it). Catch the wrong count here so the user gets a
+  // typecheck diagnostic instead of a backend codegen throw.
+  if (expr.right.type === "functionCall") {
+    const placeholders = expr.right.arguments.filter(
+      (a) => a.type === "placeholder",
+    ).length;
+    if (placeholders !== 1) {
+      ctx.errors.push({
+        message: `Function call on right side of '|>' must contain exactly one '?' placeholder, got ${placeholders}.`,
+        loc: expr.loc,
+      });
+      return;
+    }
+  }
+
   const slotType = pipeRhsSlotType(expr.right, ctx);
   if (slotType === undefined || slotType === "any") return;
 

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -150,6 +150,16 @@ function checkSingleFunctionCall(
       });
       return;
     }
+    if (call.block) {
+      // None of the entries in BUILTIN_FUNCTION_TYPES take a block. (fork /
+      // race do, but they're special-cased in the backend and never reach
+      // this branch — they fall through with no params lookup at all.)
+      ctx.errors.push({
+        message: `'${call.functionName}' does not accept a block argument.`,
+        loc: call.block.loc ?? call.loc,
+      });
+      return;
+    }
     const sig = BUILTIN_FUNCTION_TYPES[call.functionName];
     const minArgs = sig.minParams ?? sig.params.length;
     const hasRest = sig.restParam !== undefined;
@@ -181,8 +191,21 @@ function checkBlockArgShape(
   ctx: TypeCheckerContext,
 ): boolean {
   if (!call.block) return true;
-  const hasBlockParam = params.some((p) => p.typeHint?.type === "blockType");
-  if (hasBlockParam) return true;
+  // The backend pushes `call.block` as the final positional argument, so the
+  // last parameter is what receives it. Accept a block-typed slot, or the
+  // permissive cases — untyped (no hint) and `any` — that could legitimately
+  // hold a block.
+  const lastParam = params[params.length - 1];
+  if (lastParam) {
+    const hint = lastParam.typeHint;
+    if (
+      hint === undefined ||
+      hint.type === "blockType" ||
+      (hint.type === "primitiveType" && hint.value === "any")
+    ) {
+      return true;
+    }
+  }
   ctx.errors.push({
     message: `'${call.functionName}' does not accept a block argument.`,
     loc: call.block.loc ?? call.loc,

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -14,6 +14,7 @@ import {
 import type { SourceLocation } from "../types/base.js";
 import { TypeCheckError, TypeCheckResult, TypeCheckerContext } from "./types.js";
 import { validateTypeReferences } from "./validate.js";
+import { applySuppressions, parseSuppressions } from "./suppression.js";
 import { inferReturnTypes } from "./inference.js";
 import { buildScopes } from "./scopes.js";
 import { checkScopes } from "./checker.js";
@@ -60,6 +61,7 @@ export class TypeChecker {
   private errors: TypeCheckError[] = [];
   private inferredReturnTypes: Record<string, VariableType | "any"> = {};
   private inferringReturnType = new Set<string>();
+  private sourceText: string | undefined;
 
   constructor(program: AgencyProgram, config: AgencyConfig = {}, info?: CompilationUnit) {
     this.program = program;
@@ -71,6 +73,7 @@ export class TypeChecker {
       resolved.graphNodes.map((n) => [n.nodeName, n]),
     );
     this.importedFunctions = { ...resolved.importedFunctions };
+    this.sourceText = resolved.sourceText;
   }
 
   private get typeAliases(): Record<string, VariableType> {
@@ -194,7 +197,12 @@ export class TypeChecker {
     // 4. Check function calls, return types, and expressions
     checkScopes(scopes, ctx);
 
-    return { errors: this.deduplicateErrors(), scopes };
+    return { errors: this.applySuppressions(this.deduplicateErrors()), scopes };
+  }
+
+  private applySuppressions(errors: TypeCheckError[]): TypeCheckError[] {
+    if (this.sourceText === undefined) return errors;
+    return applySuppressions(errors, parseSuppressions(this.sourceText));
   }
 
   private deduplicateErrors(): TypeCheckError[] {

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -15,6 +15,7 @@ import type { SourceLocation } from "../types/base.js";
 import { TypeCheckError, TypeCheckResult, TypeCheckerContext } from "./types.js";
 import { validateTypeReferences } from "./validate.js";
 import { applySuppressions, parseSuppressions } from "./suppression.js";
+import { AGENCY_TEMPLATE_OFFSET } from "../parsers/parsers.js";
 import { inferReturnTypes } from "./inference.js";
 import { buildScopes } from "./scopes.js";
 import { checkScopes } from "./checker.js";
@@ -62,6 +63,7 @@ export class TypeChecker {
   private inferredReturnTypes: Record<string, VariableType | "any"> = {};
   private inferringReturnType = new Set<string>();
   private sourceText: string | undefined;
+  private templateApplied: boolean = true;
 
   constructor(program: AgencyProgram, config: AgencyConfig = {}, info?: CompilationUnit) {
     this.program = program;
@@ -74,6 +76,7 @@ export class TypeChecker {
     );
     this.importedFunctions = { ...resolved.importedFunctions };
     this.sourceText = resolved.sourceText;
+    this.templateApplied = resolved.templateApplied ?? true;
   }
 
   private get typeAliases(): Record<string, VariableType> {
@@ -202,7 +205,16 @@ export class TypeChecker {
 
   private applySuppressions(errors: TypeCheckError[]): TypeCheckError[] {
     if (this.sourceText === undefined) return errors;
-    return applySuppressions(errors, parseSuppressions(this.sourceText));
+    // When the source was parsed without the template wrapper, error
+    // loc.line is shifted by -AGENCY_TEMPLATE_OFFSET from raw-source 0-
+    // indexed lines (the convention parseSuppressions emits in). Pass
+    // that offset so applySuppressions can align them.
+    const lineOffset = this.templateApplied ? 0 : AGENCY_TEMPLATE_OFFSET;
+    return applySuppressions(
+      errors,
+      parseSuppressions(this.sourceText),
+      lineOffset,
+    );
   }
 
   private deduplicateErrors(): TypeCheckError[] {

--- a/packages/agency-lang/lib/typeChecker/suppression.test.ts
+++ b/packages/agency-lang/lib/typeChecker/suppression.test.ts
@@ -92,11 +92,11 @@ describe("applySuppressions", () => {
 });
 
 describe("typeCheck honors suppressions end-to-end", () => {
-  function check(source: string) {
-    const parseResult = parseAgency(source, {}, true);
+  function check(source: string, applyTemplate: boolean = true) {
+    const parseResult = parseAgency(source, {}, applyTemplate);
     if (!parseResult.success) throw new Error(`Parse failed: ${parseResult.message}`);
     const program = parseResult.result;
-    const info = buildCompilationUnit(program, undefined, undefined, source);
+    const info = buildCompilationUnit(program, undefined, undefined, source, applyTemplate);
     return typeCheck(program, {}, info);
   }
 
@@ -118,5 +118,18 @@ describe("typeCheck honors suppressions end-to-end", () => {
   it("@tc-nocheck mid-file is not honored", () => {
     const src = `def take(x: number): void { print(x) }\n\n// @tc-nocheck\nnode main() {\n  take("a")\n}\n`;
     expect(check(src).errors.length).toBeGreaterThan(0);
+  });
+
+  it("@tc-ignore works when source is parsed without the template (LSP path)", () => {
+    // LSP calls parseAgency(source, config, false). The parser shifts
+    // loc.line by -AGENCY_TEMPLATE_OFFSET in this mode, so suppression
+    // line numbers must be aligned with that shift to actually filter.
+    const src = `def take(x: number): void { print(x) }\n\nnode main() {\n  // @tc-ignore\n  take("not a number")\n}\n`;
+    expect(check(src, false).errors).toEqual([]);
+  });
+
+  it("@tc-nocheck works in LSP-mode parsing", () => {
+    const src = `// @tc-nocheck\ndef take(x: number): void { print(x) }\n\nnode main() {\n  take("a")\n}\n`;
+    expect(check(src, false).errors).toEqual([]);
   });
 });

--- a/packages/agency-lang/lib/typeChecker/suppression.test.ts
+++ b/packages/agency-lang/lib/typeChecker/suppression.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import { applySuppressions, parseSuppressions } from "./suppression.js";
+import type { TypeCheckError } from "./types.js";
+import { parseAgency } from "../parser.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+
+describe("parseSuppressions", () => {
+  it("returns empty defaults for source with no directives", () => {
+    const r = parseSuppressions(`def foo() {}\n`);
+    expect(r.nocheck).toBe(false);
+    expect(r.ignoreLines.size).toBe(0);
+  });
+
+  it("recognizes @tc-nocheck at the top of the file", () => {
+    const r = parseSuppressions(`// @tc-nocheck\ndef foo() {}\n`);
+    expect(r.nocheck).toBe(true);
+  });
+
+  it("recognizes @tc-nocheck after blank lines and other comments", () => {
+    const src = `// some banner\n\n// @tc-nocheck\ndef foo() {}\n`;
+    expect(parseSuppressions(src).nocheck).toBe(true);
+  });
+
+  it("ignores @tc-nocheck once code has appeared", () => {
+    const src = `def foo() {}\n// @tc-nocheck\n`;
+    expect(parseSuppressions(src).nocheck).toBe(false);
+  });
+
+  it("ignores @tc-nocheck on a trailing comment of a code line", () => {
+    // Trailing comments ("code // @tc-nocheck") aren't a leading directive
+    // — the line containing code is what ends the directive region.
+    const src = `def foo() {} // @tc-nocheck\n`;
+    expect(parseSuppressions(src).nocheck).toBe(false);
+  });
+
+  it("collects @tc-ignore lines, suppressing the line that follows", () => {
+    // line 0: let x = 1
+    // line 1: // @tc-ignore
+    // line 2: let y = 2  ← suppressed
+    const src = `let x = 1\n// @tc-ignore\nlet y = 2\n`;
+    const r = parseSuppressions(src);
+    expect(r.ignoreLines.has(2)).toBe(true);
+    expect(r.ignoreLines.has(1)).toBe(false);
+  });
+
+  it("supports multiple @tc-ignore directives", () => {
+    // lines: 0=ignore, 1=x, 2=y, 3=ignore, 4=z → suppress 1 and 4
+    const src = `// @tc-ignore\nlet x = 1\nlet y = 2\n// @tc-ignore\nlet z = 3\n`;
+    const r = parseSuppressions(src);
+    expect(r.ignoreLines.has(1)).toBe(true);
+    expect(r.ignoreLines.has(4)).toBe(true);
+  });
+
+  it("does not honor @tc-ignore on a trailing comment", () => {
+    // TS rule: only standalone comment lines suppress.
+    const src = `let x = 1 // @tc-ignore\nlet y = 2\n`;
+    const r = parseSuppressions(src);
+    expect(r.ignoreLines.has(1)).toBe(false);
+  });
+});
+
+describe("applySuppressions", () => {
+  const err = (line: number, message = "boom"): TypeCheckError => ({
+    message,
+    loc: { line, col: 0, start: 0, end: 0 },
+  });
+
+  it("returns the input unchanged when no suppressions apply", () => {
+    const errs = [err(1), err(5)];
+    const r = applySuppressions(errs, { nocheck: false, ignoreLines: new Set() });
+    expect(r).toEqual(errs);
+  });
+
+  it("drops every error when nocheck is set", () => {
+    const errs = [err(1), err(5)];
+    const r = applySuppressions(errs, { nocheck: true, ignoreLines: new Set([3]) });
+    expect(r).toEqual([]);
+  });
+
+  it("drops errors on ignored lines only", () => {
+    const errs = [err(2), err(3), err(4)];
+    const r = applySuppressions(errs, { nocheck: false, ignoreLines: new Set([3]) });
+    expect(r.map((e) => e.loc!.line)).toEqual([2, 4]);
+  });
+
+  it("never drops errors with no loc", () => {
+    const errs: TypeCheckError[] = [{ message: "global" }, err(3)];
+    const r = applySuppressions(errs, { nocheck: false, ignoreLines: new Set([3]) });
+    expect(r).toEqual([{ message: "global" }]);
+  });
+});
+
+describe("typeCheck honors suppressions end-to-end", () => {
+  function check(source: string) {
+    const parseResult = parseAgency(source, {}, true);
+    if (!parseResult.success) throw new Error(`Parse failed: ${parseResult.message}`);
+    const program = parseResult.result;
+    const info = buildCompilationUnit(program, undefined, undefined, source);
+    return typeCheck(program, {}, info);
+  }
+
+  it("@tc-ignore suppresses the next-line error", () => {
+    const src = `def take(x: number): void { print(x) }\n\nnode main() {\n  // @tc-ignore\n  take("not a number")\n}\n`;
+    expect(check(src).errors).toEqual([]);
+  });
+
+  it("without @tc-ignore the same error fires", () => {
+    const src = `def take(x: number): void { print(x) }\n\nnode main() {\n  take("not a number")\n}\n`;
+    expect(check(src).errors.length).toBeGreaterThan(0);
+  });
+
+  it("@tc-nocheck at top of file silences every error", () => {
+    const src = `// @tc-nocheck\ndef take(x: number): void { print(x) }\n\nnode main() {\n  take("a")\n  take(true)\n}\n`;
+    expect(check(src).errors).toEqual([]);
+  });
+
+  it("@tc-nocheck mid-file is not honored", () => {
+    const src = `def take(x: number): void { print(x) }\n\n// @tc-nocheck\nnode main() {\n  take("a")\n}\n`;
+    expect(check(src).errors.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/suppression.ts
+++ b/packages/agency-lang/lib/typeChecker/suppression.ts
@@ -53,13 +53,26 @@ export function parseSuppressions(source: string): Suppressions {
   return { nocheck, ignoreLines };
 }
 
+/**
+ * Drop errors covered by `suppressions`. `lineOffset` is subtracted from
+ * each ignoreLine before comparing against `error.loc.line` — needed when
+ * the parser produced loc.line values in a different convention than the
+ * raw-source 0-indexed lines `parseSuppressions` emits (e.g. LSP path,
+ * where `applyTemplate=false` shifts loc.line by -AGENCY_TEMPLATE_OFFSET).
+ */
 export function applySuppressions(
   errors: TypeCheckError[],
   suppressions: Suppressions,
+  lineOffset: number = 0,
 ): TypeCheckError[] {
   if (suppressions.nocheck) return [];
   if (suppressions.ignoreLines.size === 0) return errors;
-  return errors.filter(
-    (e) => !e.loc || !suppressions.ignoreLines.has(e.loc.line),
-  );
+  if (lineOffset === 0) {
+    return errors.filter(
+      (e) => !e.loc || !suppressions.ignoreLines.has(e.loc.line),
+    );
+  }
+  const adjusted = new Set<number>();
+  for (const line of suppressions.ignoreLines) adjusted.add(line - lineOffset);
+  return errors.filter((e) => !e.loc || !adjusted.has(e.loc.line));
 }

--- a/packages/agency-lang/lib/typeChecker/suppression.ts
+++ b/packages/agency-lang/lib/typeChecker/suppression.ts
@@ -54,11 +54,14 @@ export function parseSuppressions(source: string): Suppressions {
 }
 
 /**
- * Drop errors covered by `suppressions`. `lineOffset` is subtracted from
- * each ignoreLine before comparing against `error.loc.line` — needed when
- * the parser produced loc.line values in a different convention than the
- * raw-source 0-indexed lines `parseSuppressions` emits (e.g. LSP path,
- * where `applyTemplate=false` shifts loc.line by -AGENCY_TEMPLATE_OFFSET).
+ * Drop errors covered by `suppressions`. `lineOffset` is added to each
+ * `error.loc.line` before checking membership in `ignoreLines` — needed
+ * when the parser produced loc.line values in a different convention
+ * than the raw-source 0-indexed lines `parseSuppressions` emits. Pass
+ * `AGENCY_TEMPLATE_OFFSET` when the source was parsed with
+ * `applyTemplate=false`, since the parser still subtracts the offset
+ * from spans, leaving error loc.line shifted by `-AGENCY_TEMPLATE_OFFSET`
+ * relative to raw source.
  */
 export function applySuppressions(
   errors: TypeCheckError[],

--- a/packages/agency-lang/lib/typeChecker/suppression.ts
+++ b/packages/agency-lang/lib/typeChecker/suppression.ts
@@ -67,12 +67,7 @@ export function applySuppressions(
 ): TypeCheckError[] {
   if (suppressions.nocheck) return [];
   if (suppressions.ignoreLines.size === 0) return errors;
-  if (lineOffset === 0) {
-    return errors.filter(
-      (e) => !e.loc || !suppressions.ignoreLines.has(e.loc.line),
-    );
-  }
-  const adjusted = new Set<number>();
-  for (const line of suppressions.ignoreLines) adjusted.add(line - lineOffset);
-  return errors.filter((e) => !e.loc || !adjusted.has(e.loc.line));
+  return errors.filter(
+    (e) => !e.loc || !suppressions.ignoreLines.has(e.loc.line + lineOffset),
+  );
 }

--- a/packages/agency-lang/lib/typeChecker/suppression.ts
+++ b/packages/agency-lang/lib/typeChecker/suppression.ts
@@ -1,0 +1,65 @@
+import type { TypeCheckError } from "./types.js";
+
+export type Suppressions = {
+  /** True when `// @tc-nocheck` appears in the file's leading directive
+   * region — silences all typecheck errors for the file. */
+  nocheck: boolean;
+  /** 0-indexed line numbers where typecheck errors should be suppressed —
+   * matches the parser's `SourceLocation.line` convention. Populated for
+   * every line *following* a `// @tc-ignore` comment. */
+  ignoreLines: Set<number>;
+};
+
+const NOCHECK = "@tc-nocheck";
+const IGNORE = "@tc-ignore";
+
+/**
+ * Scan source text for typecheck-suppression directives:
+ *
+ *   // @tc-nocheck   — must appear in the file's leading directive region
+ *                     (only blank lines and other `//` comments before it);
+ *                     suppresses every typecheck error in the file.
+ *
+ *   // @tc-ignore    — suppresses typecheck errors on the next line.
+ *
+ * Only `//`-style comments are recognized. Trailing comments on a line of
+ * code do *not* count, matching TypeScript's `@ts-ignore` semantics.
+ */
+export function parseSuppressions(source: string): Suppressions {
+  const ignoreLines = new Set<number>();
+  let nocheck = false;
+  let leadingDirectiveRegion = true;
+
+  const lines = source.split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+
+    if (trimmed === "") continue; // blanks don't end the leading region
+
+    if (!trimmed.startsWith("//")) {
+      leadingDirectiveRegion = false;
+      continue;
+    }
+
+    const body = trimmed.slice(2).trim();
+    if (leadingDirectiveRegion && body.includes(NOCHECK)) {
+      nocheck = true;
+    }
+    if (body.includes(IGNORE)) {
+      ignoreLines.add(i + 1);
+    }
+  }
+
+  return { nocheck, ignoreLines };
+}
+
+export function applySuppressions(
+  errors: TypeCheckError[],
+  suppressions: Suppressions,
+): TypeCheckError[] {
+  if (suppressions.nocheck) return [];
+  if (suppressions.ignoreLines.size === 0) return errors;
+  return errors.filter(
+    (e) => !e.loc || !suppressions.ignoreLines.has(e.loc.line),
+  );
+}

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -421,7 +421,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
       ) => {
         const parsedProgram = parse(contents, config);
         const absPath = filePath ? path.resolve(filePath) : undefined;
-        const info = buildCompilationUnit(parsedProgram, symbolTable, absPath);
+        const info = buildCompilationUnit(parsedProgram, symbolTable, absPath, contents);
         const { errors } = typeCheck(parsedProgram, config, info);
         if (errors.length > 0) {
           console.error(formatErrors(errors));


### PR DESCRIPTION
## Summary

Four independent typechecker improvements stacked on this branch:

### 1. Pipe RHS placeholder count

A `functionCall` on the right of `|>` must contain exactly one `?` placeholder. Previously zero or 2+ silently passed typecheck and only failed at backend codegen with a thrown `Error`. Now surfaced as a typecheck diagnostic.

### 2. Block-type arity and assignability

- `call.block` (both trailing `as` blocks and inline `\... -> ...`) now counts toward arity. `f(x) as y { }` no longer looks like a 1-arg call to a 2-param function.
- `isAssignable` has a proper `blockType` case — contravariant in params, covariant in return — so identical block types pass and incompatible ones get a precise error.
- A check rejects calls that pass a block to a function with no block-typed param.

Block-body type-checking (walking the body in scope of the declared param types, checking returns against the declared return type) is left for a follow-up.

### 3. `// @tc-nocheck` and `// @tc-ignore`

TypeScript-style suppression directives, with `tc-` instead of `ts-` to avoid confusion with TS errors in the generated output. `@tc-nocheck` (top of file) silences every typecheck error in the file; `@tc-ignore` (own line) silences errors on the next line only. Implemented as a post-typecheck filter inside `typeCheck()` so callers don't have to remember to apply it.

### 4. Cross-file type alias resolution

Root cause of the type errors in `lib/agents/review/agent.agency`. `import { exec } from "std::shell"` previously brought in the `exec` function but not its `ExecResult` return type, so `r.exitCode` errored with "Property 'exitCode' does not exist on type 'ExecResult'." `buildCompilationUnit` now recursively walks every imported function/node signature and pulls referenced type aliases via `SymbolTable.findTypeAcrossFiles` into the global alias map. Terminates on cycles via a visited set.

## Docs

- `types.md` gains sections on `regex`, optional properties, excess properties, and the suppression directives.
- `llm.md` replaces "any Smoltalk option" prose with the typed table of options the typechecker now recognizes.

## Test plan

- [x] `pnpm test:run` — 2363 passing (16 new in `suppression.test.ts`, 6 new in `typeChecker.test.ts`)
- [x] `pnpm run agency typecheck lib/agents/review/agent.agency` — clean (was 4 errors)
- [x] Manual probes: pipe arity, block arity, block extra, identical/mismatched block types, `@tc-nocheck`, `@tc-ignore`, cross-file alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)
