### PR TITLE
feat(formatter): major formatter improvements

### DIFF
--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -62,7 +62,6 @@ export class AgencyGenerator {
   protected generatedTypeAliases: string[] = [];
   protected typeAliases: Record<string, VariableType> = {};
   protected functionsUsed: Set<string> = new Set();
-  protected importStatements: string[] = [];
   protected importNodes: ImportStatement[] = [];
   protected importedNodes: ImportNodeStatement[] = [];
   protected functionDefinitions: Record<string, FunctionDefinition> = {};
@@ -131,10 +130,9 @@ export class AgencyGenerator {
         stmtPairs.push({ type: node.type, code: result });
       }
     }
-    //console.log(JSON.stringify(stmtPairs, null, 2))
     // Join top-level statements: blank line between block declarations,
     // single newline between simple statements
-    const stmtLines: string[] = [];//stmtPairs.map((s => s.code));
+    const stmtLines: string[] = [];
     for (let i = 0; i < stmtPairs.length; i++) {
       if (i > 0) {
         const prev = stmtPairs[i - 1];
@@ -143,19 +141,17 @@ export class AgencyGenerator {
           (BLOCK_TYPES.has(prev.type) && !NO_SPACE_TYPES.has(curr.type)) ||
           (BLOCK_TYPES.has(curr.type) && !NO_SPACE_TYPES.has(prev.type))
         ) {
-          //console.log(`Adding blank line between ${prev.type} and ${curr.type}`);
           stmtLines.push(""); // blank line
         }
       }
       stmtLines.push(stmtPairs[i].code);
     }
-    //console.log(stmtLines.join("\n"))
+
     const output: string[] = [];
 
     this.addIfNonEmpty(this.sortAndRenderImports(), output);
     this.addIfNonEmpty(this.generatedTypeAliases.join("\n"), output);
     this.addIfNonEmpty(stmtLines.join("\n"), output);
-    //console.log(output)
 
     return {
       output: output.join("\n"),
@@ -637,12 +633,7 @@ export class AgencyGenerator {
       }
       return this.processNode(item).trim();
     });
