### PR TITLE
Add agency schedule CLI for local agent scheduling

### DIFF
--- a/docs/superpowers/plans/2026-05-06-schedule-cli.md
+++ b/docs/superpowers/plans/2026-05-06-schedule-cli.md
@@ -1,0 +1,1430 @@
+# Schedule CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `agency schedule add/list/remove/edit` commands that register OS-native cron jobs (launchd, systemd, crontab) to run Agency agents on a recurring schedule.
+
+**Architecture:** A JSON registry at `~/.agency/schedules/schedules.json` stores schedule metadata. Three backend implementations (launchd, systemd, crontab) handle OS-specific install/uninstall. The CLI commands in `lib/cli/schedule/index.ts` orchestrate validation, registry updates, and backend calls.
+
+**Tech Stack:** Commander (CLI), Node.js `child_process` (for launchctl/systemctl/crontab), Node.js `fs` (registry and log management), typestache (typed Mustache templates for generated config files).
+
+**Spec:** `docs/superpowers/specs/2026-05-06-schedule-cli-design.md`
+
+## File Structure
+
+```
+lib/cli/schedule/
+├── index.ts              — Public API: scheduleAdd, scheduleList, scheduleRemove, scheduleEdit
+├── index.test.ts         — Tests for the public API
+├── registry.ts           — Registry class (JSON persistence)
+├── registry.test.ts      — Registry tests
+├── cron.ts               — Cron utilities: validate, presets, nextRun, cronToOnCalendar
+├── cron.test.ts          — Cron utility tests
+├── backends/
+│   ├── index.ts          — ScheduleBackend interface, detectBackend, getBackend factory
+│   ├── launchd.ts        — LaunchdBackend
+│   ├── systemd.ts        — SystemdBackend
+│   ├── crontab.ts        — CrontabBackend
+│   └── backends.test.ts  — Backend tests
+
+lib/templates/cli/schedule/
+├── plist.mustache        — launchd plist template
+├── service.mustache      — systemd service unit template
+├── timer.mustache        — systemd timer unit template
+├── runScript.mustache    — Shared run.sh wrapper script template
+```
+
+**Template usage:** Templates are compiled to TypeScript via `pnpm run templates` (which runs `typestache ./lib/templates`). Each `.mustache` file produces a `.ts` file with a typed `render(args)` function. Backends import and call `render()` with their data — no string concatenation needed.
+
+---
+
+### Task 1: Registry and Types
+
+**Files:**
+- Create: `packages/agency-lang/lib/cli/schedule/registry.ts`
+- Create: `packages/agency-lang/lib/cli/schedule/registry.test.ts`
+
+This module manages reading/writing `~/.agency/schedules/schedules.json` and defines the core types.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Registry } from "../schedule/registry.js";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+function makeEntry(tmpDir: string, overrides = {}) {
+  return {
+    name: "test-agent",
+    agentFile: "/path/to/agent.agency",
+    cron: "0 9 * * *",
+    preset: "daily",
+    envFile: "",
+    command: "agency",
+    logDir: path.join(tmpDir, "test-agent", "logs"),
+    createdAt: "2026-05-06T10:00:00-07:00",
+    backend: "launchd" as const,
+    ...overrides,
+  };
+}
+
+describe("Registry", () => {
+  let tmpDir: string;
+  let registry: Registry;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-schedule-test-"));
+    registry = new Registry(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty object when no registry file exists", () => {
+    expect(registry.getAll()).toEqual({});
+  });
+
+  it("adds and retrieves an entry", () => {
+    const entry = makeEntry(tmpDir);
+    registry.set(entry);
+    expect(registry.get("test-agent")).toEqual(entry);
+  });
+
+  it("removes an entry", () => {
+    registry.set(makeEntry(tmpDir));
+    registry.remove("test-agent");
+    expect(registry.get("test-agent")).toBeUndefined();
+  });
+
+  it("persists across instances", () => {
+    const entry = makeEntry(tmpDir);
+    registry.set(entry);
+    const registry2 = new Registry(tmpDir);
+    expect(registry2.get("test-agent")).toEqual(entry);
+  });
+
+  it("has() returns true for existing entries", () => {
+    registry.set(makeEntry(tmpDir));
+    expect(registry.has("test-agent")).toBe(true);
+    expect(registry.has("nonexistent")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter agency-lang exec vitest run lib/cli/schedule/registry.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement Registry**
+
+```typescript
+// packages/agency-lang/lib/cli/schedule/registry.ts
+import * as fs from "fs";
+import * as path from "path";
+
+export type ScheduleEntry = {
+  name: string;
+  agentFile: string;
+  cron: string;
+  preset: string;
+  envFile: string;
+  command: string;
+  logDir: string;
+  createdAt: string;
+  backend: "launchd" | "systemd" | "crontab";
+};
+
+export type ScheduleRegistry = Record<string, ScheduleEntry>;
+
+export class Registry {
+  private filePath: string;
+
+  constructor(baseDir: string) {
+    this.filePath = path.join(baseDir, "schedules.json");
+  }
+
+  getAll(): ScheduleRegistry {
+    if (!fs.existsSync(this.filePath)) return {};
+    return JSON.parse(fs.readFileSync(this.filePath, "utf-8"));
+  }
+
+  get(name: string): ScheduleEntry | undefined {
+    return this.getAll()[name];
+  }
+
+  has(name: string): boolean {
+    return name in this.getAll();
+  }
+
+  set(entry: ScheduleEntry): void {
+    const all = this.getAll();
+    all[entry.name] = entry;
+    this.write(all);
+  }
+
+  remove(name: string): void {
+    const all = this.getAll();
+    delete all[name];
+    this.write(all);
+  }
+
+  private write(data: ScheduleRegistry): void {
+    const dir = path.dirname(this.filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2));
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter agency-lang exec vitest run lib/cli/schedule/registry.test.ts`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/agency-lang/lib/cli/schedule/registry.ts packages/agency-lang/lib/cli/schedule/registry.test.ts
+git commit -m "feat(schedule): add schedule registry with types and persistence"
+```
+
+---
+
+### Task 2: Cron Validation, Presets, and Utilities
+
+**Files:**
+- Create: `packages/agency-lang/lib/cli/schedule/cron.ts`
+- Create: `packages/agency-lang/lib/cli/schedule/cron.test.ts`
+
+This module handles all cron-related logic: presets, validation, next-run calculation, cron-to-systemd conversion, and resolving user input into a `{ cron, preset }` pair.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+import { describe, it, expect } from "vitest";
+import {
+  presetToCron,
+  validateCron,
+  formatSchedule,
+  nextRun,
+  resolveCron,
+  cronToOnCalendar,
+} from "../schedule/cron.js";
+
+describe("presetToCron", () => {
+  it("maps hourly", () => expect(presetToCron("hourly")).toBe("0 * * * *"));
+  it("maps daily", () => expect(presetToCron("daily")).toBe("0 9 * * *"));
+  it("maps weekdays", () => expect(presetToCron("weekdays")).toBe("0 9 * * 1-5"));
+  it("maps weekly", () => expect(presetToCron("weekly")).toBe("0 9 * * 1"));
+  it("throws on unknown preset", () => {
+    expect(() => presetToCron("biweekly")).toThrow("Unknown preset");
+  });
+});
+
+describe("validateCron", () => {
+  it("accepts valid 5-field expressions", () => {
+    expect(validateCron("0 9 * * *")).toBe(true);
+    expect(validateCron("*/15 * * * *")).toBe(true);
+    expect(validateCron("0 9 * * 1-5")).toBe(true);
+    expect(validateCron("30 14 1 * *")).toBe(true);
+  });
+  it("rejects invalid expressions", () => {
+    expect(validateCron("not a cron")).toBe(false);
+    expect(validateCron("* * *")).toBe(false);
+    expect(validateCron("")).toBe(false);
+    expect(validateCron("* * * * * *")).toBe(false);
+  });
+});
+
+describe("resolveCron", () => {
+  it("resolves a preset", () => {
+    expect(resolveCron({ every: "daily" })).toEqual({ cron: "0 9 * * *", preset: "daily" });
+  });
+  it("resolves a raw cron expression", () => {
+    expect(resolveCron({ cron: "*/15 * * * *" })).toEqual({ cron: "*/15 * * * *", preset: "" });
+  });
+  it("throws if neither provided", () => {
+    expect(() => resolveCron({})).toThrow("--every or --cron");
+  });
+  it("throws on invalid cron", () => {
+    expect(() => resolveCron({ cron: "bad" })).toThrow("Invalid cron expression");
+  });
+});
+
+describe("formatSchedule", () => {
+  it("shows preset name when available", () => {
+    expect(formatSchedule("0 9 * * 1-5", "weekdays")).toBe("weekdays");
+  });
+  it("shows raw cron when no preset", () => {
+    expect(formatSchedule("*/15 * * * *", "")).toBe("*/15 * * * *");
+  });
+});
+
+describe("nextRun", () => {
+  it("returns a Date in the future", () => {
+    const next = nextRun("* * * * *");
+    expect(next.getTime()).toBeGreaterThan(Date.now());
+  });
+  it("returns within 60s for minutely cron", () => {
+    const next = nextRun("* * * * *");
+    const diffMs = next.getTime() - Date.now();
+    expect(diffMs).toBeLessThanOrEqual(60_000);
+    expect(diffMs).toBeGreaterThan(0);
+  });
+});
+
+describe("cronToOnCalendar", () => {
+  it("converts daily at 9am", () => {
+    expect(cronToOnCalendar("0 9 * * *")).toBe("*-*-* 09:00:00");
+  });
+  it("converts weekdays at 9am", () => {
+    const result = cronToOnCalendar("0 9 * * 1-5");
+    expect(result).toBe("Mon,Tue,Wed,Thu,Fri *-*-* 09:00:00");
+  });
+  it("converts hourly", () => {
+    expect(cronToOnCalendar("0 * * * *")).toBe("*-*-* *:00:00");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter agency-lang exec vitest run lib/cli/schedule/cron.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement cron utilities**
+
+```typescript
+// packages/agency-lang/lib/cli/schedule/cron.ts
+
+export const PRESETS: Record<string, string> = {
+  hourly: "0 * * * *",
+  daily: "0 9 * * *",
+  weekdays: "0 9 * * 1-5",
+  weekly: "0 9 * * 1",
+};
+
+export function presetToCron(preset: string): string {
+  const cron = PRESETS[preset];
+  if (!cron) {
+    throw new Error(
+      `Unknown preset "${preset}". Valid presets: ${Object.keys(PRESETS).join(", ")}`,
+    );
+  }
+  return cron;
+}
+
+export function validateCron(expr: string): boolean {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+  const fieldPattern = /^(\*|[0-9]+(-[0-9]+)?(\/[0-9]+)?)(,(\*|[0-9]+(-[0-9]+)?(\/[0-9]+)?))*$/;
+  return fields.every((f) => fieldPattern.test(f));
+}
+
+export function resolveCron(opts: { every?: string; cron?: string }): { cron: string; preset: string } {
+  if (opts.every) {
+    return { cron: presetToCron(opts.every), preset: opts.every };
+  }
+  if (opts.cron) {
+    if (!validateCron(opts.cron)) {
+      throw new Error(
+        `Invalid cron expression "${opts.cron}". Expected 5 fields: minute hour day-of-month month day-of-week. Example: "0 9 * * 1-5" (weekdays at 9am)`,
+      );
+    }
+    return { cron: opts.cron, preset: "" };
+  }
+  throw new Error("Must provide --every or --cron to set a schedule.");
+}
+
+export function formatSchedule(cron: string, preset: string): string {
+  return preset || cron;
+}
+
+export function nextRun(cronExpr: string): Date {
+  const [minF, hourF, domF, monF, dowF] = cronExpr.trim().split(/\s+/);
+  const candidate = new Date();
+  candidate.setSeconds(0, 0);
+  candidate.setMinutes(candidate.getMinutes() + 1);
+
+  for (let i = 0; i < 527_040; i++) {
+    if (
+      matchField(minF, candidate.getMinutes()) &&
+      matchField(hourF, candidate.getHours()) &&
+      matchField(domF, candidate.getDate()) &&
+      matchField(monF, candidate.getMonth() + 1) &&
+      matchField(dowF, candidate.getDay())
+    ) {
+      return candidate;
+    }
+    candidate.setMinutes(candidate.getMinutes() + 1);
+  }
+  return candidate;
+}
+
+const DOW_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+export function cronToOnCalendar(cron: string): string {
+  const [min, hour, dom, mon, dow] = cron.split(/\s+/);
+
+  const dowPart = dow === "*" ? "" : expandDow(dow);
+  const datePart = `*-${field(mon)}-${field(dom)}`;
+  const timePart = `${field(hour)}:${field(min)}:00`;
+
+  return dowPart ? `${dowPart} ${datePart} ${timePart}` : `${datePart} ${timePart}`;
+}
+
+function expandDow(dow: string): string {
+  if (dow.includes("-")) {
+    const [lo, hi] = dow.split("-").map(Number);
+    const days = [];
+    for (let i = lo; i <= hi; i++) days.push(DOW_NAMES[i]);
+    return days.join(",");
+  }
+  return DOW_NAMES[Number(dow)] || dow;
+}
+
+function field(f: string): string {
+  if (f === "*") return "*";
+  return f.padStart(2, "0");
+}
+
+function matchField(field: string, value: number): boolean {
+  return field.split(",").some((part) => matchPart(part, value));
+}
+
+function matchPart(part: string, value: number): boolean {
+  const [range, stepStr] = part.split("/");
+  const step = stepStr ? parseInt(stepStr, 10) : 1;
+
+  if (range === "*") return value % step === 0;
+
+  if (range.includes("-")) {
+    const [low, high] = range.split("-").map(Number);
+    return value >= low && value <= high && (value - low) % step === 0;
+  }
+
+  return parseInt(range, 10) === value;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter agency-lang exec vitest run lib/cli/schedule/cron.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/agency-lang/lib/cli/schedule/cron.ts packages/agency-lang/lib/cli/schedule/cron.test.ts
+git commit -m "feat(schedule): add cron validation, presets, nextRun, and systemd conversion"
+```
+
+---
+
+### Task 3: Typestache Templates
+
+**Files:**
+- Create: `packages/agency-lang/lib/templates/cli/schedule/runScript.mustache`
+- Create: `packages/agency-lang/lib/templates/cli/schedule/plist.mustache`
+- Create: `packages/agency-lang/lib/templates/cli/schedule/service.mustache`
+- Create: `packages/agency-lang/lib/templates/cli/schedule/timer.mustache`
+
+All multi-line config strings are expressed as Mustache templates. After creating them, run `pnpm run templates` to generate the typed `.ts` files.
+
+- [ ] **Step 1: Create the run script template**
+
+```mustache
+{{! packages/agency-lang/lib/templates/cli/schedule/runScript.mustache }}
+#!/bin/bash
+set -e
+cd "{{{agentDir:string}}}"
+{{#hasEnvFile:boolean}}
+export $(grep -v '^#' "{{{envFile:string}}}" | xargs)
+{{/hasEnvFile}}
+LOGFILE="{{{logDir:string}}}/$(date +%Y-%m-%dT%H-%M-%S).log"
+{{{command:string}}} run "{{{agentFile:string}}}" >> "$LOGFILE" 2>&1
+
+# Rotate: keep last 50 logs
+cd "{{{logDir}}}"
+ls -t *.log 2>/dev/null | tail -n +51 | xargs rm -f 2>/dev/null || true
+```
+
+- [ ] **Step 2: Create the plist template**
+
+```mustache
+{{! packages/agency-lang/lib/templates/cli/schedule/plist.mustache }}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agency.schedule.{{{name:string}}}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>{{{runScriptPath:string}}}</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>{{{agentDir:string}}}</string>
+  <key>StartCalendarInterval</key>
+  <dict>
+{{{intervals:string}}}
+  </dict>
+  <key>StandardOutPath</key>
+  <string>{{{logDir:string}}}/launchd-stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{{logDir:string}}}/launchd-stderr.log</string>
+</dict>
+</plist>
+```
+
+- [ ] **Step 3: Create the systemd service template**
+
+```mustache
+{{! packages/agency-lang/lib/templates/cli/schedule/service.mustache }}
+[Unit]
+Description=Agency scheduled agent: {{{name:string}}}
+
+[Service]
+Type=oneshot
+WorkingDirectory={{{agentDir:string}}}
+ExecStart=/bin/bash {{{runScriptPath:string}}}
+```
+
+- [ ] **Step 4: Create the systemd timer template**
+
+```mustache
+{{! packages/agency-lang/lib/templates/cli/schedule/timer.mustache }}
+[Unit]
+Description=Timer for agency-schedule-{{{name:string}}}
+
+[Timer]
+OnCalendar={{{onCalendar:string}}}
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+- [ ] **Step 5: Compile templates**
+
+Run: `pnpm run templates`
+Expected: Generates `.ts` files alongside each `.mustache` file.
+
+- [ ] **Step 6: Commit**
+
+```
+git add packages/agency-lang/lib/templates/cli/schedule/
+git commit -m "feat(schedule): add typestache templates for plist, systemd units, and run script"
+```
+
+---
+
+### Task 4: Backend Abstraction and Implementations
+
+**Files:**
+- Create: `packages/agency-lang/lib/cli/schedule/backends/index.ts`
+- Create: `packages/agency-lang/lib/cli/schedule/backends/launchd.ts`
+- Create: `packages/agency-lang/lib/cli/schedule/backends/systemd.ts`
+- Create: `packages/agency-lang/lib/cli/schedule/backends/crontab.ts`
+- Create: `packages/agency-lang/lib/cli/schedule/backends/backends.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as childProcess from "child_process";
+import * as fs from "fs";
+import { LaunchdBackend } from "../schedule/backends/launchd.js";
+import { CrontabBackend } from "../schedule/backends/crontab.js";
+import { detectBackend } from "../schedule/backends/index.js";
+import type { ScheduleEntry } from "../schedule/registry.js";
+
+vi.mock("child_process");
+vi.mock("fs");
+
+const mockEntry: ScheduleEntry = {
+  name: "test-agent",
+  agentFile: "/home/user/project/agent.agency",
+  cron: "0 9 * * *",
+  preset: "daily",
+  envFile: "/home/user/project/.env",
+  command: "agency",
+  logDir: "/home/user/.agency/schedules/test-agent/logs",
+  createdAt: "2026-05-06T10:00:00-07:00",
+  backend: "launchd",
+};
+
+// Mock writeRunScript so backends don't actually write files
+vi.mock("../schedule/backends/writeRunScript.js", () => ({
+  writeRunScript: () => "/mock/path/run.sh",
+}));
+
+describe("LaunchdBackend", () => {
+  const backend = new LaunchdBackend();
+
+  beforeEach(() => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined as any);
+    vi.mocked(fs.unlinkSync).mockImplementation(() => {});
+    vi.mocked(childProcess.execSync).mockImplementation(() => Buffer.from(""));
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("install writes a plist and calls launchctl load", () => {
+    backend.install(mockEntry);
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+    const plistPath = writeCall[0] as string;
+    const plistContent = writeCall[1] as string;
+    expect(plistPath).toContain("com.agency.schedule.test-agent.plist");
+    expect(plistContent).toContain("<key>StartCalendarInterval</key>");
+    expect(plistContent).toContain("<key>Hour</key>");
+    expect(plistContent).toContain("<integer>9</integer>");
+    expect(vi.mocked(childProcess.execSync)).toHaveBeenCalledWith(
+      expect.stringContaining("launchctl load"),
+    );
+  });
+
+  it("uninstall calls launchctl unload and deletes plist", () => {
+    backend.uninstall("test-agent");
+    expect(vi.mocked(childProcess.execSync)).toHaveBeenCalledWith(
+      expect.stringContaining("launchctl unload"),
+    );
+    expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalled();
+  });
+});
+
+describe("CrontabBackend", () => {
+  const backend = new CrontabBackend();
+
+  beforeEach(() => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined as any);
+    vi.mocked(childProcess.execSync).mockImplementation((cmd) => {
+      if (typeof cmd === "string" && cmd.includes("crontab -l")) {
+        return Buffer.from("# existing crontab\n");
+      }
+      return Buffer.from("");
+    });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("install writes crontab with agency marker", () => {
+    backend.install(mockEntry);
+    const calls = vi.mocked(childProcess.execSync).mock.calls;
+    const installCall = calls.find(
+      (c) => c[1] && typeof c[1] === "object" && "input" in c[1],
+    );
+    expect(installCall).toBeDefined();
+    const input = (installCall![1] as any).input as string;
+    expect(input).toContain("# agency:test-agent");
+  });
+
+  it("uninstall removes crontab line matching agency marker", () => {
+    vi.mocked(childProcess.execSync).mockImplementation((cmd) => {
+      if (typeof cmd === "string" && cmd.includes("crontab -l")) {
+        return Buffer.from(
+          "0 * * * * other-job\n0 9 * * * /path/run.sh # agency:test-agent\n",
+        );
+      }
+      return Buffer.from("");
+    });
+    backend.uninstall("test-agent");
+    const calls = vi.mocked(childProcess.execSync).mock.calls;
+    const writeCall = calls.find(
+      (c) => c[1] && typeof c[1] === "object" && "input" in c[1],
+    );
+    const input = (writeCall![1] as any).input as string;
+    expect(input).not.toContain("agency:test-agent");
+    expect(input).toContain("other-job");
+  });
+});
+
+describe("detectBackend", () => {
+  it("returns launchd on darwin", () => {
+    const original = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    expect(detectBackend()).toBe("launchd");
+    Object.defineProperty(process, "platform", { value: original });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter agency-lang exec vitest run lib/cli/schedule/backends/backends.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement backend interface and factory**
+
+```typescript
+// packages/agency-lang/lib/cli/schedule/backends/index.ts
+import { execSync } from "child_process";
+import type { ScheduleEntry } from "../registry.js";
+import { LaunchdBackend } from "./launchd.js";
+import { SystemdBackend } from "./systemd.js";
+import { CrontabBackend } from "./crontab.js";
+
+export type ScheduleBackend = {
+  install(entry: ScheduleEntry): void;
+  uninstall(name: string): void;
+};
+
+export function detectBackend(): "launchd" | "systemd" | "crontab" {
+  if (process.platform === "darwin") return "launchd";
+  try {
+    execSync("which systemctl", { stdio: "pipe" });
+    return "systemd";
+  } catch {
+    return "crontab";
+  }
+}
+
+export function getBackend(type: "launchd" | "systemd" | "crontab"): ScheduleBackend {
+  switch (type) {
+    case "launchd": return new LaunchdBackend();
+    case "systemd": return new SystemdBackend();
+    case "crontab": return new CrontabBackend();
+  }
+}
+
+export { LaunchdBackend } from "./launchd.js";
+export { SystemdBackend } from "./systemd.js";
+export { CrontabBackend } from "./crontab.js";
+```
+
+- [ ] **Step 4: Implement shared writeRunScript helper**
+
+All backends need to write a `run.sh` file. This helper uses the typestache template:
+
+```typescript
+// packages/agency-lang/lib/cli/schedule/backends/writeRunScript.ts
+import * as fs from "fs";
+import * as path from "path";
+import type { ScheduleEntry } from "../registry.js";
+import renderRunScript from "@/templates/cli/schedule/runScript.js";
+
+export function writeRunScript(entry: ScheduleEntry): string {
+  const scriptDir = path.dirname(entry.logDir);
+  const scriptPath = path.join(scriptDir, "run.sh");
+
+  const content = renderRunScript({
+    agentDir: path.dirname(entry.agentFile),
+    hasEnvFile: !!entry.envFile,
+    envFile: entry.envFile,
+    logDir: entry.logDir,
+    command: entry.command,
+    agentFile: entry.agentFile,
+  });
+
+  if (!fs.existsSync(scriptDir)) fs.mkdirSync(scriptDir, { recursive: true });
+  fs.writeFileSync(scriptPath, content, { mode: 0o755 });
+  return scriptPath;
+}
+```
+
+- [ ] **Step 5: Implement LaunchdBackend**
+
+```typescript
+// packages/agency-lang/lib/cli/schedule/backends/launchd.ts
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import type { ScheduleEntry } from "../registry.js";
+import type { ScheduleBackend } from "./index.js";
+import { writeRunScript } from "./writeRunScript.js";
+import renderPlist from "@/templates/cli/schedule/plist.js";
+
+const PLIST_DIR = path.join(os.homedir(), "Library", "LaunchAgents");
+
+function plistPath(name: string): string {
+  return path.join(PLIST_DIR, `com.agency.schedule.${name}.plist`);
+}
+
+function buildIntervals(cron: string): string {
+  const [minute, hour, dom, month, dow] = cron.split(/\s+/);
+  return [
+    minute !== "*" && `      <key>Minute</key>\n      <integer>${minute}</integer>`,
+    hour !== "*" && `      <key>Hour</key>\n      <integer>${hour}</integer>`,
+    dom !== "*" && `      <key>Day</key>\n      <integer>${dom}</integer>`,
+    month !== "*" && `      <key>Month</key>\n      <integer>${month}</integer>`,
+    dow !== "*" && `      <key>Weekday</key>\n      <integer>${dow}</integer>`,
+  ].filter(Boolean).join("\n");
+}
+
+export class LaunchdBackend implements ScheduleBackend {
+  install(entry: ScheduleEntry): void {
+    const runScriptPath = writeRunScript(entry);
+    const plist = renderPlist({
+      name: entry.name,
+      runScriptPath,
+      agentDir: path.dirname(entry.agentFile),
+      intervals: buildIntervals(entry.cron),
+      logDir: entry.logDir,
+    });
+    const dest = plistPath(entry.name);
+
+    if (!fs.existsSync(PLIST_DIR)) fs.mkdirSync(PLIST_DIR, { recursive: true });
+    if (!fs.existsSync(entry.logDir)) fs.mkdirSync(entry.logDir, { recursive: true });
+
+    fs.writeFileSync(dest, plist);
+    execSync(`launchctl load "${dest}"`);
+  }
+
+  uninstall(name: string): void {
+    const dest = plistPath(name);
+    if (fs.existsSync(dest)) {
+      try { execSync(`launchctl unload "${dest}"`); } catch {}
+      fs.unlinkSync(dest);
+    }
+  }
+}
+```
+
+- [ ] **Step 6: Implement SystemdBackend**
+
+```typescript
+// packages/agency-lang/lib/cli/schedule/backends/systemd.ts
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import type { ScheduleEntry } from "../registry.js";
+import type { ScheduleBackend } from "./index.js";
+import { writeRunScript } from "./writeRunScript.js";
+import { cronToOnCalendar } from "../cron.js";
+import renderService from "@/templates/cli/schedule/service.js";
+import renderTimer from "@/templates/cli/schedule/timer.js";
+
+const UNIT_DIR = path.join(os.homedir(), ".config", "systemd", "user");
+
+function unitName(name: string): string {
+  return `agency-schedule-${name}`;
+}
+
+export class SystemdBackend implements ScheduleBackend {
+  install(entry: ScheduleEntry): void {
+    const runScriptPath = writeRunScript(entry);
+    const unit = unitName(entry.name);
+
+    const service = renderService({
+      name: entry.name,
+      agentDir: path.dirname(entry.agentFile),
+      runScriptPath,
+    });
+    const timer = renderTimer({
+      name: entry.name,
+      onCalendar: cronToOnCalendar(entry.cron),
+    });
+
+    if (!fs.existsSync(UNIT_DIR)) fs.mkdirSync(UNIT_DIR, { recursive: true });
+    if (!fs.existsSync(entry.logDir)) fs.mkdirSync(entry.logDir, { recursive: true });
+
+    fs.writeFileSync(path.join(UNIT_DIR, `${unit}.service`), service);
+    fs.writeFileSync(path.join(UNIT_DIR, `${unit}.timer`), timer);
+    execSync("systemctl --user daemon-reload");
+    execSync(`systemctl --user enable --now ${unit}.timer`);
+  }
+
+  uninstall(name: string): void {
+    const unit = unitName(name);
+    try { execSync(`systemctl --user disable --now ${unit}.timer`); } catch {}
+    const servicePath = path.join(UNIT_DIR, `${unit}.service`);
+    const timerPath = path.join(UNIT_DIR, `${unit}.timer`);
+    if (fs.existsSync(servicePath)) fs.unlinkSync(servicePath);
+    if (fs.existsSync(timerPath)) fs.unlinkSync(timerPath);
+    try { execSync("systemctl --user daemon-reload"); } catch {}
+  }
+}
+```
+
+- [ ] **Step 7: Implement CrontabBackend**
+
+```typescript
+// packages/agency-lang/lib/cli/schedule/backends/crontab.ts
+import { execSync } from "child_process";
+import * as fs from "fs";
+import type { ScheduleEntry } from "../registry.js";
+import type { ScheduleBackend } from "./index.js";
+import { writeRunScript } from "./writeRunScript.js";
+
+function readCrontab(): string {
+  try {
+    return execSync("crontab -l", { stdio: ["pipe", "pipe", "pipe"] }).toString();
+  } catch {
+    return "";
+  }
+}
+
+function writeCrontab(content: string): void {
+  execSync("crontab -", { input: content });
+}
+
+function filterLines(crontab: string, name: string): string[] {
+  return crontab.split("\n").filter((line) => !line.includes(`# agency:${name}`));
+}
+
+export class CrontabBackend implements ScheduleBackend {
+  install(entry: ScheduleEntry): void {
+    const runScriptPath = writeRunScript(entry);
+
+    if (!fs.existsSync(entry.logDir)) {
+      fs.mkdirSync(entry.logDir, { recursive: true });
+    }
+
+    const lines = filterLines(readCrontab(), entry.name);
+    lines.push(`${entry.cron} /bin/bash "${runScriptPath}" # agency:${entry.name}`);
+    const content = lines.filter((l) => l.trim() !== "").join("\n") + "\n";
+    writeCrontab(content);
+  }
+
+  uninstall(name: string): void {
+    const existing = readCrontab();
+    if (!existing) return;
+    const lines = filterLines(existing, name);
+    const content = lines.filter((l) => l.trim() !== "").join("\n") + "\n";
+    writeCrontab(content);
+  }
+}
+```
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `pnpm --filter agency-lang exec vitest run lib/cli/schedule/backends/backends.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 8: Commit**
+
+```
+git add packages/agency-lang/lib/cli/schedule/backends/ packages/agency-lang/lib/cli/schedule/runScript.ts
+git commit -m "feat(schedule): add launchd, systemd, and crontab backends"
+```
+
+---
+
+### Task 5: Main Schedule Module (add, list, remove, edit)
+
+**Files:**
+- Create: `packages/agency-lang/lib/cli/schedule/index.ts`
+- Create: `packages/agency-lang/lib/cli/schedule/index.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { scheduleAdd, scheduleList, scheduleRemove, scheduleEdit } from "../schedule/index.js";
+
+vi.mock("../schedule/backends/index.js", () => ({
+  detectBackend: () => "launchd" as const,
+  getBackend: () => ({
+    install: vi.fn(),
+    uninstall: vi.fn(),
+  }),
+}));
+
+describe("scheduleAdd", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sched-test-"));
+    fs.writeFileSync(path.join(tmpDir, "agent.agency"), "node main() {}");
+  });
+
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it("adds a schedule with a preset", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"].cron).toBe("0 9 * * *");
+    expect(reg["agent"].preset).toBe("daily");
+  });
+
+  it("adds a schedule with a cron expression", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), cron: "*/15 * * * *", baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"].cron).toBe("*/15 * * * *");
+    expect(reg["agent"].preset).toBe("");
+  });
+
+  it("uses custom name when provided", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", name: "custom", baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["custom"]).toBeDefined();
+  });
+
+  it("stores env-file and command", () => {
+    const envFile = path.join(tmpDir, ".env");
+    fs.writeFileSync(envFile, "KEY=value");
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", envFile, command: "pnpm run agency", baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"].envFile).toBe(envFile);
+    expect(reg["agent"].command).toBe("pnpm run agency");
+  });
+
+  it("throws if agent file does not exist", () => {
+    expect(() => scheduleAdd({ file: path.join(tmpDir, "nope.agency"), every: "daily", baseDir: tmpDir })).toThrow("does not exist");
+  });
+
+  it("throws if cron expression is invalid", () => {
+    expect(() => scheduleAdd({ file: path.join(tmpDir, "agent.agency"), cron: "bad", baseDir: tmpDir })).toThrow("Invalid cron expression");
+  });
+
+  it("throws if neither --every nor --cron is provided", () => {
+    expect(() => scheduleAdd({ file: path.join(tmpDir, "agent.agency"), baseDir: tmpDir })).toThrow("--every or --cron");
+  });
+});
+
+describe("scheduleList", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sched-test-"));
+    fs.writeFileSync(path.join(tmpDir, "agent.agency"), "node main() {}");
+  });
+
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it("returns empty array when no schedules exist", () => {
+    expect(scheduleList({ baseDir: tmpDir })).toEqual([]);
+  });
+
+  it("returns entries after adding", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    const result = scheduleList({ baseDir: tmpDir });
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("agent");
+  });
+});
+
+describe("scheduleRemove", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sched-test-"));
+    fs.writeFileSync(path.join(tmpDir, "agent.agency"), "node main() {}");
+  });
+
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it("removes an existing schedule", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    scheduleRemove({ name: "agent", baseDir: tmpDir });
+    expect(scheduleList({ baseDir: tmpDir })).toEqual([]);
+  });
+
+  it("throws if name does not exist", () => {
+    expect(() => scheduleRemove({ name: "nope", baseDir: tmpDir })).toThrow("No schedule named");
+  });
+});
+
+describe("scheduleEdit", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sched-test-"));
+    fs.writeFileSync(path.join(tmpDir, "agent.agency"), "node main() {}");
+  });
+
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it("updates cron expression", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    scheduleEdit({ name: "agent", cron: "0 8 * * *", baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"].cron).toBe("0 8 * * *");
+    expect(reg["agent"].preset).toBe("");
+  });
+
+  it("updates command while keeping other fields", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    scheduleEdit({ name: "agent", command: "npx agency-lang", baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"].command).toBe("npx agency-lang");
+    expect(reg["agent"].cron).toBe("0 9 * * *");
+  });
+
+  it("throws if name does not exist", () => {
+    expect(() => scheduleEdit({ name: "nope", baseDir: tmpDir })).toThrow("No schedule named");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm --filter agency-lang exec vitest run lib/cli/schedule/index.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the main schedule module**
+
+```typescript
+// packages/agency-lang/lib/cli/schedule/index.ts
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+import { Registry, type ScheduleEntry } from "./registry.js";
+import { resolveCron, formatSchedule, nextRun } from "./cron.js";
+import { detectBackend, getBackend } from "./backends/index.js";
+
+function defaultBaseDir(): string {
+  return path.join(os.homedir(), ".agency", "schedules");
+}
+
+export type AddOptions = {
+  file: string;
+  every?: string;
+  cron?: string;
+  name?: string;
+  envFile?: string;
+  command?: string;
+  baseDir?: string;
+  force?: boolean;
+};
+
+export function scheduleAdd(opts: AddOptions): void {
+  const baseDir = opts.baseDir ?? defaultBaseDir();
+  const registry = new Registry(baseDir);
+
+  const agentFile = path.resolve(opts.file);
+  if (!fs.existsSync(agentFile)) {
+    throw new Error(`Agent file does not exist: ${agentFile}`);
+  }
+  if (opts.envFile && !fs.existsSync(opts.envFile)) {
+    throw new Error(`Env file does not exist: ${opts.envFile}`);
+  }
+
+  const { cron, preset } = resolveCron({ every: opts.every, cron: opts.cron });
+  const name = opts.name ?? path.basename(agentFile, ".agency");
+
+  if (registry.has(name) && !opts.force) {
+    throw new Error(
+      `A schedule named "${name}" already exists. Use --name to pick a different name, or remove the existing one first.`,
+    );
+  }
+
+  const backendType = detectBackend();
+  const backend = getBackend(backendType);
+
+  const entry: ScheduleEntry = {
+    name,
+    agentFile,
+    cron,
+    preset,
+    envFile: opts.envFile ? path.resolve(opts.envFile) : "",
+    command: opts.command ?? "agency",
+    logDir: path.join(baseDir, name, "logs"),
+    createdAt: new Date().toISOString(),
+    backend: backendType,
+  };
+
+  if (registry.has(name)) backend.uninstall(name);
+  registry.set(entry);
+
+  try {
+    backend.install(entry);
+  } catch (err) {
+    registry.remove(name);
+    throw err;
+  }
+}
+
+export type ListOptions = { baseDir?: string };
+
+export type ListEntry = {
+  name: string;
+  agentFile: string;
+  schedule: string;
+  nextRun: Date;
+  broken: boolean;
+};
+
+export function scheduleList(opts: ListOptions): ListEntry[] {
+  const registry = new Registry(opts.baseDir ?? defaultBaseDir());
+  return Object.values(registry.getAll()).map((entry) => ({
+    name: entry.name,
+    agentFile: entry.agentFile,
+    schedule: formatSchedule(entry.cron, entry.preset),
+    nextRun: nextRun(entry.cron),
+    broken: !fs.existsSync(entry.agentFile),
+  }));
+}
+
+export type RemoveOptions = { name: string; baseDir?: string };
+
+export function scheduleRemove(opts: RemoveOptions): void {
+  const registry = new Registry(opts.baseDir ?? defaultBaseDir());
+  const entry = registry.get(opts.name);
+  if (!entry) {
+    throw new Error(`No schedule named "${opts.name}". Run 'agency schedule list' to see available schedules.`);
+  }
+  getBackend(entry.backend).uninstall(opts.name);
+  registry.remove(opts.name);
+}
+
+export type EditOptions = {
+  name: string;
+  every?: string;
+  cron?: string;
+  envFile?: string;
+  command?: string;
+  baseDir?: string;
+};
+
+export function scheduleEdit(opts: EditOptions): void {
+  const registry = new Registry(opts.baseDir ?? defaultBaseDir());
+  const existing = registry.get(opts.name);
+  if (!existing) {
+    throw new Error(`No schedule named "${opts.name}". Run 'agency schedule list' to see available schedules.`);
+  }
+
+  if (opts.envFile && !fs.existsSync(opts.envFile)) {
+    throw new Error(`Env file does not exist: ${opts.envFile}`);
+  }
+
+  // Only resolve cron if user provided new schedule options
+  const { cron, preset } = (opts.every || opts.cron)
+    ? resolveCron({ every: opts.every, cron: opts.cron })
+    : { cron: existing.cron, preset: existing.preset };
+
+  const updated: ScheduleEntry = {
+    ...existing,
+    cron,
+    preset,
+    envFile: opts.envFile ? path.resolve(opts.envFile) : existing.envFile,
+    command: opts.command ?? existing.command,
+  };
+
+  const backend = getBackend(existing.backend);
+  backend.uninstall(opts.name);
+  registry.set(updated);
+
+  try {
+    backend.install(updated);
+  } catch (err) {
+    registry.set(existing);
+    throw err;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm --filter agency-lang exec vitest run lib/cli/schedule/index.test.ts`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/agency-lang/lib/cli/schedule/index.ts packages/agency-lang/lib/cli/schedule/index.test.ts
+git commit -m "feat(schedule): add, list, remove, edit commands with validation"
+```
+
+---
+
+### Task 6: Wire Up Commander in agency.ts
+
+**Files:**
+- Modify: `packages/agency-lang/scripts/agency.ts`
+
+- [ ] **Step 1: Add import at the top of `scripts/agency.ts`**
+
+```typescript
+import { scheduleAdd, scheduleList, scheduleRemove, scheduleEdit } from "@/cli/schedule/index.js";
+```
+
+- [ ] **Step 2: Add schedule subcommand in `createProgram()`**
+
+Add after the `review` command block (around line 551):
+
+```typescript
+const scheduleCmd = program
+  .command("schedule")
+  .description("Manage scheduled agent runs");
+
+scheduleCmd
+  .command("add")
+  .description("Schedule an agent to run on a recurring basis")
+  .argument("<file>", "Path to .agency file")
+  .option("--every <preset>", "Schedule preset: hourly, daily, weekdays, weekly")
+  .option("--cron <expression>", "Cron expression (5 fields)")
+  .option("--name <name>", "Schedule name (default: derived from filename)")
+  .option("--env-file <path>", "Path to .env file")
+  .option("--command <cmd>", "Command to run agency (default: agency)")
+  .action(async (file: string, opts: {
+    every?: string;
+    cron?: string;
+    name?: string;
+    envFile?: string;
+    command?: string;
+  }) => {
+    try {
+      scheduleAdd({ file, ...opts });
+      const name = opts.name || path.basename(file, ".agency");
+      console.log(color.green(`Schedule "${name}" added successfully.`));
+    } catch (err: any) {
+      if (err.message.includes("already exists") && process.stdin.isTTY) {
+        const confirmed = await promptOverwrite(opts.name || path.basename(file, ".agency"));
+        if (confirmed) {
+          scheduleAdd({ file, ...opts, force: true });
+          console.log(color.green("Schedule overwritten successfully."));
+        } else {
+          console.log("Aborted.");
+        }
+      } else {
+        console.error(color.red(err.message));
+        process.exit(1);
+      }
+    }
+  });
+
+scheduleCmd
+  .command("list")
+  .alias("ls")
+  .description("List all scheduled agents")
+  .action(() => {
+    const entries = scheduleList({});
+    if (entries.length === 0) {
+      console.log("No scheduled agents. Use 'agency schedule add' to create one.");
+      return;
+    }
+    printScheduleTable(entries);
+  });
+
+scheduleCmd
+  .command("remove")
+  .alias("rm")
+  .description("Remove a scheduled agent")
+  .argument("<name>", "Name of the schedule to remove")
+  .action((name: string) => {
+    try {
+      scheduleRemove({ name });
+      console.log(color.green(`Schedule "${name}" removed.`));
+    } catch (err: any) {
+      console.error(color.red(err.message));
+      process.exit(1);
+    }
+  });
+
+scheduleCmd
+  .command("edit")
+  .description("Edit an existing scheduled agent")
+  .argument("<name>", "Name of the schedule to edit")
+  .option("--every <preset>", "Schedule preset: hourly, daily, weekdays, weekly")
+  .option("--cron <expression>", "Cron expression (5 fields)")
+  .option("--env-file <path>", "Path to .env file")
+  .option("--command <cmd>", "Command to run agency")
+  .action((name: string, opts: {
+    every?: string;
+    cron?: string;
+    envFile?: string;
+    command?: string;
+  }) => {
+    try {
+      scheduleEdit({ name, ...opts });
+      console.log(color.green(`Schedule "${name}" updated.`));
+    } catch (err: any) {
+      console.error(color.red(err.message));
+      process.exit(1);
+    }
+  });
+```
+
+- [ ] **Step 3: Add helper functions (outside `createProgram`)**
+
+```typescript
+async function promptOverwrite(name: string): Promise<boolean> {
+  const readline = await import("readline");
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise<string>((resolve) => {
+    rl.question(`A schedule named "${name}" already exists. Overwrite? (y/n) `, resolve);
+  });
+  rl.close();
+  return answer.toLowerCase() === "y";
+}
+
+function printScheduleTable(entries: { name: string; agentFile: string; schedule: string; nextRun: Date; broken: boolean }[]): void {
+  const nameW = Math.max(4, ...entries.map((e) => e.name.length)) + 2;
+  const agentW = Math.max(5, ...entries.map((e) => e.agentFile.length)) + 2;
+  const schedW = Math.max(8, ...entries.map((e) => e.schedule.length)) + 2;
+
+  console.log(
+    "Name".padEnd(nameW) + "Agent".padEnd(agentW) + "Schedule".padEnd(schedW) + "Next Run",
+  );
+  for (const entry of entries) {
+    const broken = entry.broken ? color.red(" [broken]") : "";
+    const nextRunStr = entry.nextRun.toLocaleString("en-US", {
+      weekday: "short", month: "short", day: "numeric",
+      hour: "2-digit", minute: "2-digit", hour12: false,
+    });
+    console.log(
+      entry.name.padEnd(nameW) +
+      (entry.agentFile + broken).padEnd(agentW) +
+      entry.schedule.padEnd(schedW) +
+      nextRunStr,
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Build and verify CLI help**
+
+Run: `make && pnpm run agency schedule --help`
+Expected: Shows schedule subcommands (add, list, remove, edit)
+
+- [ ] **Step 5: Commit**
+
+```
+git add packages/agency-lang/scripts/agency.ts
+git commit -m "feat(schedule): wire up schedule subcommand in CLI"
+```
+
+---
+
+### Task 7: Manual Integration Test
+
+**Files:** None (manual verification)
+
+- [ ] **Step 1: Run all schedule tests**
+
+Run: `pnpm --filter agency-lang exec vitest run lib/cli/schedule/`
+Expected: All tests pass across all test files.
+
+- [ ] **Step 2: Manual smoke test (macOS)**
+
+From the `packages/agency-lang/` directory:
+
+```bash
+echo 'node main() { print("hello from scheduled agent") }' > test-schedule.agency
+pnpm run agency schedule add test-schedule.agency --every hourly --name test-schedule
+pnpm run agency schedule list
+pnpm run agency schedule edit test-schedule --every daily
+pnpm run agency schedule list
+pnpm run agency schedule remove test-schedule
+pnpm run agency schedule list
+rm test-schedule.agency
+```
+
+Verify:
+- `add` creates a plist in `~/Library/LaunchAgents/com.agency.schedule.test-schedule.plist`
+- `list` shows the entry with correct schedule and next run time
+- `edit` updates the schedule
+- `remove` cleans up the plist and registry
+
+- [ ] **Step 3: Final commit**
+
+```
+git commit --allow-empty -m "feat(schedule): verified manual integration test"
+```

--- a/docs/superpowers/specs/2026-05-06-schedule-cli-design.md
+++ b/docs/superpowers/specs/2026-05-06-schedule-cli-design.md
@@ -1,0 +1,161 @@
+# Agency Schedule CLI — Design Spec
+
+## Summary
+
+Add `agency schedule` subcommands to the CLI that let users run Agency agents on a recurring schedule using OS-native scheduling backends: launchd (macOS), systemd timers (Linux), and crontab (Linux fallback).
+
+## CLI Interface
+
+### Commands
+
+```
+agency schedule add <file> --every <preset> [--name <name>] [--env-file <path>] [--command <cmd>]
+agency schedule add <file> --cron "<expression>" [--name <name>] [--env-file <path>] [--command <cmd>]
+agency schedule edit <name> [--every <preset>] [--cron "<expression>"] [--env-file <path>] [--command <cmd>]
+agency schedule list
+agency schedule remove <name>
+```
+
+### Presets
+
+| Preset     | Cron expression | Description         |
+|------------|-----------------|---------------------|
+| `hourly`   | `0 * * * *`     | Top of every hour   |
+| `daily`    | `0 9 * * *`     | 9am local, every day|
+| `weekdays` | `0 9 * * 1-5`   | 9am local, Mon–Fri  |
+| `weekly`   | `0 9 * * 1`     | 9am local, Monday   |
+
+### Options
+
+- **`--name <name>`**: Override the schedule name. Default: derived from filename (`morning-briefing.agency` → `morning-briefing`). If a schedule with the name already exists, prompt user to confirm overwrite (error in non-interactive/no-TTY mode).
+- **`--env-file <path>`**: Path to a `.env` file to load at run time. If omitted, the agent relies on a `.env` file in its own directory (Agency's existing `loadEnv` behavior).
+- **`--command <cmd>`**: Custom command to invoke Agency. Default: `"agency"`. Useful for local installs: `--command "pnpm run agency"`, `--command "npx agency-lang"`. The scheduled run executes `<command> run <agentFile>`.
+- **`--every <preset>`**: Use a named preset (see table above). Mutually exclusive with `--cron`.
+- **`--cron "<expression>"`**: A 5-field cron expression. Mutually exclusive with `--every`. If invalid, show: `Invalid cron expression "<expr>". Expected 5 fields: minute hour day-of-month month day-of-week. Example: "0 9 * * 1-5" (weekdays at 9am)`.
+
+### `agency schedule edit <name>`
+
+Accepts the same flags as `add` except `--name` (renaming is not supported; remove and re-add instead). Merges provided flags into the existing entry, leaving unspecified fields unchanged. Implementation: read entry from registry, merge flags, uninstall old OS backend config, reinstall with updated entry, write back to registry.
+
+### `agency schedule list` Output
+
+```
+Name                Agent                          Schedule        Next Run
+morning-briefing    ./morning-briefing.agency      weekdays 9am    Wed May 6 09:00
+health-check        ./health-check.agency          0 */2 * * *     Wed May 6 12:00
+```
+
+- Agent column: path relative to cwd when possible, absolute otherwise.
+- Schedule column: preset name if used, raw cron expression otherwise.
+- Next Run column: next scheduled execution time computed from cron expression.
+- If an entry's agent file is missing, show it with a `[broken]` marker.
+
+## Registry and File Layout
+
+### Registry
+
+`~/.agency/schedules/schedules.json`:
+
+```json
+{
+  "morning-briefing": {
+    "name": "morning-briefing",
+    "agentFile": "/absolute/path/to/morning-briefing.agency",
+    "cron": "0 9 * * 1-5",
+    "preset": "weekdays",
+    "envFile": "/absolute/path/to/.env",
+    "command": "agency",
+    "logDir": "/Users/me/.agency/schedules/morning-briefing/logs",
+    "createdAt": "2026-05-06T10:00:00-07:00",
+    "backend": "launchd"
+  }
+}
+```
+
+All paths are stored as absolutes to avoid ambiguity when the OS triggers the run.
+
+### Logs
+
+`~/.agency/schedules/<name>/logs/`. Each run produces a timestamped log file: `2026-05-06T09-00-00.log` containing merged stdout/stderr. The last 50 log files per schedule are kept; older ones are deleted on each new run.
+
+### Working Directory
+
+The scheduled command `cd`s to the directory containing the agent file before running. This ensures relative imports and local `.env` files work correctly.
+
+## Backend Abstraction
+
+### Interface
+
+```typescript
+type ScheduleBackend = {
+  install(entry: ScheduleEntry): void;
+  uninstall(name: string): void;
+}
+```
+
+### Backend Selection (automatic)
+
+1. macOS (`process.platform === "darwin"`) → `LaunchdBackend`
+2. Linux with systemd (`systemctl` binary exists) → `SystemdBackend`
+3. Linux without systemd → `CrontabBackend`
+
+### LaunchdBackend
+
+- **install**: Writes a plist to `~/Library/LaunchAgents/com.agency.schedule.<name>.plist`, runs `launchctl load <plist>`. Plist sets `StandardOutPath`/`StandardErrorPath` to the log directory and `WorkingDirectory` to the agent's directory.
+- **uninstall**: Runs `launchctl unload <plist>`, deletes the plist file.
+
+### SystemdBackend
+
+- **install**: Writes a `.service` and `.timer` unit to `~/.config/systemd/user/`, runs `systemctl --user enable --now <timer>`.
+- **uninstall**: Runs `systemctl --user disable --now <timer>`, deletes both unit files.
+
+### CrontabBackend
+
+- **install**: Reads current crontab via `crontab -l`, appends a line with a comment marker (`# agency:<name>`), writes back via `crontab -`.
+- **uninstall**: Reads crontab, removes the line matching `# agency:<name>`, writes back.
+- Cron line invokes a wrapper script (`~/.agency/schedules/<name>/run.sh`) that creates a timestamped log file and runs the agent. This ensures consistent per-run log files across all backends.
+
+## Module Structure
+
+- **`lib/cli/schedule/index.ts`** — Main module: add, list, remove, edit functions. Registry read/write, log rotation, argument validation, preset-to-cron mapping.
+- **`lib/cli/schedule/backends.ts`** — ScheduleBackend interface and three implementations (launchd, systemd, crontab). Backend auto-detection.
+- **`scripts/agency.ts`** — Wire up the `schedule` subcommand with Commander.
+
+No stdlib module — this is purely a CLI feature.
+
+## Error Handling
+
+### Validation on `add`
+
+- Agent file must exist.
+- `--env-file` path must exist if specified.
+- Name must not already exist in registry (if it does, prompt to overwrite; error if no TTY).
+- Cron expression must be valid 5-field format.
+
+### Validation on `remove`/`edit`
+
+- Name must exist in registry.
+
+### Backend failures
+
+- If `launchctl load` or `systemctl enable` fails, roll back the registry entry and surface the error.
+- If `crontab -` fails, surface the error.
+
+### Stale entries
+
+- If the agent file has been moved or deleted, `agency schedule list` shows the entry with a `[broken]` marker.
+- `agency schedule remove` still works on broken entries (cleans up OS backend and registry).
+
+## Environment Variables
+
+Scheduled runs use the `.env` file in the agent's directory by default (via Agency's existing `loadEnv`). Users can override with `--env-file <path>`. The env file path is stored in the registry so the scheduled command knows where to find it.
+
+launchd and crontab run with minimal environments, so relying on `.env` files (rather than shell profile variables) is intentional and necessary.
+
+## Out of Scope (v1)
+
+- Overlap prevention (lock files for concurrent runs)
+- `agency schedule logs <name>` command (users can read log files directly)
+- Natural language schedule parsing
+- Cloud deployment / remote scheduling
+- Notifications on agent failure

--- a/packages/agency-lang/lib/cli/schedule/backends/backends.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/backends.test.ts
@@ -202,6 +202,17 @@ describe("buildIntervals", () => {
     }
   });
 
+  it("expands */15 in minute field", () => {
+    const result = buildIntervals("*/15 * * * *");
+    expect(result).toContain("<array>");
+    const dictCount = (result.match(/<dict>/g) || []).length;
+    expect(dictCount).toBe(4); // 0, 15, 30, 45
+    expect(result).toContain("<integer>0</integer>");
+    expect(result).toContain("<integer>15</integer>");
+    expect(result).toContain("<integer>30</integer>");
+    expect(result).toContain("<integer>45</integer>");
+  });
+
   it("handles wildcard fields by omitting them", () => {
     const result = buildIntervals("* * * * 1");
     // Only Weekday should be set, no Minute/Hour/Day/Month

--- a/packages/agency-lang/lib/cli/schedule/backends/backends.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/backends.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as childProcess from "child_process";
 import * as fs from "fs";
-import { LaunchdBackend } from "./launchd.js";
+import { LaunchdBackend, buildIntervals } from "./launchd.js";
+import { SystemdBackend } from "./systemd.js";
 import { CrontabBackend } from "./crontab.js";
 import { detectBackend } from "./index.js";
 import type { ScheduleEntry } from "../registry.js";
@@ -15,6 +16,14 @@ vi.mock("./writeRunScript.js", () => ({
 
 vi.mock("@/templates/cli/schedule/plist.js", () => ({
   default: (args: any) => `<plist>${args.name}</plist>`,
+}));
+
+vi.mock("@/templates/cli/schedule/service.js", () => ({
+  default: (args: any) => `[Service] ${args.name}`,
+}));
+
+vi.mock("@/templates/cli/schedule/timer.js", () => ({
+  default: (args: any) => `[Timer] ${args.name}`,
 }));
 
 const mockEntry: ScheduleEntry = {
@@ -131,6 +140,74 @@ describe("CrontabBackend", () => {
     const input = (writeCall![1] as any).input as string;
     expect(input).not.toContain("# agency:foo\n");
     expect(input).toContain("# agency:foo-bar");
+  });
+});
+
+describe("SystemdBackend", () => {
+  const backend = new SystemdBackend();
+
+  beforeEach(() => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined as any);
+    vi.mocked(fs.unlinkSync).mockImplementation(() => {});
+    vi.mocked(childProcess.execFileSync).mockImplementation(
+      () => Buffer.from(""),
+    );
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("install writes service and timer files and enables timer", () => {
+    backend.install(mockEntry);
+    const writeCalls = vi.mocked(fs.writeFileSync).mock.calls;
+    const paths = writeCalls.map((c) => c[0] as string);
+    expect(paths.some((p) => p.endsWith("agency-schedule-test-agent.service"))).toBe(true);
+    expect(paths.some((p) => p.endsWith("agency-schedule-test-agent.timer"))).toBe(true);
+    expect(vi.mocked(childProcess.execFileSync)).toHaveBeenCalledWith(
+      "systemctl",
+      ["--user", "enable", "--now", "agency-schedule-test-agent.timer"],
+    );
+  });
+
+  it("uninstall disables timer and deletes unit files", () => {
+    backend.uninstall("test-agent");
+    expect(vi.mocked(childProcess.execFileSync)).toHaveBeenCalledWith(
+      "systemctl",
+      ["--user", "disable", "--now", "agency-schedule-test-agent.timer"],
+    );
+  });
+});
+
+describe("buildIntervals", () => {
+  it("generates single dict for simple cron", () => {
+    const result = buildIntervals("0 9 * * *");
+    expect(result).toContain("<dict>");
+    expect(result).toContain("<key>Minute</key>");
+    expect(result).toContain("<integer>0</integer>");
+    expect(result).toContain("<key>Hour</key>");
+    expect(result).toContain("<integer>9</integer>");
+    expect(result).not.toContain("<array>");
+  });
+
+  it("generates array of dicts for weekday range", () => {
+    const result = buildIntervals("0 9 * * 1-5");
+    expect(result).toContain("<array>");
+    // Should have 5 dicts, one per weekday
+    const dictCount = (result.match(/<dict>/g) || []).length;
+    expect(dictCount).toBe(5);
+    expect(result).toContain("<key>Weekday</key>");
+    for (let i = 1; i <= 5; i++) {
+      expect(result).toContain(`<integer>${i}</integer>`);
+    }
+  });
+
+  it("handles wildcard fields by omitting them", () => {
+    const result = buildIntervals("* * * * 1");
+    // Only Weekday should be set, no Minute/Hour/Day/Month
+    expect(result).toContain("<key>Weekday</key>");
+    expect(result).not.toContain("<key>Minute</key>");
+    expect(result).not.toContain("<key>Hour</key>");
   });
 });
 

--- a/packages/agency-lang/lib/cli/schedule/backends/backends.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/backends.test.ts
@@ -37,7 +37,7 @@ describe("LaunchdBackend", () => {
     vi.mocked(fs.writeFileSync).mockImplementation(() => {});
     vi.mocked(fs.mkdirSync).mockImplementation(() => undefined as any);
     vi.mocked(fs.unlinkSync).mockImplementation(() => {});
-    vi.mocked(childProcess.execSync).mockImplementation(
+    vi.mocked(childProcess.execFileSync).mockImplementation(
       () => Buffer.from(""),
     );
   });
@@ -49,15 +49,17 @@ describe("LaunchdBackend", () => {
     const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
     const plistPath = writeCall[0] as string;
     expect(plistPath).toContain("com.agency.schedule.test-agent.plist");
-    expect(vi.mocked(childProcess.execSync)).toHaveBeenCalledWith(
-      expect.stringContaining("launchctl load"),
+    expect(vi.mocked(childProcess.execFileSync)).toHaveBeenCalledWith(
+      "launchctl",
+      ["load", expect.stringContaining("com.agency.schedule.test-agent.plist")],
     );
   });
 
   it("uninstall calls launchctl unload and deletes plist", () => {
     backend.uninstall("test-agent");
-    expect(vi.mocked(childProcess.execSync)).toHaveBeenCalledWith(
-      expect.stringContaining("launchctl unload"),
+    expect(vi.mocked(childProcess.execFileSync)).toHaveBeenCalledWith(
+      "launchctl",
+      ["unload", expect.stringContaining("com.agency.schedule.test-agent.plist")],
     );
     expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalled();
   });
@@ -109,6 +111,26 @@ describe("CrontabBackend", () => {
     const input = (writeCall![1] as any).input as string;
     expect(input).not.toContain("agency:test-agent");
     expect(input).toContain("other-job");
+  });
+
+  it("uninstall does not remove similar names", () => {
+    vi.mocked(childProcess.execSync).mockReset();
+    vi.mocked(childProcess.execSync).mockImplementation((cmd) => {
+      if (typeof cmd === "string" && cmd.includes("crontab -l")) {
+        return Buffer.from(
+          "0 9 * * * /path/run.sh # agency:foo\n0 9 * * * /path/run2.sh # agency:foo-bar\n",
+        );
+      }
+      return Buffer.from("");
+    });
+    backend.uninstall("foo");
+    const calls = vi.mocked(childProcess.execSync).mock.calls;
+    const writeCall = calls.find(
+      (c) => c[1] && typeof c[1] === "object" && "input" in c[1],
+    );
+    const input = (writeCall![1] as any).input as string;
+    expect(input).not.toContain("# agency:foo\n");
+    expect(input).toContain("# agency:foo-bar");
   });
 });
 

--- a/packages/agency-lang/lib/cli/schedule/backends/backends.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/backends.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as childProcess from "child_process";
+import * as fs from "fs";
+import { LaunchdBackend } from "./launchd.js";
+import { CrontabBackend } from "./crontab.js";
+import { detectBackend } from "./index.js";
+import type { ScheduleEntry } from "../registry.js";
+
+vi.mock("child_process");
+vi.mock("fs");
+
+vi.mock("./writeRunScript.js", () => ({
+  writeRunScript: () => "/mock/path/run.sh",
+}));
+
+vi.mock("@/templates/cli/schedule/plist.js", () => ({
+  default: (args: any) => `<plist>${args.name}</plist>`,
+}));
+
+const mockEntry: ScheduleEntry = {
+  name: "test-agent",
+  agentFile: "/home/user/project/agent.agency",
+  cron: "0 9 * * *",
+  preset: "daily",
+  envFile: "/home/user/project/.env",
+  command: "agency",
+  logDir: "/home/user/.agency/schedules/test-agent/logs",
+  createdAt: "2026-05-06T10:00:00-07:00",
+  backend: "launchd",
+};
+
+describe("LaunchdBackend", () => {
+  const backend = new LaunchdBackend();
+
+  beforeEach(() => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined as any);
+    vi.mocked(fs.unlinkSync).mockImplementation(() => {});
+    vi.mocked(childProcess.execSync).mockImplementation(
+      () => Buffer.from(""),
+    );
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("install writes a plist and calls launchctl load", () => {
+    backend.install(mockEntry);
+    const writeCall = vi.mocked(fs.writeFileSync).mock.calls[0];
+    const plistPath = writeCall[0] as string;
+    expect(plistPath).toContain("com.agency.schedule.test-agent.plist");
+    expect(vi.mocked(childProcess.execSync)).toHaveBeenCalledWith(
+      expect.stringContaining("launchctl load"),
+    );
+  });
+
+  it("uninstall calls launchctl unload and deletes plist", () => {
+    backend.uninstall("test-agent");
+    expect(vi.mocked(childProcess.execSync)).toHaveBeenCalledWith(
+      expect.stringContaining("launchctl unload"),
+    );
+    expect(vi.mocked(fs.unlinkSync)).toHaveBeenCalled();
+  });
+});
+
+describe("CrontabBackend", () => {
+  const backend = new CrontabBackend();
+
+  beforeEach(() => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.writeFileSync).mockImplementation(() => {});
+    vi.mocked(fs.mkdirSync).mockImplementation(() => undefined as any);
+    vi.mocked(childProcess.execSync).mockImplementation((cmd) => {
+      if (typeof cmd === "string" && cmd.includes("crontab -l")) {
+        return Buffer.from("# existing crontab\n");
+      }
+      return Buffer.from("");
+    });
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it("install writes crontab with agency marker", () => {
+    backend.install(mockEntry);
+    const calls = vi.mocked(childProcess.execSync).mock.calls;
+    const installCall = calls.find(
+      (c) => c[1] && typeof c[1] === "object" && "input" in c[1],
+    );
+    expect(installCall).toBeDefined();
+    const input = (installCall![1] as any).input as string;
+    expect(input).toContain("# agency:test-agent");
+  });
+
+  it("uninstall removes crontab line matching agency marker", () => {
+    vi.mocked(childProcess.execSync).mockReset();
+    vi.mocked(childProcess.execSync).mockImplementation((cmd) => {
+      if (typeof cmd === "string" && cmd.includes("crontab -l")) {
+        return Buffer.from(
+          "0 * * * * other-job\n0 9 * * * /path/run.sh # agency:test-agent\n",
+        );
+      }
+      return Buffer.from("");
+    });
+    backend.uninstall("test-agent");
+    const calls = vi.mocked(childProcess.execSync).mock.calls;
+    const writeCall = calls.find(
+      (c) => c[1] && typeof c[1] === "object" && "input" in c[1],
+    );
+    const input = (writeCall![1] as any).input as string;
+    expect(input).not.toContain("agency:test-agent");
+    expect(input).toContain("other-job");
+  });
+});
+
+describe("detectBackend", () => {
+  it("returns launchd on darwin", () => {
+    const original = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    expect(detectBackend()).toBe("launchd");
+    Object.defineProperty(process, "platform", { value: original });
+  });
+});

--- a/packages/agency-lang/lib/cli/schedule/backends/crontab.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/crontab.ts
@@ -18,9 +18,8 @@ function writeCrontab(content: string): void {
 }
 
 function filterLines(crontab: string, name: string): string[] {
-  return crontab
-    .split("\n")
-    .filter((line) => !line.includes(`# agency:${name}`));
+  const marker = new RegExp(`# agency:${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`);
+  return crontab.split("\n").filter((line) => !marker.test(line));
 }
 
 export class CrontabBackend implements ScheduleBackend {

--- a/packages/agency-lang/lib/cli/schedule/backends/crontab.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/crontab.ts
@@ -1,0 +1,52 @@
+import { execSync } from "child_process";
+import * as fs from "fs";
+import type { ScheduleEntry } from "../registry.js";
+import type { ScheduleBackend } from "./index.js";
+import { writeRunScript } from "./writeRunScript.js";
+
+function readCrontab(): string {
+  try {
+    return execSync("crontab -l", {
+      stdio: ["pipe", "pipe", "pipe"],
+    }).toString();
+  } catch {
+    return "";
+  }
+}
+
+function writeCrontab(content: string): void {
+  execSync("crontab -", { input: content });
+}
+
+function filterLines(crontab: string, name: string): string[] {
+  return crontab
+    .split("\n")
+    .filter((line) => !line.includes(`# agency:${name}`));
+}
+
+export class CrontabBackend implements ScheduleBackend {
+  install(entry: ScheduleEntry): void {
+    const runScriptPath = writeRunScript(entry);
+
+    if (!fs.existsSync(entry.logDir)) {
+      fs.mkdirSync(entry.logDir, { recursive: true });
+    }
+
+    const lines = filterLines(readCrontab(), entry.name);
+    lines.push(
+      `${entry.cron} /bin/bash "${runScriptPath}" # agency:${entry.name}`,
+    );
+    const content =
+      lines.filter((l) => l.trim() !== "").join("\n") + "\n";
+    writeCrontab(content);
+  }
+
+  uninstall(name: string): void {
+    const existing = readCrontab();
+    if (!existing) return;
+    const lines = filterLines(existing, name);
+    const content =
+      lines.filter((l) => l.trim() !== "").join("\n") + "\n";
+    writeCrontab(content);
+  }
+}

--- a/packages/agency-lang/lib/cli/schedule/backends/crontab.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/crontab.ts
@@ -28,6 +28,8 @@ export class CrontabBackend implements ScheduleBackend {
 
 
     const lines = filterLines(readCrontab(), entry.name);
+    // The "# agency:<name>" suffix is a marker used by filterLines to identify
+    // and remove our entries without affecting the user's other crontab lines.
     lines.push(
       `${entry.cron} /bin/bash "${runScriptPath}" # agency:${entry.name}`,
     );

--- a/packages/agency-lang/lib/cli/schedule/backends/crontab.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/crontab.ts
@@ -1,5 +1,4 @@
 import { execSync } from "child_process";
-import * as fs from "fs";
 import type { ScheduleEntry } from "../registry.js";
 import type { ScheduleBackend } from "./index.js";
 import { writeRunScript } from "./writeRunScript.js";
@@ -28,9 +27,6 @@ export class CrontabBackend implements ScheduleBackend {
   install(entry: ScheduleEntry): void {
     const runScriptPath = writeRunScript(entry);
 
-    if (!fs.existsSync(entry.logDir)) {
-      fs.mkdirSync(entry.logDir, { recursive: true });
-    }
 
     const lines = filterLines(readCrontab(), entry.name);
     lines.push(

--- a/packages/agency-lang/lib/cli/schedule/backends/index.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/index.ts
@@ -1,0 +1,37 @@
+import { execSync } from "child_process";
+import type { ScheduleEntry } from "../registry.js";
+import { LaunchdBackend } from "./launchd.js";
+import { SystemdBackend } from "./systemd.js";
+import { CrontabBackend } from "./crontab.js";
+
+export type ScheduleBackend = {
+  install(entry: ScheduleEntry): void;
+  uninstall(name: string): void;
+};
+
+export function detectBackend(): "launchd" | "systemd" | "crontab" {
+  if (process.platform === "darwin") return "launchd";
+  try {
+    execSync("which systemctl", { stdio: "pipe" });
+    return "systemd";
+  } catch {
+    return "crontab";
+  }
+}
+
+export function getBackend(
+  type: "launchd" | "systemd" | "crontab",
+): ScheduleBackend {
+  switch (type) {
+    case "launchd":
+      return new LaunchdBackend();
+    case "systemd":
+      return new SystemdBackend();
+    case "crontab":
+      return new CrontabBackend();
+  }
+}
+
+export { LaunchdBackend } from "./launchd.js";
+export { SystemdBackend } from "./systemd.js";
+export { CrontabBackend } from "./crontab.js";

--- a/packages/agency-lang/lib/cli/schedule/backends/index.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/index.ts
@@ -1,15 +1,17 @@
 import { execSync } from "child_process";
-import type { ScheduleEntry } from "../registry.js";
+import type { ScheduleEntry, BackendType } from "../registry.js";
 import { LaunchdBackend } from "./launchd.js";
 import { SystemdBackend } from "./systemd.js";
 import { CrontabBackend } from "./crontab.js";
+
+export type { BackendType } from "../registry.js";
 
 export type ScheduleBackend = {
   install(entry: ScheduleEntry): void;
   uninstall(name: string): void;
 };
 
-export function detectBackend(): "launchd" | "systemd" | "crontab" {
+export function detectBackend(): BackendType {
   if (process.platform === "darwin") return "launchd";
   try {
     execSync("which systemctl", { stdio: "pipe" });
@@ -19,9 +21,7 @@ export function detectBackend(): "launchd" | "systemd" | "crontab" {
   }
 }
 
-export function getBackend(
-  type: "launchd" | "systemd" | "crontab",
-): ScheduleBackend {
+export function getBackend(type: BackendType): ScheduleBackend {
   switch (type) {
     case "launchd":
       return new LaunchdBackend();

--- a/packages/agency-lang/lib/cli/schedule/backends/index.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/index.ts
@@ -14,6 +14,7 @@ export type ScheduleBackend = {
 export function detectBackend(): BackendType {
   if (process.platform === "darwin") return "launchd";
   try {
+    // execFileSync throws if `which` exits non-zero (systemctl not found) or ENOENT
     execFileSync("which", ["systemctl"], { stdio: "pipe" });
     return "systemd";
   } catch {

--- a/packages/agency-lang/lib/cli/schedule/backends/index.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/index.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import type { ScheduleEntry, BackendType } from "../registry.js";
 import { LaunchdBackend } from "./launchd.js";
 import { SystemdBackend } from "./systemd.js";
@@ -14,7 +14,7 @@ export type ScheduleBackend = {
 export function detectBackend(): BackendType {
   if (process.platform === "darwin") return "launchd";
   try {
-    execSync("which systemctl", { stdio: "pipe" });
+    execFileSync("which", ["systemctl"], { stdio: "pipe" });
     return "systemd";
   } catch {
     return "crontab";

--- a/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -104,14 +104,14 @@ export class LaunchdBackend implements ScheduleBackend {
     fs.mkdirSync(PLIST_DIR, { recursive: true });
 
     fs.writeFileSync(dest, plist);
-    execSync(`launchctl load "${dest}"`);
+    execFileSync("launchctl", ["load", dest]);
   }
 
   uninstall(name: string): void {
     const dest = plistPath(name);
     if (fs.existsSync(dest)) {
       try {
-        execSync(`launchctl unload "${dest}"`);
+        execFileSync("launchctl", ["unload", dest]);
       } catch {}
       fs.unlinkSync(dest);
     }

--- a/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
@@ -13,22 +13,80 @@ function plistPath(name: string): string {
   return path.join(PLIST_DIR, `com.agency.schedule.${name}.plist`);
 }
 
+function expandField(field: string): number[] {
+  const results: number[] = [];
+  for (const part of field.split(",")) {
+    const [range, stepStr] = part.split("/");
+    const step = stepStr ? parseInt(stepStr, 10) : 1;
+    if (range === "*") return []; // wildcard means "don't constrain this field"
+    if (range.includes("-")) {
+      const [lo, hi] = range.split("-").map(Number);
+      for (let i = lo; i <= hi; i += step) results.push(i);
+    } else {
+      results.push(parseInt(range, 10));
+    }
+  }
+  return results;
+}
+
 function buildIntervals(cron: string): string {
   const [minute, hour, dom, month, dow] = cron.split(/\s+/);
-  return [
-    minute !== "*" &&
-      `      <key>Minute</key>\n      <integer>${minute}</integer>`,
-    hour !== "*" &&
-      `      <key>Hour</key>\n      <integer>${hour}</integer>`,
-    dom !== "*" &&
-      `      <key>Day</key>\n      <integer>${dom}</integer>`,
-    month !== "*" &&
-      `      <key>Month</key>\n      <integer>${month}</integer>`,
-    dow !== "*" &&
-      `      <key>Weekday</key>\n      <integer>${dow}</integer>`,
-  ]
-    .filter(Boolean)
+  const minutes = expandField(minute);
+  const hours = expandField(hour);
+  const days = expandField(dom);
+  const months = expandField(month);
+  const weekdays = expandField(dow);
+
+  // Generate all combinations that need separate dicts.
+  // launchd requires one dict per unique combination of constrained fields.
+  // For most presets, only weekday varies (e.g. weekdays = 5 dicts).
+  const combos = buildCombos(minutes, hours, days, months, weekdays);
+
+  if (combos.length === 1) {
+    return `  <dict>\n${formatDict(combos[0])}\n  </dict>`;
+  }
+
+  const dicts = combos
+    .map((c) => `    <dict>\n${formatDict(c)}\n    </dict>`)
     .join("\n");
+  return `  <array>\n${dicts}\n  </array>`;
+}
+
+type IntervalDict = {
+  Minute?: number;
+  Hour?: number;
+  Day?: number;
+  Month?: number;
+  Weekday?: number;
+};
+
+function buildCombos(
+  minutes: number[],
+  hours: number[],
+  days: number[],
+  months: number[],
+  weekdays: number[],
+): IntervalDict[] {
+  // Start with a single empty dict and expand for each constrained field
+  let combos: IntervalDict[] = [{}];
+
+  if (minutes.length > 0) combos = combos.flatMap((c) => minutes.map((v) => ({ ...c, Minute: v })));
+  if (hours.length > 0) combos = combos.flatMap((c) => hours.map((v) => ({ ...c, Hour: v })));
+  if (days.length > 0) combos = combos.flatMap((c) => days.map((v) => ({ ...c, Day: v })));
+  if (months.length > 0) combos = combos.flatMap((c) => months.map((v) => ({ ...c, Month: v })));
+  if (weekdays.length > 0) combos = combos.flatMap((c) => weekdays.map((v) => ({ ...c, Weekday: v })));
+
+  return combos.length === 0 ? [{}] : combos;
+}
+
+function formatDict(dict: IntervalDict): string {
+  const lines: string[] = [];
+  for (const [key, val] of Object.entries(dict)) {
+    if (val !== undefined) {
+      lines.push(`      <key>${key}</key>\n      <integer>${val}</integer>`);
+    }
+  }
+  return lines.join("\n");
 }
 
 export class LaunchdBackend implements ScheduleBackend {

--- a/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
@@ -15,20 +15,25 @@ function plistPath(name: string): string {
 
 // Declarative mapping: cron field position → launchd StartCalendarInterval key
 const CRON_TO_LAUNCHD = [
-  { index: 0, key: "Minute" },
-  { index: 1, key: "Hour" },
-  { index: 2, key: "Day" },
-  { index: 3, key: "Month" },
-  { index: 4, key: "Weekday" },
+  { index: 0, key: "Minute", bounds: [0, 59] as [number, number] },
+  { index: 1, key: "Hour", bounds: [0, 23] as [number, number] },
+  { index: 2, key: "Day", bounds: [1, 31] as [number, number] },
+  { index: 3, key: "Month", bounds: [1, 12] as [number, number] },
+  { index: 4, key: "Weekday", bounds: [0, 6] as [number, number] },
 ] as const;
 
 // Expand a cron field like "1-5" or "0,30" into an array of integers.
 // Returns [] for wildcards ("*"), meaning "don't constrain this field".
-function expandField(field: string): number[] {
+function expandField(field: string, fieldIndex: number): number[] {
   if (field === "*") return [];
+  const [min, max] = CRON_TO_LAUNCHD[fieldIndex].bounds;
   return field.split(",").flatMap((part) => {
     const [range, stepStr] = part.split("/");
     const step = stepStr ? parseInt(stepStr, 10) : 1;
+    if (range === "*") {
+      // */N — expand wildcard with step over the full domain
+      return Array.from({ length: Math.floor((max - min) / step) + 1 }, (_, i) => min + i * step);
+    }
     if (range.includes("-")) {
       const [lo, hi] = range.split("-").map(Number);
       return Array.from({ length: Math.floor((hi - lo) / step) + 1 }, (_, i) => lo + i * step);
@@ -42,7 +47,7 @@ function expandField(field: string): number[] {
 export function buildIntervals(cron: string): string {
   const cronFields = cron.split(/\s+/);
   const expanded = CRON_TO_LAUNCHD
-    .map(({ index, key }) => ({ key, values: expandField(cronFields[index]) }))
+    .map(({ index, key }, i) => ({ key, values: expandField(cronFields[index], i) }))
     .filter(({ values }) => values.length > 0);
 
   // Cartesian product of all constrained fields

--- a/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
@@ -13,80 +13,54 @@ function plistPath(name: string): string {
   return path.join(PLIST_DIR, `com.agency.schedule.${name}.plist`);
 }
 
+// Declarative mapping: cron field position → launchd StartCalendarInterval key
+const CRON_TO_LAUNCHD = [
+  { index: 0, key: "Minute" },
+  { index: 1, key: "Hour" },
+  { index: 2, key: "Day" },
+  { index: 3, key: "Month" },
+  { index: 4, key: "Weekday" },
+] as const;
+
+// Expand a cron field like "1-5" or "0,30" into an array of integers.
+// Returns [] for wildcards ("*"), meaning "don't constrain this field".
 function expandField(field: string): number[] {
-  const results: number[] = [];
-  for (const part of field.split(",")) {
+  if (field === "*") return [];
+  return field.split(",").flatMap((part) => {
     const [range, stepStr] = part.split("/");
     const step = stepStr ? parseInt(stepStr, 10) : 1;
-    if (range === "*") return []; // wildcard means "don't constrain this field"
     if (range.includes("-")) {
       const [lo, hi] = range.split("-").map(Number);
-      for (let i = lo; i <= hi; i += step) results.push(i);
-    } else {
-      results.push(parseInt(range, 10));
+      return Array.from({ length: Math.floor((hi - lo) / step) + 1 }, (_, i) => lo + i * step);
     }
-  }
-  return results;
+    return [parseInt(range, 10)];
+  });
 }
 
+// launchd requires one dict per unique combination of constrained fields.
+// E.g. "weekdays at 9am" = 5 dicts (one per weekday), each with Hour=9, Minute=0.
 export function buildIntervals(cron: string): string {
-  const [minute, hour, dom, month, dow] = cron.split(/\s+/);
-  const minutes = expandField(minute);
-  const hours = expandField(hour);
-  const days = expandField(dom);
-  const months = expandField(month);
-  const weekdays = expandField(dow);
+  const cronFields = cron.split(/\s+/);
+  const expanded = CRON_TO_LAUNCHD
+    .map(({ index, key }) => ({ key, values: expandField(cronFields[index]) }))
+    .filter(({ values }) => values.length > 0);
 
-  // Generate all combinations that need separate dicts.
-  // launchd requires one dict per unique combination of constrained fields.
-  // For most presets, only weekday varies (e.g. weekdays = 5 dicts).
-  const combos = buildCombos(minutes, hours, days, months, weekdays);
+  // Cartesian product of all constrained fields
+  const combos = expanded.reduce<Record<string, number>[]>(
+    (acc, { key, values }) => acc.flatMap((combo) => values.map((v) => ({ ...combo, [key]: v }))),
+    [{}],
+  );
+
+  const formatDict = (dict: Record<string, number>) =>
+    Object.entries(dict)
+      .map(([k, v]) => `      <key>${k}</key>\n      <integer>${v}</integer>`)
+      .join("\n");
 
   if (combos.length === 1) {
     return `  <dict>\n${formatDict(combos[0])}\n  </dict>`;
   }
-
-  const dicts = combos
-    .map((c) => `    <dict>\n${formatDict(c)}\n    </dict>`)
-    .join("\n");
+  const dicts = combos.map((c) => `    <dict>\n${formatDict(c)}\n    </dict>`).join("\n");
   return `  <array>\n${dicts}\n  </array>`;
-}
-
-type IntervalDict = {
-  Minute?: number;
-  Hour?: number;
-  Day?: number;
-  Month?: number;
-  Weekday?: number;
-};
-
-function buildCombos(
-  minutes: number[],
-  hours: number[],
-  days: number[],
-  months: number[],
-  weekdays: number[],
-): IntervalDict[] {
-  // Start with a single empty dict and expand for each constrained field
-  let combos: IntervalDict[] = [{}];
-
-  if (minutes.length > 0) combos = combos.flatMap((c) => minutes.map((v) => ({ ...c, Minute: v })));
-  if (hours.length > 0) combos = combos.flatMap((c) => hours.map((v) => ({ ...c, Hour: v })));
-  if (days.length > 0) combos = combos.flatMap((c) => days.map((v) => ({ ...c, Day: v })));
-  if (months.length > 0) combos = combos.flatMap((c) => months.map((v) => ({ ...c, Month: v })));
-  if (weekdays.length > 0) combos = combos.flatMap((c) => weekdays.map((v) => ({ ...c, Weekday: v })));
-
-  return combos.length === 0 ? [{}] : combos;
-}
-
-function formatDict(dict: IntervalDict): string {
-  const lines: string[] = [];
-  for (const [key, val] of Object.entries(dict)) {
-    if (val !== undefined) {
-      lines.push(`      <key>${key}</key>\n      <integer>${val}</integer>`);
-    }
-  }
-  return lines.join("\n");
 }
 
 export class LaunchdBackend implements ScheduleBackend {
@@ -102,7 +76,6 @@ export class LaunchdBackend implements ScheduleBackend {
     const dest = plistPath(entry.name);
 
     fs.mkdirSync(PLIST_DIR, { recursive: true });
-
     fs.writeFileSync(dest, plist);
     execFileSync("launchctl", ["load", dest]);
   }

--- a/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
@@ -43,10 +43,7 @@ export class LaunchdBackend implements ScheduleBackend {
     });
     const dest = plistPath(entry.name);
 
-    if (!fs.existsSync(PLIST_DIR))
-      fs.mkdirSync(PLIST_DIR, { recursive: true });
-    if (!fs.existsSync(entry.logDir))
-      fs.mkdirSync(entry.logDir, { recursive: true });
+    fs.mkdirSync(PLIST_DIR, { recursive: true });
 
     fs.writeFileSync(dest, plist);
     execSync(`launchctl load "${dest}"`);

--- a/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
@@ -76,6 +76,10 @@ export class LaunchdBackend implements ScheduleBackend {
     const dest = plistPath(entry.name);
 
     fs.mkdirSync(PLIST_DIR, { recursive: true });
+    // Unload first if already loaded (launchctl load fails on already-loaded plists)
+    if (fs.existsSync(dest)) {
+      try { execFileSync("launchctl", ["unload", dest]); } catch {}
+    }
     fs.writeFileSync(dest, plist);
     execFileSync("launchctl", ["load", dest]);
   }

--- a/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
@@ -1,0 +1,64 @@
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import type { ScheduleEntry } from "../registry.js";
+import type { ScheduleBackend } from "./index.js";
+import { writeRunScript } from "./writeRunScript.js";
+import renderPlist from "@/templates/cli/schedule/plist.js";
+
+const PLIST_DIR = path.join(os.homedir(), "Library", "LaunchAgents");
+
+function plistPath(name: string): string {
+  return path.join(PLIST_DIR, `com.agency.schedule.${name}.plist`);
+}
+
+function buildIntervals(cron: string): string {
+  const [minute, hour, dom, month, dow] = cron.split(/\s+/);
+  return [
+    minute !== "*" &&
+      `      <key>Minute</key>\n      <integer>${minute}</integer>`,
+    hour !== "*" &&
+      `      <key>Hour</key>\n      <integer>${hour}</integer>`,
+    dom !== "*" &&
+      `      <key>Day</key>\n      <integer>${dom}</integer>`,
+    month !== "*" &&
+      `      <key>Month</key>\n      <integer>${month}</integer>`,
+    dow !== "*" &&
+      `      <key>Weekday</key>\n      <integer>${dow}</integer>`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+export class LaunchdBackend implements ScheduleBackend {
+  install(entry: ScheduleEntry): void {
+    const runScriptPath = writeRunScript(entry);
+    const plist = renderPlist({
+      name: entry.name,
+      runScriptPath,
+      agentDir: path.dirname(entry.agentFile),
+      intervals: buildIntervals(entry.cron),
+      logDir: entry.logDir,
+    });
+    const dest = plistPath(entry.name);
+
+    if (!fs.existsSync(PLIST_DIR))
+      fs.mkdirSync(PLIST_DIR, { recursive: true });
+    if (!fs.existsSync(entry.logDir))
+      fs.mkdirSync(entry.logDir, { recursive: true });
+
+    fs.writeFileSync(dest, plist);
+    execSync(`launchctl load "${dest}"`);
+  }
+
+  uninstall(name: string): void {
+    const dest = plistPath(name);
+    if (fs.existsSync(dest)) {
+      try {
+        execSync(`launchctl unload "${dest}"`);
+      } catch {}
+      fs.unlinkSync(dest);
+    }
+  }
+}

--- a/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/launchd.ts
@@ -29,7 +29,7 @@ function expandField(field: string): number[] {
   return results;
 }
 
-function buildIntervals(cron: string): string {
+export function buildIntervals(cron: string): string {
   const [minute, hour, dom, month, dow] = cron.split(/\s+/);
   const minutes = expandField(minute);
   const hours = expandField(hour);

--- a/packages/agency-lang/lib/cli/schedule/backends/systemd.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/systemd.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -34,21 +34,21 @@ export class SystemdBackend implements ScheduleBackend {
 
     fs.writeFileSync(path.join(UNIT_DIR, `${unit}.service`), service);
     fs.writeFileSync(path.join(UNIT_DIR, `${unit}.timer`), timer);
-    execSync("systemctl --user daemon-reload");
-    execSync(`systemctl --user enable --now ${unit}.timer`);
+    execFileSync("systemctl", ["--user", "daemon-reload"]);
+    execFileSync("systemctl", ["--user", "enable", "--now", `${unit}.timer`]);
   }
 
   uninstall(name: string): void {
     const unit = unitName(name);
     try {
-      execSync(`systemctl --user disable --now ${unit}.timer`);
+      execFileSync("systemctl", ["--user", "disable", "--now", `${unit}.timer`]);
     } catch {}
     const servicePath = path.join(UNIT_DIR, `${unit}.service`);
     const timerPath = path.join(UNIT_DIR, `${unit}.timer`);
     if (fs.existsSync(servicePath)) fs.unlinkSync(servicePath);
     if (fs.existsSync(timerPath)) fs.unlinkSync(timerPath);
     try {
-      execSync("systemctl --user daemon-reload");
+      execFileSync("systemctl", ["--user", "daemon-reload"]);
     } catch {}
   }
 }

--- a/packages/agency-lang/lib/cli/schedule/backends/systemd.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/systemd.ts
@@ -30,10 +30,7 @@ export class SystemdBackend implements ScheduleBackend {
       onCalendar: cronToOnCalendar(entry.cron),
     });
 
-    if (!fs.existsSync(UNIT_DIR))
-      fs.mkdirSync(UNIT_DIR, { recursive: true });
-    if (!fs.existsSync(entry.logDir))
-      fs.mkdirSync(entry.logDir, { recursive: true });
+    fs.mkdirSync(UNIT_DIR, { recursive: true });
 
     fs.writeFileSync(path.join(UNIT_DIR, `${unit}.service`), service);
     fs.writeFileSync(path.join(UNIT_DIR, `${unit}.timer`), timer);

--- a/packages/agency-lang/lib/cli/schedule/backends/systemd.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/systemd.ts
@@ -1,0 +1,57 @@
+import { execSync } from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import type { ScheduleEntry } from "../registry.js";
+import type { ScheduleBackend } from "./index.js";
+import { writeRunScript } from "./writeRunScript.js";
+import { cronToOnCalendar } from "../cron.js";
+import renderService from "@/templates/cli/schedule/service.js";
+import renderTimer from "@/templates/cli/schedule/timer.js";
+
+const UNIT_DIR = path.join(os.homedir(), ".config", "systemd", "user");
+
+function unitName(name: string): string {
+  return `agency-schedule-${name}`;
+}
+
+export class SystemdBackend implements ScheduleBackend {
+  install(entry: ScheduleEntry): void {
+    const runScriptPath = writeRunScript(entry);
+    const unit = unitName(entry.name);
+
+    const service = renderService({
+      name: entry.name,
+      agentDir: path.dirname(entry.agentFile),
+      runScriptPath,
+    });
+    const timer = renderTimer({
+      name: entry.name,
+      onCalendar: cronToOnCalendar(entry.cron),
+    });
+
+    if (!fs.existsSync(UNIT_DIR))
+      fs.mkdirSync(UNIT_DIR, { recursive: true });
+    if (!fs.existsSync(entry.logDir))
+      fs.mkdirSync(entry.logDir, { recursive: true });
+
+    fs.writeFileSync(path.join(UNIT_DIR, `${unit}.service`), service);
+    fs.writeFileSync(path.join(UNIT_DIR, `${unit}.timer`), timer);
+    execSync("systemctl --user daemon-reload");
+    execSync(`systemctl --user enable --now ${unit}.timer`);
+  }
+
+  uninstall(name: string): void {
+    const unit = unitName(name);
+    try {
+      execSync(`systemctl --user disable --now ${unit}.timer`);
+    } catch {}
+    const servicePath = path.join(UNIT_DIR, `${unit}.service`);
+    const timerPath = path.join(UNIT_DIR, `${unit}.timer`);
+    if (fs.existsSync(servicePath)) fs.unlinkSync(servicePath);
+    if (fs.existsSync(timerPath)) fs.unlinkSync(timerPath);
+    try {
+      execSync("systemctl --user daemon-reload");
+    } catch {}
+  }
+}

--- a/packages/agency-lang/lib/cli/schedule/backends/writeRunScript.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/writeRunScript.ts
@@ -16,7 +16,8 @@ export function writeRunScript(entry: ScheduleEntry): string {
     agentFile: entry.agentFile,
   });
 
-  if (!fs.existsSync(scriptDir)) fs.mkdirSync(scriptDir, { recursive: true });
+  fs.mkdirSync(scriptDir, { recursive: true });
+  fs.mkdirSync(entry.logDir, { recursive: true });
   fs.writeFileSync(scriptPath, content, { mode: 0o755 });
   return scriptPath;
 }

--- a/packages/agency-lang/lib/cli/schedule/backends/writeRunScript.ts
+++ b/packages/agency-lang/lib/cli/schedule/backends/writeRunScript.ts
@@ -1,0 +1,22 @@
+import * as fs from "fs";
+import * as path from "path";
+import type { ScheduleEntry } from "../registry.js";
+import renderRunScript from "@/templates/cli/schedule/runScript.js";
+
+export function writeRunScript(entry: ScheduleEntry): string {
+  const scriptDir = path.dirname(entry.logDir);
+  const scriptPath = path.join(scriptDir, "run.sh");
+
+  const content = renderRunScript({
+    agentDir: path.dirname(entry.agentFile),
+    hasEnvFile: !!entry.envFile,
+    envFile: entry.envFile,
+    logDir: entry.logDir,
+    command: entry.command,
+    agentFile: entry.agentFile,
+  });
+
+  if (!fs.existsSync(scriptDir)) fs.mkdirSync(scriptDir, { recursive: true });
+  fs.writeFileSync(scriptPath, content, { mode: 0o755 });
+  return scriptPath;
+}

--- a/packages/agency-lang/lib/cli/schedule/cron.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import {
+  presetToCron,
+  validateCron,
+  formatSchedule,
+  nextRun,
+  resolveCron,
+  cronToOnCalendar,
+} from "./cron.js";
+
+describe("presetToCron", () => {
+  it("maps hourly", () => expect(presetToCron("hourly")).toBe("0 * * * *"));
+  it("maps daily", () => expect(presetToCron("daily")).toBe("0 9 * * *"));
+  it("maps weekdays", () => expect(presetToCron("weekdays")).toBe("0 9 * * 1-5"));
+  it("maps weekly", () => expect(presetToCron("weekly")).toBe("0 9 * * 1"));
+  it("throws on unknown preset", () => {
+    expect(() => presetToCron("biweekly")).toThrow("Unknown preset");
+  });
+});
+
+describe("validateCron", () => {
+  it("accepts valid 5-field expressions", () => {
+    expect(validateCron("0 9 * * *")).toBe(true);
+    expect(validateCron("*/15 * * * *")).toBe(true);
+    expect(validateCron("0 9 * * 1-5")).toBe(true);
+    expect(validateCron("30 14 1 * *")).toBe(true);
+  });
+  it("rejects invalid expressions", () => {
+    expect(validateCron("not a cron")).toBe(false);
+    expect(validateCron("* * *")).toBe(false);
+    expect(validateCron("")).toBe(false);
+    expect(validateCron("* * * * * *")).toBe(false);
+  });
+});
+
+describe("resolveCron", () => {
+  it("resolves a preset", () => {
+    expect(resolveCron({ every: "daily" })).toEqual({
+      cron: "0 9 * * *",
+      preset: "daily",
+    });
+  });
+  it("resolves a raw cron expression", () => {
+    expect(resolveCron({ cron: "*/15 * * * *" })).toEqual({
+      cron: "*/15 * * * *",
+      preset: "",
+    });
+  });
+  it("throws if neither provided", () => {
+    expect(() => resolveCron({})).toThrow("--every or --cron");
+  });
+  it("throws on invalid cron", () => {
+    expect(() => resolveCron({ cron: "bad" })).toThrow("Invalid cron expression");
+  });
+});
+
+describe("formatSchedule", () => {
+  it("shows preset name when available", () => {
+    expect(formatSchedule("0 9 * * 1-5", "weekdays")).toBe("weekdays");
+  });
+  it("shows raw cron when no preset", () => {
+    expect(formatSchedule("*/15 * * * *", "")).toBe("*/15 * * * *");
+  });
+});
+
+describe("nextRun", () => {
+  it("returns a Date in the future", () => {
+    const next = nextRun("* * * * *");
+    expect(next.getTime()).toBeGreaterThan(Date.now());
+  });
+  it("returns within 60s for minutely cron", () => {
+    const next = nextRun("* * * * *");
+    const diffMs = next.getTime() - Date.now();
+    expect(diffMs).toBeLessThanOrEqual(60_000);
+    expect(diffMs).toBeGreaterThan(0);
+  });
+});
+
+describe("cronToOnCalendar", () => {
+  it("converts daily at 9am", () => {
+    expect(cronToOnCalendar("0 9 * * *")).toBe("*-*-* 09:00:00");
+  });
+  it("converts weekdays at 9am", () => {
+    expect(cronToOnCalendar("0 9 * * 1-5")).toBe(
+      "Mon,Tue,Wed,Thu,Fri *-*-* 09:00:00",
+    );
+  });
+  it("converts hourly", () => {
+    expect(cronToOnCalendar("0 * * * *")).toBe("*-*-* *:00:00");
+  });
+});

--- a/packages/agency-lang/lib/cli/schedule/cron.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.test.ts
@@ -3,7 +3,6 @@ import {
   presetToCron,
   validateCron,
   formatSchedule,
-  nextRun,
   resolveCron,
   cronToOnCalendar,
 } from "./cron.js";
@@ -70,19 +69,6 @@ describe("formatSchedule", () => {
   });
   it("shows raw cron when no preset", () => {
     expect(formatSchedule("*/15 * * * *", "")).toBe("*/15 * * * *");
-  });
-});
-
-describe("nextRun", () => {
-  it("returns a Date in the future", () => {
-    const next = nextRun("* * * * *");
-    expect(next.getTime()).toBeGreaterThan(Date.now());
-  });
-  it("returns within 60s for minutely cron", () => {
-    const next = nextRun("* * * * *");
-    const diffMs = next.getTime() - Date.now();
-    expect(diffMs).toBeLessThanOrEqual(60_000);
-    expect(diffMs).toBeGreaterThan(0);
   });
 });
 

--- a/packages/agency-lang/lib/cli/schedule/cron.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.test.ts
@@ -31,6 +31,16 @@ describe("validateCron", () => {
     expect(validateCron("")).toBe(false);
     expect(validateCron("* * * * * *")).toBe(false);
   });
+  it("rejects out-of-range values", () => {
+    expect(validateCron("99 * * * *")).toBe(false);
+    expect(validateCron("0 25 * * *")).toBe(false);
+    expect(validateCron("0 0 32 * *")).toBe(false);
+    expect(validateCron("0 0 * 13 *")).toBe(false);
+    expect(validateCron("0 0 * * 8")).toBe(false);
+  });
+  it("rejects step of 0", () => {
+    expect(validateCron("*/0 * * * *")).toBe(false);
+  });
 });
 
 describe("resolveCron", () => {
@@ -87,5 +97,17 @@ describe("cronToOnCalendar", () => {
   });
   it("converts hourly", () => {
     expect(cronToOnCalendar("0 * * * *")).toBe("*-*-* *:00:00");
+  });
+  it("converts every 15 minutes", () => {
+    expect(cronToOnCalendar("*/15 * * * *")).toBe("*-*-* *:*/15:00");
+  });
+  it("converts every 2 hours", () => {
+    expect(cronToOnCalendar("0 */2 * * *")).toBe("*-*-* */2:00:00");
+  });
+  it("converts Sunday as 7", () => {
+    expect(cronToOnCalendar("0 9 * * 7")).toBe("Sun *-*-* 09:00:00");
+  });
+  it("converts Sunday as 0", () => {
+    expect(cronToOnCalendar("0 9 * * 0")).toBe("Sun *-*-* 09:00:00");
   });
 });

--- a/packages/agency-lang/lib/cli/schedule/cron.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.test.ts
@@ -8,10 +8,13 @@ import {
 } from "./cron.js";
 
 describe("presetToCron", () => {
+  it("maps minute", () => expect(presetToCron("minute")).toBe("* * * * *"));
   it("maps hourly", () => expect(presetToCron("hourly")).toBe("0 * * * *"));
   it("maps daily", () => expect(presetToCron("daily")).toBe("0 9 * * *"));
   it("maps weekdays", () => expect(presetToCron("weekdays")).toBe("0 9 * * 1-5"));
+  it("maps weekends", () => expect(presetToCron("weekends")).toBe("0 9 * * 0,6"));
   it("maps weekly", () => expect(presetToCron("weekly")).toBe("0 9 * * 1"));
+  it("maps monthly", () => expect(presetToCron("monthly")).toBe("0 9 1 * *"));
   it("throws on unknown preset", () => {
     expect(() => presetToCron("biweekly")).toThrow("Unknown preset");
   });

--- a/packages/agency-lang/lib/cli/schedule/cron.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.ts
@@ -15,12 +15,33 @@ export function presetToCron(preset: string): string {
   return cron;
 }
 
+const FIELD_BOUNDS: [number, number][] = [
+  [0, 59],  // minute
+  [0, 23],  // hour
+  [1, 31],  // day of month
+  [1, 12],  // month
+  [0, 7],   // day of week (0 and 7 both mean Sunday)
+];
+
 export function validateCron(expr: string): boolean {
   const fields = expr.trim().split(/\s+/);
   if (fields.length !== 5) return false;
   const fieldPattern =
     /^(\*(\/([0-9]+))?|[0-9]+(-[0-9]+)?(\/[0-9]+)?)(,(\*(\/([0-9]+))?|[0-9]+(-[0-9]+)?(\/[0-9]+)?))*$/;
-  return fields.every((f) => fieldPattern.test(f));
+  return fields.every((f, i) => {
+    if (!fieldPattern.test(f)) return false;
+    // Check bounds and reject step of 0
+    const [min, max] = FIELD_BOUNDS[i];
+    for (const part of f.split(",")) {
+      const [range, stepStr] = part.split("/");
+      if (stepStr && parseInt(stepStr, 10) === 0) return false;
+      if (range !== "*") {
+        const nums = range.split("-").map(Number);
+        if (nums.some((n) => n < min || n > max)) return false;
+      }
+    }
+    return true;
+  });
 }
 
 export function resolveCron(opts: {
@@ -47,6 +68,8 @@ export function formatSchedule(cron: string, preset: string): string {
 
 export function nextRun(cronExpr: string): Date {
   const [minF, hourF, domF, monF, dowF] = cronExpr.trim().split(/\s+/);
+  // Normalize DOW field: replace 7 with 0 (both mean Sunday, but Date.getDay() returns 0-6)
+  const normalizedDowF = dowF.replace(/7/g, "0");
   const candidate = new Date();
   candidate.setSeconds(0, 0);
   candidate.setMinutes(candidate.getMinutes() + 1);
@@ -57,7 +80,7 @@ export function nextRun(cronExpr: string): Date {
       matchField(hourF, candidate.getHours()) &&
       matchField(domF, candidate.getDate()) &&
       matchField(monF, candidate.getMonth() + 1) &&
-      matchField(dowF, candidate.getDay())
+      matchField(normalizedDowF, candidate.getDay())
     ) {
       return candidate;
     }
@@ -91,6 +114,10 @@ function expandDow(dow: string): string {
 
 function field(f: string): string {
   if (f === "*") return "*";
+  // Handle step expressions like */15 → *:00/15 is not valid for systemd;
+  // systemd uses the same */N syntax for time fields
+  if (f.includes("/")) return f;
+  if (f.includes("-") || f.includes(",")) return f;
   return f.padStart(2, "0");
 }
 

--- a/packages/agency-lang/lib/cli/schedule/cron.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.ts
@@ -66,6 +66,8 @@ export function formatSchedule(cron: string, preset: string): string {
   return preset || cron;
 }
 
+const MINUTES_IN_YEAR = 366 * 24 * 60; // upper bound for next-run search
+
 export function nextRun(cronExpr: string): Date {
   const [minF, hourF, domF, monF, dowF] = cronExpr.trim().split(/\s+/);
   // Normalize DOW field: replace 7 with 0 (both mean Sunday, but Date.getDay() returns 0-6)
@@ -74,7 +76,7 @@ export function nextRun(cronExpr: string): Date {
   candidate.setSeconds(0, 0);
   candidate.setMinutes(candidate.getMinutes() + 1);
 
-  for (let i = 0; i < 527_040; i++) {
+  for (let i = 0; i < MINUTES_IN_YEAR; i++) {
     if (
       matchField(minF, candidate.getMinutes()) &&
       matchField(hourF, candidate.getHours()) &&

--- a/packages/agency-lang/lib/cli/schedule/cron.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.ts
@@ -1,3 +1,5 @@
+// --- Presets ---
+
 export const PRESETS: Record<string, string> = {
   hourly: "0 * * * *",
   daily: "0 9 * * *",
@@ -15,6 +17,8 @@ export function presetToCron(preset: string): string {
   return cron;
 }
 
+// --- Cron validation ---
+
 const FIELD_BOUNDS: [number, number][] = [
   [0, 59],  // minute
   [0, 23],  // hour
@@ -23,14 +27,14 @@ const FIELD_BOUNDS: [number, number][] = [
   [0, 7],   // day of week (0 and 7 both mean Sunday)
 ];
 
+const FIELD_PATTERN =
+  /^(\*(\/([0-9]+))?|[0-9]+(-[0-9]+)?(\/[0-9]+)?)(,(\*(\/([0-9]+))?|[0-9]+(-[0-9]+)?(\/[0-9]+)?))*$/;
+
 export function validateCron(expr: string): boolean {
   const fields = expr.trim().split(/\s+/);
   if (fields.length !== 5) return false;
-  const fieldPattern =
-    /^(\*(\/([0-9]+))?|[0-9]+(-[0-9]+)?(\/[0-9]+)?)(,(\*(\/([0-9]+))?|[0-9]+(-[0-9]+)?(\/[0-9]+)?))*$/;
   return fields.every((f, i) => {
-    if (!fieldPattern.test(f)) return false;
-    // Check bounds and reject step of 0
+    if (!FIELD_PATTERN.test(f)) return false;
     const [min, max] = FIELD_BOUNDS[i];
     for (const part of f.split(",")) {
       const [range, stepStr] = part.split("/");
@@ -43,6 +47,8 @@ export function validateCron(expr: string): boolean {
     return true;
   });
 }
+
+// --- Resolution ---
 
 export function resolveCron(opts: {
   every?: string;
@@ -66,35 +72,29 @@ export function formatSchedule(cron: string, preset: string): string {
   return preset || cron;
 }
 
+// --- Cron to systemd OnCalendar conversion ---
+
 // Index 7 duplicates "Sun" because cron allows both 0 and 7 to mean Sunday
 const DOW_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
-export function cronToOnCalendar(cron: string): string {
-  const [min, hour, dom, mon, dow] = cron.split(/\s+/);
-
-  const dowPart = dow === "*" ? "" : expandDow(dow);
-  const datePart = `*-${field(mon)}-${field(dom)}`;
-  const timePart = `${field(hour)}:${field(min)}:00`;
-
-  return dowPart ? `${dowPart} ${datePart} ${timePart}` : `${datePart} ${timePart}`;
+function passThrough(f: string): string {
+  if (f === "*") return "*";
+  if (f.includes("/") || f.includes("-") || f.includes(",")) return f;
+  return f.padStart(2, "0");
 }
 
 function expandDow(dow: string): string {
+  if (dow === "*") return "";
   if (dow.includes("-")) {
     const [lo, hi] = dow.split("-").map(Number);
-    const days = [];
-    for (let i = lo; i <= hi; i++) days.push(DOW_NAMES[i]);
-    return days.join(",");
+    return Array.from({ length: hi - lo + 1 }, (_, i) => DOW_NAMES[lo + i]).join(",");
   }
   return DOW_NAMES[Number(dow)] || dow;
 }
 
-function field(f: string): string {
-  if (f === "*") return "*";
-  // Handle step expressions like */15 → *:00/15 is not valid for systemd;
-  // systemd uses the same */N syntax for time fields
-  if (f.includes("/")) return f;
-  if (f.includes("-") || f.includes(",")) return f;
-  return f.padStart(2, "0");
+export function cronToOnCalendar(cron: string): string {
+  const fields = cron.split(/\s+/);
+  const dow = expandDow(fields[4]);
+  const calendar = `*-${passThrough(fields[3])}-${passThrough(fields[2])} ${passThrough(fields[1])}:${passThrough(fields[0])}:00`;
+  return dow ? `${dow} ${calendar}` : calendar;
 }
-

--- a/packages/agency-lang/lib/cli/schedule/cron.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.ts
@@ -1,0 +1,112 @@
+export const PRESETS: Record<string, string> = {
+  hourly: "0 * * * *",
+  daily: "0 9 * * *",
+  weekdays: "0 9 * * 1-5",
+  weekly: "0 9 * * 1",
+};
+
+export function presetToCron(preset: string): string {
+  const cron = PRESETS[preset];
+  if (!cron) {
+    throw new Error(
+      `Unknown preset "${preset}". Valid presets: ${Object.keys(PRESETS).join(", ")}`,
+    );
+  }
+  return cron;
+}
+
+export function validateCron(expr: string): boolean {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) return false;
+  const fieldPattern =
+    /^(\*(\/([0-9]+))?|[0-9]+(-[0-9]+)?(\/[0-9]+)?)(,(\*(\/([0-9]+))?|[0-9]+(-[0-9]+)?(\/[0-9]+)?))*$/;
+  return fields.every((f) => fieldPattern.test(f));
+}
+
+export function resolveCron(opts: {
+  every?: string;
+  cron?: string;
+}): { cron: string; preset: string } {
+  if (opts.every) {
+    return { cron: presetToCron(opts.every), preset: opts.every };
+  }
+  if (opts.cron) {
+    if (!validateCron(opts.cron)) {
+      throw new Error(
+        `Invalid cron expression "${opts.cron}". Expected 5 fields: minute hour day-of-month month day-of-week. Example: "0 9 * * 1-5" (weekdays at 9am)`,
+      );
+    }
+    return { cron: opts.cron, preset: "" };
+  }
+  throw new Error("Must provide --every or --cron to set a schedule.");
+}
+
+export function formatSchedule(cron: string, preset: string): string {
+  return preset || cron;
+}
+
+export function nextRun(cronExpr: string): Date {
+  const [minF, hourF, domF, monF, dowF] = cronExpr.trim().split(/\s+/);
+  const candidate = new Date();
+  candidate.setSeconds(0, 0);
+  candidate.setMinutes(candidate.getMinutes() + 1);
+
+  for (let i = 0; i < 527_040; i++) {
+    if (
+      matchField(minF, candidate.getMinutes()) &&
+      matchField(hourF, candidate.getHours()) &&
+      matchField(domF, candidate.getDate()) &&
+      matchField(monF, candidate.getMonth() + 1) &&
+      matchField(dowF, candidate.getDay())
+    ) {
+      return candidate;
+    }
+    candidate.setMinutes(candidate.getMinutes() + 1);
+  }
+  return candidate;
+}
+
+const DOW_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+export function cronToOnCalendar(cron: string): string {
+  const [min, hour, dom, mon, dow] = cron.split(/\s+/);
+
+  const dowPart = dow === "*" ? "" : expandDow(dow);
+  const datePart = `*-${field(mon)}-${field(dom)}`;
+  const timePart = `${field(hour)}:${field(min)}:00`;
+
+  return dowPart ? `${dowPart} ${datePart} ${timePart}` : `${datePart} ${timePart}`;
+}
+
+function expandDow(dow: string): string {
+  if (dow.includes("-")) {
+    const [lo, hi] = dow.split("-").map(Number);
+    const days = [];
+    for (let i = lo; i <= hi; i++) days.push(DOW_NAMES[i]);
+    return days.join(",");
+  }
+  return DOW_NAMES[Number(dow)] || dow;
+}
+
+function field(f: string): string {
+  if (f === "*") return "*";
+  return f.padStart(2, "0");
+}
+
+function matchField(field: string, value: number): boolean {
+  return field.split(",").some((part) => matchPart(part, value));
+}
+
+function matchPart(part: string, value: number): boolean {
+  const [range, stepStr] = part.split("/");
+  const step = stepStr ? parseInt(stepStr, 10) : 1;
+
+  if (range === "*") return value % step === 0;
+
+  if (range.includes("-")) {
+    const [low, high] = range.split("-").map(Number);
+    return value >= low && value <= high && (value - low) % step === 0;
+  }
+
+  return parseInt(range, 10) === value;
+}

--- a/packages/agency-lang/lib/cli/schedule/cron.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.ts
@@ -66,31 +66,6 @@ export function formatSchedule(cron: string, preset: string): string {
   return preset || cron;
 }
 
-const MINUTES_IN_YEAR = 366 * 24 * 60; // upper bound for next-run search
-
-export function nextRun(cronExpr: string): Date {
-  const [minF, hourF, domF, monF, dowF] = cronExpr.trim().split(/\s+/);
-  // Normalize DOW field: replace 7 with 0 (both mean Sunday, but Date.getDay() returns 0-6)
-  const normalizedDowF = dowF.replace(/7/g, "0");
-  const candidate = new Date();
-  candidate.setSeconds(0, 0);
-  candidate.setMinutes(candidate.getMinutes() + 1);
-
-  for (let i = 0; i < MINUTES_IN_YEAR; i++) {
-    if (
-      matchField(minF, candidate.getMinutes()) &&
-      matchField(hourF, candidate.getHours()) &&
-      matchField(domF, candidate.getDate()) &&
-      matchField(monF, candidate.getMonth() + 1) &&
-      matchField(normalizedDowF, candidate.getDay())
-    ) {
-      return candidate;
-    }
-    candidate.setMinutes(candidate.getMinutes() + 1);
-  }
-  return candidate;
-}
-
 // Index 7 duplicates "Sun" because cron allows both 0 and 7 to mean Sunday
 const DOW_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
@@ -123,20 +98,3 @@ function field(f: string): string {
   return f.padStart(2, "0");
 }
 
-function matchField(field: string, value: number): boolean {
-  return field.split(",").some((part) => matchPart(part, value));
-}
-
-function matchPart(part: string, value: number): boolean {
-  const [range, stepStr] = part.split("/");
-  const step = stepStr ? parseInt(stepStr, 10) : 1;
-
-  if (range === "*") return value % step === 0;
-
-  if (range.includes("-")) {
-    const [low, high] = range.split("-").map(Number);
-    return value >= low && value <= high && (value - low) % step === 0;
-  }
-
-  return parseInt(range, 10) === value;
-}

--- a/packages/agency-lang/lib/cli/schedule/cron.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.ts
@@ -1,10 +1,13 @@
 // --- Presets ---
 
 export const PRESETS: Record<string, string> = {
+  minute: "* * * * *",
   hourly: "0 * * * *",
   daily: "0 9 * * *",
   weekdays: "0 9 * * 1-5",
+  weekends: "0 9 * * 0,6",
   weekly: "0 9 * * 1",
+  monthly: "0 9 1 * *",
 };
 
 export function presetToCron(preset: string): string {

--- a/packages/agency-lang/lib/cli/schedule/cron.ts
+++ b/packages/agency-lang/lib/cli/schedule/cron.ts
@@ -66,6 +66,7 @@ export function nextRun(cronExpr: string): Date {
   return candidate;
 }
 
+// Index 7 duplicates "Sun" because cron allows both 0 and 7 to mean Sunday
 const DOW_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
 export function cronToOnCalendar(cron: string): string {

--- a/packages/agency-lang/lib/cli/schedule/index.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/index.test.ts
@@ -2,13 +2,22 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { scheduleAdd, scheduleList, scheduleRemove, scheduleEdit } from "./index.js";
+import {
+  scheduleAdd,
+  scheduleList,
+  scheduleRemove,
+  scheduleEdit,
+  ScheduleExistsError,
+} from "./index.js";
+
+const mockInstall = vi.fn();
+const mockUninstall = vi.fn();
 
 vi.mock("./backends/index.js", () => ({
   detectBackend: () => "launchd" as const,
   getBackend: () => ({
-    install: vi.fn(),
-    uninstall: vi.fn(),
+    install: mockInstall,
+    uninstall: mockUninstall,
   }),
 }));
 
@@ -18,6 +27,8 @@ describe("scheduleAdd", () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sched-test-"));
     fs.writeFileSync(path.join(tmpDir, "agent.agency"), "node main() {}");
+    mockInstall.mockReset();
+    mockUninstall.mockReset();
   });
 
   afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
@@ -51,6 +62,12 @@ describe("scheduleAdd", () => {
     expect(reg["agent"].command).toBe("pnpm run agency");
   });
 
+  it("calls backend.install", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    expect(mockInstall).toHaveBeenCalledTimes(1);
+    expect(mockInstall.mock.calls[0][0].name).toBe("agent");
+  });
+
   it("throws if agent file does not exist", () => {
     expect(() => scheduleAdd({ file: path.join(tmpDir, "nope.agency"), every: "daily", baseDir: tmpDir })).toThrow("does not exist");
   });
@@ -62,6 +79,64 @@ describe("scheduleAdd", () => {
   it("throws if neither --every nor --cron is provided", () => {
     expect(() => scheduleAdd({ file: path.join(tmpDir, "agent.agency"), baseDir: tmpDir })).toThrow("--every or --cron");
   });
+
+  it("throws ScheduleExistsError when name already exists", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    try {
+      scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "hourly", baseDir: tmpDir });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ScheduleExistsError);
+      expect((err as ScheduleExistsError).scheduleName).toBe("agent");
+    }
+  });
+
+  it("overwrites when force is true", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "hourly", force: true, baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"].cron).toBe("0 * * * *");
+    expect(mockUninstall).toHaveBeenCalledWith("agent");
+  });
+
+  it("rolls back registry on install failure", () => {
+    mockInstall.mockImplementationOnce(() => { throw new Error("install failed"); });
+    expect(() =>
+      scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir }),
+    ).toThrow("install failed");
+    // Registry should be empty after rollback
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"]).toBeUndefined();
+  });
+
+  it("rolls back to old entry on overwrite install failure", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    mockInstall.mockImplementationOnce(() => { throw new Error("install failed"); });
+    expect(() =>
+      scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "hourly", force: true, baseDir: tmpDir }),
+    ).toThrow("install failed");
+    // Registry should still have the old entry
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"].cron).toBe("0 9 * * *");
+  });
+
+  it("rejects names with path separators", () => {
+    expect(() =>
+      scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", name: "../evil", baseDir: tmpDir }),
+    ).toThrow("Invalid schedule name");
+  });
+
+  it("rejects names with spaces", () => {
+    expect(() =>
+      scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", name: "my agent", baseDir: tmpDir }),
+    ).toThrow("Invalid schedule name");
+  });
+
+  it("rejects names with shell metacharacters", () => {
+    expect(() =>
+      scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", name: "foo;rm -rf", baseDir: tmpDir }),
+    ).toThrow("Invalid schedule name");
+  });
 });
 
 describe("scheduleList", () => {
@@ -70,6 +145,8 @@ describe("scheduleList", () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sched-test-"));
     fs.writeFileSync(path.join(tmpDir, "agent.agency"), "node main() {}");
+    mockInstall.mockReset();
+    mockUninstall.mockReset();
   });
 
   afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
@@ -84,6 +161,20 @@ describe("scheduleList", () => {
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe("agent");
   });
+
+  it("marks missing agent files as broken", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    // Delete the agent file after scheduling
+    fs.unlinkSync(path.join(tmpDir, "agent.agency"));
+    const result = scheduleList({ baseDir: tmpDir });
+    expect(result[0].broken).toBe(true);
+  });
+
+  it("marks existing agent files as not broken", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    const result = scheduleList({ baseDir: tmpDir });
+    expect(result[0].broken).toBe(false);
+  });
 });
 
 describe("scheduleRemove", () => {
@@ -92,6 +183,8 @@ describe("scheduleRemove", () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sched-test-"));
     fs.writeFileSync(path.join(tmpDir, "agent.agency"), "node main() {}");
+    mockInstall.mockReset();
+    mockUninstall.mockReset();
   });
 
   afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
@@ -100,6 +193,13 @@ describe("scheduleRemove", () => {
     scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
     scheduleRemove({ name: "agent", baseDir: tmpDir });
     expect(scheduleList({ baseDir: tmpDir })).toEqual([]);
+  });
+
+  it("calls backend.uninstall", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    mockUninstall.mockReset();
+    scheduleRemove({ name: "agent", baseDir: tmpDir });
+    expect(mockUninstall).toHaveBeenCalledWith("agent");
   });
 
   it("throws if name does not exist", () => {
@@ -113,6 +213,8 @@ describe("scheduleEdit", () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sched-test-"));
     fs.writeFileSync(path.join(tmpDir, "agent.agency"), "node main() {}");
+    mockInstall.mockReset();
+    mockUninstall.mockReset();
   });
 
   afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
@@ -130,6 +232,17 @@ describe("scheduleEdit", () => {
     scheduleEdit({ name: "agent", command: "npx agency-lang", baseDir: tmpDir });
     const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
     expect(reg["agent"].command).toBe("npx agency-lang");
+    expect(reg["agent"].cron).toBe("0 9 * * *");
+  });
+
+  it("rolls back on install failure", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    mockInstall.mockImplementationOnce(() => { throw new Error("install failed"); });
+    expect(() =>
+      scheduleEdit({ name: "agent", cron: "0 8 * * *", baseDir: tmpDir }),
+    ).toThrow("install failed");
+    // Registry should still have the old cron
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
     expect(reg["agent"].cron).toBe("0 9 * * *");
   });
 

--- a/packages/agency-lang/lib/cli/schedule/index.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/index.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { scheduleAdd, scheduleList, scheduleRemove, scheduleEdit } from "./index.js";
+
+vi.mock("./backends/index.js", () => ({
+  detectBackend: () => "launchd" as const,
+  getBackend: () => ({
+    install: vi.fn(),
+    uninstall: vi.fn(),
+  }),
+}));
+
+describe("scheduleAdd", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sched-test-"));
+    fs.writeFileSync(path.join(tmpDir, "agent.agency"), "node main() {}");
+  });
+
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it("adds a schedule with a preset", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"].cron).toBe("0 9 * * *");
+    expect(reg["agent"].preset).toBe("daily");
+  });
+
+  it("adds a schedule with a cron expression", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), cron: "*/15 * * * *", baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"].cron).toBe("*/15 * * * *");
+    expect(reg["agent"].preset).toBe("");
+  });
+
+  it("uses custom name when provided", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", name: "custom", baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["custom"]).toBeDefined();
+  });
+
+  it("stores env-file and command", () => {
+    const envFile = path.join(tmpDir, ".env");
+    fs.writeFileSync(envFile, "KEY=value");
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", envFile, command: "pnpm run agency", baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"].envFile).toBe(envFile);
+    expect(reg["agent"].command).toBe("pnpm run agency");
+  });
+
+  it("throws if agent file does not exist", () => {
+    expect(() => scheduleAdd({ file: path.join(tmpDir, "nope.agency"), every: "daily", baseDir: tmpDir })).toThrow("does not exist");
+  });
+
+  it("throws if cron expression is invalid", () => {
+    expect(() => scheduleAdd({ file: path.join(tmpDir, "agent.agency"), cron: "bad", baseDir: tmpDir })).toThrow("Invalid cron expression");
+  });
+
+  it("throws if neither --every nor --cron is provided", () => {
+    expect(() => scheduleAdd({ file: path.join(tmpDir, "agent.agency"), baseDir: tmpDir })).toThrow("--every or --cron");
+  });
+});
+
+describe("scheduleList", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sched-test-"));
+    fs.writeFileSync(path.join(tmpDir, "agent.agency"), "node main() {}");
+  });
+
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it("returns empty array when no schedules exist", () => {
+    expect(scheduleList({ baseDir: tmpDir })).toEqual([]);
+  });
+
+  it("returns entries after adding", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    const result = scheduleList({ baseDir: tmpDir });
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("agent");
+  });
+});
+
+describe("scheduleRemove", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sched-test-"));
+    fs.writeFileSync(path.join(tmpDir, "agent.agency"), "node main() {}");
+  });
+
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it("removes an existing schedule", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    scheduleRemove({ name: "agent", baseDir: tmpDir });
+    expect(scheduleList({ baseDir: tmpDir })).toEqual([]);
+  });
+
+  it("throws if name does not exist", () => {
+    expect(() => scheduleRemove({ name: "nope", baseDir: tmpDir })).toThrow("No schedule named");
+  });
+});
+
+describe("scheduleEdit", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-sched-test-"));
+    fs.writeFileSync(path.join(tmpDir, "agent.agency"), "node main() {}");
+  });
+
+  afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+  it("updates cron expression", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    scheduleEdit({ name: "agent", cron: "0 8 * * *", baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"].cron).toBe("0 8 * * *");
+    expect(reg["agent"].preset).toBe("");
+  });
+
+  it("updates command while keeping other fields", () => {
+    scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
+    scheduleEdit({ name: "agent", command: "npx agency-lang", baseDir: tmpDir });
+    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
+    expect(reg["agent"].command).toBe("npx agency-lang");
+    expect(reg["agent"].cron).toBe("0 9 * * *");
+  });
+
+  it("throws if name does not exist", () => {
+    expect(() => scheduleEdit({ name: "nope", baseDir: tmpDir })).toThrow("No schedule named");
+  });
+});

--- a/packages/agency-lang/lib/cli/schedule/index.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/index.test.ts
@@ -96,20 +96,18 @@ describe("scheduleAdd", () => {
     scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "hourly", force: true, baseDir: tmpDir });
     const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
     expect(reg["agent"].cron).toBe("0 * * * *");
-    expect(mockUninstall).toHaveBeenCalledWith("agent");
   });
 
-  it("rolls back registry on install failure", () => {
+  it("does not update registry if install fails", () => {
     mockInstall.mockImplementationOnce(() => { throw new Error("install failed"); });
     expect(() =>
       scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir }),
     ).toThrow("install failed");
-    // Registry should be empty after rollback
-    const reg = JSON.parse(fs.readFileSync(path.join(tmpDir, "schedules.json"), "utf-8"));
-    expect(reg["agent"]).toBeUndefined();
+    // Registry file should not exist (install failed before registry write)
+    expect(fs.existsSync(path.join(tmpDir, "schedules.json"))).toBe(false);
   });
 
-  it("rolls back to old entry on overwrite install failure", () => {
+  it("does not update registry if overwrite install fails", () => {
     scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
     mockInstall.mockImplementationOnce(() => { throw new Error("install failed"); });
     expect(() =>
@@ -235,7 +233,7 @@ describe("scheduleEdit", () => {
     expect(reg["agent"].cron).toBe("0 9 * * *");
   });
 
-  it("rolls back on install failure", () => {
+  it("does not update registry if install fails", () => {
     scheduleAdd({ file: path.join(tmpDir, "agent.agency"), every: "daily", baseDir: tmpDir });
     mockInstall.mockImplementationOnce(() => { throw new Error("install failed"); });
     expect(() =>

--- a/packages/agency-lang/lib/cli/schedule/index.ts
+++ b/packages/agency-lang/lib/cli/schedule/index.ts
@@ -5,6 +5,17 @@ import { Registry, type ScheduleEntry } from "./registry.js";
 import { resolveCron, formatSchedule, nextRun } from "./cron.js";
 import { detectBackend, getBackend } from "./backends/index.js";
 
+export async function promptScheduleOverwrite(name: string): Promise<boolean> {
+  const prompts = (await import("prompts")).default;
+  const { overwrite } = await prompts({
+    type: "confirm",
+    name: "overwrite",
+    message: `A schedule named "${name}" already exists. Overwrite?`,
+    initial: false,
+  });
+  return overwrite ?? false;
+}
+
 export class ScheduleExistsError extends Error {
   constructor(public readonly scheduleName: string) {
     super(
@@ -110,6 +121,48 @@ export function scheduleList(opts: ListOptions): ListEntry[] {
     nextRun: nextRun(entry.cron),
     broken: !fs.existsSync(entry.agentFile),
   }));
+}
+
+function displayPath(absolutePath: string): string {
+  const rel = path.relative(process.cwd(), absolutePath);
+  return rel.startsWith("..") ? absolutePath : rel;
+}
+
+export function formatListTable(entries: ListEntry[]): string {
+  if (entries.length === 0) {
+    return "No scheduled agents. Use 'agency schedule add' to create one.";
+  }
+
+  const display = entries.map((e) => ({ ...e, displayAgent: displayPath(e.agentFile) }));
+  const nameW = Math.max(4, ...display.map((e) => e.name.length)) + 2;
+  const agentW = Math.max(5, ...display.map((e) => e.displayAgent.length)) + 2;
+  const schedW = Math.max(8, ...display.map((e) => e.schedule.length)) + 2;
+
+  const lines: string[] = [];
+  lines.push(
+    "Name".padEnd(nameW) +
+      "Agent".padEnd(agentW) +
+      "Schedule".padEnd(schedW) +
+      "Next Run",
+  );
+  for (const entry of display) {
+    const broken = entry.broken ? " [broken]" : "";
+    const nextRunStr = entry.nextRun.toLocaleString("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    lines.push(
+      entry.name.padEnd(nameW) +
+        (entry.displayAgent + broken).padEnd(agentW) +
+        entry.schedule.padEnd(schedW) +
+        nextRunStr,
+    );
+  }
+  return lines.join("\n");
 }
 
 export type RemoveOptions = { name: string; baseDir?: string };

--- a/packages/agency-lang/lib/cli/schedule/index.ts
+++ b/packages/agency-lang/lib/cli/schedule/index.ts
@@ -13,8 +13,18 @@ export class ScheduleExistsError extends Error {
   }
 }
 
+const VALID_NAME = /^[A-Za-z0-9._-]+$/;
+
 function defaultBaseDir(): string {
   return path.join(os.homedir(), ".agency", "schedules");
+}
+
+function validateName(name: string): void {
+  if (!VALID_NAME.test(name)) {
+    throw new Error(
+      `Invalid schedule name "${name}". Names may only contain letters, numbers, dots, hyphens, and underscores.`,
+    );
+  }
 }
 
 export type AddOptions = {
@@ -42,6 +52,7 @@ export function scheduleAdd(opts: AddOptions): void {
 
   const { cron, preset } = resolveCron({ every: opts.every, cron: opts.cron });
   const name = opts.name ?? path.basename(agentFile, ".agency");
+  validateName(name);
 
   if (registry.has(name) && !opts.force) {
     throw new ScheduleExistsError(name);

--- a/packages/agency-lang/lib/cli/schedule/index.ts
+++ b/packages/agency-lang/lib/cli/schedule/index.ts
@@ -62,13 +62,20 @@ export function scheduleAdd(opts: AddOptions): void {
     backend: backendType,
   };
 
-  if (registry.has(name)) backend.uninstall(name);
+  const oldEntry = registry.get(name);
+  if (oldEntry) backend.uninstall(name);
   registry.set(entry);
 
   try {
     backend.install(entry);
   } catch (err) {
-    registry.remove(name);
+    // Rollback: restore old entry or remove new one
+    if (oldEntry) {
+      registry.set(oldEntry);
+      try { backend.install(oldEntry); } catch {}
+    } else {
+      registry.remove(name);
+    }
     throw err;
   }
 }
@@ -150,7 +157,9 @@ export function scheduleEdit(opts: EditOptions): void {
   try {
     backend.install(updated);
   } catch (err) {
+    // Rollback: restore old schedule
     registry.set(existing);
+    try { backend.install(existing); } catch {}
     throw err;
   }
 }

--- a/packages/agency-lang/lib/cli/schedule/index.ts
+++ b/packages/agency-lang/lib/cli/schedule/index.ts
@@ -5,6 +5,14 @@ import { Registry, type ScheduleEntry } from "./registry.js";
 import { resolveCron, formatSchedule, nextRun } from "./cron.js";
 import { detectBackend, getBackend } from "./backends/index.js";
 
+export class ScheduleExistsError extends Error {
+  constructor(public readonly scheduleName: string) {
+    super(
+      `A schedule named "${scheduleName}" already exists. Use --name to pick a different name, or remove the existing one first.`,
+    );
+  }
+}
+
 function defaultBaseDir(): string {
   return path.join(os.homedir(), ".agency", "schedules");
 }
@@ -36,9 +44,7 @@ export function scheduleAdd(opts: AddOptions): void {
   const name = opts.name ?? path.basename(agentFile, ".agency");
 
   if (registry.has(name) && !opts.force) {
-    throw new Error(
-      `A schedule named "${name}" already exists. Use --name to pick a different name, or remove the existing one first.`,
-    );
+    throw new ScheduleExistsError(name);
   }
 
   const backendType = detectBackend();

--- a/packages/agency-lang/lib/cli/schedule/index.ts
+++ b/packages/agency-lang/lib/cli/schedule/index.ts
@@ -1,0 +1,150 @@
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+import { Registry, type ScheduleEntry } from "./registry.js";
+import { resolveCron, formatSchedule, nextRun } from "./cron.js";
+import { detectBackend, getBackend } from "./backends/index.js";
+
+function defaultBaseDir(): string {
+  return path.join(os.homedir(), ".agency", "schedules");
+}
+
+export type AddOptions = {
+  file: string;
+  every?: string;
+  cron?: string;
+  name?: string;
+  envFile?: string;
+  command?: string;
+  baseDir?: string;
+  force?: boolean;
+};
+
+export function scheduleAdd(opts: AddOptions): void {
+  const baseDir = opts.baseDir ?? defaultBaseDir();
+  const registry = new Registry(baseDir);
+
+  const agentFile = path.resolve(opts.file);
+  if (!fs.existsSync(agentFile)) {
+    throw new Error(`Agent file does not exist: ${agentFile}`);
+  }
+  if (opts.envFile && !fs.existsSync(opts.envFile)) {
+    throw new Error(`Env file does not exist: ${opts.envFile}`);
+  }
+
+  const { cron, preset } = resolveCron({ every: opts.every, cron: opts.cron });
+  const name = opts.name ?? path.basename(agentFile, ".agency");
+
+  if (registry.has(name) && !opts.force) {
+    throw new Error(
+      `A schedule named "${name}" already exists. Use --name to pick a different name, or remove the existing one first.`,
+    );
+  }
+
+  const backendType = detectBackend();
+  const backend = getBackend(backendType);
+
+  const entry: ScheduleEntry = {
+    name,
+    agentFile,
+    cron,
+    preset,
+    envFile: opts.envFile ? path.resolve(opts.envFile) : "",
+    command: opts.command ?? "agency",
+    logDir: path.join(baseDir, name, "logs"),
+    createdAt: new Date().toISOString(),
+    backend: backendType,
+  };
+
+  if (registry.has(name)) backend.uninstall(name);
+  registry.set(entry);
+
+  try {
+    backend.install(entry);
+  } catch (err) {
+    registry.remove(name);
+    throw err;
+  }
+}
+
+export type ListOptions = { baseDir?: string };
+
+export type ListEntry = {
+  name: string;
+  agentFile: string;
+  schedule: string;
+  nextRun: Date;
+  broken: boolean;
+};
+
+export function scheduleList(opts: ListOptions): ListEntry[] {
+  const registry = new Registry(opts.baseDir ?? defaultBaseDir());
+  return Object.values(registry.getAll()).map((entry) => ({
+    name: entry.name,
+    agentFile: entry.agentFile,
+    schedule: formatSchedule(entry.cron, entry.preset),
+    nextRun: nextRun(entry.cron),
+    broken: !fs.existsSync(entry.agentFile),
+  }));
+}
+
+export type RemoveOptions = { name: string; baseDir?: string };
+
+export function scheduleRemove(opts: RemoveOptions): void {
+  const registry = new Registry(opts.baseDir ?? defaultBaseDir());
+  const entry = registry.get(opts.name);
+  if (!entry) {
+    throw new Error(
+      `No schedule named "${opts.name}". Run 'agency schedule list' to see available schedules.`,
+    );
+  }
+  getBackend(entry.backend).uninstall(opts.name);
+  registry.remove(opts.name);
+}
+
+export type EditOptions = {
+  name: string;
+  every?: string;
+  cron?: string;
+  envFile?: string;
+  command?: string;
+  baseDir?: string;
+};
+
+export function scheduleEdit(opts: EditOptions): void {
+  const registry = new Registry(opts.baseDir ?? defaultBaseDir());
+  const existing = registry.get(opts.name);
+  if (!existing) {
+    throw new Error(
+      `No schedule named "${opts.name}". Run 'agency schedule list' to see available schedules.`,
+    );
+  }
+
+  if (opts.envFile && !fs.existsSync(opts.envFile)) {
+    throw new Error(`Env file does not exist: ${opts.envFile}`);
+  }
+
+  const { cron, preset } =
+    opts.every || opts.cron
+      ? resolveCron({ every: opts.every, cron: opts.cron })
+      : { cron: existing.cron, preset: existing.preset };
+
+  const updated: ScheduleEntry = {
+    ...existing,
+    cron,
+    preset,
+    envFile: opts.envFile ? path.resolve(opts.envFile) : existing.envFile,
+    command: opts.command ?? existing.command,
+  };
+
+  const backend = getBackend(existing.backend);
+  backend.uninstall(opts.name);
+  registry.set(updated);
+
+  try {
+    backend.install(updated);
+  } catch (err) {
+    registry.set(existing);
+    throw err;
+  }
+}

--- a/packages/agency-lang/lib/cli/schedule/index.ts
+++ b/packages/agency-lang/lib/cli/schedule/index.ts
@@ -84,22 +84,10 @@ export function scheduleAdd(opts: AddOptions): void {
     backend: backendType,
   };
 
-  const oldEntry = registry.get(name);
-  if (oldEntry) backend.uninstall(name);
+  // Install first (overwrites existing config files in-place), then update registry.
+  // If install fails, the old config files are still in place and the registry is unchanged.
+  backend.install(entry);
   registry.set(entry);
-
-  try {
-    backend.install(entry);
-  } catch (err) {
-    // Rollback: restore old entry or remove new one
-    if (oldEntry) {
-      registry.set(oldEntry);
-      try { backend.install(oldEntry); } catch {}
-    } else {
-      registry.remove(name);
-    }
-    throw err;
-  }
 }
 
 export type ListOptions = { baseDir?: string };
@@ -197,16 +185,9 @@ export function scheduleEdit(opts: EditOptions): void {
     command: opts.command ?? existing.command,
   };
 
+  // Install first (overwrites existing config files in-place), then update registry.
+  // If install fails, the old config files are still in place and the registry is unchanged.
   const backend = getBackend(existing.backend);
-  backend.uninstall(opts.name);
+  backend.install(updated);
   registry.set(updated);
-
-  try {
-    backend.install(updated);
-  } catch (err) {
-    // Rollback: restore old schedule
-    registry.set(existing);
-    try { backend.install(existing); } catch {}
-    throw err;
-  }
 }

--- a/packages/agency-lang/lib/cli/schedule/index.ts
+++ b/packages/agency-lang/lib/cli/schedule/index.ts
@@ -2,7 +2,7 @@ import * as path from "path";
 import * as fs from "fs";
 import * as os from "os";
 import { Registry, type ScheduleEntry } from "./registry.js";
-import { resolveCron, formatSchedule, nextRun } from "./cron.js";
+import { resolveCron, formatSchedule } from "./cron.js";
 import { detectBackend, getBackend } from "./backends/index.js";
 
 export async function promptScheduleOverwrite(name: string): Promise<boolean> {
@@ -108,7 +108,6 @@ export type ListEntry = {
   name: string;
   agentFile: string;
   schedule: string;
-  nextRun: Date;
   broken: boolean;
 };
 
@@ -118,7 +117,6 @@ export function scheduleList(opts: ListOptions): ListEntry[] {
     name: entry.name,
     agentFile: entry.agentFile,
     schedule: formatSchedule(entry.cron, entry.preset),
-    nextRun: nextRun(entry.cron),
     broken: !fs.existsSync(entry.agentFile),
   }));
 }
@@ -136,30 +134,15 @@ export function formatListTable(entries: ListEntry[]): string {
   const display = entries.map((e) => ({ ...e, displayAgent: displayPath(e.agentFile) }));
   const nameW = Math.max(4, ...display.map((e) => e.name.length)) + 2;
   const agentW = Math.max(5, ...display.map((e) => e.displayAgent.length)) + 2;
-  const schedW = Math.max(8, ...display.map((e) => e.schedule.length)) + 2;
 
   const lines: string[] = [];
-  lines.push(
-    "Name".padEnd(nameW) +
-      "Agent".padEnd(agentW) +
-      "Schedule".padEnd(schedW) +
-      "Next Run",
-  );
+  lines.push("Name".padEnd(nameW) + "Agent".padEnd(agentW) + "Schedule");
   for (const entry of display) {
     const broken = entry.broken ? " [broken]" : "";
-    const nextRunStr = entry.nextRun.toLocaleString("en-US", {
-      weekday: "short",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
     lines.push(
       entry.name.padEnd(nameW) +
         (entry.displayAgent + broken).padEnd(agentW) +
-        entry.schedule.padEnd(schedW) +
-        nextRunStr,
+        entry.schedule,
     );
   }
   return lines.join("\n");

--- a/packages/agency-lang/lib/cli/schedule/registry.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/registry.test.ts
@@ -60,4 +60,9 @@ describe("Registry", () => {
     expect(registry.has("test-agent")).toBe(true);
     expect(registry.has("nonexistent")).toBe(false);
   });
+
+  it("throws helpful error on corrupted JSON", () => {
+    fs.writeFileSync(path.join(tmpDir, "schedules.json"), "{invalid json");
+    expect(() => registry.getAll()).toThrow("Failed to parse schedule registry");
+  });
 });

--- a/packages/agency-lang/lib/cli/schedule/registry.test.ts
+++ b/packages/agency-lang/lib/cli/schedule/registry.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Registry } from "./registry.js";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+function makeEntry(tmpDir: string, overrides = {}) {
+  return {
+    name: "test-agent",
+    agentFile: "/path/to/agent.agency",
+    cron: "0 9 * * *",
+    preset: "daily",
+    envFile: "",
+    command: "agency",
+    logDir: path.join(tmpDir, "test-agent", "logs"),
+    createdAt: "2026-05-06T10:00:00-07:00",
+    backend: "launchd" as const,
+    ...overrides,
+  };
+}
+
+describe("Registry", () => {
+  let tmpDir: string;
+  let registry: Registry;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-schedule-test-"));
+    registry = new Registry(tmpDir);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns empty object when no registry file exists", () => {
+    expect(registry.getAll()).toEqual({});
+  });
+
+  it("adds and retrieves an entry", () => {
+    const entry = makeEntry(tmpDir);
+    registry.set(entry);
+    expect(registry.get("test-agent")).toEqual(entry);
+  });
+
+  it("removes an entry", () => {
+    registry.set(makeEntry(tmpDir));
+    registry.remove("test-agent");
+    expect(registry.get("test-agent")).toBeUndefined();
+  });
+
+  it("persists across instances", () => {
+    const entry = makeEntry(tmpDir);
+    registry.set(entry);
+    const registry2 = new Registry(tmpDir);
+    expect(registry2.get("test-agent")).toEqual(entry);
+  });
+
+  it("has() returns true for existing entries", () => {
+    registry.set(makeEntry(tmpDir));
+    expect(registry.has("test-agent")).toBe(true);
+    expect(registry.has("nonexistent")).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/cli/schedule/registry.ts
+++ b/packages/agency-lang/lib/cli/schedule/registry.ts
@@ -1,0 +1,57 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export type ScheduleEntry = {
+  name: string;
+  agentFile: string;
+  cron: string;
+  preset: string;
+  envFile: string;
+  command: string;
+  logDir: string;
+  createdAt: string;
+  backend: "launchd" | "systemd" | "crontab";
+};
+
+export type ScheduleRegistry = Record<string, ScheduleEntry>;
+
+export class Registry {
+  private filePath: string;
+
+  constructor(baseDir: string) {
+    this.filePath = path.join(baseDir, "schedules.json");
+  }
+
+  getAll(): ScheduleRegistry {
+    if (!fs.existsSync(this.filePath)) return {};
+    return JSON.parse(fs.readFileSync(this.filePath, "utf-8"));
+  }
+
+  get(name: string): ScheduleEntry | undefined {
+    return this.getAll()[name];
+  }
+
+  has(name: string): boolean {
+    return name in this.getAll();
+  }
+
+  set(entry: ScheduleEntry): void {
+    const all = this.getAll();
+    all[entry.name] = entry;
+    this.write(all);
+  }
+
+  remove(name: string): void {
+    const all = this.getAll();
+    delete all[name];
+    this.write(all);
+  }
+
+  private write(data: ScheduleRegistry): void {
+    const dir = path.dirname(this.filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2));
+  }
+}

--- a/packages/agency-lang/lib/cli/schedule/registry.ts
+++ b/packages/agency-lang/lib/cli/schedule/registry.ts
@@ -26,7 +26,13 @@ export class Registry {
 
   getAll(): ScheduleRegistry {
     if (!fs.existsSync(this.filePath)) return {};
-    return JSON.parse(fs.readFileSync(this.filePath, "utf-8"));
+    try {
+      return JSON.parse(fs.readFileSync(this.filePath, "utf-8"));
+    } catch {
+      throw new Error(
+        `Failed to parse schedule registry at ${this.filePath}. The file may be corrupted. Delete it to reset: rm "${this.filePath}"`,
+      );
+    }
   }
 
   get(name: string): ScheduleEntry | undefined {

--- a/packages/agency-lang/lib/cli/schedule/registry.ts
+++ b/packages/agency-lang/lib/cli/schedule/registry.ts
@@ -1,6 +1,8 @@
 import * as fs from "fs";
 import * as path from "path";
 
+export type BackendType = "launchd" | "systemd" | "crontab";
+
 export type ScheduleEntry = {
   name: string;
   agentFile: string;
@@ -10,7 +12,7 @@ export type ScheduleEntry = {
   command: string;
   logDir: string;
   createdAt: string;
-  backend: "launchd" | "systemd" | "crontab";
+  backend: BackendType;
 };
 
 export type ScheduleRegistry = Record<string, ScheduleEntry>;
@@ -48,10 +50,7 @@ export class Registry {
   }
 
   private write(data: ScheduleRegistry): void {
-    const dir = path.dirname(this.filePath);
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
+    fs.mkdirSync(path.dirname(this.filePath), { recursive: true });
     fs.writeFileSync(this.filePath, JSON.stringify(data, null, 2));
   }
 }

--- a/packages/agency-lang/lib/cli/schedule/registry.ts
+++ b/packages/agency-lang/lib/cli/schedule/registry.ts
@@ -40,7 +40,7 @@ export class Registry {
   }
 
   has(name: string): boolean {
-    return name in this.getAll();
+    return Object.hasOwn(this.getAll(), name);
   }
 
   set(entry: ScheduleEntry): void {

--- a/packages/agency-lang/lib/templates/cli/schedule/plist.mustache
+++ b/packages/agency-lang/lib/templates/cli/schedule/plist.mustache
@@ -12,9 +12,7 @@
   <key>WorkingDirectory</key>
   <string>{{{agentDir:string}}}</string>
   <key>StartCalendarInterval</key>
-  <dict>
 {{{intervals:string}}}
-  </dict>
   <key>StandardOutPath</key>
   <string>{{{logDir:string}}}/launchd-stdout.log</string>
   <key>StandardErrorPath</key>

--- a/packages/agency-lang/lib/templates/cli/schedule/plist.mustache
+++ b/packages/agency-lang/lib/templates/cli/schedule/plist.mustache
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agency.schedule.{{{name:string}}}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>{{{runScriptPath:string}}}</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>{{{agentDir:string}}}</string>
+  <key>StartCalendarInterval</key>
+  <dict>
+{{{intervals:string}}}
+  </dict>
+  <key>StandardOutPath</key>
+  <string>{{{logDir:string}}}/launchd-stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{{logDir:string}}}/launchd-stderr.log</string>
+</dict>
+</plist>

--- a/packages/agency-lang/lib/templates/cli/schedule/plist.ts
+++ b/packages/agency-lang/lib/templates/cli/schedule/plist.ts
@@ -1,0 +1,44 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/cli/schedule/plist.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.agency.schedule.{{{name:string}}}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>{{{runScriptPath:string}}}</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>{{{agentDir:string}}}</string>
+  <key>StartCalendarInterval</key>
+  <dict>
+{{{intervals:string}}}
+  </dict>
+  <key>StandardOutPath</key>
+  <string>{{{logDir:string}}}/launchd-stdout.log</string>
+  <key>StandardErrorPath</key>
+  <string>{{{logDir:string}}}/launchd-stderr.log</string>
+</dict>
+</plist>
+`;
+
+export type TemplateType = {
+  name: string;
+  runScriptPath: string;
+  agentDir: string;
+  intervals: string;
+  logDir: string;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/cli/schedule/plist.ts
+++ b/packages/agency-lang/lib/templates/cli/schedule/plist.ts
@@ -17,9 +17,7 @@ export const template = `<?xml version="1.0" encoding="UTF-8"?>
   <key>WorkingDirectory</key>
   <string>{{{agentDir:string}}}</string>
   <key>StartCalendarInterval</key>
-  <dict>
 {{{intervals:string}}}
-  </dict>
   <key>StandardOutPath</key>
   <string>{{{logDir:string}}}/launchd-stdout.log</string>
   <key>StandardErrorPath</key>

--- a/packages/agency-lang/lib/templates/cli/schedule/runScript.mustache
+++ b/packages/agency-lang/lib/templates/cli/schedule/runScript.mustache
@@ -2,7 +2,9 @@
 set -e
 cd "{{{agentDir:string}}}"
 {{#hasEnvFile:boolean}}
-export $(grep -v '^#' "{{{envFile:string}}}" | xargs)
+set -a
+. "{{{envFile:string}}}"
+set +a
 {{/hasEnvFile}}
 LOGFILE="{{{logDir:string}}}/$(date +%Y-%m-%dT%H-%M-%S).log"
 {{{command:string}}} run "{{{agentFile:string}}}" >> "$LOGFILE" 2>&1

--- a/packages/agency-lang/lib/templates/cli/schedule/runScript.mustache
+++ b/packages/agency-lang/lib/templates/cli/schedule/runScript.mustache
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+cd "{{{agentDir:string}}}"
+{{#hasEnvFile:boolean}}
+export $(grep -v '^#' "{{{envFile:string}}}" | xargs)
+{{/hasEnvFile}}
+LOGFILE="{{{logDir:string}}}/$(date +%Y-%m-%dT%H-%M-%S).log"
+{{{command:string}}} run "{{{agentFile:string}}}" >> "$LOGFILE" 2>&1
+
+# Rotate: keep last 50 logs
+cd "{{{logDir}}}"
+ls -t *.log 2>/dev/null | tail -n +51 | xargs rm -f 2>/dev/null || true

--- a/packages/agency-lang/lib/templates/cli/schedule/runScript.ts
+++ b/packages/agency-lang/lib/templates/cli/schedule/runScript.ts
@@ -1,0 +1,34 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/cli/schedule/runScript.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `#!/bin/bash
+set -e
+cd "{{{agentDir:string}}}"
+{{#hasEnvFile:boolean}}
+export $(grep -v '^#' "{{{envFile:string}}}" | xargs)
+{{/hasEnvFile}}
+LOGFILE="{{{logDir:string}}}/$(date +%Y-%m-%dT%H-%M-%S).log"
+{{{command:string}}} run "{{{agentFile:string}}}" >> "$LOGFILE" 2>&1
+
+# Rotate: keep last 50 logs
+cd "{{{logDir}}}"
+ls -t *.log 2>/dev/null | tail -n +51 | xargs rm -f 2>/dev/null || true
+`;
+
+export type TemplateType = {
+  agentDir: string;
+  hasEnvFile: boolean;
+  envFile: string;
+  logDir: string;
+  command: string;
+  agentFile: string;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/cli/schedule/runScript.ts
+++ b/packages/agency-lang/lib/templates/cli/schedule/runScript.ts
@@ -7,7 +7,9 @@ export const template = `#!/bin/bash
 set -e
 cd "{{{agentDir:string}}}"
 {{#hasEnvFile:boolean}}
-export $(grep -v '^#' "{{{envFile:string}}}" | xargs)
+set -a
+. "{{{envFile:string}}}"
+set +a
 {{/hasEnvFile}}
 LOGFILE="{{{logDir:string}}}/$(date +%Y-%m-%dT%H-%M-%S).log"
 {{{command:string}}} run "{{{agentFile:string}}}" >> "$LOGFILE" 2>&1

--- a/packages/agency-lang/lib/templates/cli/schedule/service.mustache
+++ b/packages/agency-lang/lib/templates/cli/schedule/service.mustache
@@ -1,0 +1,7 @@
+[Unit]
+Description=Agency scheduled agent: {{{name:string}}}
+
+[Service]
+Type=oneshot
+WorkingDirectory={{{agentDir:string}}}
+ExecStart=/bin/bash {{{runScriptPath:string}}}

--- a/packages/agency-lang/lib/templates/cli/schedule/service.mustache
+++ b/packages/agency-lang/lib/templates/cli/schedule/service.mustache
@@ -4,4 +4,4 @@ Description=Agency scheduled agent: {{{name:string}}}
 [Service]
 Type=oneshot
 WorkingDirectory={{{agentDir:string}}}
-ExecStart=/bin/bash {{{runScriptPath:string}}}
+ExecStart=/bin/bash "{{{runScriptPath:string}}}"

--- a/packages/agency-lang/lib/templates/cli/schedule/service.ts
+++ b/packages/agency-lang/lib/templates/cli/schedule/service.ts
@@ -1,0 +1,26 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/cli/schedule/service.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `[Unit]
+Description=Agency scheduled agent: {{{name:string}}}
+
+[Service]
+Type=oneshot
+WorkingDirectory={{{agentDir:string}}}
+ExecStart=/bin/bash {{{runScriptPath:string}}}
+`;
+
+export type TemplateType = {
+  name: string;
+  agentDir: string;
+  runScriptPath: string;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/cli/schedule/service.ts
+++ b/packages/agency-lang/lib/templates/cli/schedule/service.ts
@@ -9,7 +9,7 @@ Description=Agency scheduled agent: {{{name:string}}}
 [Service]
 Type=oneshot
 WorkingDirectory={{{agentDir:string}}}
-ExecStart=/bin/bash {{{runScriptPath:string}}}
+ExecStart=/bin/bash "{{{runScriptPath:string}}}"
 `;
 
 export type TemplateType = {

--- a/packages/agency-lang/lib/templates/cli/schedule/timer.mustache
+++ b/packages/agency-lang/lib/templates/cli/schedule/timer.mustache
@@ -1,0 +1,9 @@
+[Unit]
+Description=Timer for agency-schedule-{{{name:string}}}
+
+[Timer]
+OnCalendar={{{onCalendar:string}}}
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/packages/agency-lang/lib/templates/cli/schedule/timer.ts
+++ b/packages/agency-lang/lib/templates/cli/schedule/timer.ts
@@ -1,0 +1,27 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/cli/schedule/timer.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `[Unit]
+Description=Timer for agency-schedule-{{{name:string}}}
+
+[Timer]
+OnCalendar={{{onCalendar:string}}}
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+`;
+
+export type TemplateType = {
+  name: string;
+  onCalendar: string;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -569,7 +569,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .argument("<file>", "Path to .agency file")
     .option(
       "--every <preset>",
-      "Schedule preset: hourly, daily, weekdays, weekly",
+      "Schedule preset: minute, hourly, daily, weekdays, weekends, weekly, monthly",
     )
     .option("--cron <expression>", "Cron expression (5 fields)")
     .option(
@@ -651,7 +651,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .argument("<name>", "Name of the schedule to edit")
     .option(
       "--every <preset>",
-      "Schedule preset: hourly, daily, weekdays, weekly",
+      "Schedule preset: minute, hourly, daily, weekdays, weekends, weekly, monthly",
     )
     .option("--cron <expression>", "Cron expression (5 fields)")
     .option("--env-file <path>", "Path to .env file")

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -32,6 +32,8 @@ import {
   scheduleList,
   scheduleRemove,
   scheduleEdit,
+  ScheduleExistsError,
+  type ListEntry,
 } from "@/cli/schedule/index.js";
 import { loadEnv } from "@/utils/envfile.js";
 import { debug } from "@/cli/debug.js";
@@ -69,30 +71,17 @@ async function defaultLoadMcpStartServer(): Promise<() => void> {
 }
 
 async function promptOverwrite(name: string): Promise<boolean> {
-  const readline = await import("readline");
-  const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stdout,
+  const prompts = (await import("prompts")).default;
+  const { overwrite } = await prompts({
+    type: "confirm",
+    name: "overwrite",
+    message: `A schedule named "${name}" already exists. Overwrite?`,
+    initial: false,
   });
-  const answer = await new Promise<string>((resolve) => {
-    rl.question(
-      `A schedule named "${name}" already exists. Overwrite? (y/n) `,
-      resolve,
-    );
-  });
-  rl.close();
-  return answer.toLowerCase() === "y";
+  return overwrite ?? false;
 }
 
-function printScheduleTable(
-  entries: {
-    name: string;
-    agentFile: string;
-    schedule: string;
-    nextRun: Date;
-    broken: boolean;
-  }[],
-): void {
+function printScheduleTable(entries: ListEntry[]): void {
   const nameW = Math.max(4, ...entries.map((e) => e.name.length)) + 2;
   const agentW = Math.max(5, ...entries.map((e) => e.agentFile.length)) + 2;
   const schedW = Math.max(8, ...entries.map((e) => e.schedule.length)) + 2;
@@ -610,8 +599,6 @@ export function createProgram(deps: CliDependencies = {}): Command {
       review(config, file);
     });
 
-  // --- Schedule subcommand ---
-
   const scheduleCmd = program
     .command("schedule")
     .description("Manage scheduled agent runs");
@@ -652,13 +639,8 @@ export function createProgram(deps: CliDependencies = {}): Command {
             color.green(`Schedule "${name}" added successfully.`),
           );
         } catch (err: any) {
-          if (
-            err.message.includes("already exists") &&
-            process.stdin.isTTY
-          ) {
-            const confirmed = await promptOverwrite(
-              opts.name || path.basename(file, ".agency"),
-            );
+          if (err instanceof ScheduleExistsError && process.stdin.isTTY) {
+            const confirmed = await promptOverwrite(err.scheduleName);
             if (confirmed) {
               scheduleAdd({ file, ...opts, force: true });
               console.log(

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -27,6 +27,12 @@ import { TarsecError } from "tarsec";
 import process from "process";
 import { agent } from "@/cli/agent.js";
 import { review } from "@/cli/review.js";
+import {
+  scheduleAdd,
+  scheduleList,
+  scheduleRemove,
+  scheduleEdit,
+} from "@/cli/schedule/index.js";
 import { loadEnv } from "@/utils/envfile.js";
 import { debug } from "@/cli/debug.js";
 import { generateDoc } from "@/cli/doc.js";
@@ -60,6 +66,60 @@ async function defaultLoadLspStartServer(): Promise<() => void> {
 
 async function defaultLoadMcpStartServer(): Promise<() => void> {
   return startMcpServer;
+}
+
+async function promptOverwrite(name: string): Promise<boolean> {
+  const readline = await import("readline");
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  const answer = await new Promise<string>((resolve) => {
+    rl.question(
+      `A schedule named "${name}" already exists. Overwrite? (y/n) `,
+      resolve,
+    );
+  });
+  rl.close();
+  return answer.toLowerCase() === "y";
+}
+
+function printScheduleTable(
+  entries: {
+    name: string;
+    agentFile: string;
+    schedule: string;
+    nextRun: Date;
+    broken: boolean;
+  }[],
+): void {
+  const nameW = Math.max(4, ...entries.map((e) => e.name.length)) + 2;
+  const agentW = Math.max(5, ...entries.map((e) => e.agentFile.length)) + 2;
+  const schedW = Math.max(8, ...entries.map((e) => e.schedule.length)) + 2;
+
+  console.log(
+    "Name".padEnd(nameW) +
+      "Agent".padEnd(agentW) +
+      "Schedule".padEnd(schedW) +
+      "Next Run",
+  );
+  for (const entry of entries) {
+    const broken = entry.broken ? color.red(" [broken]") : "";
+    const nextRunStr = entry.nextRun.toLocaleString("en-US", {
+      weekday: "short",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    console.log(
+      entry.name.padEnd(nameW) +
+        (entry.agentFile + broken).padEnd(agentW) +
+        entry.schedule.padEnd(schedW) +
+        nextRunStr,
+    );
+  }
 }
 
 export function createProgram(deps: CliDependencies = {}): Command {
@@ -549,6 +609,132 @@ export function createProgram(deps: CliDependencies = {}): Command {
       const config = getConfig();
       review(config, file);
     });
+
+  // --- Schedule subcommand ---
+
+  const scheduleCmd = program
+    .command("schedule")
+    .description("Manage scheduled agent runs");
+
+  scheduleCmd
+    .command("add")
+    .description("Schedule an agent to run on a recurring basis")
+    .argument("<file>", "Path to .agency file")
+    .option(
+      "--every <preset>",
+      "Schedule preset: hourly, daily, weekdays, weekly",
+    )
+    .option("--cron <expression>", "Cron expression (5 fields)")
+    .option(
+      "--name <name>",
+      "Schedule name (default: derived from filename)",
+    )
+    .option("--env-file <path>", "Path to .env file")
+    .option(
+      "--command <cmd>",
+      "Command to run agency (default: agency)",
+    )
+    .action(
+      async (
+        file: string,
+        opts: {
+          every?: string;
+          cron?: string;
+          name?: string;
+          envFile?: string;
+          command?: string;
+        },
+      ) => {
+        try {
+          scheduleAdd({ file, ...opts });
+          const name = opts.name || path.basename(file, ".agency");
+          console.log(
+            color.green(`Schedule "${name}" added successfully.`),
+          );
+        } catch (err: any) {
+          if (
+            err.message.includes("already exists") &&
+            process.stdin.isTTY
+          ) {
+            const confirmed = await promptOverwrite(
+              opts.name || path.basename(file, ".agency"),
+            );
+            if (confirmed) {
+              scheduleAdd({ file, ...opts, force: true });
+              console.log(
+                color.green("Schedule overwritten successfully."),
+              );
+            } else {
+              console.log("Aborted.");
+            }
+          } else {
+            console.error(color.red(err.message));
+            process.exit(1);
+          }
+        }
+      },
+    );
+
+  scheduleCmd
+    .command("list")
+    .alias("ls")
+    .description("List all scheduled agents")
+    .action(() => {
+      const entries = scheduleList({});
+      if (entries.length === 0) {
+        console.log(
+          "No scheduled agents. Use 'agency schedule add' to create one.",
+        );
+        return;
+      }
+      printScheduleTable(entries);
+    });
+
+  scheduleCmd
+    .command("remove")
+    .alias("rm")
+    .description("Remove a scheduled agent")
+    .argument("<name>", "Name of the schedule to remove")
+    .action((name: string) => {
+      try {
+        scheduleRemove({ name });
+        console.log(color.green(`Schedule "${name}" removed.`));
+      } catch (err: any) {
+        console.error(color.red(err.message));
+        process.exit(1);
+      }
+    });
+
+  scheduleCmd
+    .command("edit")
+    .description("Edit an existing scheduled agent")
+    .argument("<name>", "Name of the schedule to edit")
+    .option(
+      "--every <preset>",
+      "Schedule preset: hourly, daily, weekdays, weekly",
+    )
+    .option("--cron <expression>", "Cron expression (5 fields)")
+    .option("--env-file <path>", "Path to .env file")
+    .option("--command <cmd>", "Command to run agency")
+    .action(
+      (
+        name: string,
+        opts: {
+          every?: string;
+          cron?: string;
+          envFile?: string;
+          command?: string;
+        },
+      ) => {
+        try {
+          scheduleEdit({ name, ...opts });
+          console.log(color.green(`Schedule "${name}" updated.`));
+        } catch (err: any) {
+          console.error(color.red(err.message));
+          process.exit(1);
+        }
+      },
+    );
 
   const lspCmd = program
     .command("lsp")

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -81,10 +81,17 @@ async function promptOverwrite(name: string): Promise<boolean> {
   return overwrite ?? false;
 }
 
+function displayPath(absolutePath: string): string {
+  const rel = path.relative(process.cwd(), absolutePath);
+  // Use relative if it's shorter and doesn't escape cwd
+  return rel.startsWith("..") ? absolutePath : rel;
+}
+
 function printScheduleTable(entries: ListEntry[]): void {
-  const nameW = Math.max(4, ...entries.map((e) => e.name.length)) + 2;
-  const agentW = Math.max(5, ...entries.map((e) => e.agentFile.length)) + 2;
-  const schedW = Math.max(8, ...entries.map((e) => e.schedule.length)) + 2;
+  const display = entries.map((e) => ({ ...e, displayAgent: displayPath(e.agentFile) }));
+  const nameW = Math.max(4, ...display.map((e) => e.name.length)) + 2;
+  const agentW = Math.max(5, ...display.map((e) => e.displayAgent.length)) + 2;
+  const schedW = Math.max(8, ...display.map((e) => e.schedule.length)) + 2;
 
   console.log(
     "Name".padEnd(nameW) +
@@ -92,7 +99,7 @@ function printScheduleTable(entries: ListEntry[]): void {
       "Schedule".padEnd(schedW) +
       "Next Run",
   );
-  for (const entry of entries) {
+  for (const entry of display) {
     const broken = entry.broken ? color.red(" [broken]") : "";
     const nextRunStr = entry.nextRun.toLocaleString("en-US", {
       weekday: "short",
@@ -104,7 +111,7 @@ function printScheduleTable(entries: ListEntry[]): void {
     });
     console.log(
       entry.name.padEnd(nameW) +
-        (entry.agentFile + broken).padEnd(agentW) +
+        (entry.displayAgent + broken).padEnd(agentW) +
         entry.schedule.padEnd(schedW) +
         nextRunStr,
     );
@@ -642,10 +649,15 @@ export function createProgram(deps: CliDependencies = {}): Command {
           if (err instanceof ScheduleExistsError && process.stdin.isTTY) {
             const confirmed = await promptOverwrite(err.scheduleName);
             if (confirmed) {
-              scheduleAdd({ file, ...opts, force: true });
-              console.log(
-                color.green("Schedule overwritten successfully."),
-              );
+              try {
+                scheduleAdd({ file, ...opts, force: true });
+                console.log(
+                  color.green("Schedule overwritten successfully."),
+                );
+              } catch (overwriteErr: any) {
+                console.error(color.red(overwriteErr.message));
+                process.exit(1);
+              }
             } else {
               console.log("Aborted.");
             }

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -33,7 +33,8 @@ import {
   scheduleRemove,
   scheduleEdit,
   ScheduleExistsError,
-  type ListEntry,
+  promptScheduleOverwrite,
+  formatListTable,
 } from "@/cli/schedule/index.js";
 import { loadEnv } from "@/utils/envfile.js";
 import { debug } from "@/cli/debug.js";
@@ -68,54 +69,6 @@ async function defaultLoadLspStartServer(): Promise<() => void> {
 
 async function defaultLoadMcpStartServer(): Promise<() => void> {
   return startMcpServer;
-}
-
-async function promptOverwrite(name: string): Promise<boolean> {
-  const prompts = (await import("prompts")).default;
-  const { overwrite } = await prompts({
-    type: "confirm",
-    name: "overwrite",
-    message: `A schedule named "${name}" already exists. Overwrite?`,
-    initial: false,
-  });
-  return overwrite ?? false;
-}
-
-function displayPath(absolutePath: string): string {
-  const rel = path.relative(process.cwd(), absolutePath);
-  // Use relative if it's shorter and doesn't escape cwd
-  return rel.startsWith("..") ? absolutePath : rel;
-}
-
-function printScheduleTable(entries: ListEntry[]): void {
-  const display = entries.map((e) => ({ ...e, displayAgent: displayPath(e.agentFile) }));
-  const nameW = Math.max(4, ...display.map((e) => e.name.length)) + 2;
-  const agentW = Math.max(5, ...display.map((e) => e.displayAgent.length)) + 2;
-  const schedW = Math.max(8, ...display.map((e) => e.schedule.length)) + 2;
-
-  console.log(
-    "Name".padEnd(nameW) +
-      "Agent".padEnd(agentW) +
-      "Schedule".padEnd(schedW) +
-      "Next Run",
-  );
-  for (const entry of display) {
-    const broken = entry.broken ? color.red(" [broken]") : "";
-    const nextRunStr = entry.nextRun.toLocaleString("en-US", {
-      weekday: "short",
-      month: "short",
-      day: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-      hour12: false,
-    });
-    console.log(
-      entry.name.padEnd(nameW) +
-        (entry.displayAgent + broken).padEnd(agentW) +
-        entry.schedule.padEnd(schedW) +
-        nextRunStr,
-    );
-  }
 }
 
 export function createProgram(deps: CliDependencies = {}): Command {
@@ -647,7 +600,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
           );
         } catch (err: any) {
           if (err instanceof ScheduleExistsError && process.stdin.isTTY) {
-            const confirmed = await promptOverwrite(err.scheduleName);
+            const confirmed = await promptScheduleOverwrite(err.scheduleName);
             if (confirmed) {
               try {
                 scheduleAdd({ file, ...opts, force: true });
@@ -674,14 +627,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .alias("ls")
     .description("List all scheduled agents")
     .action(() => {
-      const entries = scheduleList({});
-      if (entries.length === 0) {
-        console.log(
-          "No scheduled agents. Use 'agency schedule add' to create one.",
-        );
-        return;
-      }
-      printScheduleTable(entries);
+      console.log(formatListTable(scheduleList({})));
     });
 
   scheduleCmd


### PR DESCRIPTION
## Summary

- Adds `agency schedule add/list/remove/edit` commands to run agents on a recurring schedule using OS-native scheduling (launchd on macOS, systemd or crontab on Linux)
- JSON registry at `~/.agency/schedules/schedules.json` stores schedule metadata
- Supports presets (`--every daily`), custom cron (`--cron "0 9 * * 1-5"`), custom commands (`--command "pnpm run agency"`), and env files (`--env-file .env`)
- Per-run timestamped log files with automatic rotation (last 50 kept)
- Config files (plist, systemd units, run scripts) generated from typestache templates
- 42 unit tests across 4 test files

## Test plan

- [x] All 42 unit tests pass (`vitest run lib/cli/schedule/`)
- [x] `make` builds cleanly
- [x] `agency schedule --help` shows correct subcommands
- [x] `agency schedule add --help` shows all options
- [ ] Manual smoke test: add/list/edit/remove a schedule on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)