### PR TITLE
Add std::sms (Twilio) and std::imessage stdlib modules

### DIFF
--- a/packages/agency-lang/stdlib/imessage.agency
+++ b/packages/agency-lang/stdlib/imessage.agency
@@ -1,0 +1,30 @@
+import { _sendIMessage } from "./lib/imessage.js"
+
+type IMessageResult = {
+  sent: boolean
+}
+
+/**
+  ## Usage
+
+  ```ts
+  import { sendIMessage } from "std::imessage"
+
+  node main() {
+    const result = sendIMessage("+15551234567", "Hello from my agent!")
+    print(result)
+  }
+  ```
+
+  ## Requirements
+  - macOS only
+  - Messages.app must be signed in to iMessage
+  - No API key required
+*/
+
+export def sendIMessage(to: string, message: string): Result {
+  """
+  Send an iMessage via the macOS Messages app. Only works on macOS with Messages.app signed in. Parameters: to (phone number or email address of the recipient), message (the text to send). No API key or account required.
+  """
+  return try _sendIMessage(to, message)
+}

--- a/packages/agency-lang/stdlib/lib/__tests__/imessage.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/imessage.test.ts
@@ -93,15 +93,17 @@ describe("_sendIMessage", () => {
     );
   });
 
-  it("throws with descriptive error when osascript fails", async () => {
+  it("throws with stderr info when osascript fails, without leaking script contents", async () => {
     (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
-      (_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
-        cb(new Error("Messages app not available"));
+      (_cmd: string, _args: string[], cb: (err: unknown) => void) => {
+        cb({ stderr: "execution error: Messages got an error", code: 1 });
       }
     );
 
-    await expect(_sendIMessage("+15551234567", "Hi")).rejects.toThrow(
-      "Failed to send iMessage: Messages app not available"
-    );
+    const err = await _sendIMessage("+15551234567", "Hi").catch((e) => e);
+    expect(err.message).toContain("Failed to send iMessage:");
+    expect(err.message).toContain("execution error");
+    // Should NOT contain the phone number or message in the error
+    expect(err.message).not.toContain("+15551234567");
   });
 });

--- a/packages/agency-lang/stdlib/lib/__tests__/imessage.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/imessage.test.ts
@@ -56,6 +56,25 @@ describe("_sendIMessage", () => {
     expect(script).toContain("path\\\\to\\\\file");
   });
 
+  it("escapes newlines to prevent AppleScript injection", async () => {
+    await _sendIMessage("+15551234567", "line1\nline2\rline3\r\nline4");
+
+    const [, args] = (execFile as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const script = args[1];
+    // All line breaks should be escaped as \n, not literal newlines in the AppleScript string
+    expect(script).toContain("line1\\nline2\\nline3\\nline4");
+    // Should not contain unescaped newlines within the send command's string literal
+    expect(script.match(/send "[^"]*\n[^"]*"/)).toBeNull();
+  });
+
+  it("escapes tabs", async () => {
+    await _sendIMessage("+15551234567", "col1\tcol2");
+
+    const [, args] = (execFile as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const script = args[1];
+    expect(script).toContain("col1\\tcol2");
+  });
+
   it("throws on non-macOS platforms", async () => {
     Object.defineProperty(process, "platform", { value: "linux", writable: true });
 

--- a/packages/agency-lang/stdlib/lib/__tests__/imessage.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/imessage.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { _sendIMessage } from "../imessage.js";
+
+vi.mock("child_process", () => ({
+  execFile: vi.fn((_cmd: string, _args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+    cb(null, { stdout: "", stderr: "" });
+  }),
+}));
+
+import { execFile } from "child_process";
+
+describe("_sendIMessage", () => {
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+  });
+
+  it("calls osascript with AppleScript", async () => {
+    const result = await _sendIMessage("+15551234567", "Hello!");
+
+    expect(result).toEqual({ sent: true });
+    expect(execFile).toHaveBeenCalledWith(
+      "osascript",
+      ["-e", expect.stringContaining("+15551234567")],
+      expect.any(Function)
+    );
+  });
+
+  it("includes message in script", async () => {
+    await _sendIMessage("+15551234567", "Test message");
+
+    const [, args] = (execFile as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(args[1]).toContain("Test message");
+  });
+
+  it("escapes double quotes in recipient and message", async () => {
+    await _sendIMessage('user"@test.com', 'say "hello"');
+
+    const [, args] = (execFile as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const script = args[1];
+    expect(script).toContain('user\\"@test.com');
+    expect(script).toContain('say \\"hello\\"');
+  });
+
+  it("escapes backslashes", async () => {
+    await _sendIMessage("+15551234567", "path\\to\\file");
+
+    const [, args] = (execFile as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const script = args[1];
+    expect(script).toContain("path\\\\to\\\\file");
+  });
+
+  it("throws on non-macOS platforms", async () => {
+    Object.defineProperty(process, "platform", { value: "linux", writable: true });
+
+    await expect(_sendIMessage("+15551234567", "Hi")).rejects.toThrow(
+      "only available on macOS"
+    );
+  });
+
+  it("throws when recipient is empty", async () => {
+    await expect(_sendIMessage("", "Hi")).rejects.toThrow("Missing recipient");
+  });
+
+  it("throws when message is empty", async () => {
+    await expect(_sendIMessage("+15551234567", "")).rejects.toThrow(
+      "Missing message body"
+    );
+  });
+
+  it("throws with descriptive error when osascript fails", async () => {
+    (execFile as unknown as ReturnType<typeof vi.fn>).mockImplementation(
+      (_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
+        cb(new Error("Messages app not available"));
+      }
+    );
+
+    await expect(_sendIMessage("+15551234567", "Hi")).rejects.toThrow(
+      "Failed to send iMessage: Messages app not available"
+    );
+  });
+});

--- a/packages/agency-lang/stdlib/lib/__tests__/sms.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/sms.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { _sendSms } from "../sms.js";
+
+function mockFetchResponse(body: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  });
+}
+
+describe("_sendSms", () => {
+  const originalFetch = globalThis.fetch;
+  const originalSid = process.env.TWILIO_ACCOUNT_SID;
+  const originalToken = process.env.TWILIO_AUTH_TOKEN;
+  const originalFrom = process.env.TWILIO_FROM_NUMBER;
+
+  beforeEach(() => {
+    process.env.TWILIO_ACCOUNT_SID = "AC_test_sid";
+    process.env.TWILIO_AUTH_TOKEN = "test_auth_token";
+    process.env.TWILIO_FROM_NUMBER = "+15550001234";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalSid !== undefined) process.env.TWILIO_ACCOUNT_SID = originalSid;
+    else delete process.env.TWILIO_ACCOUNT_SID;
+    if (originalToken !== undefined) process.env.TWILIO_AUTH_TOKEN = originalToken;
+    else delete process.env.TWILIO_AUTH_TOKEN;
+    if (originalFrom !== undefined) process.env.TWILIO_FROM_NUMBER = originalFrom;
+    else delete process.env.TWILIO_FROM_NUMBER;
+  });
+
+  it("sends SMS to correct Twilio endpoint", async () => {
+    const mockFetch = mockFetchResponse({ sid: "SM123", status: "queued" });
+    globalThis.fetch = mockFetch;
+
+    await _sendSms("+15559876543", "Hello!");
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe(
+      "https://api.twilio.com/2010-04-01/Accounts/AC_test_sid/Messages.json"
+    );
+    expect(init.method).toBe("POST");
+  });
+
+  it("uses Basic Auth with SID:Token", async () => {
+    const mockFetch = mockFetchResponse({ sid: "SM123", status: "queued" });
+    globalThis.fetch = mockFetch;
+
+    await _sendSms("+15559876543", "Hello!");
+
+    const [, init] = mockFetch.mock.calls[0];
+    const expected = Buffer.from("AC_test_sid:test_auth_token").toString("base64");
+    expect(init.headers["Authorization"]).toBe(`Basic ${expected}`);
+  });
+
+  it("sends correct form data", async () => {
+    const mockFetch = mockFetchResponse({ sid: "SM456", status: "queued" });
+    globalThis.fetch = mockFetch;
+
+    await _sendSms("+15559876543", "Test message");
+
+    const [, init] = mockFetch.mock.calls[0];
+    const params = new URLSearchParams(init.body);
+    expect(params.get("To")).toBe("+15559876543");
+    expect(params.get("From")).toBe("+15550001234");
+    expect(params.get("Body")).toBe("Test message");
+  });
+
+  it("returns sid and status", async () => {
+    globalThis.fetch = mockFetchResponse({ sid: "SM789", status: "queued" });
+
+    const result = await _sendSms("+15559876543", "Hi");
+
+    expect(result).toEqual({ sid: "SM789", status: "queued" });
+  });
+
+  it("uses option params over env vars", async () => {
+    const mockFetch = mockFetchResponse({ sid: "SM000", status: "queued" });
+    globalThis.fetch = mockFetch;
+
+    await _sendSms("+15559876543", "Hi", {
+      accountSid: "AC_override",
+      authToken: "override_token",
+      from: "+15551111111",
+    });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toContain("AC_override");
+    const expected = Buffer.from("AC_override:override_token").toString("base64");
+    expect(init.headers["Authorization"]).toBe(`Basic ${expected}`);
+    const params = new URLSearchParams(init.body);
+    expect(params.get("From")).toBe("+15551111111");
+  });
+
+  it("throws when no account SID", async () => {
+    delete process.env.TWILIO_ACCOUNT_SID;
+    await expect(_sendSms("+15559876543", "Hi")).rejects.toThrow(
+      "TWILIO_ACCOUNT_SID"
+    );
+  });
+
+  it("throws when no auth token", async () => {
+    delete process.env.TWILIO_AUTH_TOKEN;
+    await expect(_sendSms("+15559876543", "Hi")).rejects.toThrow(
+      "TWILIO_AUTH_TOKEN"
+    );
+  });
+
+  it("throws when no from number", async () => {
+    delete process.env.TWILIO_FROM_NUMBER;
+    await expect(_sendSms("+15559876543", "Hi")).rejects.toThrow(
+      "TWILIO_FROM_NUMBER"
+    );
+  });
+
+  it("throws on error response", async () => {
+    globalThis.fetch = mockFetchResponse({ message: "Invalid number" }, 400);
+    await expect(_sendSms("+15559876543", "Hi")).rejects.toThrow(
+      "Twilio API error (400)"
+    );
+  });
+
+  it("URL-encodes account SID in path", async () => {
+    const mockFetch = mockFetchResponse({ sid: "SM123", status: "queued" });
+    globalThis.fetch = mockFetch;
+
+    await _sendSms("+15559876543", "Hi", {
+      accountSid: "AC test/weird",
+      authToken: "token",
+      from: "+15550001234",
+    });
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("AC%20test%2Fweird");
+  });
+});

--- a/packages/agency-lang/stdlib/lib/__tests__/sms.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/sms.test.ts
@@ -123,6 +123,19 @@ describe("_sendSms", () => {
     );
   });
 
+  it("throws when to is empty", async () => {
+    await expect(_sendSms("", "Hi")).rejects.toThrow("Missing recipient");
+  });
+
+  it("throws when to is not E.164 format", async () => {
+    await expect(_sendSms("5551234567", "Hi")).rejects.toThrow("E.164");
+    await expect(_sendSms("not-a-number", "Hi")).rejects.toThrow("E.164");
+  });
+
+  it("throws when body is empty", async () => {
+    await expect(_sendSms("+15559876543", "")).rejects.toThrow("Missing message body");
+  });
+
   it("URL-encodes account SID in path", async () => {
     const mockFetch = mockFetchResponse({ sid: "SM123", status: "queued" });
     globalThis.fetch = mockFetch;

--- a/packages/agency-lang/stdlib/lib/imessage.ts
+++ b/packages/agency-lang/stdlib/lib/imessage.ts
@@ -1,0 +1,47 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+export type IMessageResult = {
+  sent: boolean;
+};
+
+export async function _sendIMessage(
+  to: string,
+  message: string
+): Promise<IMessageResult> {
+  if (process.platform !== "darwin") {
+    throw new Error("iMessage is only available on macOS.");
+  }
+
+  if (!to) {
+    throw new Error("Missing recipient. Provide a phone number or email address.");
+  }
+
+  if (!message) {
+    throw new Error("Missing message body.");
+  }
+
+  // Use AppleScript via osascript to send an iMessage
+  const script = `
+    tell application "Messages"
+      set targetService to 1st account whose service type = iMessage
+      set targetBuddy to participant "${escapedAppleScript(to)}" of targetService
+      send "${escapedAppleScript(message)}" to targetBuddy
+    end tell
+  `;
+
+  try {
+    await execFileAsync("osascript", ["-e", script]);
+    return { sent: true };
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to send iMessage: ${msg}`);
+  }
+}
+
+function escapedAppleScript(str: string): string {
+  // Escape backslashes first, then double quotes
+  return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}

--- a/packages/agency-lang/stdlib/lib/imessage.ts
+++ b/packages/agency-lang/stdlib/lib/imessage.ts
@@ -34,9 +34,12 @@ export async function _sendIMessage(
   try {
     await execFileAsync("osascript", ["-e", script]);
     return { sent: true };
-  } catch (error) {
-    const msg = error instanceof Error ? error.message : String(error);
-    throw new Error(`Failed to send iMessage: ${msg}`);
+  } catch (error: unknown) {
+    // Avoid leaking script contents (which contain recipient/message) into error messages.
+    // execFile errors include stderr which has the actionable info.
+    const err = error as { stderr?: string; code?: number };
+    const detail = err.stderr?.trim() || `exit code ${err.code ?? "unknown"}`;
+    throw new Error(`Failed to send iMessage: ${detail}`);
   }
 }
 

--- a/packages/agency-lang/stdlib/lib/imessage.ts
+++ b/packages/agency-lang/stdlib/lib/imessage.ts
@@ -23,12 +23,11 @@ export async function _sendIMessage(
     throw new Error("Missing message body.");
   }
 
-  // Use AppleScript via osascript to send an iMessage
   const script = `
     tell application "Messages"
       set targetService to 1st account whose service type = iMessage
-      set targetBuddy to participant "${escapedAppleScript(to)}" of targetService
-      send "${escapedAppleScript(message)}" to targetBuddy
+      set targetBuddy to participant "${escapeAppleScriptString(to)}" of targetService
+      send "${escapeAppleScriptString(message)}" to targetBuddy
     end tell
   `;
 
@@ -41,7 +40,16 @@ export async function _sendIMessage(
   }
 }
 
-function escapedAppleScript(str: string): string {
-  // Escape backslashes first, then double quotes
-  return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+function escapeAppleScriptString(str: string): string {
+  // Escape backslashes, double quotes, and replace characters that would
+  // terminate an AppleScript string literal or inject new statements.
+  return str
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\r\n/g, "\\n")
+    .replace(/\r/g, "\\n")
+    .replace(/\n/g, "\\n")
+    .replace(/\t/g, "\\t")
+    .replace(/\u2028/g, "\\n")
+    .replace(/\u2029/g, "\\n");
 }

--- a/packages/agency-lang/stdlib/lib/sms.ts
+++ b/packages/agency-lang/stdlib/lib/sms.ts
@@ -37,6 +37,18 @@ export async function _sendSms(
     );
   }
 
+  if (!to) {
+    throw new Error("Missing recipient phone number.");
+  }
+  if (!/^\+[1-9]\d{1,14}$/.test(to)) {
+    throw new Error(
+      `Invalid phone number "${to}". Must be in E.164 format (e.g. "+15551234567").`
+    );
+  }
+  if (!body) {
+    throw new Error("Missing message body.");
+  }
+
   const formData = new URLSearchParams();
   formData.set("To", to);
   formData.set("From", from);

--- a/packages/agency-lang/stdlib/lib/sms.ts
+++ b/packages/agency-lang/stdlib/lib/sms.ts
@@ -1,0 +1,66 @@
+const TWILIO_BASE_URL = "https://api.twilio.com/2010-04-01/Accounts";
+
+export type SmsResult = {
+  sid: string;
+  status: string;
+};
+
+export type SmsOptions = {
+  accountSid?: string;
+  authToken?: string;
+  from?: string;
+};
+
+export async function _sendSms(
+  to: string,
+  body: string,
+  options?: SmsOptions
+): Promise<SmsResult> {
+  const accountSid = options?.accountSid || process.env.TWILIO_ACCOUNT_SID;
+  if (!accountSid) {
+    throw new Error(
+      "Missing Twilio Account SID. Set TWILIO_ACCOUNT_SID env var or pass accountSid option."
+    );
+  }
+
+  const authToken = options?.authToken || process.env.TWILIO_AUTH_TOKEN;
+  if (!authToken) {
+    throw new Error(
+      "Missing Twilio Auth Token. Set TWILIO_AUTH_TOKEN env var or pass authToken option."
+    );
+  }
+
+  const from = options?.from || process.env.TWILIO_FROM_NUMBER;
+  if (!from) {
+    throw new Error(
+      "Missing Twilio phone number. Set TWILIO_FROM_NUMBER env var or pass from option."
+    );
+  }
+
+  const formData = new URLSearchParams();
+  formData.set("To", to);
+  formData.set("From", from);
+  formData.set("Body", body);
+
+  const credentials = Buffer.from(`${accountSid}:${authToken}`).toString("base64");
+
+  const response = await fetch(
+    `${TWILIO_BASE_URL}/${encodeURIComponent(accountSid)}/Messages.json`,
+    {
+      method: "POST",
+      headers: {
+        "Authorization": `Basic ${credentials}`,
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: formData.toString(),
+    }
+  );
+
+  if (!response.ok) {
+    const responseBody = await response.text();
+    throw new Error(`Twilio API error (${response.status}): ${responseBody}`);
+  }
+
+  const data = await response.json() as { sid: string; status: string };
+  return { sid: data.sid, status: data.status };
+}

--- a/packages/agency-lang/stdlib/sms.agency
+++ b/packages/agency-lang/stdlib/sms.agency
@@ -1,0 +1,35 @@
+import { _sendSms } from "./lib/sms.js"
+
+type SmsResult = {
+  sid: string;
+  status: string
+}
+
+/**
+  ## Usage
+
+  ```ts
+  import { sendSms } from "std::sms"
+
+  node main() {
+    const result = sendSms("+15551234567", "Hello from my agent!")
+    print(result)
+  }
+  ```
+
+  ## Environment Variables
+  - `TWILIO_ACCOUNT_SID` — Your Twilio Account SID
+  - `TWILIO_AUTH_TOKEN` — Your Twilio Auth Token
+  - `TWILIO_FROM_NUMBER` — Your Twilio phone number (e.g. "+15550001234")
+*/
+
+export def sendSms(to: string, body: string, from: string = "", accountSid: string = "", authToken: string = ""): Result {
+  """
+  Send an SMS text message via the Twilio API. Requires TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, and TWILIO_FROM_NUMBER env vars, or pass them directly. Parameters: to (recipient phone number in E.164 format), body (message text), and optionally from, accountSid, authToken.
+  """
+  return try _sendSms(to, body, {
+    from: from,
+    accountSid: accountSid,
+    authToken: authToken
+  })
+}


### PR DESCRIPTION
## Summary

- **`std::sms`**: Send SMS text messages via the Twilio REST API. Zero dependencies (pure fetch with Basic Auth). Requires `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, and `TWILIO_FROM_NUMBER` env vars.
- **`std::imessage`**: Send iMessages via macOS Messages.app using AppleScript. Zero dependencies, macOS only. No API key required.

Both modules include proper input validation and escaping (URL-encoding for Twilio account SID in path, AppleScript string escaping for iMessage).

## Test plan

- [x] `std::sms` — 10 unit tests passing (mocked fetch)
- [x] `std::imessage` — 8 unit tests passing (mocked child_process)
- [x] Both `.agency` files parse correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
