### PR TITLE
Stdlib: async I/O, interrupt safety, and @module doc comments

### DIFF
--- a/packages/agency-lang/docs/superpowers/specs/2026-05-04-nested-functions-with-closures-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-04-nested-functions-with-closures-design.md
@@ -1,0 +1,990 @@
+# Nested Functions with Compiler-Managed Closures
+
+## Overview
+
+Add support for defining functions inside other functions (nested `def`). The inner function captures variables from the enclosing scope. The captured data is snapshotted into the `AgencyFunction` at creation time, travels with the value, and survives serialization through interrupts. This enables dynamic tool creation — functions whose behavior and description depend on runtime data.
+
+## Motivation
+
+Agency functions are first-class values, but they can only be defined at the top level of a file. You can't create a tool dynamically — one whose behavior or description depends on runtime data. Example use case:
+
+```
+def skill(dir: string) {
+  const files = listFiles(dir)
+  const names = files.join(", ")
+
+  def readSkill(filename: string): string {
+    """
+    Reads a skill file. Available: ${names}
+    """
+    return readFile("${dir}/${filename}")
+  }
+
+  return readSkill
+}
+
+node main() {
+  const tool = skill("./skills")
+  const result = llm("Pick a skill to read", { tools: [tool] })
+  print(result)
+}
+```
+
+`skill()` reads a directory, caches the file list, and returns a tool whose description lists the available files. The LLM can then call this tool by filename.
+
+## Syntax
+
+### Nested function definition
+
+`def` inside `def` or `node`. Statement only (not an expression):
+
+```
+def outer(x: number) {
+  const multiplier = x * 2
+
+  def inner(y: number): number {
+    return y * multiplier
+  }
+
+  return inner
+}
+```
+
+### Dynamic docstrings
+
+Docstrings can contain template expressions. When the docstring is on an inner function, the template is evaluated at the point the inner function is created (not at parse time):
+
+```
+def skill(dir: string) {
+  const files = listFiles(dir)
+
+  def readSkill(filename: string): string {
+    """
+    Available files: ${files.join(", ")}
+    """
+    return readFile("${dir}/${filename}")
+  }
+
+  return readSkill
+}
+```
+
+The resulting `AgencyFunction`'s `toolDefinition.description` is the evaluated string — e.g., `"Available files: foo.md, bar.md"`.
+
+For top-level functions, docstrings remain static (evaluated at compile time) as they are today. Dynamic evaluation only applies to inner functions where the template references captured variables.
+
+### Returning inner functions
+
+Define the function, then return by name:
+
+```
+def outer() {
+  def inner() { ... }
+  return inner
+}
+```
+
+Future work: `return def inner() { ... }` as sugar (statement + return in one).
+
+### Multiple inner functions
+
+A function can define multiple inner functions:
+
+```
+def createTools(dir: string) {
+  const files = listFiles(dir)
+
+  def readFile(filename: string): string {
+    """Read a file from ${dir}"""
+    return read("${dir}/${filename}")
+  }
+
+  def listAvailable(): string[] {
+    """List files in ${dir}"""
+    return files
+  }
+
+  return [readFile, listAvailable]
+}
+```
+
+### Nesting depth
+
+Inner functions can be nested further (closures within closures):
+
+```
+def a() {
+  const x = 1
+  def b() {
+    const y = 2
+    def c(): number {
+      return x + y  // captures from both a and b
+    }
+    return c
+  }
+  return b
+}
+```
+
+### Same-name inner functions
+
+Two different outer functions can each define an inner function with the same name — they are distinguished by their full path. However, defining two inner functions with the same name in the same outer function is disallowed (even in different branches). The typechecker rejects this:
+
+```
+// ERROR: duplicate inner function name "inner" in "outer"
+def outer() {
+  if (x) {
+    def inner() { return 1 }
+  } else {
+    def inner() { return 2 }  // error
+  }
+}
+```
+
+## Core Design: Closure Data on AgencyFunction
+
+The closure data lives on the `AgencyFunction` instance, NOT on the state stack. This completely avoids the state stack fold/unfold problem.
+
+When `outer()` executes:
+1. `outer()` gets a normal stack frame, computes variables
+2. At the inner `def`, the compiler emits code that snapshots captured variables into `closureData` on the new `AgencyFunction`
+3. `outer()` returns the `AgencyFunction` and its frame is popped normally
+4. The returned `AgencyFunction` (with `closureData`) is stored in whatever variable the caller assigns it to
+
+The closure data is just data on a value that happens to live in a stack frame's locals. The stack fold/unfold proceeds exactly as before.
+
+### Snapshot semantics
+
+Closure data is captured at the point of the `def` statement via **shallow copy**. This means:
+
+- **Primitives** (strings, numbers, booleans): true snapshot — mutation of the variable after `def` has no effect on the closure.
+- **Objects and arrays**: the reference is snapshotted. Reassigning the variable after `def` has no effect. However, mutations to the object's properties ARE visible to the closure (same reference).
+
+**Important difference from JavaScript:** JavaScript closures capture by *reference* (the variable binding). `let x = 1; const f = () => x; x = 2; f()` returns `2` in JavaScript, but would return `1` in Agency. This is an intentional design choice — Agency's serialization model requires snapshot semantics because live variable bindings cannot survive serialization/deserialization across interrupt boundaries. This should be documented prominently in the language guide.
+
+Capture by reference is not feasible because: (1) after the outer function returns, its stack frame is popped — there's no binding to share, and (2) serialization destroys shared object identity — two references to the same object become independent copies after deserialization.
+
+If users want true isolation for objects, they should clone before capturing:
+
+```
+def outer() {
+  const data = { count: 0 }
+  const snapshot = { ...data }  // explicit shallow clone
+
+  def inner() {
+    return snapshot.count  // won't see mutations to data
+  }
+}
+```
+
+## Compilation
+
+### Hoisting
+
+The inner function's implementation is hoisted to module level with a unique namespaced name:
+
+```typescript
+// Hoisted to module level
+async function __outer__inner_impl(y, __state) {
+  const { stateStack, stack } = setupFunction({ state: __state });
+  const __self = stack.locals;
+  const __args = stack.args;
+  __args.y = y;
+
+  // Initialize closure data into locals on first entry
+  if (__self.__closureInit === undefined) {
+    __self.__closureInit = true;
+    __self.__c_multiplier = __state.closure.multiplier;
+  }
+
+  // step 0
+  if (stack.step <= 0) {
+    __self.__step0 = __args.y * __self.__c_multiplier;
+    stack.step = 1;
+  }
+
+  stateStack.pop();
+  return __self.__step0;
+}
+```
+
+Key points:
+- Full `setupFunction` / stack frame / step tracking — interrupts work everywhere
+- Closure variables are copied from `__state.closure` into `__self` on first initialization
+- On interrupt resume, `setupFunction` restores the frame (which already has `__c_multiplier` in locals), so the `__closureInit` check is skipped (it's already set to `true`)
+- The `__c_` prefix distinguishes closure-derived locals from regular locals
+- The `__closureInit` prefix is reserved (like existing `__substep_`, `__condbranch_` prefixes)
+
+### Closure registry
+
+A global registry maps namespaced keys to hoisted implementations along with their param metadata. The `FunctionRefReviver` uses this to find the implementation on deserialization.
+
+The registry lives in its own file (`lib/runtime/closureRegistry.ts`):
+
+```typescript
+// lib/runtime/closureRegistry.ts
+const globalClosureRegistry: Record<string, { fn: Function, params: FuncParam[] }> = {};
+
+export function registerClosure(key: string, entry: { fn: Function, params: FuncParam[] }): void {
+  globalClosureRegistry[key] = entry;
+}
+
+export function lookupClosure(key: string): { fn: Function, params: FuncParam[] } | undefined {
+  return globalClosureRegistry[key];
+}
+```
+
+Each compiled module registers its closure entries at module load time:
+
+```typescript
+// In compiled module (top-level side effect)
+import { registerClosure } from "agency-lang/runtime";
+
+registerClosure("main.agency:outer::inner", {
+  fn: __outer__inner_impl,
+  params: [{ name: "y", hasDefault: false, defaultValue: undefined, variadic: false }],
+});
+```
+
+The registry stores `{ fn, params }` tuples because the reviver needs param metadata to reconstruct the `AgencyFunction` on deserialization.
+
+### Registry design: why a global registry is safe
+
+The closure registry only stores **static code** — hoisted implementation functions and their parameter metadata. It is populated at module load time and is read-only after that. It is analogous to a vtable: shared, static, and immutable.
+
+This does NOT violate Agency's execution isolation guarantee. Each concurrent agent invocation shares the same compiled module code (the same JavaScript functions). What's isolated is the *data* — the state stack, globals, and the `closureData` on each `AgencyFunction` instance. The registry maps closure keys to code; the per-invocation data travels on the `AgencyFunction` value inside each invocation's isolated state.
+
+### Cross-module closure resolution
+
+The global registry handles cross-module usage automatically. If module A defines an inner function and passes it (as a tool, argument, or via globals) to module B:
+
+1. Module A's closure entries are registered at module A's load time
+2. Module B serializes the `AgencyFunction` (including `closureKey` and `closureData`)
+3. On deserialization, the reviver calls `lookupClosure(closureKey)` and finds module A's entry
+
+This works because all imported modules are loaded before any node execution begins. The `closureKey` includes the module path for global uniqueness (e.g., `"main.agency:outer::inner"`).
+
+### Closure snapshot at creation point
+
+At the point where the inner `def` appears in the outer function's compiled code:
+
+```typescript
+// Inside __outer_impl, at the step where inner is defined:
+__self.inner = new AgencyFunction({
+  name: "inner",
+  module: "main.agency",
+  fn: __outer__inner_impl,
+  params: [{ name: "y", hasDefault: false, defaultValue: undefined, variadic: false }],
+  toolDefinition: {
+    name: "inner",
+    description: `${__self.multiplier}`,
+    schema: z.object({ y: z.number() }),
+  },
+  closureData: { multiplier: __self.multiplier },
+  closureKey: "main.agency:outer::inner",
+});
+```
+
+Note: `AgencyFunction.name` is the **short name** (`"inner"`), used by the LLM for tool calls and by `runPrompt` for handler lookup. The `closureKey` is the **namespaced key** (`"main.agency:outer::inner"`), used only for registry lookup during serialization/deserialization.
+
+### Dynamic docstring compilation
+
+The docstring template `"Available files: ${files.join(", ")}"` compiles to a template literal expression evaluated at the creation point:
+
+```typescript
+toolDefinition: {
+  name: "readSkill",
+  description: `Available files: ${__self.files.join(", ")}`,
+  schema: ...
+}
+```
+
+This means the description is a plain string by the time it's stored on the `AgencyFunction`. It references the outer function's locals, which are in scope at creation time.
+
+### Naming convention for hoisted functions
+
+Implementation function: `__<outerName>__<innerName>_impl`
+For deeper nesting: `__<a>__<b>__<c>_impl`
+Registry key: `"<module>:<outer>::<inner>"` (e.g., `"main.agency:outer::inner"` or `"utils.agency:a::b::c"`)
+
+The module path prefix ensures global uniqueness across modules. Different outer functions with identically-named inner functions produce different keys:
+- `main.agency:foo::helper` and `main.agency:bar::helper` are distinct
+- `main.agency:outer::inner` and `utils.agency:outer::inner` are distinct
+
+## AgencyFunction Changes
+
+### New fields
+
+```typescript
+export type AgencyFunctionOpts = {
+  name: string;
+  module: string;
+  fn: Function;
+  params: FuncParam[];
+  toolDefinition: ToolDefinition | null;
+  closureData?: Record<string, unknown> | null;  // NEW
+  closureKey?: string | null;                     // NEW
+};
+
+export class AgencyFunction {
+  // ... existing fields ...
+  readonly closureData: Record<string, unknown> | null;
+  readonly closureKey: string | null;
+
+  constructor(opts: AgencyFunctionOpts) {
+    // ... existing ...
+    this.closureData = opts.closureData ?? null;
+    this.closureKey = opts.closureKey ?? null;
+  }
+}
+```
+
+- `closureData`: the captured variable values (null for top-level functions)
+- `closureKey`: the namespaced registry key for deserialization (null for top-level functions)
+
+### Updated `invoke()`
+
+When invoking an `AgencyFunction` with closure data, the `__state` passed to the underlying `_fn` includes the closure:
+
+```typescript
+async invoke(descriptor: CallType, state?: unknown): Promise<unknown> {
+  const resolvedArgs = this.resolveArgs(descriptor);
+  const effectiveState = this.closureData
+    ? { ...(state as any), closure: this.closureData }
+    : state;
+  return this._fn(...resolvedArgs, effectiveState);
+}
+```
+
+This injects `closure` into the state object. `setupFunction` ignores unknown fields on state, so this is non-breaking. The hoisted implementation reads `__state.closure` after `setupFunction` (the parameter is still in scope).
+
+### `isAgencyFunction` and `create()`
+
+No changes needed. Inner functions are created with `new AgencyFunction(...)` directly — they do NOT use `AgencyFunction.create()` because they should NOT be auto-registered in `__toolRegistry`. They only become tools when explicitly passed to `llm()`.
+
+## Serialization
+
+### Serialized form
+
+```json
+{
+  "__nativeType": "FunctionRef",
+  "name": "inner",
+  "module": "main.agency",
+  "closureKey": "main.agency:outer::inner",
+  "closureData": { "multiplier": 6 },
+  "toolDefinition": {
+    "name": "inner",
+    "description": "Multiplies by 6",
+    "schema": {}
+  },
+  "params": [
+    { "name": "y", "hasDefault": false, "defaultValue": null, "variadic": false }
+  ]
+}
+```
+
+Closure functions serialize: `name`, `module`, `closureKey`, `closureData`, `toolDefinition`, and `params`. The `closureKey` includes the module path for global uniqueness (e.g., `"main.agency:outer::inner"`). The `params` are included because they aren't available from just the registry entry (the registry has the full params, but chained binds could have modified them — including params in the serialized form is simpler and more robust).
+
+Top-level functions continue to serialize as `{ name, module }` only — no closureKey, no closureData.
+
+### FunctionRefReviver changes
+
+**`serialize()`**: If `value.closureKey` is non-null, include closureKey, closureData, toolDefinition, and params:
+
+```typescript
+serialize(value: AgencyFunction): Record<string, unknown> {
+  const result: Record<string, unknown> = {
+    __nativeType: this.nativeTypeName(),
+    name: value.name,
+    module: value.module,
+  };
+  if (value.closureKey) {
+    result.closureKey = value.closureKey;
+    result.closureData = value.closureData;
+    result.toolDefinition = value.toolDefinition;
+    result.params = value.params;
+  }
+  return result;
+}
+```
+
+**`validate()`**: Accept records with or without `closureKey`.
+
+**`revive()`**:
+
+```typescript
+import { lookupClosure } from "./closureRegistry.js";
+
+revive(value: Record<string, unknown>): AgencyFunction {
+  const name = value.name as string;
+  const module = value.module as string;
+
+  // Closure function path
+  if (value.closureKey) {
+    const key = value.closureKey as string;
+    const entry = lookupClosure(key);
+    if (!entry) {
+      throw new Error(`Cannot revive closure function "${key}" — module not loaded`);
+    }
+    const fn = new AgencyFunction({
+      name,
+      module,
+      fn: entry.fn,
+      params: value.params as FuncParam[],
+      toolDefinition: value.toolDefinition as ToolDefinition | null,
+      closureData: value.closureData as Record<string, unknown>,
+      closureKey: key,
+    });
+    // Replace __self__ sentinels for recursive inner functions
+    if (fn.closureData) {
+      for (const [k, v] of Object.entries(fn.closureData)) {
+        if (v === "__self__") fn.closureData[k] = fn;
+      }
+    }
+    return fn;
+  }
+
+  // Regular function path (unchanged)
+  // ... existing lookup in this.registry ...
+}
+```
+
+The reviver uses the global `lookupClosure()` function — no per-instance registry field needed for closures.
+
+### Closure data serialization
+
+The `closureData` object goes through the same `nativeTypeReplacer` / reviver pipeline as any other value in the state stack. Closure values must be serializable:
+- Primitives, objects, arrays: fine
+- Other `AgencyFunction` instances: fine (recursive serialization via FunctionRefReviver)
+- Non-serializable values (file handles, etc.): fail at serialize time (same constraint as any stack frame local)
+
+## Tool Name Resolution in runPrompt
+
+When the LLM calls a tool, `runPrompt` looks up the handler by name (line ~304 in prompt.ts):
+
+```typescript
+const handler = toolFunctions.find((fn) => fn.name === toolCall.name);
+```
+
+The LLM receives tool definitions from `toolDefinition.name`. For inner functions, both `AgencyFunction.name` and `toolDefinition.name` are the **short name** (e.g., `"readSkill"`), so this lookup works correctly.
+
+The namespaced `closureKey` (`"skill::readSkill"`) is only used for registry lookup during serialization/deserialization — it never appears in the LLM's tool schema.
+
+## Closure Analysis (Preprocessor)
+
+### New scope type: `captured`
+
+When the preprocessor encounters a `def` inside another `def` or `node`, it creates a new scope. Variables referenced from the enclosing function scope get a new scope type:
+
+- Variables declared in the inner function → `local`
+- Variables from the enclosing function's args or locals → `captured`
+- Variables from the global scope → `global` (unchanged)
+- Imports → `imported` (unchanged)
+- Function references → `functionRef` (unchanged)
+
+### Algorithm
+
+The preprocessor already walks up the scope chain for variable resolution (it does this for blocks). The extension:
+
+1. When resolving a variable inside an inner function body, if it resolves to a local/arg in an enclosing FUNCTION scope (not the immediate function — that's just `local`), mark it as `captured`.
+2. Collect the set of captured variables for each inner function definition and attach it to the AST node.
+
+### What the builder receives
+
+The inner function's AST node carries a `capturedVariables` list:
+
+```
+capturedVariables: [
+  { name: "multiplier", sourceScope: "outer", sourceType: "local" },
+  { name: "dir", sourceScope: "outer", sourceType: "arg" },
+]
+```
+
+The builder uses this to:
+1. Generate the `closureData` snapshot at the creation point
+2. Generate the `__closureInit` block in the hoisted implementation
+3. Rewrite variable references in the inner function body from `__self.multiplier` to `__self.__c_multiplier`
+
+### Nested closures (closures capturing from closures)
+
+```
+def a() {
+  const x = 1
+  def b() {
+    const y = 2
+    def c(): number {
+      return x + y
+    }
+    return c
+  }
+  return b
+}
+```
+
+When `b()` captures `x` from `a()`, `x` becomes a closure variable in `b`'s locals as `__c_x`. When `c()` captures from `b()`, it sees `__c_x` and `y` as locals of `b` — both are capturable. The preprocessor doesn't need to know whether `__c_x` was itself captured; it's just a local in `b`'s scope.
+
+In the compiled output:
+- `b`'s closureData: `{ x: __self.x }` (from `a`'s frame)
+- `c`'s closureData: `{ x: __self.__c_x, y: __self.y }` (from `b`'s frame)
+
+Each level snapshots from its immediate enclosing scope's locals. No transitive capture needed.
+
+### Distinguishing from blocks
+
+Blocks already capture from enclosing scope and reference `__stack` directly. Inner functions are different:
+- Blocks execute immediately in the same stack frame context.
+- Inner functions are values that may be called later, in a different context.
+
+The preprocessor distinguishes these via AST node type: blocks are `blockExpression` nodes, inner functions are `functionDefinition` nodes nested inside another function.
+
+### Tool/async marking
+
+The preprocessor should NOT mark inner function definitions as async LLM calls or tool registrations. Inner functions become tools only when passed to `llm()` at the call site. The preprocessor treats the inner `def` as a regular assignment step.
+
+## Builder Changes
+
+### Detecting inner function definitions
+
+When processing a `functionDefinition` node, the builder checks if it's nested inside another function (the current scope is a function/node body, not the module top level). If so, it's an inner function.
+
+### What the builder emits for an inner function
+
+1. **Hoisted implementation** (emitted at module level):
+   - Full function with `setupFunction`, step tracking, interrupt support
+   - `__closureInit` block that copies closure data into locals
+   - Variable references for captured vars use `__self.__c_varName`
+
+2. **Closure registry entry** (emitted at module level):
+   ```typescript
+   __closureRegistry["main.agency:outer::inner"] = {
+     fn: __outer__inner_impl,
+     params: [{ name: "y", hasDefault: false, defaultValue: undefined, variadic: false }],
+   };
+   ```
+
+3. **Creation point** (emitted inline where the `def` appears in the outer function):
+   ```typescript
+   __self.inner = new AgencyFunction({
+     name: "inner",
+     module: "main.agency",
+     fn: __outer__inner_impl,
+     params: [{ name: "y", hasDefault: false, defaultValue: undefined, variadic: false }],
+     toolDefinition: { name: "inner", description: `...`, schema: ... },
+     closureData: { multiplier: __self.multiplier, dir: __args.dir },
+     closureKey: "outer::inner",
+   });
+   ```
+
+### Step tracking at the creation point
+
+The inner function definition IS a step in the outer function. It gets a step number and participates in the step counter for interrupt resume.
+
+### Tool definition generation
+
+The inner function's tool definition (Zod schema, description) is generated at the creation point using the same logic as top-level functions, but the description template is evaluated as a runtime expression rather than a static string.
+
+## Typechecker Changes
+
+- Inner function definitions typecheck like top-level functions — params, return type, body.
+- Captured variable types are inferred from the enclosing scope.
+- Template expressions in docstrings must reference in-scope variables.
+- Same-name inner functions within the same outer function are rejected.
+- The return type of a function that returns an inner function is `AgencyFunction` (or a more specific function type if we add that later).
+- `export` on inner function definitions is rejected (inner functions are not at module scope).
+- `safe` on inner function definitions is allowed and handled the same as top-level functions.
+
+## Formatter Changes
+
+The formatter (`AgencyGenerator`) needs to handle nested `def` statements. Changes:
+- Indent inner function definitions to match the enclosing scope
+- Handle blank lines around inner function definitions (same rules as top-level functions)
+- Format `safe def` inside function bodies
+
+## Debugger and Source Map Changes
+
+Inner functions are hoisted to module level in compiled output, but the debugger should show the original nested source location.
+
+- The Runner for a hoisted inner function uses `scopeName` set to the user-facing namespaced name (e.g., `"outer::inner"`), not the implementation name (`"__outer__inner_impl"`)
+- Source map entries for the hoisted implementation point back to the original nested `def` position in the `.agency` file
+- Stepping into an inner function call works the same as stepping into a regular function — the debugger enters the hoisted implementation's steps via the Runner's `debugStep` hooks
+
+No fundamental issues expected — inner functions get full Runner/step tracking, so the debugger's checkpoint and time-travel features work as-is. The main work is ensuring the source mapping displays correctly.
+
+## Parser Changes
+
+Minimal. The parser already knows how to parse `def`. The changes:
+- Allow `functionDefinition` nodes inside `functionBody` / `nodeBody` (currently only allowed at the top level).
+- Parse docstrings with template expressions as template literals rather than plain strings (if not already the case).
+
+## Edge Cases
+
+### Captured variable is an AgencyFunction
+
+```
+def outer() {
+  def helper(): string { return "hi" }
+
+  def tool(): string {
+    """Uses helper internally"""
+    const result = helper()
+    return result
+  }
+
+  return tool
+}
+```
+
+`tool` captures `helper`. `helper` is itself an `AgencyFunction`. This works because:
+- `AgencyFunction` instances are serializable via `FunctionRefReviver`
+- `closureData: { helper: <AgencyFunction> }` serializes recursively
+- On deserialization, `helper` is revived first (it has its own closureKey), then `tool`'s closure data gets the revived instance
+
+### Captured variable is mutated after creation
+
+```
+def outer() {
+  let x = 1
+  def inner(): number { return x }
+  x = 2
+  return inner
+}
+```
+
+`inner` captures `x` at the point of the `def inner()` statement. The closure snapshot is taken at that point, so `closureData.x = 1`. The subsequent `x = 2` does NOT affect the captured value (shallow copy of a primitive). See the "Snapshot semantics" section above for object behavior.
+
+### Inner function calls another inner function
+
+```
+def outer() {
+  def a(): number { return 1 }
+  def b(): number {
+    return a()
+  }
+  return b
+}
+```
+
+`b` captures `a`. When `b` is invoked, it reads `a` from its closure data and calls it via `__call()`. This works because `a` is an `AgencyFunction` stored in `b`'s closure.
+
+### Inner function with no captures
+
+```
+def outer() {
+  def inner(x: number): number { return x + 1 }
+  return inner
+}
+```
+
+If the inner function captures nothing, `closureData` is `null`. The hoisted implementation has no `__closureInit` block. It behaves identically to a top-level function, just defined in a nested position.
+
+### Recursive inner functions
+
+```
+def outer() {
+  def fib(n: number): number {
+    if (n <= 1) { return n }
+    return fib(n - 1) + fib(n - 2)
+  }
+  return fib
+}
+```
+
+`fib` references itself. A naive approach would store the `AgencyFunction` in its own `closureData`, creating a circular reference that breaks `JSON.stringify`. Instead, we use a **sentinel value** (`"__self__"`).
+
+At creation time, the builder emits:
+
+```typescript
+__self.fib = new AgencyFunction({
+  name: "fib",
+  module: "main.agency",
+  fn: __outer__fib_impl,
+  params: [...],
+  toolDefinition: ...,
+  closureData: { fib: "__self__" },
+  closureKey: "main.agency:outer::fib",
+});
+```
+
+No circular reference — `closureData.fib` is just the string `"__self__"`.
+
+In `invoke()`, `__state.self` is set to the `AgencyFunction` instance itself (alongside `__state.closure`):
+
+```typescript
+const effectiveState = this.closureData
+  ? { ...(state as any), closure: this.closureData, self: this }
+  : state;
+```
+
+In the hoisted implementation's `__closureInit` block, the sentinel is replaced with the actual instance:
+
+```typescript
+if (__self.__closureInit === undefined) {
+  __self.__closureInit = true;
+  for (const [k, v] of Object.entries(__state.closure)) {
+    __self[`__c_${k}`] = v === "__self__" ? __state.self : v;
+  }
+}
+```
+
+In `FunctionRefReviver.serialize()`, self-references are detected and emitted as the sentinel:
+
+```typescript
+if (value.closureData) {
+  result.closureData = {};
+  for (const [k, v] of Object.entries(value.closureData)) {
+    result.closureData[k] = v === value ? "__self__" : v;
+  }
+}
+```
+
+In `FunctionRefReviver.revive()`, the sentinel is replaced after construction:
+
+```typescript
+const fn = new AgencyFunction({ ... });
+if (fn.closureData) {
+  for (const [k, v] of Object.entries(fn.closureData)) {
+    if (v === "__self__") fn.closureData[k] = fn;
+  }
+}
+return fn;
+```
+
+The builder detects self-references during closure analysis (the inner function's name appears in its own captured variables list) and emits the sentinel pattern.
+
+Note: mutual recursion between two inner functions (`a` calls `b`, `b` calls `a`) would also create cycles. This can be deferred — it's rare in practice. If needed later, the sentinel can be extended to `"__ref__:outer::a"` to reference other inner functions by key.
+
+### Inner function used as tool — interrupts
+
+```
+def skill(dir: string) {
+  const files = listFiles(dir)
+
+  def readSkill(filename: string): string {
+    return interrupt("Read ${filename}?")
+    return readFile("${dir}/${filename}")
+  }
+
+  return readSkill
+}
+
+node main() {
+  const tool = skill("./skills")
+  handle {
+    const result = llm("Pick a skill", { tools: [tool] })
+  } with (data) {
+    return approve()
+  }
+}
+```
+
+When the LLM calls `readSkill`:
+1. `runPrompt` finds `tool` in the tools array by matching `fn.name` ("readSkill") against `toolCall.name`
+2. Calls `tool.invoke({ type: "named", namedArgs: { filename: "foo.md" } }, state)`
+3. `invoke()` injects `closureData` into state as `state.closure`
+4. The hoisted implementation runs with full step tracking
+5. `interrupt()` fires — the stack frame (with `__c_dir`, `__c_files` in locals) is serialized
+6. On resume, `setupFunction` restores the frame — closure data is already in locals via `__closureInit`
+7. Execution continues past the interrupt
+
+The closure data does NOT need to be re-injected from `__state.closure` on resume — it was copied into the stack frame's locals on first init, and the frame was serialized with those values.
+
+### Inner function defined inside a loop
+
+```
+def createTools(items: string[]) {
+  const tools = []
+  for (item in items) {
+    def handler(query: string): string {
+      """Handles ${item}"""
+      return process(item, query)
+    }
+    tools.push(handler)
+  }
+  return tools
+}
+```
+
+Each iteration creates a new `AgencyFunction` with the same `closureKey` (e.g., `"main.agency:createTools::handler"`) but different `closureData` (different `item` value). This works because:
+- The `closureKey` maps to the static hoisted implementation (shared code)
+- The `closureData` is per-instance (different data on each `AgencyFunction`)
+- On serialization, each instance serializes its own `closureData`
+- On deserialization, each is revived with its own `closureData` + the shared implementation
+
+### Inner function inside a conditional
+
+```
+def outer(mode: string) {
+  if (mode == "a") {
+    def handler(): string { return "mode a" }
+    return handler
+  }
+  return null
+}
+```
+
+The hoisted implementation and closure registry entry are always emitted (they're static module-level code). Unused registry entries are harmless. The conditional branch's step tracking ensures the `closureData` snapshot and `AgencyFunction` construction only happen when the branch executes.
+
+### `safe` keyword on inner functions
+
+Inner functions can be marked `safe`:
+
+```
+def outer() {
+  safe def helper(x: number): number {
+    return x + 1
+  }
+  return helper
+}
+```
+
+The `safe` annotation is stored on the `AgencyFunction` and affects retry behavior when the inner function is used as a tool, same as top-level functions.
+
+### `export` on inner functions
+
+Inner functions cannot be exported — they are defined inside a function body, not at module scope. The typechecker rejects `export` on inner function definitions.
+
+### Direct calls to inner functions via `__call()`
+
+When an inner function is called directly in Agency code (not as a tool by the LLM):
+
+```
+def outer() {
+  def inner(x: number): number { return x + 1 }
+  const result = inner(5)
+}
+```
+
+The compiled code uses `__call(target, descriptor, state)`. The `target` is the `AgencyFunction` in `__self.inner`. `__call` checks `AgencyFunction.isAgencyFunction(target)` and calls `target.invoke(descriptor, state)`. The `invoke` method then injects closure data into state. This works identically to the tool-call path.
+
+## Testing Strategy
+
+### Unit tests (`lib/runtime/agencyFunction.test.ts`)
+
+- `AgencyFunction` with `closureData` — invoke injects closure into state
+- `closureData: null` — invoke passes state unchanged
+- `closureKey` field stored correctly
+- Serialization round-trip with closureData
+- Serialization of nested closureData (closure containing another AgencyFunction)
+
+### Unit tests for FunctionRefReviver
+
+- `serialize()` includes closureKey/closureData/toolDefinition/params when closureKey present
+- `serialize()` produces minimal output for non-closure functions (backward compatible)
+- `revive()` reconstructs AgencyFunction from closureRegistry + closureData
+- `revive()` falls back to toolRegistry for non-closure functions
+- Round-trip with closureData containing various types (primitives, objects, arrays, AgencyFunction)
+
+### Preprocessor tests
+
+- Variable inside inner function referencing enclosing local → marked as `captured`
+- Variable inside inner function referencing enclosing arg → marked as `captured`
+- Variable inside inner function referencing global → marked as `global` (not captured)
+- Variable inside inner function referencing its own local → marked as `local`
+- Nested inner functions — correct capture attribution at each level
+- Inner function with no captures — empty captured list
+- Self-referencing inner function detected
+
+### Parser tests
+
+- `def` inside `def` body parses correctly
+- `def` inside `node` body parses correctly
+- Multiple `def`s inside one function
+- Nested `def` inside `def` inside `def`
+- Docstring with template expression inside inner function
+
+### Builder / fixture tests (`tests/typescriptGenerator/`)
+
+- Inner function hoisted to module level with correct name
+- Closure registry entry generated with fn and params
+- closureData snapshot generated at creation point
+- `__closureInit` block in hoisted implementation
+- Captured vars rewritten to `__self.__c_varName`
+- Dynamic docstring compiled as template literal at creation point
+- Step tracking in hoisted implementation
+- Self-referencing inner function uses two-step construction
+- `AgencyFunction.name` is short name, `closureKey` is namespaced
+
+### Integration tests (`tests/agency/`)
+
+- Define inner function, call it — basic closure works
+- Define inner function, return it, caller calls it — closure survives return
+- Inner function captures multiple variables
+- Inner function captures an argument of the outer function
+- Inner function captures another AgencyFunction
+- Nested closures (3 levels)
+- Inner function used as tool with `llm()` — LLM calls it successfully
+- Inner function throws interrupt — serialize, resume, completes
+- Inner function in a handler block — interrupt propagation works
+- Inner function in fork — each branch gets correct closure
+- Dynamic docstring with template expression — LLM sees correct description
+- Snapshot semantics — reassignment after def doesn't affect closure
+- Recursive inner function works correctly
+- Inner function with no captures works (closureData is null)
+- Inner function defined inside a loop — each iteration captures different data
+- Inner function passed cross-module — interrupt resume works
+- Two different outer functions with same-named inner functions — tool name collision (first match wins, same as regular functions)
+- `safe` inner function used as tool — retry works correctly
+- Inner function inside a conditional branch — only created when branch executes
+
+## Implementation Phases
+
+### Phase 1: Runtime changes
+
+- Create `lib/runtime/closureRegistry.ts` with `registerClosure()` and `lookupClosure()`
+- Add `closureData` and `closureKey` fields to `AgencyFunction` constructor and class
+- Update `invoke()` to inject closure data and self-reference into state
+- Update `FunctionRefReviver` to serialize/revive closure functions using the global registry
+- Handle `__self__` sentinel in serialize/revive for recursive inner functions
+- Unit tests for AgencyFunction and FunctionRefReviver changes
+
+### Phase 2: Parser
+
+- Allow `functionDefinition` inside function/node bodies
+- Ensure docstring template expressions parse correctly in nested position
+- Parser tests
+
+### Phase 3: Preprocessor — closure analysis
+
+- Detect inner function definitions (nested `def`)
+- Walk scope chain to identify captured variables
+- Mark captured variables with new `captured` scope type
+- Attach `capturedVariables` metadata to inner function AST nodes
+- Detect self-references for recursive inner functions
+- Preprocessor tests
+
+### Phase 4: Builder — code generation
+
+- Hoist inner function implementations to module level
+- Generate `registerClosure()` calls at module level (with module-prefixed keys)
+- Generate `closureData` snapshot at creation point
+- Generate `__closureInit` block in hoisted functions (with `__self__` sentinel handling)
+- Rewrite captured variable references to `__self.__c_varName`
+- Compile dynamic docstrings as runtime template literals
+- Generate unique namespaced names for hoisted functions
+- Handle self-referencing inner functions (sentinel pattern)
+- Fixture tests
+
+### Phase 5: Typechecker
+
+- Type-check inner function bodies with captured variable types in scope
+- Validate captured variables are used correctly
+- Reject same-name inner functions in same outer function
+- Reject `export` on inner function definitions
+- Allow `safe` on inner function definitions
+- Infer return type when returning an inner function
+
+### Phase 6: Formatter and debugger
+
+- Update formatter to handle nested `def` statements (indentation, blank lines)
+- Ensure source maps for hoisted implementations point to original nested `def` location
+- Set `scopeName` to user-facing namespaced name (e.g., `"outer::inner"`) in hoisted implementations
+
+### Phase 7: Integration tests and documentation
+
+- Full end-to-end tests (see testing strategy above)
+- Interrupt survival tests
+- Dynamic tool with LLM tests
+- Cross-module inner function tests
+- Write `docs/dev/closures.md` documenting the mental model, data flow, and naming conventions
+- Update the language guide to document nested functions and snapshot semantics

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-05-nested-functions-progress.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-05-nested-functions-progress.md
@@ -1,0 +1,134 @@
+# Nested Functions with Closures — Implementation Progress
+
+## Branch
+
+`feature/nested-functions-closures` — pushed to remote.
+
+Design spec: `docs/superpowers/specs/2026-05-04-nested-functions-with-closures-design.md`
+
+## What's Done
+
+### Phase 1: Runtime changes (complete, all tests pass)
+
+**Files changed:**
+- `lib/runtime/closureRegistry.ts` (new) — global registry mapping closure keys to hoisted implementation functions. Populated at module load time, read-only after that. Also exports `CLOSURE_SELF_SENTINEL` for recursive inner function handling.
+- `lib/runtime/agencyFunction.ts` — added `closureData` and `closureKey` fields to `AgencyFunction`. Updated `invoke()` to inject `closure` and `self` into the state object when `closureData` is present.
+- `lib/runtime/revivers/functionRefReviver.ts` — updated `serialize()` to include `closureKey`, `closureData`, `toolDefinition`, and `params` for closure functions. Updated `revive()` to look up the implementation via `lookupClosure()` from the global registry and replace `__self__` sentinels for recursive inner functions.
+- `lib/runtime/index.ts` — exported `registerClosure`, `lookupClosure`, `CLOSURE_SELF_SENTINEL`, and `ClosureRegistryEntry`.
+
+**Tests:** 47 pass (21 AgencyFunction + 26 FunctionRefReviver, including new closure-specific tests).
+
+### Phase 2: Parser changes (complete, all tests pass)
+
+**Files changed:**
+- `lib/parsers/parsers.ts` — added `functionParser` to the `bodyNodeParser` list inside `bodyParser`, allowing `def` statements inside function/node bodies.
+
+**Tests:** 231 pass (9 body + 222 function parser tests, including new nested def tests).
+
+### Phase 3: Preprocessor — closure analysis (partial)
+
+**Files changed:**
+- `lib/types.ts` — added `"captured"` to the `ScopeType` union.
+- `lib/types/function.ts` — added `CapturedVariable` type and `capturedVariables`/`selfReferencing` fields to `FunctionDefinition`.
+- `lib/preprocessors/typescriptPreprocessor.ts` — added `lookupScopeWithCapture()` and `getCaptureInfo()` helpers. Modified `resolveVariableScopes()` to detect nested functions via the `scopes` chain, and use capture-aware lookup (`effectiveLookup`) that checks enclosing function scopes and marks matches as `"captured"`. At the end of processing a nested function, captured variables are attached to the AST node.
+- `lib/utils/node.ts` — modified `getAllVariablesInBody()` to not explicitly recurse into nested function params/body (yields the function name only).
+
+**Tests:** Existing tests (73 preprocessor, 148 builder) all pass. New closure analysis tests are written but 3 of 5 are failing due to the blocker below.
+
+## The Blocker
+
+### `getAllVariablesInBody` and `walkNodes` double-recursion
+
+`getAllVariablesInBody()` iterates using `walkNodes()` at its core (line 133 of `lib/utils/node.ts`):
+
+```typescript
+for (const { node } of walkNodes(body)) {
+```
+
+`walkNodes()` recurses into nested function bodies automatically (line 275-280 of `lib/utils/node.ts`):
+
+```typescript
+if (node.type === "function") {
+  yield* walkNodes(node.body, [...ancestors, node], [...scopes, functionScope(node.functionName)]);
+}
+```
+
+So even though I stopped `getAllVariablesInBody` from explicitly recursing into nested function bodies, `walkNodes` still yields those inner body nodes as part of its depth-first traversal.
+
+**The effect:** When the preprocessor processes the outer function's body in Phase 2:
+1. `getAllVariablesInBodyArray(outer.body)` is called
+2. `walkNodes` yields nodes from both the outer and inner function bodies
+3. The outer function's Phase 2 scopes the inner function's variables (`x`, `y`, `z`) using the outer function's lookup — giving them `"args"`, `"local"`, `"imported"` respectively
+4. When the inner function later gets its own processing pass, those variables already have `scope` set, so `if (varNode.scope) continue` skips them
+5. The capture logic never fires
+
+**The fix needed:** `getAllVariablesInBody` needs to skip nodes that `walkNodes` yields from inside a deeper function scope. The `walkNodes` generator already provides `scopes` alongside each node — `getAllVariablesInBody` currently destructures only `{ node }` and ignores `scopes`. By also checking `scopes`, it can filter out nodes whose function scope depth exceeds the starting depth.
+
+Concretely, change the iteration from:
+```typescript
+for (const { node } of walkNodes(body)) {
+```
+to:
+```typescript
+let initialFuncDepth: number | null = null;
+for (const { node, scopes } of walkNodes(body)) {
+  const funcDepth = scopes.filter(s => s.type === "function" || s.type === "node").length;
+  if (initialFuncDepth === null) initialFuncDepth = funcDepth;
+  if (funcDepth > initialFuncDepth) continue;
+```
+
+This is a safe change because `getAllVariablesInBody` is only used for variable scope resolution, and nested function bodies get their own scope processing pass via `walkNodesArray` in `resolveVariableScopes`.
+
+However, `getAllVariablesInBody` is used broadly (preprocessor, builder lookups), so the change needs careful testing to make sure it doesn't break anything. The existing 148 builder integration tests and 73 preprocessor tests should be sufficient to validate this.
+
+## What's Left
+
+### Phase 3 completion
+- Apply the `getAllVariablesInBody` scope-depth fix
+- Verify the 3 failing closure analysis tests pass
+- Run full test suite
+
+### Phase 4: Builder — code generation
+- Detect nested vs top-level functions in `processFunctionDefinition()`
+- Prevent `isTopLevelDeclaration()` from returning true for nested functions
+- Hoist inner function implementations to module level with namespaced names
+- Generate `registerClosure()` calls at module level
+- Generate `closureData` snapshot at the creation point
+- Generate `__closureInit` block in hoisted implementations
+- Rewrite captured variable references to `__self.__c_varName`
+- Handle self-referencing inner functions (sentinel pattern)
+- Use `new AgencyFunction()` instead of `AgencyFunction.create()` (no auto-registration in `__toolRegistry`)
+- Fixture tests
+
+### Phase 5: Typechecker
+- Build scopes for nested functions (currently `buildScopes()` only handles top-level)
+- Type-check inner function bodies with captured variable types in scope
+- Reject `export` on inner function definitions
+- Allow `safe` on inner function definitions
+- Reject same-name inner functions in same outer function
+
+### Phase 6: Formatter and debugger
+- Update formatter for nested `def` indentation/blank lines
+- Source maps for hoisted implementations
+- `scopeName` for debugger display
+
+### Phase 7: Integration tests and documentation
+- End-to-end Agency tests (basic closure, interrupt survival, fork, cross-module)
+- `docs/dev/closures.md` documenting the mental model and naming conventions
+- Language guide updates
+
+## Scoping Issues Inventory
+
+During investigation, I found all places in the pipeline that assume functions are top-level. These need guard clauses (most are one-line changes) across Phases 3-5:
+
+| File | Location | Issue |
+|------|----------|-------|
+| Preprocessor `getFunctionDefinitions()` | line 385-391 | Only collects from `program.nodes` |
+| Preprocessor `containsInterrupt()` | line 564 | Flat lookup in `functionDefinitions` |
+| Preprocessor `topologicalSortFunctions()` | lines 700-710 | Iterates `functionDefinitions` keys |
+| Preprocessor variable resolution | lines 1539, 1551, 1576 | Flat `this.functionDefinitions[name]` lookups |
+| Compilation unit | lines 136-141 | Only collects top-level functions |
+| Builder `isTopLevelDeclaration()` | lines 402-405 | Returns true for any `function` node |
+| Builder `processFunctionDefinition()` | lines 1792-1871 | Auto-registers in `__toolRegistry` |
+| Builder flat lookups | lines 436-437, 461-462, 1485-1486 | `compilationUnit.functionDefinitions[name]` |
+| Type checker `buildScopes()` | lines 36-41 in `scopes.ts` | Only iterates top-level function defs |

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-05-nested-functions-surprises.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-05-nested-functions-surprises.md
@@ -1,0 +1,135 @@
+# Nested Functions with Closures — Surprises and Lessons Learned
+
+## 1. The spec underestimated the scope of "scoping"
+
+The design spec's preprocessor section (Phase 3) said:
+
+> The preprocessor already walks up the scope chain for variable resolution (it does this for blocks). The extension: When resolving a variable inside an inner function body, if it resolves to a local/arg in an enclosing FUNCTION scope, mark it as "captured".
+
+This turned out to be wrong. The spec assumed the preprocessor has a scope chain it walks up, like blocks do. But blocks and functions work completely differently in the preprocessor:
+
+**Blocks** share the enclosing function's scope. When a block references a variable, `lookupScope(enclosingFuncName, varName)` is called — the lookup is on the *enclosing function's* name, not the block's. Blocks don't create a new scope entry in `funcArgs`/`localVarsInFunction`. They're transparent.
+
+**Functions** create their own entry. `funcArgs["inner"]` and `localVarsInFunction["inner"]` are separate from the outer function's entries. The `lookupScope` function takes a single `funcName` and checks only that function's args/locals, then falls through to global/imported/static. There is no parent chain.
+
+The spec said "the preprocessor already walks up the scope chain" — it doesn't. The preprocessor's scope resolution is flat: one function name, one lookup. The "walk up" behavior for blocks is an illusion created by the fact that blocks use the enclosing function's name for lookup.
+
+**Time spent:** Understanding this mismatch and designing the `lookupScopeWithCapture`/`effectiveLookup` solution took significant time, mostly because I had to trace through the actual preprocessor code to understand how scope resolution really works, versus how the spec assumed it works.
+
+## 2. `getAllVariablesInBody` and `walkNodes` are coupled in a way that makes filtering hard
+
+This was the biggest surprise and is the current blocker. The spec didn't mention `getAllVariablesInBody` at all — it's an internal utility function that the preprocessor uses to collect all variable references in a function body.
+
+The problem is architectural: `getAllVariablesInBody` uses `walkNodes` as its iteration driver:
+
+```typescript
+for (const { node } of walkNodes(body)) {
+```
+
+`walkNodes` is a general-purpose AST walker that recurses into *everything* — including nested function bodies. It's designed this way because it's used for many purposes (scope chain tracking, AST traversal, etc.).
+
+Before nested functions existed, this coupling was fine — there were no nested function bodies to worry about. `getAllVariablesInBody` also had its own explicit recursion into function bodies at line 137-142:
+
+```typescript
+} else if (node.type === "function") {
+  yield { name: node.functionName, node };
+  for (const param of node.parameters) {
+    yield { name: param.name, node };
+  }
+  yield* getAllVariablesInBody(node.body);  // explicit recursion
+}
+```
+
+So it was double-recursing: `walkNodes` recurses into the function body AND `getAllVariablesInBody` explicitly recurses too. This was redundant but harmless when all functions were top-level (the same variables just got yielded twice and scoped the same way).
+
+My first fix removed the explicit recursion (lines 139-142), thinking that would stop `getAllVariablesInBody` from seeing inner function variables. But `walkNodes` is still yielding them! The `for (const { node } of walkNodes(body))` loop gets every node from the entire subtree, including nodes deep inside nested function bodies.
+
+**What the spec should have said:** "The `getAllVariablesInBody` utility needs to be modified to not yield variables from nested function bodies, but this is complicated by the fact that it delegates to `walkNodes` which recurses unconditionally. The fix requires using the `scopes` array from `walkNodes` to filter by function scope depth."
+
+**Time spent:** This consumed the most debugging time. I made the initial change, ran tests (they passed because there were no nested functions in existing tests), wrote new tests, and they failed. Then I had to trace through the execution to understand *why* — the outer function's Phase 2 was scoping inner function variables before the inner function got its own pass. The root cause (walkNodes recursion) wasn't obvious from reading the code because the coupling between `getAllVariablesInBody` and `walkNodes` is implicit.
+
+## 3. The breadth of "top-level function" assumptions was much larger than expected
+
+The spec identified changes needed in the preprocessor, builder, and typechecker, but described them at a high level. During investigation, I found **10 specific locations** across 5 files that assume functions are top-level:
+
+- Preprocessor: `getFunctionDefinitions()`, `containsInterrupt()`, `topologicalSortFunctions()`, three variable resolution lookups
+- Compilation unit: `functionDefinitions` collection
+- Builder: `isTopLevelDeclaration()`, `processFunctionDefinition()`, three flat lookups
+- Type checker: `buildScopes()`
+
+The spec mentioned the preprocessor and builder changes but didn't enumerate the specific locations. Most of these are one-line guard clauses (check if the function is nested and skip it), but knowing the complete list upfront would have avoided potential surprises during Phase 4 and 5.
+
+**What the spec should have said:** Listed every place in the pipeline that references `functionDefinitions` or assumes functions are at the module top level, with the specific fix needed for each.
+
+## 4. The `FunctionRefReviver` needs `closureData` to go through the replacer/reviver pipeline
+
+The spec correctly described the serialization format and the reviver changes. What it didn't call out explicitly is that `closureData` is a plain object that gets serialized as part of the JSON — and since it's embedded in the `FunctionRefReviver.serialize()` output, it goes through `nativeTypeReplacer` automatically when the containing object is stringified.
+
+This means nested `AgencyFunction` instances inside `closureData` (like when an inner function captures another inner function) get recursively serialized by the replacer. And on the revive path, the `nativeTypeReviver` processes the nested objects before the parent — so by the time `FunctionRefReviver.revive()` runs for the outer function, the inner `AgencyFunction` in `closureData` has already been revived.
+
+This "just works" because of how `JSON.parse` with a reviver processes bottom-up. But it's subtle and I only confirmed it worked correctly by writing an explicit test (`"round-trips closure containing another AgencyFunction"`).
+
+**Not really a gap in the spec** — the spec said "closureData goes through the same nativeTypeReplacer/reviver pipeline as any other value." But it's the kind of thing you need to verify with a test because the ordering is non-obvious.
+
+## 5. The `__self__` sentinel approach required changes in more places than expected
+
+The spec described the sentinel pattern clearly for recursive inner functions. But implementing it required touching four places, not just two:
+
+1. **Builder** (creation point): emit `closureData: { fib: "__self__" }` instead of a circular reference
+2. **`AgencyFunction.invoke()`**: inject `self: this` alongside `closure` so the hoisted impl can resolve the sentinel
+3. **`FunctionRefReviver.serialize()`**: detect `value === value` (self-reference) and replace with sentinel
+4. **`FunctionRefReviver.revive()`**: detect sentinel string and replace with the reconstructed `AgencyFunction`
+
+The spec described all four but framed them as small additions. In practice, the `serialize()` change required iterating over `closureData` entries and comparing each value against the parent `AgencyFunction` instance — a pattern that's a bit unusual in a serializer. And the `revive()` change mutates `closureData` after constructing the `AgencyFunction`, which means `closureData` can't be truly `readonly` at the TypeScript level (the field is declared `readonly` but we cast to mutate it).
+
+**Time spent:** Not much — the implementation was straightforward once I understood all four touch points.
+
+## 6. Lambda implications were not in the spec at all
+
+During review, the user asked about how lambdas (the next feature after nested functions) would interact with this design. This surfaced several assumptions baked into the spec that won't hold for lambdas:
+
+- **Inner functions have names.** The closure key, hoisted impl name, and registry key all depend on the function name. Lambdas are anonymous.
+- **Inner functions are statements.** The parser change adds `functionParser` to `bodyParser` — statement position only. Lambdas are expressions.
+- **Inner functions are always inside a `def` or `node`.** The closure analysis assumes an enclosing function scope. Lambdas at global scope wouldn't have one.
+
+The decision was to accept some rework later rather than over-engineer now, but documenting these assumptions explicitly in the spec would help future work.
+
+## 7. The execution isolation model needed careful thought for the global closure registry
+
+The initial plan proposed a per-module `__closureRegistry` object that would be passed to the `FunctionRefReviver`. During review, the user pointed out that this breaks Agency's execution isolation guarantee — each concurrent agent invocation should get isolated state.
+
+After analysis, we determined that a global registry is actually safe because it only stores static code (hoisted implementation functions and parameter metadata), not per-invocation data. The per-invocation data (closureData) travels on the `AgencyFunction` instance in the isolated state stack.
+
+But this required careful reasoning. The key insight: the global registry is analogous to the compiled JavaScript module's exported functions — shared code, not shared state. Multiple concurrent invocations of `greet("Alice")` and `greet("Bob")` each create their own `AgencyFunction` with different `closureData`, but they all reference the same hoisted implementation function from the registry. This is safe because the implementation is pure code.
+
+**What the spec should have said:** Explicitly called out the execution isolation concern and explained why the global registry doesn't violate it. The updated spec now includes a "Registry design: why a global registry is safe" section.
+
+## 8. Cross-module closure resolution was completely missing from the original spec
+
+The original spec defined `__closureRegistry` as a per-module object with no discussion of what happens when an inner function crosses module boundaries. If module A creates an inner function and passes it to module B, and an interrupt fires in module B, the reviver needs to find module A's closure implementation.
+
+This was caught during review and addressed by making the registry global with module-prefixed keys (e.g., `"main.agency:outer::inner"`). The fix was straightforward but the gap was significant — without it, any cross-module usage of inner functions would fail silently on interrupt resume.
+
+## 9. Parser change was trivially easy — a single line
+
+The spec estimated Phase 2 as a meaningful chunk of work. In practice, it was adding one line to `bodyParser`:
+
+```typescript
+functionParser,
+```
+
+The existing `functionParser` already handles `export`, `safe`, `callback` modifiers, parameter parsing, body parsing, and docstrings. Since `bodyParser` uses `or()` to try each parser in order, and `functionParser` is positioned before `assignmentParser` and `binOpParser`, it just works. The parser is already recursive (function bodies use `bodyParser`, which now includes `functionParser`), and JavaScript's evaluation-time resolution of `const` references handles the circular dependency.
+
+**Time spent:** About 5 minutes including tests.
+
+## Summary: where the time went
+
+1. **~40% — Understanding the preprocessor's scope resolution.** Reading `resolveVariableScopes()`, tracing through `lookupScope`, `getAllVariablesInBody`, `walkNodes`, understanding how blocks vs functions handle scope differently, and discovering the `walkNodes` recursion issue.
+
+2. **~25% — Investigating the full pipeline for top-level assumptions.** Searching through the symbol table, compilation unit, preprocessor, builder, and type checker for every place that references `functionDefinitions` or assumes functions are at module scope.
+
+3. **~20% — Runtime implementation and tests.** The actual `AgencyFunction`, `FunctionRefReviver`, and `closureRegistry` changes, plus comprehensive tests including round-trip serialization tests.
+
+4. **~10% — Design review and spec updates.** Identifying the circular reference issue, cross-module registry gap, lambda implications, and updating the spec.
+
+5. **~5% — Parser change.** One line of code plus tests.

--- a/packages/agency-lang/lib/parsers/body.test.ts
+++ b/packages/agency-lang/lib/parsers/body.test.ts
@@ -113,4 +113,38 @@ describe("functionBodyParser", () => {
       });
     }
   });
