### PR TITLE
Typecheck block bodies: route returns and propagate slot types

### DIFF
--- a/packages/agency-lang/lib/typeChecker/blockBody.test.ts
+++ b/packages/agency-lang/lib/typeChecker/blockBody.test.ts
@@ -12,8 +12,6 @@ function check(source: string): string[] {
 
 describe("block body type-checking", () => {
   it("block return doesn't leak into the enclosing function's return inference", () => {
-    // `return "hello"` belongs to the block, not `main`. Without the fix, it
-    // gets folded into main's inferred return type and fights with `return 42`.
     const errs = check(`
 def twice(b: () => string): string[] {
   return [b(), b()]
@@ -30,8 +28,6 @@ def main(): number {
   });
 
   it("block return is checked against the slot's return type", () => {
-    // Slot says block returns number; literal returns a string — diagnostic
-    // should mention 'block return', not the enclosing function's return.
     const errs = check(`
 def f(b: () => number): number {
   return b()
@@ -47,8 +43,6 @@ def main(): void {
   });
 
   it("block params pick up types from the slot when the literal is unannotated", () => {
-    // Slot is `(number) => void`, so `x` should be number inside the block.
-    // Assigning to `let y: string = x` must error.
     const errs = check(`
 def each(items: number[], cb: (number) => void): void {
   cb(items[0])
@@ -64,8 +58,6 @@ def main(): void {
   });
 
   it("untyped slot leaves block params as any (no spurious errors)", () => {
-    // Callee's block-receiving param has no type annotation, so the literal's
-    // params and returns aren't constrained by a contract.
     const errs = check(`
 def each(items: number[], cb): void {
   print("hi")
@@ -82,8 +74,6 @@ def main(): void {
   });
 
   it("nested block returns are routed to the right slot", () => {
-    // Outer block's return is checked against `outer`'s slot (number).
-    // Inner block's return is checked against `inner`'s slot (string).
     const outerOK = check(`
 def outer(b: () => number): number { return b() }
 def inner(b: () => string): string { return b() }

--- a/packages/agency-lang/lib/typeChecker/blockBody.test.ts
+++ b/packages/agency-lang/lib/typeChecker/blockBody.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+
+function check(source: string): string[] {
+  const parsed = parseAgency(source);
+  if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
+  const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
+  return typeCheck(parsed.result, {}, info).errors.map((e) => e.message);
+}
+
+describe("block body type-checking", () => {
+  it("block return doesn't leak into the enclosing function's return inference", () => {
+    // `return "hello"` belongs to the block, not `main`. Without the fix, it
+    // gets folded into main's inferred return type and fights with `return 42`.
+    const errs = check(`
+def twice(b: () => string): string[] {
+  return [b(), b()]
+}
+
+def main(): number {
+  let r = twice() as {
+    return "hello"
+  }
+  return 42
+}
+`);
+    expect(errs).toEqual([]);
+  });
+
+  it("block return is checked against the slot's return type", () => {
+    // Slot says block returns number; literal returns a string — diagnostic
+    // should mention 'block return', not the enclosing function's return.
+    const errs = check(`
+def f(b: () => number): number {
+  return b()
+}
+
+def main(): void {
+  let n = f() as {
+    return "not a number"
+  }
+}
+`);
+    expect(errs.some((m) => /not assignable/i.test(m) && /block return/.test(m))).toBe(true);
+  });
+
+  it("block params pick up types from the slot when the literal is unannotated", () => {
+    // Slot is `(number) => void`, so `x` should be number inside the block.
+    // Assigning to `let y: string = x` must error.
+    const errs = check(`
+def each(items: number[], cb: (number) => void): void {
+  cb(items[0])
+}
+
+def main(): void {
+  each([1, 2, 3]) as x {
+    let y: string = x
+  }
+}
+`);
+    expect(errs.some((m) => /not assignable/i.test(m))).toBe(true);
+  });
+
+  it("untyped slot leaves block params as any (no spurious errors)", () => {
+    // Callee's block-receiving param has no type annotation, so the literal's
+    // params and returns aren't constrained by a contract.
+    const errs = check(`
+def each(items: number[], cb): void {
+  print("hi")
+}
+
+def main(): void {
+  each([1, 2, 3]) as x {
+    let y: string = x
+    return 42
+  }
+}
+`);
+    expect(errs).toEqual([]);
+  });
+
+  it("nested block returns are routed to the right slot", () => {
+    // Outer block's return is checked against `outer`'s slot (number).
+    // Inner block's return is checked against `inner`'s slot (string).
+    const outerOK = check(`
+def outer(b: () => number): number { return b() }
+def inner(b: () => string): string { return b() }
+
+def main(): void {
+  let r: number = outer() as {
+    let s: string = inner() as { return "ok" }
+    return 1
+  }
+}
+`);
+    expect(outerOK).toEqual([]);
+
+    const innerWrong = check(`
+def outer(b: () => number): number { return b() }
+def inner(b: () => string): string { return b() }
+
+def main(): void {
+  let r: number = outer() as {
+    let s: string = inner() as { return 99 }
+    return 1
+  }
+}
+`);
+    expect(innerWrong.some((m) => /not assignable/i.test(m) && /block return/.test(m))).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -4,7 +4,7 @@ import {
   FunctionParameter,
   VariableType,
 } from "../types.js";
-import { walkNodes } from "../utils/node.js";
+import { walkNodes, type WalkAncestor } from "../utils/node.js";
 import { formatTypeHint } from "../cli/util.js";
 import { BUILTIN_FUNCTION_TYPES } from "./builtins.js";
 import { isAssignable } from "./assignability.js";
@@ -15,6 +15,7 @@ import {
   checkType,
   isAnyType,
   getParamsForNodeOrFunc,
+  getBlockSlot,
   checkExcessObjectProperties,
 } from "./utils.js";
 import { Scope } from "./scope.js";
@@ -425,28 +426,65 @@ function checkReturnTypesInScope(
 ): void {
   if (!info.returnType) return;
 
-  for (const { node } of walkNodes(info.body)) {
-    if (node.type === "returnStatement" && node.value) {
-      checkType(
-        node.value,
-        info.returnType,
-        info.scope,
-        `return in '${info.name}'`,
-        ctx,
-      );
-    }
+  for (const { node, ancestors } of walkNodes(info.body)) {
+    if (node.type !== "returnStatement" || !node.value) continue;
+    // Returns inside a block belong to the block, not the enclosing function;
+    // they're checked against the slot's return type by checkExpressionsInScope.
+    if (ancestors.some((a) => a.type === "blockArgument")) continue;
+    checkType(
+      node.value,
+      info.returnType,
+      info.scope,
+      `return in '${info.name}'`,
+      ctx,
+    );
   }
+}
+
+/**
+ * Find the `blockType` slot for the innermost enclosing block, if any.
+ * `walkNodes` includes the `blockArgument` AST node in `ancestors` when
+ * descending into a block body, so the innermost `blockArgument` ancestor
+ * marks "we're inside a block" and the immediately preceding ancestor is
+ * the call that received it.
+ */
+function findEnclosingBlockSlot(
+  ancestors: WalkAncestor[],
+  ctx: TypeCheckerContext,
+) {
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    if (ancestors[i].type !== "blockArgument") continue;
+    const parent = ancestors[i - 1];
+    if (parent?.type !== "functionCall") return undefined;
+    return getBlockSlot(parent.functionName, ctx);
+  }
+  return undefined;
 }
 
 function checkExpressionsInScope(
   info: ScopeInfo,
   ctx: TypeCheckerContext,
 ): void {
-  for (const { node } of walkNodes(info.body)) {
+  for (const { node, ancestors } of walkNodes(info.body)) {
     if (node.type === "valueAccess") {
       synthType(node, info.scope, ctx);
     } else if (node.type === "returnStatement" && node.value) {
-      synthType(node.value, info.scope, ctx);
+      // A return inside a block body belongs to the block, not the enclosing
+      // function. If the block fills a typed slot, check the return value
+      // against the slot's declared return type. (Inference for the enclosing
+      // function already excludes block returns — see inference.ts.)
+      const blockSlot = findEnclosingBlockSlot(ancestors, ctx);
+      if (blockSlot) {
+        checkType(
+          node.value,
+          blockSlot.returnType,
+          info.scope,
+          "block return",
+          ctx,
+        );
+      } else {
+        synthType(node.value, info.scope, ctx);
+      }
     } else if (node.type === "ifElse" || node.type === "whileLoop") {
       checkType(node.condition, BOOLEAN_T, info.scope, "condition", ctx);
     } else if (node.type === "binOpExpression" && node.operator === "catch") {

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -4,7 +4,7 @@ import {
   FunctionParameter,
   VariableType,
 } from "../types.js";
-import { walkNodes, type WalkAncestor } from "../utils/node.js";
+import { walkNodes, isInsideBlock, type WalkAncestor } from "../utils/node.js";
 import { formatTypeHint } from "../cli/util.js";
 import { BUILTIN_FUNCTION_TYPES } from "./builtins.js";
 import { isAssignable } from "./assignability.js";
@@ -20,6 +20,7 @@ import {
 } from "./utils.js";
 import { Scope } from "./scope.js";
 import { BOOLEAN_T, REGEX_T, STRING_T } from "./primitives.js";
+import type { BlockType } from "../types/typeHints.js";
 
 /**
  * Derive arity bounds and per-position param types from a parameter list,
@@ -430,7 +431,7 @@ function checkReturnTypesInScope(
     if (node.type !== "returnStatement" || !node.value) continue;
     // Returns inside a block belong to the block, not the enclosing function;
     // they're checked against the slot's return type by checkExpressionsInScope.
-    if (ancestors.some((a) => a.type === "blockArgument")) continue;
+    if (isInsideBlock(ancestors)) continue;
     checkType(
       node.value,
       info.returnType,
@@ -451,7 +452,7 @@ function checkReturnTypesInScope(
 function findEnclosingBlockSlot(
   ancestors: WalkAncestor[],
   ctx: TypeCheckerContext,
-) {
+): BlockType | undefined {
   for (let i = ancestors.length - 1; i >= 0; i--) {
     if (ancestors[i].type !== "blockArgument") continue;
     const parent = ancestors[i - 1];

--- a/packages/agency-lang/lib/typeChecker/inference.ts
+++ b/packages/agency-lang/lib/typeChecker/inference.ts
@@ -63,7 +63,10 @@ export function inferReturnTypeFor(
     for (const { node, ancestors } of walkNodes(def.body)) {
       if (node.type === "returnStatement" && node.value) {
         const insideNested = ancestors.some(
-          (a) => a.type === "function" || a.type === "graphNode",
+          (a) =>
+            a.type === "function" ||
+            a.type === "graphNode" ||
+            a.type === "blockArgument",
         );
         if (!insideNested) {
           returnValues.push(node.value);

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -16,7 +16,7 @@ import { validateTypeReferences } from "./validate.js";
 import { ScopeInfo, TypeCheckerContext } from "./types.js";
 import { Scope } from "./scope.js";
 import { formatTypeHint } from "../cli/util.js";
-import { checkType } from "./utils.js";
+import { checkType, getBlockSlot } from "./utils.js";
 import { NUMBER_T } from "./primitives.js";
 
 export function buildScopes(ctx: TypeCheckerContext): ScopeInfo[] {
@@ -238,9 +238,17 @@ export function walkScopeBody(
         break;
       case "functionCall":
         if (node.block) {
-          for (const param of node.block.params) {
-            scope.declare(param.name, param.typeHint ?? "any");
-          }
+          // Block params are typed (in priority order): an explicit annotation
+          // on the literal (`as x: T { ... }`); otherwise the matching slot
+          // type from the callee's `blockType` param; otherwise `any`.
+          const slot = getBlockSlot(node.functionName, ctx);
+          node.block.params.forEach((param, i) => {
+            const slotType = slot?.params[i]?.typeAnnotation;
+            scope.declare(
+              param.name,
+              param.typeHint ?? slotType ?? "any",
+            );
+          });
           walkScopeBody(node.block.body, scope, ctx);
         }
         break;

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -238,9 +238,11 @@ export function walkScopeBody(
         break;
       case "functionCall":
         if (node.block) {
-          // Block params are typed (in priority order): an explicit annotation
-          // on the literal (`as x: T { ... }`); otherwise the matching slot
-          // type from the callee's `blockType` param; otherwise `any`.
+          // Block params today have no syntax for an explicit type annotation,
+          // so the type comes from the matching slot in the callee's
+          // `blockType` param (when present), falling back to `any`. The
+          // `param.typeHint` branch is dead code that anticipates a future
+          // typed-block-param syntax.
           const slot = getBlockSlot(node.functionName, ctx);
           node.block.params.forEach((param, i) => {
             const slotType = slot?.params[i]?.typeAnnotation;

--- a/packages/agency-lang/lib/typeChecker/utils.ts
+++ b/packages/agency-lang/lib/typeChecker/utils.ts
@@ -1,4 +1,5 @@
 import { AgencyNode, FunctionParameter, VariableType } from "../types.js";
+import type { BlockType } from "../types/typeHints.js";
 import { formatTypeHint } from "../cli/util.js";
 import { isAssignable, resolveType } from "./assignability.js";
 import { synthType } from "./synthesizer.js";
@@ -18,6 +19,23 @@ export function getParamsForNodeOrFunc(
   const def =
     ctx.functionDefs[name] ?? ctx.nodeDefs[name] ?? ctx.importedFunctions[name];
   return def?.parameters;
+}
+
+/**
+ * If the named callable's last parameter is `blockType`, return that signature
+ * — the slot a trailing/inline block fills. Returns undefined for callables
+ * whose block param is untyped, `any`, or absent (block bodies in those cases
+ * keep their literal annotations and aren't checked against a contract).
+ */
+export function getBlockSlot(
+  name: string,
+  ctx: TypeCheckerContext,
+): BlockType | undefined {
+  const params = getParamsForNodeOrFunc(name, ctx);
+  if (!params || params.length === 0) return undefined;
+  const last = params[params.length - 1];
+  if (last.typeHint?.type !== "blockType") return undefined;
+  return last.typeHint;
 }
 
 export function isAnyType(t: VariableType): boolean {

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -13,13 +13,18 @@ import {
   Scope,
 } from "@/types.js";
 import type { BlockArgument } from "@/types/blockArgument.js";
-
-/** Block bodies can sit on the ancestors list even though `BlockArgument`
- * isn't a member of `AgencyNode` (it's a child of `FunctionCall`, never a
- * standalone statement). Widen the ancestor type so consumers can match it. */
-export type WalkAncestor = AgencyNode | BlockArgument;
 import { variableTypeToString } from "@/backends/typescriptGenerator/typeToString.js";
 import { color } from "@/utils/termcolors.js";
+
+/** `BlockArgument` is a child of `FunctionCall`, not a standalone statement,
+ * so it isn't in the `AgencyNode` union. But blocks DO appear on the ancestors
+ * list when `walkNodes` descends into a block body — widen the type so
+ * consumers can match `a.type === "blockArgument"`. */
+export type WalkAncestor = AgencyNode | BlockArgument;
+
+export function isInsideBlock(ancestors: WalkAncestor[]): boolean {
+  return ancestors.some((a) => a.type === "blockArgument");
+}
 
 /** Unwrap a function call argument to its inner expression. */
 function unwrapCallArg(arg: Expression | SplatExpression | NamedArgument): Expression {

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -12,6 +12,12 @@ import {
   nodeScope,
   Scope,
 } from "@/types.js";
+import type { BlockArgument } from "@/types/blockArgument.js";
+
+/** Block bodies can sit on the ancestors list even though `BlockArgument`
+ * isn't a member of `AgencyNode` (it's a child of `FunctionCall`, never a
+ * standalone statement). Widen the ancestor type so consumers can match it. */
+export type WalkAncestor = AgencyNode | BlockArgument;
 import { variableTypeToString } from "@/backends/typescriptGenerator/typeToString.js";
 import { color } from "@/utils/termcolors.js";
 
@@ -262,9 +268,9 @@ export let walkNodeDebug = false;
 export const setWalkNodeDebug = (value: boolean) => (walkNodeDebug = value);
 export function* walkNodes(
   nodes: AgencyNode[],
-  ancestors: AgencyNode[] = [],
+  ancestors: WalkAncestor[] = [],
   scopes: Scope[] = [],
-): Generator<{ node: AgencyNode; ancestors: AgencyNode[]; scopes: Scope[] }> {
+): Generator<{ node: AgencyNode; ancestors: WalkAncestor[]; scopes: Scope[] }> {
   if (scopes.length === 0) {
     scopes.push(globalScope());
   }
@@ -355,7 +361,11 @@ export function* walkNodes(
         yield* walkNodes([unwrapCallArg(arg) as AgencyNode], [...ancestors, node], scopes);
       }
       if (node.block) {
-        yield* walkNodes(node.block.body, [...ancestors, node], scopes);
+        yield* walkNodes(
+          node.block.body,
+          [...ancestors, node, node.block],
+          scopes,
+        );
       }
     } else if (node.type === "matchBlock") {
       yield* walkNodes([node.expression], [...ancestors, node], scopes);
@@ -419,12 +429,12 @@ export function* walkNodes(
 
 export function walkNodesArray(
   nodes: AgencyNode[],
-  ancestors: AgencyNode[] = [],
+  ancestors: WalkAncestor[] = [],
   scopes: Scope[] = [],
 ) {
   const results: {
     node: AgencyNode;
-    ancestors: AgencyNode[];
+    ancestors: WalkAncestor[];
     scopes: Scope[];
   }[] = [];
   for (const result of walkNodes(nodes, ancestors, scopes)) {


### PR DESCRIPTION
## Summary

Three connected fixes for type-checking blocks (`f(...) as x { ... }`):

- **Block returns no longer leak.** A `return` inside a block belongs to the block, not the enclosing function. Both `inferReturnTypeFor` and `checkReturnTypesInScope` were treating block returns as enclosing-function returns, producing spurious "not assignable" errors.
- **Block params pick up types from the slot.** When the receiving function declares `(b: (number) => string)` and the call site is `f() as x { ... }`, `x` is now typed as `number` instead of `any`. An explicit `typeHint` on the literal still wins (placeholder for future typed block params).
- **Block returns are checked against the slot's declared `returnType`.** Diagnostics say "block return" so they're not confused with the enclosing function's return.

`walkNodes` now includes the `BlockArgument` AST node in `ancestors` when descending into a block body, so consumers can detect "we're inside a block" with a normal ancestor check (new `WalkAncestor = AgencyNode | BlockArgument` type).

## Known follow-ups (not in this PR)

- **Runtime nested-block variable capture is broken.** Inner-block code references outer-block params via the inner block's own stack frame, which is empty for those names. Generated code resolves to `undefined` and arithmetic returns `NaN`. Needs preprocessor + codegen work to either chain stack frames or capture outer params via JS closure. Tracked separately.
- **Block param leak / shadow at the typechecker level.** Block params currently get added to the enclosing function's flat scope, so they remain visible after the block ends and clobber outer vars with the same name. The `Scope` class already has `parent`/`child()` infrastructure — needs a `declareLocal` method and a per-block child scope. Naturally pairs with the runtime fix above.
- **Typed block params.** Parser explicitly rejects `as x: T { ... }` today. Adding it is a small parser change once we want it.

## Test plan

- [x] New `lib/typeChecker/blockBody.test.ts` covers the three fixes plus an unannotated-slot case and a nested-block routing case.
- [x] Full suite passes (2433 tests).