### PR TITLE
feat(tui): add @agency-lang/tui library

### DIFF
--- a/packages/agency-lang/docs/superpowers/plans/2026-05-05-tui-library-and-debugger-test-harness.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-05-tui-library-and-debugger-test-harness.md
@@ -1,0 +1,1572 @@
+# TUI Library and Debugger Test Harness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a testable TUI library (`@agency-lang/tui`) to replace blessed in the Agency debugger, and a new test harness that produces visual HTML artifacts for easy debugging.
+
+**Architecture:** Immediate-mode TUI library with flexbox-lite layout engine, multiple output adapters (ANSI, HTML, plain text), and pluggable input sources. The debugger test harness wraps the TUI lib and debugger driver, providing a step-at-a-time API with frame inspection.
+
+**Tech Stack:** TypeScript, vitest, pnpm workspace
+
+**Spec:** `docs/superpowers/specs/2026-05-05-tui-library-and-debugger-test-harness-design.md`
+
+---
+
+## File Structure
+
+### New package: `packages/tui/`
+
+```
+packages/tui/
+  package.json
+  tsconfig.json
+  vitest.config.ts
+  lib/
+    index.ts              # Public API re-exports
+    elements.ts           # Element, Style, StyleProps types
+    builders.ts           # box(), row(), column(), text(), list(), textInput()
+    layout.ts             # Flexbox-lite layout engine
+    frame.ts              # Frame class, Cell type, FrameStyle type, flatten utility
+    styleParser.ts        # Parse inline style tags ({bold}, {red-fg}, etc.)
+    colors.ts             # Color name -> ANSI code / CSS color mappings
+    render/
+      renderer.ts         # Element tree -> Frame tree
+      flatten.ts          # Composite Frame tree into 2D cell grid (shared by all adapters)
+      ansi.ts             # Frame -> ANSI escape codes
+      html.ts             # Frame -> HTML string
+      plaintext.ts        # Frame -> plain text string
+    input/
+      types.ts            # KeyEvent, InputSource types
+      terminal.ts         # TerminalInput (stdin raw mode)
+      scripted.ts         # ScriptedInput (programmatic)
+    output/
+      types.ts            # OutputTarget type
+      terminal.ts         # TerminalOutput (ANSI to stdout)
+      recorder.ts         # FrameRecorder (collect frames)
+    screen.ts             # Screen class
+  test/
+    elements.test.ts
+    builders.test.ts
+    layout.test.ts
+    styleParser.test.ts
+    frame.test.ts
+    renderer.test.ts
+    ansi.test.ts
+    html.test.ts
+    plaintext.test.ts
+    scripted.test.ts
+    recorder.test.ts
+    screen.test.ts
+```
+
+### Modified in `packages/agency-lang/`
+
+```
+lib/debugger/
+  testSession.ts          # NEW: DebuggerTestSession class
+  testSession.test.ts     # NEW: Tests for DebuggerTestSession
+  ui.ts                   # REWRITE: Replace blessed with @agency-lang/tui
+  driver.test.ts          # REWRITE: Use DebuggerTestSession instead of TestDebuggerIO
+  testHelpers.ts          # MODIFY: Update/simplify helpers, keep freshImport
+```
+
+---
+
+## Task 1: Package scaffolding
+
+**Files:**
+- Create: `packages/tui/package.json`
+- Create: `packages/tui/tsconfig.json`
+- Create: `packages/tui/vitest.config.ts`
+- Create: `packages/tui/lib/index.ts`
+
+- [ ] **Step 1: Create `packages/tui/package.json`**
+
+```json
+{
+  "name": "@agency-lang/tui",
+  "version": "0.0.1",
+  "description": "A testable TUI library with immediate-mode rendering and flexbox layout",
+  "type": "module",
+  "main": "./dist/lib/index.js",
+  "types": "./dist/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/lib/index.d.ts",
+      "import": "./dist/lib/index.js"
+    }
+  },
+  "files": ["dist/"],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "keywords": ["tui", "terminal", "ui", "flexbox"],
+  "author": "Aditya Bhargava",
+  "license": "ISC",
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}
+```
+
+- [ ] **Step 2: Create `packages/tui/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "esnext",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["lib"],
+  "exclude": ["node_modules", "dist", "test"]
+}
+```
+
+- [ ] **Step 3: Create `packages/tui/vitest.config.ts`**
+
+```typescript
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts", "lib/**/*.test.ts"],
+  },
+});
+```
+
+- [ ] **Step 4: Create empty `packages/tui/lib/index.ts`**
+
+```typescript
+// Public API — exports will be added as modules are built
+```
+
+- [ ] **Step 5: Install dependencies**
+
+Run: `cd packages/tui && pnpm install`
+
+- [ ] **Step 6: Verify build works**
+
+Run: `cd packages/tui && pnpm run build`
+Expected: Compiles with no errors, creates `dist/` directory.
+
+- [ ] **Step 7: Commit**
+
+```
+feat(tui): scaffold @agency-lang/tui package
+```
+
+---
+
+## Task 2: Element types and builder functions
+
+**Files:**
+- Create: `packages/tui/lib/elements.ts`
+- Create: `packages/tui/lib/builders.ts`
+- Create: `packages/tui/test/builders.test.ts`
+
+- [ ] **Step 1: Write the test for builder functions**
+
+```typescript
+// test/builders.test.ts
+import { describe, it, expect } from "vitest";
+import { box, row, column, text, list, textInput } from "../lib/builders.js";
+
+describe("builders", () => {
+  it("text() creates a text element", () => {
+    const el = text("hello");
+    expect(el).toEqual({ type: "text", content: "hello" });
+  });
+
+  it("box() with style and children", () => {
+    const el = box({ border: true, key: "mybox" }, text("hi"));
+    expect(el.type).toBe("box");
+    expect(el.key).toBe("mybox");
+    expect(el.style?.border).toBe(true);
+    expect(el.children).toHaveLength(1);
+    expect(el.children![0].content).toBe("hi");
+  });
+
+  it("box() without style treats all args as children", () => {
+    const el = box(text("a"), text("b"));
+    expect(el.type).toBe("box");
+    expect(el.style).toBeUndefined();
+    expect(el.children).toHaveLength(2);
+  });
+
+  it("row() sets flexDirection to row", () => {
+    const el = row({ flex: 1 }, text("a"));
+    expect(el.style?.flexDirection).toBe("row");
+  });
+
+  it("column() sets flexDirection to column", () => {
+    const el = column({ flex: 1 }, text("a"));
+    expect(el.style?.flexDirection).toBe("column");
+  });
+
+  it("list() creates a list element", () => {
+    const el = list({ key: "mylist" }, ["a", "b", "c"], 1);
+    expect(el.type).toBe("list");
+    expect(el.items).toEqual(["a", "b", "c"]);
+    expect(el.selectedIndex).toBe(1);
+  });
+
+  it("textInput() creates a textInput element", () => {
+    const el = textInput({ key: "input" }, "hello");
+    expect(el.type).toBe("textInput");
+    expect(el.value).toBe("hello");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/tui && pnpm vitest run test/builders.test.ts`
+Expected: FAIL — modules don't exist yet.
+
+- [ ] **Step 3: Implement `elements.ts`**
+
+Define the `Element`, `StyleProps`, `Cell`, `FrameStyle` types and the `PositionedElement` type used by the layout engine. See the spec's "Element Descriptor" section for the full type. Also define `Cell` and `FrameStyle` here since they are foundational types.
+
+```typescript
+// lib/elements.ts
+export type Element = {
+  type: "box" | "text" | "list" | "textInput";
+  style?: Style;
+  content?: string;
+  children?: Element[];
+  items?: string[];
+  selectedIndex?: number;
+  value?: string;
+  key?: string;
+};
+
+export type Style = {
+  flexDirection?: "row" | "column";
+  flex?: number;
+  justifyContent?: "flex-start" | "center" | "flex-end" | "space-between";
+  alignItems?: "flex-start" | "center" | "flex-end" | "stretch";
+  width?: number | string;
+  height?: number | string;
+  minWidth?: number;
+  minHeight?: number;
+  maxWidth?: number;
+  maxHeight?: number;
+  padding?: number | { top?: number; bottom?: number; left?: number; right?: number };
+  margin?: number | { top?: number; bottom?: number; left?: number; right?: number };
+  border?: boolean;
+  borderColor?: string;
+  label?: string;
+  labelColor?: string;
+  fg?: string;
+  bg?: string;
+  bold?: boolean;
+  scrollable?: boolean;
+  scrollOffset?: number;
+  visible?: boolean;
+};
+
+export type StyleProps = Style & { key?: string };
+
+export type Cell = {
+  char: string;
+  fg?: string;
+  bg?: string;
+  bold?: boolean;
+};
+
+export type FrameStyle = {
+  border?: boolean;
+  borderColor?: string;
+  bg?: string;
+  label?: string;
+  labelColor?: string;
+};
+
+export type PositionedElement = Element & {
+  resolvedX: number;
+  resolvedY: number;
+  resolvedWidth: number;
+  resolvedHeight: number;
+  children?: PositionedElement[];
+};
+```
+
+- [ ] **Step 4: Implement `builders.ts`**
+
+```typescript
+// lib/builders.ts
+import type { Element, StyleProps } from "./elements.js";
+
+function isStyleProps(arg: any): arg is StyleProps {
+  return arg !== null && typeof arg === "object" && !("type" in arg);
+}
+
+function splitStyleAndKey(props: StyleProps): { style: Element["style"]; key?: string } {
+  const { key, ...style } = props;
+  return { style: Object.keys(style).length > 0 ? style : undefined, key };
+}
+
+export function box(styleOrChild?: StyleProps | Element, ...children: Element[]): Element {
+  if (styleOrChild === undefined) {
+    return { type: "box" };
+  }
+  if (isStyleProps(styleOrChild)) {
+    const { style, key } = splitStyleAndKey(styleOrChild);
+    return { type: "box", style, key, children: children.length > 0 ? children : undefined };
+  }
+  return { type: "box", children: [styleOrChild, ...children] };
+}
+
+export function row(styleOrChild?: StyleProps | Element, ...children: Element[]): Element {
+  if (styleOrChild === undefined) {
+    return { type: "box", style: { flexDirection: "row" } };
+  }
+  if (isStyleProps(styleOrChild)) {
+    const { style, key } = splitStyleAndKey(styleOrChild);
+    return {
+      type: "box",
+      style: { ...style, flexDirection: "row" },
+      key,
+      children: children.length > 0 ? children : undefined,
+    };
+  }
+  return { type: "box", style: { flexDirection: "row" }, children: [styleOrChild, ...children] };
+}
+
+export function column(styleOrChild?: StyleProps | Element, ...children: Element[]): Element {
+  if (styleOrChild === undefined) {
+    return { type: "box", style: { flexDirection: "column" } };
+  }
+  if (isStyleProps(styleOrChild)) {
+    const { style, key } = splitStyleAndKey(styleOrChild);
+    return {
+      type: "box",
+      style: { ...style, flexDirection: "column" },
+      key,
+      children: children.length > 0 ? children : undefined,
+    };
+  }
+  return { type: "box", style: { flexDirection: "column" }, children: [styleOrChild, ...children] };
+}
+
+export function text(content: string): Element {
+  return { type: "text", content };
+}
+
+export function list(style: StyleProps, items: string[], selectedIndex?: number): Element {
+  const { style: resolvedStyle, key } = splitStyleAndKey(style);
+  return { type: "list", style: resolvedStyle, key, items, selectedIndex };
+}
+
+export function textInput(style: StyleProps, value?: string): Element {
+  const { style: resolvedStyle, key } = splitStyleAndKey(style);
+  return { type: "textInput", style: resolvedStyle, key, value };
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/tui && pnpm vitest run test/builders.test.ts`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Export from index.ts**
+
+Add to `lib/index.ts`:
+```typescript
+export * from "./elements.js";
+export * from "./builders.js";
+```
+
+- [ ] **Step 7: Commit**
+
+```
+feat(tui): add element types and builder functions
+```
+
+---
+
+## Task 3: Style tag parser and color system
+
+**Files:**
+- Create: `packages/tui/lib/styleParser.ts`
+- Create: `packages/tui/lib/colors.ts`
+- Create: `packages/tui/test/styleParser.test.ts`
+
+- [ ] **Step 1: Write tests for the style tag parser**
+
+The parser takes a string like `"{bold}hello{/bold} {red-fg}world{/red-fg}"` and returns an array of styled spans: `[{ text: "hello", bold: true }, { text: " " }, { text: "world", fg: "red" }]`.
+
+```typescript
+// test/styleParser.test.ts
+import { describe, it, expect } from "vitest";
+import { parseStyledText, type StyledSpan } from "../lib/styleParser.js";
+
+describe("parseStyledText", () => {
+  it("returns plain text as a single span", () => {
+    expect(parseStyledText("hello")).toEqual([{ text: "hello" }]);
+  });
+
+  it("parses bold tags", () => {
+    expect(parseStyledText("{bold}hi{/bold}")).toEqual([{ text: "hi", bold: true }]);
+  });
+
+  it("parses fg color tags", () => {
+    expect(parseStyledText("{red-fg}hi{/red-fg}")).toEqual([{ text: "hi", fg: "red" }]);
+  });
+
+  it("parses bg color tags", () => {
+    expect(parseStyledText("{blue-bg}hi{/blue-bg}")).toEqual([{ text: "hi", bg: "blue" }]);
+  });
+
+  it("handles nested tags", () => {
+    const result = parseStyledText("{bold}{red-fg}hi{/red-fg}{/bold}");
+    expect(result).toEqual([{ text: "hi", bold: true, fg: "red" }]);
+  });
+
+  it("handles mixed styled and unstyled text", () => {
+    const result = parseStyledText("hello {bold}world{/bold} foo");
+    expect(result).toEqual([
+      { text: "hello " },
+      { text: "world", bold: true },
+      { text: " foo" },
+    ]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseStyledText("")).toEqual([]);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/tui && pnpm vitest run test/styleParser.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `colors.ts`**
+
+Map named colors to ANSI codes and CSS values. See the spec's "Color System" section.
+
+```typescript
+// lib/colors.ts
+export const ansiColors: Record<string, string> = {
+  black: "\x1b[30m", red: "\x1b[31m", green: "\x1b[32m", yellow: "\x1b[33m",
+  blue: "\x1b[34m", magenta: "\x1b[35m", cyan: "\x1b[36m", white: "\x1b[37m",
+  gray: "\x1b[90m",
+  "bright-red": "\x1b[91m", "bright-green": "\x1b[92m", "bright-yellow": "\x1b[93m",
+  "bright-blue": "\x1b[94m", "bright-magenta": "\x1b[95m", "bright-cyan": "\x1b[96m",
+  "bright-white": "\x1b[97m",
+};
+
+export const ansiBgColors: Record<string, string> = {
+  black: "\x1b[40m", red: "\x1b[41m", green: "\x1b[42m", yellow: "\x1b[43m",
+  blue: "\x1b[44m", magenta: "\x1b[45m", cyan: "\x1b[46m", white: "\x1b[47m",
+  gray: "\x1b[100m",
+  "bright-red": "\x1b[101m", "bright-green": "\x1b[102m", "bright-yellow": "\x1b[103m",
+  "bright-blue": "\x1b[104m", "bright-magenta": "\x1b[105m", "bright-cyan": "\x1b[106m",
+  "bright-white": "\x1b[107m",
+};
+
+export const cssColors: Record<string, string> = {
+  black: "#000", red: "#c00", green: "#0a0", yellow: "#aa0",
+  blue: "#00a", magenta: "#a0a", cyan: "#0aa", white: "#ccc",
+  gray: "#888",
+  "bright-red": "#f55", "bright-green": "#5f5", "bright-yellow": "#ff5",
+  "bright-blue": "#55f", "bright-magenta": "#f5f", "bright-cyan": "#5ff",
+  "bright-white": "#fff",
+};
+```
+
+- [ ] **Step 4: Implement `styleParser.ts`**
+
+Parse inline style tags into spans. The parser walks the string, tracking a style stack. Opening tags like `{bold}` push onto the stack, closing tags like `{/bold}` pop.
+
+```typescript
+// lib/styleParser.ts
+export type StyledSpan = {
+  text: string;
+  fg?: string;
+  bg?: string;
+  bold?: boolean;
+};
+
+export function parseStyledText(input: string): StyledSpan[] {
+  // Implementation: regex-based tag parser that maintains a style stack.
+  // Opens: {bold}, {red-fg}, {blue-bg}
+  // Closes: {/bold}, {/red-fg}, {/blue-bg}
+  // Between tags: accumulate text into current span with current style.
+  // See spec "Inline Style Tags" section for the full tag syntax.
+  // ...
+}
+```
+
+Implement the full parser. Key behavior:
+- `{bold}` pushes bold onto style stack
+- `{COLOR-fg}` pushes fg color onto style stack
+- `{COLOR-bg}` pushes bg color onto style stack
+- `{/TAG}` pops matching entry from style stack
+- Text between tags becomes a `StyledSpan` with the current accumulated style
+- Return `[]` for empty string
+
+Also implement `escapeStyleTags(text: string): string` — escapes `{` and `}` in user-provided text so they aren't interpreted as style tags. This is the equivalent of blessed's `blessed.escape()`, which the current debugger UI calls on all variable values, file paths, and log messages before rendering. Without this, a variable containing `{bold}` would be misinterpreted.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/tui && pnpm vitest run test/styleParser.test.ts`
+Expected: All tests PASS.
+
+- [ ] **Step 6: Export from index.ts**
+
+Add to `lib/index.ts`:
+```typescript
+export * from "./styleParser.js";
+export * from "./colors.js";
+```
+
+- [ ] **Step 7: Commit**
+
+```
+feat(tui): add style tag parser and color system
+```
+
+---
+
+## Task 4: Flexbox-lite layout engine
+
+**Files:**
+- Create: `packages/tui/lib/layout.ts`
+- Create: `packages/tui/test/layout.test.ts`
+
+This is the most complex task. The layout engine is a pure function: `(element, width, height) -> PositionedElement`. It resolves flexbox properties to absolute positions.
+
+- [ ] **Step 1: Write tests for the layout engine**
+
+Test cases cover: fixed sizing, percentage sizing, flex grow, row vs column direction, nested layouts, padding, margin, border space, min/max constraints, invisible elements. Write at least 10-15 tests.
+
+```typescript
+// test/layout.test.ts
+import { describe, it, expect } from "vitest";
+import { layout } from "../lib/layout.js";
+import { box, row, column, text } from "../lib/builders.js";
+
+describe("layout", () => {
+  it("single box fills available space", () => {
+    const el = box({ key: "a" });
+    const result = layout(el, 80, 24);
+    expect(result.resolvedX).toBe(0);
+    expect(result.resolvedY).toBe(0);
+    expect(result.resolvedWidth).toBe(80);
+    expect(result.resolvedHeight).toBe(24);
+  });
+
+  it("fixed width and height", () => {
+    const el = box({ width: 40, height: 10 });
+    const result = layout(el, 80, 24);
+    expect(result.resolvedWidth).toBe(40);
+    expect(result.resolvedHeight).toBe(10);
+  });
+
+  it("percentage width", () => {
+    const el = box({ width: "50%" });
+    const result = layout(el, 80, 24);
+    expect(result.resolvedWidth).toBe(40);
+  });
+
+  it("column direction stacks children vertically", () => {
+    const el = column(
+      box({ key: "a", height: 5 }),
+      box({ key: "b", height: 5 }),
+    );
+    const result = layout(el, 80, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    const b = result.children!.find(c => c.key === "b")!;
+    expect(a.resolvedY).toBe(0);
+    expect(b.resolvedY).toBe(5);
+  });
+
+  it("row direction places children horizontally", () => {
+    const el = row(
+      box({ key: "a", width: 20 }),
+      box({ key: "b", width: 30 }),
+    );
+    const result = layout(el, 80, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    const b = result.children!.find(c => c.key === "b")!;
+    expect(a.resolvedX).toBe(0);
+    expect(b.resolvedX).toBe(20);
+  });
+
+  it("flex distributes remaining space", () => {
+    const el = row(
+      box({ key: "a", width: 20 }),
+      box({ key: "b", flex: 1 }),
+    );
+    const result = layout(el, 80, 24);
+    const b = result.children!.find(c => c.key === "b")!;
+    expect(b.resolvedWidth).toBe(60);
+  });
+
+  it("multiple flex children split space proportionally", () => {
+    const el = row(
+      box({ key: "a", flex: 1 }),
+      box({ key: "b", flex: 2 }),
+    );
+    const result = layout(el, 90, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    const b = result.children!.find(c => c.key === "b")!;
+    expect(a.resolvedWidth).toBe(30);
+    expect(b.resolvedWidth).toBe(60);
+  });
+
+  it("border reduces inner space by 2 in each dimension", () => {
+    const el = box({ width: 20, height: 10, border: true },
+      box({ key: "inner", flex: 1 })
+    );
+    const result = layout(el, 80, 24);
+    const inner = result.children!.find(c => c.key === "inner")!;
+    expect(inner.resolvedWidth).toBe(18);
+    expect(inner.resolvedHeight).toBe(8);
+  });
+
+  it("invisible elements take no space", () => {
+    const el = column(
+      box({ key: "a", height: 5 }),
+      box({ key: "b", height: 5, visible: false }),
+      box({ key: "c", height: 5 }),
+    );
+    const result = layout(el, 80, 24);
+    const c = result.children!.find(c => c.key === "c")!;
+    expect(c.resolvedY).toBe(5);
+  });
+
+  it("nested layout", () => {
+    const el = column(
+      box({ key: "top", height: "40%" }),
+      row({ flex: 1 },
+        box({ key: "left", width: "50%" }),
+        box({ key: "right", flex: 1 }),
+      ),
+    );
+    const result = layout(el, 100, 20);
+    const top = result.children!.find(c => c.key === "top")!;
+    expect(top.resolvedHeight).toBe(8);
+    const rowEl = result.children![1];
+    const left = rowEl.children!.find(c => c.key === "left")!;
+    const right = rowEl.children!.find(c => c.key === "right")!;
+    expect(left.resolvedWidth).toBe(50);
+    expect(right.resolvedWidth).toBe(50);
+    expect(left.resolvedY).toBe(8);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/tui && pnpm vitest run test/layout.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement `layout.ts`**
+
+Implement the `layout(element, width, height): PositionedElement` function. The algorithm:
+
+1. Resolve the root element's size (use provided width/height if no explicit size).
+2. For each element with children, determine the main axis (row = horizontal, column = vertical).
+3. First pass: allocate fixed and percentage children along the main axis. Track remaining space.
+4. Second pass: distribute remaining space to flex children proportionally.
+5. Position children along the main axis according to `justifyContent`.
+6. Position children along the cross axis according to `alignItems`.
+7. Account for border (reduces inner area by 1 on each side) and padding.
+8. Skip invisible elements (`visible: false`).
+9. Recurse into children.
+
+See spec sections "Flexbox-Lite Layout Engine" and "Text Overflow and Scrolling".
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/tui && pnpm vitest run test/layout.test.ts`
+Expected: All tests PASS.
+
+- [ ] **Step 5: Export from index.ts**
+
+Add to `lib/index.ts`:
+```typescript
+export * from "./layout.js";
+```
+
+- [ ] **Step 6: Commit**
+
+```
+feat(tui): add flexbox-lite layout engine
+```
+
+---
+
+## Task 5: Frame class
+
+**Files:**
+- Create: `packages/tui/lib/frame.ts`
+- Create: `packages/tui/test/frame.test.ts`
+
+- [ ] **Step 1: Write tests**
+
+```typescript
+// test/frame.test.ts
+import { describe, it, expect } from "vitest";
+import { Frame } from "../lib/frame.js";
+
+describe("Frame", () => {
+  it("findByKey returns matching child", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 80, height: 24, style: {},
+      children: [
+        new Frame({ key: "a", x: 0, y: 0, width: 40, height: 24, style: {} }),
+        new Frame({ key: "b", x: 40, y: 0, width: 40, height: 24, style: {} }),
+      ],
+    });
+    expect(frame.findByKey("b")).toBeDefined();
+    expect(frame.findByKey("b")!.key).toBe("b");
+  });
+
+  it("findByKey searches recursively", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 80, height: 24, style: {},
+      children: [
+        new Frame({
+          key: "parent", x: 0, y: 0, width: 80, height: 24, style: {},
+          children: [
+            new Frame({ key: "nested", x: 0, y: 0, width: 40, height: 12, style: {} }),
+          ],
+        }),
+      ],
+    });
+    expect(frame.findByKey("nested")).toBeDefined();
+  });
+
+  it("findByKey returns undefined for missing key", () => {
+    const frame = new Frame({ x: 0, y: 0, width: 80, height: 24, style: {} });
+    expect(frame.findByKey("nope")).toBeUndefined();
+  });
+
+  it("toPlainText produces text from content cells", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 5, height: 1, style: {},
+      content: [[
+        { char: "h" }, { char: "e" }, { char: "l" }, { char: "l" }, { char: "o" },
+      ]],
+    });
+    expect(frame.toPlainText()).toContain("hello");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/tui && pnpm vitest run test/frame.test.ts`
+
+- [ ] **Step 3: Create stub output adapter files**
+
+The Frame class imports `toPlainText` and `toHTML`, which are implemented fully in Task 7. Create stubs now so imports resolve:
+
+```typescript
+// lib/render/plaintext.ts
+import type { Frame } from "../frame.js";
+export function toPlainText(frame: Frame): string {
+  // Stub — full implementation in Task 7
+  const lines: string[] = [];
+  for (const row of frame.content ?? []) {
+    lines.push(row.map(c => c.char).join(""));
+  }
+  return lines.join("\n");
+}
+```
+
+```typescript
+// lib/render/html.ts
+import type { Frame } from "../frame.js";
+export function toHTML(frame: Frame): string {
+  // Stub — full implementation in Task 7
+  return `<pre>${frame.content?.map(row => row.map(c => c.char).join("")).join("\n") ?? ""}</pre>`;
+}
+```
+
+- [ ] **Step 4: Implement `frame.ts`**
+
+```typescript
+// lib/frame.ts
+import type { Cell, FrameStyle } from "./elements.js";
+import { toPlainText } from "./render/plaintext.js";
+import { toHTML } from "./render/html.js";
+import * as fs from "fs";
+
+type FrameArgs = {
+  key?: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  style: FrameStyle;
+  content?: Cell[][];
+  children?: Frame[];
+};
+
+export class Frame {
+  key?: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  style: FrameStyle;
+  content?: Cell[][];
+  children?: Frame[];
+
+  constructor(args: FrameArgs) {
+    this.key = args.key;
+    this.x = args.x;
+    this.y = args.y;
+    this.width = args.width;
+    this.height = args.height;
+    this.style = args.style;
+    this.content = args.content;
+    this.children = args.children;
+  }
+
+  findByKey(key: string): Frame | undefined {
+    if (this.key === key) return this;
+    for (const child of this.children ?? []) {
+      const found = child.findByKey(key);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  toPlainText(): string {
+    return toPlainText(this);
+  }
+
+  toHTML(): string {
+    return toHTML(this);
+  }
+
+  image(path: string): void {
+    fs.writeFileSync(path, this.toHTML());
+  }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd packages/tui && pnpm vitest run test/frame.test.ts`
+
+- [ ] **Step 6: Export from index.ts**
+
+Add to `lib/index.ts`:
+```typescript
+export * from "./frame.js";
+```
+
+- [ ] **Step 7: Commit**
+
+```
+feat(tui): add Frame class with findByKey, toPlainText, toHTML, image
+```
+
+---
+
+## Task 6: Renderer (element tree -> frame tree)
+
+**Files:**
+- Create: `packages/tui/lib/render/renderer.ts`
+- Create: `packages/tui/test/renderer.test.ts`
+
+The renderer takes a `PositionedElement` tree (output of layout) and produces a `Frame` tree. It handles: borders, labels, text content (parsed via styleParser), scrolling, list rendering, text input rendering.
+
+- [ ] **Step 1: Write tests**
+
+Test that the renderer produces correct Frame trees with cells for: plain text, styled text, borders with labels, scrollable content with offset, list items with selection highlight, text input with cursor.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Implement `renderer.ts`**
+
+The `render(positioned: PositionedElement): Frame` function:
+1. Create a Frame with the element's resolved position/size.
+2. If the element has a border, draw border characters into cells. If it has a label, render label text into the top border.
+3. Parse content with `parseStyledText()`, render spans into cells. Apply scrollOffset for scrollable elements (skip `scrollOffset` lines, clip to available height).
+4. For `list` elements: render items as lines, highlight selectedIndex with a distinct bg. Auto-scroll to keep selected item visible.
+5. For `textInput` elements: render the value text, optionally show a cursor character.
+6. Recurse into children.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+- [ ] **Step 5: Export from index.ts and commit**
+
+```
+feat(tui): add renderer (element tree to frame tree)
+```
+
+---
+
+## Task 7: Output adapters (plain text, HTML, ANSI)
+
+**Files:**
+- Create: `packages/tui/lib/render/plaintext.ts`
+- Create: `packages/tui/lib/render/html.ts`
+- Create: `packages/tui/lib/render/ansi.ts`
+- Create: `packages/tui/test/plaintext.test.ts`
+- Create: `packages/tui/test/html.test.ts`
+
+- [ ] **Step 1: Write tests for plain text adapter**
+
+```typescript
+// test/plaintext.test.ts
+import { describe, it, expect } from "vitest";
+import { toPlainText } from "../lib/render/plaintext.js";
+import { Frame } from "../lib/frame.js";
+
+describe("toPlainText", () => {
+  it("renders content cells as text", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 5, height: 1, style: {},
+      content: [[
+        { char: "h" }, { char: "i" }, { char: " " }, { char: " " }, { char: " " },
+      ]],
+    });
+    expect(toPlainText(frame)).toContain("hi");
+  });
+
+  it("renders nested children", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 80, height: 2, style: {},
+      children: [
+        new Frame({
+          key: "a", x: 0, y: 0, width: 5, height: 1, style: {},
+          content: [[{ char: "A" }, { char: "B" }, { char: "C" }, { char: " " }, { char: " " }]],
+        }),
+      ],
+    });
+    expect(toPlainText(frame)).toContain("ABC");
+  });
+});
+```
+
+- [ ] **Step 2: Write tests for HTML adapter**
+
+Test that `toHTML` produces valid HTML with monospace font, correct CSS colors for fg/bg/bold cells, and that the output contains the text content.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+- [ ] **Step 4: Implement shared `flatten.ts` helper**
+
+All three output adapters need to composite a Frame tree into a flat 2D cell grid. Extract this shared logic into `lib/render/flatten.ts`:
+
+```typescript
+// lib/render/flatten.ts
+import type { Cell } from "../elements.js";
+import type { Frame } from "../frame.js";
+
+// Composite a Frame tree into a flat 2D grid of Cells.
+// Recursively blits children on top of parents.
+export function flatten(frame: Frame, width: number, height: number): Cell[][] { ... }
+```
+
+This function creates a `width x height` grid, fills the frame's background, draws borders, writes content cells, then recursively composites children on top. Each output adapter calls `flatten()` and then formats the resulting grid in its own way.
+
+- [ ] **Step 5: Implement `plaintext.ts`**
+
+Call `flatten()` to get the 2D cell grid, then join each row's characters into a string, trim trailing spaces, join rows with newlines.
+
+- [ ] **Step 6: Implement `html.ts`**
+
+Call `flatten()` to get the 2D cell grid, then produce HTML: a `<pre>` block with `<span>` elements for styled runs. Use CSS classes or inline styles mapping named colors via `cssColors` from `colors.ts`.
+
+- [ ] **Step 7: Implement `ansi.ts`**
+
+Call `flatten()` to get the 2D cell grid, then produce ANSI output: for each row, emit escape codes for style changes between adjacent cells, using `ansiColors`/`ansiBgColors` from `colors.ts`. Reset at the end of each row.
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+- [ ] **Step 9: Export from index.ts and commit**
+
+```
+feat(tui): add plain text, HTML, and ANSI output adapters
+```
+
+---
+
+## Task 8: Input sources (ScriptedInput, TerminalInput)
+
+**Files:**
+- Create: `packages/tui/lib/input/types.ts`
+- Create: `packages/tui/lib/input/scripted.ts`
+- Create: `packages/tui/lib/input/terminal.ts`
+- Create: `packages/tui/test/scripted.test.ts`
+
+- [ ] **Step 1: Write tests for ScriptedInput**
+
+```typescript
+// test/scripted.test.ts
+import { describe, it, expect } from "vitest";
+import { ScriptedInput } from "../lib/input/scripted.js";
+
+describe("ScriptedInput", () => {
+  it("replays key events in order", async () => {
+    const input = new ScriptedInput();
+    input.feedKey({ key: "a" });
+    input.feedKey({ key: "b" });
+    expect(await input.nextKey()).toEqual({ key: "a" });
+    expect(await input.nextKey()).toEqual({ key: "b" });
+  });
+
+  it("nextKey waits for input when queue is empty", async () => {
+    const input = new ScriptedInput();
+    const promise = input.nextKey();
+    // Feed after a delay
+    setTimeout(() => input.feedKey({ key: "x" }), 10);
+    const result = await promise;
+    expect(result).toEqual({ key: "x" });
+  });
+
+  it("nextLine returns fed line", async () => {
+    const input = new ScriptedInput();
+    input.feedLine("hello world");
+    const line = await input.nextLine("prompt>");
+    expect(line).toBe("hello world");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Implement `types.ts`**
+
+```typescript
+// lib/input/types.ts
+export type KeyEvent = {
+  key: string;
+  shift?: boolean;
+  ctrl?: boolean;
+};
+
+export type InputSource = {
+  nextKey(): Promise<KeyEvent>;
+  nextLine(prompt: string): Promise<string>;
+  destroy(): void;
+};
+```
+
+- [ ] **Step 4: Implement `scripted.ts`**
+
+`ScriptedInput` maintains two queues: one for key events, one for line inputs. `feedKey()` and `feedLine()` push to the queues. `nextKey()` and `nextLine()` pop from the queues, or return a promise that resolves when the next item is fed.
+
+- [ ] **Step 5: Implement `terminal.ts`**
+
+`TerminalInput` puts stdin in raw mode, reads keypresses, and maps escape sequences (arrow keys, Ctrl combos, etc.) to `KeyEvent` objects. `nextLine()` temporarily exits raw mode and uses readline. `destroy()` restores stdin.
+
+Must handle terminal lifecycle signals that blessed currently manages:
+- **SIGINT (Ctrl-C):** Clean up terminal state and exit. In raw mode, SIGINT is not generated automatically — must detect Ctrl-C keypress and handle it.
+- **SIGTSTP (Ctrl-Z):** Exit raw mode and alternate screen buffer, then send SIGTSTP to suspend. On SIGCONT, re-enter raw mode and alternate buffer, force full repaint.
+- **SIGCONT:** Re-enter raw mode and alternate screen buffer, trigger a full repaint.
+- **uncaughtException:** Clean up terminal state before crashing (exit alternate buffer, show cursor, restore stdin).
+
+These can be installed in `TerminalInput.init()` or in a shared `TerminalLifecycle` helper used by both `TerminalInput` and `TerminalOutput`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd packages/tui && pnpm vitest run test/scripted.test.ts`
+
+- [ ] **Step 7: Export and commit**
+
+```
+feat(tui): add ScriptedInput and TerminalInput
+```
+
+---
+
+## Task 9: Output targets (TerminalOutput, FrameRecorder)
+
+**Files:**
+- Create: `packages/tui/lib/output/types.ts`
+- Create: `packages/tui/lib/output/terminal.ts`
+- Create: `packages/tui/lib/output/recorder.ts`
+- Create: `packages/tui/test/recorder.test.ts`
+
+- [ ] **Step 1: Write tests for FrameRecorder**
+
+```typescript
+// test/recorder.test.ts
+import { describe, it, expect } from "vitest";
+import { FrameRecorder } from "../lib/output/recorder.js";
+import { Frame } from "../lib/frame.js";
+
+describe("FrameRecorder", () => {
+  it("records frames with labels", () => {
+    const recorder = new FrameRecorder();
+    const frame = new Frame({ x: 0, y: 0, width: 80, height: 24, style: {} });
+    recorder.write(frame, "press s");
+    expect(recorder.frames).toHaveLength(1);
+    expect(recorder.frames[0].label).toBe("press s");
+  });
+
+  it("writeHTML produces valid HTML with all frames", () => {
+    const recorder = new FrameRecorder();
+    recorder.write(
+      new Frame({ x: 0, y: 0, width: 10, height: 2, style: {},
+        content: [[{ char: "h" }, { char: "i" }]] }),
+      "step 1"
+    );
+    recorder.write(
+      new Frame({ x: 0, y: 0, width: 10, height: 2, style: {},
+        content: [[{ char: "b" }, { char: "y" }]] }),
+      "step 2"
+    );
+    const html = recorder.toHTML();
+    expect(html).toContain("step 1");
+    expect(html).toContain("step 2");
+    expect(html).toContain("<pre");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Implement `types.ts`, `recorder.ts`, `terminal.ts`**
+
+`OutputTarget` interface (note: adds `label` parameter not in original spec — needed so `FrameRecorder` can label each frame with the command that produced it):
+```typescript
+export type OutputTarget = {
+  write(frame: Frame, label?: string): void;
+  flush?(): void;
+};
+```
+
+`FrameRecorder`: stores `{ frame: Frame, label?: string }[]`. Has `toHTML()` that produces a single HTML file with all frames rendered, each labeled with the command, and prev/next navigation via simple JS.
+
+`TerminalOutput`: takes a Frame, calls `toANSI()`, writes to stdout. On first write, enters alternate screen buffer and hides cursor. On destroy, exits alternate buffer, shows cursor, restores terminal state. Coordinates with `TerminalInput` on signal handling (SIGTSTP/SIGCONT need both input and output to participate).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+- [ ] **Step 5: Export and commit**
+
+```
+feat(tui): add FrameRecorder and TerminalOutput
+```
+
+---
+
+## Task 10: Screen class
+
+**Files:**
+- Create: `packages/tui/lib/screen.ts`
+- Create: `packages/tui/test/screen.test.ts`
+
+- [ ] **Step 1: Write tests**
+
+Test that Screen orchestrates layout -> render -> output in a single `render()` call. Use `ScriptedInput` and `FrameRecorder` so everything is in-process.
+
+```typescript
+// test/screen.test.ts
+import { describe, it, expect } from "vitest";
+import { Screen } from "../lib/screen.js";
+import { ScriptedInput } from "../lib/input/scripted.js";
+import { FrameRecorder } from "../lib/output/recorder.js";
+import { box, text } from "../lib/builders.js";
+
+describe("Screen", () => {
+  it("render produces a frame and writes to output", () => {
+    const recorder = new FrameRecorder();
+    const input = new ScriptedInput();
+    const screen = new Screen({ output: recorder, input, width: 40, height: 10 });
+
+    const frame = screen.render(box({ border: true, key: "main" }, text("hello")));
+    expect(frame).toBeDefined();
+    expect(frame.findByKey("main")).toBeDefined();
+    expect(recorder.frames).toHaveLength(1);
+  });
+
+  it("nextKey returns events from input source", async () => {
+    const recorder = new FrameRecorder();
+    const input = new ScriptedInput();
+    input.feedKey({ key: "s" });
+    const screen = new Screen({ output: recorder, input, width: 40, height: 10 });
+
+    const key = await screen.nextKey();
+    expect(key).toEqual({ key: "s" });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+- [ ] **Step 3: Implement `screen.ts`**
+
+```typescript
+// lib/screen.ts
+import type { Element } from "./elements.js";
+import type { InputSource, KeyEvent } from "./input/types.js";
+import type { OutputTarget } from "./output/types.js";
+import { layout } from "./layout.js";
+import { render } from "./render/renderer.js";
+import { Frame } from "./frame.js";
+
+export class Screen {
+  private output: OutputTarget;
+  private input: InputSource;
+  private width: number;
+  private height: number;
+
+  constructor(opts: { output: OutputTarget; input: InputSource; width: number; height: number }) {
+    this.output = opts.output;
+    this.input = opts.input;
+    this.width = opts.width;
+    this.height = opts.height;
+  }
+
+  render(root: Element, label?: string): Frame {
+    const positioned = layout(root, this.width, this.height);
+    const frame = render(positioned);
+    this.output.write(frame, label);
+    return frame;
+  }
+
+  nextKey(): Promise<KeyEvent> {
+    return this.input.nextKey();
+  }
+
+  nextLine(prompt: string): Promise<string> {
+    return this.input.nextLine(prompt);
+  }
+
+  size(): { width: number; height: number } {
+    return { width: this.width, height: this.height };
+  }
+
+  destroy(): void {
+    this.input.destroy();
+    if (this.output.flush) this.output.flush();
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+- [ ] **Step 5: Final index.ts exports**
+
+Make sure `lib/index.ts` exports everything:
+```typescript
+export * from "./elements.js";
+export * from "./builders.js";
+export * from "./styleParser.js";
+export * from "./colors.js";
+export * from "./layout.js";
+export * from "./frame.js";
+export * from "./render/renderer.js";
+export * from "./render/plaintext.js";
+export * from "./render/html.js";
+export * from "./render/ansi.js";
+export * from "./input/types.js";
+export * from "./input/scripted.js";
+export * from "./input/terminal.js";
+export * from "./output/types.js";
+export * from "./output/terminal.js";
+export * from "./output/recorder.js";
+export * from "./screen.js";
+```
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `cd packages/tui && pnpm vitest run`
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```
+feat(tui): add Screen class — completes TUI library core
+```
+
+---
+
+## Task 11: Migrate debugger UI from blessed to @agency-lang/tui
+
+**Files:**
+- Modify: `packages/agency-lang/package.json` — add `@agency-lang/tui`, keep `blessed` for now
+- Rewrite: `packages/agency-lang/lib/debugger/ui.ts`
+
+The key design decision: `DebuggerUI` is refactored to accept a `Screen` via its constructor instead of creating blessed widgets. In production, it gets a `Screen` wired to `TerminalInput`/`TerminalOutput`. In tests, it gets a `Screen` wired to `ScriptedInput`/`FrameRecorder`. This means the same UI code runs in both contexts — no duplication of rendering logic or key mappings.
+
+- [ ] **Step 1: Add `@agency-lang/tui` dependency to agency-lang**
+
+Add to `packages/agency-lang/package.json` dependencies:
+```json
+"@agency-lang/tui": "workspace:*"
+```
+
+Run: `pnpm install`
+
+- [ ] **Step 2: Rewrite `ui.ts`**
+
+Replace the blessed-based `DebuggerUI` with a new implementation that uses `@agency-lang/tui`. The new class:
+
+1. Implements `DebuggerIO` (same interface as before — driver doesn't change).
+2. Constructor accepts a `Screen` instance instead of creating its own blessed widgets. This makes the class testable — production code passes a terminal-backed Screen, tests pass a recorder-backed Screen.
+3. In `render()`, builds an element tree from `UIState` data using builder functions. Uses the same layout as the current UI: source (40%), locals+globals+callstack (25%), activity+stdout (remaining), command bar (3 rows), stats bar (1 row). All panes get a `key` prop for frame inspection.
+4. In `waitForCommand()`, calls `screen.nextKey()` and maps key events to `DebuggerCommand` objects.
+5. `showRewindSelector()` and `showCheckpointsPanel()` switch to overlay element trees and handle their own key loop via `screen.nextKey()`.
+6. Focus cycling (tab), zoom (z), thread cycling ([ / ]) are handled as state that affects the element tree built in `render()`.
+
+Port the following from the current `ui.ts`:
+- Key mappings from `waitForCommand()`
+- Source pane rendering (syntax highlighting, line numbers, current line marker)
+- Locals/globals/callstack pane formatting
+- Activity and stdout pane rendering
+- Rewind selector and checkpoints panel overlay logic
+- Spinner (can be simplified — just show "working..." text)
+- Text input for command bar
+
+Reference the spec's "Dynamic Layout Examples" for how to handle conditional panes and overlays.
+
+- [ ] **Step 3: Manually test the debugger interactively**
+
+Run: `cd packages/agency-lang && pnpm run agency debug tests/debugger/step-test.agency`
+Verify: Debugger launches, stepping works, variable display works, quit works.
+
+- [ ] **Step 4: Commit**
+
+```
+feat(debugger): rewrite UI from blessed to @agency-lang/tui
+```
+
+---
+
+## Task 12: DebuggerTestSession
+
+**Files:**
+- Create: `packages/agency-lang/lib/debugger/testSession.ts`
+- Create: `packages/agency-lang/lib/debugger/testSession.test.ts`
+
+`DebuggerTestSession` is a thin wrapper that creates a `DebuggerUI` wired to test infrastructure (`ScriptedInput` + `FrameRecorder`). It does NOT duplicate the UI rendering or key mapping — it reuses `DebuggerUI` from Task 11. The only new code is the step-at-a-time API (`press()`, `frame()`, `writeHTML()`, etc.) that feeds keys into the `ScriptedInput` and inspects the `FrameRecorder`'s captured frames.
+
+- [ ] **Step 1: Write tests**
+
+```typescript
+// lib/debugger/testSession.test.ts
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { compile } from "../cli/commands.js";
+import { freshImport, fixtureDir } from "./testHelpers.js";
+import { DebuggerTestSession } from "./testSession.js";
+
+const stepTestAgency = path.join(fixtureDir, "step-test.agency");
+const stepTestCompiled = path.join(fixtureDir, "step-test.ts");
+
+beforeAll(() => {
+  compile({ debugger: true }, stepTestAgency, stepTestCompiled, { ts: true });
+});
+
+afterAll(() => {
+  try { fs.unlinkSync(stepTestCompiled); } catch {}
+});
+
+describe("DebuggerTestSession", () => {
+  it("steps through and returns correct value", async () => {
+    const mod = await freshImport(stepTestCompiled);
+    const session = new DebuggerTestSession({ mod });
+
+    // step-test.agency: x = 1, y = 2, z = x + y, return z
+    await session.press("s"); // past x = 1
+    await session.press("s"); // past y = 2
+    await session.press("s"); // past z = x + y
+    await session.press("c"); // continue to completion
+
+    expect(session.returnValue()).toBe(3);
+  });
+
+  it("frame inspection works", async () => {
+    const mod = await freshImport(stepTestCompiled);
+    const session = new DebuggerTestSession({ mod });
+
+    await session.press("s"); // past x = 1
+    const frame = session.frame();
+    expect(frame).toBeDefined();
+    expect(frame.findByKey("locals")).toBeDefined();
+    expect(frame.findByKey("locals")!.toPlainText()).toContain("x");
+  });
+
+  it("variable override changes return value", async () => {
+    const mod = await freshImport(stepTestCompiled);
+    const session = new DebuggerTestSession({ mod });
+    await session.press("s"); // past x = 1
+    await session.type(":set x = 10");
+    await session.press("c");
+    expect(session.returnValue()).toBe(12); // 10 + 2
+  });
+
+  it("writeHTML produces output file", async () => {
+    const mod = await freshImport(stepTestCompiled);
+    const session = new DebuggerTestSession({ mod });
+
+    await session.press("s");
+    await session.press("c");
+
+    const outPath = path.join(fixtureDir, "__test-output.html");
+    session.writeHTML(outPath);
+    expect(fs.existsSync(outPath)).toBe(true);
+    fs.unlinkSync(outPath);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd packages/agency-lang && pnpm vitest run lib/debugger/testSession.test.ts 2>&1 | tee /tmp/test-output.txt`
+
+- [ ] **Step 3: Implement `testSession.ts`**
+
+`DebuggerTestSession` internally:
+1. Creates a `ScriptedInput`, `FrameRecorder`, and `Screen` from `@agency-lang/tui`.
+2. Creates a `DebuggerUI` with that `Screen` — reusing all the rendering and key mapping logic from Task 11.
+3. Creates a `DebuggerDriver` with this `DebuggerUI` as the `DebuggerIO`.
+4. Extracts `sourceMap` from `mod.__sourceMap`, computes `rewindSize`.
+5. Runs `mod.main()` to get the initial interrupt.
+6. Starts the driver loop in the background — it blocks on `waitForCommand()`, which blocks on `screen.nextKey()`, which blocks on `ScriptedInput.nextKey()`.
+7. `press(key)` feeds a key to `ScriptedInput` and waits for the driver to pause again.
+8. `frame()` returns the last frame from `FrameRecorder`.
+9. `writeHTML(path)` calls `recorder.toHTML()` and writes to disk.
+
+Key methods to implement: `press()`, `type()`, `frame()`, `image()`, `writeHTML()`, `returnValue()`.
+
+See spec sections "Integration with the Driver", "API", "Remaining DebuggerIO Methods".
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/agency-lang && pnpm vitest run lib/debugger/testSession.test.ts 2>&1 | tee /tmp/test-output.txt`
+
+- [ ] **Step 5: Commit**
+
+```
+feat(debugger): add DebuggerTestSession with visual test harness
+```
+
+---
+
+## Task 13: Rewrite debugger tests
+
+**Files:**
+- Rewrite: `packages/agency-lang/lib/debugger/driver.test.ts`
+- Modify: `packages/agency-lang/lib/debugger/testHelpers.ts`
+
+- [ ] **Step 1: Update `testHelpers.ts`**
+
+Keep `freshImport()` and `fixtureDir`. Add any shared helpers needed for the new tests. Do NOT remove `TestDebuggerIO`, `makeDriver`, or `getInitialResult` yet — they will be removed in Task 14 after all tests are migrated.
+
+- [ ] **Step 2: Rewrite `driver.test.ts` — stepping tests**
+
+Replace the skipped `describe.skip("DebuggerDriver stepping")` block with new tests using `DebuggerTestSession`. Un-skip them.
+
+```typescript
+describe("Debugger stepping", () => {
+  it("steps through each statement and returns correct result", async () => {
+    const mod = await freshImport(stepTestCompiled);
+    const session = new DebuggerTestSession({ mod });
+    await session.press("s", { times: 10 });
+    expect(session.returnValue()).toBe(3);
+  });
+
+  it("continue runs to completion", async () => {
+    const mod = await freshImport(stepTestCompiled);
+    const session = new DebuggerTestSession({ mod });
+    await session.press("c");
+    expect(session.returnValue()).toBe(3);
+  });
+
+  // ... port remaining stepping tests
+});
+```
+
+- [ ] **Step 3: Rewrite function call tests (stepIn, next, stepOut)**
+
+Port the `describe.skip("DebuggerDriver stepping with function calls")` tests. Use `function-call-test.agency` and `nested-calls-test.agency` fixtures. Assert using `frame().findByKey("source").toPlainText()` to check which file/function is being shown.
+
+- [ ] **Step 4: Rewrite variable override and print tests**
+
+Port the `describe.skip("DebuggerDriver set")` and `describe.skip("DebuggerDriver print and checkpoint")` tests.
+
+- [ ] **Step 5: Rewrite interrupt handling tests**
+
+Port the `describe.skip("DebuggerDriver user interrupt handling")` tests using `interrupt-test.agency`.
+
+- [ ] **Step 6: Rewrite stepBack and rewind tests**
+
+Port the `describe.skip("DebuggerDriver stepBack and rewind")` tests.
+
+- [ ] **Step 7: Rewrite loop and if/else tests**
+
+Port the `describe.skip("DebuggerDriver with loops")` and `describe.skip("DebuggerDriver with if/else")` tests.
+
+- [ ] **Step 8: Rewrite save/load tests**
+
+Port the `describe.skip("DebuggerDriver save and load")` tests.
+
+- [ ] **Step 9: Rewrite nested function call tests**
+
+Port the `describe.skip("DebuggerDriver with nested function calls")` tests using `nested-calls-test.agency`.
+
+- [ ] **Step 10: Rewrite trace checkpoint tests**
+
+Port the `describe.skip("DebuggerDriver with loaded trace checkpoints")` and `describe.skip("DebuggerDriver with loaded single checkpoint")` tests.
+
+- [ ] **Step 11: Rewrite thread tests**
+
+Port the tests in `lib/debugger/thread.test.ts` using `thread-test.agency`.
+
+- [ ] **Step 12: Run full debugger test suite**
+
+Run: `cd packages/agency-lang && pnpm vitest run lib/debugger/ 2>&1 | tee /tmp/test-output.txt`
+Expected: All tests pass with no `describe.skip` blocks remaining.
+
+- [ ] **Step 13: Commit**
+
+```
+feat(debugger): rewrite all debugger tests using DebuggerTestSession
+```
+
+---
+
+## Task 14: Cleanup
+
+**Files:**
+- Modify: `packages/agency-lang/package.json` — remove `blessed` dependency
+- Modify: `packages/agency-lang/lib/debugger/testHelpers.ts` — remove dead code
+
+- [ ] **Step 1: Remove blessed dependencies**
+
+Remove `blessed` and `@types/blessed` from `packages/agency-lang/package.json`. Run `pnpm install`.
+
+- [ ] **Step 2: Remove dead test helpers**
+
+Remove `TestDebuggerIO`, `makeDriver`, and `getInitialResult` from `testHelpers.ts`. Verify no remaining imports reference them.
+
+- [ ] **Step 3: Add `test-output/` to `.gitignore`**
+
+Ensure test artifacts are not committed.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `cd packages/agency-lang && pnpm vitest run 2>&1 | tee /tmp/test-output.txt`
+Expected: All tests pass. No imports of `blessed` remain.
+
+- [ ] **Step 5: Commit**
+
+```
+chore: remove blessed dependency, clean up dead test helpers
+```

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-05-tui-library-and-debugger-test-harness-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-05-tui-library-and-debugger-test-harness-design.md
@@ -1,0 +1,561 @@
+# TUI Library and Debugger Test Harness
+
+## Problem
+
+The Agency debugger is built on blessed, an unmaintained TUI library that is difficult to test headlessly. Writing debugger tests requires scripting a sequence of abstract commands upfront and running them blind — when tests fail, there's no way to see what the debugger state looked like at each step. This makes writing and debugging tests extremely painful, which in turn has caused the debugger feature to stagnate.
+
+All existing driver integration tests are currently skipped (`describe.skip`) pending migration work, and the `TestDebuggerIO` mock provides no visual feedback.
+
+## Solution
+
+Build a custom, general-purpose TUI library (`@agency-lang/tui`) designed for testability from the ground up. Use it to replace blessed in the debugger and build a new test harness that produces visual artifacts (HTML snapshots) at each step.
+
+## TUI Library: `@agency-lang/tui`
+
+### Architecture
+
+The library uses an **immediate-mode rendering model**. Each render cycle, the consumer builds a fresh element tree describing the entire screen. The library resolves layout, produces a frame tree, and outputs to a target (terminal, HTML, or plain text). No mutable widget objects, no retained state — each render is a pure function from `(elementTree, terminalSize) -> frameTree`.
+
+Three layers:
+
+1. **Layout Engine** — Takes an element tree and terminal dimensions, resolves flexbox layout, outputs a positioned element tree with absolute `{ x, y, width, height }` on every node.
+2. **Renderer** — Takes a positioned element tree, produces a `Frame` tree (nested frames with cells).
+3. **Output Adapters** — Take a frame tree and produce final output (ANSI escape codes, HTML, or plain text).
+
+### Element Types
+
+Four element types cover all TUI needs:
+
+- **Box** — Container with optional border, label, background. Can contain text content, child elements, or both.
+- **Text** — Styled text content with inline style support (bold, colors).
+- **List** — Selectable list of items with a highlighted selection index. When a list has more items than visible rows, it scrolls to keep the selected item visible. Items are rendered as text lines; the selected item is highlighted with a distinct background color.
+- **TextInput** — Single-line text input field.
+
+### Element Descriptor
+
+```typescript
+type Element = {
+  type: "box" | "text" | "list" | "textInput"
+  style?: {
+    // Flexbox
+    flexDirection?: "row" | "column"    // default: "column"
+    flex?: number                        // flex grow factor
+    justifyContent?: "flex-start" | "center" | "flex-end" | "space-between"
+    alignItems?: "flex-start" | "center" | "flex-end" | "stretch"
+
+    // Sizing
+    width?: number | string              // fixed or "50%"
+    height?: number | string
+    minWidth?: number
+    minHeight?: number
+    maxWidth?: number
+    maxHeight?: number
+
+    // Spacing
+    padding?: number | { top?: number, bottom?: number, left?: number, right?: number }
+    margin?: number | { top?: number, bottom?: number, left?: number, right?: number }
+
+    // Box decoration
+    border?: boolean
+    borderColor?: string
+    label?: string
+    labelColor?: string
+
+    // Content styling
+    fg?: string
+    bg?: string
+    bold?: boolean
+    scrollable?: boolean
+    scrollOffset?: number    // current scroll position (0-indexed line offset)
+    visible?: boolean        // default true
+  }
+  content?: string           // text content (supports inline style tags)
+  children?: Element[]
+  items?: string[]           // for list
+  selectedIndex?: number     // for list
+  value?: string             // for textInput
+  key?: string               // identity for lookup across renders
+}
+```
+
+### Builder Functions
+
+Building element trees as raw objects is verbose. The library provides builder functions for a concise, readable API:
+
+```typescript
+function box(style: StyleProps, ...children: Element[]): Element
+function box(...children: Element[]): Element
+
+function row(style: StyleProps, ...children: Element[]): Element   // shorthand for box with flexDirection: "row"
+function row(...children: Element[]): Element
+
+function column(style: StyleProps, ...children: Element[]): Element // shorthand for box with flexDirection: "column"
+function column(...children: Element[]): Element
+
+function text(content: string): Element
+
+function list(style: StyleProps, items: string[], selectedIndex?: number): Element
+
+function textInput(style: StyleProps, value?: string): Element
+```
+
+`StyleProps` is the `style` object plus `key`:
+
+```typescript
+type StyleProps = Element["style"] & { key?: string }
+```
+
+Example usage:
+
+```typescript
+function buildUI(state: AppState): Element {
+  return column(
+    box({ key: "header", height: 3, border: true, borderColor: "cyan", label: " My App " },
+      text("{bold}Welcome to the dashboard{/bold}")
+    ),
+
+    row({ flex: 1 },
+      list({ key: "items", width: "30%", border: true, label: " Items " },
+        state.items, state.selectedIndex
+      ),
+      box({ key: "details", flex: 1, border: true, label: " Details " },
+        text(`Selected: {yellow-fg}${state.items[state.selectedIndex]}{/yellow-fg}`)
+      ),
+    ),
+
+    box({ key: "logs", height: "25%", border: true, label: " Logs ", scrollable: true,
+          scrollOffset: state.scrollOffset },
+      text(state.logs.join("\n"))
+    ),
+
+    box({ height: 1, fg: "gray" },
+      text(" (up/down) navigate  (q) quit")
+    ),
+  )
+}
+```
+
+The raw `Element` type remains the underlying data structure. Builder functions are convenience wrappers that produce `Element` objects.
+
+### Inline Style Tags
+
+Text content supports inline style tags using the following syntax, compatible with the existing debugger codebase:
+
+- `{bold}text{/bold}` — bold text
+- `{red-fg}text{/red-fg}` — foreground color
+- `{blue-bg}text{/blue-bg}` — background color
+- Tags can be nested: `{bold}{red-fg}text{/red-fg}{/bold}`
+
+The HTML output adapter maps these to `<span>` elements with CSS styles. The ANSI adapter maps them to escape codes. The plain text adapter strips them.
+
+### Color System
+
+Colors are specified as named strings. The supported set is the standard 16 ANSI terminal colors:
+
+`black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, `gray` (alias for bright black), plus bright variants: `bright-red`, `bright-green`, etc.
+
+The ANSI adapter maps these to standard escape codes. The HTML adapter maps them to CSS color values.
+
+### Flexbox-Lite Layout Engine
+
+A minimal, pure-TypeScript flexbox implementation. No native dependencies. Supports:
+
+- `flexDirection`: row and column
+- `flex`: grow factor for distributing remaining space
+- `justifyContent`: flex-start, center, flex-end, space-between
+- `alignItems`: flex-start, center, flex-end, stretch
+- Percentage and fixed sizing for width/height
+- Min/max constraints
+- Padding and margin
+
+The layout engine is a pure function: `(elementTree, width, height) -> positionedTree`. This makes it independently testable.
+
+### Text Overflow and Scrolling
+
+When text content exceeds the available space within an element:
+
+- **Non-scrollable elements**: text is **truncated** at the element boundary. Lines longer than the width are clipped. Lines beyond the height are not rendered.
+- **Scrollable elements** (`scrollable: true`): the element acts as a viewport. The `scrollOffset` style property controls which line is at the top of the viewport. Content is clipped to the viewport.
+
+Since the library is immediate-mode (no retained state), scroll position is managed by the consumer. The consumer tracks `scrollOffset` in its own state and passes it into the element tree each render cycle. This keeps the library stateless while giving the consumer full control.
+
+For example, the debugger's activity pane would track its own scroll offset and set `scrollOffset` to show the most recent entries at the bottom:
+
+```typescript
+{
+  type: "box",
+  key: "activity",
+  style: { scrollable: true, scrollOffset: Math.max(0, lines.length - visibleHeight) },
+  content: activityLines.join("\n")
+}
+```
+
+### Frame and Cell Model
+
+The renderer produces a tree of frames that mirrors the element tree.
+
+```typescript
+type Cell = {
+  char: string
+  fg?: string
+  bg?: string
+  bold?: boolean
+}
+
+type FrameStyle = {
+  border?: boolean
+  borderColor?: string
+  bg?: string
+  label?: string
+  labelColor?: string
+}
+
+type Frame = {
+  key?: string
+  x: number
+  y: number
+  width: number
+  height: number
+  style: FrameStyle
+  content?: Cell[][]         // text content within the frame (after border/padding)
+  children?: Frame[]         // nested child frames
+}
+```
+
+The separation:
+- **Frame** = layout + styling (position, size, border, background, label)
+- **Cell** = content (a single character with its own fg/bg/bold)
+
+To produce the final screen buffer, the renderer recursively:
+1. Fills the frame's area with its background
+2. Draws the border and label
+3. Renders the content cells in the inner area
+4. Recursively renders children on top
+
+Frames are nested, so individual panes can be inspected independently — you can extract just the "locals" frame without parsing the full screen.
+
+### Output Adapters
+
+Three output adapters, all operating on the Frame tree:
+
+- **`toANSI(frame): string`** — Produces ANSI escape codes for real terminal output. Used in production.
+- **`toHTML(frame): string`** — Produces an HTML representation with monospace text and CSS colors. Used for test visual artifacts.
+- **`toPlainText(frame): string`** — Strips styling, returns just characters. Used for test assertions.
+
+### Input Handling
+
+```typescript
+type KeyEvent = {
+  key: string              // "s", "tab", "escape", "up", "down", etc.
+  shift?: boolean
+  ctrl?: boolean
+}
+
+type InputSource = {
+  nextKey(): Promise<KeyEvent>
+  nextLine(prompt: string): Promise<string>
+  destroy(): void
+}
+```
+
+Two implementations:
+
+- **`TerminalInput`** — Production use. Puts stdin in raw mode, reads keypresses, maps escape sequences to KeyEvents.
+- **`ScriptedInput`** — Test use. Replays a programmatic sequence of key events.
+
+### The Screen Class
+
+The `Screen` class is the top-level orchestrator that ties together layout, rendering, input, and output. It owns the render cycle.
+
+```typescript
+class Screen {
+  constructor(opts: {
+    output: OutputTarget       // terminal, html recorder, etc.
+    input: InputSource         // terminal or scripted
+    width: number
+    height: number
+  })
+
+  // Run one render cycle: layout the element tree, produce frames, write output
+  render(root: Element): Frame
+
+  // Wait for the next key event from the input source
+  nextKey(): Promise<KeyEvent>
+
+  // Prompt for text input (switches to line mode)
+  nextLine(prompt: string): Promise<string>
+
+  // Get the current terminal dimensions
+  size(): { width: number, height: number }
+
+  // Clean up (restore terminal state, etc.)
+  destroy(): void
+}
+```
+
+`OutputTarget` is an interface for where frames go:
+
+```typescript
+type OutputTarget = {
+  write(frame: Frame): void    // output a frame (e.g., write ANSI to terminal)
+  flush?(): void               // optional: flush output
+}
+```
+
+Implementations:
+- **`TerminalOutput`** — Writes ANSI to stdout. Handles alternate screen buffer, cursor hiding, and differential updates.
+- **`FrameRecorder`** — Collects frames in memory for later export to HTML. Used by the test harness.
+
+The consumer's main loop looks like:
+
+```typescript
+const screen = new Screen({ output, input, width: 120, height: 40 })
+
+while (true) {
+  const elementTree = buildUI(state)    // consumer builds fresh element tree
+  screen.render(elementTree)            // layout + render + output
+  const key = await screen.nextKey()    // wait for input
+  state = update(state, key)            // consumer updates its state
+}
+```
+
+### Package Structure
+
+```
+packages/tui/
+  lib/
+    elements.ts         # Element type definitions
+    builders.ts         # Builder functions (box, row, column, text, list, textInput)
+    layout.ts           # Flexbox layout engine
+    frame.ts            # Frame, Cell, FrameStyle types and Frame utilities (findByKey, image, etc.)
+    render/
+      renderer.ts       # Renderer: positioned elements -> Frame tree
+      ansi.ts           # ANSI output adapter
+      html.ts           # HTML output adapter
+      plaintext.ts      # Plain text output adapter
+    input/
+      terminal.ts       # Real stdin input
+      scripted.ts       # Programmatic input for tests
+    output/
+      terminal.ts       # TerminalOutput (ANSI to stdout)
+      recorder.ts       # FrameRecorder (collect frames for HTML export)
+    screen.ts           # Screen class (orchestrates render cycle)
+  test/
+    layout.test.ts
+    render.test.ts
+    ...
+```
+
+The library has zero dependency on Agency. It is a standalone package publishable as `@agency-lang/tui`.
+
+## Debugger Test Harness
+
+### Overview
+
+A new `DebuggerTestSession` class replaces `TestDebuggerIO` entirely. It provides a step-at-a-time API where each input is sent individually, and the state can be inspected and exported after every step.
+
+### Integration with the Driver
+
+`DebuggerTestSession` implements the `DebuggerIO` interface internally, bridging between the TUI lib and the existing `DebuggerDriver`. The integration works as follows:
+
+1. The constructor takes a compiled module (same as `makeDriver` today) and sets up the driver, the TUI `Screen` with a `ScriptedInput` and `FrameRecorder`, and all necessary wiring.
+2. Internally, it implements `DebuggerIO` using the TUI lib's `Screen`. The key mapping — translating raw key events like `"s"` into `DebuggerCommand` objects like `{ type: "step" }` — lives in this implementation, ported from the current `DebuggerUI.waitForCommand()`.
+3. Each `press()` call feeds a key event to the `ScriptedInput`, which unblocks the `Screen.nextKey()` call inside the driver's `waitForCommand()`. The driver processes the command, runs until the next pause, and renders. The `FrameRecorder` captures the frame.
+4. Interactive overlays (rewind selector, checkpoints panel) are handled transparently. When the driver calls `showRewindSelector()`, the overlay renders as part of the element tree. Subsequent `press()` calls send keys to the overlay (up/down to navigate, enter to select, escape to cancel). The test sees the overlay in the captured frames just like any other UI state.
+
+```typescript
+// Constructor handles all the wiring that makeDriver + TestDebuggerIO did
+const session = new DebuggerTestSession({
+  mod,                           // compiled module (from freshImport)
+  terminalSize: { width: 120, height: 40 },  // optional, defaults provided
+  checkpoints: [],               // optional, for trace replay
+  nodeArgs: [arg1, arg2],        // optional, arguments for the main node
+})
+```
+
+The constructor internally:
+- Extracts `sourceMap` from `mod.__sourceMap` and computes `rewindSize` automatically
+- Calls `mod.__setDebugger(debuggerState)`
+- Creates the `DebuggerDriver` with the internal `DebuggerIO` implementation
+- Calls `mod.main(...nodeArgs)` with the driver's callbacks to get the initial debug interrupt
+- Is ready for `press()` calls
+
+Note: tests must call `freshImport()` before constructing a session to get a cache-busted module with clean state. `DebuggerTestSession` does not handle module importing — it receives the already-imported module.
+
+### API
+
+```typescript
+const session = new DebuggerTestSession({ mod })
+
+// Send input and run until next pause
+await session.press("s")
+
+// Inspect the current frame
+const frame = session.frame()
+expect(frame.findByKey("locals").toPlainText()).toContain("x = 1")
+
+// Send more input
+await session.press("s")
+
+// Type a command (enters command mode, types text, presses enter)
+await session.type(":set x = 10")
+
+// Step with override applied
+await session.press("s")
+const frame3 = session.frame()
+expect(frame3.findByKey("locals").toPlainText()).toContain("x = 10")
+
+// Export visual snapshot of current frame (full screen)
+await session.image("debug-step-3.html")
+
+// Export just a single pane
+await session.frame().findByKey("locals").image("locals.html")
+
+// Bulk input
+await session.press("s", { times: 5 })
+
+// Continue to completion
+await session.press("c")
+expect(session.returnValue()).toBe(12)
+
+// Export all frames as a navigable HTML file
+session.writeHTML("test-output/step-test.html")
+```
+
+### Interacting with Overlays
+
+The rewind selector and checkpoints panel are interactive overlays. In the new model, they are simply different element trees rendered by the debugger UI. Tests interact with them the same way they interact with the main debugger:
+
+```typescript
+// Press "r" to open the rewind selector
+await session.press("r")
+
+// The frame now shows the overlay — we can verify it
+expect(session.frame().findByKey("rewind-selector")).toBeDefined()
+
+// Navigate and select a checkpoint
+await session.press("up")
+await session.press("up")
+await session.press("enter")
+
+// We're back in the debugger, rewound to the selected checkpoint
+expect(session.frame().findByKey("source").toPlainText()).toContain("> 2")
+```
+
+### Key Methods
+
+- **`press(key, opts?)`** — Sends a key event, runs the driver until it pauses for the next command, captures the resulting frame. Supports `{ times: N }` for bulk input.
+- **`type(text)`** — Types text into a text input. If the text starts with `:`, it first presses `:` to enter command mode, then types the remaining text and presses enter. If it doesn't start with `:`, it types the text directly and presses enter (for use with `promptForInput`, e.g., typing "approve" at an interrupt prompt).
+- **`frame()`** — Returns the most recent Frame for inspection and assertions.
+- **`image(path, opts?)`** — Exports the current frame as an HTML file. Supports `{ key: "pane-name" }` to export a single pane.
+- **`writeHTML(path)`** — Exports all captured frames as a single navigable HTML file with prev/next navigation. Each frame is labeled with the command that was just executed.
+- **`returnValue()`** — Returns the program's final return value after completion.
+
+### Remaining DebuggerIO Methods
+
+The `DebuggerIO` interface has several methods beyond `waitForCommand` and `render`. Here's how each maps to the new model:
+
+- **`promptForNodeArgs(parameters)`** — Node arguments are provided via the `nodeArgs` constructor option. The internal `DebuggerIO` implementation returns these directly.
+- **`promptForInput(prompt)`** — Used during user interrupt handling (approve/reject/resolve). In the test harness, the next `type()` call provides the response. The internal implementation uses `Screen.nextLine()`, which reads from the `ScriptedInput`.
+- **`appendStdout(text)`** — Appends to an internal stdout buffer. The stdout content is rendered in the "stdout" pane of the element tree, so it's visible in captured frames.
+- **`renderActivityOnly()`** — Triggers a render cycle (same as `render()` but the element tree naturally shows the updated activity log).
+- **`startSpinner()` / `stopSpinner()`** — In production, shows a spinner animation in the command bar. In tests, these are no-ops — the spinner is a cosmetic detail irrelevant to test assertions.
+- **`showRewindSelector(checkpoints)` / `showCheckpointsPanel(checkpoints)`** — Render as overlays in the element tree. See "Interacting with Overlays" section.
+
+### Behavior After Program Completion
+
+After the program finishes (either by running to completion or via `press("c")`), `press()` calls that would move execution forward (step, next, stepIn, stepOut, continue) are no-ops — the driver returns the "Already at end of execution" message, visible in the activity log. Backward commands (stepBack, rewind) still work. `returnValue()` returns the final result. This matches the current driver behavior.
+
+### Frame Inspection
+
+`Frame` is a class with utility methods for inspection and export:
+
+- **`findByKey(key)`** — Recursively search children for a frame with the given key. Returns a `Frame` or `undefined`.
+- **`toPlainText()`** — Flatten the frame to plain text (strips all styling). Calls the plain text output adapter on this frame.
+- **`toHTML()`** — Render the frame as styled HTML. Calls the HTML output adapter on this frame.
+- **`image(path)`** — Export the frame to an HTML file (convenience method that calls `toHTML()` and writes to disk).
+
+These methods work on any frame in the tree, including sub-frames returned by `findByKey()`, so you can inspect and export individual panes.
+
+### HTML Output Format
+
+The `writeHTML()` output is a single HTML file containing all frames captured during the test session. Each frame shows:
+
+- The full TUI rendered in a monospace font with terminal colors
+- A label showing which command was just executed (e.g., "After: press s", "After: type :set x = 10")
+- Navigation between frames (prev/next or scrollable)
+
+Individual `image()` calls produce single-frame HTML files. When called on a sub-frame (via `findByKey`), only that pane is rendered.
+
+### Test Artifact Location
+
+Test artifacts (HTML files from `image()` and `writeHTML()`) should be written to a `test-output/` directory at the project root. This directory is gitignored. Artifacts are generated on every test run so they're always available for inspection. In CI, they could be uploaded as build artifacts for debugging failures.
+
+### Location
+
+The `DebuggerTestSession` lives in `packages/agency-lang/lib/debugger/` since it is specific to the Agency debugger. It depends on `@agency-lang/tui` for rendering and input, and on the debugger driver for execution.
+
+## Debugger Migration
+
+The existing `DebuggerUI` class (`lib/debugger/ui.ts`) will be rewritten to use `@agency-lang/tui` instead of blessed. The `DebuggerIO` interface remains the same — the driver doesn't need to change. Only the UI implementation changes.
+
+The new UI implementation will build an element tree each render cycle (immediate mode) instead of mutating blessed widget objects (retained mode). The element tree describes the same layout: source pane, locals, globals, call stack, activity, stdout, threads, command bar.
+
+### Dynamic Layout Examples
+
+The current debugger has several dynamic layout behaviors that map naturally to the immediate-mode model. Instead of mutating widget properties and calling show/hide, the consumer conditionally includes elements in the tree.
+
+**Threads pane (conditionally shown):**
+
+```typescript
+// When threads are available, source shrinks and threads pane appears
+const sourceWidth = hasThreads ? "65%" : "100%"
+const topRow = [
+  box({ key: "source", width: sourceWidth, height: "40%" }, text(sourceContent)),
+]
+if (hasThreads) {
+  topRow.push(box({ key: "threads", flex: 1, height: "40%" }, text(threadsContent)))
+}
+return row(...topRow)
+```
+
+**Zoom (full-screen a single pane):**
+
+```typescript
+if (zoomedPane) {
+  return column(
+    box({ key: zoomedPane, width: "100%", flex: 1 }, text(paneContent)),
+    commandBar,
+  )
+} else {
+  return normalLayout
+}
+```
+
+**Checkpoints panel overlay:**
+
+```typescript
+if (showCheckpointsPanel) {
+  return column(
+    checkpointListPane,
+    checkpointDetailPane,
+    helpBar,
+  )
+} else {
+  return normalLayout
+}
+```
+
+## Migration Plan
+
+1. **Build the TUI lib** — `packages/tui/` with layout engine, renderers, input handling, Screen class. Test independently with simple examples.
+2. **Build the test harness** — `DebuggerTestSession` using the TUI lib. Validate with a simple fixture (e.g., `step-test.agency`).
+3. **Migrate the debugger UI** — Rewrite `ui.ts` to use the TUI lib instead of blessed. Verify by writing basic debugger tests with the new harness that exercise stepping, continue, rewind, variable inspection, and the rewind/checkpoints overlays.
+4. **Rewrite debugger tests** — Replace all `TestDebuggerIO`-based tests with `DebuggerTestSession`-based tests. Un-skip the currently skipped test suites.
+
+## Out of Scope
+
+- Browser-based interactive rendering (the `InputSource` interface allows adding this later)
+- Constraint-based or grid layout (flexbox-lite is sufficient)
+- Animation or transitions
+- Mouse input

--- a/packages/tui/CLAUDE.md
+++ b/packages/tui/CLAUDE.md
@@ -1,0 +1,60 @@
+# @agency-lang/tui
+
+Testable TUI library with immediate-mode rendering and flexbox-lite layout. Designed to replace blessed in the Agency debugger.
+
+## Key Commands
+
+```bash
+pnpm run build     # TypeScript build
+pnpm vitest run    # Run all tests
+pnpm test          # Watch mode
+```
+
+## Architecture
+
+Immediate-mode rendering: each cycle builds a fresh element tree, runs it through `layout() -> render() -> flatten() -> output adapter`. No mutable widget state.
+
+Testability via DI: `Screen` accepts `InputSource` + `OutputTarget`. Production uses `TerminalInput` + `TerminalOutput`. Tests use `ScriptedInput` + `FrameRecorder`.
+
+## Dev Docs (how the code works)
+
+- `docs/dev/elements-and-builders.md` — Element model, Style type, builder functions (`box`, `row`, `column`, `text`, `list`, `textInput`), PositionedElement, FrameStyle
+- `docs/dev/layout.md` — Flexbox-lite layout algorithm: parent-owns-main/child-owns-cross design, 3-pass algorithm, justifyContent, alignItems
+- `docs/dev/rendering.md` — Full rendering pipeline: layout -> render -> flatten -> output adapters. Frame/Cell model, scroll propagation, border rendering
+- `docs/dev/style-parser.md` — Inline style tag parser (`{bold}`, `{red-fg}`), escaping, closing tag matching, regex safety, color system
+- `docs/dev/input-output.md` — Input sources (ScriptedInput, TerminalInput), output targets (FrameRecorder, TerminalOutput), Screen class, signal handling, lifecycle
+
+## Guide Docs (how to use the library)
+
+- `docs/guide/getting-started.md` — Installation, quick example, core concepts (immediate-mode, builders, flexbox, style tags, frame inspection)
+- `docs/guide/testing.md` — Writing headless tests with ScriptedInput + FrameRecorder, step-at-a-time testing, visual HTML artifacts
+- `docs/guide/terminal-usage.md` — Setting up a terminal screen, main loop pattern, signal handling, key events, cleanup
+
+## File Structure
+
+```
+lib/
+  index.ts              — public API re-exports
+  elements.ts           — Element, Style, Cell, FrameStyle, PositionedElement types
+  builders.ts           — box(), row(), column(), text(), list(), textInput()
+  layout.ts             — flexbox-lite layout engine
+  frame.ts              — Frame class (findByKey, toPlainText, toHTML, image)
+  styleParser.ts        — inline style tag parser and escaping
+  colors.ts             — ANSI and CSS color mappings
+  utils.ts              — shared utilities (resolveEdges, sameStyle, escapeHtml)
+  screen.ts             — Screen class (orchestrates layout -> render -> output)
+  render/
+    renderer.ts         — element tree -> frame tree
+    flatten.ts          — composite frame tree into 2D cell grid
+    ansi.ts             — ANSI terminal output adapter
+    html.ts             — HTML output adapter
+    plaintext.ts        — plain text output adapter
+  input/
+    types.ts            — KeyEvent, InputSource types
+    scripted.ts         — ScriptedInput (for tests)
+    terminal.ts         — TerminalInput (raw stdin)
+  output/
+    types.ts            — OutputTarget type
+    recorder.ts         — FrameRecorder (test frame collection + HTML export)
+    terminal.ts         — TerminalOutput (alternate screen + ANSI)
+```

--- a/packages/tui/docs/dev/elements-and-builders.md
+++ b/packages/tui/docs/dev/elements-and-builders.md
@@ -1,0 +1,75 @@
+# Elements and Builders
+
+## Element Model
+
+The library uses an **immediate-mode rendering model**. Each render cycle, the consumer builds a fresh element tree describing the entire screen. No mutable widget objects, no retained state — each render is a pure function.
+
+### Element Type
+
+```typescript
+type Element = {
+  type: "box" | "text" | "list" | "textInput";
+  style?: Style;
+  content?: string;       // text content (supports inline style tags)
+  children?: Element[];
+  items?: string[];       // for list
+  selectedIndex?: number; // for list
+  value?: string;         // for textInput
+  key?: string;           // identity for lookup via findByKey()
+};
+```
+
+Four element types:
+- **box** — container with optional border, label, background. Can have children and/or direct text content.
+- **text** — styled text content. Inline style tags like `{bold}` and `{red-fg}` are parsed by the style parser.
+- **list** — selectable list of items. `selectedIndex` highlights one item. Auto-scrolls to keep selection visible.
+- **textInput** — single-line text input with cursor.
+
+### Style Type
+
+See `lib/elements.ts` — the `Style` type has inline comments explaining each field, including what units numbers represent (terminal columns/rows).
+
+### StyleProps
+
+`StyleProps = Style & { key?: string }` — used by builder functions so you can pass `key` alongside style properties.
+
+## Builder Functions (`lib/builders.ts`)
+
+Raw element objects are verbose. Builders provide a concise API:
+
+```typescript
+box(style?, ...children)    // generic container
+row(style?, ...children)    // box with flexDirection: "row"
+column(style?, ...children) // box with flexDirection: "column"
+text(content)               // text element
+list(style, items, selectedIndex?)
+textInput(style, value?)
+```
+
+### Overloaded Signatures
+
+`box`, `row`, and `column` accept an optional `StyleProps` as the first argument. The `isStyleProps` guard distinguishes style objects from child elements by checking for the absence of a `type` field.
+
+If the first argument has a `type` field, it's treated as a child element, not a style object.
+
+### splitStyleAndKey
+
+Separates `key` from the rest of the style props. If the remaining style object is empty (no properties), it's set to `undefined` to keep the element clean.
+
+## PositionedElement
+
+After layout, elements get absolute coordinates:
+
+```typescript
+type PositionedElement = Element & {
+  resolvedX: number;
+  resolvedY: number;
+  resolvedWidth: number;
+  resolvedHeight: number;
+  children?: PositionedElement[];
+};
+```
+
+## FrameStyle
+
+`Pick<Style, "border" | "borderColor" | "bg" | "label" | "labelColor">` — the subset of style that applies to frame-level decoration (not content or layout).

--- a/packages/tui/docs/dev/input-output.md
+++ b/packages/tui/docs/dev/input-output.md
@@ -1,0 +1,77 @@
+# Input and Output
+
+## Architecture
+
+The TUI library uses dependency injection for I/O. The `Screen` class accepts an `InputSource` and `OutputTarget` via its constructor. In production these are terminal-backed; in tests they are scripted/recorded.
+
+```
+Production:  Screen(TerminalInput, TerminalOutput)
+Tests:       Screen(ScriptedInput, FrameRecorder)
+```
+
+This is the core of the testability design — the same UI code runs in both contexts with no code duplication.
+
+## InputSource (`lib/input/types.ts`)
+
+```typescript
+type InputSource = {
+  nextKey(): Promise<KeyEvent>;
+  nextLine(prompt: string): Promise<string>;
+  destroy(): void;
+};
+```
+
+### ScriptedInput (`lib/input/scripted.ts`)
+
+For tests. Maintains two queues (keys and lines) with a waiter pattern:
+- `feedKey(key)` / `feedLine(line)` — push data, or resolve a waiting consumer
+- `nextKey()` / `nextLine()` — pop from queue, or register a waiter promise
+- `destroy()` — clears all queues and pending waiters
+
+### TerminalInput (`lib/input/terminal.ts`)
+
+For production. Puts stdin into raw mode and parses ANSI escape sequences.
+
+Key implementation details:
+- **KEY_MAP**: A single lookup table maps all known sequences (escape sequences, special keys like enter/backspace/tab) to `KeyEvent` objects. Ctrl+letter combinations are handled separately via character code math.
+- **Auto-initialization**: `ensureInitialized()` is called on first `nextKey()`. Throws if stdin is not a TTY.
+- **nextLine()**: Temporarily exits raw mode, creates a readline interface (per-call, because readline takes ownership of stdin), then re-enters raw mode after the answer. Guarded by `inLineMode` flag to prevent concurrent calls from double-registering the data listener.
+- **destroy()**: Removes the data handler, restores original raw mode state, clears queues and waiters.
+
+## OutputTarget (`lib/output/types.ts`)
+
+```typescript
+type OutputTarget = {
+  write(frame: Frame, label?: string): void;
+  destroy?(): void;
+};
+```
+
+### FrameRecorder (`lib/output/recorder.ts`)
+
+For tests. Collects frames with labels into an array. Has:
+- `frames` — the accumulated `{ frame, label }[]`
+- `clear()` — releases all accumulated frames (important for long-running sessions)
+- `toHTML()` — produces a single HTML file with all frames, prev/next navigation via arrow keys
+- `writeHTML(path)` — writes the HTML to a file
+
+### TerminalOutput (`lib/output/terminal.ts`)
+
+For production. Uses the alternate screen buffer and hides the cursor.
+
+Key implementation details:
+- **Alternate screen buffer**: `init()` enters it; `destroy()` exits it
+- **Signal handlers**: Installed on `init()`, removed on `destroy()`:
+  - `SIGINT` / `SIGTERM`: destroy and exit with appropriate code
+  - `SIGTSTP`: suspend (exit alt screen), then re-raise SIGTSTP for the default handler
+  - `SIGCONT`: resume (re-enter alt screen)
+  - `exit`: destroy as a safety net
+- **suspend/resume**: Exit and re-enter the alternate screen buffer. Used by signal handlers and available for manual use.
+
+## Screen (`lib/screen.ts`)
+
+Orchestrates the pipeline:
+- `render(root, label?)` — runs `layout() → render() → output.write()`, returns the Frame
+- `nextKey()` / `nextLine()` — delegates to input source
+- `size()` — returns `{ width, height }`
+- `destroy()` — calls `input.destroy()` and `output.destroy()`

--- a/packages/tui/docs/dev/layout.md
+++ b/packages/tui/docs/dev/layout.md
@@ -1,0 +1,67 @@
+# Layout Engine
+
+## Overview
+
+`lib/layout.ts` implements a flexbox-lite layout engine. It is a pure function: `layout(element, width, height) -> PositionedElement`. Given an element tree and available terminal dimensions, it produces a tree of positioned elements with absolute `{ resolvedX, resolvedY, resolvedWidth, resolvedHeight }` on every node.
+
+## Architecture
+
+Three functions divide the work:
+
+- **`layoutRoot`** — Handles the root element, which has no parent. Both axes are resolved by the element itself against the available space.
+- **`layoutChild`** — Handles child elements. The parent has already determined the main-axis size. The child resolves only its cross-axis size.
+- **`layoutChildren`** — The core flexbox algorithm. Shared by both `layoutRoot` and `layoutChild`. Takes an element's children and positions them using a 3-pass approach.
+
+### The Parent-Owns-Main / Child-Owns-Cross Design
+
+This is the key architectural decision. In a flex container:
+
+- The **main axis** (horizontal for `row`, vertical for `column`) is the direction children are laid out. The *parent* must own this axis because it distributes space among siblings — only it knows about remaining space and flex ratios.
+- The **cross axis** (perpendicular) can be resolved by the *child* itself, subject to the parent's `alignItems`.
+
+`layoutChild` receives `mainAxisSize` (already computed, used as-is) and `crossAxisAvailable` (the child resolves its own cross dimension against this). This eliminates the double-resolution bug where a percentage would be resolved twice against shrinking contexts.
+
+## The Three-Pass Algorithm
+
+### Pass 1: Measure fixed children, defer flex children
+
+For each visible child, determine its main-axis size:
+- **Fixed/percentage children**: Resolve `width`/`height` against the parent's inner dimension. Add to `usedMain`.
+- **Flex children** (or children with no explicit size): Record their flex value, defer sizing to pass 2. Children with no explicit size and no flex are treated as `flex: 1`.
+
+Also caches each child's resolved margins to avoid recomputing in pass 3.
+
+### Pass 2: Distribute remaining space
+
+`remainingMain = max(0, mainSize - usedMain)`. Distribute proportionally among flex children based on their flex values.
+
+### Pass 3: Position children
+
+Compute each child's `(x, y)` position along the main axis. This is where `justifyContent` and `alignItems` take effect:
+
+- **`justifyContent`** controls main-axis distribution:
+  - `flex-start` (default): children start at the beginning
+  - `flex-end`: children are pushed to the end
+  - `center`: children are centered
+  - `space-between`: remaining space distributed as gaps between children
+
+- **`alignItems`** controls cross-axis positioning (passed to `layoutChild`):
+  - `stretch` (default): child fills the cross axis
+  - `flex-start`: child at the start of the cross axis
+  - `flex-end`: child at the end
+  - `center`: child centered on the cross axis
+
+## Inner Area Computation
+
+Before laying out children, the parent's inner area is computed by subtracting border (1 per side if present) and padding. Both `innerWidth` and `innerHeight` are clamped to 0 to handle cases where border+padding exceeds the element's total size.
+
+## Key Types
+
+- `PositionedElement` — extends `Element` with `resolvedX`, `resolvedY`, `resolvedWidth`, `resolvedHeight`
+- `Edges` — `{ top, bottom, left, right }` used for padding and margin
+
+## Dependencies
+
+- `resolveEdges` from `utils.ts` — normalizes padding/margin from `number | object | undefined` to `Edges`
+- `resolveDimension` — resolves `number | "50%" | undefined` against available space
+- `clampDimension` — applies min/max constraints

--- a/packages/tui/docs/dev/rendering.md
+++ b/packages/tui/docs/dev/rendering.md
@@ -1,0 +1,59 @@
+# Rendering Pipeline
+
+## Overview
+
+The rendering pipeline converts an element tree into visual output in three stages:
+
+```
+Element tree → layout() → PositionedElement tree → render() → Frame tree → flatten() → Cell[][] → toANSI/toHTML/toPlainText
+```
+
+This runs on every keypress in the debugger, so the pipeline is performance-sensitive.
+
+## Stage 1: Layout (`lib/layout.ts`)
+
+See `docs/dev/layout.md` for details. Produces a `PositionedElement` tree with absolute positions and sizes.
+
+## Stage 2: Render (`lib/render/renderer.ts`)
+
+`render(positioned: PositionedElement): Frame` converts positioned elements into a `Frame` tree with content cells.
+
+For each element:
+1. Compute inner area (subtract border + padding)
+2. If the element has a border or background, create a full `Cell[][]` grid and draw the border/background
+3. Render inner content based on element type:
+   - **text/box with content**: parse styled text via `parseStyledText()`, render spans into cells. Apply `scrollOffset` for scrollable containers.
+   - **list**: render items as rows, highlight `selectedIndex` with blue background. Auto-scroll to keep selection visible.
+   - **textInput**: render value text with a cursor character (`█`)
+4. Blit inner content into the frame grid using `blitCells()`
+5. Recurse into children
+
+### Scroll Propagation
+
+Scrolling is an interesting case: the `scrollable` and `scrollOffset` styles are on a *parent* box, but the actual text content is in a *child* text element. The renderer passes `parentScrollOffset` down to children so text elements can apply it.
+
+## Stage 3: Flatten (`lib/render/flatten.ts`)
+
+`flatten(frame, width, height): Cell[][]` composites a Frame tree into a flat 2D cell grid. It creates a blank grid, then recursively blits each frame's content cells at its absolute position. Children are blitted after parents, so they paint on top.
+
+The flatten function uses the root frame's `x`/`y` as the origin offset. This is critical for sub-frames: when you call `frame.findByKey("child").toPlainText()`, the child frame's `x`/`y` are non-zero (absolute coordinates from the full screen), but the output grid should be sized to the child's dimensions. The origin offset ensures the child's content starts at grid position (0, 0).
+
+## Stage 4: Output Adapters
+
+All three adapters call `flatten()` first, then format the resulting grid:
+
+- **`toANSI`** (`lib/render/ansi.ts`): Collects runs of same-styled cells, emits ANSI escape codes for color/bold, resets at run boundaries.
+- **`toHTML`** (`lib/render/html.ts`): Collects runs of same-styled cells, wraps in `<span style="...">`. Only emits known color names (from `cssColors`) to prevent CSS injection. Uses shared `escapeHtml()` from `utils.ts`.
+- **`toPlainText`** (`lib/render/plaintext.ts`): Just joins characters, trims trailing spaces per row.
+
+## Key Types
+
+- **`Frame`** (`lib/frame.ts`): A class with `key`, `x`, `y`, `width`, `height`, `style` (FrameStyle), `content` (Cell[][]), and `children` (Frame[]). Has `findByKey()`, `toPlainText()`, `toHTML()`, and `image()` methods.
+- **`Cell`** (`lib/elements.ts`): `{ char, fg?, bg?, bold? }` — a single character with styling.
+- **`FrameStyle`**: `Pick<Style, "border" | "borderColor" | "bg" | "label" | "labelColor">` — the subset of Style that applies to frame decoration.
+
+## Helper Functions
+
+- `blitCells(dest, src, startX, startY, maxW, maxH)` — copies a source Cell[][] into a destination at an offset
+- `makeGrid(width, height, bg?)` — creates a blank Cell[][] filled with spaces
+- `renderBorder(grid, width, height, borderColor, label, labelColor)` — draws box-drawing characters into a grid

--- a/packages/tui/docs/dev/style-parser.md
+++ b/packages/tui/docs/dev/style-parser.md
@@ -1,0 +1,42 @@
+# Style Tag Parser
+
+## Overview
+
+`lib/styleParser.ts` parses inline style tags in text content. The syntax is `{bold}text{/bold}`, `{red-fg}text{/red-fg}`, `{blue-bg}text{/blue-bg}`. Tags can be nested.
+
+The parser produces an array of `StyledSpan` objects: `{ text, fg?, bg?, bold? }`.
+
+## How It Works
+
+The parser uses a regex to find tag boundaries, maintaining a style stack:
+
+1. Walk the input string, matching `{tag}` and `{/tag}` patterns
+2. Text between tags becomes a `StyledSpan` with the current accumulated style
+3. Opening tags (`{bold}`, `{red-fg}`, `{blue-bg}`) push onto the style stack
+4. Closing tags (`{/bold}`, `{/red-fg}`, `{/blue-bg}`) pop the matching entry from the stack
+5. Unrecognized tags (not `bold`, `*-fg`, or `*-bg`) are preserved as literal text
+
+## Closing Tag Matching
+
+Closing tags match by both type AND value. `{/red-fg}` only pops a `{ type: "fg", color: "red" }` entry, not a `{ type: "fg", color: "green" }`. This is important for nested colors like `{red-fg}{green-fg}x{/green-fg}y{/red-fg}`.
+
+## Escaping
+
+`escapeStyleTags(text)` escapes `{` and `}` with backslashes: `{bold}` becomes `\{bold\}`.
+
+The regex uses a negative lookbehind `(?<!\\)` to skip escaped braces. The `makeSpan` function unescapes `\{` and `\}` in the output text.
+
+## Regex Safety
+
+The regex `TAG_PATTERN` is defined at module level but a new `RegExp` instance is created per `parseStyledText()` call. This prevents `lastIndex` corruption if the function is called reentrantly (e.g., from parallel renders). The pattern `[^}]+` is a negated character class that cannot catastrophically backtrack.
+
+## Color System (`lib/colors.ts`)
+
+Three lookup tables map named colors to output formats:
+- `ansiColors` — foreground ANSI escape codes
+- `ansiBgColors` — background ANSI escape codes
+- `cssColors` — CSS hex color values
+
+Supported colors: `black`, `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white`, `gray`, plus bright variants (`bright-red`, `bright-green`, etc.).
+
+The HTML adapter only emits colors found via `hasOwnProperty` in `cssColors` to prevent CSS injection from user-controlled color names.

--- a/packages/tui/docs/guide/getting-started.md
+++ b/packages/tui/docs/guide/getting-started.md
@@ -1,0 +1,98 @@
+# Getting Started
+
+## Installation
+
+```bash
+pnpm add @agency-lang/tui
+```
+
+## Quick Example
+
+```typescript
+import {
+  Screen, ScriptedInput, FrameRecorder,
+  box, row, column, text, list,
+} from "@agency-lang/tui";
+
+// Create a screen with test I/O
+const recorder = new FrameRecorder();
+const input = new ScriptedInput();
+const screen = new Screen({ output: recorder, input, width: 80, height: 24 });
+
+// Build a UI
+const frame = screen.render(
+  column(
+    box({ height: 3, border: true, label: " Header " },
+      text("{bold}My TUI App{/bold}")
+    ),
+    row({ flex: 1 },
+      list({ key: "items", width: "30%", border: true },
+        ["Apple", "Banana", "Cherry"], 0
+      ),
+      box({ key: "details", flex: 1, border: true },
+        text("Selected: Apple")
+      ),
+    ),
+  )
+);
+
+// Inspect the frame
+const itemsPane = frame.findByKey("items");
+console.log(itemsPane?.toPlainText());
+
+// Export as HTML
+recorder.writeHTML("output.html");
+```
+
+## Core Concepts
+
+### Immediate-Mode Rendering
+
+Unlike retained-mode UI libraries (React, blessed), this library has no persistent widget state. Each render cycle, you build a fresh element tree describing the entire screen. The library resolves layout, produces a frame tree, and outputs to a target.
+
+### Elements and Builders
+
+Elements are plain data objects describing the UI. Builder functions provide a concise API:
+
+- `box(style?, ...children)` — container
+- `row(style?, ...children)` — horizontal layout
+- `column(style?, ...children)` — vertical layout (default)
+- `text(content)` — styled text
+- `list(style, items, selectedIndex?)` — selectable list
+- `textInput(style, value?)` — text input
+
+### Flexbox-Lite Layout
+
+Elements are laid out using a simplified flexbox model:
+
+- `flexDirection: "row" | "column"` — layout direction (default: column)
+- `flex: number` — grow factor for distributing remaining space
+- `width` / `height` — fixed (number of columns/rows) or percentage ("50%")
+- `justifyContent` — main-axis alignment (flex-start, center, flex-end, space-between)
+- `alignItems` — cross-axis alignment (stretch, flex-start, center, flex-end)
+- `border: true` — reduces inner area by 1 on each side
+- `padding` / `margin` — spacing in columns/rows
+
+Elements with no explicit size and no flex default to `flex: 1`.
+
+### Inline Style Tags
+
+Text content supports inline styling:
+
+```
+{bold}bold text{/bold}
+{red-fg}red text{/red-fg}
+{blue-bg}blue background{/blue-bg}
+{bold}{cyan-fg}combined{/cyan-fg}{/bold}
+```
+
+Use `escapeStyleTags(userText)` to prevent user-provided text from being interpreted as tags.
+
+### Frame Inspection
+
+After rendering, `screen.render()` returns a `Frame` object:
+
+- `frame.findByKey("name")` — find a nested frame by key
+- `frame.toPlainText()` — plain text (for assertions)
+- `frame.toHTML()` — HTML with CSS colors (for visual artifacts)
+- `frame.image("path.html")` — write HTML to file

--- a/packages/tui/docs/guide/terminal-usage.md
+++ b/packages/tui/docs/guide/terminal-usage.md
@@ -1,0 +1,93 @@
+# Terminal Usage
+
+## Setting Up a Terminal Screen
+
+```typescript
+import {
+  Screen, TerminalInput, TerminalOutput,
+  box, text, column,
+} from "@agency-lang/tui";
+
+const input = new TerminalInput();
+const output = new TerminalOutput();
+const screen = new Screen({
+  output,
+  input,
+  width: process.stdout.columns,
+  height: process.stdout.rows,
+});
+```
+
+`TerminalInput` auto-initializes on first `nextKey()` call: it puts stdin in raw mode and starts listening for keypresses. `TerminalOutput` enters the alternate screen buffer and hides the cursor on first `write()`.
+
+## Main Loop
+
+```typescript
+let running = true;
+let count = 0;
+
+while (running) {
+  screen.render(
+    column(
+      box({ border: true, label: " Counter " },
+        text(`Count: {bold}${count}{/bold}`)
+      ),
+      box({ height: 1, fg: "gray" },
+        text(" (up) increment  (down) decrement  (q) quit")
+      ),
+    )
+  );
+
+  const key = await screen.nextKey();
+  if (key.key === "up") count++;
+  else if (key.key === "down") count--;
+  else if (key.key === "q") running = false;
+}
+
+screen.destroy();
+```
+
+## Signal Handling
+
+`TerminalOutput` automatically installs signal handlers on init:
+
+- **Ctrl+C (SIGINT)**: Restores terminal and exits with code 130
+- **SIGTERM**: Restores terminal and exits with code 143
+- **Ctrl+Z (SIGTSTP)**: Exits alternate screen, suspends the process
+- **SIGCONT** (resume after Ctrl+Z): Re-enters alternate screen
+
+All handlers are removed when `destroy()` is called.
+
+## Line Input
+
+For text input that needs a readline prompt (e.g., a command input):
+
+```typescript
+const answer = await screen.nextLine("Enter command: ");
+```
+
+This temporarily exits raw mode, shows a readline prompt, then re-enters raw mode after the user presses Enter.
+
+## Key Events
+
+`nextKey()` returns `KeyEvent` objects:
+
+```typescript
+type KeyEvent = {
+  key: string;      // "a", "up", "enter", "escape", etc.
+  shift?: boolean;
+  ctrl?: boolean;
+};
+```
+
+Special keys: `up`, `down`, `left`, `right`, `home`, `end`, `pageup`, `pagedown`, `delete`, `insert`, `enter`, `escape`, `backspace`, `tab`.
+
+Ctrl combinations: `{ key: "c", ctrl: true }` for Ctrl+C (if you handle it before the signal handler).
+
+## Cleanup
+
+Always call `screen.destroy()` when done. This:
+- Restores stdin to its original raw mode state
+- Exits the alternate screen buffer
+- Shows the cursor
+- Removes all signal handlers

--- a/packages/tui/docs/guide/testing.md
+++ b/packages/tui/docs/guide/testing.md
@@ -1,0 +1,97 @@
+# Testing with @agency-lang/tui
+
+The library is designed for testability. Use `ScriptedInput` and `FrameRecorder` to write headless tests with visual artifacts.
+
+## Basic Test Setup
+
+```typescript
+import { describe, it, expect } from "vitest";
+import {
+  Screen, ScriptedInput, FrameRecorder,
+  box, text, column,
+} from "@agency-lang/tui";
+
+function createTestScreen(width = 80, height = 24) {
+  const recorder = new FrameRecorder();
+  const input = new ScriptedInput();
+  const screen = new Screen({ output: recorder, input, width, height });
+  return { screen, recorder, input };
+}
+
+describe("my app", () => {
+  it("renders the main screen", () => {
+    const { screen, recorder } = createTestScreen();
+
+    const frame = screen.render(
+      box({ key: "main", border: true },
+        text("Hello World")
+      )
+    );
+
+    // Assert on structure
+    expect(frame.findByKey("main")).toBeDefined();
+
+    // Assert on text content
+    const main = frame.findByKey("main")!;
+    expect(main.toPlainText()).toContain("Hello World");
+
+    // Write visual artifact for debugging
+    recorder.writeHTML("test-output/main-screen.html");
+  });
+});
+```
+
+## Step-at-a-Time Testing
+
+For interactive UIs, feed keys and inspect frames after each step:
+
+```typescript
+it("navigates a list", async () => {
+  const { screen, input, recorder } = createTestScreen();
+
+  // Initial render
+  let items = ["A", "B", "C"];
+  let selected = 0;
+
+  function renderUI() {
+    return screen.render(
+      list({ key: "menu", border: true }, items, selected),
+      `selected: ${selected}`
+    );
+  }
+
+  // Step 1: initial state
+  let frame = renderUI();
+  expect(frame.toPlainText()).toContain("A");
+
+  // Step 2: press down
+  input.feedKey({ key: "down" });
+  const key = await screen.nextKey();
+  selected = 1;
+  frame = renderUI();
+
+  // Step 3: verify
+  const menu = frame.findByKey("menu")!;
+  expect(menu.toPlainText()).toContain("B");
+
+  // Export all frames as HTML for visual inspection
+  recorder.writeHTML("test-output/list-navigation.html");
+});
+```
+
+## Visual Artifacts
+
+`FrameRecorder.writeHTML(path)` produces an HTML file with:
+- All captured frames, each labeled with the label passed to `screen.render()`
+- Prev/Next buttons and arrow key navigation
+- Dark theme with monospace rendering
+
+Open the HTML file in a browser to visually step through each frame.
+
+## Tips
+
+- Use `frame.findByKey("name")` to inspect specific panes without parsing the full screen
+- `toPlainText()` is best for assertions; `toHTML()` is best for visual debugging
+- Call `recorder.clear()` between test cases to prevent memory buildup
+- The `label` parameter on `screen.render()` describes what happened (e.g., "press down", "type 'hello'")
+- Screen dimensions default to 80x24 but can be set to any size for testing edge cases

--- a/packages/tui/lib/builders.ts
+++ b/packages/tui/lib/builders.ts
@@ -1,6 +1,6 @@
 import type { Element, StyleProps } from "./elements.js";
 
-function isStyleProps(arg: any): arg is StyleProps {
+function isStyleProps(arg: StyleProps | Element): arg is StyleProps {
   return arg !== null && typeof arg === "object" && !("type" in arg);
 }
 

--- a/packages/tui/lib/builders.ts
+++ b/packages/tui/lib/builders.ts
@@ -1,0 +1,67 @@
+import type { Element, StyleProps } from "./elements.js";
+
+function isStyleProps(arg: any): arg is StyleProps {
+  return arg !== null && typeof arg === "object" && !("type" in arg);
+}
+
+function splitStyleAndKey(props: StyleProps): { style: Element["style"]; key?: string } {
+  const { key, ...style } = props;
+  return { style: Object.keys(style).length > 0 ? style : undefined, key };
+}
+
+export function box(styleOrChild?: StyleProps | Element, ...children: Element[]): Element {
+  if (styleOrChild === undefined) {
+    return { type: "box" };
+  }
+  if (isStyleProps(styleOrChild)) {
+    const { style, key } = splitStyleAndKey(styleOrChild);
+    return { type: "box", style, key, children: children.length > 0 ? children : undefined };
+  }
+  return { type: "box", children: [styleOrChild, ...children] };
+}
+
+export function row(styleOrChild?: StyleProps | Element, ...children: Element[]): Element {
+  if (styleOrChild === undefined) {
+    return { type: "box", style: { flexDirection: "row" } };
+  }
+  if (isStyleProps(styleOrChild)) {
+    const { style, key } = splitStyleAndKey(styleOrChild);
+    return {
+      type: "box",
+      style: { ...style, flexDirection: "row" },
+      key,
+      children: children.length > 0 ? children : undefined,
+    };
+  }
+  return { type: "box", style: { flexDirection: "row" }, children: [styleOrChild, ...children] };
+}
+
+export function column(styleOrChild?: StyleProps | Element, ...children: Element[]): Element {
+  if (styleOrChild === undefined) {
+    return { type: "box", style: { flexDirection: "column" } };
+  }
+  if (isStyleProps(styleOrChild)) {
+    const { style, key } = splitStyleAndKey(styleOrChild);
+    return {
+      type: "box",
+      style: { ...style, flexDirection: "column" },
+      key,
+      children: children.length > 0 ? children : undefined,
+    };
+  }
+  return { type: "box", style: { flexDirection: "column" }, children: [styleOrChild, ...children] };
+}
+
+export function text(content: string): Element {
+  return { type: "text", content };
+}
+
+export function list(style: StyleProps, items: string[], selectedIndex?: number): Element {
+  const { style: resolvedStyle, key } = splitStyleAndKey(style);
+  return { type: "list", style: resolvedStyle, key, items, selectedIndex };
+}
+
+export function textInput(style: StyleProps, value?: string): Element {
+  const { style: resolvedStyle, key } = splitStyleAndKey(style);
+  return { type: "textInput", style: resolvedStyle, key, value };
+}

--- a/packages/tui/lib/colors.ts
+++ b/packages/tui/lib/colors.ts
@@ -1,0 +1,26 @@
+export const ansiColors: Record<string, string> = {
+  black: "\x1b[30m", red: "\x1b[31m", green: "\x1b[32m", yellow: "\x1b[33m",
+  blue: "\x1b[34m", magenta: "\x1b[35m", cyan: "\x1b[36m", white: "\x1b[37m",
+  gray: "\x1b[90m",
+  "bright-red": "\x1b[91m", "bright-green": "\x1b[92m", "bright-yellow": "\x1b[93m",
+  "bright-blue": "\x1b[94m", "bright-magenta": "\x1b[95m", "bright-cyan": "\x1b[96m",
+  "bright-white": "\x1b[97m",
+};
+
+export const ansiBgColors: Record<string, string> = {
+  black: "\x1b[40m", red: "\x1b[41m", green: "\x1b[42m", yellow: "\x1b[43m",
+  blue: "\x1b[44m", magenta: "\x1b[45m", cyan: "\x1b[46m", white: "\x1b[47m",
+  gray: "\x1b[100m",
+  "bright-red": "\x1b[101m", "bright-green": "\x1b[102m", "bright-yellow": "\x1b[103m",
+  "bright-blue": "\x1b[104m", "bright-magenta": "\x1b[105m", "bright-cyan": "\x1b[106m",
+  "bright-white": "\x1b[107m",
+};
+
+export const cssColors: Record<string, string> = {
+  black: "#000", red: "#c00", green: "#0a0", yellow: "#aa0",
+  blue: "#00a", magenta: "#a0a", cyan: "#0aa", white: "#ccc",
+  gray: "#888",
+  "bright-red": "#f55", "bright-green": "#5f5", "bright-yellow": "#ff5",
+  "bright-blue": "#55f", "bright-magenta": "#f5f", "bright-cyan": "#5ff",
+  "bright-white": "#fff",
+};

--- a/packages/tui/lib/elements.ts
+++ b/packages/tui/lib/elements.ts
@@ -1,0 +1,60 @@
+export type Element = {
+  type: "box" | "text" | "list" | "textInput";
+  style?: Style;
+  content?: string;
+  children?: Element[];
+  items?: string[];
+  selectedIndex?: number;
+  value?: string;
+  key?: string;
+};
+
+export type Style = {
+  flexDirection?: "row" | "column";
+  flex?: number;
+  justifyContent?: "flex-start" | "center" | "flex-end" | "space-between";
+  alignItems?: "flex-start" | "center" | "flex-end" | "stretch";
+  width?: number | string;
+  height?: number | string;
+  minWidth?: number;
+  minHeight?: number;
+  maxWidth?: number;
+  maxHeight?: number;
+  padding?: number | { top?: number; bottom?: number; left?: number; right?: number };
+  margin?: number | { top?: number; bottom?: number; left?: number; right?: number };
+  border?: boolean;
+  borderColor?: string;
+  label?: string;
+  labelColor?: string;
+  fg?: string;
+  bg?: string;
+  bold?: boolean;
+  scrollable?: boolean;
+  scrollOffset?: number;
+  visible?: boolean;
+};
+
+export type StyleProps = Style & { key?: string };
+
+export type Cell = {
+  char: string;
+  fg?: string;
+  bg?: string;
+  bold?: boolean;
+};
+
+export type FrameStyle = {
+  border?: boolean;
+  borderColor?: string;
+  bg?: string;
+  label?: string;
+  labelColor?: string;
+};
+
+export type PositionedElement = Element & {
+  resolvedX: number;
+  resolvedY: number;
+  resolvedWidth: number;
+  resolvedHeight: number;
+  children?: PositionedElement[];
+};

--- a/packages/tui/lib/elements.ts
+++ b/packages/tui/lib/elements.ts
@@ -43,13 +43,7 @@ export type Cell = {
   bold?: boolean;
 };
 
-export type FrameStyle = {
-  border?: boolean;
-  borderColor?: string;
-  bg?: string;
-  label?: string;
-  labelColor?: string;
-};
+export type FrameStyle = Pick<Style, "border" | "borderColor" | "bg" | "label" | "labelColor">;
 
 export type PositionedElement = Element & {
   resolvedX: number;

--- a/packages/tui/lib/elements.ts
+++ b/packages/tui/lib/elements.ts
@@ -10,28 +10,40 @@ export type Element = {
 };
 
 export type Style = {
-  flexDirection?: "row" | "column";
-  flex?: number;
-  justifyContent?: "flex-start" | "center" | "flex-end" | "space-between";
-  alignItems?: "flex-start" | "center" | "flex-end" | "stretch";
+  // Layout
+  flexDirection?: "row" | "column";  // default: "column"
+  flex?: number;                     // flex grow factor; elements without explicit size default to flex: 1
+  justifyContent?: "flex-start" | "center" | "flex-end" | "space-between";  // main-axis alignment
+  alignItems?: "flex-start" | "center" | "flex-end" | "stretch";            // cross-axis alignment; default: "stretch"
+
+  // Sizing — numbers are terminal columns/rows, strings are percentages (e.g. "50%")
   width?: number | string;
   height?: number | string;
-  minWidth?: number;
-  minHeight?: number;
-  maxWidth?: number;
-  maxHeight?: number;
+  minWidth?: number;   // minimum columns
+  minHeight?: number;  // minimum rows
+  maxWidth?: number;   // maximum columns
+  maxHeight?: number;  // maximum rows
+
+  // Spacing — number applies uniformly to all sides; object allows per-side values (in columns/rows)
   padding?: number | { top?: number; bottom?: number; left?: number; right?: number };
   margin?: number | { top?: number; bottom?: number; left?: number; right?: number };
-  border?: boolean;
-  borderColor?: string;
-  label?: string;
-  labelColor?: string;
-  fg?: string;
-  bg?: string;
+
+  // Box decoration
+  border?: boolean;        // draw a single-line box border (reduces inner area by 1 on each side)
+  borderColor?: string;    // named color (e.g. "cyan", "bright-red")
+  label?: string;          // text rendered into the top border
+  labelColor?: string;     // named color for the label
+
+  // Content styling
+  fg?: string;             // foreground color name
+  bg?: string;             // background color name
   bold?: boolean;
-  scrollable?: boolean;
-  scrollOffset?: number;
-  visible?: boolean;
+
+  // Scrolling
+  scrollable?: boolean;    // enable scroll viewport
+  scrollOffset?: number;   // 0-indexed line offset for the viewport
+
+  visible?: boolean;       // default: true; invisible elements take no space in layout
 };
 
 export type StyleProps = Style & { key?: string };

--- a/packages/tui/lib/frame.ts
+++ b/packages/tui/lib/frame.ts
@@ -1,0 +1,58 @@
+import type { Cell, FrameStyle } from "./elements.js";
+import { toPlainText as toPlainTextAdapter } from "./render/plaintext.js";
+import { toHTML as toHTMLAdapter } from "./render/html.js";
+import * as fs from "node:fs";
+
+type FrameArgs = {
+  key?: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  style: FrameStyle;
+  content?: Cell[][];
+  children?: Frame[];
+};
+
+export class Frame {
+  key?: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  style: FrameStyle;
+  content?: Cell[][];
+  children?: Frame[];
+
+  constructor(args: FrameArgs) {
+    this.key = args.key;
+    this.x = args.x;
+    this.y = args.y;
+    this.width = args.width;
+    this.height = args.height;
+    this.style = args.style;
+    this.content = args.content;
+    this.children = args.children;
+  }
+
+  findByKey(key: string): Frame | undefined {
+    if (this.key === key) return this;
+    for (const child of this.children ?? []) {
+      const found = child.findByKey(key);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  toPlainText(): string {
+    return toPlainTextAdapter(this);
+  }
+
+  toHTML(): string {
+    return toHTMLAdapter(this);
+  }
+
+  image(path: string): void {
+    fs.writeFileSync(path, this.toHTML());
+  }
+}

--- a/packages/tui/lib/index.ts
+++ b/packages/tui/lib/index.ts
@@ -1,0 +1,18 @@
+export * from "./elements.js";
+export * from "./builders.js";
+export * from "./styleParser.js";
+export * from "./colors.js";
+export * from "./layout.js";
+export * from "./frame.js";
+export { render } from "./render/renderer.js";
+export { flatten } from "./render/flatten.js";
+export { toPlainText } from "./render/plaintext.js";
+export { toHTML } from "./render/html.js";
+export { toANSI } from "./render/ansi.js";
+export * from "./input/types.js";
+export { ScriptedInput } from "./input/scripted.js";
+export { TerminalInput } from "./input/terminal.js";
+export * from "./output/types.js";
+export { TerminalOutput } from "./output/terminal.js";
+export { FrameRecorder } from "./output/recorder.js";
+export { Screen } from "./screen.js";

--- a/packages/tui/lib/input/scripted.ts
+++ b/packages/tui/lib/input/scripted.ts
@@ -41,6 +41,9 @@ export class ScriptedInput implements InputSource {
   }
 
   destroy(): void {
-    // Nothing to clean up for scripted input
+    this.keyQueue = [];
+    this.keyWaiters = [];
+    this.lineQueue = [];
+    this.lineWaiters = [];
   }
 }

--- a/packages/tui/lib/input/scripted.ts
+++ b/packages/tui/lib/input/scripted.ts
@@ -1,0 +1,46 @@
+import type { KeyEvent, InputSource } from "./types.js";
+
+export class ScriptedInput implements InputSource {
+  private keyQueue: KeyEvent[] = [];
+  private keyWaiters: ((key: KeyEvent) => void)[] = [];
+  private lineQueue: string[] = [];
+  private lineWaiters: ((line: string) => void)[] = [];
+
+  feedKey(key: KeyEvent): void {
+    const waiter = this.keyWaiters.shift();
+    if (waiter) {
+      waiter(key);
+    } else {
+      this.keyQueue.push(key);
+    }
+  }
+
+  feedLine(line: string): void {
+    const waiter = this.lineWaiters.shift();
+    if (waiter) {
+      waiter(line);
+    } else {
+      this.lineQueue.push(line);
+    }
+  }
+
+  nextKey(): Promise<KeyEvent> {
+    const queued = this.keyQueue.shift();
+    if (queued) return Promise.resolve(queued);
+    return new Promise((resolve) => {
+      this.keyWaiters.push(resolve);
+    });
+  }
+
+  nextLine(_prompt: string): Promise<string> {
+    const queued = this.lineQueue.shift();
+    if (queued) return Promise.resolve(queued);
+    return new Promise((resolve) => {
+      this.lineWaiters.push(resolve);
+    });
+  }
+
+  destroy(): void {
+    // Nothing to clean up for scripted input
+  }
+}

--- a/packages/tui/lib/input/terminal.ts
+++ b/packages/tui/lib/input/terminal.ts
@@ -60,6 +60,7 @@ export class TerminalInput implements InputSource {
   private dataHandler: ((data: Buffer) => void) | null = null;
   private wasRaw = false;
   private initialized = false;
+  private inLineMode = false;
 
   private ensureInitialized(): void {
     if (this.initialized) return;
@@ -100,7 +101,10 @@ export class TerminalInput implements InputSource {
   }
 
   nextLine(prompt: string): Promise<string> {
-    // Temporarily exit raw mode for line input
+    if (this.inLineMode) {
+      return Promise.reject(new Error("nextLine() already in progress"));
+    }
+    this.inLineMode = true;
     if (process.stdin.isTTY && process.stdin.isRaw) {
       process.stdin.setRawMode(false);
     }
@@ -116,7 +120,7 @@ export class TerminalInput implements InputSource {
     return new Promise<string>((resolve) => {
       rl.question(prompt, (answer) => {
         rl.close();
-        // Re-enter raw mode
+        this.inLineMode = false;
         if (process.stdin.isTTY) {
           process.stdin.setRawMode(true);
           process.stdin.resume();
@@ -138,5 +142,7 @@ export class TerminalInput implements InputSource {
       process.stdin.setRawMode(this.wasRaw);
     }
     process.stdin.pause();
+    this.keyQueue = [];
+    this.keyWaiters = [];
   }
 }

--- a/packages/tui/lib/input/terminal.ts
+++ b/packages/tui/lib/input/terminal.ts
@@ -1,0 +1,132 @@
+import * as readline from "node:readline";
+import type { KeyEvent, InputSource } from "./types.js";
+
+// Map ANSI escape sequences to key names
+const ESC_MAP: Record<string, KeyEvent> = {
+  "\x1b[A": { key: "up" },
+  "\x1b[B": { key: "down" },
+  "\x1b[C": { key: "right" },
+  "\x1b[D": { key: "left" },
+  "\x1b[H": { key: "home" },
+  "\x1b[F": { key: "end" },
+  "\x1b[5~": { key: "pageup" },
+  "\x1b[6~": { key: "pagedown" },
+  "\x1b[3~": { key: "delete" },
+  "\x1b[2~": { key: "insert" },
+  "\x1bOA": { key: "up" },
+  "\x1bOB": { key: "down" },
+  "\x1bOC": { key: "right" },
+  "\x1bOD": { key: "left" },
+  "\x1bOH": { key: "home" },
+  "\x1bOF": { key: "end" },
+  // Shift+arrow
+  "\x1b[1;2A": { key: "up", shift: true },
+  "\x1b[1;2B": { key: "down", shift: true },
+  "\x1b[1;2C": { key: "right", shift: true },
+  "\x1b[1;2D": { key: "left", shift: true },
+};
+
+function parseKeypress(data: string): KeyEvent {
+  // Check escape sequence map
+  const mapped = ESC_MAP[data];
+  if (mapped) return mapped;
+
+  // Single escape
+  if (data === "\x1b") return { key: "escape" };
+
+  // Ctrl+letter (0x01-0x1a)
+  const code = data.charCodeAt(0);
+  if (data.length === 1 && code >= 1 && code <= 26) {
+    const letter = String.fromCharCode(code + 96); // 1 -> 'a', 3 -> 'c', etc.
+    return { key: letter, ctrl: true };
+  }
+
+  // Enter
+  if (data === "\r" || data === "\n") return { key: "enter" };
+
+  // Backspace
+  if (data === "\x7f") return { key: "backspace" };
+
+  // Tab
+  if (data === "\t") return { key: "tab" };
+
+  // Regular character
+  return { key: data };
+}
+
+export class TerminalInput implements InputSource {
+  private keyWaiters: ((key: KeyEvent) => void)[] = [];
+  private keyQueue: KeyEvent[] = [];
+  private dataHandler: ((data: Buffer) => void) | null = null;
+  private wasRaw = false;
+
+  init(): void {
+    if (!process.stdin.isTTY) return;
+
+    this.wasRaw = process.stdin.isRaw;
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+
+    this.dataHandler = (data: Buffer) => {
+      const str = data.toString("utf-8");
+      const key = parseKeypress(str);
+      const waiter = this.keyWaiters.shift();
+      if (waiter) {
+        waiter(key);
+      } else {
+        this.keyQueue.push(key);
+      }
+    };
+
+    process.stdin.on("data", this.dataHandler);
+  }
+
+  nextKey(): Promise<KeyEvent> {
+    const queued = this.keyQueue.shift();
+    if (queued) return Promise.resolve(queued);
+    return new Promise((resolve) => {
+      this.keyWaiters.push(resolve);
+    });
+  }
+
+  nextLine(prompt: string): Promise<string> {
+    // Temporarily exit raw mode for line input
+    if (process.stdin.isTTY && process.stdin.isRaw) {
+      process.stdin.setRawMode(false);
+    }
+    if (this.dataHandler) {
+      process.stdin.removeListener("data", this.dataHandler);
+    }
+
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    return new Promise<string>((resolve) => {
+      rl.question(prompt, (answer) => {
+        rl.close();
+        // Re-enter raw mode
+        if (process.stdin.isTTY) {
+          process.stdin.setRawMode(true);
+          process.stdin.resume();
+        }
+        if (this.dataHandler) {
+          process.stdin.on("data", this.dataHandler);
+        }
+        resolve(answer);
+      });
+    });
+  }
+
+  destroy(): void {
+    if (this.dataHandler) {
+      process.stdin.removeListener("data", this.dataHandler);
+      this.dataHandler = null;
+    }
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(this.wasRaw);
+    }
+    process.stdin.pause();
+  }
+}

--- a/packages/tui/lib/input/terminal.ts
+++ b/packages/tui/lib/input/terminal.ts
@@ -59,6 +59,13 @@ export class TerminalInput implements InputSource {
   private keyQueue: KeyEvent[] = [];
   private dataHandler: ((data: Buffer) => void) | null = null;
   private wasRaw = false;
+  private initialized = false;
+
+  private ensureInitialized(): void {
+    if (this.initialized) return;
+    this.initialized = true;
+    this.init();
+  }
 
   init(): void {
     if (!process.stdin.isTTY) return;
@@ -82,6 +89,7 @@ export class TerminalInput implements InputSource {
   }
 
   nextKey(): Promise<KeyEvent> {
+    this.ensureInitialized();
     const queued = this.keyQueue.shift();
     if (queued) return Promise.resolve(queued);
     return new Promise((resolve) => {

--- a/packages/tui/lib/input/terminal.ts
+++ b/packages/tui/lib/input/terminal.ts
@@ -1,24 +1,32 @@
 import * as readline from "node:readline";
 import type { KeyEvent, InputSource } from "./types.js";
 
-// Map ANSI escape sequences to key names
-const ESC_MAP: Record<string, KeyEvent> = {
+const KEY_MAP: Record<string, KeyEvent> = {
+  // Special keys
+  "\x1b": { key: "escape" },
+  "\r": { key: "enter" },
+  "\n": { key: "enter" },
+  "\x7f": { key: "backspace" },
+  "\t": { key: "tab" },
+  // Arrow keys (CSI)
   "\x1b[A": { key: "up" },
   "\x1b[B": { key: "down" },
   "\x1b[C": { key: "right" },
   "\x1b[D": { key: "left" },
-  "\x1b[H": { key: "home" },
-  "\x1b[F": { key: "end" },
-  "\x1b[5~": { key: "pageup" },
-  "\x1b[6~": { key: "pagedown" },
-  "\x1b[3~": { key: "delete" },
-  "\x1b[2~": { key: "insert" },
+  // Arrow keys (SS3)
   "\x1bOA": { key: "up" },
   "\x1bOB": { key: "down" },
   "\x1bOC": { key: "right" },
   "\x1bOD": { key: "left" },
+  // Navigation
+  "\x1b[H": { key: "home" },
+  "\x1b[F": { key: "end" },
   "\x1bOH": { key: "home" },
   "\x1bOF": { key: "end" },
+  "\x1b[5~": { key: "pageup" },
+  "\x1b[6~": { key: "pagedown" },
+  "\x1b[3~": { key: "delete" },
+  "\x1b[2~": { key: "insert" },
   // Shift+arrow
   "\x1b[1;2A": { key: "up", shift: true },
   "\x1b[1;2B": { key: "down", shift: true },
@@ -27,30 +35,15 @@ const ESC_MAP: Record<string, KeyEvent> = {
 };
 
 function parseKeypress(data: string): KeyEvent {
-  // Check escape sequence map
-  const mapped = ESC_MAP[data];
+  const mapped = KEY_MAP[data];
   if (mapped) return mapped;
-
-  // Single escape
-  if (data === "\x1b") return { key: "escape" };
 
   // Ctrl+letter (0x01-0x1a)
   const code = data.charCodeAt(0);
   if (data.length === 1 && code >= 1 && code <= 26) {
-    const letter = String.fromCharCode(code + 96); // 1 -> 'a', 3 -> 'c', etc.
-    return { key: letter, ctrl: true };
+    return { key: String.fromCharCode(code + 96), ctrl: true };
   }
 
-  // Enter
-  if (data === "\r" || data === "\n") return { key: "enter" };
-
-  // Backspace
-  if (data === "\x7f") return { key: "backspace" };
-
-  // Tab
-  if (data === "\t") return { key: "tab" };
-
-  // Regular character
   return { key: data };
 }
 
@@ -112,6 +105,8 @@ export class TerminalInput implements InputSource {
       process.stdin.removeListener("data", this.dataHandler);
     }
 
+    // Created per-call because readline takes ownership of stdin and
+    // must be closed before we can re-enter raw mode for key input.
     const rl = readline.createInterface({
       input: process.stdin,
       output: process.stdout,

--- a/packages/tui/lib/input/terminal.ts
+++ b/packages/tui/lib/input/terminal.ts
@@ -68,7 +68,9 @@ export class TerminalInput implements InputSource {
   }
 
   init(): void {
-    if (!process.stdin.isTTY) return;
+    if (!process.stdin.isTTY) {
+      throw new Error("TerminalInput requires a TTY stdin");
+    }
 
     this.wasRaw = process.stdin.isRaw;
     process.stdin.setRawMode(true);

--- a/packages/tui/lib/input/types.ts
+++ b/packages/tui/lib/input/types.ts
@@ -1,0 +1,11 @@
+export type KeyEvent = {
+  key: string;
+  shift?: boolean;
+  ctrl?: boolean;
+};
+
+export type InputSource = {
+  nextKey(): Promise<KeyEvent>;
+  nextLine(prompt: string): Promise<string>;
+  destroy(): void;
+};

--- a/packages/tui/lib/layout.ts
+++ b/packages/tui/lib/layout.ts
@@ -65,6 +65,8 @@ function layoutRoot(
  * Lay out a child element. The parent has already resolved the main-axis
  * size. The child resolves only its cross-axis size.
  */
+type AlignItems = "flex-start" | "center" | "flex-end" | "stretch";
+
 function layoutChild(
   element: Element,
   x: number,
@@ -72,17 +74,37 @@ function layoutChild(
   mainAxisSize: number,
   crossAxisAvailable: number,
   mainAxis: "width" | "height",
+  alignItems: AlignItems,
 ): PositionedElement {
   const style = element.style ?? {};
   const margin = resolveEdges(style.margin);
 
   const crossAxis = mainAxis === "width" ? "height" : "width";
 
+  // For stretch (default), fill available cross space.
+  // For other alignments, use child's own size if specified.
   const crossProp = style[crossAxis];
-  let crossDim = resolveDimension(crossProp, crossAxisAvailable) ?? crossAxisAvailable;
+  let crossDim: number;
+  if (alignItems === "stretch") {
+    crossDim = resolveDimension(crossProp, crossAxisAvailable) ?? crossAxisAvailable;
+  } else {
+    crossDim = resolveDimension(crossProp, crossAxisAvailable) ?? crossAxisAvailable;
+  }
   const crossMin = crossAxis === "width" ? style.minWidth : style.minHeight;
   const crossMax = crossAxis === "width" ? style.maxWidth : style.maxHeight;
   crossDim = clampDimension(crossDim, crossMin, crossMax);
+
+  // Cross-axis offset based on alignItems
+  let crossOffset = 0;
+  if (alignItems === "center") {
+    crossOffset = Math.floor((crossAxisAvailable - crossDim) / 2);
+  } else if (alignItems === "flex-end") {
+    crossOffset = crossAxisAvailable - crossDim;
+  }
+
+  const isRow = mainAxis === "width";
+  const adjustedX = x + (isRow ? 0 : crossOffset);
+  const adjustedY = y + (isRow ? crossOffset : 0);
 
   const width = mainAxis === "width" ? mainAxisSize : crossDim;
   const height = mainAxis === "height" ? mainAxisSize : crossDim;
@@ -90,8 +112,8 @@ function layoutChild(
 
   const result: PositionedElement = {
     ...rest,
-    resolvedX: x + margin.left,
-    resolvedY: y + margin.top,
+    resolvedX: adjustedX + margin.left,
+    resolvedY: adjustedY + margin.top,
     resolvedWidth: width,
     resolvedHeight: height,
   };
@@ -174,7 +196,27 @@ function layoutChildren(
   }
 
   // --- Pass 3: position children and recurse ---
+  // Compute total used main-axis space (after flex distribution)
+  let totalUsedMain = 0;
+  for (let i = 0; i < visibleChildren.length; i++) {
+    const m = childMargins[i];
+    const marginSum = isRow ? m.left + m.right : m.top + m.bottom;
+    totalUsedMain += childMainSizes[i]! + marginSum;
+  }
+  const freeMain = Math.max(0, mainSize - totalUsedMain);
+
+  const justify = style.justifyContent ?? "flex-start";
   let mainOffset = 0;
+  let gap = 0;
+  if (justify === "flex-end") {
+    mainOffset = freeMain;
+  } else if (justify === "center") {
+    mainOffset = Math.floor(freeMain / 2);
+  } else if (justify === "space-between" && visibleChildren.length > 1) {
+    gap = Math.floor(freeMain / (visibleChildren.length - 1));
+  }
+
+  const alignItems: AlignItems = style.alignItems ?? "stretch";
   const positionedChildren: PositionedElement[] = [];
 
   for (let i = 0; i < visibleChildren.length; i++) {
@@ -188,17 +230,18 @@ function layoutChildren(
     if (isRow) {
       childX = innerX + mainOffset;
       childY = innerY;
-      mainOffset += childMainSize + childMargin.left + childMargin.right;
+      mainOffset += childMainSize + childMargin.left + childMargin.right + gap;
     } else {
       childX = innerX;
       childY = innerY + mainOffset;
-      mainOffset += childMainSize + childMargin.top + childMargin.bottom;
+      mainOffset += childMainSize + childMargin.top + childMargin.bottom + gap;
     }
 
     const positioned = layoutChild(
       child, childX, childY,
       childMainSize, crossSize,
       mainAxis,
+      alignItems,
     );
     positionedChildren.push(positioned);
   }

--- a/packages/tui/lib/layout.ts
+++ b/packages/tui/lib/layout.ts
@@ -1,17 +1,5 @@
 import type { Element, PositionedElement } from "./elements.js";
-
-type Edges = { top: number; bottom: number; left: number; right: number };
-
-function resolveEdges(value: number | { top?: number; bottom?: number; left?: number; right?: number } | undefined): Edges {
-  if (value === undefined) return { top: 0, bottom: 0, left: 0, right: 0 };
-  if (typeof value === "number") return { top: value, bottom: value, left: value, right: value };
-  return {
-    top: value.top ?? 0,
-    bottom: value.bottom ?? 0,
-    left: value.left ?? 0,
-    right: value.right ?? 0,
-  };
-}
+import { resolveEdges, type Edges } from "./utils.js";
 
 function resolveDimension(
   value: number | string | undefined,
@@ -90,18 +78,14 @@ function layoutChild(
 
   const crossAxis = mainAxis === "width" ? "height" : "width";
 
-  // Main axis: already resolved by parent, use directly
-  const mainDim = mainAxisSize;
-
-  // Cross axis: child resolves its own size against available space
   const crossProp = style[crossAxis];
   let crossDim = resolveDimension(crossProp, crossAxisAvailable) ?? crossAxisAvailable;
   const crossMin = crossAxis === "width" ? style.minWidth : style.minHeight;
   const crossMax = crossAxis === "width" ? style.maxWidth : style.maxHeight;
   crossDim = clampDimension(crossDim, crossMin, crossMax);
 
-  const width = mainAxis === "width" ? mainDim : crossDim;
-  const height = mainAxis === "height" ? mainDim : crossDim;
+  const width = mainAxis === "width" ? mainAxisSize : crossDim;
+  const height = mainAxis === "height" ? mainAxisSize : crossDim;
   const { children: _, ...rest } = element;
 
   const result: PositionedElement = {
@@ -154,10 +138,12 @@ function layoutChildren(
   let usedMain = 0;
   let totalFlex = 0;
   const childMainSizes: (number | null)[] = [];
+  const childMargins: Edges[] = [];
 
   for (const child of visibleChildren) {
     const cs = child.style ?? {};
     const childMargin = resolveEdges(cs.margin);
+    childMargins.push(childMargin);
     const mainMarginSum = isRow
       ? childMargin.left + childMargin.right
       : childMargin.top + childMargin.bottom;
@@ -167,8 +153,6 @@ function layoutChildren(
     const hasExplicitMainSize = mainProp !== undefined;
 
     if (hasFlex || !hasExplicitMainSize) {
-      // Flex children and children with no explicit main-axis size both
-      // get their space from pass 2. Treat no-size-no-flex as flex: 1.
       const flexValue = cs.flex ?? 1;
       totalFlex += flexValue;
       childMainSizes.push(null);
@@ -196,8 +180,7 @@ function layoutChildren(
   for (let i = 0; i < visibleChildren.length; i++) {
     const child = visibleChildren[i];
     const childMainSize = childMainSizes[i]!;
-    const cs = child.style ?? {};
-    const childMargin = resolveEdges(cs.margin);
+    const childMargin = childMargins[i];
 
     let childX: number;
     let childY: number;
@@ -212,7 +195,6 @@ function layoutChildren(
       mainOffset += childMainSize + childMargin.top + childMargin.bottom;
     }
 
-    // Parent owns the main axis; child resolves the cross axis.
     const positioned = layoutChild(
       child, childX, childY,
       childMainSize, crossSize,

--- a/packages/tui/lib/layout.ts
+++ b/packages/tui/lib/layout.ts
@@ -1,0 +1,225 @@
+import type { Element, PositionedElement } from "./elements.js";
+
+type Edges = { top: number; bottom: number; left: number; right: number };
+
+function resolveEdges(value: number | { top?: number; bottom?: number; left?: number; right?: number } | undefined): Edges {
+  if (value === undefined) return { top: 0, bottom: 0, left: 0, right: 0 };
+  if (typeof value === "number") return { top: value, bottom: value, left: value, right: value };
+  return {
+    top: value.top ?? 0,
+    bottom: value.bottom ?? 0,
+    left: value.left ?? 0,
+    right: value.right ?? 0,
+  };
+}
+
+function resolveDimension(
+  value: number | string | undefined,
+  available: number,
+): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value === "number") return value;
+  if (typeof value === "string" && value.endsWith("%")) {
+    const pct = parseFloat(value) / 100;
+    return Math.floor(available * pct);
+  }
+  return undefined;
+}
+
+function clampDimension(value: number, min?: number, max?: number): number {
+  if (min !== undefined && value < min) value = min;
+  if (max !== undefined && value > max) value = max;
+  return value;
+}
+
+/**
+ * Entry point: lay out the root element. Both axes are resolved by the
+ * element itself against the available terminal dimensions.
+ */
+export function layout(element: Element, availableWidth: number, availableHeight: number): PositionedElement {
+  return layoutRoot(element, 0, 0, availableWidth, availableHeight);
+}
+
+/**
+ * Lay out the root element. The root has no parent, so it resolves both
+ * axes itself against the available space.
+ */
+function layoutRoot(
+  element: Element,
+  x: number,
+  y: number,
+  availableWidth: number,
+  availableHeight: number,
+): PositionedElement {
+  const style = element.style ?? {};
+
+  let width = resolveDimension(style.width, availableWidth) ?? availableWidth;
+  let height = resolveDimension(style.height, availableHeight) ?? availableHeight;
+  width = clampDimension(width, style.minWidth, style.maxWidth);
+  height = clampDimension(height, style.minHeight, style.maxHeight);
+
+  const margin = resolveEdges(style.margin);
+  const { children: _, ...rest } = element;
+
+  const result: PositionedElement = {
+    ...rest,
+    resolvedX: x + margin.left,
+    resolvedY: y + margin.top,
+    resolvedWidth: width,
+    resolvedHeight: height,
+  };
+
+  result.children = layoutChildren(element, result);
+  return result;
+}
+
+/**
+ * Lay out a child element. The parent has already resolved the main-axis
+ * size. The child resolves only its cross-axis size.
+ */
+function layoutChild(
+  element: Element,
+  x: number,
+  y: number,
+  mainAxisSize: number,
+  crossAxisAvailable: number,
+  mainAxis: "width" | "height",
+): PositionedElement {
+  const style = element.style ?? {};
+  const margin = resolveEdges(style.margin);
+
+  const crossAxis = mainAxis === "width" ? "height" : "width";
+
+  // Main axis: already resolved by parent, use directly
+  const mainDim = mainAxisSize;
+
+  // Cross axis: child resolves its own size against available space
+  const crossProp = style[crossAxis];
+  let crossDim = resolveDimension(crossProp, crossAxisAvailable) ?? crossAxisAvailable;
+  const crossMin = crossAxis === "width" ? style.minWidth : style.minHeight;
+  const crossMax = crossAxis === "width" ? style.maxWidth : style.maxHeight;
+  crossDim = clampDimension(crossDim, crossMin, crossMax);
+
+  const width = mainAxis === "width" ? mainDim : crossDim;
+  const height = mainAxis === "height" ? mainDim : crossDim;
+  const { children: _, ...rest } = element;
+
+  const result: PositionedElement = {
+    ...rest,
+    resolvedX: x + margin.left,
+    resolvedY: y + margin.top,
+    resolvedWidth: width,
+    resolvedHeight: height,
+  };
+
+  result.children = layoutChildren(element, result);
+  return result;
+}
+
+/**
+ * Lay out the children of a positioned parent element. This is the core
+ * flexbox-lite algorithm, shared by both layoutRoot and layoutChild.
+ */
+function layoutChildren(
+  element: Element,
+  parent: PositionedElement,
+): PositionedElement[] | undefined {
+  const style = element.style ?? {};
+
+  const visibleChildren = (element.children ?? []).filter(
+    (c) => c.style?.visible !== false,
+  );
+
+  if (visibleChildren.length === 0) return undefined;
+
+  const padding = resolveEdges(style.padding);
+  const borderSize = style.border ? 1 : 0;
+
+  // Inner area after border and padding
+  const innerX = parent.resolvedX + borderSize + padding.left;
+  const innerY = parent.resolvedY + borderSize + padding.top;
+  const innerWidth = parent.resolvedWidth - 2 * borderSize - padding.left - padding.right;
+  const innerHeight = parent.resolvedHeight - 2 * borderSize - padding.top - padding.bottom;
+
+  const direction = style.flexDirection ?? "column";
+  const isRow = direction === "row";
+  const mainAxis: "width" | "height" = isRow ? "width" : "height";
+
+  const mainSize = isRow ? innerWidth : innerHeight;
+  const crossSize = isRow ? innerHeight : innerWidth;
+
+  // --- Pass 1: compute each child's main-axis size ---
+  // Fixed and percentage children are resolved against the parent's inner
+  // dimension. Flex children are deferred (null) for pass 2.
+  let usedMain = 0;
+  let totalFlex = 0;
+  const childMainSizes: (number | null)[] = [];
+
+  for (const child of visibleChildren) {
+    const cs = child.style ?? {};
+    const childMargin = resolveEdges(cs.margin);
+    const mainMarginSum = isRow
+      ? childMargin.left + childMargin.right
+      : childMargin.top + childMargin.bottom;
+
+    const mainProp = isRow ? cs.width : cs.height;
+    const hasFlex = cs.flex !== undefined && cs.flex > 0;
+    const hasExplicitMainSize = mainProp !== undefined;
+
+    if (hasFlex || !hasExplicitMainSize) {
+      // Flex children and children with no explicit main-axis size both
+      // get their space from pass 2. Treat no-size-no-flex as flex: 1.
+      const flexValue = cs.flex ?? 1;
+      totalFlex += flexValue;
+      childMainSizes.push(null);
+      usedMain += mainMarginSum;
+    } else {
+      const resolved = resolveDimension(mainProp, mainSize) ?? 0;
+      childMainSizes.push(resolved);
+      usedMain += resolved + mainMarginSum;
+    }
+  }
+
+  // --- Pass 2: distribute remaining space to flex/unsized children ---
+  const remainingMain = Math.max(0, mainSize - usedMain);
+  for (let i = 0; i < visibleChildren.length; i++) {
+    if (childMainSizes[i] === null) {
+      const flexValue = visibleChildren[i].style?.flex ?? 1;
+      childMainSizes[i] = Math.floor(remainingMain * (flexValue / totalFlex));
+    }
+  }
+
+  // --- Pass 3: position children and recurse ---
+  let mainOffset = 0;
+  const positionedChildren: PositionedElement[] = [];
+
+  for (let i = 0; i < visibleChildren.length; i++) {
+    const child = visibleChildren[i];
+    const childMainSize = childMainSizes[i]!;
+    const cs = child.style ?? {};
+    const childMargin = resolveEdges(cs.margin);
+
+    let childX: number;
+    let childY: number;
+
+    if (isRow) {
+      childX = innerX + mainOffset;
+      childY = innerY;
+      mainOffset += childMainSize + childMargin.left + childMargin.right;
+    } else {
+      childX = innerX;
+      childY = innerY + mainOffset;
+      mainOffset += childMainSize + childMargin.top + childMargin.bottom;
+    }
+
+    // Parent owns the main axis; child resolves the cross axis.
+    const positioned = layoutChild(
+      child, childX, childY,
+      childMainSize, crossSize,
+      mainAxis,
+    );
+    positionedChildren.push(positioned);
+  }
+
+  return positionedChildren;
+}

--- a/packages/tui/lib/layout.ts
+++ b/packages/tui/lib/layout.ts
@@ -144,8 +144,8 @@ function layoutChildren(
   // Inner area after border and padding
   const innerX = parent.resolvedX + borderSize + padding.left;
   const innerY = parent.resolvedY + borderSize + padding.top;
-  const innerWidth = parent.resolvedWidth - 2 * borderSize - padding.left - padding.right;
-  const innerHeight = parent.resolvedHeight - 2 * borderSize - padding.top - padding.bottom;
+  const innerWidth = Math.max(0, parent.resolvedWidth - 2 * borderSize - padding.left - padding.right);
+  const innerHeight = Math.max(0, parent.resolvedHeight - 2 * borderSize - padding.top - padding.bottom);
 
   const direction = style.flexDirection ?? "column";
   const isRow = direction === "row";

--- a/packages/tui/lib/output/recorder.ts
+++ b/packages/tui/lib/output/recorder.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import type { Frame } from "../frame.js";
 import type { OutputTarget } from "./types.js";
 import { toHTML as frameToHTML } from "../render/html.js";
+import { escapeHtml } from "../utils.js";
 
 type RecordedFrame = {
   frame: Frame;
@@ -73,8 +74,4 @@ show(0);
   writeHTML(path: string): void {
     fs.writeFileSync(path, this.toHTML());
   }
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }

--- a/packages/tui/lib/output/recorder.ts
+++ b/packages/tui/lib/output/recorder.ts
@@ -1,0 +1,76 @@
+import type { Frame } from "../frame.js";
+import type { OutputTarget } from "./types.js";
+import { toHTML as frameToHTML } from "../render/html.js";
+
+type RecordedFrame = {
+  frame: Frame;
+  label?: string;
+};
+
+export class FrameRecorder implements OutputTarget {
+  frames: RecordedFrame[] = [];
+
+  write(frame: Frame, label?: string): void {
+    this.frames.push({ frame, label });
+  }
+
+  toHTML(): string {
+    const frameHtmls = this.frames.map((entry, i) => {
+      const label = entry.label ?? `Frame ${i + 1}`;
+      const rendered = frameToHTML(entry.frame);
+      return `<div class="frame" id="frame-${i}">
+<h3>${escapeHtml(label)}</h3>
+${rendered}
+</div>`;
+    });
+
+    return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>TUI Frames</title>
+<style>
+body { background: #1e1e1e; color: #ccc; font-family: sans-serif; padding: 20px; }
+.frame { margin-bottom: 20px; }
+.frame h3 { color: #7af; margin: 0 0 8px 0; font-size: 14px; }
+pre { background: #000; padding: 4px; border: 1px solid #333; display: inline-block; }
+.nav { position: fixed; top: 10px; right: 20px; background: #333; padding: 10px; border-radius: 4px; }
+.nav button { margin: 0 4px; padding: 4px 12px; cursor: pointer; }
+</style>
+</head>
+<body>
+<div class="nav">
+<button onclick="prev()">Prev</button>
+<span id="counter">1 / ${this.frames.length}</span>
+<button onclick="next()">Next</button>
+</div>
+${frameHtmls.join("\n")}
+<script>
+const frames = document.querySelectorAll('.frame');
+let current = 0;
+function show(i) {
+  frames.forEach((f, j) => f.style.display = j === i ? 'block' : 'none');
+  document.getElementById('counter').textContent = (i+1) + ' / ' + frames.length;
+  current = i;
+}
+function prev() { if (current > 0) show(current - 1); }
+function next() { if (current < frames.length - 1) show(current + 1); }
+document.addEventListener('keydown', e => {
+  if (e.key === 'ArrowLeft') prev();
+  if (e.key === 'ArrowRight') next();
+});
+show(0);
+</script>
+</body>
+</html>`;
+  }
+
+  writeHTML(path: string): void {
+    const fs = require("node:fs");
+    fs.writeFileSync(path, this.toHTML());
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/packages/tui/lib/output/recorder.ts
+++ b/packages/tui/lib/output/recorder.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs";
 import type { Frame } from "../frame.js";
 import type { OutputTarget } from "./types.js";
 import { toHTML as frameToHTML } from "../render/html.js";
@@ -66,7 +67,6 @@ show(0);
   }
 
   writeHTML(path: string): void {
-    const fs = require("node:fs");
     fs.writeFileSync(path, this.toHTML());
   }
 }

--- a/packages/tui/lib/output/recorder.ts
+++ b/packages/tui/lib/output/recorder.ts
@@ -15,6 +15,10 @@ export class FrameRecorder implements OutputTarget {
     this.frames.push({ frame, label });
   }
 
+  clear(): void {
+    this.frames = [];
+  }
+
   toHTML(): string {
     const frameHtmls = this.frames.map((entry, i) => {
       const label = entry.label ?? `Frame ${i + 1}`;

--- a/packages/tui/lib/output/terminal.ts
+++ b/packages/tui/lib/output/terminal.ts
@@ -11,11 +11,26 @@ const CURSOR_HOME = "\x1b[H";
 export class TerminalOutput implements OutputTarget {
   private inAltScreen = false;
   private exitHandler = () => this.destroy();
+  private sigintHandler = () => { this.destroy(); process.exit(130); };
+  private sigtermHandler = () => { this.destroy(); process.exit(143); };
+  private sigtstpHandler = () => {
+    this.suspend();
+    process.kill(process.pid, "SIGTSTP");
+  };
+  private sigcontHandler = () => {
+    this.resume();
+  };
 
   init(): void {
     process.stdout.write(ENTER_ALT_SCREEN + HIDE_CURSOR);
     this.inAltScreen = true;
     process.on("exit", this.exitHandler);
+    process.on("SIGINT", this.sigintHandler);
+    process.on("SIGTERM", this.sigtermHandler);
+    // For SIGTSTP, we need to remove the handler before re-raising so the
+    // default handler can actually suspend the process.
+    process.on("SIGTSTP", this.sigtstpHandler);
+    process.on("SIGCONT", this.sigcontHandler);
   }
 
   write(frame: Frame): void {
@@ -31,7 +46,7 @@ export class TerminalOutput implements OutputTarget {
       process.stdout.write(SHOW_CURSOR + EXIT_ALT_SCREEN);
       this.inAltScreen = false;
     }
-    process.removeListener("exit", this.exitHandler);
+    this.removeSignalHandlers();
   }
 
   suspend(): void {
@@ -46,5 +61,13 @@ export class TerminalOutput implements OutputTarget {
       process.stdout.write(ENTER_ALT_SCREEN + HIDE_CURSOR);
       this.inAltScreen = true;
     }
+  }
+
+  private removeSignalHandlers(): void {
+    process.removeListener("exit", this.exitHandler);
+    process.removeListener("SIGINT", this.sigintHandler);
+    process.removeListener("SIGTERM", this.sigtermHandler);
+    process.removeListener("SIGTSTP", this.sigtstpHandler);
+    process.removeListener("SIGCONT", this.sigcontHandler);
   }
 }

--- a/packages/tui/lib/output/terminal.ts
+++ b/packages/tui/lib/output/terminal.ts
@@ -34,12 +34,14 @@ export class TerminalOutput implements OutputTarget {
   suspend(): void {
     if (this.inAltScreen) {
       process.stdout.write(SHOW_CURSOR + EXIT_ALT_SCREEN);
+      this.inAltScreen = false;
     }
   }
 
   resume(): void {
-    if (this.inAltScreen) {
+    if (!this.inAltScreen) {
       process.stdout.write(ENTER_ALT_SCREEN + HIDE_CURSOR);
+      this.inAltScreen = true;
     }
   }
 }

--- a/packages/tui/lib/output/terminal.ts
+++ b/packages/tui/lib/output/terminal.ts
@@ -1,0 +1,45 @@
+import type { Frame } from "../frame.js";
+import type { OutputTarget } from "./types.js";
+import { toANSI } from "../render/ansi.js";
+
+const ENTER_ALT_SCREEN = "\x1b[?1049h";
+const EXIT_ALT_SCREEN = "\x1b[?1049l";
+const HIDE_CURSOR = "\x1b[?25l";
+const SHOW_CURSOR = "\x1b[?25h";
+const CURSOR_HOME = "\x1b[H";
+
+export class TerminalOutput implements OutputTarget {
+  private inAltScreen = false;
+
+  init(): void {
+    process.stdout.write(ENTER_ALT_SCREEN + HIDE_CURSOR);
+    this.inAltScreen = true;
+  }
+
+  write(frame: Frame): void {
+    if (!this.inAltScreen) {
+      this.init();
+    }
+    const ansi = toANSI(frame);
+    process.stdout.write(CURSOR_HOME + ansi);
+  }
+
+  destroy(): void {
+    if (this.inAltScreen) {
+      process.stdout.write(SHOW_CURSOR + EXIT_ALT_SCREEN);
+      this.inAltScreen = false;
+    }
+  }
+
+  suspend(): void {
+    if (this.inAltScreen) {
+      process.stdout.write(SHOW_CURSOR + EXIT_ALT_SCREEN);
+    }
+  }
+
+  resume(): void {
+    if (this.inAltScreen) {
+      process.stdout.write(ENTER_ALT_SCREEN + HIDE_CURSOR);
+    }
+  }
+}

--- a/packages/tui/lib/output/terminal.ts
+++ b/packages/tui/lib/output/terminal.ts
@@ -10,10 +10,12 @@ const CURSOR_HOME = "\x1b[H";
 
 export class TerminalOutput implements OutputTarget {
   private inAltScreen = false;
+  private exitHandler = () => this.destroy();
 
   init(): void {
     process.stdout.write(ENTER_ALT_SCREEN + HIDE_CURSOR);
     this.inAltScreen = true;
+    process.on("exit", this.exitHandler);
   }
 
   write(frame: Frame): void {
@@ -29,6 +31,7 @@ export class TerminalOutput implements OutputTarget {
       process.stdout.write(SHOW_CURSOR + EXIT_ALT_SCREEN);
       this.inAltScreen = false;
     }
+    process.removeListener("exit", this.exitHandler);
   }
 
   suspend(): void {

--- a/packages/tui/lib/output/types.ts
+++ b/packages/tui/lib/output/types.ts
@@ -2,5 +2,5 @@ import type { Frame } from "../frame.js";
 
 export type OutputTarget = {
   write(frame: Frame, label?: string): void;
-  flush?(): void;
+  destroy?(): void;
 };

--- a/packages/tui/lib/output/types.ts
+++ b/packages/tui/lib/output/types.ts
@@ -1,0 +1,6 @@
+import type { Frame } from "../frame.js";
+
+export type OutputTarget = {
+  write(frame: Frame, label?: string): void;
+  flush?(): void;
+};

--- a/packages/tui/lib/render/ansi.ts
+++ b/packages/tui/lib/render/ansi.ts
@@ -1,6 +1,7 @@
 import type { Cell } from "../elements.js";
 import type { Frame } from "../frame.js";
 import { ansiColors, ansiBgColors } from "../colors.js";
+import { sameStyle } from "../utils.js";
 import { flatten } from "./flatten.js";
 
 const RESET = "\x1b[0m";
@@ -12,10 +13,6 @@ function cellEscapes(cell: Cell): string {
   if (cell.fg) seq += ansiColors[cell.fg] ?? "";
   if (cell.bg) seq += ansiBgColors[cell.bg] ?? "";
   return seq;
-}
-
-function sameStyle(a: Cell, b: Cell): boolean {
-  return a.fg === b.fg && a.bg === b.bg && a.bold === b.bold;
 }
 
 export function toANSI(frame: Frame): string {

--- a/packages/tui/lib/render/ansi.ts
+++ b/packages/tui/lib/render/ansi.ts
@@ -1,0 +1,51 @@
+import type { Cell } from "../elements.js";
+import type { Frame } from "../frame.js";
+import { ansiColors, ansiBgColors } from "../colors.js";
+import { flatten } from "./flatten.js";
+
+const RESET = "\x1b[0m";
+const BOLD = "\x1b[1m";
+
+function cellEscapes(cell: Cell): string {
+  let seq = "";
+  if (cell.bold) seq += BOLD;
+  if (cell.fg) seq += ansiColors[cell.fg] ?? "";
+  if (cell.bg) seq += ansiBgColors[cell.bg] ?? "";
+  return seq;
+}
+
+function sameStyle(a: Cell, b: Cell): boolean {
+  return a.fg === b.fg && a.bg === b.bg && a.bold === b.bold;
+}
+
+export function toANSI(frame: Frame): string {
+  const grid = flatten(frame, frame.width, frame.height);
+  const lines: string[] = [];
+
+  for (const row of grid) {
+    let line = "";
+    let i = 0;
+    while (i < row.length) {
+      const cell = row[i];
+      const esc = cellEscapes(cell);
+
+      // Collect run of cells with same style
+      let run = cell.char;
+      let j = i + 1;
+      while (j < row.length && sameStyle(row[j], cell)) {
+        run += row[j].char;
+        j++;
+      }
+
+      if (esc) {
+        line += esc + run + RESET;
+      } else {
+        line += run;
+      }
+      i = j;
+    }
+    lines.push(line);
+  }
+
+  return lines.join("\n");
+}

--- a/packages/tui/lib/render/flatten.ts
+++ b/packages/tui/lib/render/flatten.ts
@@ -1,0 +1,39 @@
+import type { Cell } from "../elements.js";
+import type { Frame } from "../frame.js";
+
+/**
+ * Composite a Frame tree into a flat 2D grid of Cells.
+ * Recursively blits children on top of parents.
+ */
+export function flatten(frame: Frame, width: number, height: number): Cell[][] {
+  // Initialize grid with spaces
+  const grid: Cell[][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => ({ char: " " })),
+  );
+
+  blitFrame(grid, frame, width, height);
+  return grid;
+}
+
+function blitFrame(grid: Cell[][], frame: Frame, gridWidth: number, gridHeight: number): void {
+  // Blit this frame's content cells
+  if (frame.content) {
+    for (let y = 0; y < frame.content.length; y++) {
+      const gridY = frame.y + y;
+      if (gridY < 0 || gridY >= gridHeight) continue;
+      const row = frame.content[y];
+      for (let x = 0; x < row.length; x++) {
+        const gridX = frame.x + x;
+        if (gridX < 0 || gridX >= gridWidth) continue;
+        grid[gridY][gridX] = row[x];
+      }
+    }
+  }
+
+  // Recursively blit children on top
+  if (frame.children) {
+    for (const child of frame.children) {
+      blitFrame(grid, child, gridWidth, gridHeight);
+    }
+  }
+}

--- a/packages/tui/lib/render/flatten.ts
+++ b/packages/tui/lib/render/flatten.ts
@@ -4,36 +4,35 @@ import type { Frame } from "../frame.js";
 /**
  * Composite a Frame tree into a flat 2D grid of Cells.
  * Recursively blits children on top of parents.
+ * Uses the frame's own x/y as the origin so sub-frames
+ * returned by findByKey() render correctly.
  */
 export function flatten(frame: Frame, width: number, height: number): Cell[][] {
-  // Initialize grid with spaces
   const grid: Cell[][] = Array.from({ length: height }, () =>
     Array.from({ length: width }, () => ({ char: " " })),
   );
 
-  blitFrame(grid, frame, width, height);
+  blitFrame(grid, frame, width, height, frame.x, frame.y);
   return grid;
 }
 
-function blitFrame(grid: Cell[][], frame: Frame, gridWidth: number, gridHeight: number): void {
-  // Blit this frame's content cells
+function blitFrame(grid: Cell[][], frame: Frame, gridWidth: number, gridHeight: number, originX: number, originY: number): void {
   if (frame.content) {
     for (let y = 0; y < frame.content.length; y++) {
-      const gridY = frame.y + y;
+      const gridY = frame.y - originY + y;
       if (gridY < 0 || gridY >= gridHeight) continue;
       const row = frame.content[y];
       for (let x = 0; x < row.length; x++) {
-        const gridX = frame.x + x;
+        const gridX = frame.x - originX + x;
         if (gridX < 0 || gridX >= gridWidth) continue;
         grid[gridY][gridX] = row[x];
       }
     }
   }
 
-  // Recursively blit children on top
   if (frame.children) {
     for (const child of frame.children) {
-      blitFrame(grid, child, gridWidth, gridHeight);
+      blitFrame(grid, child, gridWidth, gridHeight, originX, originY);
     }
   }
 }

--- a/packages/tui/lib/render/html.ts
+++ b/packages/tui/lib/render/html.ts
@@ -1,7 +1,7 @@
 import type { Cell } from "../elements.js";
 import type { Frame } from "../frame.js";
 import { cssColors } from "../colors.js";
-import { sameStyle } from "../utils.js";
+import { sameStyle, escapeHtml } from "../utils.js";
 import { flatten } from "./flatten.js";
 
 function cellStyle(cell: Cell): string {
@@ -18,13 +18,6 @@ function cellStyle(cell: Cell): string {
   return parts.join(";");
 }
 
-function escapeHTML(ch: string): string {
-  if (ch === "<") return "&lt;";
-  if (ch === ">") return "&gt;";
-  if (ch === "&") return "&amp;";
-  return ch;
-}
-
 export function toHTML(frame: Frame): string {
   const grid = flatten(frame, frame.width, frame.height);
   const lines: string[] = [];
@@ -37,10 +30,10 @@ export function toHTML(frame: Frame): string {
       const style = cellStyle(cell);
 
       // Collect run of cells with same style
-      let run = escapeHTML(cell.char);
+      let run = escapeHtml(cell.char);
       let j = i + 1;
       while (j < row.length && sameStyle(row[j], cell)) {
-        run += escapeHTML(row[j].char);
+        run += escapeHtml(row[j].char);
         j++;
       }
 

--- a/packages/tui/lib/render/html.ts
+++ b/packages/tui/lib/render/html.ts
@@ -1,0 +1,64 @@
+import type { Cell } from "../elements.js";
+import type { Frame } from "../frame.js";
+import { cssColors } from "../colors.js";
+import { flatten } from "./flatten.js";
+
+function cellStyle(cell: Cell): string {
+  const parts: string[] = [];
+  if (cell.fg) {
+    const color = cssColors[cell.fg] ?? cell.fg;
+    parts.push(`color:${color}`);
+  }
+  if (cell.bg) {
+    const color = cssColors[cell.bg] ?? cell.bg;
+    parts.push(`background-color:${color}`);
+  }
+  if (cell.bold) {
+    parts.push("font-weight:bold");
+  }
+  return parts.join(";");
+}
+
+function sameStyle(a: Cell, b: Cell): boolean {
+  return a.fg === b.fg && a.bg === b.bg && a.bold === b.bold;
+}
+
+function escapeHTML(ch: string): string {
+  if (ch === "<") return "&lt;";
+  if (ch === ">") return "&gt;";
+  if (ch === "&") return "&amp;";
+  return ch;
+}
+
+export function toHTML(frame: Frame): string {
+  const grid = flatten(frame, frame.width, frame.height);
+  const lines: string[] = [];
+
+  for (const row of grid) {
+    let line = "";
+    let i = 0;
+    while (i < row.length) {
+      const cell = row[i];
+      const style = cellStyle(cell);
+
+      // Collect run of cells with same style
+      let run = escapeHTML(cell.char);
+      let j = i + 1;
+      while (j < row.length && sameStyle(row[j], cell)) {
+        run += escapeHTML(row[j].char);
+        j++;
+      }
+
+      if (style) {
+        line += `<span style="${style}">${run}</span>`;
+      } else {
+        line += run;
+      }
+      i = j;
+    }
+    lines.push(line);
+  }
+
+  const body = lines.join("\n");
+  return `<pre style="font-family:monospace;line-height:1;margin:0">${body}</pre>`;
+}

--- a/packages/tui/lib/render/html.ts
+++ b/packages/tui/lib/render/html.ts
@@ -1,6 +1,7 @@
 import type { Cell } from "../elements.js";
 import type { Frame } from "../frame.js";
 import { cssColors } from "../colors.js";
+import { sameStyle } from "../utils.js";
 import { flatten } from "./flatten.js";
 
 function cellStyle(cell: Cell): string {
@@ -17,10 +18,6 @@ function cellStyle(cell: Cell): string {
     parts.push("font-weight:bold");
   }
   return parts.join(";");
-}
-
-function sameStyle(a: Cell, b: Cell): boolean {
-  return a.fg === b.fg && a.bg === b.bg && a.bold === b.bold;
 }
 
 function escapeHTML(ch: string): string {

--- a/packages/tui/lib/render/html.ts
+++ b/packages/tui/lib/render/html.ts
@@ -6,13 +6,11 @@ import { flatten } from "./flatten.js";
 
 function cellStyle(cell: Cell): string {
   const parts: string[] = [];
-  if (cell.fg) {
-    const color = cssColors[cell.fg] ?? cell.fg;
-    parts.push(`color:${color}`);
+  if (cell.fg && cell.fg in cssColors) {
+    parts.push(`color:${cssColors[cell.fg]}`);
   }
-  if (cell.bg) {
-    const color = cssColors[cell.bg] ?? cell.bg;
-    parts.push(`background-color:${color}`);
+  if (cell.bg && cell.bg in cssColors) {
+    parts.push(`background-color:${cssColors[cell.bg]}`);
   }
   if (cell.bold) {
     parts.push("font-weight:bold");

--- a/packages/tui/lib/render/html.ts
+++ b/packages/tui/lib/render/html.ts
@@ -6,10 +6,10 @@ import { flatten } from "./flatten.js";
 
 function cellStyle(cell: Cell): string {
   const parts: string[] = [];
-  if (cell.fg && cell.fg in cssColors) {
+  if (cell.fg && Object.prototype.hasOwnProperty.call(cssColors, cell.fg)) {
     parts.push(`color:${cssColors[cell.fg]}`);
   }
-  if (cell.bg && cell.bg in cssColors) {
+  if (cell.bg && Object.prototype.hasOwnProperty.call(cssColors, cell.bg)) {
     parts.push(`background-color:${cssColors[cell.bg]}`);
   }
   if (cell.bold) {

--- a/packages/tui/lib/render/plaintext.ts
+++ b/packages/tui/lib/render/plaintext.ts
@@ -1,0 +1,9 @@
+import type { Frame } from "../frame.js";
+import { flatten } from "./flatten.js";
+
+export function toPlainText(frame: Frame): string {
+  const grid = flatten(frame, frame.width, frame.height);
+  return grid
+    .map((row) => row.map((c) => c.char).join("").trimEnd())
+    .join("\n");
+}

--- a/packages/tui/lib/render/renderer.ts
+++ b/packages/tui/lib/render/renderer.ts
@@ -2,6 +2,7 @@ import type { Cell, PositionedElement } from "../elements.js";
 import type { FrameStyle } from "../elements.js";
 import { Frame } from "../frame.js";
 import { parseStyledText } from "../styleParser.js";
+import { resolveEdges } from "../utils.js";
 
 // Box-drawing characters for borders
 const BORDER = {
@@ -12,6 +13,14 @@ const BORDER = {
   horizontal: "─",
   vertical: "│",
 };
+
+function blitCells(dest: Cell[][], src: Cell[][], startX: number, startY: number, maxW: number, maxH: number): void {
+  for (let y = 0; y < src.length && y < maxH; y++) {
+    for (let x = 0; x < src[y].length && x < maxW; x++) {
+      dest[startY + y][startX + x] = src[y][x];
+    }
+  }
+}
 
 function emptyCell(bg?: string): Cell {
   return { char: " ", bg };
@@ -165,7 +174,7 @@ export function render(positioned: PositionedElement, parentScrollOffset = 0): F
   const hasBorder = style.border ?? false;
   const borderSize = hasBorder ? 1 : 0;
 
-  const padding = normalizePadding(style.padding);
+  const padding = resolveEdges(style.padding);
   const width = positioned.resolvedWidth;
   const height = positioned.resolvedHeight;
 
@@ -193,14 +202,14 @@ export function render(positioned: PositionedElement, parentScrollOffset = 0): F
 
   // Render inner content based on element type
   let innerContent: Cell[][] | undefined;
+  const effectiveScrollOffset = style.scrollOffset ?? parentScrollOffset;
 
-  if (positioned.type === "text" && positioned.content !== undefined) {
-    const scrollOffset = style.scrollOffset ?? parentScrollOffset;
+  if ((positioned.type === "text" || positioned.type === "box") && positioned.content !== undefined) {
     innerContent = renderTextContent(
       positioned.content,
       innerWidth,
       innerHeight,
-      scrollOffset,
+      effectiveScrollOffset,
       style.fg,
       style.bg,
       style.bold,
@@ -223,42 +232,11 @@ export function render(positioned: PositionedElement, parentScrollOffset = 0): F
     );
   }
 
-  // If there's inner content, blit it into the frame grid
   if (innerContent) {
     if (!content) {
       content = makeGrid(width, height, style.bg);
     }
-    const startX = borderSize + padding.left;
-    const startY = borderSize + padding.top;
-    for (let y = 0; y < innerContent.length && y < innerHeight; y++) {
-      for (let x = 0; x < innerContent[y].length && x < innerWidth; x++) {
-        content[startY + y][startX + x] = innerContent[y][x];
-      }
-    }
-  }
-
-  // Handle box elements with text content (box wrapping a text child is
-  // handled by recursion, but a box can also have direct content)
-  if (positioned.type === "box" && positioned.content !== undefined) {
-    const boxInner = renderTextContent(
-      positioned.content,
-      innerWidth,
-      innerHeight,
-      style.scrollOffset ?? 0,
-      style.fg,
-      style.bg,
-      style.bold,
-    );
-    if (!content) {
-      content = makeGrid(width, height, style.bg);
-    }
-    const startX = borderSize + padding.left;
-    const startY = borderSize + padding.top;
-    for (let y = 0; y < boxInner.length && y < innerHeight; y++) {
-      for (let x = 0; x < boxInner[y].length && x < innerWidth; x++) {
-        content[startY + y][startX + x] = boxInner[y][x];
-      }
-    }
+    blitCells(content, innerContent, borderSize + padding.left, borderSize + padding.top, innerWidth, innerHeight);
   }
 
   // Recurse into children, passing scroll offset if this element is scrollable
@@ -277,15 +255,4 @@ export function render(positioned: PositionedElement, parentScrollOffset = 0): F
   });
 
   return frame;
-}
-
-function normalizePadding(padding: undefined | number | { top?: number; bottom?: number; left?: number; right?: number }): { top: number; bottom: number; left: number; right: number } {
-  if (padding === undefined) return { top: 0, bottom: 0, left: 0, right: 0 };
-  if (typeof padding === "number") return { top: padding, bottom: padding, left: padding, right: padding };
-  return {
-    top: padding.top ?? 0,
-    bottom: padding.bottom ?? 0,
-    left: padding.left ?? 0,
-    right: padding.right ?? 0,
-  };
 }

--- a/packages/tui/lib/render/renderer.ts
+++ b/packages/tui/lib/render/renderer.ts
@@ -1,0 +1,291 @@
+import type { Cell, PositionedElement } from "../elements.js";
+import type { FrameStyle } from "../elements.js";
+import { Frame } from "../frame.js";
+import { parseStyledText } from "../styleParser.js";
+
+// Box-drawing characters for borders
+const BORDER = {
+  topLeft: "┌",
+  topRight: "┐",
+  bottomLeft: "└",
+  bottomRight: "┘",
+  horizontal: "─",
+  vertical: "│",
+};
+
+function emptyCell(bg?: string): Cell {
+  return { char: " ", bg };
+}
+
+function makeRow(width: number, bg?: string): Cell[] {
+  return Array.from({ length: width }, () => emptyCell(bg));
+}
+
+function makeGrid(width: number, height: number, bg?: string): Cell[][] {
+  return Array.from({ length: height }, () => makeRow(width, bg));
+}
+
+function renderBorder(grid: Cell[][], width: number, height: number, borderColor?: string, label?: string, labelColor?: string): void {
+  if (height < 2 || width < 2) return;
+
+  // Top row
+  grid[0][0] = { char: BORDER.topLeft, fg: borderColor };
+  for (let x = 1; x < width - 1; x++) {
+    grid[0][x] = { char: BORDER.horizontal, fg: borderColor };
+  }
+  grid[0][width - 1] = { char: BORDER.topRight, fg: borderColor };
+
+  // Bottom row
+  grid[height - 1][0] = { char: BORDER.bottomLeft, fg: borderColor };
+  for (let x = 1; x < width - 1; x++) {
+    grid[height - 1][x] = { char: BORDER.horizontal, fg: borderColor };
+  }
+  grid[height - 1][width - 1] = { char: BORDER.bottomRight, fg: borderColor };
+
+  // Side borders
+  for (let y = 1; y < height - 1; y++) {
+    grid[y][0] = { char: BORDER.vertical, fg: borderColor };
+    grid[y][width - 1] = { char: BORDER.vertical, fg: borderColor };
+  }
+
+  // Label on top border
+  if (label && width > 2) {
+    const maxLabelLen = width - 2;
+    const truncated = label.slice(0, maxLabelLen);
+    for (let i = 0; i < truncated.length; i++) {
+      grid[0][1 + i] = { char: truncated[i], fg: labelColor ?? borderColor };
+    }
+  }
+}
+
+function renderTextContent(
+  content: string,
+  innerWidth: number,
+  innerHeight: number,
+  scrollOffset: number,
+  fg?: string,
+  bg?: string,
+  bold?: boolean,
+): Cell[][] {
+  const lines = content.split("\n");
+  const visibleLines = lines.slice(scrollOffset, scrollOffset + innerHeight);
+  const grid: Cell[][] = [];
+
+  for (const line of visibleLines) {
+    const spans = parseStyledText(line);
+    const row: Cell[] = [];
+    for (const span of spans) {
+      for (const ch of span.text) {
+        if (row.length >= innerWidth) break;
+        row.push({
+          char: ch,
+          fg: span.fg ?? fg,
+          bg: span.bg ?? bg,
+          bold: span.bold ?? bold,
+        });
+      }
+    }
+    // Pad to inner width
+    while (row.length < innerWidth) {
+      row.push(emptyCell(bg));
+    }
+    grid.push(row);
+  }
+
+  // Pad remaining rows
+  while (grid.length < innerHeight) {
+    grid.push(makeRow(innerWidth, bg));
+  }
+
+  return grid;
+}
+
+function renderListContent(
+  items: string[],
+  selectedIndex: number | undefined,
+  innerWidth: number,
+  innerHeight: number,
+  fg?: string,
+  bg?: string,
+): Cell[][] {
+  // Auto-scroll to keep selected item visible
+  let scrollOffset = 0;
+  if (selectedIndex !== undefined && selectedIndex >= innerHeight) {
+    scrollOffset = selectedIndex - innerHeight + 1;
+  }
+
+  const grid: Cell[][] = [];
+  for (let i = 0; i < innerHeight; i++) {
+    const itemIdx = i + scrollOffset;
+    if (itemIdx >= items.length) {
+      grid.push(makeRow(innerWidth, bg));
+      continue;
+    }
+
+    const isSelected = itemIdx === selectedIndex;
+    const itemBg = isSelected ? "blue" : bg;
+    const itemFg = isSelected ? "white" : fg;
+    const text = items[itemIdx].slice(0, innerWidth);
+    const row: Cell[] = [];
+    for (const ch of text) {
+      row.push({ char: ch, fg: itemFg, bg: itemBg });
+    }
+    while (row.length < innerWidth) {
+      row.push(emptyCell(itemBg));
+    }
+    grid.push(row);
+  }
+
+  return grid;
+}
+
+function renderTextInputContent(
+  value: string | undefined,
+  innerWidth: number,
+  fg?: string,
+  bg?: string,
+): Cell[][] {
+  const text = (value ?? "").slice(0, innerWidth);
+  const row: Cell[] = [];
+  for (const ch of text) {
+    row.push({ char: ch, fg, bg });
+  }
+  // Cursor position
+  if (row.length < innerWidth) {
+    row.push({ char: "█", fg, bg });
+  }
+  while (row.length < innerWidth) {
+    row.push(emptyCell(bg));
+  }
+  return [row];
+}
+
+export function render(positioned: PositionedElement, parentScrollOffset = 0): Frame {
+  const style = positioned.style ?? {};
+  const hasBorder = style.border ?? false;
+  const borderSize = hasBorder ? 1 : 0;
+
+  const padding = normalizePadding(style.padding);
+  const width = positioned.resolvedWidth;
+  const height = positioned.resolvedHeight;
+
+  const innerWidth = Math.max(0, width - 2 * borderSize - padding.left - padding.right);
+  const innerHeight = Math.max(0, height - 2 * borderSize - padding.top - padding.bottom);
+
+  const frameStyle: FrameStyle = {
+    border: hasBorder || undefined,
+    borderColor: style.borderColor,
+    bg: style.bg,
+    label: style.label,
+    labelColor: style.labelColor,
+  };
+
+  // Build content cells for this frame
+  let content: Cell[][] | undefined;
+
+  if (hasBorder || style.bg) {
+    // Start with a full grid for the frame (border + bg fill)
+    content = makeGrid(width, height, style.bg);
+    if (hasBorder) {
+      renderBorder(content, width, height, style.borderColor, style.label, style.labelColor);
+    }
+  }
+
+  // Render inner content based on element type
+  let innerContent: Cell[][] | undefined;
+
+  if (positioned.type === "text" && positioned.content !== undefined) {
+    const scrollOffset = style.scrollOffset ?? parentScrollOffset;
+    innerContent = renderTextContent(
+      positioned.content,
+      innerWidth,
+      innerHeight,
+      scrollOffset,
+      style.fg,
+      style.bg,
+      style.bold,
+    );
+  } else if (positioned.type === "list" && positioned.items) {
+    innerContent = renderListContent(
+      positioned.items,
+      positioned.selectedIndex,
+      innerWidth,
+      innerHeight,
+      style.fg,
+      style.bg,
+    );
+  } else if (positioned.type === "textInput") {
+    innerContent = renderTextInputContent(
+      positioned.value,
+      innerWidth,
+      style.fg,
+      style.bg,
+    );
+  }
+
+  // If there's inner content, blit it into the frame grid
+  if (innerContent) {
+    if (!content) {
+      content = makeGrid(width, height, style.bg);
+    }
+    const startX = borderSize + padding.left;
+    const startY = borderSize + padding.top;
+    for (let y = 0; y < innerContent.length && y < innerHeight; y++) {
+      for (let x = 0; x < innerContent[y].length && x < innerWidth; x++) {
+        content[startY + y][startX + x] = innerContent[y][x];
+      }
+    }
+  }
+
+  // Handle box elements with text content (box wrapping a text child is
+  // handled by recursion, but a box can also have direct content)
+  if (positioned.type === "box" && positioned.content !== undefined) {
+    const boxInner = renderTextContent(
+      positioned.content,
+      innerWidth,
+      innerHeight,
+      style.scrollOffset ?? 0,
+      style.fg,
+      style.bg,
+      style.bold,
+    );
+    if (!content) {
+      content = makeGrid(width, height, style.bg);
+    }
+    const startX = borderSize + padding.left;
+    const startY = borderSize + padding.top;
+    for (let y = 0; y < boxInner.length && y < innerHeight; y++) {
+      for (let x = 0; x < boxInner[y].length && x < innerWidth; x++) {
+        content[startY + y][startX + x] = boxInner[y][x];
+      }
+    }
+  }
+
+  // Recurse into children, passing scroll offset if this element is scrollable
+  const scrollForChildren = style.scrollable ? (style.scrollOffset ?? 0) : 0;
+  const childFrames = ((positioned.children ?? []) as PositionedElement[]).map((child) => render(child, scrollForChildren));
+
+  const frame = new Frame({
+    key: positioned.key,
+    x: positioned.resolvedX,
+    y: positioned.resolvedY,
+    width,
+    height,
+    style: frameStyle,
+    content,
+    children: childFrames.length > 0 ? childFrames : undefined,
+  });
+
+  return frame;
+}
+
+function normalizePadding(padding: undefined | number | { top?: number; bottom?: number; left?: number; right?: number }): { top: number; bottom: number; left: number; right: number } {
+  if (padding === undefined) return { top: 0, bottom: 0, left: 0, right: 0 };
+  if (typeof padding === "number") return { top: padding, bottom: padding, left: padding, right: padding };
+  return {
+    top: padding.top ?? 0,
+    bottom: padding.bottom ?? 0,
+    left: padding.left ?? 0,
+    right: padding.right ?? 0,
+  };
+}

--- a/packages/tui/lib/screen.ts
+++ b/packages/tui/lib/screen.ts
@@ -1,0 +1,44 @@
+import type { Element } from "./elements.js";
+import type { InputSource, KeyEvent } from "./input/types.js";
+import type { OutputTarget } from "./output/types.js";
+import { layout } from "./layout.js";
+import { render } from "./render/renderer.js";
+import { Frame } from "./frame.js";
+
+export class Screen {
+  private output: OutputTarget;
+  private input: InputSource;
+  private width: number;
+  private height: number;
+
+  constructor(opts: { output: OutputTarget; input: InputSource; width: number; height: number }) {
+    this.output = opts.output;
+    this.input = opts.input;
+    this.width = opts.width;
+    this.height = opts.height;
+  }
+
+  render(root: Element, label?: string): Frame {
+    const positioned = layout(root, this.width, this.height);
+    const frame = render(positioned);
+    this.output.write(frame, label);
+    return frame;
+  }
+
+  nextKey(): Promise<KeyEvent> {
+    return this.input.nextKey();
+  }
+
+  nextLine(prompt: string): Promise<string> {
+    return this.input.nextLine(prompt);
+  }
+
+  size(): { width: number; height: number } {
+    return { width: this.width, height: this.height };
+  }
+
+  destroy(): void {
+    this.input.destroy();
+    if (this.output.flush) this.output.flush();
+  }
+}

--- a/packages/tui/lib/screen.ts
+++ b/packages/tui/lib/screen.ts
@@ -39,6 +39,6 @@ export class Screen {
 
   destroy(): void {
     this.input.destroy();
-    if (this.output.flush) this.output.flush();
+    if (this.output.destroy) this.output.destroy();
   }
 }

--- a/packages/tui/lib/styleParser.ts
+++ b/packages/tui/lib/styleParser.ts
@@ -10,7 +10,7 @@ type StyleEntry =
   | { type: "fg"; color: string }
   | { type: "bg"; color: string };
 
-const TAG_RE = /\{(\/?)([^}]+)\}/g;
+const TAG_RE = /(?<!\\)\{(\/?)([^}]+)(?<!\\)\}/g;
 
 function currentStyle(stack: StyleEntry[]): Omit<StyledSpan, "text"> {
   const style: Omit<StyledSpan, "text"> = {};
@@ -22,12 +22,22 @@ function currentStyle(stack: StyleEntry[]): Omit<StyledSpan, "text"> {
   return style;
 }
 
+function unescape(text: string): string {
+  return text.replace(/\\([{}])/g, "$1");
+}
+
 function makeSpan(text: string, style: Omit<StyledSpan, "text">): StyledSpan {
-  const span: StyledSpan = { text };
+  const span: StyledSpan = { text: unescape(text) };
   if (style.bold) span.bold = true;
   if (style.fg) span.fg = style.fg;
   if (style.bg) span.bg = style.bg;
   return span;
+}
+
+function matchesEntry(a: StyleEntry, b: StyleEntry): boolean {
+  if (a.type !== b.type) return false;
+  if (a.type === "bold") return true;
+  return (a as { color: string }).color === (b as { color: string }).color;
 }
 
 function parseTag(tag: string): StyleEntry | null {
@@ -58,9 +68,8 @@ export function parseStyledText(input: string): StyledSpan[] {
     const entry = parseTag(tagName);
     if (entry) {
       if (isClosing) {
-        // Pop matching entry from stack
         for (let i = stack.length - 1; i >= 0; i--) {
-          if (stack[i].type === entry.type) {
+          if (matchesEntry(stack[i], entry)) {
             stack.splice(i, 1);
             break;
           }

--- a/packages/tui/lib/styleParser.ts
+++ b/packages/tui/lib/styleParser.ts
@@ -77,6 +77,9 @@ export function parseStyledText(input: string): StyledSpan[] {
       } else {
         stack.push(entry);
       }
+    } else {
+      // Unrecognized tag — treat as literal text
+      spans.push(makeSpan(fullMatch, currentStyle(stack)));
     }
 
     lastIndex = match.index + fullMatch.length;

--- a/packages/tui/lib/styleParser.ts
+++ b/packages/tui/lib/styleParser.ts
@@ -10,7 +10,7 @@ type StyleEntry =
   | { type: "fg"; color: string }
   | { type: "bg"; color: string };
 
-const TAG_RE = /(?<!\\)\{(\/?)([^}]+)(?<!\\)\}/g;
+const TAG_PATTERN = /(?<!\\)\{(\/?)([^}]+)(?<!\\)\}/g;
 
 function currentStyle(stack: StyleEntry[]): Omit<StyledSpan, "text"> {
   const style: Omit<StyledSpan, "text"> = {};
@@ -54,9 +54,9 @@ export function parseStyledText(input: string): StyledSpan[] {
   const stack: StyleEntry[] = [];
   let lastIndex = 0;
 
-  TAG_RE.lastIndex = 0;
+  const tagRe = new RegExp(TAG_PATTERN.source, TAG_PATTERN.flags);
   let match;
-  while ((match = TAG_RE.exec(input)) !== null) {
+  while ((match = tagRe.exec(input)) !== null) {
     const [fullMatch, isClosing, tagName] = match;
 
     // Text before this tag

--- a/packages/tui/lib/styleParser.ts
+++ b/packages/tui/lib/styleParser.ts
@@ -1,0 +1,86 @@
+export type StyledSpan = {
+  text: string;
+  fg?: string;
+  bg?: string;
+  bold?: boolean;
+};
+
+type StyleEntry =
+  | { type: "bold" }
+  | { type: "fg"; color: string }
+  | { type: "bg"; color: string };
+
+const TAG_RE = /\{(\/?)([^}]+)\}/g;
+
+function currentStyle(stack: StyleEntry[]): Omit<StyledSpan, "text"> {
+  const style: Omit<StyledSpan, "text"> = {};
+  for (const entry of stack) {
+    if (entry.type === "bold") style.bold = true;
+    else if (entry.type === "fg") style.fg = entry.color;
+    else if (entry.type === "bg") style.bg = entry.color;
+  }
+  return style;
+}
+
+function makeSpan(text: string, style: Omit<StyledSpan, "text">): StyledSpan {
+  const span: StyledSpan = { text };
+  if (style.bold) span.bold = true;
+  if (style.fg) span.fg = style.fg;
+  if (style.bg) span.bg = style.bg;
+  return span;
+}
+
+function parseTag(tag: string): StyleEntry | null {
+  if (tag === "bold") return { type: "bold" };
+  if (tag.endsWith("-fg")) return { type: "fg", color: tag.slice(0, -3) };
+  if (tag.endsWith("-bg")) return { type: "bg", color: tag.slice(0, -3) };
+  return null;
+}
+
+export function parseStyledText(input: string): StyledSpan[] {
+  if (input === "") return [];
+
+  const spans: StyledSpan[] = [];
+  const stack: StyleEntry[] = [];
+  let lastIndex = 0;
+
+  TAG_RE.lastIndex = 0;
+  let match;
+  while ((match = TAG_RE.exec(input)) !== null) {
+    const [fullMatch, isClosing, tagName] = match;
+
+    // Text before this tag
+    if (match.index > lastIndex) {
+      const textBefore = input.slice(lastIndex, match.index);
+      spans.push(makeSpan(textBefore, currentStyle(stack)));
+    }
+
+    const entry = parseTag(tagName);
+    if (entry) {
+      if (isClosing) {
+        // Pop matching entry from stack
+        for (let i = stack.length - 1; i >= 0; i--) {
+          if (stack[i].type === entry.type) {
+            stack.splice(i, 1);
+            break;
+          }
+        }
+      } else {
+        stack.push(entry);
+      }
+    }
+
+    lastIndex = match.index + fullMatch.length;
+  }
+
+  // Remaining text after last tag
+  if (lastIndex < input.length) {
+    spans.push(makeSpan(input.slice(lastIndex), currentStyle(stack)));
+  }
+
+  return spans;
+}
+
+export function escapeStyleTags(text: string): string {
+  return text.replace(/[{}]/g, (ch) => `\\${ch}`);
+}

--- a/packages/tui/lib/utils.ts
+++ b/packages/tui/lib/utils.ts
@@ -16,3 +16,7 @@ export function resolveEdges(value: number | { top?: number; bottom?: number; le
 export function sameStyle(a: Cell, b: Cell): boolean {
   return a.fg === b.fg && a.bg === b.bg && a.bold === b.bold;
 }
+
+export function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/packages/tui/lib/utils.ts
+++ b/packages/tui/lib/utils.ts
@@ -1,0 +1,18 @@
+import type { Cell } from "./elements.js";
+
+export type Edges = { top: number; bottom: number; left: number; right: number };
+
+export function resolveEdges(value: number | { top?: number; bottom?: number; left?: number; right?: number } | undefined): Edges {
+  if (value === undefined) return { top: 0, bottom: 0, left: 0, right: 0 };
+  if (typeof value === "number") return { top: value, bottom: value, left: value, right: value };
+  return {
+    top: value.top ?? 0,
+    bottom: value.bottom ?? 0,
+    left: value.left ?? 0,
+    right: value.right ?? 0,
+  };
+}
+
+export function sameStyle(a: Cell, b: Cell): boolean {
+  return a.fg === b.fg && a.bg === b.bg && a.bold === b.bold;
+}

--- a/packages/tui/makefile
+++ b/packages/tui/makefile
@@ -1,0 +1,5 @@
+all:
+	pnpm run build
+
+publish:
+	npm publish --access public --no-git-checks

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@agency-lang/tui",
+  "version": "0.0.1",
+  "description": "A testable TUI library with immediate-mode rendering and flexbox layout",
+  "type": "module",
+  "main": "./dist/lib/index.js",
+  "types": "./dist/lib/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/lib/index.d.ts",
+      "import": "./dist/lib/index.js"
+    }
+  },
+  "files": ["dist/"],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest",
+    "test:run": "vitest run"
+  },
+  "keywords": ["tui", "terminal", "ui", "flexbox"],
+  "author": "Aditya Bhargava",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -9,7 +9,8 @@
     ".": {
       "types": "./dist/lib/index.d.ts",
       "import": "./dist/lib/index.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": ["dist/"],
   "scripts": {
@@ -21,7 +22,7 @@
   "author": "Aditya Bhargava",
   "license": "ISC",
   "devDependencies": {
-    "@types/node": "^22.0.0",
+    "@types/node": "^25.0.0",
     "typescript": "^5.0.0",
     "vitest": "^3.0.0"
   }

--- a/packages/tui/test/builders.test.ts
+++ b/packages/tui/test/builders.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { box, row, column, text, list, textInput } from "../lib/builders.js";
+
+describe("builders", () => {
+  it("text() creates a text element", () => {
+    const el = text("hello");
+    expect(el).toEqual({ type: "text", content: "hello" });
+  });
+
+  it("box() with style and children", () => {
+    const el = box({ border: true, key: "mybox" }, text("hi"));
+    expect(el.type).toBe("box");
+    expect(el.key).toBe("mybox");
+    expect(el.style?.border).toBe(true);
+    expect(el.children).toHaveLength(1);
+    expect(el.children![0].content).toBe("hi");
+  });
+
+  it("box() without style treats all args as children", () => {
+    const el = box(text("a"), text("b"));
+    expect(el.type).toBe("box");
+    expect(el.style).toBeUndefined();
+    expect(el.children).toHaveLength(2);
+  });
+
+  it("row() sets flexDirection to row", () => {
+    const el = row({ flex: 1 }, text("a"));
+    expect(el.style?.flexDirection).toBe("row");
+  });
+
+  it("column() sets flexDirection to column", () => {
+    const el = column({ flex: 1 }, text("a"));
+    expect(el.style?.flexDirection).toBe("column");
+  });
+
+  it("list() creates a list element", () => {
+    const el = list({ key: "mylist" }, ["a", "b", "c"], 1);
+    expect(el.type).toBe("list");
+    expect(el.items).toEqual(["a", "b", "c"]);
+    expect(el.selectedIndex).toBe(1);
+  });
+
+  it("textInput() creates a textInput element", () => {
+    const el = textInput({ key: "input" }, "hello");
+    expect(el.type).toBe("textInput");
+    expect(el.value).toBe("hello");
+  });
+});

--- a/packages/tui/test/frame.test.ts
+++ b/packages/tui/test/frame.test.ts
@@ -43,4 +43,20 @@ describe("Frame", () => {
     });
     expect(frame.toPlainText()).toContain("hello");
   });
+
+  it("toPlainText works on nested frame with non-zero x/y via findByKey", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 80, height: 24, style: {},
+      children: [
+        new Frame({
+          key: "child", x: 10, y: 5, width: 5, height: 1, style: {},
+          content: [[
+            { char: "A" }, { char: "B" }, { char: "C" }, { char: " " }, { char: " " },
+          ]],
+        }),
+      ],
+    });
+    const child = frame.findByKey("child")!;
+    expect(child.toPlainText()).toContain("ABC");
+  });
 });

--- a/packages/tui/test/frame.test.ts
+++ b/packages/tui/test/frame.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { Frame } from "../lib/frame.js";
+
+describe("Frame", () => {
+  it("findByKey returns matching child", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 80, height: 24, style: {},
+      children: [
+        new Frame({ key: "a", x: 0, y: 0, width: 40, height: 24, style: {} }),
+        new Frame({ key: "b", x: 40, y: 0, width: 40, height: 24, style: {} }),
+      ],
+    });
+    expect(frame.findByKey("b")).toBeDefined();
+    expect(frame.findByKey("b")!.key).toBe("b");
+  });
+
+  it("findByKey searches recursively", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 80, height: 24, style: {},
+      children: [
+        new Frame({
+          key: "parent", x: 0, y: 0, width: 80, height: 24, style: {},
+          children: [
+            new Frame({ key: "nested", x: 0, y: 0, width: 40, height: 12, style: {} }),
+          ],
+        }),
+      ],
+    });
+    expect(frame.findByKey("nested")).toBeDefined();
+  });
+
+  it("findByKey returns undefined for missing key", () => {
+    const frame = new Frame({ x: 0, y: 0, width: 80, height: 24, style: {} });
+    expect(frame.findByKey("nope")).toBeUndefined();
+  });
+
+  it("toPlainText produces text from content cells", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 5, height: 1, style: {},
+      content: [[
+        { char: "h" }, { char: "e" }, { char: "l" }, { char: "l" }, { char: "o" },
+      ]],
+    });
+    expect(frame.toPlainText()).toContain("hello");
+  });
+});

--- a/packages/tui/test/html.test.ts
+++ b/packages/tui/test/html.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { toHTML } from "../lib/render/html.js";
+import { Frame } from "../lib/frame.js";
+
+describe("toHTML", () => {
+  it("produces HTML with monospace font", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 5, height: 1, style: {},
+      content: [[
+        { char: "h" }, { char: "i" }, { char: " " }, { char: " " }, { char: " " },
+      ]],
+    });
+    const html = toHTML(frame);
+    expect(html).toContain("monospace");
+    expect(html).toContain("hi");
+  });
+
+  it("produces colored spans for styled cells", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 2, height: 1, style: {},
+      content: [[
+        { char: "h", fg: "red" },
+        { char: "i", fg: "red" },
+      ]],
+    });
+    const html = toHTML(frame);
+    expect(html).toContain("hi");
+    // Should have color styling
+    expect(html).toContain("color:");
+  });
+
+  it("handles bold cells", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 2, height: 1, style: {},
+      content: [[
+        { char: "h", bold: true },
+        { char: "i", bold: true },
+      ]],
+    });
+    const html = toHTML(frame);
+    expect(html).toContain("font-weight:bold");
+  });
+
+  it("renders nested children", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 10, height: 2, style: {},
+      children: [
+        new Frame({
+          x: 0, y: 0, width: 3, height: 1, style: {},
+          content: [[{ char: "A" }, { char: "B" }, { char: "C" }]],
+        }),
+      ],
+    });
+    const html = toHTML(frame);
+    expect(html).toContain("ABC");
+  });
+});

--- a/packages/tui/test/layout.test.ts
+++ b/packages/tui/test/layout.test.ts
@@ -150,4 +150,66 @@ describe("layout", () => {
     const result = layout(el, 80, 24);
     expect(result.resolvedHeight).toBe(12);
   });
+
+  it("justifyContent flex-end pushes children to end", () => {
+    const el = column({ justifyContent: "flex-end" },
+      box({ key: "a", height: 5 }),
+    );
+    const result = layout(el, 80, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    expect(a.resolvedY).toBe(19); // 24 - 5
+  });
+
+  it("justifyContent center centers children", () => {
+    const el = row({ justifyContent: "center" },
+      box({ key: "a", width: 20 }),
+    );
+    const result = layout(el, 80, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    expect(a.resolvedX).toBe(30); // (80 - 20) / 2
+  });
+
+  it("justifyContent space-between distributes gaps", () => {
+    const el = row({ justifyContent: "space-between" },
+      box({ key: "a", width: 10 }),
+      box({ key: "b", width: 10 }),
+      box({ key: "c", width: 10 }),
+    );
+    const result = layout(el, 80, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    const b = result.children!.find(c => c.key === "b")!;
+    const c = result.children!.find(c => c.key === "c")!;
+    expect(a.resolvedX).toBe(0);
+    // gap = floor((80 - 30) / 2) = 25
+    expect(b.resolvedX).toBe(35); // 0 + 10 + 25
+    expect(c.resolvedX).toBe(70); // 35 + 10 + 25
+  });
+
+  it("alignItems center centers children on cross axis", () => {
+    const el = row({ alignItems: "center" },
+      box({ key: "a", width: 20, height: 10 }),
+    );
+    const result = layout(el, 80, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    expect(a.resolvedY).toBe(7); // (24 - 10) / 2
+    expect(a.resolvedHeight).toBe(10);
+  });
+
+  it("alignItems flex-end positions children at cross axis end", () => {
+    const el = row({ alignItems: "flex-end" },
+      box({ key: "a", width: 20, height: 10 }),
+    );
+    const result = layout(el, 80, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    expect(a.resolvedY).toBe(14); // 24 - 10
+  });
+
+  it("alignItems stretch fills cross axis (default)", () => {
+    const el = row(
+      box({ key: "a", width: 20 }),
+    );
+    const result = layout(el, 80, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    expect(a.resolvedHeight).toBe(24);
+  });
 });

--- a/packages/tui/test/layout.test.ts
+++ b/packages/tui/test/layout.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from "vitest";
+import { layout } from "../lib/layout.js";
+import { box, row, column, text } from "../lib/builders.js";
+
+describe("layout", () => {
+  it("single box fills available space", () => {
+    const el = box({ key: "a" });
+    const result = layout(el, 80, 24);
+    expect(result.resolvedX).toBe(0);
+    expect(result.resolvedY).toBe(0);
+    expect(result.resolvedWidth).toBe(80);
+    expect(result.resolvedHeight).toBe(24);
+  });
+
+  it("fixed width and height", () => {
+    const el = box({ width: 40, height: 10 });
+    const result = layout(el, 80, 24);
+    expect(result.resolvedWidth).toBe(40);
+    expect(result.resolvedHeight).toBe(10);
+  });
+
+  it("percentage width", () => {
+    const el = box({ width: "50%" });
+    const result = layout(el, 80, 24);
+    expect(result.resolvedWidth).toBe(40);
+  });
+
+  it("column direction stacks children vertically", () => {
+    const el = column(
+      box({ key: "a", height: 5 }),
+      box({ key: "b", height: 5 }),
+    );
+    const result = layout(el, 80, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    const b = result.children!.find(c => c.key === "b")!;
+    expect(a.resolvedY).toBe(0);
+    expect(b.resolvedY).toBe(5);
+  });
+
+  it("row direction places children horizontally", () => {
+    const el = row(
+      box({ key: "a", width: 20 }),
+      box({ key: "b", width: 30 }),
+    );
+    const result = layout(el, 80, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    const b = result.children!.find(c => c.key === "b")!;
+    expect(a.resolvedX).toBe(0);
+    expect(b.resolvedX).toBe(20);
+  });
+
+  it("flex distributes remaining space", () => {
+    const el = row(
+      box({ key: "a", width: 20 }),
+      box({ key: "b", flex: 1 }),
+    );
+    const result = layout(el, 80, 24);
+    const b = result.children!.find(c => c.key === "b")!;
+    expect(b.resolvedWidth).toBe(60);
+  });
+
+  it("multiple flex children split space proportionally", () => {
+    const el = row(
+      box({ key: "a", flex: 1 }),
+      box({ key: "b", flex: 2 }),
+    );
+    const result = layout(el, 90, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    const b = result.children!.find(c => c.key === "b")!;
+    expect(a.resolvedWidth).toBe(30);
+    expect(b.resolvedWidth).toBe(60);
+  });
+
+  it("border reduces inner space by 2 in each dimension", () => {
+    const el = box({ width: 20, height: 10, border: true },
+      box({ key: "inner", flex: 1 })
+    );
+    const result = layout(el, 80, 24);
+    const inner = result.children!.find(c => c.key === "inner")!;
+    expect(inner.resolvedWidth).toBe(18);
+    expect(inner.resolvedHeight).toBe(8);
+  });
+
+  it("invisible elements take no space", () => {
+    const el = column(
+      box({ key: "a", height: 5 }),
+      box({ key: "b", height: 5, visible: false }),
+      box({ key: "c", height: 5 }),
+    );
+    const result = layout(el, 80, 24);
+    const c = result.children!.find(c => c.key === "c")!;
+    expect(c.resolvedY).toBe(5);
+  });
+
+  it("nested layout", () => {
+    const el = column(
+      box({ key: "top", height: "40%" }),
+      row({ flex: 1 },
+        box({ key: "left", width: "50%" }),
+        box({ key: "right", flex: 1 }),
+      ),
+    );
+    const result = layout(el, 100, 20);
+    const top = result.children!.find(c => c.key === "top")!;
+    expect(top.resolvedHeight).toBe(8);
+    const rowEl = result.children![1];
+    const left = rowEl.children!.find(c => c.key === "left")!;
+    const right = rowEl.children!.find(c => c.key === "right")!;
+    expect(left.resolvedWidth).toBe(50);
+    expect(right.resolvedWidth).toBe(50);
+    expect(left.resolvedY).toBe(8);
+  });
+
+  it("padding reduces inner space", () => {
+    const el = box({ width: 20, height: 10, padding: 2 },
+      box({ key: "inner", flex: 1 })
+    );
+    const result = layout(el, 80, 24);
+    const inner = result.children!.find(c => c.key === "inner")!;
+    expect(inner.resolvedWidth).toBe(16);
+    expect(inner.resolvedHeight).toBe(6);
+  });
+
+  it("margin offsets element position", () => {
+    const el = column(
+      box({ key: "a", height: 5, margin: { top: 2, left: 3 } }),
+    );
+    const result = layout(el, 80, 24);
+    const a = result.children!.find(c => c.key === "a")!;
+    expect(a.resolvedX).toBe(3);
+    expect(a.resolvedY).toBe(2);
+  });
+
+  it("minWidth and minHeight are respected", () => {
+    const el = box({ width: 5, height: 3, minWidth: 10, minHeight: 8 });
+    const result = layout(el, 80, 24);
+    expect(result.resolvedWidth).toBe(10);
+    expect(result.resolvedHeight).toBe(8);
+  });
+
+  it("maxWidth and maxHeight are respected", () => {
+    const el = box({ width: 50, height: 30, maxWidth: 20, maxHeight: 10 });
+    const result = layout(el, 80, 40);
+    expect(result.resolvedWidth).toBe(20);
+    expect(result.resolvedHeight).toBe(10);
+  });
+
+  it("percentage height", () => {
+    const el = box({ height: "50%" });
+    const result = layout(el, 80, 24);
+    expect(result.resolvedHeight).toBe(12);
+  });
+});

--- a/packages/tui/test/plaintext.test.ts
+++ b/packages/tui/test/plaintext.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { toPlainText } from "../lib/render/plaintext.js";
+import { Frame } from "../lib/frame.js";
+
+describe("toPlainText", () => {
+  it("renders content cells as text", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 5, height: 1, style: {},
+      content: [[
+        { char: "h" }, { char: "i" }, { char: " " }, { char: " " }, { char: " " },
+      ]],
+    });
+    expect(toPlainText(frame)).toContain("hi");
+  });
+
+  it("renders nested children", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 80, height: 2, style: {},
+      children: [
+        new Frame({
+          key: "a", x: 0, y: 0, width: 5, height: 1, style: {},
+          content: [[{ char: "A" }, { char: "B" }, { char: "C" }, { char: " " }, { char: " " }]],
+        }),
+      ],
+    });
+    expect(toPlainText(frame)).toContain("ABC");
+  });
+
+  it("renders border characters", () => {
+    const frame = new Frame({
+      x: 0, y: 0, width: 5, height: 3, style: { border: true },
+      content: [
+        [{ char: "┌" }, { char: "─" }, { char: "─" }, { char: "─" }, { char: "┐" }],
+        [{ char: "│" }, { char: " " }, { char: " " }, { char: " " }, { char: "│" }],
+        [{ char: "└" }, { char: "─" }, { char: "─" }, { char: "─" }, { char: "┘" }],
+      ],
+    });
+    const text = toPlainText(frame);
+    expect(text).toContain("┌───┐");
+    expect(text).toContain("└───┘");
+  });
+});

--- a/packages/tui/test/recorder.test.ts
+++ b/packages/tui/test/recorder.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { FrameRecorder } from "../lib/output/recorder.js";
+import { Frame } from "../lib/frame.js";
+
+describe("FrameRecorder", () => {
+  it("records frames with labels", () => {
+    const recorder = new FrameRecorder();
+    const frame = new Frame({ x: 0, y: 0, width: 80, height: 24, style: {} });
+    recorder.write(frame, "press s");
+    expect(recorder.frames).toHaveLength(1);
+    expect(recorder.frames[0].label).toBe("press s");
+  });
+
+  it("writeHTML produces valid HTML with all frames", () => {
+    const recorder = new FrameRecorder();
+    recorder.write(
+      new Frame({ x: 0, y: 0, width: 10, height: 2, style: {},
+        content: [[{ char: "h" }, { char: "i" }]] }),
+      "step 1"
+    );
+    recorder.write(
+      new Frame({ x: 0, y: 0, width: 10, height: 2, style: {},
+        content: [[{ char: "b" }, { char: "y" }]] }),
+      "step 2"
+    );
+    const html = recorder.toHTML();
+    expect(html).toContain("step 1");
+    expect(html).toContain("step 2");
+    expect(html).toContain("<pre");
+  });
+});

--- a/packages/tui/test/renderer.test.ts
+++ b/packages/tui/test/renderer.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { render } from "../lib/render/renderer.js";
+import { layout } from "../lib/layout.js";
+import { box, text, list, textInput, column, row } from "../lib/builders.js";
+
+function renderElement(element: ReturnType<typeof box>, width = 80, height = 24) {
+  const positioned = layout(element, width, height);
+  return render(positioned);
+}
+
+function contentText(frame: ReturnType<typeof render>): string {
+  if (!frame.content) return "";
+  return frame.content.map(row => row.map(c => c.char).join("")).join("\n");
+}
+
+describe("render", () => {
+  it("renders plain text content into cells", () => {
+    const frame = renderElement(box({ width: 10, height: 1 }, text("hello")), 80, 24);
+    const child = frame.children![0];
+    expect(contentText(child)).toContain("hello");
+  });
+
+  it("renders a box with border", () => {
+    const frame = renderElement(
+      box({ width: 10, height: 3, border: true }),
+      80, 24,
+    );
+    // Border should produce content cells with box-drawing chars
+    const topRow = frame.content![0];
+    expect(topRow[0].char).toBe("┌");
+    expect(topRow[9].char).toBe("┐");
+    const bottomRow = frame.content![2];
+    expect(bottomRow[0].char).toBe("└");
+    expect(bottomRow[9].char).toBe("┘");
+  });
+
+  it("renders border with label", () => {
+    const frame = renderElement(
+      box({ width: 20, height: 3, border: true, label: " Test " }),
+      80, 24,
+    );
+    const topRow = frame.content![0];
+    const topText = topRow.map(c => c.char).join("");
+    expect(topText).toContain(" Test ");
+  });
+
+  it("renders styled text with color", () => {
+    const frame = renderElement(
+      box({ width: 20, height: 1 }, text("{red-fg}hi{/red-fg}")),
+      80, 24,
+    );
+    const child = frame.children![0];
+    const hiCells = child.content![0];
+    expect(hiCells[0].char).toBe("h");
+    expect(hiCells[0].fg).toBe("red");
+    expect(hiCells[1].char).toBe("i");
+    expect(hiCells[1].fg).toBe("red");
+  });
+
+  it("renders a list with selected item highlighted", () => {
+    const el = list({ width: 10, height: 3, key: "mylist" }, ["a", "b", "c"], 1);
+    const frame = renderElement(el, 80, 24);
+    // The selected item (index 1, "b") should have a distinct bg
+    const row1 = frame.content![1];
+    expect(row1[0].char).toBe("b");
+    expect(row1[0].bg).toBeDefined();
+  });
+
+  it("renders a textInput with its value", () => {
+    const el = textInput({ width: 15, height: 1, key: "input" }, "hello");
+    const frame = renderElement(el, 80, 24);
+    const text = contentText(frame);
+    expect(text).toContain("hello");
+  });
+
+  it("handles scrollable content with scrollOffset", () => {
+    const lines = Array.from({ length: 10 }, (_, i) => `line${i}`);
+    const el = box(
+      { width: 20, height: 3, scrollable: true, scrollOffset: 5 },
+      text(lines.join("\n")),
+    );
+    const frame = renderElement(el, 80, 24);
+    // Should show lines starting from offset 5
+    const child = frame.children![0];
+    const visibleText = contentText(child);
+    expect(visibleText).toContain("line5");
+    expect(visibleText).not.toContain("line0");
+  });
+
+  it("recurses into children and produces child frames", () => {
+    const el = column(
+      box({ key: "top", height: 5 }, text("top")),
+      box({ key: "bottom", flex: 1 }, text("bottom")),
+    );
+    const frame = renderElement(el, 80, 24);
+    expect(frame.children).toHaveLength(2);
+    expect(frame.children![0].key).toBe("top");
+    expect(frame.children![1].key).toBe("bottom");
+  });
+});

--- a/packages/tui/test/screen.test.ts
+++ b/packages/tui/test/screen.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { Screen } from "../lib/screen.js";
+import { ScriptedInput } from "../lib/input/scripted.js";
+import { FrameRecorder } from "../lib/output/recorder.js";
+import { box, text } from "../lib/builders.js";
+
+describe("Screen", () => {
+  it("render produces a frame and writes to output", () => {
+    const recorder = new FrameRecorder();
+    const input = new ScriptedInput();
+    const screen = new Screen({ output: recorder, input, width: 40, height: 10 });
+
+    const frame = screen.render(box({ border: true, key: "main" }, text("hello")));
+    expect(frame).toBeDefined();
+    expect(frame.findByKey("main")).toBeDefined();
+    expect(recorder.frames).toHaveLength(1);
+  });
+
+  it("nextKey returns events from input source", async () => {
+    const recorder = new FrameRecorder();
+    const input = new ScriptedInput();
+    input.feedKey({ key: "s" });
+    const screen = new Screen({ output: recorder, input, width: 40, height: 10 });
+
+    const key = await screen.nextKey();
+    expect(key).toEqual({ key: "s" });
+  });
+});

--- a/packages/tui/test/scripted.test.ts
+++ b/packages/tui/test/scripted.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { ScriptedInput } from "../lib/input/scripted.js";
+
+describe("ScriptedInput", () => {
+  it("replays key events in order", async () => {
+    const input = new ScriptedInput();
+    input.feedKey({ key: "a" });
+    input.feedKey({ key: "b" });
+    expect(await input.nextKey()).toEqual({ key: "a" });
+    expect(await input.nextKey()).toEqual({ key: "b" });
+  });
+
+  it("nextKey waits for input when queue is empty", async () => {
+    const input = new ScriptedInput();
+    const promise = input.nextKey();
+    setTimeout(() => input.feedKey({ key: "x" }), 10);
+    const result = await promise;
+    expect(result).toEqual({ key: "x" });
+  });
+
+  it("nextLine returns fed line", async () => {
+    const input = new ScriptedInput();
+    input.feedLine("hello world");
+    const line = await input.nextLine("prompt>");
+    expect(line).toBe("hello world");
+  });
+});

--- a/packages/tui/test/styleParser.test.ts
+++ b/packages/tui/test/styleParser.test.ts
@@ -48,6 +48,15 @@ describe("parseStyledText", () => {
       { text: "y", fg: "red" },
     ]);
   });
+
+  it("unrecognized tags are preserved as literal text", () => {
+    const result = parseStyledText("hello {unknown} world");
+    expect(result).toEqual([
+      { text: "hello " },
+      { text: "{unknown}" },
+      { text: " world" },
+    ]);
+  });
 });
 
 describe("escapeStyleTags", () => {

--- a/packages/tui/test/styleParser.test.ts
+++ b/packages/tui/test/styleParser.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { parseStyledText, escapeStyleTags } from "../lib/styleParser.js";
+
+describe("parseStyledText", () => {
+  it("returns plain text as a single span", () => {
+    expect(parseStyledText("hello")).toEqual([{ text: "hello" }]);
+  });
+
+  it("parses bold tags", () => {
+    expect(parseStyledText("{bold}hi{/bold}")).toEqual([{ text: "hi", bold: true }]);
+  });
+
+  it("parses fg color tags", () => {
+    expect(parseStyledText("{red-fg}hi{/red-fg}")).toEqual([{ text: "hi", fg: "red" }]);
+  });
+
+  it("parses bg color tags", () => {
+    expect(parseStyledText("{blue-bg}hi{/blue-bg}")).toEqual([{ text: "hi", bg: "blue" }]);
+  });
+
+  it("handles nested tags", () => {
+    const result = parseStyledText("{bold}{red-fg}hi{/red-fg}{/bold}");
+    expect(result).toEqual([{ text: "hi", bold: true, fg: "red" }]);
+  });
+
+  it("handles mixed styled and unstyled text", () => {
+    const result = parseStyledText("hello {bold}world{/bold} foo");
+    expect(result).toEqual([
+      { text: "hello " },
+      { text: "world", bold: true },
+      { text: " foo" },
+    ]);
+  });
+
+  it("returns empty array for empty string", () => {
+    expect(parseStyledText("")).toEqual([]);
+  });
+});
+
+describe("escapeStyleTags", () => {
+  it("escapes curly braces", () => {
+    expect(escapeStyleTags("{bold}")).toBe("\\{bold\\}");
+  });
+
+  it("leaves text without braces unchanged", () => {
+    expect(escapeStyleTags("hello world")).toBe("hello world");
+  });
+});

--- a/packages/tui/test/styleParser.test.ts
+++ b/packages/tui/test/styleParser.test.ts
@@ -35,6 +35,19 @@ describe("parseStyledText", () => {
   it("returns empty array for empty string", () => {
     expect(parseStyledText("")).toEqual([]);
   });
+
+  it("escaped braces are not parsed as tags", () => {
+    const result = parseStyledText(escapeStyleTags("{bold}hello{/bold}"));
+    expect(result).toEqual([{ text: "{bold}hello{/bold}" }]);
+  });
+
+  it("closing tag matches by type and color", () => {
+    const result = parseStyledText("{red-fg}{green-fg}x{/green-fg}y{/red-fg}");
+    expect(result).toEqual([
+      { text: "x", fg: "green" },
+      { text: "y", fg: "red" },
+    ]);
+  });
 });
 
 describe("escapeStyleTags", () => {

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["lib"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/tui/tsconfig.json
+++ b/packages/tui/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "declaration": true,
+    "rootDir": ".",
     "outDir": "./dist",
     "strict": true,
     "esModuleInterop": true,

--- a/packages/tui/vitest.config.ts
+++ b/packages/tui/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts", "lib/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,14 +178,14 @@ importers:
   packages/tui:
     devDependencies:
       '@types/node':
-        specifier: ^22.0.0
-        version: 22.19.15
+        specifier: ^25.0.0
+        version: 25.0.6
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/node@22.19.15)
+        version: 3.2.4(@types/node@25.0.6)
 
   packages/web-fetch:
     dependencies:
@@ -3625,14 +3625,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.15)
-
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.0.6))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -5321,27 +5313,6 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@22.19.15):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.15)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-node@3.2.4(@types/node@25.0.6):
     dependencies:
       cac: 6.7.14
