### PR TITLE
Add std::oauth - general-purpose OAuth 2.0 module

### DIFF
--- a/packages/agency-lang/stdlib/keyring.agency
+++ b/packages/agency-lang/stdlib/keyring.agency
@@ -1,0 +1,55 @@
+import { _setSecret, _getSecret, _deleteSecret, _isKeyringAvailable } from "./lib/keyring.js"
+
+/**
+  ## Usage
+
+  ```ts
+  import { setSecret, getSecret, deleteSecret, isKeyringAvailable } from "std::keyring"
+
+  node main() {
+    if (isKeyringAvailable()) {
+      setSecret("my-api-key", "sk-abc123")
+      const key = getSecret("my-api-key")
+      print(key)
+      deleteSecret("my-api-key")
+    }
+  }
+  ```
+
+  ## How it works
+  - macOS: Uses Keychain via the `security` CLI tool
+  - Linux: Uses Secret Service via the `secret-tool` CLI tool
+  - Windows: Not currently supported (use env vars instead)
+
+  All secrets are stored under the "agency-lang" service name by default.
+  Pass a custom `service` parameter to use a different namespace.
+  No external dependencies required.
+*/
+
+export def setSecret(key: string, value: string, service: string = "agency-lang"): Result {
+  """
+  Store a secret in the system keyring (macOS Keychain or Linux Secret Service). The secret is stored under the given service name (default "agency-lang") with the given key. Overwrites any existing value for the same key.
+  """
+  return try _setSecret(key, value, service)
+}
+
+export def getSecret(key: string, service: string = "agency-lang"): Result {
+  """
+  Retrieve a secret from the system keyring by key. Returns the secret value as a string, or null if not found. Uses the "agency-lang" service by default.
+  """
+  return try _getSecret(key, service)
+}
+
+export def deleteSecret(key: string, service: string = "agency-lang"): Result {
+  """
+  Delete a secret from the system keyring. Returns true if deleted, false if the key did not exist.
+  """
+  return try _deleteSecret(key, service)
+}
+
+export safe def isKeyringAvailable(): boolean {
+  """
+  Check if the system keyring is available on this platform. Returns true on macOS (Keychain) and Linux (with secret-tool installed), false otherwise.
+  """
+  return _isKeyringAvailable()
+}

--- a/packages/agency-lang/stdlib/lib/__tests__/keyring.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/keyring.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
 import { _setSecret, _getSecret, _deleteSecret, _isKeyringAvailable } from "../keyring.js";
 
 // Mock child_process
@@ -9,6 +9,11 @@ vi.mock("child_process", () => ({
   execFile: (...args: unknown[]) => mockExecFile(...args),
   spawn: (...args: unknown[]) => mockSpawn(...args),
 }));
+
+const originalPlatform = process.platform;
+afterAll(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform, writable: true });
+});
 
 describe("keyring (macOS)", () => {
   beforeEach(() => {

--- a/packages/agency-lang/stdlib/lib/__tests__/keyring.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/keyring.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { _setSecret, _getSecret, _deleteSecret, _isKeyringAvailable } from "../keyring.js";
+
+// Mock child_process
+const mockExecFile = vi.fn();
+const mockSpawn = vi.fn();
+
+vi.mock("child_process", () => ({
+  execFile: (...args: unknown[]) => mockExecFile(...args),
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+describe("keyring (macOS)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(process, "platform", { value: "darwin", writable: true });
+    // Default: execFile succeeds
+    mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+      cb(null, { stdout: "", stderr: "" });
+    });
+  });
+
+  describe("_setSecret", () => {
+    it("calls security add-generic-password with correct args", async () => {
+      // First call is delete (may fail), second is add
+      let callCount = 0;
+      mockExecFile.mockImplementation((_cmd: string, args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+        callCount++;
+        if (callCount === 1) {
+          // delete call - can fail
+          cb(new Error("not found"), { stdout: "", stderr: "" });
+        } else {
+          cb(null, { stdout: "", stderr: "" });
+        }
+      });
+
+      await _setSecret("my-key", "my-value");
+
+      const addCall = mockExecFile.mock.calls[1];
+      expect(addCall[0]).toBe("security");
+      expect(addCall[1]).toContain("add-generic-password");
+      expect(addCall[1]).toContain("-a");
+      expect(addCall[1]).toContain("my-key");
+      expect(addCall[1]).toContain("-w");
+      expect(addCall[1]).toContain("my-value");
+      expect(addCall[1]).toContain("-s");
+      expect(addCall[1]).toContain("agency-lang");
+    });
+
+    it("uses custom service name", async () => {
+      let callCount = 0;
+      mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+        callCount++;
+        if (callCount === 1) cb(new Error("not found"), { stdout: "", stderr: "" });
+        else cb(null, { stdout: "", stderr: "" });
+      });
+
+      await _setSecret("key", "val", "my-app");
+
+      const addCall = mockExecFile.mock.calls[1];
+      expect(addCall[1]).toContain("my-app");
+    });
+
+    it("throws on empty key", async () => {
+      await expect(_setSecret("", "value")).rejects.toThrow("key must not be empty");
+    });
+
+    it("throws on empty value", async () => {
+      await expect(_setSecret("key", "")).rejects.toThrow("value must not be empty");
+    });
+  });
+
+  describe("_getSecret", () => {
+    it("returns the secret value", async () => {
+      mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+        cb(null, { stdout: "my-secret-value\n", stderr: "" });
+      });
+
+      const result = await _getSecret("my-key");
+      expect(result).toBe("my-secret-value");
+    });
+
+    it("returns null when secret not found", async () => {
+      mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+        cb(new Error("security: SecKeychainSearchCopyNext: not found"), { stdout: "", stderr: "" });
+      });
+
+      const result = await _getSecret("nonexistent");
+      expect(result).toBeNull();
+    });
+
+    it("uses correct security command", async () => {
+      mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+        cb(null, { stdout: "val", stderr: "" });
+      });
+
+      await _getSecret("test-key", "custom-svc");
+
+      const [cmd, args] = mockExecFile.mock.calls[0];
+      expect(cmd).toBe("security");
+      expect(args).toContain("find-generic-password");
+      expect(args).toContain("-s");
+      expect(args).toContain("custom-svc");
+      expect(args).toContain("-a");
+      expect(args).toContain("test-key");
+      expect(args).toContain("-w");
+    });
+  });
+
+  describe("_deleteSecret", () => {
+    it("returns true when deleted", async () => {
+      const result = await _deleteSecret("my-key");
+      expect(result).toBe(true);
+    });
+
+    it("returns false when not found", async () => {
+      mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+        cb(new Error("not found"), { stdout: "", stderr: "" });
+      });
+
+      const result = await _deleteSecret("nonexistent");
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("_isKeyringAvailable", () => {
+    it("returns true when security command works", async () => {
+      expect(await _isKeyringAvailable()).toBe(true);
+    });
+
+    it("returns false when security command fails", async () => {
+      mockExecFile.mockImplementation((_cmd: string, _args: string[], cb: (err: Error | null, result: { stdout: string; stderr: string }) => void) => {
+        cb(new Error("command not found"), { stdout: "", stderr: "" });
+      });
+
+      expect(await _isKeyringAvailable()).toBe(false);
+    });
+  });
+});
+
+describe("keyring (unsupported platform)", () => {
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { value: "win32", writable: true });
+  });
+
+  it("_setSecret throws on unsupported platform", async () => {
+    await expect(_setSecret("key", "val")).rejects.toThrow("not supported");
+  });
+
+  it("_getSecret throws on unsupported platform", async () => {
+    await expect(_getSecret("key")).rejects.toThrow("not supported");
+  });
+
+  it("_deleteSecret throws on unsupported platform", async () => {
+    await expect(_deleteSecret("key")).rejects.toThrow("not supported");
+  });
+
+  it("_isKeyringAvailable returns false", async () => {
+    expect(await _isKeyringAvailable()).toBe(false);
+  });
+});

--- a/packages/agency-lang/stdlib/lib/__tests__/oauth.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/oauth.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach, afterAll } from "vitest";
 import fs from "fs/promises";
 import fsSync from "fs";
 import path from "path";
@@ -6,7 +6,16 @@ import os from "os";
 
 // Set temp dir BEFORE importing oauth (getTokenDir() reads env at call time)
 const TOKEN_DIR = path.join(os.tmpdir(), "agency-oauth-test-" + process.pid);
+const originalTokenDir = process.env.AGENCY_OAUTH_TOKEN_DIR;
 process.env.AGENCY_OAUTH_TOKEN_DIR = TOKEN_DIR;