+
+  it("parses a nested def inside a function body", () => {
+    const input = `def inner(x: number): number {\n  return x + 1\n}`;
+    const result = bodyParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.length).toBe(1);
+      expect(result.result[0].type).toBe("function");
+      expect((result.result[0] as any).functionName).toBe("inner");
+    }
+  });
+
+  it("parses multiple nested defs", () => {
+    const input = `def a(): number {\n  return 1\n}\ndef b(): number {\n  return 2\n}`;
+    const result = bodyParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const fns = result.result.filter((n: any) => n.type === "function");
+      expect(fns.length).toBe(2);
+      expect((fns[0] as any).functionName).toBe("a");
+      expect((fns[1] as any).functionName).toBe("b");
+    }
+  });
+
+  it("parses safe def inside a function body", () => {
+    const input = `safe def helper(x: number): number {\n  return x + 1\n}`;
+    const result = bodyParser(input);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.length).toBe(1);
+      expect(result.result[0].type).toBe("function");
+      expect((result.result[0] as any).safe).toBe(true);
+    }
+  });
 });

--- a/packages/agency-lang/lib/parsers/function.test.ts
+++ b/packages/agency-lang/lib/parsers/function.test.ts
@@ -3489,3 +3489,103 @@ describe("bang (!) validated type annotations", () => {
     }
   });
 });