@@ -5370,18 +5341,6 @@ snapshots:
       rollup: 4.55.1
     optionalDependencies:
       '@types/node': 25.0.6
-      fsevents: 2.3.3
-
-  vite@7.3.1(@types/node@22.19.15):
-    dependencies:
-      esbuild: 0.27.4
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-      postcss: 8.5.6
-      rollup: 4.55.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 22.19.15
       fsevents: 2.3.3
 
   vite@7.3.1(@types/node@25.0.6):
@@ -5444,47 +5403,6 @@ snapshots:
       - terser
       - typescript
       - universal-cookie
-
-  vitest@3.2.4(@types/node@22.19.15):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.15)
-      vite-node: 3.2.4(@types/node@22.19.15)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.19.15
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vitest@3.2.4(@types/node@25.0.6):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,18 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.0.6)
 
+  packages/tui:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.15
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@22.19.15)
+
   packages/web-fetch:
     dependencies:
       '@mozilla/readability':
@@ -3613,6 +3625,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.15)
+
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.0.6))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -5301,6 +5321,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@22.19.15):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@22.19.15)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@25.0.6):
     dependencies:
       cac: 6.7.14
@@ -5329,6 +5370,18 @@ snapshots:
       rollup: 4.55.1
     optionalDependencies:
       '@types/node': 25.0.6