+
+afterAll(() => {
+  if (originalTokenDir !== undefined) {
+    process.env.AGENCY_OAUTH_TOKEN_DIR = originalTokenDir;
+  } else {
+    delete process.env.AGENCY_OAUTH_TOKEN_DIR;
+  }
+});
 
 // Mock encryption to return null key (plaintext mode) so tests don't hit real keyring
 vi.mock("../oauthEncryption.js", () => ({

--- a/packages/agency-lang/stdlib/lib/__tests__/oauth.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/oauth.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "fs";
+import path from "path";
+import {
+  _authorize,
+  _getAccessToken,
+  _isAuthorized,
+  _revokeAuth,
+} from "../oauth.js";
+
+// Mock child_process (for openBrowser)
+vi.mock("child_process", () => ({
+  execFile: vi.fn((_cmd, _args, _cb) => {}),
+}));
+
+// Mock http server and fetch
+const mockServerInstance = {
+  listen: vi.fn((_port: number, _host: string, cb: () => void) => cb()),
+  close: vi.fn(),
+};
+
+vi.mock("http", () => ({
+  default: {
+    createServer: vi.fn((handler: (req: unknown, res: unknown) => void) => {
+      // Store handler so we can trigger it in tests
+      (mockServerInstance as unknown as { _handler: typeof handler })._handler =
+        handler;
+      return mockServerInstance;
+    }),
+  },
+}));
+
+const TOKEN_DIR = path.join(
+  process.env.HOME || process.env.USERPROFILE || "~",
+  ".agency",
+  "oauth"
+);
+
+function mockFetchResponse(body: unknown, status = 200) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  });
+}
+
+describe("_isAuthorized", () => {
+  const testTokenPath = path.join(TOKEN_DIR, "test-provider.json");
+
+  afterEach(() => {
+    if (fs.existsSync(testTokenPath)) {
+      fs.unlinkSync(testTokenPath);
+    }
+  });
+
+  it("returns false when no token file exists", () => {
+    expect(_isAuthorized("nonexistent-provider")).toBe(false);
+  });
+
+  it("returns true when token file exists", () => {
+    fs.mkdirSync(TOKEN_DIR, { recursive: true });
+    fs.writeFileSync(
+      testTokenPath,
+      JSON.stringify({ access_token: "test", refresh_token: "test", expires_at: 0 })
+    );
+    expect(_isAuthorized("test-provider")).toBe(true);
+  });
+});
+
+describe("_revokeAuth", () => {
+  const testTokenPath = path.join(TOKEN_DIR, "revoke-test.json");
+
+  afterEach(() => {
+    if (fs.existsSync(testTokenPath)) {
+      fs.unlinkSync(testTokenPath);
+    }
+  });
+
+  it("returns revoked:false when no tokens exist", () => {
+    expect(_revokeAuth("revoke-test")).toEqual({ revoked: false });
+  });
+
+  it("deletes token file and returns revoked:true", () => {
+    fs.mkdirSync(TOKEN_DIR, { recursive: true });
+    fs.writeFileSync(testTokenPath, JSON.stringify({ access_token: "x" }));
+    expect(_revokeAuth("revoke-test")).toEqual({ revoked: true });
+    expect(fs.existsSync(testTokenPath)).toBe(false);
+  });
+});
+
+describe("_getAccessToken", () => {
+  const testTokenPath = path.join(TOKEN_DIR, "token-test.json");
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (fs.existsSync(testTokenPath)) {
+      fs.unlinkSync(testTokenPath);
+    }
+  });
+
+  it("throws when no tokens exist", async () => {
+    await expect(_getAccessToken("no-such-provider")).rejects.toThrow(
+      "No OAuth tokens found"
+    );
+  });
+
+  it("returns access token when not expired", async () => {
+    fs.mkdirSync(TOKEN_DIR, { recursive: true });
+    fs.writeFileSync(
+      testTokenPath,
+      JSON.stringify({
+        access_token: "valid-token",
+        refresh_token: "refresh-123",
+        expires_at: Date.now() + 3600000, // 1 hour from now
+        token_url: "https://example.com/token",
+        client_id: "id",
+        client_secret: "secret",
+      })
+    );
+
+    const token = await _getAccessToken("token-test");
+    expect(token).toBe("valid-token");
+  });
+
+  it("refreshes token when expired", async () => {
+    fs.mkdirSync(TOKEN_DIR, { recursive: true });
+    fs.writeFileSync(
+      testTokenPath,
+      JSON.stringify({
+        access_token: "expired-token",
+        refresh_token: "refresh-456",
+        expires_at: Date.now() - 1000, // already expired
+        token_url: "https://example.com/token",
+        client_id: "id",
+        client_secret: "secret",
+      })
+    );
+
+    globalThis.fetch = mockFetchResponse({
+      access_token: "new-token",
+      refresh_token: "new-refresh",
+      expires_in: 3600,
+    });
+
+    const token = await _getAccessToken("token-test");
+    expect(token).toBe("new-token");
+
+    // Verify it was saved
+    const saved = JSON.parse(fs.readFileSync(testTokenPath, "utf-8"));
+    expect(saved.access_token).toBe("new-token");
+    expect(saved.refresh_token).toBe("new-refresh");
+  });
+
+  it("keeps old refresh token when new one not provided", async () => {
+    fs.mkdirSync(TOKEN_DIR, { recursive: true });
+    fs.writeFileSync(
+      testTokenPath,
+      JSON.stringify({
+        access_token: "expired",
+        refresh_token: "keep-this-refresh",
+        expires_at: Date.now() - 1000,
+        token_url: "https://example.com/token",
+        client_id: "id",
+        client_secret: "secret",
+      })
+    );
+
+    globalThis.fetch = mockFetchResponse({
+      access_token: "refreshed",
+      expires_in: 3600,
+      // No refresh_token in response
+    });
+
+    await _getAccessToken("token-test");
+
+    const saved = JSON.parse(fs.readFileSync(testTokenPath, "utf-8"));
+    expect(saved.refresh_token).toBe("keep-this-refresh");
+  });
+
+  it("sends correct refresh request", async () => {
+    fs.mkdirSync(TOKEN_DIR, { recursive: true });
+    fs.writeFileSync(
+      testTokenPath,
+      JSON.stringify({
+        access_token: "expired",
+        refresh_token: "my-refresh",
+        expires_at: Date.now() - 1000,
+        token_url: "https://auth.example.com/token",
+        client_id: "my-client",
+        client_secret: "my-secret",
+      })
+    );
+
+    const mockFetch = mockFetchResponse({
+      access_token: "new",
+      expires_in: 3600,
+    });
+    globalThis.fetch = mockFetch;
+
+    await _getAccessToken("token-test");
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("https://auth.example.com/token");
+    const params = new URLSearchParams(init.body);
+    expect(params.get("grant_type")).toBe("refresh_token");
+    expect(params.get("refresh_token")).toBe("my-refresh");
+    expect(params.get("client_id")).toBe("my-client");
+    expect(params.get("client_secret")).toBe("my-secret");
+  });
+
+  it("throws when refresh fails", async () => {
+    fs.mkdirSync(TOKEN_DIR, { recursive: true });
+    fs.writeFileSync(
+      testTokenPath,
+      JSON.stringify({
+        access_token: "expired",
+        refresh_token: "bad-refresh",
+        expires_at: Date.now() - 1000,
+        token_url: "https://example.com/token",
+        client_id: "id",
+        client_secret: "secret",
+      })
+    );
+
+    globalThis.fetch = mockFetchResponse({ error: "invalid_grant" }, 400);
+
+    await expect(_getAccessToken("token-test")).rejects.toThrow(
+      "OAuth token exchange failed (400)"
+    );
+  });
+
+  it("throws when no refresh token available", async () => {
+    fs.mkdirSync(TOKEN_DIR, { recursive: true });
+    fs.writeFileSync(
+      testTokenPath,
+      JSON.stringify({
+        access_token: "expired",
+        refresh_token: "",
+        expires_at: Date.now() - 1000,
+        token_url: "https://example.com/token",
+        client_id: "id",
+        client_secret: "secret",
+      })
+    );
+
+    await expect(_getAccessToken("token-test")).rejects.toThrow(
+      "no refresh token"
+    );
+  });
+});
+
+describe("input validation", () => {
+  it("rejects provider names with path separators", () => {
+    expect(() => _isAuthorized("../evil")).toThrow("Invalid OAuth provider name");
+    expect(() => _isAuthorized("foo/bar")).toThrow("Invalid OAuth provider name");
+    expect(() => _isAuthorized("foo\\bar")).toThrow("Invalid OAuth provider name");
+  });
+});

--- a/packages/agency-lang/stdlib/lib/__tests__/oauth.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/oauth.test.ts
@@ -1,17 +1,16 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import fs from "fs/promises";
 import fsSync from "fs";
 import path from "path";
-import {
-  _authorize,
-  _getAccessToken,
-  _isAuthorized,
-  _revokeAuth,
-} from "../oauth.js";
+import os from "os";
+
+// Set temp dir BEFORE importing oauth (getTokenDir() reads env at call time)
+const TOKEN_DIR = path.join(os.tmpdir(), "agency-oauth-test-" + process.pid);
+process.env.AGENCY_OAUTH_TOKEN_DIR = TOKEN_DIR;
 
 // Mock child_process (for openBrowser)
 vi.mock("child_process", () => ({
-  execFile: vi.fn((_cmd, _args, _cb) => {}),
+  execFile: vi.fn((_cmd: unknown, _args: unknown, _cb: unknown) => {}),
 }));
 
 // Mock http server
@@ -31,11 +30,11 @@ vi.mock("http", () => ({
   },
 }));
 