+
+describe("nested function definitions", () => {
+  it("parses def inside a def body", () => {
+    const code = `def outer(x: number) {
+  def inner(y: number): number {
+    return y + 1
+  }
+  return inner
+}`;
+    const result = functionParser(code);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.functionName).toBe("outer");
+      const innerDef = result.result.body.find((n: any) => n.type === "function");
+      expect(innerDef).toBeDefined();
+      expect((innerDef as any).functionName).toBe("inner");
+    }
+  });
+
+  it("parses def inside a node body", () => {
+    const code = `node main() {
+  def helper(): string {
+    return "hello"
+  }
+  const result = helper()
+}`;
+    const result = graphNodeParser(code);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.nodeName).toBe("main");
+      const innerDef = result.result.body.find((n: any) => n.type === "function");
+      expect(innerDef).toBeDefined();
+      expect((innerDef as any).functionName).toBe("helper");
+    }
+  });
+
+  it("parses nested def inside def inside def", () => {
+    const code = `def a() {
+  def b() {
+    def c(): number {
+      return 1
+    }
+    return c
+  }
+  return b
+}`;
+    const result = functionParser(code);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const bDef = result.result.body.find((n: any) => n.type === "function") as any;
+      expect(bDef).toBeDefined();
+      expect(bDef.functionName).toBe("b");
+      const cDef = bDef.body.find((n: any) => n.type === "function");
+      expect(cDef).toBeDefined();
+      expect((cDef as any).functionName).toBe("c");
+    }
+  });
+
+  it("parses multiple nested defs in one function", () => {
+    const code = `def outer() {
+  def a(): number { return 1 }
+  def b(): number { return 2 }
+  return [a, b]
+}`;
+    const result = functionParser(code);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const fns = result.result.body.filter((n: any) => n.type === "function");
+      expect(fns.length).toBe(2);
+      expect((fns[0] as any).functionName).toBe("a");
+      expect((fns[1] as any).functionName).toBe("b");
+    }
+  });
+
+  it("parses full agency file with nested def via parseAgency", () => {
+    const code = `def outer(x: number) {
+  const multiplier = x * 2
+
+  def inner(y: number): number {
+    return y * multiplier
+  }
+
+  return inner
+}
+
+node main() {
+  const fn = outer(3)
+}`;
+    const result = parseAgency(code);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const nodes = result.result.nodes;
+      const outerDef = nodes.find((n: any) => n.type === "function" && n.functionName === "outer") as any;
+      expect(outerDef).toBeDefined();
+      const innerDef = outerDef.body.find((n: any) => n.type === "function");
+      expect(innerDef).toBeDefined();
+      expect(innerDef.functionName).toBe("inner");
+    }
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -2210,6 +2210,7 @@ export const bodyParser = (input: string): ParserResult<AgencyNode[]> => {
     multiLineCommentParser,
     commentParser,
     skillParser,
+    functionParser,
     withModifierParser,
     assignmentParser,
     binOpParser,

--- a/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.core.test.ts
+++ b/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.core.test.ts
@@ -1192,4 +1192,214 @@ describe("TypescriptPreprocessor Core Functionality", () => {
       expect(fn.docComment.content).toBe(" Func docs ");
     });
   });