-    const inline = `[${items.join(", ")}]`;
-    if (inline.length <= 80) return inline;
-    this.increaseIndent();
-    const indented = items.map((item) => this.indentStr(item));
-    this.decreaseIndent();
-    return `[\n${indented.join(",\n")}\n${this.indentStr("]")}`;
+    return this.wrapList(items, "", "[", "]");
   }
 
   protected processAgencyObject(node: AgencyObject): string {
@@ -925,9 +916,9 @@ export class AgencyGenerator {
     this.increaseIndent();
 
     if (node.docString) {
-      const docLines = [`"""`, ...node.docString.value.split("\n"), `"""`];
-      const docStr = docLines.join("\n");
-      //const docStr = docLines.map((line) => this.indentStr(line)).join("\n");
+      const lines = node.docString.value.split("\n").map(l => l.trim());
+      const docLines = [`"""`, ...lines, `"""`];
+      const docStr = docLines.map((line) => this.indentStr(line)).join("\n");
       result += `${docStr}\n`;
     }
 

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -26,7 +26,7 @@ import {
   AgencyObject,
   AgencyObjectKV,
 } from "../types/dataStructures.js";
-import { FunctionCall, FunctionDefinition } from "../types/function.js";
+import { FunctionCall, FunctionDefinition, FunctionParameter } from "../types/function.js";
 import { GraphNodeDefinition, Visibility } from "../types/graphNode.js";
 import { IfElse } from "../types/ifElse.js";
 import {
@@ -63,6 +63,7 @@ export class AgencyGenerator {
   protected typeAliases: Record<string, VariableType> = {};
   protected functionsUsed: Set<string> = new Set();
   protected importStatements: string[] = [];
+  protected importNodes: ImportStatement[] = [];
   protected importedNodes: ImportNodeStatement[] = [];
   protected functionDefinitions: Record<string, FunctionDefinition> = {};
   protected currentScope: Scope[] = [{ type: "global" }];
@@ -120,43 +121,42 @@ export class AgencyGenerator {
 
     // Types that should have a blank line before/after them at the top level
     const BLOCK_TYPES = new Set(["graphNode", "function", "typeAlias"]);
-    const NO_SPACE_TYPES = new Set(["comment", "multiLineComment", "tag"]);
+    const NO_SPACE_TYPES = new Set(["comment", "multiLineComment", "tag", "newLine"]);
 
     // Pass 5: Process all nodes and generate code
     const stmtPairs: { type: string; code: string }[] = [];
     for (const node of program.nodes) {
       const result = this.processNode(node);
-      if (result !== "") {
+      if (result !== "" || node.type === "newLine") {
         stmtPairs.push({ type: node.type, code: result });
       }
     }
-
+    //console.log(JSON.stringify(stmtPairs, null, 2))
     // Join top-level statements: blank line between block declarations,
     // single newline between simple statements
-    const stmtLines: string[] = [];
+    const stmtLines: string[] = [];//stmtPairs.map((s => s.code));
     for (let i = 0; i < stmtPairs.length; i++) {
       if (i > 0) {
         const prev = stmtPairs[i - 1];
         const curr = stmtPairs[i];
         if (
-          BLOCK_TYPES.has(prev.type) ||
+          (BLOCK_TYPES.has(prev.type) && !NO_SPACE_TYPES.has(curr.type)) ||
           (BLOCK_TYPES.has(curr.type) && !NO_SPACE_TYPES.has(prev.type))
         ) {
+          //console.log(`Adding blank line between ${prev.type} and ${curr.type}`);
           stmtLines.push(""); // blank line
         }
       }
       stmtLines.push(stmtPairs[i].code);
     }
-
+    //console.log(stmtLines.join("\n"))
     const output: string[] = [];
 
-    this.addIfNonEmpty(this.preprocess(), output);
-    this.addIfNonEmpty(this.importStatements.join("\n"), output);
-    this.addIfNonEmpty(this.generateImports(), output);
-    this.addIfNonEmpty(this.generateBuiltins(), output);
-    output.push(...this.generatedTypeAliases);
-    output.push(stmtLines.join("\n"));
-    this.addIfNonEmpty(this.postprocess(), output);
+    this.addIfNonEmpty(this.sortAndRenderImports(), output);
+    this.addIfNonEmpty(this.generatedTypeAliases.join("\n"), output);
+    this.addIfNonEmpty(stmtLines.join("\n"), output);
+    //console.log(output)
+
     return {
       output: output.join("\n"),
     };
@@ -230,10 +230,10 @@ export class AgencyGenerator {
       case "graphNode":
         return this.processGraphNode(node);
       case "importStatement":
-        this.importStatements.push(this.processImportStatement(node));
+        this.importNodes.push(node);
         return "";
       case "importNodeStatement":
-        this.importStatements.push(this.processImportNodeStatement(node));
+        this.importedNodes.push(node);
         return "";
       case "forLoop":
         return this.processForLoop(node);
@@ -344,6 +344,39 @@ export class AgencyGenerator {
 
   private indentStr(str: string): string {
     return `${this.indent()}${str}`;
+  }
+
+  // Wrapping helpers
+
+  private wrapList(
+    items: string[],
+    prefix: string,
+    open: string,
+    close: string,
+    suffix: string = "",
+  ): string {
+    const inline = `${prefix}${open}${items.join(", ")}${close}${suffix}`;
+    if (this.indentStr(inline).length <= 80) return inline;
+    this.increaseIndent();
+    const lines = items.map((item) => this.indentStr(`${item},`));
+    this.decreaseIndent();
+    return `${prefix}${open}\n${lines.join("\n")}\n${this.indent()}${close}${suffix}`;
+  }
+
+  private renderParams(parameters: FunctionParameter[]): string[] {
+    return parameters.map((p) => {
+      const prefix = p.variadic ? "..." : "";
+      const defaultSuffix = p.defaultValue
+        ? ` = ${this.processNode(p.defaultValue).trim()}`
+        : "";
+      if (p.typeHint) {
+        const typeStr = variableTypeToString(p.typeHint, this.typeAliases);
+        const bang = p.validated ? "!" : "";
+        return `${prefix}${p.name}: ${typeStr}${bang}${defaultSuffix}`;
+      } else {
+        return `${prefix}${p.name}${defaultSuffix}`;
+      }
+    });
   }
 
   // Type system methods
@@ -487,55 +520,35 @@ export class AgencyGenerator {
     const tags = this.formatAttachedTags(node);
     const { functionName, body, parameters } = node;
 
-    const params = parameters
-      .map((p) => {
-        const prefix = p.variadic ? "..." : "";
-        const defaultSuffix = p.defaultValue
-          ? ` = ${this.processNode(p.defaultValue).trim()}`
-          : "";
-        if (p.typeHint) {
-          const typeStr = variableTypeToString(p.typeHint, this.typeAliases);
-          const bang = p.validated ? "!" : "";
-          return `${prefix}${p.name}: ${typeStr}${bang}${defaultSuffix}`;
-        } else {
-          return `${prefix}${p.name}${defaultSuffix}`;
-        }
-      })
-      .join(", ");
-
     const returnTypeBang = node.returnTypeValidated ? "!" : "";
     const returnTypeStr = node.returnType
       ? ": " + variableTypeToString(node.returnType, this.typeAliases) + returnTypeBang
       : "";
 
-    let safePrefix = node.safe ? "safe " : "";
+    const prefixes: string[] = [];
+    if (node.exported) prefixes.push("export");
+    if (node.safe) prefixes.push("safe");
+    node.callback ? prefixes.push("callback") : prefixes.push("def");
 
-    const exportPrefix = node.exported ? "export " : "";
+    const prefix = `${prefixes.join(" ")} ${functionName}`;
+    const renderedParams = this.renderParams(parameters);
+    const signature = this.wrapList(renderedParams, prefix, "(", ")", `${returnTypeStr} {`);
 
-    const keyword = node.callback ? "callback" : "def";
-
-    let result = this.indentStr(
-      `${exportPrefix}${safePrefix}${keyword} ${functionName}(${params})${returnTypeStr} {\n`,
-    );
+    let result = this.indentStr(`${signature}\n`);
 
     this.increaseIndent();
 
     if (node.docString) {
-      const docLines = [`"""`, ...node.docString.value.split("\n"), `"""`];
+      const lines = node.docString.value.split("\n").map(l => l.trim());
+      const docLines = [`"""`, ...lines, `"""`];
       const docStr = docLines.map((line) => this.indentStr(line)).join("\n");
       result += `${docStr}\n`;
     }
 
-    const lines: string[] = [];
-    for (const stmt of body) {
-      lines.push(this.processNode(stmt));
+    const bodyStr = this.renderBody(body);
+    if (bodyStr.trim() !== "") {
+      result += bodyStr;
     }
-    const bodyCode =
-      lines
-        .filter((s) => s !== "")
-        .join("\n")
-        .trimEnd() + "\n";
-    result += bodyCode;
 
     this.decreaseIndent();
 
@@ -550,8 +563,8 @@ export class AgencyGenerator {
     return tags + this.indentStr(`${expr}`);
   }
 
-  // Render arguments (and optional inline block) into a parenthesized string: (arg1, arg2, \x -> expr)
-  protected renderArgList(args: FunctionCall["arguments"], block?: BlockArgument): string {
+  // Render each argument to a string array
+  protected renderArgs(args: FunctionCall["arguments"], block?: BlockArgument): string[] {
     const rendered = args.map((arg) => {
       if (arg.type === "namedArgument") {
         return `${arg.name}: ${this.processNode(arg.value).trim()}`;
@@ -572,6 +585,12 @@ export class AgencyGenerator {
       }
       rendered.push(`\\${params} -> ${exprStr}`);
     }
+    return rendered;
+  }
+
+  // Format args as inline parenthesized list (no wrapping — used by access chain callers)
+  protected renderArgList(args: FunctionCall["arguments"], block?: BlockArgument): string {
+    const rendered = this.renderArgs(args, block);
     return `(${rendered.join(", ")})`;
   }
 
@@ -587,7 +606,9 @@ export class AgencyGenerator {
     }
 
     const block = node.block;
-    let result = `${asyncPrefix}${node.functionName}${this.renderArgList(node.arguments, block?.inline ? block : undefined)}`;
+    const inlineBlock = block?.inline ? block : undefined;
+    const rendered = this.renderArgs(node.arguments, inlineBlock);
+    let result = this.wrapList(rendered, `${asyncPrefix}${node.functionName}`, "(", ")", "");
 
     if (block && !block.inline) {
       let asClause = "as ";
@@ -598,16 +619,8 @@ export class AgencyGenerator {
       }
 
       this.increaseIndent();
-      const bodyLines: string[] = [];
-      for (const stmt of block.body) {
-        bodyLines.push(this.processNode(stmt));
-      }
+      const bodyStr = this.renderBody(block.body);
       this.decreaseIndent();
-      const bodyStr =
-        bodyLines
-          .filter((s) => s !== "")
-          .join("\n")
-          .trimEnd() + "\n";
 
       result += ` ${asClause}{\n${bodyStr}${this.indentStr("}")}`;
     }
@@ -649,7 +662,7 @@ export class AgencyGenerator {
     }
     let entriesStr = "\n" + entries.join(",\n") + "\n";
 
-    return `{ ${entriesStr}` + this.indentStr("}");
+    return `{${entriesStr}` + this.indentStr("}");
   }
 
   private addQuotesToKey(key: string): string {
@@ -692,6 +705,11 @@ export class AgencyGenerator {
         continue;
       }
 
+      if (caseNode.type === "newLine") {
+        result += this.processNewLine(caseNode);
+        continue
+      }
+
       const pattern =
         caseNode.caseValue === "_"
           ? "_"
@@ -717,15 +735,7 @@ export class AgencyGenerator {
     let result = this.indentStr(`for (${vars} in ${iterableCode}) {\n`);
 
     this.increaseIndent();
-    const lines: string[] = [];
-    for (const stmt of node.body) {
-      lines.push(this.processNode(stmt));
-    }
-    result +=
-      lines
-        .filter((s) => s !== "")
-        .join("\n")
-        .trimEnd() + "\n";
+    result += this.renderBody(node.body);
     this.decreaseIndent();
 
     result += this.indentStr(`}`);
@@ -738,15 +748,7 @@ export class AgencyGenerator {
     let result = this.indentStr(`while (${conditionCode}) {\n`);
 
     this.increaseIndent();
-    const lines: string[] = [];
-    for (const stmt of node.body) {
-      lines.push(this.processNode(stmt));
-    }
-    result +=
-      lines
-        .filter((s) => s !== "")
-        .join("\n")
-        .trimEnd() + "\n";
+    result += this.renderBody(node.body);
     this.decreaseIndent();
 
     result += this.indentStr(`}`);
@@ -759,18 +761,9 @@ export class AgencyGenerator {
     const lines = [];
     lines.push(this.indentStr(`if (${conditionCode}) {\n`));
 
-    const bodyLines: string[] = [];
     this.increaseIndent();
-    for (const stmt of node.thenBody) {
-      bodyLines.push(this.processNode(stmt));
-    }
+    lines.push(this.renderBody(node.thenBody));
     this.decreaseIndent();
-    lines.push(
-      bodyLines
-        .filter((s) => s !== "")
-        .join("\n")
-        .trimEnd() + "\n",
-    );
 
     if (node.elseBody && node.elseBody.length > 0) {
       if (node.elseBody.length === 1 && node.elseBody[0].type === "ifElse") {
@@ -778,19 +771,10 @@ export class AgencyGenerator {
         lines.push(this.indentStr(`} else ${elseIfCode.trimStart()}`));
         return lines.join("");
       } else {
-        const elseBodyLines: string[] = [];
         lines.push(this.indentStr(`} else {\n`));
         this.increaseIndent();
-        for (const stmt of node.elseBody) {
-          elseBodyLines.push(this.processNode(stmt));
-        }
+        lines.push(this.renderBody(node.elseBody));
         this.decreaseIndent();
-        lines.push(
-          elseBodyLines
-            .filter((s) => s !== "")
-            .join("\n")
-            .trimEnd() + "\n",
-        );
       }
     }
 
@@ -834,16 +818,27 @@ export class AgencyGenerator {
   }
 
   protected processImportStatement(node: ImportStatement): string {
-    const importedNames = node.importedNames.map((name) =>
-      this.processImportNameType(name),
-    );
     const modulePath = node.modulePath.startsWith("std::")
       ? node.modulePath.replace(/\.agency$/, "")
       : node.modulePath;
-    const str = this.indentStr(
-      `import ${importedNames.join(", ")} from "${modulePath}"`,
+    const suffix = ` from "${modulePath}"`;
+
+    // For single named import, use wrapList
+    if (node.importedNames.length === 1 && node.importedNames[0].type === "namedImport") {
+      const namedImport = node.importedNames[0];
+      const names = namedImport.importedNames.map((name) => {
+        const alias = namedImport.aliases[name];
+        const base = alias ? `${name} as ${alias}` : name;
+        return namedImport.safeNames?.includes(name) ? `safe ${base}` : base;
+      });
+      return this.indentStr(this.wrapList(names, "import ", "{ ", " }", suffix));
+    }
+
+    // Default/namespace/mixed imports — always inline
+    const importedNames = node.importedNames.map((name) =>
+      this.processImportNameType(name),
     );
-    return str;
+    return this.indentStr(`import ${importedNames.join(", ")}${suffix}`);
   }
 
   protected processImportNameType(node: ImportNameType): string {
@@ -867,6 +862,40 @@ export class AgencyGenerator {
     return `import node { ${node.importedNodes.join(", ")} } from "${node.agencyFile}"`;
   }
 
+  private sortAndRenderImports(): string {
+    type ImportEntry = { modulePath: string; render: () => string };
+
+    const stdlib: ImportEntry[] = [];
+    const packages: ImportEntry[] = [];
+    const relative: ImportEntry[] = [];
+
+    for (const node of this.importNodes) {
+      const entry: ImportEntry = { modulePath: node.modulePath, render: () => this.processImportStatement(node) };
+      if (node.modulePath.startsWith("std::")) {
+        stdlib.push(entry);
+      } else if (node.modulePath.startsWith("pkg::")) {
+        packages.push(entry);
+      } else {
+        relative.push(entry);
+      }
+    }
+
+    for (const node of this.importedNodes) {
+      relative.push({ modulePath: node.agencyFile, render: () => this.processImportNodeStatement(node) });
+    }
+
+    const sort = (arr: ImportEntry[]) =>
+      arr.sort((a, b) => a.modulePath.localeCompare(b.modulePath));
+    sort(stdlib);
+    sort(packages);
+    sort(relative);
+
+    const groups = [stdlib, packages, relative]
+      .filter((g) => g.length > 0)
+      .map((g) => g.map((e) => e.render()).join("\n"));
+    return groups.join("\n\n");
+  }
+
 
   protected visibilityToString(vis: Visibility): string {
     switch (vis) {
@@ -882,42 +911,27 @@ export class AgencyGenerator {
   protected processGraphNode(node: GraphNodeDefinition): string {
     const tags = this.formatAttachedTags(node);
     const { nodeName, body, parameters } = node;
-    const params = parameters
-      .map((p) => {
-        if (p.typeHint) {
-          const bang = p.validated ? "!" : "";
-          return `${p.name}: ${variableTypeToString(p.typeHint, this.typeAliases)}${bang}`;
-        }
-        return p.name;
-      })
-      .join(", ");
     const returnTypeBang = node.returnTypeValidated ? "!" : "";
     const returnTypeStr = node.returnType
       ? ": " + variableTypeToString(node.returnType, this.typeAliases) + returnTypeBang
       : "";
     const visibilityStr = this.visibilityToString(node.visibility);
-    let result = this.indentStr(
-      `${visibilityStr}node ${nodeName}(${params})${returnTypeStr} {\n`,
-    );
+    const prefix = `${visibilityStr}node ${nodeName}`;
+    const renderedParams = this.renderParams(parameters);
+    const signature = this.wrapList(renderedParams, prefix, "(", ")", `${returnTypeStr} {`);
+
+    let result = this.indentStr(`${signature}\n`);
 
     this.increaseIndent();
 
     if (node.docString) {
       const docLines = [`"""`, ...node.docString.value.split("\n"), `"""`];
-      const docStr = docLines.map((line) => this.indentStr(line)).join("\n");
+      const docStr = docLines.join("\n");
+      //const docStr = docLines.map((line) => this.indentStr(line)).join("\n");
       result += `${docStr}\n`;
     }
 
-    const lines: string[] = [];
-    for (const stmt of body) {
-      lines.push(this.processNode(stmt));
-    }
-    const bodyCode =
-      lines
-        .filter((s) => s !== "")
-        .join("\n")
-        .trimEnd() + "\n";
-    result += bodyCode;
+    result += this.renderBody(body);
 
     this.decreaseIndent();
 
@@ -952,15 +966,7 @@ export class AgencyGenerator {
       result +=
         "\n" + this.indentStr(`${method.name}(${params})${returnTypeStr} {\n`);
       this.increaseIndent();
-      const methodLines: string[] = [];
-      for (const stmt of method.body) {
-        methodLines.push(this.processNode(stmt));
-      }
-      result +=
-        methodLines
-          .filter((s) => s !== "")
-          .join("\n")
-          .trimEnd() + "\n";
+      result += this.renderBody(method.body);
       this.decreaseIndent();
       result += this.indentStr(`}\n`);
     }
@@ -984,18 +990,21 @@ export class AgencyGenerator {
     return "";
   }
 
+  protected renderBody(body: AgencyNode[]): string {
+    const lines: string[] = [];
+    for (const stmt of body) {
+      const line = this.processNode(stmt);
+      if (line !== "" || stmt.type === "newLine") {
+        lines.push(line);
+      }
+    }
+    return lines.join("\n").trimEnd() + "\n";
+  }
+
   protected processMessageThread(node: MessageThread): string {
     this.increaseIndent();
-    const bodyCodes: string[] = [];
-    for (const stmt of node.body) {
-      bodyCodes.push(this.processNode(stmt));
-    }
+    const bodyCodeStr = this.renderBody(node.body);
     this.decreaseIndent();
-    const bodyCodeStr =
-      bodyCodes
-        .filter((s) => s !== "")
-        .join("\n")
-        .trimEnd() + "\n";
     const threadType = node.threadType;
     return this.indentStr(
       `${threadType} {\n${bodyCodeStr}${this.indentStr("}")}`,
@@ -1004,16 +1013,8 @@ export class AgencyGenerator {
 
   protected processParallelBlock(node: ParallelBlock): string {
     this.increaseIndent();
-    const bodyCodes: string[] = [];
-    for (const stmt of node.body) {
-      bodyCodes.push(this.processNode(stmt));
-    }
+    const bodyCodeStr = this.renderBody(node.body);
     this.decreaseIndent();
-    const bodyCodeStr =
-      bodyCodes
-        .filter((s) => s !== "")
-        .join("\n")
-        .trimEnd() + "\n";
     return this.indentStr(
       `parallel {\n${bodyCodeStr}${this.indentStr("}")}`,
     );
@@ -1021,16 +1022,8 @@ export class AgencyGenerator {
 
   protected processSeqBlock(node: SeqBlock): string {
     this.increaseIndent();
-    const bodyCodes: string[] = [];
-    for (const stmt of node.body) {
-      bodyCodes.push(this.processNode(stmt));
-    }
+    const bodyCodeStr = this.renderBody(node.body);
     this.decreaseIndent();
-    const bodyCodeStr =
-      bodyCodes
-        .filter((s) => s !== "")
-        .join("\n")
-        .trimEnd() + "\n";
     return this.indentStr(
       `seq {\n${bodyCodeStr}${this.indentStr("}")}`,
     );
@@ -1038,16 +1031,8 @@ export class AgencyGenerator {
 
   protected processHandleBlock(node: HandleBlock): string {
     this.increaseIndent();
-    const bodyCodes: string[] = [];
-    for (const stmt of node.body) {
-      bodyCodes.push(this.processNode(stmt));
-    }
+    const bodyCodeStr = this.renderBody(node.body);
     this.decreaseIndent();
-    const bodyCodeStr =
-      bodyCodes
-        .filter((s) => s !== "")
-        .join("\n")
-        .trimEnd() + "\n";
 
     let handlerStr: string;
     if (node.handler.kind === "inline") {
@@ -1056,16 +1041,8 @@ export class AgencyGenerator {
         ? `${node.handler.param.name}: ${variableTypeToString(node.handler.param.typeHint, this.typeAliases)}${handlerBang}`
         : node.handler.param.name;
       this.increaseIndent();
-      const handlerBodyCodes: string[] = [];
-      for (const stmt of node.handler.body) {
-        handlerBodyCodes.push(this.processNode(stmt));
-      }
+      const handlerBodyStr = this.renderBody(node.handler.body);
       this.decreaseIndent();
-      const handlerBodyStr =
-        handlerBodyCodes
-          .filter((s) => s !== "")
-          .join("\n")
-          .trimEnd() + "\n";
       handlerStr = `(${paramStr}) {\n${handlerBodyStr}${this.indentStr("}")}`;
     } else {
       handlerStr = node.handler.functionName;
@@ -1105,8 +1082,27 @@ export class AgencyGenerator {
     const rightStr = this.processNode(node.right).trim();
     const left = this.needsParensLeft(node.left, op) ? `(${leftStr})` : leftStr;
     const right = this.needsParensRight(node.right, op) ? `(${rightStr})` : rightStr;
-    const result = `${left} ${op} ${right}`;
-    return assigned ? result : this.indentStr(result);
+    const inline = `${left} ${op} ${right}`;
+
+    // For pipe chains, break into multiple lines if the inline version is too long
+    if (op === "|>" && inline.length > 80) {
+      const segments = this.flattenPipeChain(node);
+      const multiline = segments.join(`\n${this.indent()}|> `);
+      return assigned ? multiline : this.indentStr(multiline);
+    }
+
+    return assigned ? inline : this.indentStr(inline);
+  }
+
+  private flattenPipeChain(node: BinOpExpression): string[] {
+    const segments: string[] = [];
+    let current: BinOpArgument = node;
+    while (current.type === "binOpExpression" && current.operator === "|>") {
+      segments.unshift(this.processNode(current.right).trim());
+      current = current.left;
+    }
+    segments.unshift(this.processNode(current).trim());
+    return segments;
   }
 
   protected processAccessChainElement(node: AccessChainElement): string {
@@ -1160,5 +1156,8 @@ export class AgencyGenerator {
 
 export function generateAgency(program: AgencyProgram): string {
   const generator = new AgencyGenerator();
-  return generator.generate(program).output.trim();
+  return generator.generate(program).output
+    .trim()
+    .replace(/[ \t]+$/gm, "")
+    + "\n";
 }

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -21,7 +21,7 @@ import {
   RunStrategy,
   type ImportStrategy,
 } from "../importStrategy.js";
-import { parseAgency } from "../parser.js";
+import { parseAgency, replaceBlankLines } from "../parser.js";
 import { findRecursively, getImports } from "./util.js";
 
 // Load configuration from agency.json
@@ -240,7 +240,7 @@ export async function format(
   contents: string,
   config: AgencyConfig = {},
 ): Promise<string> {
-  const program = parse(contents, config, false);
+  const program = parse(replaceBlankLines(contents), config, false);
   return generateAgency(program);
 }
 

--- a/packages/agency-lang/lib/formatter.test.ts
+++ b/packages/agency-lang/lib/formatter.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { formatSource } from "./formatter.js";
+import fs from "fs";
+import path from "path";
 
 describe("formatSource", () => {
   it("does not inject stdlib imports when formatting user source", () => {
@@ -7,5 +9,135 @@ describe("formatSource", () => {
     expect(formatted).toContain("node main()");
     expect(formatted).not.toContain('import {');
     expect(formatted).not.toContain('"std::index"');
+  });
+
+  it("preserves blank lines between statements", () => {
+    const input = 'node main() {\n  print("a")\n\n  print("b")\n}\n';
+    const formatted = formatSource(input);
+    expect(formatted).toContain('print("a")\n\n  print("b")');
+  });
+
+  it("preserves multiple blank line regions", () => {
+    const input = 'node main() {\n  print("a")\n\n  print("b")\n\n  print("c")\n}\n';
+    const formatted = formatSource(input);
+    const matches = formatted!.match(/\n\n/g);
+    expect(matches?.length).toBe(2);
+  });
+
+  it("collapses multiple consecutive blank lines into one", () => {
+    const input = 'node main() {\n  print("a")\n\n\n\n  print("b")\n}\n';
+    const formatted = formatSource(input);
+    expect(formatted).toContain('print("a")\n\n  print("b")');
+    expect(formatted).not.toContain('\n\n\n');
+  });
+
+  it("output ends with exactly one trailing newline", () => {
+    const input = 'node main() {\n  print("a")\n}\n';
+    const formatted = formatSource(input);
+    expect(formatted).toMatch(/[^\n]\n$/);
+  });
+
+  it("removes trailing whitespace from lines", () => {
+    const input = 'node main() {\n  print("a")\n}\n';
+    const formatted = formatSource(input);
+    const lines = formatted!.split("\n");
+    for (const line of lines) {
+      expect(line).toBe(line.trimEnd());
+    }
+  });
+
+  it("keeps short function signatures on one line", () => {
+    const input = 'def add(a: number, b: number): number {\n  return a + b\n}\n';
+    const formatted = formatSource(input);
+    expect(formatted).toContain("def add(a: number, b: number): number {");
+  });
+
+  it("wraps long function signatures to multi-line", () => {
+    const input = 'def processData(inputFile: string, outputFile: string, format: string, verbose: boolean) {\n  return 1\n}\n';
+    const formatted = formatSource(input);
+    expect(formatted).toContain("def processData(\n");
+    expect(formatted).toContain("  inputFile: string,\n");
+    expect(formatted).toContain("  verbose: boolean,\n");
+    expect(formatted).toContain(") {");
+  });
+
+  it("wraps long node signatures to multi-line", () => {
+    const input = 'node handleRequest(message: string, context: string, options: string, verbose: boolean) {\n  return 1\n}\n';
+    const formatted = formatSource(input);
+    expect(formatted).toContain("node handleRequest(\n");
+    expect(formatted).toContain(") {");
+  });
+
+  it("keeps short function calls on one line", () => {
+    const input = 'node main() {\n  print("hello")\n}\n';
+    const formatted = formatSource(input);
+    expect(formatted).toContain('print("hello")');
+  });
+
+  it("wraps long function call arguments to multi-line", () => {
+    const input = 'node main() {\n  someFunction("a very long argument", "another long argument", "yet another", "and more")\n}\n';
+    const formatted = formatSource(input);
+    expect(formatted).toContain("someFunction(\n");
+    expect(formatted).toContain('"a very long argument",');
+  });
+
+  it("wraps long call arguments with trailing as block", () => {
+    const input = 'node main() {\n  const result = longFunctionName("very long first argument string here", "second long argument string") as item {\n    return item\n  }\n}\n';
+    const formatted = formatSource(input);
+    expect(formatted).toContain("longFunctionName(\n");
+    expect(formatted).toContain(") as item {");
+  });
+
+  it("keeps short imports on one line", () => {
+    const input = 'import { foo, bar } from "./utils.agency"\nnode main() {\n  print(1)\n}\n';
+    const formatted = formatSource(input);
+    expect(formatted).toContain('import { foo, bar } from "./utils.agency"');
+  });
+
+  it("wraps long named imports to multi-line", () => {
+    const input = 'import { alpha, bravo, charlie, delta, echo, foxtrot, golf } from "./utils.agency"\nnode main() {\n  print(1)\n}\n';
+    const formatted = formatSource(input);
+    expect(formatted).toContain("import {\n");
+    expect(formatted).toContain("  alpha,\n");
+    expect(formatted).toContain('} from "./utils.agency"');
+  });
+
+  it("preserves safe and alias in wrapped imports", () => {
+    const input = 'import { safe alpha, bravo as b, charlie, delta, echo, foxtrot } from "./utils.agency"\nnode main() {\n  print(1)\n}\n';
+    const formatted = formatSource(input);
+    expect(formatted).toContain("  safe alpha,");
+    expect(formatted).toContain("  bravo as b,");
+  });
+
+  it("sorts imports into groups: stdlib, packages, relative", () => {
+    const input = [
+      'import { bar } from "./bar.agency"',
+      'import { bash } from "std::shell"',
+      'import { foo } from "./foo.js"',
+      'import { mcp } from "pkg::@agency-lang/mcp"',
+      'node main() {',
+      '  print(1)',
+      '}',
+    ].join("\n") + "\n";
+    const formatted = formatSource(input);
+    const lines = formatted!.split("\n");
+    // stdlib first
+    expect(lines[0]).toBe('import { bash } from "std::shell"');
+    // blank line
+    expect(lines[1]).toBe('');
+    // packages
+    expect(lines[2]).toBe('import { mcp } from "pkg::@agency-lang/mcp"');
+    // blank line
+    expect(lines[3]).toBe('');
+    // relative (alphabetized)
+    expect(lines[4]).toBe('import { bar } from "./bar.agency"');
+    expect(lines[5]).toBe('import { foo } from "./foo.js"');
+  });
+
+  it("round-trips a correctly formatted file unchanged", () => {
+    const fixturePath = path.join(__dirname, "../tests/formatter/roundtrip.agency");
+    const input = fs.readFileSync(fixturePath, "utf-8");
+    const formatted = formatSource(input);
+    expect(formatted).toBe(input.trimEnd() + "\n");
   });
 });

--- a/packages/agency-lang/lib/formatter.test.ts
+++ b/packages/agency-lang/lib/formatter.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { formatSource } from "./formatter.js";
 import fs from "fs";
+import { fileURLToPath } from "url";
 import path from "path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe("formatSource", () => {
   it("does not inject stdlib imports when formatting user source", () => {

--- a/packages/agency-lang/lib/formatter.ts
+++ b/packages/agency-lang/lib/formatter.ts
@@ -1,13 +1,13 @@
 import { AgencyConfig } from "./config.js";
 import { generateAgency } from "./backends/agencyGenerator.js";
-import { parseAgency } from "./parser.js";
+import { parseAgency, replaceBlankLines } from "./parser.js";
 
 /**
  * Parse an Agency source string and return the formatted output.
  * Returns null if parsing fails.
  */
 export function formatSource(source: string, config: AgencyConfig = {}): string | null {
-  const result = parseAgency(source, config, false);
+  const result = parseAgency(replaceBlankLines(source), config, false);
   if (!result.success) return null;
   return generateAgency(result.result);
 }

--- a/packages/agency-lang/lib/parser.test.ts
+++ b/packages/agency-lang/lib/parser.test.ts
@@ -1,5 +1,39 @@
 import { describe, it, expect } from "vitest";
-import { agencyNode, agencyParser, parseAgency } from "./parser.js";
+import { agencyNode, agencyParser, parseAgency, replaceBlankLines } from "./parser.js";
+
+const S = "\uE000";
+
+describe("replaceBlankLines", () => {
+  it("replaces a simple blank line", () => {
+    const input = "a\n\nb";
+    expect(replaceBlankLines(input)).toBe(`a${S}\nb`);
+  });
+
+  it("replaces multiple consecutive blank lines", () => {
+    const input = "a\n\n\nb";
+    expect(replaceBlankLines(input)).toBe(`a${S}${S}\nb`);
+  });
+
+  it("preserves length", () => {
+    const input = "a\n\nb";
+    expect(replaceBlankLines(input).length).toBe(input.length);
+  });
+
+  it("does not touch non-blank lines", () => {
+    const input = "a\nb\nc";
+    expect(replaceBlankLines(input)).toBe("a\nb\nc");
+  });
+
+  it("handles blank line at start of input", () => {
+    const input = "\n\na";
+    expect(replaceBlankLines(input)).toBe(`${S}\na`);
+  });
+
+  it("handles blank line at end of input", () => {
+    const input = "a\n\n";
+    expect(replaceBlankLines(input)).toBe(`a${S}\n`);
+  });
+});
 
 describe("agencyNode", () => {
   const testCases = [

--- a/packages/agency-lang/lib/parser.ts
+++ b/packages/agency-lang/lib/parser.ts
@@ -113,7 +113,7 @@ export const normalizeCode = (code: string) => {
 };
 
 export function replaceBlankLines(input: string): string {
-  return input.replace(/\n\n+/g, (match) =>
+  return input.replace(/(\r?\n)(\r?\n)+/g, (match) =>
     BLANK_LINE_SENTINEL.repeat(match.length - 1) + "\n"
   );
 }

--- a/packages/agency-lang/lib/parser.ts
+++ b/packages/agency-lang/lib/parser.ts
@@ -41,6 +41,8 @@ import {
   messageThreadParser,
   multiLineCommentParser,
   newLineParser,
+  blankLineParser,
+  BLANK_LINE_SENTINEL,
   optionalSpacesOrNewline,
   returnStatementParser,
   staticAssignmentParser,
@@ -82,6 +84,7 @@ const nodeParser = or(
   valueAccessParser,
   multiLineCommentParser,
   commentParser,
+  blankLineParser,
   newLineParser,
 );
 
@@ -108,6 +111,12 @@ export const agencyParser: Parser<AgencyProgram> = seqC(
 export const normalizeCode = (code: string) => {
   return code;
 };
+
+export function replaceBlankLines(input: string): string {
+  return input.replace(/\n\n+/g, (match) =>
+    BLANK_LINE_SENTINEL.repeat(match.length - 1) + "\n"
+  );
+}
 
 export function _parseAgency(
   input: string,

--- a/packages/agency-lang/lib/parsers/blankLine.test.ts
+++ b/packages/agency-lang/lib/parsers/blankLine.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency, replaceBlankLines } from "../parser.js";
+
+function parseWithBlankLines(input: string) {
+  return parseAgency(replaceBlankLines(input), {}, false);
+}
+
+describe("blank line parsing", () => {
+  it("produces a newLine node for a blank line between statements", () => {
+    const input = `node main() {\n  print("a")\n\n  print("b")\n}\n`;
+    const result = parseWithBlankLines(input);
+    if (!result.success) throw new Error("parse failed");
+
+    const body = (result.result.nodes[0] as any).body;
+    const types = body.map((n: any) => n.type);
+    expect(types).toContain("newLine");
+  });
+
+  it("collapses multiple consecutive blank lines into one newLine node", () => {
+    const input = `node main() {\n  print("a")\n\n\n\n  print("b")\n}\n`;
+    const result = parseWithBlankLines(input);
+    if (!result.success) throw new Error("parse failed");
+
+    const body = (result.result.nodes[0] as any).body;
+    const newLines = body.filter((n: any) => n.type === "newLine");
+    expect(newLines.length).toBe(1);
+  });
+
+  it("does not produce newLine nodes when there are no blank lines", () => {
+    const input = `node main() {\n  print("a")\n  print("b")\n}\n`;
+    const result = parseWithBlankLines(input);
+    if (!result.success) throw new Error("parse failed");
+
+    const body = (result.result.nodes[0] as any).body;
+    const types = body.map((n: any) => n.type);
+    expect(types).not.toContain("newLine");
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -218,6 +218,8 @@ export const newLineParser: Parser<NewLine> = seqC(
 
 export const BLANK_LINE_SENTINEL = "\uE000";
 
+export const stripSentinels = (s: string) => s.replaceAll(BLANK_LINE_SENTINEL, "\n");
+
 export const blankLineParser: Parser<NewLine> = map(
   many1(char(BLANK_LINE_SENTINEL)),
   () => ({ type: "newLine" as const }),
@@ -255,10 +257,10 @@ export const multiLineCommentParser: Parser<AgencyMultiLineComment> = (
   );
   const result = parser(input);
   if (result.success) {
-    const content = result.result.content;
-    if (content.startsWith("*")) {
+    result.result.content = stripSentinels(result.result.content);
+    if (result.result.content.startsWith("*")) {
       result.result.isDoc = true;
-      result.result.content = content.slice(1);
+      result.result.content = result.result.content.slice(1);
     }
   }
   return result;
@@ -415,6 +417,9 @@ export const stringParser: Parser<StringLiteral> = label("a string", (input: str
       });
     }
   });
+  for (const seg of segments) {
+    if (seg.type === "text") seg.value = stripSentinels(seg.value);
+  }
   return success(
     {
       type: "string" as const,
@@ -424,15 +429,24 @@ export const stringParser: Parser<StringLiteral> = label("a string", (input: str
   );
 });
 
-export const multiLineStringParser: Parser<MultiLineStringLiteral> = seqC(
-  set("type", "multiLineString"),
-  str('"""'),
-  capture(
-    many(or(multiLineStringTextSegmentParser, interpolationSegmentParser)),
-    "segments",
-  ),
-  str('"""'),
-);
+export const multiLineStringParser: Parser<MultiLineStringLiteral> = (input: string) => {
+  const parser = seqC(
+    set("type", "multiLineString"),
+    str('"""'),
+    capture(
+      many(or(multiLineStringTextSegmentParser, interpolationSegmentParser)),
+      "segments",
+    ),
+    str('"""'),
+  );
+  const result = parser(input);
+  if (result.success) {
+    for (const seg of result.result.segments) {
+      if (seg.type === "text") seg.value = stripSentinels(seg.value);
+    }
+  }
+  return result;
+};
 
 export const variableNameParser: Parser<VariableNameLiteral> = label("an identifier", (
   input: string,
@@ -1144,7 +1158,7 @@ const namedArgumentParser: Parser<NamedArgument> = trace(
 // Used by both _functionCallParser and callChainParser.
 const argumentListParser = seqC(
   char("("),
-  optionalSpaces,
+  optionalSpacesOrNewline,
   capture(
     sepBy(
       comma,
@@ -1157,7 +1171,8 @@ const argumentListParser = seqC(
     ),
     "arguments",
   ),
-  optionalSpaces,
+  optional(comma),
+  optionalSpacesOrNewline,
   char(")"),
 );
 
@@ -1990,6 +2005,7 @@ const namedImportParser: Parser<NamedImport> = trace(
       char("{"),
       optionalSpacesOrNewline,
       capture(sepBy1(commaWithNewline, safeNameItem), "items"),
+      optional(commaWithNewline),
       optionalSpacesOrNewline,
       char("}"),
     ),
@@ -2150,15 +2166,22 @@ export const staticAssignmentParser: Parser<Assignment> = (input: string) => {
 };
 
 const trim = (s: string) => s.trim();
-export const docStringParser: Parser<DocString> = trace(
-  "docStringParser",
-  seqC(
-    set("type", "docString"),
-    str('"""'),
-    capture(map(many1Till(str('"""')), trim), "value"),
-    str('"""'),
-  ),
-);
+export const docStringParser: Parser<DocString> = (input: string) => {
+  const parser = trace(
+    "docStringParser",
+    seqC(
+      set("type", "docString"),
+      str('"""'),
+      capture(map(many1Till(str('"""')), trim), "value"),
+      str('"""'),
+    ),
+  );
+  const result = parser(input);
+  if (result.success) {
+    result.result.value = stripSentinels(result.result.value);
+  }
+  return result;
+};
 
 export const bodyParser = (input: string): ParserResult<AgencyNode[]> => {
   const bodyNodeParser = or(
@@ -2594,7 +2617,8 @@ const _baseFunctionParser: Parser<any> = trace(
       ),
       "parameters",
     ),
-    optionalSpaces,
+    optional(comma),
+    optionalSpacesOrNewline,
     char(")"),
     optionalSpaces,
     capture(optional(functionReturnTypeParser), "returnType"),
@@ -2793,6 +2817,7 @@ const classMethodParser: Parser<ClassMethod> = map(
       sepBy(comma, or(variadicParameterParser, functionParameterParser)),
       "parameters",
     ),
+    optional(comma),
     optionalSpaces,
     char(")"),
     optionalSpaces,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -216,6 +216,13 @@ export const newLineParser: Parser<NewLine> = seqC(
   or(str("\r\n"), str("\n")),
 );
 
+export const BLANK_LINE_SENTINEL = "\uE000";
+
+export const blankLineParser: Parser<NewLine> = map(
+  many1(char(BLANK_LINE_SENTINEL)),
+  () => ({ type: "newLine" as const }),
+);
+
 // =============================================================================
 // comment.ts
 // =============================================================================
@@ -225,7 +232,7 @@ export const commentParser: Parser<AgencyComment> = (input: string) => {
     set("type", "comment"),
     optionalSpaces,
     str("//"),
-    capture(manyTill(newline), "content"),
+    capture(manyTill(or(newline, blankLineParser)), "content"),
     optionalSpacesOrNewline,
   );
   return parser(input);
@@ -1887,7 +1894,7 @@ export const matchBlockParser = label("a match block", withLoc(seqC(
     parseError(
       "expected match cases of the form `value => expression` separated by `;` or newlines, followed by `}`",
       optionalSpacesOrNewline,
-      capture(many(or(commentParser, matchBlockParserCase)), "cases"),
+      capture(many(or(blankLineParser, commentParser, matchBlockParserCase)), "cases"),
       optionalSpaces,
       char("}"),
     ),
@@ -1930,9 +1937,9 @@ export const importNodeStatmentParser: Parser<ImportNodeStatement> = trace(
         "expected a statement of the form `import nodes { x, y } from 'filename.agency'`",
         spaces,
         char("{"),
-        optionalSpaces,
-        capture(sepBy1(comma, many1WithJoin(varNameChar)), "importedNodes"),
-        optionalSpaces,
+        optionalSpacesOrNewline,
+        capture(sepBy1(commaWithNewline, many1WithJoin(varNameChar)), "importedNodes"),
+        optionalSpacesOrNewline,
         char("}"),
         spaces,
         str("from"),
@@ -1981,9 +1988,9 @@ const namedImportParser: Parser<NamedImport> = trace(
   map(
     seqC(
       char("{"),
-      optionalSpaces,
-      capture(sepBy1(comma, safeNameItem), "items"),
-      optionalSpaces,
+      optionalSpacesOrNewline,
+      capture(sepBy1(commaWithNewline, safeNameItem), "items"),
+      optionalSpacesOrNewline,
       char("}"),
     ),
     (result) => {
@@ -2179,6 +2186,7 @@ export const bodyParser = (input: string): ParserResult<AgencyNode[]> => {
     booleanParser,
     valueAccessParser,
     literalParser,
+    blankLineParser,
     newLineParser,
   );
   const parser = trace(
@@ -2813,6 +2821,7 @@ const classBodyMemberParser = or(
   rejectConstructorParser,
   classMethodParser,
   classFieldParser,
+  blankLineParser,
 );
 
 const _classParserInner: Parser<ClassDefinition> = (input: string) => {
@@ -2855,6 +2864,7 @@ const _classParserInner: Parser<ClassDefinition> = (input: string) => {
     } else if (member.type === "classMethod") {
       methods.push(member);
     }
+    // Skip newLine nodes from blank lines
   }
 
   const parentClass = result.result._extends?.parentClass;

--- a/packages/agency-lang/lib/preprocessors/parallelDesugar.ts
+++ b/packages/agency-lang/lib/preprocessors/parallelDesugar.ts
@@ -165,6 +165,7 @@ function walkForBindings(node: AgencyNode, binds: Set<string>): void {
   if (node.type === "matchBlock") {
     for (const c of node.cases) {
       if (c.type === "comment") continue;
+      if (c.type === "newLine") continue;
       walkForBindings(c.body as any, binds);
     }
     return;
@@ -439,6 +440,7 @@ function descendIntoSubstructures(node: AgencyNode): void {
     case "matchBlock":
       for (const c of node.cases) {
         if (c.type === "comment") continue;
+        if (c.type === "newLine") continue;
         c.body = desugarParallelInBody([c.body as any])[0] as any;
       }
       return;

--- a/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
+++ b/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
@@ -51,6 +51,7 @@ function walkBody(
     } else if (node.type === "matchBlock") {
       for (const caseItem of node.cases) {
         if (caseItem.type === "comment") continue;
+        if (caseItem.type === "newLine") continue;
         caseItem.body = walkBody([caseItem.body], fn)[0] as any;
       }
     } else if (node.type === "handleBlock") {
@@ -117,7 +118,7 @@ function attachTags(nodes: AgencyNode[]): AgencyNode[] {
 
     if (pendingTags.length > 0) {
       if (node.type === "graphNode" || node.type === "function" ||
-          node.type === "assignment" || node.type === "functionCall") {
+        node.type === "assignment" || node.type === "functionCall") {
         node.tags = [...(node.tags || []), ...pendingTags];
         pendingTags = [];
       } else {
@@ -1187,6 +1188,9 @@ export class TypescriptPreprocessor {
       } else if (node.type === "matchBlock") {
         node.cases = node.cases.map((caseItem) => {
           if (caseItem.type === "comment") {
+            return caseItem;
+          }
+          if (caseItem.type === "newLine") {
             return caseItem;
           }
           return {

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -217,6 +217,7 @@ export function walkScopeBody(
       case "matchBlock":
         for (const caseItem of node.cases) {
           if (caseItem.type === "comment") continue;
+          if (caseItem.type === "newLine") continue;
           walkScopeBody([caseItem.body], scope, ctx);
         }
         break;

--- a/packages/agency-lang/lib/types/matchBlock.ts
+++ b/packages/agency-lang/lib/types/matchBlock.ts
@@ -1,4 +1,4 @@
-import { Assignment, AgencyComment, Expression } from "../types.js";
+import { Assignment, AgencyComment, Expression, NewLine } from "../types.js";
 import { BaseNode } from "./base.js";
 import { ReturnStatement } from "./returnStatement.js";
 
@@ -13,5 +13,5 @@ export type MatchBlockCase = {
 export type MatchBlock = BaseNode & {
   type: "matchBlock";
   expression: Expression;
-  cases: (MatchBlockCase | AgencyComment)[];
+  cases: (MatchBlockCase | AgencyComment | NewLine)[];
 };

--- a/packages/agency-lang/lib/utils/markdown.ts
+++ b/packages/agency-lang/lib/utils/markdown.ts
@@ -3,7 +3,7 @@ export function heading(level: number, text: string): string {
 }
 
 export function codeFence(code: string, lang: string = "ts"): string {
-  return `\`\`\`${lang}\n${code}\n\`\`\``;
+  return `\`\`\`${lang}\n${code.trimEnd()}\n\`\`\``;
 }
 
 export function bold(text: string): string {

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -176,6 +176,7 @@ export function* getAllVariablesInBody(
     } else if (node.type === "matchBlock") {
       for (const caseItem of node.cases) {
         if (caseItem.type === "comment") continue;
+        if (caseItem.type === "newLine") continue;
         if (caseItem.caseValue === "_") continue;
         yield* getAllVariablesInBody([caseItem.caseValue]);
       }
@@ -360,6 +361,7 @@ export function* walkNodes(
       yield* walkNodes([node.expression], [...ancestors, node], scopes);
       for (const caseItem of node.cases) {
         if (caseItem.type === "comment") continue;
+        if (caseItem.type === "newLine") continue;
         if (caseItem.caseValue !== "_") {
           yield* walkNodes([caseItem.caseValue], [...ancestors, node], scopes);
         }

--- a/packages/agency-lang/tests/formatter/roundtrip.agency
+++ b/packages/agency-lang/tests/formatter/roundtrip.agency
@@ -1,0 +1,125 @@
+import { bar as baz } from "./bar.agency"
+import { foo } from "./foo.js"
+
+type Person = {
+  name: string;
+  age: number
+}
+
+type Status = "active" | "inactive"
+
+// A simple helper function
+def greet(name: string): string {
+  """
+  This function takes a name and returns a greeting message.
+  It demonstrates a multi-line docstring that should be preserved
+  during formatting. The docstring can include details about the function's
+  parameters, return value, and any other relevant information.
+  """
+  return "Hello, ${name}!"
+}
+
+safe def add(a: number, b: number): number {
+  return a + b
+}
+
+def withDefaults(x: number, y: number = 10) {
+  return add(x, y)
+}
+
+def withBlock(items: string[], block: (string) => string): string[] {
+  const result = []
+  for (item in items) {
+    result.push(block(item))
+  }
+  return result
+}
+
+def validated(arg: string!): string! {
+  if (arg.length < 5) {
+    const issue = "short"
+    return failure("Argument too ${issue}")
+  }
+  return arg
+}
+
+def tail(str: string): string {
+  if (str.length === 0) {
+    return ""
+  }
+  return str.substring(1)
+}
+
+node main(message: string) {
+  const greeting = greet("world")
+  print(greeting)
+
+  let x = 5
+  let y = 10
+
+  if (x > 3) {
+    print("x is big")
+  } else {
+    print("x is small")
+  }
+
+  for (item in ["a", "b", "c"]) {
+    print(item)
+  }
+
+  while (x > 0) {
+    x = x - 1
+  }
+
+  const person: Person = {
+    name: "Alice",
+    age: 30
+  }
+  const items = [1, 2, 3]
+
+  thread {
+    const result = llm("Say hello")
+  }
+
+  subthread {
+    const other = llm("Say goodbye")
+  }
+
+  match(person.name) {
+    "Alice" => print("Found Alice")
+    "Bob" => print("Found Bob")
+    _ => print("Unknown")
+  }
+
+  handle {
+    const name = "alice"
+    const data = llm("Do something risky with the name ${name}")
+  } with (data) {
+    return approve()
+  }
+
+  const foo = read("foo.txt") with reject
+
+  const mapped = map(items) as item {
+    return item + 1
+  }
+
+  const inlined = map(items, \item -> item + 1)
+
+  const orDef = try validated("hi") catch "default"
+
+  const chopped = validated("greeting")
+  |> validated
+  |> validated
+  |> validated
+  |> validated
+  |> validated + " world"
+
+  const res = 1 + 3.14 + 2.71 + 100 + 100000
+
+  return greeting
+}
+
+node other() {
+  return main("test")
+}


### PR DESCRIPTION
## Summary

- Preserve blank lines through parse/format round-trip using a Unicode sentinel pre-pass (formatter-only, does not affect compilation or LSP)
- Line-length wrapping (>80 chars) for function/node signatures, call arguments, imports, and pipe chains
- Import sorting: stdlib → packages → relative, alphabetized within groups
- Trailing newline enforcement and trailing whitespace removal
- Single `wrapList` helper for all wrapping decisions — measures full line including indentation

## Test plan

- [x] All 2356 existing tests pass
- [x] New round-trip test: correctly formatted file stays unchanged through formatter
- [x] Blank line preservation tests (single, multiple regions, collapse)
- [x] Wrapping tests (short stays inline, long wraps correctly)
- [x] Import sorting test
- [x] Trailing newline/whitespace tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)