-const TOKEN_DIR = path.join(
-  process.env.HOME || process.env.USERPROFILE || "~",
-  ".agency",
-  "oauth"
-);
+import {
+  _getAccessToken,
+  _isAuthorized,
+  _revokeAuth,
+} from "../oauth.js";
 
 function mockFetchResponse(body: unknown, status = 200) {
   return vi.fn().mockResolvedValue({
@@ -46,12 +45,15 @@ function mockFetchResponse(body: unknown, status = 200) {
   });
 }
 
+// Cleanup after each test
+afterEach(async () => {
+  try {
+    await fs.rm(TOKEN_DIR, { recursive: true, force: true });
+  } catch {}
+});
+
 describe("_isAuthorized", () => {
   const testTokenPath = path.join(TOKEN_DIR, "test-provider.json");
-
-  afterEach(async () => {
-    try { await fs.unlink(testTokenPath); } catch {}
-  });
 
   it("returns false when no token file exists", async () => {
     expect(await _isAuthorized("nonexistent-provider")).toBe(false);
@@ -77,17 +79,17 @@ describe("_isAuthorized", () => {
 describe("_revokeAuth", () => {
   const testTokenPath = path.join(TOKEN_DIR, "revoke-test.json");
 
-  afterEach(async () => {
-    try { await fs.unlink(testTokenPath); } catch {}
-  });
-
   it("returns revoked:false when no tokens exist", async () => {
     expect(await _revokeAuth("revoke-test")).toEqual({ revoked: false });
   });
 
   it("deletes token file and returns revoked:true", async () => {
     await fs.mkdir(TOKEN_DIR, { recursive: true });
-    await fs.writeFile(testTokenPath, JSON.stringify({ access_token: "x" }));
+    await fs.writeFile(testTokenPath, JSON.stringify({
+      access_token: "x",
+      token_url: "https://example.com/token",
+      client_id: "id",
+    }));
     expect(await _revokeAuth("revoke-test")).toEqual({ revoked: true });
     expect(fsSync.existsSync(testTokenPath)).toBe(false);
   });
@@ -97,9 +99,8 @@ describe("_getAccessToken", () => {
   const testTokenPath = path.join(TOKEN_DIR, "token-test.json");
   const originalFetch = globalThis.fetch;
 
-  afterEach(async () => {
+  afterEach(() => {
     globalThis.fetch = originalFetch;
-    try { await fs.unlink(testTokenPath); } catch {}
   });
 
   it("throws when no tokens exist", async () => {
@@ -267,7 +268,6 @@ describe("_getAccessToken", () => {
     let fetchCallCount = 0;
     globalThis.fetch = vi.fn().mockImplementation(async () => {
       fetchCallCount++;
-      // Simulate network delay
       await new Promise((r) => setTimeout(r, 10));
       return {
         ok: true,
@@ -275,7 +275,6 @@ describe("_getAccessToken", () => {
       };
     });
 
-    // Fire two concurrent getAccessToken calls
     const [token1, token2] = await Promise.all([
       _getAccessToken("token-test"),
       _getAccessToken("token-test"),
@@ -283,7 +282,6 @@ describe("_getAccessToken", () => {
 
     expect(token1).toBe("refreshed");
     expect(token2).toBe("refreshed");
-    // Only one fetch call should have been made
     expect(fetchCallCount).toBe(1);
   });
 });

--- a/packages/agency-lang/stdlib/lib/__tests__/oauth.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/oauth.test.ts
@@ -8,6 +8,13 @@ import os from "os";
 const TOKEN_DIR = path.join(os.tmpdir(), "agency-oauth-test-" + process.pid);
 process.env.AGENCY_OAUTH_TOKEN_DIR = TOKEN_DIR;
 
+// Mock encryption to return null key (plaintext mode) so tests don't hit real keyring
+vi.mock("../oauthEncryption.js", () => ({
+  getEncryptionKey: vi.fn().mockResolvedValue(null),
+  encrypt: vi.fn(),
+  decrypt: vi.fn(),
+}));
+
 // Mock child_process (for openBrowser)
 vi.mock("child_process", () => ({
   execFile: vi.fn((_cmd: unknown, _args: unknown, _cb: unknown) => {}),

--- a/packages/agency-lang/stdlib/lib/__tests__/oauth.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/oauth.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import fs from "fs";
+import fs from "fs/promises";
+import fsSync from "fs";
 import path from "path";
 import {
   _authorize,
@@ -13,16 +14,16 @@ vi.mock("child_process", () => ({
   execFile: vi.fn((_cmd, _args, _cb) => {}),
 }));
 
-// Mock http server and fetch
+// Mock http server
 const mockServerInstance = {
-  listen: vi.fn((_port: number, _host: string, cb: () => void) => cb()),
+  listen: vi.fn((_port: number, _host: string) => {}),
   close: vi.fn(),
+  on: vi.fn(),
 };
 
 vi.mock("http", () => ({
   default: {
     createServer: vi.fn((handler: (req: unknown, res: unknown) => void) => {
-      // Store handler so we can trigger it in tests
       (mockServerInstance as unknown as { _handler: typeof handler })._handler =
         handler;
       return mockServerInstance;
@@ -48,44 +49,47 @@ function mockFetchResponse(body: unknown, status = 200) {
 describe("_isAuthorized", () => {
   const testTokenPath = path.join(TOKEN_DIR, "test-provider.json");
 
-  afterEach(() => {
-    if (fs.existsSync(testTokenPath)) {
-      fs.unlinkSync(testTokenPath);
-    }
+  afterEach(async () => {
+    try { await fs.unlink(testTokenPath); } catch {}
   });
 
-  it("returns false when no token file exists", () => {
-    expect(_isAuthorized("nonexistent-provider")).toBe(false);
+  it("returns false when no token file exists", async () => {
+    expect(await _isAuthorized("nonexistent-provider")).toBe(false);
   });
 
-  it("returns true when token file exists", () => {
-    fs.mkdirSync(TOKEN_DIR, { recursive: true });
-    fs.writeFileSync(
+  it("returns true when token file exists with required fields", async () => {
+    await fs.mkdir(TOKEN_DIR, { recursive: true });
+    await fs.writeFile(
       testTokenPath,
-      JSON.stringify({ access_token: "test", refresh_token: "test", expires_at: 0 })
+      JSON.stringify({
+        access_token: "test",
+        refresh_token: "test",
+        expires_at: 0,
+        token_url: "https://example.com/token",
+        client_id: "id",
+        client_secret: "secret",
+      })
     );
-    expect(_isAuthorized("test-provider")).toBe(true);
+    expect(await _isAuthorized("test-provider")).toBe(true);
   });
 });
 
 describe("_revokeAuth", () => {
   const testTokenPath = path.join(TOKEN_DIR, "revoke-test.json");
 
-  afterEach(() => {
-    if (fs.existsSync(testTokenPath)) {
-      fs.unlinkSync(testTokenPath);
-    }
+  afterEach(async () => {
+    try { await fs.unlink(testTokenPath); } catch {}
   });
 
-  it("returns revoked:false when no tokens exist", () => {
-    expect(_revokeAuth("revoke-test")).toEqual({ revoked: false });
+  it("returns revoked:false when no tokens exist", async () => {
+    expect(await _revokeAuth("revoke-test")).toEqual({ revoked: false });
   });
 
-  it("deletes token file and returns revoked:true", () => {
-    fs.mkdirSync(TOKEN_DIR, { recursive: true });
-    fs.writeFileSync(testTokenPath, JSON.stringify({ access_token: "x" }));
-    expect(_revokeAuth("revoke-test")).toEqual({ revoked: true });
-    expect(fs.existsSync(testTokenPath)).toBe(false);
+  it("deletes token file and returns revoked:true", async () => {
+    await fs.mkdir(TOKEN_DIR, { recursive: true });
+    await fs.writeFile(testTokenPath, JSON.stringify({ access_token: "x" }));
+    expect(await _revokeAuth("revoke-test")).toEqual({ revoked: true });
+    expect(fsSync.existsSync(testTokenPath)).toBe(false);
   });
 });
 
@@ -93,11 +97,9 @@ describe("_getAccessToken", () => {
   const testTokenPath = path.join(TOKEN_DIR, "token-test.json");
   const originalFetch = globalThis.fetch;
 
-  afterEach(() => {
+  afterEach(async () => {
     globalThis.fetch = originalFetch;
-    if (fs.existsSync(testTokenPath)) {
-      fs.unlinkSync(testTokenPath);
-    }
+    try { await fs.unlink(testTokenPath); } catch {}
   });
 
   it("throws when no tokens exist", async () => {
@@ -107,13 +109,13 @@ describe("_getAccessToken", () => {
   });
 
   it("returns access token when not expired", async () => {
-    fs.mkdirSync(TOKEN_DIR, { recursive: true });
-    fs.writeFileSync(
+    await fs.mkdir(TOKEN_DIR, { recursive: true });
+    await fs.writeFile(
       testTokenPath,
       JSON.stringify({
         access_token: "valid-token",
         refresh_token: "refresh-123",
-        expires_at: Date.now() + 3600000, // 1 hour from now
+        expires_at: Date.now() + 3600000,
         token_url: "https://example.com/token",
         client_id: "id",
         client_secret: "secret",
@@ -125,13 +127,13 @@ describe("_getAccessToken", () => {
   });
 
   it("refreshes token when expired", async () => {
-    fs.mkdirSync(TOKEN_DIR, { recursive: true });
-    fs.writeFileSync(
+    await fs.mkdir(TOKEN_DIR, { recursive: true });
+    await fs.writeFile(
       testTokenPath,
       JSON.stringify({
         access_token: "expired-token",
         refresh_token: "refresh-456",
-        expires_at: Date.now() - 1000, // already expired
+        expires_at: Date.now() - 1000,
         token_url: "https://example.com/token",
         client_id: "id",
         client_secret: "secret",
@@ -147,15 +149,14 @@ describe("_getAccessToken", () => {
     const token = await _getAccessToken("token-test");
     expect(token).toBe("new-token");
 
-    // Verify it was saved
-    const saved = JSON.parse(fs.readFileSync(testTokenPath, "utf-8"));
+    const saved = JSON.parse(await fs.readFile(testTokenPath, "utf-8"));
     expect(saved.access_token).toBe("new-token");
     expect(saved.refresh_token).toBe("new-refresh");
   });
 
   it("keeps old refresh token when new one not provided", async () => {
-    fs.mkdirSync(TOKEN_DIR, { recursive: true });
-    fs.writeFileSync(
+    await fs.mkdir(TOKEN_DIR, { recursive: true });
+    await fs.writeFile(
       testTokenPath,
       JSON.stringify({
         access_token: "expired",
@@ -170,18 +171,17 @@ describe("_getAccessToken", () => {
     globalThis.fetch = mockFetchResponse({
       access_token: "refreshed",
       expires_in: 3600,
-      // No refresh_token in response
     });
 
     await _getAccessToken("token-test");
 
-    const saved = JSON.parse(fs.readFileSync(testTokenPath, "utf-8"));
+    const saved = JSON.parse(await fs.readFile(testTokenPath, "utf-8"));
     expect(saved.refresh_token).toBe("keep-this-refresh");
   });
 
   it("sends correct refresh request", async () => {
-    fs.mkdirSync(TOKEN_DIR, { recursive: true });
-    fs.writeFileSync(
+    await fs.mkdir(TOKEN_DIR, { recursive: true });
+    await fs.writeFile(
       testTokenPath,
       JSON.stringify({
         access_token: "expired",
@@ -211,8 +211,8 @@ describe("_getAccessToken", () => {
   });
 
   it("throws when refresh fails", async () => {
-    fs.mkdirSync(TOKEN_DIR, { recursive: true });
-    fs.writeFileSync(
+    await fs.mkdir(TOKEN_DIR, { recursive: true });
+    await fs.writeFile(
       testTokenPath,
       JSON.stringify({
         access_token: "expired",
@@ -232,8 +232,8 @@ describe("_getAccessToken", () => {
   });
 
   it("throws when no refresh token available", async () => {
-    fs.mkdirSync(TOKEN_DIR, { recursive: true });
-    fs.writeFileSync(
+    await fs.mkdir(TOKEN_DIR, { recursive: true });
+    await fs.writeFile(
       testTokenPath,
       JSON.stringify({
         access_token: "expired",
@@ -249,12 +249,60 @@ describe("_getAccessToken", () => {
       "no refresh token"
     );
   });
+
+  it("deduplicates concurrent refresh requests", async () => {
+    await fs.mkdir(TOKEN_DIR, { recursive: true });
+    await fs.writeFile(
+      testTokenPath,
+      JSON.stringify({
+        access_token: "expired",
+        refresh_token: "refresh",
+        expires_at: Date.now() - 1000,
+        token_url: "https://example.com/token",
+        client_id: "id",
+        client_secret: "secret",
+      })
+    );
+
+    let fetchCallCount = 0;
+    globalThis.fetch = vi.fn().mockImplementation(async () => {
+      fetchCallCount++;
+      // Simulate network delay
+      await new Promise((r) => setTimeout(r, 10));
+      return {
+        ok: true,
+        json: async () => ({ access_token: "refreshed", expires_in: 3600 }),
+      };
+    });
+
+    // Fire two concurrent getAccessToken calls
+    const [token1, token2] = await Promise.all([
+      _getAccessToken("token-test"),
+      _getAccessToken("token-test"),
+    ]);
+
+    expect(token1).toBe("refreshed");
+    expect(token2).toBe("refreshed");
+    // Only one fetch call should have been made
+    expect(fetchCallCount).toBe(1);
+  });
 });
 
 describe("input validation", () => {
-  it("rejects provider names with path separators", () => {
-    expect(() => _isAuthorized("../evil")).toThrow("Invalid OAuth provider name");
-    expect(() => _isAuthorized("foo/bar")).toThrow("Invalid OAuth provider name");
-    expect(() => _isAuthorized("foo\\bar")).toThrow("Invalid OAuth provider name");
+  it("rejects provider names with path separators", async () => {
+    await expect(_isAuthorized("../evil")).rejects.toThrow("Invalid OAuth provider name");
+    await expect(_isAuthorized("foo/bar")).rejects.toThrow("Invalid OAuth provider name");
+    await expect(_isAuthorized("foo\\bar")).rejects.toThrow("Invalid OAuth provider name");
+  });
+
+  it("rejects provider names with invalid characters", async () => {
+    await expect(_isAuthorized("foo bar")).rejects.toThrow("Invalid OAuth provider name");
+    await expect(_isAuthorized("")).rejects.toThrow("Invalid OAuth provider name");
+  });
+
+  it("accepts valid provider names", async () => {
+    expect(await _isAuthorized("google-calendar")).toBe(false);
+    expect(await _isAuthorized("my_provider.v2")).toBe(false);
+    expect(await _isAuthorized("GitHub")).toBe(false);
   });
 });

--- a/packages/agency-lang/stdlib/lib/__tests__/oauthEncryption.test.ts
+++ b/packages/agency-lang/stdlib/lib/__tests__/oauthEncryption.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import crypto from "crypto";
+import { encrypt, decrypt } from "../oauthEncryption.js";
+
+describe("encrypt/decrypt", () => {
+  const key = crypto.randomBytes(32);
+
+  it("round-trips plaintext through encrypt then decrypt", () => {
+    const plaintext = JSON.stringify({ access_token: "abc", secret: "xyz" });
+    const ciphertext = encrypt(plaintext, key);
+    const result = decrypt(ciphertext, key);
+    expect(result).toBe(plaintext);
+  });
+
+  it("produces different ciphertext for same plaintext (random IV)", () => {
+    const plaintext = "hello world";
+    const c1 = encrypt(plaintext, key);
+    const c2 = encrypt(plaintext, key);
+    expect(c1).not.toBe(c2);
+  });
+
+  it("ciphertext is base64 encoded", () => {
+    const ciphertext = encrypt("test", key);
+    expect(() => Buffer.from(ciphertext, "base64")).not.toThrow();
+    // Re-encoding should match (valid base64)
+    expect(Buffer.from(ciphertext, "base64").toString("base64")).toBe(ciphertext);
+  });
+
+  it("throws on tampered ciphertext", () => {
+    const ciphertext = encrypt("secret data", key);
+    const buf = Buffer.from(ciphertext, "base64");
+    buf[buf.length - 1] ^= 0xff; // flip last byte
+    const tampered = buf.toString("base64");
+    expect(() => decrypt(tampered, key)).toThrow();
+  });
+
+  it("throws with wrong key", () => {
+    const ciphertext = encrypt("secret", key);
+    const wrongKey = crypto.randomBytes(32);
+    expect(() => decrypt(ciphertext, wrongKey)).toThrow();
+  });
+
+  it("throws on too-short input", () => {
+    const short = Buffer.from("too short").toString("base64");
+    expect(() => decrypt(short, key)).toThrow("too short");
+  });
+
+  it("handles empty string plaintext", () => {
+    const ciphertext = encrypt("", key);
+    expect(decrypt(ciphertext, key)).toBe("");
+  });
+
+  it("handles unicode content", () => {
+    const plaintext = "Hello 🌍 café résumé 日本語";
+    const ciphertext = encrypt(plaintext, key);
+    expect(decrypt(ciphertext, key)).toBe(plaintext);
+  });
+});

--- a/packages/agency-lang/stdlib/lib/keyring.ts
+++ b/packages/agency-lang/stdlib/lib/keyring.ts
@@ -1,0 +1,156 @@
+import { execFile, spawn } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_SERVICE = "agency-lang";
+
+/**
+ * Store a secret in the system keyring.
+ * macOS: Keychain via `security` CLI
+ * Linux: Secret Service via `secret-tool` CLI
+ */
+export async function _setSecret(key: string, value: string, service?: string): Promise<void> {
+  if (!key) throw new Error("Keyring key must not be empty.");
+  if (!value) throw new Error("Keyring value must not be empty.");
+  const svc = service || DEFAULT_SERVICE;
+
+  if (process.platform === "darwin") {
+    try {
+      await execFileAsync("security", [
+        "delete-generic-password",
+        "-s", svc,
+        "-a", key,
+      ]);
+    } catch {}
+
+    await execFileAsync("security", [
+      "add-generic-password",
+      "-s", svc,
+      "-a", key,
+      "-w", value,
+      "-U",
+    ]);
+  } else if (process.platform === "linux") {
+    const child = spawn("secret-tool", [
+      "store",
+      "--label", `${svc}:${key}`,
+      "service", svc,
+      "account", key,
+    ], { stdio: ["pipe", "pipe", "pipe"] });
+
+    child.stdin.write(value);
+    child.stdin.end();
+
+    await new Promise<void>((resolve, reject) => {
+      child.on("close", (code: number) => {
+        if (code === 0) resolve();
+        else reject(new Error(`secret-tool store failed with exit code ${code}`));
+      });
+      child.on("error", reject);
+    });
+  } else {
+    throw new Error(
+      `System keyring is not supported on ${process.platform}. ` +
+      `Set the AGENCY_OAUTH_KEY environment variable instead.`
+    );
+  }
+}
+
+/**
+ * Retrieve a secret from the system keyring.
+ * Returns null if the secret doesn't exist.
+ */
+export async function _getSecret(key: string, service?: string): Promise<string | null> {
+  if (!key) throw new Error("Keyring key must not be empty.");
+  const svc = service || DEFAULT_SERVICE;
+
+  if (process.platform === "darwin") {
+    try {
+      const { stdout } = await execFileAsync("security", [
+        "find-generic-password",
+        "-s", svc,
+        "-a", key,
+        "-w",
+      ]);
+      return stdout.trimEnd();
+    } catch {
+      return null;
+    }
+  } else if (process.platform === "linux") {
+    try {
+      const { stdout } = await execFileAsync("secret-tool", [
+        "lookup",
+        "service", svc,
+        "account", key,
+      ]);
+      return stdout.trimEnd();
+    } catch {
+      return null;
+    }
+  } else {
+    throw new Error(
+      `System keyring is not supported on ${process.platform}. ` +
+      `Set the AGENCY_OAUTH_KEY environment variable instead.`
+    );
+  }
+}
+
+/**
+ * Delete a secret from the system keyring.
+ * Returns true if the secret was deleted, false if it didn't exist.
+ */
+export async function _deleteSecret(key: string, service?: string): Promise<boolean> {
+  if (!key) throw new Error("Keyring key must not be empty.");
+  const svc = service || DEFAULT_SERVICE;
+
+  if (process.platform === "darwin") {
+    try {
+      await execFileAsync("security", [
+        "delete-generic-password",
+        "-s", svc,
+        "-a", key,
+      ]);
+      return true;
+    } catch {
+      return false;
+    }
+  } else if (process.platform === "linux") {
+    try {
+      await execFileAsync("secret-tool", [
+        "clear",
+        "service", svc,
+        "account", key,
+      ]);
+      return true;
+    } catch {
+      return false;
+    }
+  } else {
+    throw new Error(
+      `System keyring is not supported on ${process.platform}. ` +
+      `Set the AGENCY_OAUTH_KEY environment variable instead.`
+    );
+  }
+}
+
+/**
+ * Check if the system keyring is available on this platform.
+ */
+export async function _isKeyringAvailable(): Promise<boolean> {
+  if (process.platform === "darwin") {
+    try {
+      await execFileAsync("security", ["help"]);
+      return true;
+    } catch {
+      return false;
+    }
+  } else if (process.platform === "linux") {
+    try {
+      await execFileAsync("secret-tool", ["--version"]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}

--- a/packages/agency-lang/stdlib/lib/oauth.ts
+++ b/packages/agency-lang/stdlib/lib/oauth.ts
@@ -1,0 +1,262 @@
+import http from "http";
+import crypto from "crypto";
+import fs from "fs";
+import path from "path";
+import { execFile } from "child_process";
+
+const TOKEN_DIR = path.join(
+  process.env.HOME || process.env.USERPROFILE || "~",
+  ".agency",
+  "oauth"
+);
+
+const DEFAULT_PORT = 8914;
+const EXPIRY_BUFFER_MS = 60000; // refresh 60s before expiry
+
+export type OAuthConfig = {
+  authUrl: string;
+  tokenUrl: string;
+  clientId: string;
+  clientSecret: string;
+  scopes: string | string[];
+  port?: number;
+};
+
+type StoredTokens = {
+  access_token: string;
+  refresh_token: string;
+  expires_at: number;
+  token_url: string;
+  client_id: string;
+  client_secret: string;
+};
+
+function getTokenPath(name: string): string {
+  if (name.includes("/") || name.includes("\\") || name.includes("..")) {
+    throw new Error(`Invalid OAuth provider name: "${name}"`);
+  }
+  return path.join(TOKEN_DIR, `${name}.json`);
+}
+
+function generateCodeVerifier(): string {
+  return crypto.randomBytes(32).toString("base64url");
+}
+
+function generateCodeChallenge(verifier: string): string {
+  return crypto.createHash("sha256").update(verifier).digest("base64url");
+}
+
+function openBrowser(url: string): void {
+  const cmd =
+    process.platform === "darwin"
+      ? "open"
+      : process.platform === "win32"
+        ? "start"
+        : "xdg-open";
+  execFile(cmd, [url], () => {});
+}
+
+function waitForCallback(
+  port: number
+): Promise<{ code: string; state: string }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const url = new URL(req.url ?? "/", `http://127.0.0.1:${port}`);
+      const code = url.searchParams.get("code");
+      const error = url.searchParams.get("error");
+      const state = url.searchParams.get("state") ?? "";
+
+      if (error) {
+        res.writeHead(400, { "Content-Type": "text/html" });
+        res.end(`<h1>Authorization failed</h1><p>${error}</p>`);
+        server.close();
+        reject(new Error(`OAuth authorization failed: ${error}`));
+        return;
+      }
+
+      if (!code) {
+        res.writeHead(400, { "Content-Type": "text/html" });
+        res.end("<h1>Missing authorization code</h1>");
+        server.close();
+        reject(new Error("No authorization code received"));
+        return;
+      }
+
+      res.writeHead(200, { "Content-Type": "text/html" });
+      res.end(
+        "<h1>Authorization successful!</h1><p>You can close this tab and return to your terminal.</p>"
+      );
+      server.close();
+      resolve({ code, state });
+    });
+
+    server.listen(port, "127.0.0.1", () => {});
+
+    // Timeout after 5 minutes
+    setTimeout(() => {
+      server.close();
+      reject(new Error("OAuth authorization timed out (5 minutes)"));
+    }, 300000);
+  });
+}
+
+async function exchangeCodeForTokens(
+  tokenUrl: string,
+  params: Record<string, string>
+): Promise<{ access_token: string; refresh_token: string; expires_in: number }> {
+  const body = new URLSearchParams(params);
+
+  const response = await fetch(tokenUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    const responseBody = await response.text();
+    throw new Error(
+      `OAuth token exchange failed (${response.status}): ${responseBody}`
+    );
+  }
+
+  const data = (await response.json()) as Record<string, unknown>;
+
+  if (!data.access_token) {
+    throw new Error("OAuth token response missing access_token");
+  }
+
+  return {
+    access_token: data.access_token as string,
+    refresh_token: (data.refresh_token as string) ?? "",
+    expires_in: (data.expires_in as number) ?? 3600,
+  };
+}
+
+function saveTokens(name: string, tokens: StoredTokens): void {
+  fs.mkdirSync(TOKEN_DIR, { recursive: true });
+  fs.writeFileSync(getTokenPath(name), JSON.stringify(tokens, null, 2), "utf-8");
+}
+
+function loadTokens(name: string): StoredTokens | null {
+  const tokenPath = getTokenPath(name);
+  if (!fs.existsSync(tokenPath)) {
+    return null;
+  }
+  const data = fs.readFileSync(tokenPath, "utf-8");
+  return JSON.parse(data) as StoredTokens;
+}
+
+export async function _authorize(
+  name: string,
+  config: OAuthConfig
+): Promise<{ success: boolean }> {
+  const port = config.port ?? DEFAULT_PORT;
+  const redirectUri = `http://127.0.0.1:${port}`;
+  const state = crypto.randomBytes(16).toString("hex");
+  const codeVerifier = generateCodeVerifier();
+  const codeChallenge = generateCodeChallenge(codeVerifier);
+
+  const scopes = Array.isArray(config.scopes)
+    ? config.scopes.join(" ")
+    : config.scopes;
+
+  const authParams = new URLSearchParams({
+    client_id: config.clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: scopes,
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: "S256",
+    access_type: "offline",
+    prompt: "consent",
+  });
+
+  const authorizationUrl = `${config.authUrl}?${authParams.toString()}`;
+
+  // Start callback server before opening browser
+  const callbackPromise = waitForCallback(port);
+
+  openBrowser(authorizationUrl);
+
+  const { code, state: returnedState } = await callbackPromise;
+
+  if (returnedState !== state) {
+    throw new Error("OAuth state mismatch — possible CSRF attack.");
+  }
+
+  const tokenResponse = await exchangeCodeForTokens(config.tokenUrl, {
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: redirectUri,
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+    code_verifier: codeVerifier,
+  });
+
+  const tokens: StoredTokens = {
+    access_token: tokenResponse.access_token,
+    refresh_token: tokenResponse.refresh_token,
+    expires_at: Date.now() + tokenResponse.expires_in * 1000,
+    token_url: config.tokenUrl,
+    client_id: config.clientId,
+    client_secret: config.clientSecret,
+  };
+
+  saveTokens(name, tokens);
+
+  return { success: true };
+}
+
+export async function _getAccessToken(name: string): Promise<string> {
+  const tokens = loadTokens(name);
+  if (!tokens) {
+    throw new Error(
+      `No OAuth tokens found for "${name}". Run authorize("${name}", config) first.`
+    );
+  }
+
+  // Token still valid
+  if (Date.now() < tokens.expires_at - EXPIRY_BUFFER_MS) {
+    return tokens.access_token;
+  }
+
+  // Need to refresh
+  if (!tokens.refresh_token) {
+    throw new Error(
+      `OAuth token for "${name}" has expired and no refresh token is available. Run authorize("${name}", config) again.`
+    );
+  }
+
+  const refreshResponse = await exchangeCodeForTokens(tokens.token_url, {
+    grant_type: "refresh_token",
+    refresh_token: tokens.refresh_token,
+    client_id: tokens.client_id,
+    client_secret: tokens.client_secret,
+  });
+
+  // Update stored tokens
+  tokens.access_token = refreshResponse.access_token;
+  tokens.expires_at = Date.now() + refreshResponse.expires_in * 1000;
+  // Some providers rotate refresh tokens
+  if (refreshResponse.refresh_token) {
+    tokens.refresh_token = refreshResponse.refresh_token;
+  }
+
+  saveTokens(name, tokens);
+
+  return tokens.access_token;
+}
+
+export function _isAuthorized(name: string): boolean {
+  return loadTokens(name) !== null;
+}
+
+export function _revokeAuth(name: string): { revoked: boolean } {
+  const tokenPath = getTokenPath(name);
+  if (fs.existsSync(tokenPath)) {
+    fs.unlinkSync(tokenPath);
+    return { revoked: true };
+  }
+  return { revoked: false };
+}

--- a/packages/agency-lang/stdlib/lib/oauth.ts
+++ b/packages/agency-lang/stdlib/lib/oauth.ts
@@ -1,15 +1,13 @@
 import http from "http";
 import crypto from "crypto";
 import fs from "fs/promises";
+import os from "os";
 import path from "path";
 import { execFile } from "child_process";
 
-const TOKEN_DIR = path.join(
-  process.env.HOME || process.env.USERPROFILE || "~",
-  ".agency",
-  "oauth"
-);
-
+function getTokenDir(): string {
+  return process.env.AGENCY_OAUTH_TOKEN_DIR || path.join(os.homedir(), ".agency", "oauth");
+}
 const DEFAULT_PORT = 8914;
 const EXPIRY_BUFFER_MS = 60000;
 const AUTH_TIMEOUT_MS = 300000;
@@ -25,6 +23,7 @@ export type OAuthConfig = {
   clientSecret: string;
   scopes: string | string[];
   port?: number;
+  extraAuthParams?: string | Record<string, string>;
 };
 
 type StoredTokens = {
@@ -42,7 +41,7 @@ function getTokenPath(name: string): string {
       `Invalid OAuth provider name: "${name}". Use only letters, numbers, dots, hyphens, and underscores.`
     );
   }
-  return path.join(TOKEN_DIR, `${name}.json`);
+  return path.join(getTokenDir(), `${name}.json`);
 }
 
 function generateCodeVerifier(): string {
@@ -57,14 +56,26 @@ function escapeHtml(str: string): string {
   return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
+function parseExtraParams(str: string): Record<string, string> {
+  if (!str.trim()) return {};
+  const result: Record<string, string> = {};
+  for (const pair of str.trim().split(/\s+/)) {
+    const eqIdx = pair.indexOf("=");
+    if (eqIdx > 0) {
+      result[pair.slice(0, eqIdx)] = pair.slice(eqIdx + 1);
+    }
+  }
+  return result;
+}
+
 function openBrowser(url: string): void {
-  const cmd =
-    process.platform === "darwin"
-      ? "open"
-      : process.platform === "win32"
-        ? "start"
-        : "xdg-open";
-  execFile(cmd, [url], () => {});
+  if (process.platform === "darwin") {
+    execFile("open", [url], () => {});
+  } else if (process.platform === "win32") {
+    execFile("cmd.exe", ["/c", "start", "", url], () => {});
+  } else {
+    execFile("xdg-open", [url], () => {});
+  }
 }
 
 function waitForCallback(
@@ -167,7 +178,7 @@ async function exchangeCodeForTokens(
 }
 
 async function saveTokens(name: string, tokens: StoredTokens): Promise<void> {
-  await fs.mkdir(TOKEN_DIR, { recursive: true });
+  await fs.mkdir(getTokenDir(), { recursive: true });
   await fs.writeFile(getTokenPath(name), JSON.stringify(tokens, null, 2), {
     encoding: "utf-8",
     mode: 0o600,
@@ -192,7 +203,7 @@ export async function _authorize(
   name: string,
   config: OAuthConfig
 ): Promise<{ success: boolean }> {
-  const port = config.port ?? DEFAULT_PORT;
+  const port = (config.port && config.port > 0) ? config.port : DEFAULT_PORT;
   const redirectUri = `http://127.0.0.1:${port}`;
   const state = crypto.randomBytes(16).toString("hex");
   const codeVerifier = generateCodeVerifier();
@@ -210,9 +221,17 @@ export async function _authorize(
     state,
     code_challenge: codeChallenge,
     code_challenge_method: "S256",
-    access_type: "offline",
-    prompt: "consent",
   });
+
+  // Provider-specific params (e.g. access_type=offline for Google)
+  if (config.extraAuthParams) {
+    const params = typeof config.extraAuthParams === "string"
+      ? parseExtraParams(config.extraAuthParams)
+      : config.extraAuthParams;
+    for (const [key, value] of Object.entries(params)) {
+      authParams.set(key, value);
+    }
+  }
 
   const authorizationUrl = `${config.authUrl}?${authParams.toString()}`;
 
@@ -252,7 +271,7 @@ export async function _getAccessToken(name: string): Promise<string> {
   const tokens = await loadTokens(name);
   if (!tokens) {
     throw new Error(
-      `No OAuth tokens found for "${name}". Run authorize("${name}", config) first.`
+      `No OAuth tokens found for "${name}". Run authorize() first.`
     );
   }
 
@@ -262,12 +281,11 @@ export async function _getAccessToken(name: string): Promise<string> {
 
   if (!tokens.refresh_token) {
     throw new Error(
-      `OAuth token for "${name}" has expired and no refresh token is available. Run authorize("${name}", config) again.`
+      `OAuth token for "${name}" has expired and no refresh token is available. Run authorize() again.`
     );
   }
 
   // Use a mutex to prevent concurrent refresh attempts for the same provider.
-  // If a refresh is already in flight, wait for it instead of firing another.
   if (refreshLocks[name]) {
     return refreshLocks[name]!;
   }

--- a/packages/agency-lang/stdlib/lib/oauth.ts
+++ b/packages/agency-lang/stdlib/lib/oauth.ts
@@ -1,6 +1,6 @@
 import http from "http";
 import crypto from "crypto";
-import fs from "fs";
+import fs from "fs/promises";
 import path from "path";
 import { execFile } from "child_process";
 
@@ -11,7 +11,12 @@ const TOKEN_DIR = path.join(
 );
 
 const DEFAULT_PORT = 8914;
-const EXPIRY_BUFFER_MS = 60000; // refresh 60s before expiry
+const EXPIRY_BUFFER_MS = 60000;
+const AUTH_TIMEOUT_MS = 300000;
+const VALID_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/i;
+
+// Per-provider mutex to prevent concurrent refresh races
+const refreshLocks: Record<string, Promise<string> | undefined> = {};
 
 export type OAuthConfig = {
   authUrl: string;
@@ -32,8 +37,10 @@ type StoredTokens = {
 };
 
 function getTokenPath(name: string): string {
-  if (name.includes("/") || name.includes("\\") || name.includes("..")) {
-    throw new Error(`Invalid OAuth provider name: "${name}"`);
+  if (!VALID_NAME_PATTERN.test(name)) {
+    throw new Error(
+      `Invalid OAuth provider name: "${name}". Use only letters, numbers, dots, hyphens, and underscores.`
+    );
   }
   return path.join(TOKEN_DIR, `${name}.json`);
 }
@@ -44,6 +51,10 @@ function generateCodeVerifier(): string {
 
 function generateCodeChallenge(verifier: string): string {
   return crypto.createHash("sha256").update(verifier).digest("base64url");
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
 function openBrowser(url: string): void {
@@ -60,15 +71,25 @@ function waitForCallback(
   port: number
 ): Promise<{ code: string; state: string }> {
   return new Promise((resolve, reject) => {
+    let settled = false;
+
     const server = http.createServer((req, res) => {
+      if (settled) {
+        res.writeHead(200);
+        res.end();
+        return;
+      }
+
       const url = new URL(req.url ?? "/", `http://127.0.0.1:${port}`);
       const code = url.searchParams.get("code");
       const error = url.searchParams.get("error");
       const state = url.searchParams.get("state") ?? "";
 
       if (error) {
+        settled = true;
         res.writeHead(400, { "Content-Type": "text/html" });
-        res.end(`<h1>Authorization failed</h1><p>${error}</p>`);
+        res.end(`<h1>Authorization failed</h1><p>${escapeHtml(error)}</p>`);
+        clearTimeout(timer);
         server.close();
         reject(new Error(`OAuth authorization failed: ${error}`));
         return;
@@ -77,26 +98,39 @@ function waitForCallback(
       if (!code) {
         res.writeHead(400, { "Content-Type": "text/html" });
         res.end("<h1>Missing authorization code</h1>");
-        server.close();
-        reject(new Error("No authorization code received"));
         return;
       }
 
+      settled = true;
       res.writeHead(200, { "Content-Type": "text/html" });
       res.end(
         "<h1>Authorization successful!</h1><p>You can close this tab and return to your terminal.</p>"
       );
+      clearTimeout(timer);
       server.close();
       resolve({ code, state });
     });
 
-    server.listen(port, "127.0.0.1", () => {});
+    server.on("error", (err: NodeJS.ErrnoException) => {
+      settled = true;
+      clearTimeout(timer);
+      if (err.code === "EADDRINUSE") {
+        reject(new Error(`OAuth callback port ${port} is already in use. Try a different port.`));
+      } else {
+        reject(new Error(`OAuth callback server error: ${err.message}`));
+      }
+    });
 
-    // Timeout after 5 minutes
-    setTimeout(() => {
-      server.close();
-      reject(new Error("OAuth authorization timed out (5 minutes)"));
-    }, 300000);
+    server.listen(port, "127.0.0.1");
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        server.close();
+        reject(new Error("OAuth authorization timed out (5 minutes)"));
+      }
+    }, AUTH_TIMEOUT_MS);
+    timer.unref();
   });
 }
 
@@ -128,22 +162,30 @@ async function exchangeCodeForTokens(
   return {
     access_token: data.access_token as string,
     refresh_token: (data.refresh_token as string) ?? "",
-    expires_in: (data.expires_in as number) ?? 3600,
+    expires_in: Number(data.expires_in) || 3600,
   };
 }
 
-function saveTokens(name: string, tokens: StoredTokens): void {
-  fs.mkdirSync(TOKEN_DIR, { recursive: true });
-  fs.writeFileSync(getTokenPath(name), JSON.stringify(tokens, null, 2), "utf-8");
+async function saveTokens(name: string, tokens: StoredTokens): Promise<void> {
+  await fs.mkdir(TOKEN_DIR, { recursive: true });
+  await fs.writeFile(getTokenPath(name), JSON.stringify(tokens, null, 2), {
+    encoding: "utf-8",
+    mode: 0o600,
+  });
 }
 
-function loadTokens(name: string): StoredTokens | null {
+async function loadTokens(name: string): Promise<StoredTokens | null> {
   const tokenPath = getTokenPath(name);
-  if (!fs.existsSync(tokenPath)) {
+  try {
+    const data = await fs.readFile(tokenPath, "utf-8");
+    const parsed = JSON.parse(data) as Record<string, unknown>;
+    if (!parsed.access_token || !parsed.token_url || !parsed.client_id) {
+      return null;
+    }
+    return parsed as unknown as StoredTokens;
+  } catch {
     return null;
   }
-  const data = fs.readFileSync(tokenPath, "utf-8");
-  return JSON.parse(data) as StoredTokens;
 }
 
 export async function _authorize(
@@ -174,9 +216,7 @@ export async function _authorize(
 
   const authorizationUrl = `${config.authUrl}?${authParams.toString()}`;
 
-  // Start callback server before opening browser
   const callbackPromise = waitForCallback(port);
-
   openBrowser(authorizationUrl);
 
   const { code, state: returnedState } = await callbackPromise;
@@ -203,60 +243,73 @@ export async function _authorize(
     client_secret: config.clientSecret,
   };
 
-  saveTokens(name, tokens);
+  await saveTokens(name, tokens);
 
   return { success: true };
 }
 
 export async function _getAccessToken(name: string): Promise<string> {
-  const tokens = loadTokens(name);
+  const tokens = await loadTokens(name);
   if (!tokens) {
     throw new Error(
       `No OAuth tokens found for "${name}". Run authorize("${name}", config) first.`
     );
   }
 
-  // Token still valid
   if (Date.now() < tokens.expires_at - EXPIRY_BUFFER_MS) {
     return tokens.access_token;
   }
 
-  // Need to refresh
   if (!tokens.refresh_token) {
     throw new Error(
       `OAuth token for "${name}" has expired and no refresh token is available. Run authorize("${name}", config) again.`
     );
   }
 
-  const refreshResponse = await exchangeCodeForTokens(tokens.token_url, {
-    grant_type: "refresh_token",
-    refresh_token: tokens.refresh_token,
-    client_id: tokens.client_id,
-    client_secret: tokens.client_secret,
-  });
-
-  // Update stored tokens
-  tokens.access_token = refreshResponse.access_token;
-  tokens.expires_at = Date.now() + refreshResponse.expires_in * 1000;
-  // Some providers rotate refresh tokens
-  if (refreshResponse.refresh_token) {
-    tokens.refresh_token = refreshResponse.refresh_token;
+  // Use a mutex to prevent concurrent refresh attempts for the same provider.
+  // If a refresh is already in flight, wait for it instead of firing another.
+  if (refreshLocks[name]) {
+    return refreshLocks[name]!;
   }
 
-  saveTokens(name, tokens);
+  const refreshPromise = (async () => {
+    try {
+      const refreshResponse = await exchangeCodeForTokens(tokens.token_url, {
+        grant_type: "refresh_token",
+        refresh_token: tokens.refresh_token,
+        client_id: tokens.client_id,
+        client_secret: tokens.client_secret,
+      });
 
-  return tokens.access_token;
+      tokens.access_token = refreshResponse.access_token;
+      tokens.expires_at = Date.now() + refreshResponse.expires_in * 1000;
+      // Some providers rotate refresh tokens
+      if (refreshResponse.refresh_token) {
+        tokens.refresh_token = refreshResponse.refresh_token;
+      }
+
+      await saveTokens(name, tokens);
+
+      return tokens.access_token;
+    } finally {
+      delete refreshLocks[name];
+    }
+  })();
+
+  refreshLocks[name] = refreshPromise;
+  return refreshPromise;
 }
 
-export function _isAuthorized(name: string): boolean {
-  return loadTokens(name) !== null;
+export async function _isAuthorized(name: string): Promise<boolean> {
+  return (await loadTokens(name)) !== null;
 }
 
-export function _revokeAuth(name: string): { revoked: boolean } {
+export async function _revokeAuth(name: string): Promise<{ revoked: boolean }> {
   const tokenPath = getTokenPath(name);
-  if (fs.existsSync(tokenPath)) {
-    fs.unlinkSync(tokenPath);
+  try {
+    await fs.unlink(tokenPath);
     return { revoked: true };
+  } catch {
+    return { revoked: false };
   }
-  return { revoked: false };
 }

--- a/packages/agency-lang/stdlib/lib/oauth.ts
+++ b/packages/agency-lang/stdlib/lib/oauth.ts
@@ -281,14 +281,16 @@ export async function _authorize(
     throw new Error("OAuth state mismatch — possible CSRF attack.");
   }
 
-  const tokenResponse = await exchangeCodeForTokens(config.tokenUrl, {
+  const exchangeParams: Record<string, string> = {
     grant_type: "authorization_code",
     code,
     redirect_uri: redirectUri,
     client_id: config.clientId,
-    client_secret: config.clientSecret,
     code_verifier: codeVerifier,
-  });
+  };
+  if (config.clientSecret) exchangeParams.client_secret = config.clientSecret;
+
+  const tokenResponse = await exchangeCodeForTokens(config.tokenUrl, exchangeParams);
 
   const tokens: StoredTokens = {
     access_token: tokenResponse.access_token,
@@ -329,12 +331,14 @@ export async function _getAccessToken(name: string): Promise<string> {
 
   const refreshPromise = (async () => {
     try {
-      const refreshResponse = await exchangeCodeForTokens(tokens.token_url, {
+      const refreshParams: Record<string, string> = {
         grant_type: "refresh_token",
         refresh_token: tokens.refresh_token,
         client_id: tokens.client_id,
-        client_secret: tokens.client_secret,
-      });
+      };
+      if (tokens.client_secret) refreshParams.client_secret = tokens.client_secret;
+
+      const refreshResponse = await exchangeCodeForTokens(tokens.token_url, refreshParams);
 
       tokens.access_token = refreshResponse.access_token;
       tokens.expires_at = Date.now() + refreshResponse.expires_in * 1000;
@@ -364,7 +368,10 @@ export async function _revokeAuth(name: string): Promise<{ revoked: boolean }> {
   try {
     await fs.unlink(tokenPath);
     return { revoked: true };
-  } catch {
-    return { revoked: false };
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { revoked: false };
+    }
+    throw err;
   }
 }

--- a/packages/agency-lang/stdlib/lib/oauth.ts
+++ b/packages/agency-lang/stdlib/lib/oauth.ts
@@ -218,20 +218,8 @@ async function loadTokens(name: string): Promise<StoredTokens | null> {
   try {
     const raw = await fs.readFile(tokenPath, "utf-8");
 
-    // Determine if file is encrypted or plaintext JSON
-    let json: string;
-    if (raw.trimStart().startsWith("{")) {
-      json = raw;
-    } else {
-      const key = await getEncryptionKey();
-      if (!key) {
-        throw new Error(
-          `OAuth token file for "${name}" is encrypted but no decryption key is available. ` +
-          `Set AGENCY_OAUTH_KEY env var or ensure the system keyring is accessible.`
-        );
-      }
-      json = decrypt(raw, key);
-    }
+    const key = await getEncryptionKey();
+    const json = key ? decrypt(raw, key) : raw;
 
     const parsed = JSON.parse(json) as Record<string, unknown>;
     if (

--- a/packages/agency-lang/stdlib/lib/oauth.ts
+++ b/packages/agency-lang/stdlib/lib/oauth.ts
@@ -16,6 +16,16 @@ const VALID_NAME_PATTERN = /^[a-z0-9][a-z0-9._-]*$/i;
 // Per-provider mutex to prevent concurrent refresh races
 const refreshLocks: Record<string, Promise<string> | undefined> = {};
 
+function requireHttps(url: string, label: string): void {
+  const parsed = new URL(url);
+  if (parsed.protocol !== "https:" && parsed.hostname !== "localhost" && parsed.hostname !== "127.0.0.1") {
+    throw new Error(
+      `${label} must use HTTPS (got "${parsed.protocol}//"). ` +
+      `HTTP is only allowed for localhost during development.`
+    );
+  }
+}
+
 export type OAuthConfig = {
   authUrl: string;
   tokenUrl: string;
@@ -93,6 +103,14 @@ function waitForCallback(
       }
 
       const url = new URL(req.url ?? "/", `http://127.0.0.1:${port}`);
+
+      // Only handle the callback path; ignore favicon, prefetch, etc.
+      if (url.pathname !== "/oauth/callback" && url.pathname !== "/") {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
+
       const code = url.searchParams.get("code");
       const error = url.searchParams.get("error");
       const state = url.searchParams.get("state") ?? "";
@@ -160,8 +178,11 @@ async function exchangeCodeForTokens(
 
   if (!response.ok) {
     const responseBody = await response.text();
+    const truncated = responseBody.length > 200
+      ? responseBody.slice(0, 200) + "..."
+      : responseBody;
     throw new Error(
-      `OAuth token exchange failed (${response.status}): ${responseBody}`
+      `OAuth token exchange failed (${response.status}): ${truncated}`
     );
   }
 
@@ -210,8 +231,11 @@ export async function _authorize(
   name: string,
   config: OAuthConfig
 ): Promise<{ success: boolean }> {
+  requireHttps(config.authUrl, "authUrl");
+  requireHttps(config.tokenUrl, "tokenUrl");
+
   const port = (config.port && config.port > 0) ? config.port : DEFAULT_PORT;
-  const redirectUri = `http://127.0.0.1:${port}`;
+  const redirectUri = `http://127.0.0.1:${port}/oauth/callback`;
   const state = crypto.randomBytes(16).toString("hex");
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = generateCodeChallenge(codeVerifier);

--- a/packages/agency-lang/stdlib/lib/oauth.ts
+++ b/packages/agency-lang/stdlib/lib/oauth.ts
@@ -83,6 +83,7 @@ function waitForCallback(
 ): Promise<{ code: string; state: string }> {
   return new Promise((resolve, reject) => {
     let settled = false;
+    let timer: ReturnType<typeof setTimeout>;
 
     const server = http.createServer((req, res) => {
       if (settled) {
@@ -134,7 +135,7 @@ function waitForCallback(
 
     server.listen(port, "127.0.0.1");
 
-    const timer = setTimeout(() => {
+    timer = setTimeout(() => {
       if (!settled) {
         settled = true;
         server.close();
@@ -190,7 +191,13 @@ async function loadTokens(name: string): Promise<StoredTokens | null> {
   try {
     const data = await fs.readFile(tokenPath, "utf-8");
     const parsed = JSON.parse(data) as Record<string, unknown>;
-    if (!parsed.access_token || !parsed.token_url || !parsed.client_id) {
+    if (
+      !parsed.access_token ||
+      !parsed.token_url ||
+      !parsed.client_id ||
+      !parsed.client_secret ||
+      typeof parsed.expires_at !== "number"
+    ) {
       return null;
     }
     return parsed as unknown as StoredTokens;
@@ -213,30 +220,26 @@ export async function _authorize(
     ? config.scopes.join(" ")
     : config.scopes;
 
-  const authParams = new URLSearchParams({
-    client_id: config.clientId,
-    redirect_uri: redirectUri,
-    response_type: "code",
-    scope: scopes,
-    state,
-    code_challenge: codeChallenge,
-    code_challenge_method: "S256",
-  });
+  const authorizationUrl = new URL(config.authUrl);
+  authorizationUrl.searchParams.set("client_id", config.clientId);
+  authorizationUrl.searchParams.set("redirect_uri", redirectUri);
+  authorizationUrl.searchParams.set("response_type", "code");
+  authorizationUrl.searchParams.set("scope", scopes);
+  authorizationUrl.searchParams.set("state", state);
+  authorizationUrl.searchParams.set("code_challenge", codeChallenge);
+  authorizationUrl.searchParams.set("code_challenge_method", "S256");
 
-  // Provider-specific params (e.g. access_type=offline for Google)
   if (config.extraAuthParams) {
     const params = typeof config.extraAuthParams === "string"
       ? parseExtraParams(config.extraAuthParams)
       : config.extraAuthParams;
     for (const [key, value] of Object.entries(params)) {
-      authParams.set(key, value);
+      authorizationUrl.searchParams.set(key, value);
     }
   }
 
-  const authorizationUrl = `${config.authUrl}?${authParams.toString()}`;
-
   const callbackPromise = waitForCallback(port);
-  openBrowser(authorizationUrl);
+  openBrowser(authorizationUrl.toString());
 
   const { code, state: returnedState } = await callbackPromise;
 

--- a/packages/agency-lang/stdlib/lib/oauth.ts
+++ b/packages/agency-lang/stdlib/lib/oauth.ts
@@ -4,6 +4,7 @@ import fs from "fs/promises";
 import os from "os";
 import path from "path";
 import { execFile } from "child_process";
+import { getEncryptionKey, encrypt, decrypt } from "./oauthEncryption.js";
 
 function getTokenDir(): string {
   return process.env.AGENCY_OAUTH_TOKEN_DIR || path.join(os.homedir(), ".agency", "oauth");
@@ -201,7 +202,12 @@ async function exchangeCodeForTokens(
 
 async function saveTokens(name: string, tokens: StoredTokens): Promise<void> {
   await fs.mkdir(getTokenDir(), { recursive: true });
-  await fs.writeFile(getTokenPath(name), JSON.stringify(tokens, null, 2), {
+  const json = JSON.stringify(tokens, null, 2);
+
+  const key = await getEncryptionKey();
+  const content = key ? encrypt(json, key) : json;
+
+  await fs.writeFile(getTokenPath(name), content, {
     encoding: "utf-8",
     mode: 0o600,
   });
@@ -210,8 +216,24 @@ async function saveTokens(name: string, tokens: StoredTokens): Promise<void> {
 async function loadTokens(name: string): Promise<StoredTokens | null> {
   const tokenPath = getTokenPath(name);
   try {
-    const data = await fs.readFile(tokenPath, "utf-8");
-    const parsed = JSON.parse(data) as Record<string, unknown>;
+    const raw = await fs.readFile(tokenPath, "utf-8");
+
+    // Determine if file is encrypted or plaintext JSON
+    let json: string;
+    if (raw.trimStart().startsWith("{")) {
+      json = raw;
+    } else {
+      const key = await getEncryptionKey();
+      if (!key) {
+        throw new Error(
+          `OAuth token file for "${name}" is encrypted but no decryption key is available. ` +
+          `Set AGENCY_OAUTH_KEY env var or ensure the system keyring is accessible.`
+        );
+      }
+      json = decrypt(raw, key);
+    }
+
+    const parsed = JSON.parse(json) as Record<string, unknown>;
     if (
       !parsed.access_token ||
       !parsed.token_url ||

--- a/packages/agency-lang/stdlib/lib/oauthEncryption.ts
+++ b/packages/agency-lang/stdlib/lib/oauthEncryption.ts
@@ -1,0 +1,71 @@
+import crypto from "crypto";
+import { _getSecret, _setSecret, _isKeyringAvailable } from "./keyring.js";
+
+const KEYRING_KEY = "oauth-encryption-key";
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
+
+/**
+ * Get or create the encryption key for OAuth token files.
+ * Priority: AGENCY_OAUTH_KEY env var > system keyring > null (plaintext fallback)
+ */
+export async function getEncryptionKey(): Promise<Buffer | null> {
+  // 1. Check env var
+  const envKey = process.env.AGENCY_OAUTH_KEY;
+  if (envKey) {
+    // Derive a 256-bit key from the env var using SHA-256
+    return crypto.createHash("sha256").update(envKey).digest();
+  }
+
+  // 2. Try system keyring
+  if (await _isKeyringAvailable()) {
+    const stored = await _getSecret(KEYRING_KEY);
+    if (stored) {
+      return Buffer.from(stored, "hex");
+    }
+
+    // Generate and store a new key
+    const newKey = crypto.randomBytes(32);
+    await _setSecret(KEYRING_KEY, newKey.toString("hex"));
+    return newKey;
+  }
+
+  // 3. No encryption available
+  return null;
+}
+
+/**
+ * Encrypt a string using AES-256-GCM.
+ * Returns a base64-encoded string containing: iv + ciphertext + auth tag
+ */
+export function encrypt(plaintext: string, key: Buffer): string {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf-8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  // Pack: iv (12) + tag (16) + ciphertext
+  const packed = Buffer.concat([iv, tag, encrypted]);
+  return packed.toString("base64");
+}
+
+/**
+ * Decrypt a base64-encoded string that was encrypted with encrypt().
+ */
+export function decrypt(ciphertext: string, key: Buffer): string {
+  const packed = Buffer.from(ciphertext, "base64");
+
+  if (packed.length < IV_LENGTH + TAG_LENGTH) {
+    throw new Error("Invalid encrypted token data (too short).");
+  }
+
+  const iv = packed.subarray(0, IV_LENGTH);
+  const tag = packed.subarray(IV_LENGTH, IV_LENGTH + TAG_LENGTH);
+  const encrypted = packed.subarray(IV_LENGTH + TAG_LENGTH);
+
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+  return decrypted.toString("utf-8");
+}

--- a/packages/agency-lang/stdlib/lib/oauthEncryption.ts
+++ b/packages/agency-lang/stdlib/lib/oauthEncryption.ts
@@ -3,6 +3,7 @@ import { _getSecret, _setSecret, _isKeyringAvailable } from "./keyring.js";
 
 const KEYRING_KEY = "oauth-encryption-key";
 const ALGORITHM = "aes-256-gcm";
+const KEY_LENGTH = 32;
 const IV_LENGTH = 12;
 const TAG_LENGTH = 16;
 
@@ -11,33 +12,42 @@ const TAG_LENGTH = 16;
  * Priority: AGENCY_OAUTH_KEY env var > system keyring > null (plaintext fallback)
  */
 export async function getEncryptionKey(): Promise<Buffer | null> {
-  // 1. Check env var
   const envKey = process.env.AGENCY_OAUTH_KEY;
   if (envKey) {
-    // Derive a 256-bit key from the env var using SHA-256
     return crypto.createHash("sha256").update(envKey).digest();
   }
 
-  // 2. Try system keyring
   if (await _isKeyringAvailable()) {
     const stored = await _getSecret(KEYRING_KEY);
     if (stored) {
-      return Buffer.from(stored, "hex");
+      const decoded = Buffer.from(stored, "hex");
+      if (decoded.length !== KEY_LENGTH) {
+        // Corrupted key — regenerate
+        const newKey = crypto.randomBytes(KEY_LENGTH);
+        await _setSecret(KEYRING_KEY, newKey.toString("hex"));
+        return newKey;
+      }
+      return decoded;
     }
 
-    // Generate and store a new key
-    const newKey = crypto.randomBytes(32);
+    // Generate a new key, store it, then re-read to handle races
+    const newKey = crypto.randomBytes(KEY_LENGTH);
     await _setSecret(KEYRING_KEY, newKey.toString("hex"));
+
+    // Re-read to converge on a single key if another process raced us
+    const verify = await _getSecret(KEYRING_KEY);
+    if (verify) {
+      return Buffer.from(verify, "hex");
+    }
     return newKey;
   }
 
-  // 3. No encryption available
   return null;
 }
 
 /**
  * Encrypt a string using AES-256-GCM.
- * Returns a base64-encoded string containing: iv + ciphertext + auth tag
+ * Returns a base64-encoded string: iv (12 bytes) + auth tag (16 bytes) + ciphertext
  */
 export function encrypt(plaintext: string, key: Buffer): string {
   const iv = crypto.randomBytes(IV_LENGTH);
@@ -45,13 +55,13 @@ export function encrypt(plaintext: string, key: Buffer): string {
   const encrypted = Buffer.concat([cipher.update(plaintext, "utf-8"), cipher.final()]);
   const tag = cipher.getAuthTag();
 
-  // Pack: iv (12) + tag (16) + ciphertext
   const packed = Buffer.concat([iv, tag, encrypted]);
   return packed.toString("base64");
 }
 
 /**
- * Decrypt a base64-encoded string that was encrypted with encrypt().
+ * Decrypt a base64-encoded string produced by encrypt().
+ * Layout: iv (12 bytes) + auth tag (16 bytes) + ciphertext
  */
 export function decrypt(ciphertext: string, key: Buffer): string {
   const packed = Buffer.from(ciphertext, "base64");

--- a/packages/agency-lang/stdlib/oauth.agency
+++ b/packages/agency-lang/stdlib/oauth.agency
@@ -1,0 +1,76 @@
+import { _authorize, _getAccessToken, _isAuthorized, _revokeAuth } from "./lib/oauth.js"
+
+/**
+  ## Usage
+
+  ```ts
+  import { authorize, getAccessToken, isAuthorized } from "std::oauth"
+
+  node main() {
+    // One-time: opens browser for user consent, saves tokens locally
+    if (!isAuthorized("google-calendar")) {
+      authorize("google-calendar", {
+        authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
+        tokenUrl: "https://oauth2.googleapis.com/token",
+        clientId: env("GOOGLE_CLIENT_ID"),
+        clientSecret: env("GOOGLE_CLIENT_SECRET"),
+        scopes: ["https://www.googleapis.com/auth/calendar"]
+      })
+    }
+
+    // Get a valid access token (auto-refreshes if expired)
+    const token = getAccessToken("google-calendar")
+
+    // Use with any API
+    const events = fetchJSON("https://www.googleapis.com/calendar/v3/calendars/primary/events", {
+      headers: { "Authorization": "Bearer ${token}" }
+    })
+    print(events)
+  }
+  ```
+
+  ## Setup
+
+  To use OAuth with a provider, you need:
+  1. Register an app with the provider (e.g. Google Cloud Console)
+  2. Get a client ID and client secret
+  3. Set them as env vars or pass directly
+
+  Tokens are stored in `~/.agency/oauth/{name}.json`.
+  The authorization flow uses PKCE for security.
+*/
+
+export def authorize(name: string, authUrl: string, tokenUrl: string, clientId: string, clientSecret: string, scopes: string, port: number = 0): Result {
+  """
+  Start an OAuth 2.0 authorization flow. Opens the user's browser for consent, captures the callback, exchanges the code for tokens, and saves them locally. Only needs to be run once per provider. Parameters: name (identifier for this auth, e.g. "google-calendar"), authUrl (provider's authorization endpoint), tokenUrl (provider's token endpoint), clientId, clientSecret, scopes (space-separated), port (localhost callback port, default 8914).
+  """
+  return try _authorize(name, {
+    authUrl: authUrl,
+    tokenUrl: tokenUrl,
+    clientId: clientId,
+    clientSecret: clientSecret,
+    scopes: scopes,
+    port: port
+  })
+}
+
+export def getAccessToken(name: string): Result {
+  """
+  Get a valid OAuth access token for a previously authorized provider. Automatically refreshes the token if it has expired. Returns the access token string. Throws if not yet authorized (run authorize first).
+  """
+  return try _getAccessToken(name)
+}
+
+export safe def isAuthorized(name: string): boolean {
+  """
+  Check if OAuth tokens exist for a given provider name. Returns true if tokens are stored locally (does not verify they are still valid).
+  """
+  return _isAuthorized(name)
+}
+
+export def revokeAuth(name: string): Result {
+  """
+  Delete stored OAuth tokens for a provider. The user will need to run authorize again to re-authenticate.
+  """
+  return try _revokeAuth(name)
+}

--- a/packages/agency-lang/stdlib/oauth.agency
+++ b/packages/agency-lang/stdlib/oauth.agency
@@ -7,21 +7,19 @@ import { _authorize, _getAccessToken, _isAuthorized, _revokeAuth } from "./lib/o
   import { authorize, getAccessToken, isAuthorized } from "std::oauth"
 
   node main() {
-    // One-time: opens browser for user consent, saves tokens locally
     if (!isAuthorized("google-calendar")) {
-      authorize("google-calendar", {
+      authorize("google-calendar",
         authUrl: "https://accounts.google.com/o/oauth2/v2/auth",
         tokenUrl: "https://oauth2.googleapis.com/token",
         clientId: env("GOOGLE_CLIENT_ID"),
         clientSecret: env("GOOGLE_CLIENT_SECRET"),
-        scopes: ["https://www.googleapis.com/auth/calendar"]
-      })
+        scopes: "https://www.googleapis.com/auth/calendar",
+        extraAuthParams: "access_type=offline prompt=consent"
+      )
     }
 
-    // Get a valid access token (auto-refreshes if expired)
     const token = getAccessToken("google-calendar")
 
-    // Use with any API
     const events = fetchJSON("https://www.googleapis.com/calendar/v3/calendars/primary/events", {
       headers: { "Authorization": "Bearer ${token}" }
     })
@@ -40,9 +38,9 @@ import { _authorize, _getAccessToken, _isAuthorized, _revokeAuth } from "./lib/o
   The authorization flow uses PKCE for security.
 */
 
-export def authorize(name: string, authUrl: string, tokenUrl: string, clientId: string, clientSecret: string, scopes: string, port: number = 0): Result {
+export def authorize(name: string, authUrl: string, tokenUrl: string, clientId: string, clientSecret: string, scopes: string, port: number = 0, extraAuthParams: string = ""): Result {
   """
-  Start an OAuth 2.0 authorization flow. Opens the user's browser for consent, captures the callback, exchanges the code for tokens, and saves them locally. Only needs to be run once per provider. Parameters: name (identifier for this auth, e.g. "google-calendar"), authUrl (provider's authorization endpoint), tokenUrl (provider's token endpoint), clientId, clientSecret, scopes (space-separated), port (localhost callback port, default 8914).
+  Start an OAuth 2.0 authorization flow. Opens the user's browser for consent, captures the callback, exchanges the code for tokens, and saves them locally. Only needs to be run once per provider. Parameters: name (identifier like "google-calendar"), authUrl (authorization endpoint), tokenUrl (token endpoint), clientId, clientSecret, scopes (space-separated), port (callback port, default 8914), extraAuthParams (space-separated key=value pairs for provider-specific params like "access_type=offline prompt=consent").
   """
   return try _authorize(name, {
     authUrl: authUrl,
@@ -50,13 +48,14 @@ export def authorize(name: string, authUrl: string, tokenUrl: string, clientId: 
     clientId: clientId,
     clientSecret: clientSecret,
     scopes: scopes,
-    port: port
+    port: port,
+    extraAuthParams: extraAuthParams
   })
 }
 
 export def getAccessToken(name: string): Result {
   """
-  Get a valid OAuth access token for a previously authorized provider. Automatically refreshes the token if it has expired. Returns the access token string. Throws if not yet authorized (run authorize first).
+  Get a valid OAuth access token for a previously authorized provider. Automatically refreshes the token if it has expired. Returns the access token string. Throws if not yet authorized.
   """
   return try _getAccessToken(name)
 }

--- a/packages/agency-lang/stdlib/oauth.agency
+++ b/packages/agency-lang/stdlib/oauth.agency
@@ -38,7 +38,7 @@ import { _authorize, _getAccessToken, _isAuthorized, _revokeAuth } from "./lib/o
   The authorization flow uses PKCE for security.
 */
 
-export def authorize(name: string, authUrl: string, tokenUrl: string, clientId: string, clientSecret: string, scopes: string, port: number = 0, extraAuthParams: string = ""): Result {
+export def authorize(name: string, authUrl: string, tokenUrl: string, clientId: string, clientSecret: string, scopes: string, port: number = 8914, extraAuthParams: string = ""): Result {
   """
   Start an OAuth 2.0 authorization flow. Opens the user's browser for consent, captures the callback, exchanges the code for tokens, and saves them locally. Only needs to be run once per provider. Parameters: name (identifier like "google-calendar"), authUrl (authorization endpoint), tokenUrl (token endpoint), clientId, clientSecret, scopes (space-separated), port (callback port, default 8914), extraAuthParams (space-separated key=value pairs for provider-specific params like "access_type=offline prompt=consent").
   """

--- a/packages/agency-lang/stdlib/oauth.agency
+++ b/packages/agency-lang/stdlib/oauth.agency
@@ -36,6 +36,13 @@ import { _authorize, _getAccessToken, _isAuthorized, _revokeAuth } from "./lib/o
 
   Tokens are stored in `~/.agency/oauth/{name}.json`.
   The authorization flow uses PKCE for security.
+
+  ## Token encryption
+  Token files are encrypted at rest using AES-256-GCM.
+  The encryption key is resolved in this order:
+  1. `AGENCY_OAUTH_KEY` env var (for servers/CI)
+  2. System keyring (macOS Keychain / Linux Secret Service) — key is auto-generated on first use
+  3. If neither is available, tokens are stored unencrypted
 */
 
 export def authorize(name: string, authUrl: string, tokenUrl: string, clientId: string, clientSecret: string, scopes: string, port: number = 8914, extraAuthParams: string = ""): Result {


### PR DESCRIPTION
## Summary

- **`std::oauth`**: General-purpose OAuth 2.0 authorization code flow with PKCE. Zero external dependencies — uses only Node built-ins (`http`, `crypto`, `fs`, `child_process`).

### Functions

| Function | Purpose |
|----------|---------|
| `authorize(name, authUrl, tokenUrl, clientId, clientSecret, scopes, port?)` | One-time: opens browser for consent, captures callback, saves tokens |
| `getAccessToken(name)` | Returns valid access token (auto-refreshes if expired) |
| `isAuthorized(name)` | Check if tokens exist for a provider |
| `revokeAuth(name)` | Delete stored tokens |

### How it works

1. User calls `authorize("google-calendar", ...)` once
2. Opens browser → user consents → localhost server captures callback
3. Exchanges auth code for tokens (with PKCE), saves to `~/.agency/oauth/google-calendar.json`
4. After that, `getAccessToken("google-calendar")` returns a valid token (refreshing automatically when expired)

Works with any OAuth 2.0 provider: Google, Microsoft, GitHub, Spotify, Slack, etc.

## Test plan

- [x] 12 unit tests passing (token storage, refresh flow, validation, error cases)
- [x] `.agency` file parses correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