+
+  describe("closure analysis for nested functions", () => {
+    it("marks variables from enclosing function as captured", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "outer",
+            parameters: [
+              { type: "functionParameter", name: "x" },
+            ],
+            body: [
+              {
+                type: "assignment",
+                variableName: "y",
+                declKind: "const",
+                value: { type: "number", value: "5" },
+              },
+              {
+                type: "function",
+                functionName: "inner",
+                parameters: [
+                  { type: "functionParameter", name: "z" },
+                ],
+                body: [
+                  {
+                    type: "variableName",
+                    value: "x",
+                  },
+                  {
+                    type: "variableName",
+                    value: "y",
+                  },
+                  {
+                    type: "variableName",
+                    value: "z",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+
+      const outer = program.nodes[0] as any;
+      const inner = outer.body.find((n: any) => n.type === "function");
+      expect(inner).toBeDefined();
+
+      // x and y should be captured from outer
+      expect(inner.capturedVariables).toBeDefined();
+      expect(inner.capturedVariables).toHaveLength(2);
+      const capturedNames = inner.capturedVariables.map((v: any) => v.name);
+      expect(capturedNames).toContain("x");
+      expect(capturedNames).toContain("y");
+
+      // x is an arg, y is a local in outer
+      const xCapture = inner.capturedVariables.find((v: any) => v.name === "x");
+      expect(xCapture.sourceType).toBe("args");
+      const yCapture = inner.capturedVariables.find((v: any) => v.name === "y");
+      expect(yCapture.sourceType).toBe("local");
+
+      // z is inner's own param — should be scoped as "args", not captured
+      const zNode = inner.body.find((n: any) => n.type === "variableName" && n.value === "z");
+      expect(zNode.scope).toBe("args");
+
+      // x and y in inner's body should be scoped as "captured"
+      const xNode = inner.body.find((n: any) => n.type === "variableName" && n.value === "x");
+      expect(xNode.scope).toBe("captured");
+      const yNode = inner.body.find((n: any) => n.type === "variableName" && n.value === "y");
+      expect(yNode.scope).toBe("captured");
+    });
+
+    it("inner function with no captures has no capturedVariables", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "outer",
+            parameters: [],
+            body: [
+              {
+                type: "function",
+                functionName: "inner",
+                parameters: [
+                  { type: "functionParameter", name: "x" },
+                ],
+                body: [
+                  { type: "variableName", value: "x" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+
+      const outer = program.nodes[0] as any;
+      const inner = outer.body.find((n: any) => n.type === "function");
+      expect(inner.capturedVariables).toBeUndefined();
+    });
+
+    it("globals are not captured — they keep global scope", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "assignment",
+            variableName: "g",
+            declKind: "const",
+            value: { type: "number", value: "1" },
+          },
+          {
+            type: "function",
+            functionName: "outer",
+            parameters: [],
+            body: [
+              {
+                type: "function",
+                functionName: "inner",
+                parameters: [],
+                body: [
+                  { type: "variableName", value: "g" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+
+      const outer = program.nodes.find((n: any) => n.type === "function") as any;
+      const inner = outer.body.find((n: any) => n.type === "function");
+      const gNode = inner.body.find((n: any) => n.type === "variableName" && n.value === "g");
+      expect(gNode.scope).toBe("global");
+      expect(inner.capturedVariables).toBeUndefined();
+    });
+
+    it("detects self-referencing inner function", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "function",
+            functionName: "outer",
+            parameters: [],
+            body: [
+              {
+                type: "function",
+                functionName: "fib",
+                parameters: [
+                  { type: "functionParameter", name: "n" },
+                ],
+                body: [
+                  { type: "variableName", value: "fib" },
+                  { type: "variableName", value: "n" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+
+      const outer = program.nodes[0] as any;
+      const fib = outer.body.find((n: any) => n.type === "function");
+      expect(fib.selfReferencing).toBe(true);
+      // Self-reference should not appear in capturedVariables
+      expect(fib.capturedVariables ?? []).toHaveLength(0);
+    });
+
+    it("nested def inside a node body captures node args", () => {
+      const program: AgencyProgram = {
+        type: "agencyProgram",
+        nodes: [
+          {
+            type: "graphNode",
+            nodeName: "main",
+            parameters: [
+              { type: "functionParameter", name: "name" },
+            ],
+            body: [
+              {
+                type: "function",
+                functionName: "greet",
+                parameters: [],
+                body: [
+                  { type: "variableName", value: "name" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const preprocessor = new TypescriptPreprocessor(program);
+      preprocessor.preprocess();
+
+      const main = program.nodes[0] as any;
+      const greet = main.body.find((n: any) => n.type === "function");
+      expect(greet.capturedVariables).toHaveLength(1);
+      expect(greet.capturedVariables[0].name).toBe("name");
+      expect(greet.capturedVariables[0].sourceType).toBe("args");
+    });
+  });
 });

--- a/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
+++ b/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
@@ -19,6 +19,7 @@ import {
   WhileLoop,
   isClassKeyword,
 } from "@/types.js";
+import type { CapturedVariable } from "@/types/function.js";
 import { MessageThread } from "@/types/messageThread.js";
 // import { Skill } from "@/types/skill.js"; // Unused after llm() refactor
 import {
@@ -1438,6 +1439,45 @@ export class TypescriptPreprocessor {
       return null;
     };
 
+    // Like lookupScope but also checks enclosing function scopes.
+    // Returns "captured" if the variable is found in an enclosing function's args/locals.
+    const lookupScopeWithCapture = (
+      funcName: string,
+      varName: string,
+      enclosingFuncNames: string[],
+    ): ScopeType | null => {
+      // Check current function first
+      const direct = lookupScope(funcName, varName);
+      if (direct) return direct;
+
+      // Check enclosing function scopes (innermost first)
+      for (let i = enclosingFuncNames.length - 1; i >= 0; i--) {
+        const enclosing = enclosingFuncNames[i];
+        if (funcArgs[enclosing]?.includes(varName)) return "captured";
+        if (localVarsInFunction[enclosing]?.has(varName)) return "captured";
+      }
+
+      return null;
+    };
+
+    // Track which enclosing function scope a captured variable comes from
+    // and whether it's an arg or local in that scope.
+    const getCaptureInfo = (
+      varName: string,
+      enclosingFuncNames: string[],
+    ): CapturedVariable | null => {
+      for (let i = enclosingFuncNames.length - 1; i >= 0; i--) {
+        const enclosing = enclosingFuncNames[i];
+        if (funcArgs[enclosing]?.includes(varName)) {
+          return { name: varName, sourceScope: enclosing, sourceType: "args" };
+        }
+        if (localVarsInFunction[enclosing]?.has(varName)) {
+          return { name: varName, sourceScope: enclosing, sourceType: "local" };
+        }
+      }
+      return null;
+    };
+
     // second, make sure all args are scoped correctly,
     // and all vars defined within a function or graph node are scoped to that function or graph node.
     for (const { node, scopes } of walkNodesArray(this.program.nodes)) {
@@ -1454,6 +1494,29 @@ export class TypescriptPreprocessor {
         funcArgs[nodeName] = [...node.parameters.map((p) => p.name)];
         localVarsInFunction[nodeName] = new Set();
 
+        // Detect if this function is nested inside another function/node.
+        // scopes looks like [global, function:outer] for a nested function.
+        const enclosingFuncNames: string[] = [];
+        for (const s of scopes) {
+          if (s.type === "function") enclosingFuncNames.push(s.functionName);
+          else if (s.type === "node") enclosingFuncNames.push(s.nodeName);
+        }
+        const isNested = enclosingFuncNames.length > 0;
+        const capturedVars = new Map<string, CapturedVariable>();
+
+        // Effective lookup: use capture-aware lookup for nested functions
+        const effectiveLookup = (varName: string): ScopeType | null => {
+          if (isNested) {
+            const result = lookupScopeWithCapture(nodeName, varName, enclosingFuncNames);
+            if (result === "captured") {
+              const info = getCaptureInfo(varName, enclosingFuncNames);
+              if (info) capturedVars.set(varName, info);
+            }
+            return result;
+          }
+          return lookupScope(nodeName, varName);
+        };
+
         // Phase 1: Resolve block body variables first.
         // Block params get "blockArgs" scope, new variables inside blocks get "block" scope,
         // and references to outer-scope variables keep their original scope (captured via closure).
@@ -1468,7 +1531,7 @@ export class TypescriptPreprocessor {
             for (const { node: blockVarNode } of getAllVariablesInBodyArray(bodyNode.block.body)) {
               if (blockVarNode.type === "assignment") {
                 const name = blockVarNode.variableName;
-                if (!blockParamNames.has(name) && lookupScope(nodeName, name) === null) {
+                if (!blockParamNames.has(name) && effectiveLookup(name) === null) {
                   blockLocalNames.add(name);
                 }
               }
@@ -1482,7 +1545,7 @@ export class TypescriptPreprocessor {
                 } else if (blockLocalNames.has(blockVarNode.variableName)) {
                   blockVarNode.scope = "block";
                 } else {
-                  const resolved = lookupScope(nodeName, blockVarNode.variableName);
+                  const resolved = effectiveLookup(blockVarNode.variableName);
                   if (resolved) blockVarNode.scope = resolved;
                   // else: leave unscoped — Phase 2 will resolve once locals are registered
                 }
@@ -1492,7 +1555,7 @@ export class TypescriptPreprocessor {
                 } else if (blockLocalNames.has(blockVarNode.value)) {
                   blockVarNode.scope = "block";
                 } else {
-                  const resolved = lookupScope(nodeName, blockVarNode.value);
+                  const resolved = effectiveLookup(blockVarNode.value);
                   if (resolved) blockVarNode.scope = resolved;
                   // else: leave unscoped — Phase 2 will resolve once locals are registered
                 }
@@ -1515,7 +1578,7 @@ export class TypescriptPreprocessor {
               scope = "local";
               localVarsInFunction[nodeName].add(varNode.variableName);
             } else {
-              scope = lookupScope(nodeName, varNode.variableName) ?? "local";
+              scope = effectiveLookup(varNode.variableName) ?? "local";
               if (scope === "static") {
                 throw new Error(
                   `Cannot reassign static variable '${varNode.variableName}'. Static variables are immutable after initialization.`
@@ -1529,7 +1592,7 @@ export class TypescriptPreprocessor {
           } else if (varNode.type === "variableName") {
             if (varNode.scope) continue; // already resolved in block Phase 1
             if (isClassKeyword(varNode.value)) continue;
-            const resolved = lookupScope(nodeName, varNode.value);
+            const resolved = effectiveLookup(varNode.value);
             if (resolved) {
               varNode.scope = resolved;
             } else if (this.graphNodeDefinitions[varNode.value]) {
@@ -1551,9 +1614,25 @@ export class TypescriptPreprocessor {
             if (this.functionDefinitions[name]) {
               callNode.scope = "functionRef";
             } else {
-              const resolved = lookupScope(nodeName, name);
+              const resolved = effectiveLookup(name);
               callNode.scope = resolved ?? "imported";
             }
+          }
+        }
+
+        // For nested functions, attach captured variables and detect self-references
+        if (isNested && node.type === "function") {
+          const fnNode = node as FunctionDefinition;
+          if (capturedVars.size > 0) {
+            fnNode.capturedVariables = Array.from(capturedVars.values());
+          }
+          // Detect self-referencing inner function (name appears in captured vars)
+          if (capturedVars.has(fnNode.functionName)) {
+            fnNode.selfReferencing = true;
+            // Remove self from captured vars — it's handled via sentinel
+            fnNode.capturedVariables = fnNode.capturedVariables?.filter(
+              (v) => v.name !== fnNode.functionName,
+            );
           }
         }
       }

--- a/packages/agency-lang/lib/runtime/agencyFunction.test.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.test.ts
@@ -170,4 +170,57 @@ describe("AgencyFunction", () => {
       expect(fn.name).toBe("add");
     });
   });
+
+  describe("closure support", () => {
+    it("sets closureData and closureKey to null by default", () => {
+      const fn = makeFunction([{ name: "a" }]);
+      expect(fn.closureData).toBeNull();
+      expect(fn.closureKey).toBeNull();
+    });
+
+    it("stores closureData and closureKey when provided", () => {
+      const fn = new AgencyFunction({
+        name: "inner",
+        module: "test.agency",
+        fn: async (...args: unknown[]) => args,
+        params: [],
+        toolDefinition: null,
+        closureData: { x: 1, y: "hello" },
+        closureKey: "test.agency:outer::inner",
+      });
+      expect(fn.closureData).toEqual({ x: 1, y: "hello" });
+      expect(fn.closureKey).toBe("test.agency:outer::inner");
+    });
+
+    it("invoke injects closure data and self into state when closureData is set", async () => {
+      let capturedState: any = null;
+      const fn = new AgencyFunction({
+        name: "inner",
+        module: "test.agency",
+        fn: async (x: any, state: any) => { capturedState = state; return x; },
+        params: [{ name: "x", hasDefault: false, defaultValue: undefined, variadic: false }],
+        toolDefinition: null,
+        closureData: { multiplier: 6 },
+        closureKey: "test.agency:outer::inner",
+      });
+      await fn.invoke({ type: "positional", args: [42] }, { ctx: "mock" });
+      expect(capturedState.closure).toEqual({ multiplier: 6 });
+      expect(capturedState.self).toBe(fn);
+      expect(capturedState.ctx).toBe("mock");
+    });
+
+    it("invoke passes state unchanged when closureData is null", async () => {
+      let capturedState: any = null;
+      const fn = new AgencyFunction({
+        name: "inner",
+        module: "test.agency",
+        fn: async (x: any, state: any) => { capturedState = state; return x; },
+        params: [{ name: "x", hasDefault: false, defaultValue: undefined, variadic: false }],
+        toolDefinition: null,
+      });
+      const mockState = { ctx: "mock" };
+      await fn.invoke({ type: "positional", args: [42] }, mockState);
+      expect(capturedState).toBe(mockState);
+    });
+  });
 });

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -23,6 +23,8 @@ export type AgencyFunctionOpts = {
   fn: Function;
   params: FuncParam[];
   toolDefinition: ToolDefinition | null;
+  closureData?: Record<string, unknown> | null;
+  closureKey?: string | null;
 };
 
 export class AgencyFunction {
@@ -31,6 +33,8 @@ export class AgencyFunction {
   readonly module: string;
   readonly params: FuncParam[];
   readonly toolDefinition: ToolDefinition | null;
+  readonly closureData: Record<string, unknown> | null;
+  readonly closureKey: string | null;
   private readonly _fn: Function;
   private readonly _nonVariadicParams: FuncParam[];
   private readonly _hasVariadic: boolean;
@@ -41,13 +45,19 @@ export class AgencyFunction {
     this._fn = opts.fn;
     this.params = opts.params;
     this.toolDefinition = opts.toolDefinition;
+    this.closureData = opts.closureData ?? null;
+    this.closureKey = opts.closureKey ?? null;
     this._nonVariadicParams = opts.params.filter(p => !p.variadic);
     this._hasVariadic = opts.params.length > 0 && opts.params[opts.params.length - 1].variadic;
   }
 
   async invoke(descriptor: CallType, state?: unknown): Promise<unknown> {
     const resolvedArgs = this.resolveArgs(descriptor);
-    return this._fn(...resolvedArgs, state);
+    // Closure support: inject captured data so the hoisted impl can read it
+    const effectiveState = this.closureData
+      ? { ...(state as any), closure: this.closureData, self: this }
+      : state;
+    return this._fn(...resolvedArgs, effectiveState);
   }
 
   private resolveArgs(descriptor: CallType): unknown[] {

--- a/packages/agency-lang/lib/runtime/closureRegistry.ts
+++ b/packages/agency-lang/lib/runtime/closureRegistry.ts
@@ -1,0 +1,28 @@
+import type { FuncParam } from "./agencyFunction.js";
+
+export type ClosureRegistryEntry = {
+  fn: Function;
+  params: FuncParam[];
+};
+
+const globalClosureRegistry: Record<string, ClosureRegistryEntry> = {};
+
+/** Register a closure implementation at module load time.
+ * Keys are globally unique: "module:outer::inner". */
+export function registerClosure(
+  key: string,
+  entry: ClosureRegistryEntry,
+): void {
+  globalClosureRegistry[key] = entry;
+}
+
+/** Look up a closure implementation by key. */
+export function lookupClosure(
+  key: string,
+): ClosureRegistryEntry | undefined {
+  return globalClosureRegistry[key];
+}
+
+/** Sentinel value used in closureData to represent a self-reference,
+ * avoiding circular references during JSON serialization. */
+export const CLOSURE_SELF_SENTINEL = "__self__";

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -29,6 +29,8 @@ export {
 export { functionRefReviver } from "./revivers/index.js";
 export { AgencyFunction, UNSET } from "./agencyFunction.js";
 export type { FuncParam, CallType, ToolDefinition, AgencyFunctionOpts } from "./agencyFunction.js";
+export { registerClosure, lookupClosure, CLOSURE_SELF_SENTINEL } from "./closureRegistry.js";
+export type { ClosureRegistryEntry } from "./closureRegistry.js";
 export { __call, __callMethod } from "./call.js";
 
 export { callHook, registerGlobalHook } from "./hooks.js";

--- a/packages/agency-lang/lib/runtime/revivers/functionRefReviver.test.ts
+++ b/packages/agency-lang/lib/runtime/revivers/functionRefReviver.test.ts
@@ -1,7 +1,9 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { AgencyFunction } from "../agencyFunction.js";
+import type { FuncParam } from "../agencyFunction.js";
 import { FunctionRefReviver } from "./functionRefReviver.js";
 import { nativeTypeReplacer, nativeTypeReviver, functionRefReviver } from "./index.js";
+import { registerClosure, CLOSURE_SELF_SENTINEL } from "../closureRegistry.js";
 
 function makeAgencyFunction(name: string, module: string): AgencyFunction {
   return new AgencyFunction({
@@ -12,6 +14,11 @@ function makeAgencyFunction(name: string, module: string): AgencyFunction {
     toolDefinition: null,
   });
 }
+
+const testClosureImpl = async (...args: unknown[]) => args;
+const testClosureParams: FuncParam[] = [
+  { name: "y", hasDefault: false, defaultValue: undefined, variadic: false },
+];
 
 describe("FunctionRefReviver", () => {
   const reviver = new FunctionRefReviver();
@@ -167,5 +174,196 @@ describe("full round-trip: serialize then deserialize", () => {
     expect(restored.data).toBe("hello");
 
     functionRefReviver.registry = null;
+  });
+});
+
+describe("FunctionRefReviver closure support", () => {
+  const reviver = new FunctionRefReviver();
+  const closureKey = "test.agency:outer::inner";
+
+  beforeEach(() => {
+    registerClosure(closureKey, { fn: testClosureImpl, params: testClosureParams });
+  });
+
+  describe("serialize", () => {
+    it("includes closureKey, closureData, toolDefinition, and params for closure functions", () => {
+      const fn = new AgencyFunction({
+        name: "inner",
+        module: "test.agency",
+        fn: testClosureImpl,
+        params: testClosureParams,
+        toolDefinition: { name: "inner", description: "A tool", schema: {} },
+        closureData: { multiplier: 6 },
+        closureKey,
+      });
+      const result = reviver.serialize(fn);
+      expect(result).toEqual({
+        __nativeType: "FunctionRef",
+        name: "inner",
+        module: "test.agency",
+        closureKey,
+        closureData: { multiplier: 6 },
+        toolDefinition: { name: "inner", description: "A tool", schema: {} },
+        params: testClosureParams,
+      });
+    });
+
+    it("produces minimal output for non-closure functions (backward compatible)", () => {
+      const fn = makeAgencyFunction("greet", "test.agency");
+      const result = reviver.serialize(fn);
+      expect(result).toEqual({
+        __nativeType: "FunctionRef",
+        name: "greet",
+        module: "test.agency",
+      });
+      expect(result.closureKey).toBeUndefined();
+      expect(result.closureData).toBeUndefined();
+    });
+
+    it("replaces self-reference with sentinel to avoid circular JSON", () => {
+      const fn = new AgencyFunction({
+        name: "fib",
+        module: "test.agency",
+        fn: testClosureImpl,
+        params: testClosureParams,
+        toolDefinition: null,
+        closureData: { fib: null as any },
+        closureKey: "test.agency:outer::fib",
+      });
+      // Set the self-reference
+      (fn.closureData as any).fib = fn;
+
+      const result = reviver.serialize(fn);
+      expect(result.closureData).toEqual({ fib: CLOSURE_SELF_SENTINEL });
+    });
+  });
+
+  describe("revive", () => {
+    it("reconstructs AgencyFunction from closure registry + closureData", () => {
+      const result = reviver.revive({
+        name: "inner",
+        module: "test.agency",
+        closureKey,
+        closureData: { multiplier: 6 },
+        toolDefinition: { name: "inner", description: "A tool", schema: {} },
+        params: testClosureParams,
+      });
+      expect(result).toBeInstanceOf(AgencyFunction);
+      expect(result.name).toBe("inner");
+      expect(result.closureKey).toBe(closureKey);
+      expect(result.closureData).toEqual({ multiplier: 6 });
+    });
+
+    it("replaces __self__ sentinel with the revived AgencyFunction", () => {
+      registerClosure("test.agency:outer::fib", { fn: testClosureImpl, params: testClosureParams });
+      const result = reviver.revive({
+        name: "fib",
+        module: "test.agency",
+        closureKey: "test.agency:outer::fib",
+        closureData: { fib: CLOSURE_SELF_SENTINEL },
+        toolDefinition: null,
+        params: testClosureParams,
+      });
+      expect(result.closureData!.fib).toBe(result);
+    });
+
+    it("falls back to toolRegistry for non-closure functions", () => {
+      const fn = makeAgencyFunction("greet", "test.agency");
+      reviver.registry = { greet: fn };
+      const result = reviver.revive({ name: "greet", module: "test.agency" });
+      expect(result).toBe(fn);
+      reviver.registry = null;
+    });
+
+    it("throws when closure key is not found in registry", () => {
+      expect(() =>
+        reviver.revive({
+          name: "missing",
+          module: "test.agency",
+          closureKey: "test.agency:outer::missing",
+          closureData: {},
+          params: [],
+        })
+      ).toThrow("cannot revive closure function");
+    });
+  });
+
+  describe("round-trip", () => {
+    it("round-trips closure function through JSON serialize/deserialize", () => {
+      const fn = new AgencyFunction({
+        name: "inner",
+        module: "test.agency",
+        fn: testClosureImpl,
+        params: testClosureParams,
+        toolDefinition: { name: "inner", description: "test", schema: {} },
+        closureData: { x: 1, y: "hello", z: [1, 2, 3] },
+        closureKey,
+      });
+
+      const obj = { tool: fn, data: "test" };
+      const json = JSON.stringify(obj, nativeTypeReplacer);
+      const restored = JSON.parse(json, nativeTypeReviver);
+
+      expect(restored.tool).toBeInstanceOf(AgencyFunction);
+      expect(restored.tool.name).toBe("inner");
+      expect(restored.tool.closureKey).toBe(closureKey);
+      expect(restored.tool.closureData).toEqual({ x: 1, y: "hello", z: [1, 2, 3] });
+      expect(restored.data).toBe("test");
+    });
+
+    it("round-trips closure containing another AgencyFunction", () => {
+      const helperKey = "test.agency:outer::helper";
+      registerClosure(helperKey, { fn: testClosureImpl, params: [] });
+
+      const helper = new AgencyFunction({
+        name: "helper",
+        module: "test.agency",
+        fn: testClosureImpl,
+        params: [],
+        toolDefinition: null,
+        closureData: null,
+        closureKey: helperKey,
+      });
+
+      const tool = new AgencyFunction({
+        name: "tool",
+        module: "test.agency",
+        fn: testClosureImpl,
+        params: testClosureParams,
+        toolDefinition: null,
+        closureData: { helper },
+        closureKey: "test.agency:outer::tool",
+      });
+      registerClosure("test.agency:outer::tool", { fn: testClosureImpl, params: testClosureParams });
+
+      const json = JSON.stringify({ tool }, nativeTypeReplacer);
+      const restored = JSON.parse(json, nativeTypeReviver);
+
+      expect(restored.tool).toBeInstanceOf(AgencyFunction);
+      expect(restored.tool.closureData.helper).toBeInstanceOf(AgencyFunction);
+      expect(restored.tool.closureData.helper.name).toBe("helper");
+    });
+
+    it("round-trips recursive inner function with self-reference", () => {
+      const fibKey = "test.agency:outer::fib";
+      registerClosure(fibKey, { fn: testClosureImpl, params: testClosureParams });
+
+      const fib = new AgencyFunction({
+        name: "fib",
+        module: "test.agency",
+        fn: testClosureImpl,
+        params: testClosureParams,
+        toolDefinition: null,
+        closureData: { fib: null as any },
+        closureKey: fibKey,
+      });
+      (fib.closureData as any).fib = fib;
+
+      const json = JSON.stringify({ fn: fib }, nativeTypeReplacer);
+      const restored = JSON.parse(json, nativeTypeReviver);
+
+      expect(restored.fn).toBeInstanceOf(AgencyFunction);
+      expect(restored.fn.closureData.fib).toBe(restored.fn);
+    });
   });
 });

--- a/packages/agency-lang/lib/runtime/revivers/functionRefReviver.ts
+++ b/packages/agency-lang/lib/runtime/revivers/functionRefReviver.ts
@@ -1,5 +1,7 @@
 import { BaseReviver } from "./baseReviver.js";
 import { AgencyFunction } from "../agencyFunction.js";
+import { lookupClosure, CLOSURE_SELF_SENTINEL } from "../closureRegistry.js";
+import type { FuncParam, ToolDefinition } from "../agencyFunction.js";
 
 type FunctionRefRegistry = Record<string, AgencyFunction>;
 
@@ -15,7 +17,27 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
   }
 
   serialize(value: AgencyFunction): Record<string, unknown> {
-    return { __nativeType: this.nativeTypeName(), name: value.name, module: value.module };
+    const result: Record<string, unknown> = {
+      __nativeType: this.nativeTypeName(),
+      name: value.name,
+      module: value.module,
+    };
+    if (value.closureKey) {
+      result.closureKey = value.closureKey;
+      // Replace self-references with sentinel to avoid circular JSON
+      if (value.closureData) {
+        const sanitized: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(value.closureData)) {
+          sanitized[k] = v === value ? CLOSURE_SELF_SENTINEL : v;
+        }
+        result.closureData = sanitized;
+      } else {
+        result.closureData = null;
+      }
+      result.toolDefinition = value.toolDefinition;
+      result.params = value.params;
+    }
+    return result;
   }
 
   validate(value: Record<string, unknown>): boolean {
@@ -23,13 +45,45 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
   }
 
   revive(value: Record<string, unknown>): AgencyFunction {
-    if (!this.registry) {
-      throw new Error(
-        `FunctionRefReviver: no registry set. Cannot revive function "${value.name}" from module "${value.module}".`
-      );
-    }
     const name = value.name as string;
     const module = value.module as string;
+
+    // Closure function path
+    if (value.closureKey) {
+      const key = value.closureKey as string;
+      const entry = lookupClosure(key);
+      if (!entry) {
+        throw new Error(
+          `FunctionRefReviver: cannot revive closure function "${key}" — module not loaded.`
+        );
+      }
+      const closureData = (value.closureData as Record<string, unknown>) ?? null;
+      const fn = new AgencyFunction({
+        name,
+        module,
+        fn: entry.fn,
+        params: value.params as FuncParam[],
+        toolDefinition: (value.toolDefinition as ToolDefinition | null) ?? null,
+        closureData,
+        closureKey: key,
+      });
+      // Replace __self__ sentinels for recursive inner functions
+      if (fn.closureData) {
+        for (const [k, v] of Object.entries(fn.closureData)) {
+          if (v === CLOSURE_SELF_SENTINEL) {
+            (fn.closureData as Record<string, unknown>)[k] = fn;
+          }
+        }
+      }
+      return fn;
+    }
+
+    // Regular function path (unchanged)
+    if (!this.registry) {
+      throw new Error(
+        `FunctionRefReviver: no registry set. Cannot revive function "${name}" from module "${module}".`
+      );
+    }
 
     // Fast path: direct lookup by name
     const direct = this.registry[name];

--- a/packages/agency-lang/lib/types.ts
+++ b/packages/agency-lang/lib/types.ts
@@ -124,7 +124,7 @@ export type Scope =
   | StaticScope
   | LocalScope
   | BlockScope;
-export type ScopeType = Scope["type"] | "args" | "blockArgs" | "functionRef";
+export type ScopeType = Scope["type"] | "args" | "blockArgs" | "functionRef" | "captured";
 export type GlobalScope = {
   type: "global";
 };

--- a/packages/agency-lang/lib/types/function.ts
+++ b/packages/agency-lang/lib/types/function.ts
@@ -39,6 +39,12 @@ export const VALID_CALLBACK_NAMES = [
 
 export type CallbackName = (typeof VALID_CALLBACK_NAMES)[number];
 
+export type CapturedVariable = {
+  name: string;
+  sourceScope: string;
+  sourceType: "local" | "args";
+};
+
 export type FunctionDefinition = BaseNode & {
   type: "function";
   functionName: string;
@@ -53,6 +59,8 @@ export type FunctionDefinition = BaseNode & {
   exported?: boolean;
   callback?: boolean;
   tags?: Tag[];
+  capturedVariables?: CapturedVariable[];
+  selfReferencing?: boolean;
 };
 
 export type FunctionCall = BaseNode & {

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -130,16 +130,26 @@ export function expressionToString(expr: Expression): string {
 export function* getAllVariablesInBody(
   body: AgencyNode[],
 ): Generator<{ name: string; node: AgencyNode }> {
-  for (const { node } of walkNodes(body)) {
+  // Track the initial function scope depth so we can skip nodes
+  // that belong to nested function definitions (they get their
+  // own scope processing pass).
+  let initialFuncDepth: number | null = null;
+  for (const { node, scopes } of walkNodes(body)) {
+    const funcDepth = scopes.filter(
+      (s) => s.type === "function" || s.type === "node",
+    ).length;
+    if (initialFuncDepth === null) initialFuncDepth = funcDepth;
+    // Skip nodes inside nested function bodies
+    if (funcDepth > initialFuncDepth) continue;
+
     if (node.type === "assignment") {
       yield { name: node.variableName, node };
       yield* getAllVariablesInBody([node.value as AgencyNode]);
     } else if (node.type === "function") {
+      // Yield the function name as a binding in the enclosing scope,
+      // but do NOT recurse into params or body — those belong to the
+      // inner function's own scope and are processed separately.
       yield { name: node.functionName, node };
-      for (const param of node.parameters) {
-        yield { name: param.name, node };
-      }
-      yield* getAllVariablesInBody(node.body);
     } else if (node.type === "graphNode") {
       yield { name: node.nodeName, node };
       for (const param of node.parameters) {


### PR DESCRIPTION
## Summary

Three improvements to the Agency standard library:

- **Async stdlib**: Converted all synchronous/blocking calls across 7 stdlib TypeScript files to async equivalents (`fs/promises`, promisified `execFile`/`spawn`), so the stdlib no longer blocks the Node.js event loop in web server contexts.

- **Interrupt safety**: Added interrupts to 13 functions across 8 stdlib `.agency` files that were missing them — email sending (Resend, SendGrid, Mailgun), SMS, iMessage, screenshots, clipboard access, browser automation, speech, transcription, URL opening, and OAuth token retrieval. Sensitive data (message bodies, API keys, tokens) is excluded from interrupt data.

- **`/** @module */` doc comments**: Introduced new `@module` syntax for file-level doc comments, replacing the ambiguous heuristic that tried to guess which `/** */` comment was file-level. The compiler throws an error if `@module` appears after non-import code. Updated all 9 stdlib files that have file-level docs to use the new syntax.

## Test plan

- [x] All 144 stdlib unit tests pass
- [x] Agency integration tests pass (exists, stat, ls, grep, glob, which, env, cwd, shell, fs-ops)
- [x] Parser tests pass with new `isModuleDoc` field (15 tests)
- [x] Preprocessor `attachDocComments` tests pass including new @module cases (35 tests)
- [x] Doc generation tests pass with @module syntax (11 tests)
- [x] All updated stdlib .agency files compile successfully
- [x] `agency doc` generates correct output for calendar.agency (module doc at top, not inside function)
- [x] Misplaced @module comment correctly throws an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)