+      fsevents: 2.3.3
+
+  vite@7.3.1(@types/node@22.19.15):
+    dependencies:
+      esbuild: 0.27.4
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.6
+      rollup: 4.55.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.19.15
       fsevents: 2.3.3
 
   vite@7.3.1(@types/node@25.0.6):
@@ -5391,6 +5444,47 @@ snapshots:
       - terser
       - typescript
       - universal-cookie
+
+  vitest@3.2.4(@types/node@22.19.15):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.15))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@22.19.15)
+      vite-node: 3.2.4(@types/node@22.19.15)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@types/node@25.0.6):
     dependencies:


### PR DESCRIPTION
## Summary

- New package: `@agency-lang/tui` — a testable TUI library with immediate-mode rendering and flexbox-lite layout, designed to replace `blessed` in the Agency debugger
- Includes spec and implementation plan for the full migration (Tasks 11-14 are follow-up: debugger UI rewrite, test harness, test migration, cleanup)
- 57 tests across 10 test files, all passing

### What's in the library

- **Flexbox-lite layout engine** with clean parent-owns-main-axis / child-owns-cross-axis architecture
- **Builder functions**: `box()`, `row()`, `column()`, `text()`, `list()`, `textInput()`
- **Style tag parser** for `{bold}`, `{red-fg}`, `{blue-bg}` inline formatting
- **Three output adapters**: ANSI (terminal), HTML (test artifacts with prev/next navigation), plain text (assertions)
- **Pluggable I/O**: `ScriptedInput` + `FrameRecorder` for tests, `TerminalInput` + `TerminalOutput` for production
- **Screen class** orchestrating layout -> render -> output via dependency injection

## Test plan

- [x] All 57 TUI library tests pass (`pnpm vitest run` in `packages/tui/`)
- [x] TypeScript build passes (`pnpm run build` in `packages/tui/`)
- [ ] Follow-up PR: migrate debugger UI from blessed to @agency-lang/tui (Tasks 11-14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)