### PR TITLE
Add development harness for code quality enforcement

### DIFF
--- a/.claude/commands/review-changes.md
+++ b/.claude/commands/review-changes.md
@@ -1,6 +1,6 @@
 Review the current changes in this branch for violations of the project's coding standards and anti-patterns.
 
-1. Run `git diff main` to get the full diff of changes in this branch.
+1. Run `git diff origin/main` to get the full diff of changes in this branch.
 2. Read `packages/agency-lang/docs/dev/anti-patterns.md` — the anti-pattern catalog.
 3. Read `packages/agency-lang/docs/dev/coding-standards.md` — the coding standards.
 4. Review the diff against both documents. For each violation found, report:

--- a/.claude/commands/review-changes.md
+++ b/.claude/commands/review-changes.md
@@ -1,0 +1,12 @@
+Review the current changes in this branch for violations of the project's coding standards and anti-patterns.
+
+1. Run `git diff main` to get the full diff of changes in this branch.
+2. Read `packages/agency-lang/docs/dev/anti-patterns.md` — the anti-pattern catalog.
+3. Read `packages/agency-lang/docs/dev/coding-standards.md` — the coding standards.
+4. Review the diff against both documents. For each violation found, report:
+   - Which anti-pattern or coding standard was violated
+   - The file and approximate line number
+   - A specific suggested fix
+5. Focus ONLY on patterns documented in those two files. Do not invent new rules.
+6. Do not flag things that are clearly intentional or necessary for the context.
+7. If no violations are found, report that the changes look clean.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,19 @@
+name: Structural Lint
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint:structure
+        working-directory: packages/agency-lang

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,75 +22,12 @@ pnpm run ast <file>     # Parse .agency and print AST as JSON
 pnpm run preprocess <file>     # Parse .agency, run preprocessor, and print the resulting AST as JSON
 pnpm run fmt <file>     # Format .agency file using the AgencyGenerator
 make fixtures           # Rebuild all integration test fixtures
+pnpm run lint:structure # Run structural linter
 ```
 
 ## The full pipeline
-The full pipeline is: `parse → SymbolTable.build → buildCompilationUnit → TypescriptPreprocessor → TypeScriptBuilder.build() → printTs()`.
 
-### Parse
-Parses the code into an AST. Uses parsers in `lib/parser.ts` and `lib/parsers/`. The main entry point is the `parseAgency()` function in `lib/parser.ts`, which returns an Agency AST.
-
-All the types for the AST nodes are defined in `lib/types/` and `lib/types.ts`.
-
-### SymbolTable.build
-Builds a `SymbolTable` — a cross-file index of every declaration reachable from the entrypoint. For each symbol it records its kind (node, function, type, class) plus signature data. The preprocessor uses this to rewrite generic `importStatement` nodes into the specific kind (e.g. importing a node becomes an `importNodeStatement`). The class also exposes query methods like `resolveImport`, `findTypeAcrossFiles`, and `getFile` so consumers don't reach into the underlying record. See `lib/symbolTable.ts`.
-
-### buildCompilationUnit
-Collects all sorts of program info for the file being compiled: function definitions, type aliases, graph nodes, imports, safe-function markings, etc. Cross-file lookups (resolving imported types/functions) delegate to `SymbolTable`. See `lib/compilationUnit.ts`.
-
-### preprocessor
-Runs several transforms on the agency AST before it is sent to the builder. The preprocessor marks certain LLM calls as asynchronous, removes unused LLM code, and resolves variable scopes; that is, for each variable used, it identifies whether it is a global variable, local variable, imported variable, shared variable, etc. See `lib/preprocessors/typescriptPreprocessor.ts`.
-
-### build
-Transforms the agency AST into the TypeScript IR, which is one step above simple strings of TypeScript code. The TypeScript IR was introduced because it was a useful way to modify and transform TypeScript code. Without the TypeScript IR, we'd be running modifications on strings directly, which is extremely buggy and error-prone. See `lib/backends/typescriptBuilder.ts`.
-
-### Generate TypeScript code
-We use the `printTs()` function in `lib/ir/prettyPrint.ts` to convert the TypeScript IR AST into TypeScript code. See `lib/backends/typescriptGenerator.ts` and `lib/ir/prettyPrint.ts`.
-
-## Language design and features
-See `docs-new/guide/` for the full language reference and design docs.
-
-## Code generation and backends
-The code that gets written and executed from an agency program comes from two places.
-One is new TypeScript code written for the program. This comes from the builder, which in turn uses a combination of the TypeScript IR and the Mustache templates.
-The other is TypeScript libraries and functions that get run by the generated TypeScript code. Much of this is in the runtime directory (`lib/runtime`) or imported from other libraries such as Zod.
-As you can imagine, it's much better to have functionality in these shared libraries because then it is easily testable and refactorable, and we get type safety etc. The code for generating new TypeScript code on the other hand is much harder to work with. It's harder to read and reason about, and it doesn't have the same type safety. The TypeScript IR ameliorates some of this pain, but in general, when you are thinking of adding new features or modifying existing features, you should try to push as much of the functionality as you can into the runtime TypeScript libraries. Anything that can't be pushed to this should go in the builder if possible, especially if it is TypeScript code that may need to be manipulated later. For anything that's too complex and can't be put in the runtime libs, consider putting it in a Mustache file instead, so it's easy to read.
-
-## How to debug parser errors
-If you're having a hard time debugging a parser error, you can always use Tarsec's built-in debugger functionality. For an agency file, try running
-
-```
-DEBUG=1 pnpm run ast foo.agency
-```
-
-The "DEBUG=1" will tell Tarsec to print debug information as the parser runs. This output will be very large, so you'll want to redirect it to a file.
-
-```
-DEBUG=1 pnpm run ast foo.agency > foo.debuglog
-```
-
-Then, you can search through the contents of the file.
-
-The file will have this format:
-
-lines that start with a `🔍` tell you what parser it's going to try.
-Lines that start with a tick mark ( ✅) mean the parser succeeded.
-Lines with a star (⭐) mean a variable was either captured with "capture" or set with "set."
-Lines that start with a cross ( ❌) mean that the parser failed.
-You can see that the lines have different levels of indentation. The indentation indicates parsers that were nested within other parsers.
-
-Each line will also contain the name of the parser as well as the full input string being tried. You can use this to narrow down the relevant sections where the parser is trying to parse the input that is failing. Then, look at lines with a cross to figure out which parser is failing.
-
-## Implementation details
-
-## Parsers
-
-Parsers use the **tarsec** parser combinator library. Parser files live in `lib/parsers/` with co-located `.test.ts` files for unit tests.
-See Tarsec docs: https://egonschiele.github.io/tarsec/.
-
-If you want to modify parsers, you will first need to do a little bit of research on parser combinators. Tarsec comes with some tutorials:
-
-https://github.com/egonSchiele/tarsec/tree/main/tutorials
+`parse → SymbolTable.build → buildCompilationUnit → TypescriptPreprocessor → TypeScriptBuilder.build() → printTs()`
 
 ## Testing
 
@@ -98,62 +35,11 @@ See `docs/TESTING.md` for the full testing guide.
 
 Agency execution tests (`tests/agency/`) do NOT require LLM calls. They can test pure logic, interrupts, async calls, etc. without any LLM involvement. Use them for any runtime behavior test.
 
-Agency-js tests (`tests/agency/`) are similar, but let you test how agency code interacts with js code.
+Agency-js tests (`tests/agency-js/`) are similar, but let you test how agency code interacts with js code.
 
 Note that although agency and agency-js tests don't *require* LLM calls, they can support them if needed. Don't make any extra LLM calls because they are slow and expensive, but if you are writing a test and you *need* to make an LLM call, please feel free to make one.
 
 IMPORTANT! When you run tests, save the output to a file so that if the tests fail, you don't need to rerun them to see what failed. The tests in this repo are very expensive and slow to rerun, so if you keep rerunning tests to see what failed, you're going to waste a lot of time. So for God's sake, just run the test and save the output in a file once so you can examine the output at your leisure!!
-
-## Typechecker
-See docs/dev/typechecker.md and docs/typeChecker.md for more information. Code it at lib/typeChecker.ts.
-
-## TypeScript IR
-The TypeScript IR was introduced because it was a useful way to modify and transform TypeScript code. Without the TypeScript IR, we'd be running modifications on strings directly, which is extremely buggy and error-prone.
-See docs/dev/typescript-ir.md and lib/ir/ for more information.
-
-## Templates (typestache)
-
-Mustache templates in `lib/templates/` are compiled to TypeScript files using [typestache](https://www.npmjs.com/package/typestache). Run `pnpm run templates` to recompile them. The generated `.ts` files export a default render function you can import and call to produce a string from template data. If you create or modify a `.mustache` file, you must run `pnpm run templates` before building. Do not modify the TypeScript files directly; only modify the Mustache files.
-
-## Runtime
-
-The runtime (`lib/runtime/`) is the library that compiled Agency code imports and uses at execution time. It was created to separate the execution concerns from the code generation concerns — compiled `.ts` files import runtime functions rather than inlining all execution logic.
-
-Key components:
-- **`RuntimeContext`** (`lib/runtime/state/context.ts`) — A shared context object passed through all nodes and functions during execution. Holds the `StateStack`, `GlobalStore`, graph instance (`SimpleMachine`), lifecycle callbacks, the statelog client for tracing, and the working directory. Avoids threading many individual arguments through every function call.
-- **`GlobalStore`** (`lib/runtime/state/globalStore.ts`) — Stores global variables keyed by module ID, so each compiled Agency file gets its own namespace. Also tracks which modules have been initialized and stores internal data like token usage stats.
-- **`StateStack`** (`lib/runtime/state/stateStack.ts`) — Manages the call stack for serialization/deserialization (see Interrupts section above).
-- **`runPrompt`** (`lib/runtime/prompt.ts`) — Executes LLM calls via smoltalk.
-- **`setupNode` / `setupFunction` / `runNode`** (`lib/runtime/node.ts`) — Entry points for executing compiled nodes and functions.
-
-## Common Tasks
-
-### Adding a new AST node type
-
-1. **Define the type** in `lib/types/` (create a new file or add to an existing one). Export it from `lib/types.ts`. Add the new type to the `AgencyNode` union type in `lib/types.ts`.
-2. **Add a parser** in `lib/parsers/`. Wire it into the main parser in `lib/parser.ts`. Add unit tests in a co-located `.test.ts` file.
-3. **Add code generation** by adding a case to `processNode` in `lib/backends/typescriptBuilder.ts`. You may also need to create new `.mustache` template files in `lib/templates/backends/` and run `pnpm run templates`.
-5. **Add integration test fixtures** — create `.agency` and `.mts` files in `tests/typescriptGenerator/`.
-
-### Adding a CLI command
-
-1. Add the command definition in `scripts/agency.ts` using commander (`.command()`, `.argument()`, `.option()`, `.action()`).
-2. Implement the command logic in `lib/cli/` (create a new file or add to an existing one). Shared utilities like `parseTarget`, `pickANode`, `executeNode` live in `lib/cli/util.ts`.
-3. Optionally add a shortcut script in `package.json` under `"scripts"`.
-
-## Other miscellaneous things to know about
-
-### SimpleMachine (graph execution)
-Agency programs compile to graphs executed by `SimpleMachine` (`lib/simplemachine/`). See `docs/dev/simplemachine.md` for details on nodes, edges, conditional transitions, and how compiled Agency code maps to graph operations.
-
-### Smoltalk (LLM client)
-All LLM interactions go through the [smoltalk](https://www.npmjs.com/package/smoltalk) library. See `docs/dev/smoltalk.md` for how Agency uses it for structured output requests, message construction, and token tracking.
-
-### Statelog (tracing)
-`StatelogClient` (`lib/statelogClient.ts`) provides optional execution tracing — graph topology, node lifecycle, LLM calls, and tool executions. See `docs/dev/statelog.md`.
-
-### Configuration
-`AgencyConfig` (`lib/config.ts`) defines all compiler and runtime options. See `docs/dev/config.md` for the full option reference and `docs/config.md` for basic usage.
 
 ## CRITICAL: Handlers are safety infrastructure
 Handlers (`handle` blocks) are a crucial part of what makes Agency safe. They must NEVER be accidentally skipped or left unregistered. Any feature that affects execution flow (rewind, interrupts, checkpoints, state restoration) must ensure handlers are correctly registered and invoked. If there is any risk of a handler being skipped, treat it as a critical issue and flag it immediately. Handlers are registered on `__ctx.handlers` via `pushHandler()` in the generated code and are NOT serialized as part of checkpoint state — be aware of this when working on state restoration features.
@@ -189,37 +75,45 @@ Tools and functions are the same thing in the agency. Functions are tools. So th
 
 Please note that you cannot write and run agency files in the `/tmp` directory or any directory outside of the current directory, because certain node modules are needed for the files to run and the `/tmp` directory does not have those node modules.
 
-## Other docs and resources:
-- `docs/envFiles.md` — documentation on environment variables and .env files
-- `docs/config.md` — documentation on the `agency.json` configuration file
-- `docs/lifecycleHooks.md` — documentation on lifecycle hooks and callbacks
-- `docs/stateStack.md` — documentation on how the state stack works, including serialization and deserialization for interrupts.
-- `docs/TESTING.md` — documentation on how to write and run tests in the Agency repo, including unit tests, integration tests, and fixtures.
-- `docs/typeChecker.md` — documentation on the type checker, how it works, and how to use it.
-
-## docs/dev/ reference
-There are plenty of files that dive into implementation details on specific features:
-
-- `docs/dev/async-info-for-claude.md` — edge cases and test cases for async function behavior
-- `docs/dev/async.md` — how async function calls work, problems encountered, and solutions
-- `docs/dev/binop-parser.md` — binary expression parser using precedence climbing
-- `docs/dev/checkpointing.md` — snapshotting execution state for retry loops and rollback
-- `docs/dev/concurrent-interrupts.md` — supporting multiple concurrent threads that interrupt simultaneously
-- `docs/dev/config.md` — AgencyConfig options for compiler and runtime configuration
-- `docs/dev/debugger.md` — interactive debugger for stepping through and rewinding execution
-- `docs/dev/globalstore.md` — global variable management with module isolation and serialization
-- `docs/dev/init.md` — issues with global variable initialization outside graph node context
-- `docs/dev/interrupts.md` — how interrupts resume inside blocks using step counters (substeps)
-- `docs/dev/locations.md` — how `loc.line` / `loc.col` / parse-mode template offset interact; reference for any source-position bug
-- `docs/dev/message-thread-tests.md` — test cases for message threads and thread behavior
-- `docs/dev/pkg-imports.md` — importing Agency code from npm packages using `pkg::` prefix
-- `docs/dev/simplemachine.md` — graph execution engine that runs compiled Agency programs
-- `docs/dev/smoltalk.md` — external LLM client library for structured output requests
-- `docs/dev/statelog.md` — observability and tracing system for execution events
-- `docs/dev/threads.md` — ThreadStore and MessageThread system for LLM conversation history
-- `docs/dev/trace.md` — execution traces capturing checkpoints at every step
-- `docs/dev/typechecker.md` — bidirectional type checking to catch errors before compilation
-- `docs/dev/typescript-ir.md` — structured TsNode tree representation of generated TypeScript
-
 ## Guidance on writing commit messages and PR descriptions
 If you try to write commit messages with apostrophes right on the command line, you will get an error. I'm telling you this now because you do this every time. Same with PR descriptions. Instead you need to write the commit message or PR description in a file, and then pass that in to the git command.
+
+## Deeper docs
+
+Read these before starting work:
+- `docs/dev/coding-standards.md` — Banned patterns and style rules. Enforced by the structural linter.
+- `docs/dev/anti-patterns.md` — Common mistakes with before/after examples.
+- `docs/dev/adding-features.md` — Step-by-step guides for adding AST nodes, CLI commands, etc.
+
+Pipeline and architecture:
+- `docs/dev/typescript-ir.md` — Structured TsNode tree representation of generated TypeScript
+- `docs/dev/typechecker.md` — Bidirectional type checking
+- `docs/dev/interrupts.md` — How interrupts resume inside blocks using step counters (substeps)
+- `docs/dev/simplemachine.md` — Graph execution engine that runs compiled Agency programs
+- `docs/dev/async.md` — How async function calls work
+- `docs/dev/checkpointing.md` — Snapshotting execution state for retry loops and rollback
+- `docs/dev/threads.md` — ThreadStore and MessageThread system for LLM conversation history
+- `docs/dev/globalstore.md` — Global variable management with module isolation and serialization
+- `docs/dev/smoltalk.md` — External LLM client library for structured output requests
+- `docs/dev/statelog.md` — Observability and tracing system for execution events
+- `docs/dev/config.md` — AgencyConfig options for compiler and runtime configuration
+- `docs/dev/debugger.md` — Interactive debugger for stepping through and rewinding execution
+- `docs/dev/concurrent-interrupts.md` — Supporting multiple concurrent threads that interrupt simultaneously
+- `docs/dev/pkg-imports.md` — Importing Agency code from npm packages using `pkg::` prefix
+- `docs/dev/trace.md` — Execution traces capturing checkpoints at every step
+- `docs/dev/binop-parser.md` — Binary expression parser using precedence climbing
+- `docs/dev/locations.md` — How `loc.line` / `loc.col` / parse-mode template offset interact
+
+Other references:
+- `docs/TESTING.md` — Full testing guide (unit tests, fixtures, execution tests, agency-js tests)
+- `docs/config.md` — `agency.json` configuration file
+- `docs/lifecycleHooks.md` — Lifecycle hooks and callbacks
+- `docs/stateStack.md` — State stack serialization/deserialization for interrupts
+- `docs/typeChecker.md` — Type checker usage
+- `docs/envFiles.md` — Environment variables and .env files
+
+Parsers use the **tarsec** parser combinator library. Parser files live in `lib/parsers/` with co-located `.test.ts` files. See Tarsec docs: https://egonschiele.github.io/tarsec/. Debug parser errors with `DEBUG=1 pnpm run ast foo.agency > foo.debuglog`.
+
+Templates in `lib/templates/` are compiled via [typestache](https://www.npmjs.com/package/typestache). Run `pnpm run templates` to recompile. Only modify `.mustache` files, not the generated `.ts` files.
+
+The runtime (`lib/runtime/`) is the library that compiled Agency code imports at execution time. Push functionality here whenever possible — it's testable and type-safe, unlike generated code.

--- a/packages/agency-lang/docs/TESTING.md
+++ b/packages/agency-lang/docs/TESTING.md
@@ -11,7 +11,7 @@ Note: All `agency` commands in this file should be run using `pnpm run agency`.
 | Generator fixtures | `tests/typescriptGenerator/` | `pnpm test:run` |
 | Preprocessor fixtures | `tests/typescriptPreprocessor/` | `pnpm test:run` |
 | Agency execution tests | `tests/agency/` | `agency test tests/agency` |
-| Multi-step JS tests | `tests/agency-js/` | `agency test --js tests/agency-js` |
+| Multi-step JS tests | `tests/agency-js/` | `agency test js tests/agency-js` |
 
 ---
 
@@ -170,13 +170,13 @@ The `fixtures` command walks you through creating test cases:
 
 ```bash
 # Interactive — prompts for file and node
-agency fixtures
+agency test fixtures
 
 # Specify file
-agency fixtures tests/agency/example.agency
+agency test fixtures tests/agency/example.agency
 
 # Specify file and node
-agency fixtures tests/agency/example.agency:categorize
+agency test fixtures tests/agency/example.agency:categorize
 ```
 
 The command will:
@@ -247,13 +247,11 @@ If `fixture.json` doesn't exist yet, you'll be prompted to save the result as th
 
 ### Generating fixtures
 
-To auto-generate (or regenerate) fixtures without being prompted:
+To auto-generate fixtures, use the `fixtures` subcommand:
 
 ```bash
-agency test --gen-fixtures tests/agency-js
+agency test fixtures tests/agency-js
 ```
-
-This compiles and runs each test, then saves the result directly as `fixture.json`.
 
 ---
 
@@ -272,13 +270,10 @@ agency test tests/agency
 agency test tests/agency/example.test.json
 
 # Create test cases interactively
-agency fixtures tests/agency/example.agency
-agency fixtures tests/agency/example.agency:nodeName
+agency test fixtures tests/agency/example.agency
+agency test fixtures tests/agency/example.agency:nodeName
 
 # Multi-step JavaScript tests
 agency test js tests/agency-js
 agency test js tests/agency-js/my-test
-
-# Generate JavaScript test fixtures
-agency fixtures tests/agency-js
 ```

--- a/packages/agency-lang/docs/TESTING.md
+++ b/packages/agency-lang/docs/TESTING.md
@@ -11,7 +11,7 @@ Note: All `agency` commands in this file should be run using `pnpm run agency`.
 | Generator fixtures | `tests/typescriptGenerator/` | `pnpm test:run` |
 | Preprocessor fixtures | `tests/typescriptPreprocessor/` | `pnpm test:run` |
 | Agency execution tests | `tests/agency/` | `agency test tests/agency` |
-| Multi-step TS tests | `tests/agency-ts/` | `agency test --ts tests/agency-ts` |
+| Multi-step JS tests | `tests/agency-js/` | `agency test --js tests/agency-js` |
 
 ---
 
@@ -191,16 +191,16 @@ If the node triggers interrupts, you'll be prompted to approve, reject, or modif
 
 ---
 
-## 5. Multi-Step TypeScript Tests (agency-ts)
+## 5. Multi-Step JavaScript Tests (agency-js)
 
-For tests that need to call a compiled Agency agent multiple times, pass results between calls, or run arbitrary imperative logic, use TypeScript integration tests.
+For tests that need to call a compiled Agency agent multiple times, pass results between calls, or run arbitrary imperative logic, use JavaScript integration tests.
 
-**Location:** `tests/agency-ts/`
+**Location:** `tests/agency-js/`
 
 Each test is a directory containing:
 
 ```
-tests/agency-ts/my-test/
+tests/agency-js/my-test/
 ├── agent.agency       # Agency source code
 ├── test.js            # Test script that imports the compiled agent
 └── fixture.json       # Expected result
@@ -229,10 +229,10 @@ You control everything: what arguments to pass, whether to pass `messages` betwe
 
 ```bash
 # Run all tests in the directory
-agency test --js tests/agency-js
+agency test js tests/agency-js
 
 # Run a specific test directory
-agency test --js tests/agency-js/my-test
+agency test js tests/agency-js/my-test
 ```
 
 The runner will:
@@ -250,7 +250,7 @@ If `fixture.json` doesn't exist yet, you'll be prompted to save the result as th
 To auto-generate (or regenerate) fixtures without being prompted:
 
 ```bash
-agency test --gen-fixtures tests/agency-ts
+agency test --gen-fixtures tests/agency-js
 ```
 
 This compiles and runs each test, then saves the result directly as `fixture.json`.
@@ -276,8 +276,8 @@ agency fixtures tests/agency/example.agency
 agency fixtures tests/agency/example.agency:nodeName
 
 # Multi-step JavaScript tests
-agency test --js tests/agency-js
-agency test --js tests/agency-js/my-test
+agency test js tests/agency-js
+agency test js tests/agency-js/my-test
 
 # Generate JavaScript test fixtures
 agency fixtures tests/agency-js

--- a/packages/agency-lang/docs/dev/adding-features.md
+++ b/packages/agency-lang/docs/dev/adding-features.md
@@ -1,0 +1,20 @@
+# Adding Features
+
+Step-by-step guides for common tasks in the Agency codebase.
+
+---
+
+## Adding a new AST node type
+
+1. **Define the type** in `lib/types/` (create a new file or add to an existing one). Export it from `lib/types.ts`. Add the new type to the `AgencyNode` union type in `lib/types.ts`.
+2. **Add a parser** in `lib/parsers/`. Wire it into the main parser in `lib/parser.ts`. Add unit tests in a co-located `.test.ts` file.
+3. **Add code generation** by adding a case to `processNode` in `lib/backends/typescriptBuilder.ts`. You may also need to create new `.mustache` template files in `lib/templates/backends/` and run `pnpm run templates`.
+4. **Add integration test fixtures** — create `.agency` and `.mts` files in `tests/typescriptGenerator/`.
+
+---
+
+## Adding a CLI command
+
+1. Add the command definition in `scripts/agency.ts` using commander (`.command()`, `.argument()`, `.option()`, `.action()`).
+2. Implement the command logic in `lib/cli/` (create a new file or add to an existing one). Shared utilities like `parseTarget`, `pickANode`, `executeNode` live in `lib/cli/util.ts`.
+3. Optionally add a shortcut script in `package.json` under `"scripts"`.

--- a/packages/agency-lang/docs/dev/anti-patterns.md
+++ b/packages/agency-lang/docs/dev/anti-patterns.md
@@ -224,11 +224,10 @@ for (const node of nodes) {
 
 **Good:**
 ```ts
-const result = [...new Set(
-  nodes
-    .filter(n => n.kind === "functionDefinition" && n.exported)
-    .map(n => n.name)
-)];
+const names = nodes
+  .filter(n => n.kind === "functionDefinition" && n.exported)
+  .map(n => n.name);
+const result = names.filter((name, i) => names.indexOf(name) === i);
 ```
 
 **Why:** The declarative version says *what* we want (exported function names, deduplicated), not *how* to get it. Imperative code should be encapsulated behind a clear declarative interface.

--- a/packages/agency-lang/docs/dev/anti-patterns.md
+++ b/packages/agency-lang/docs/dev/anti-patterns.md
@@ -1,0 +1,289 @@
+# Anti-Pattern Catalog
+
+Common mistakes to avoid when writing code in the Agency codebase. Each entry has a concrete before/after example. Read this before starting a task.
+
+---
+
+### 1. Unnecessary wrapper classes
+
+**What it looks like:** Creating a class to wrap simple data or a thin layer over an existing API when a plain object or direct function would suffice.
+
+**Bad:**
+```ts
+class CompilationResult {
+  private output: string;
+  private errors: string[];
+
+  constructor(output: string, errors: string[]) {
+    this.output = output;
+    this.errors = errors;
+  }
+
+  getOutput(): string { return this.output; }
+  getErrors(): string[] { return this.errors; }
+  hasErrors(): boolean { return this.errors.length > 0; }
+}
+```
+
+**Good:**
+```ts
+type CompilationResult = {
+  output: string
+  errors: string[]
+}
+
+// hasErrors is just a check on the array — inline it where needed
+if (result.errors.length > 0) { ... }
+```
+
+**Why:** The class adds indirection without adding value. The data is simple, the accessors do nothing, and `hasErrors()` is a trivial check that's clearer inline.
+
+---
+
+### 2. Premature abstraction
+
+**What it looks like:** Extracting a helper or utility for something that's only used once, or creating a shared function before there are multiple callers.
+
+**Bad:**
+```ts
+function formatNodeName(name: string): string {
+  return `node_${name}`;
+}
+
+// used in exactly one place:
+const id = formatNodeName(node.name);
+```
+
+**Good:**
+```ts
+const id = `node_${node.name}`;
+```
+
+**Why:** Three similar lines of code are better than a premature abstraction. Extract a helper when you actually have multiple callers, not before.
+
+---
+
+### 3. Over-engineered configuration
+
+**What it looks like:** Adding options, flags, or configurability for things that only have one use case.
+
+**Bad:**
+```ts
+type ProcessOptions = {
+  includeComments: boolean
+  stripWhitespace: boolean
+  maxDepth: number
+  outputFormat: "json" | "text"
+}
+
+function processNode(node: AgencyNode, options: ProcessOptions) {
+  // only ever called with the same options
+}
+```
+
+**Good:**
+```ts
+function processNode(node: AgencyNode) {
+  // hardcode the behavior — there's only one use case
+}
+```
+
+**Why:** Build for the current need, not hypothetical future requirements. If a second use case arises, add the option then.
+
+---
+
+### 4. Logic in the wrong layer
+
+**What it looks like:** Putting functionality in the builder/codegen that should live in the runtime, or vice versa.
+
+**Bad:**
+```ts
+// In typescriptBuilder.ts — generating complex logic as code strings
+function processRetryLogic(node: AgencyNode): TsNode {
+  return ts.raw(`
+    let attempts = 0;
+    while (attempts < 3) {
+      try {
+        const result = await ${funcCall};
+        if (isValid(result)) return result;
+      } catch (e) { /* retry */ }
+      attempts++;
+    }
+  `);
+}
+```
+
+**Good:**
+```ts
+// In lib/runtime/retry.ts — a real function that's testable and type-safe
+function runWithRetry<T>(fn: () => Promise<T>, maxAttempts: number): Promise<T> {
+  let attempts = 0;
+  while (attempts < maxAttempts) {
+    try {
+      const result = await fn();
+      if (isValid(result)) return result;
+    } catch (e) { /* retry */ }
+    attempts++;
+  }
+  throw new Error("Max retries exceeded");
+}
+
+// In typescriptBuilder.ts — just generate a call to the runtime function
+function processRetryLogic(node: AgencyNode): TsNode {
+  return ts.call("runWithRetry", [funcCallNode, ts.raw("3")]);
+}
+```
+
+**Why:** Runtime code is testable, type-safe, and reusable. Generated code is hard to read, debug, and refactor. Push logic into runtime libs whenever possible.
+
+---
+
+### 5. Duplicating existing code
+
+**What it looks like:** Reimplementing something that already exists in the codebase instead of finding and reusing it.
+
+**Bad:**
+```ts
+// Writing a new function to walk AST nodes
+function findAllFunctions(nodes: AgencyNode[]): FunctionDefinition[] {
+  const result: FunctionDefinition[] = [];
+  for (const node of nodes) {
+    if (node.kind === "functionDefinition") {
+      result.push(node);
+    }
+    if ("body" in node && Array.isArray(node.body)) {
+      result.push(...findAllFunctions(node.body));
+    }
+  }
+  return result;
+}
+```
+
+**Good:**
+```ts
+// Use the existing walkNodesArray from lib/utils/node.ts
+import { walkNodesArray } from "@/utils/node.js";
+
+const functions = walkNodesArray(nodes)
+  .filter((n): n is FunctionDefinition => n.kind === "functionDefinition");
+```
+
+**Why:** The codebase already has utilities for common operations. Always search for existing implementations before writing new code.
+
+---
+
+### 6. Unnecessary error handling
+
+**What it looks like:** Validating things that can't happen, adding fallbacks for impossible states, or wrapping in try-catch when the framework already handles errors.
+
+**Bad:**
+```ts
+function getNodeName(node: GraphNode): string {
+  if (!node) {
+    throw new Error("Node is null");
+  }
+  if (!node.name) {
+    throw new Error("Node has no name");
+  }
+  if (typeof node.name !== "string") {
+    throw new Error("Node name is not a string");
+  }
+  return node.name;
+}
+```
+
+**Good:**
+```ts
+function getNodeName(node: GraphNode): string {
+  return node.name;
+}
+```
+
+**Why:** TypeScript's type system guarantees `node` exists and `node.name` is a string. Trust internal code and framework guarantees. Only validate at system boundaries (user input, external APIs).
+
+---
+
+### 7. Imperative code where declarative would work
+
+**What it looks like:** Writing long sequences of imperative steps when the intent could be expressed more clearly with a declarative approach.
+
+**Bad:**
+```ts
+const result: string[] = [];
+for (const node of nodes) {
+  if (node.kind === "functionDefinition") {
+    if (node.exported) {
+      const name = node.name;
+      if (!result.includes(name)) {
+        result.push(name);
+      }
+    }
+  }
+}
+```
+
+**Good:**
+```ts
+const result = [...new Set(
+  nodes
+    .filter(n => n.kind === "functionDefinition" && n.exported)
+    .map(n => n.name)
+)];
+```
+
+**Why:** The declarative version says *what* we want (exported function names, deduplicated), not *how* to get it. Imperative code should be encapsulated behind a clear declarative interface.
+
+---
+
+### 8. Order-dependent mutable state
+
+**What it looks like:** Code where multiple variables must be set in a specific sequence to work correctly. Reordering lines breaks things silently.
+
+**Bad:**
+```ts
+let scopeType = "global";
+let prefix = "";
+let needsAwait = false;
+
+// these must happen in this exact order or things break
+scopeType = determineScopeType(node);
+prefix = scopeType === "function" ? "__fn_" : "__node_";
+needsAwait = prefix === "__fn_" && hasAsyncCalls(node);
+```
+
+**Good:**
+```ts
+const scopeType = determineScopeType(node);
+const prefix = scopeType === "function" ? "__fn_" : "__node_";
+const needsAwait = scopeType === "function" && hasAsyncCalls(node);
+```
+
+**Why:** Using `const` and deriving each value from its inputs (not from other mutable variables) makes the dependencies explicit. You can read any line in isolation without worrying about what happened before it.
+
+---
+
+### 9. Leaky abstractions
+
+**What it looks like:** Code where understanding one piece requires reading many other pieces because they're all connected. The internal implementation details leak into the interface.
+
+**Bad:**
+```ts
+// Caller has to know about internal stack structure
+function resumeExecution(checkpoint: Checkpoint) {
+  const stack = checkpoint.__internalStack;
+  const step = stack.locals.__substep_0;
+  const branch = stack.locals.__condbranch_0;
+  // manually reconstruct state from internal details...
+}
+```
+
+**Good:**
+```ts
+// Clean interface that hides internals
+function resumeExecution(checkpoint: Checkpoint) {
+  restoreState(checkpoint);
+  // restoreState handles all the internal stack reconstruction
+}
+```
+
+**Why:** Good abstractions have clear boundaries. You should be able to understand what a unit does without reading its internals, and change the internals without breaking consumers.

--- a/packages/agency-lang/docs/dev/anti-patterns.md
+++ b/packages/agency-lang/docs/dev/anti-patterns.md
@@ -116,7 +116,7 @@ function processRetryLogic(node: AgencyNode): TsNode {
 **Good:**
 ```ts
 // In lib/runtime/retry.ts — a real function that's testable and type-safe
-function runWithRetry<T>(fn: () => Promise<T>, maxAttempts: number): Promise<T> {
+async function runWithRetry<T>(fn: () => Promise<T>, maxAttempts: number): Promise<T> {
   let attempts = 0;
   while (attempts < maxAttempts) {
     try {

--- a/packages/agency-lang/docs/dev/anti-patterns.md
+++ b/packages/agency-lang/docs/dev/anti-patterns.md
@@ -2,143 +2,7 @@
 
 Common mistakes to avoid when writing code in the Agency codebase. Each entry has a concrete before/after example. Read this before starting a task.
 
----
-
-### 1. Unnecessary wrapper classes
-
-**What it looks like:** Creating a class to wrap simple data or a thin layer over an existing API when a plain object or direct function would suffice.
-
-**Bad:**
-```ts
-class CompilationResult {
-  private output: string;
-  private errors: string[];
-
-  constructor(output: string, errors: string[]) {
-    this.output = output;
-    this.errors = errors;
-  }
-
-  getOutput(): string { return this.output; }
-  getErrors(): string[] { return this.errors; }
-  hasErrors(): boolean { return this.errors.length > 0; }
-}
-```
-
-**Good:**
-```ts
-type CompilationResult = {
-  output: string
-  errors: string[]
-}
-
-// hasErrors is just a check on the array — inline it where needed
-if (result.errors.length > 0) { ... }
-```
-
-**Why:** The class adds indirection without adding value. The data is simple, the accessors do nothing, and `hasErrors()` is a trivial check that's clearer inline.
-
----
-
-### 2. Premature abstraction
-
-**What it looks like:** Extracting a helper or utility for something that's only used once, or creating a shared function before there are multiple callers.
-
-**Bad:**
-```ts
-function formatNodeName(name: string): string {
-  return `node_${name}`;
-}
-
-// used in exactly one place:
-const id = formatNodeName(node.name);
-```
-
-**Good:**
-```ts
-const id = `node_${node.name}`;
-```
-
-**Why:** Three similar lines of code are better than a premature abstraction. Extract a helper when you actually have multiple callers, not before.
-
----
-
-### 3. Over-engineered configuration
-
-**What it looks like:** Adding options, flags, or configurability for things that only have one use case.
-
-**Bad:**
-```ts
-type ProcessOptions = {
-  includeComments: boolean
-  stripWhitespace: boolean
-  maxDepth: number
-  outputFormat: "json" | "text"
-}
-
-function processNode(node: AgencyNode, options: ProcessOptions) {
-  // only ever called with the same options
-}
-```
-
-**Good:**
-```ts
-function processNode(node: AgencyNode) {
-  // hardcode the behavior — there's only one use case
-}
-```
-
-**Why:** Build for the current need, not hypothetical future requirements. If a second use case arises, add the option then.
-
----
-
-### 4. Logic in the wrong layer
-
-**What it looks like:** Putting functionality in the builder/codegen that should live in the runtime, or vice versa.
-
-**Bad:**
-```ts
-// In typescriptBuilder.ts — generating complex logic as code strings
-function processRetryLogic(node: AgencyNode): TsNode {
-  return ts.raw(`
-    let attempts = 0;
-    while (attempts < 3) {
-      try {
-        const result = await ${funcCall};
-        if (isValid(result)) return result;
-      } catch (e) { /* retry */ }
-      attempts++;
-    }
-  `);
-}
-```
-
-**Good:**
-```ts
-// In lib/runtime/retry.ts — a real function that's testable and type-safe
-async function runWithRetry<T>(fn: () => Promise<T>, maxAttempts: number): Promise<T> {
-  let attempts = 0;
-  while (attempts < maxAttempts) {
-    try {
-      const result = await fn();
-      if (isValid(result)) return result;
-    } catch (e) { /* retry */ }
-    attempts++;
-  }
-  throw new Error("Max retries exceeded");
-}
-
-// In typescriptBuilder.ts — just generate a call to the runtime function
-function processRetryLogic(node: AgencyNode): TsNode {
-  return ts.call("runWithRetry", [funcCallNode, ts.raw("3")]);
-}
-```
-
-**Why:** Runtime code is testable, type-safe, and reusable. Generated code is hard to read, debug, and refactor. Push logic into runtime libs whenever possible.
-
----
-
-### 5. Duplicating existing code
+### Duplicating existing code
 
 **What it looks like:** Reimplementing something that already exists in the codebase instead of finding and reusing it.
 
@@ -172,40 +36,9 @@ const functions = walkNodesArray(nodes)
 
 ---
 
-### 6. Unnecessary error handling
+### Imperative code everywhere
 
-**What it looks like:** Validating things that can't happen, adding fallbacks for impossible states, or wrapping in try-catch when the framework already handles errors.
-
-**Bad:**
-```ts
-function getNodeName(node: GraphNode): string {
-  if (!node) {
-    throw new Error("Node is null");
-  }
-  if (!node.name) {
-    throw new Error("Node has no name");
-  }
-  if (typeof node.name !== "string") {
-    throw new Error("Node name is not a string");
-  }
-  return node.name;
-}
-```
-
-**Good:**
-```ts
-function getNodeName(node: GraphNode): string {
-  return node.name;
-}
-```
-
-**Why:** TypeScript's type system guarantees `node` exists and `node.name` is a string. Trust internal code and framework guarantees. Only validate at system boundaries (user input, external APIs).
-
----
-
-### 7. Imperative code where declarative would work
-
-**What it looks like:** Writing long sequences of imperative steps when the intent could be expressed more clearly with a declarative approach.
+**What it looks like:** Writing imperative code everywhere, instead of encapsulating it in a few places and exposing a nice abstraction that the user can use to write their code in a declarative manner. The logic for the "what" and the logic for the "how" should be split apart, so in the future, it's easier to make changes... you simply need to change the code for the "what" and not touch the code for the "how."
 
 **Bad:**
 ```ts
@@ -234,7 +67,7 @@ const result = names.filter((name, i) => names.indexOf(name) === i);
 
 ---
 
-### 8. Order-dependent mutable state
+### Order-dependent mutable state
 
 **What it looks like:** Code where multiple variables must be set in a specific sequence to work correctly. Reordering lines breaks things silently.
 
@@ -259,9 +92,11 @@ const needsAwait = scopeType === "function" && hasAsyncCalls(node);
 
 **Why:** Using `const` and deriving each value from its inputs (not from other mutable variables) makes the dependencies explicit. You can read any line in isolation without worrying about what happened before it.
 
+Note: this rule does not apply to parsers, which need to have a specific order due to their very nature.
+
 ---
 
-### 9. Leaky abstractions
+### Leaky abstractions
 
 **What it looks like:** Code where understanding one piece requires reading many other pieces because they're all connected. The internal implementation details leak into the interface.
 

--- a/packages/agency-lang/docs/dev/coding-standards.md
+++ b/packages/agency-lang/docs/dev/coding-standards.md
@@ -32,20 +32,6 @@ const lookup: Record<string, number> = {};
 
 ---
 
-### Use plain arrays instead of `Set`
-
-```ts
-// Bad
-const seen = new Set<string>();
-
-// Good
-const seen: string[] = [];
-```
-
-**Rationale:** Same as Map — serializability and simplicity.
-
----
-
 ### No dynamic imports
 
 ```ts
@@ -83,9 +69,9 @@ If a function exceeds 100 lines, break it into smaller, focused functions. Blank
 
 ---
 
-### Keep files under 600 lines
+### Keep files under 1000 lines
 
-If a file exceeds 600 lines, consider splitting it into smaller modules. Blank lines and comments don't count toward the limit.
+If a file exceeds 1000 lines, consider splitting it into smaller modules. Blank lines and comments don't count toward the limit.
 
 Some files are exempt from this rule (e.g., `typescriptBuilder.ts`, `parser.ts`) because they are inherently large due to the nature of their work. These are configured as exceptions in the ESLint config.
 

--- a/packages/agency-lang/docs/dev/coding-standards.md
+++ b/packages/agency-lang/docs/dev/coding-standards.md
@@ -1,6 +1,6 @@
 # Coding Standards
 
-Mechanical rules enforced by the structural linter (`pnpm run lint:structure`). These are not suggestions — they are enforced automatically and will block PRs.
+Rules for writing code in the Agency codebase. Most are enforced by the structural linter (`pnpm run lint:structure`). The last two are conventions that are not mechanically enforced.
 
 ---
 

--- a/packages/agency-lang/docs/dev/coding-standards.md
+++ b/packages/agency-lang/docs/dev/coding-standards.md
@@ -1,0 +1,132 @@
+# Coding Standards
+
+Mechanical rules enforced by the structural linter (`pnpm run lint:structure`). These are not suggestions — they are enforced automatically and will block PRs.
+
+---
+
+### Use `type`, not `interface`
+
+```ts
+// Bad
+interface Foo { name: string }
+
+// Good
+type Foo = { name: string }
+```
+
+**Rationale:** Consistency. The codebase uses `type` everywhere; `interface` introduces a second way to do the same thing.
+
+---
+
+### Use plain objects instead of `Map`
+
+```ts
+// Bad
+const lookup = new Map<string, number>();
+
+// Good
+const lookup: Record<string, number> = {};
+```
+
+**Rationale:** Plain objects are serializable (important for checkpointing/interrupts) and simpler to work with.
+
+---
+
+### Use plain arrays instead of `Set`
+
+```ts
+// Bad
+const seen = new Set<string>();
+
+// Good
+const seen: string[] = [];
+```
+
+**Rationale:** Same as Map — serializability and simplicity.
+
+---
+
+### No dynamic imports
+
+```ts
+// Bad
+const module = await import("./foo.js");
+
+// Good
+import { foo } from "./foo.js";
+```
+
+**Rationale:** Dynamic imports break static analysis and make the dependency graph harder to reason about.
+
+---
+
+### Prefer `const` over `let`
+
+```ts
+// Bad
+let name = "Alice";
+// name is never reassigned
+
+// Good
+const name = "Alice";
+```
+
+**Rationale:** `const` signals that a value won't change, reducing cognitive load when reading code.
+
+---
+
+### Keep functions under 100 lines
+
+If a function exceeds 100 lines, break it into smaller, focused functions. Blank lines and comments don't count toward the limit.
+
+**Rationale:** Long functions are hard to understand, test, and modify. Smaller functions with clear names serve as documentation.
+
+---
+
+### Keep files under 600 lines
+
+If a file exceeds 600 lines, consider splitting it into smaller modules. Blank lines and comments don't count toward the limit.
+
+Some files are exempt from this rule (e.g., `typescriptBuilder.ts`, `parser.ts`) because they are inherently large due to the nature of their work. These are configured as exceptions in the ESLint config.
+
+**Rationale:** Large files are hard to navigate and often indicate that a module has too many responsibilities.
+
+---
+
+### Keep nesting depth under 4 levels
+
+```ts
+// Bad
+if (a) {
+  for (x in items) {
+    if (b) {
+      for (y in things) {
+        if (c) { // 5 levels deep
+```
+
+```ts
+// Good — use early returns and extracted functions
+if (!a) return;
+for (x in items) {
+  if (!b) continue;
+  processThings(x);
+}
+```
+
+**Rationale:** Deeply nested code is hard to follow. Extract inner logic into functions or use early returns to flatten the structure.
+
+---
+
+### Push functionality into runtime libs, not the builder
+
+When adding new features, put as much logic as possible in `lib/runtime/` (where it's testable and type-safe). The builder should generate calls to runtime functions, not inline complex logic as code strings.
+
+**Rationale:** Runtime code is easier to read, test, refactor, and debug than generated code. See anti-pattern #4 (logic in the wrong layer) in `docs/dev/anti-patterns.md`.
+
+---
+
+### Never force push or amend commits
+
+Always create new commits. Never use `git push --force` or `git commit --amend`.
+
+**Rationale:** Force-pushing and amending can destroy work and make history hard to follow.

--- a/packages/agency-lang/docs/dev/typechecker.md
+++ b/packages/agency-lang/docs/dev/typechecker.md
@@ -1,6 +1,6 @@
 # Type Checker
 
-The type checker (`lib/typeChecker.ts`) uses **bidirectional type checking** to catch type errors in Agency programs before they are compiled to TypeScript. It can be run standalone via `agency typecheck` or integrated into the compile/run pipeline via config flags.
+The type checker (`lib/typeChecker/`) uses **bidirectional type checking** to catch type errors in Agency programs before they are compiled to TypeScript. It can be run standalone via `agency typecheck` or integrated into the compile/run pipeline via config flags.
 
 This document explains what bidirectional type checking is, how it's implemented for Agency, the special cases required by the language, and how it gets triggered.
 

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-07-harness-engineering.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-07-harness-engineering.md
@@ -1,0 +1,549 @@
+# Harness Engineering Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a development harness (ESLint linter, doc restructuring, anti-pattern catalog, self-review command, CI) to mechanically enforce coding standards and reduce human review burden.
+
+**Architecture:** Six independent components built in dependency order: doc audit first (so docs are accurate), then anti-pattern catalog and coding standards docs, then CLAUDE.md restructuring (which points to those docs), then ESLint structural linter, then CI workflow, then self-review slash command.
+
+**Tech Stack:** ESLint 9 (flat config), @typescript-eslint/parser, GitHub Actions, Claude Code custom commands (.claude/commands/)
+
+**Spec:** `packages/agency-lang/docs/superpowers/specs/2026-05-06-harness-engineering-design.md`
+
+---
+
+### Task 1: Doc Audit — High Priority Docs
+
+Audit the high-priority docs that CLAUDE.md will point to. This is a shallow pass: verify file paths and function/class names still exist, check that overall structure matches reality. Do NOT deep-verify behavioral claims.
+
+**Files:**
+- Audit: `packages/agency-lang/docs/TESTING.md`
+- Audit: `packages/agency-lang/docs/dev/typescript-ir.md`
+- Audit: `packages/agency-lang/docs/dev/typechecker.md`
+- Audit: `packages/agency-lang/docs/dev/interrupts.md`
+- Audit: `packages/agency-lang/docs/dev/simplemachine.md`
+
+- [ ] **Step 1: Audit `docs/TESTING.md`**
+
+Read the file. For each file path, function name, and command mentioned, verify it exists in the current codebase using Glob/Grep. Classify as Accurate, Needs Update, or Obsolete.
+
+- [ ] **Step 2: Audit `docs/dev/typescript-ir.md`**
+
+Same process. Check that TsNode types, builder functions, and file paths mentioned still exist in `lib/ir/`.
+
+- [ ] **Step 3: Audit `docs/dev/typechecker.md`**
+
+Same process. Check that the type checker API, file paths, and function names mentioned still exist in `lib/typeChecker/`.
+
+- [ ] **Step 4: Audit `docs/dev/interrupts.md`**
+
+Same process. Check that interrupt-related types, functions, and file paths mentioned still exist in `lib/runtime/`.
+
+- [ ] **Step 5: Audit `docs/dev/simplemachine.md`**
+
+Same process. Check that SimpleMachine types, functions, and file paths mentioned still exist in `lib/simplemachine/`.
+
+- [ ] **Step 6: Fix stale docs**
+
+For any file classified as Needs Update, make the necessary changes. For any classified as Obsolete, flag it for removal or rewrite. Update file paths, function names, and structural descriptions to match current code.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/TESTING.md docs/dev/typescript-ir.md docs/dev/typechecker.md docs/dev/interrupts.md docs/dev/simplemachine.md
+git commit -m "docs: audit and update high-priority dev docs"
+```
+
+---
+
+### Task 2: Doc Audit — Medium and Low Priority Docs
+
+Audit the remaining docs. Same shallow process.
+
+**Files:**
+- Audit: all remaining files in `packages/agency-lang/docs/dev/`
+- Audit: `packages/agency-lang/docs/INTERRUPT_TESTING.md`, `docs/config.md`, `docs/typeChecker.md`, `docs/lifecycleHooks.md`, `docs/stateStack.md`, `docs/envFiles.md`
+
+- [ ] **Step 1: Audit remaining `docs/dev/` files**
+
+Read each file in `docs/dev/` not already audited in Task 1. For each, verify file paths and function/class names mentioned still exist. Classify each as Accurate, Needs Update, or Obsolete. Files: `async-info-for-claude.md`, `async.md`, `binop-parser.md`, `checkpointing.md`, `concurrent-interrupts.md`, `config.md`, `debugger.md`, `globalstore.md`, `init.md`, `locations.md`, `message-thread-tests.md`, `pkg-imports.md`, `smoltalk.md`, `statelog.md`, `threads.md`, `trace.md`.
+
+- [ ] **Step 2: Audit top-level docs**
+
+Same process for: `docs/INTERRUPT_TESTING.md`, `docs/config.md`, `docs/typeChecker.md`, `docs/lifecycleHooks.md`, `docs/stateStack.md`, `docs/envFiles.md`.
+
+- [ ] **Step 3: Fix stale docs**
+
+Update all files classified as Needs Update. Flag any Obsolete files.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/
+git commit -m "docs: audit and update remaining dev docs"
+```
+
+---
+
+### Task 3: Create Anti-Pattern Catalog
+
+Create `docs/dev/anti-patterns.md` with 9 entries, each with concrete before/after code examples.
+
+**Files:**
+- Create: `packages/agency-lang/docs/dev/anti-patterns.md`
+
+**Reference:** Review memory files at `~/.claude/projects/-Users-adityabhargava-agency-lang/memory/` for past feedback. Search the codebase for real examples where possible. Where real examples are not available, write realistic synthetic examples in the style of Agency codebase code.
+
+- [ ] **Step 1: Write the anti-pattern catalog**
+
+Create `docs/dev/anti-patterns.md` with all 9 entries. Each entry must follow this format:
+
+```markdown
+### [Name]
+
+**What it looks like:** [Description]
+
+**Bad:**
+\`\`\`ts
+// concrete example
+\`\`\`
+
+**Good:**
+\`\`\`ts
+// concrete example
+\`\`\`
+
+**Why:** [1-2 sentences]
+```
+
+The 9 entries are:
+1. Unnecessary wrapper classes
+2. Premature abstraction
+3. Over-engineered configuration
+4. Logic in the wrong layer
+5. Duplicating existing code
+6. Unnecessary error handling
+7. Imperative code where declarative would work
+8. Order-dependent mutable state
+9. Leaky abstractions
+
+- [ ] **Step 2: Review the catalog**
+
+Read through the completed catalog. Check that each example is realistic and the before/after clearly demonstrates the problem and solution.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/dev/anti-patterns.md
+git commit -m "docs: add anti-pattern catalog with 9 entries"
+```
+
+---
+
+### Task 4: Create Coding Standards Doc
+
+Create `docs/dev/coding-standards.md` documenting the mechanical rules that the linter will also enforce.
+
+**Files:**
+- Create: `packages/agency-lang/docs/dev/coding-standards.md`
+
+- [ ] **Step 1: Write the coding standards doc**
+
+Create `docs/dev/coding-standards.md`. Include:
+- Use `type`, not `interface`
+- Use plain objects instead of `Map`, plain arrays instead of `Set`
+- No dynamic imports (`import(...)`)
+- Prefer `const` over `let` when the variable is never reassigned
+- Keep functions under 100 lines
+- Keep files under 600 lines (with noted exceptions for large files like `typescriptBuilder.ts`)
+- Keep nesting depth under 4 levels
+- Push functionality into runtime libs, not the builder
+- No force push or amend commits
+- Use types, not interfaces
+
+For each rule, include a one-sentence rationale.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/dev/coding-standards.md
+git commit -m "docs: add coding standards reference"
+```
+
+---
+
+### Task 5: Create Adding Features Doc
+
+Move the "Common Tasks" section from CLAUDE.md into a dedicated doc.
+
+**Files:**
+- Create: `packages/agency-lang/docs/dev/adding-features.md`
+- Reference: `CLAUDE.md` lines 129-142 (the "Common Tasks" section)
+
+- [ ] **Step 1: Write the adding features doc**
+
+Create `docs/dev/adding-features.md`. Copy the "Adding a new AST node type" and "Adding a CLI command" sections from CLAUDE.md. Keep them as-is — they are already well-written step-by-step guides.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/dev/adding-features.md
+git commit -m "docs: add adding-features guide"
+```
+
+---
+
+### Task 6: Restructure CLAUDE.md
+
+Slim down the monorepo-root CLAUDE.md to be a map that points to deeper docs.
+
+**Files:**
+- Modify: `CLAUDE.md` (at monorepo root: `/Users/adityabhargava/agency-lang/CLAUDE.md`)
+
+- [ ] **Step 1: Read the current CLAUDE.md**
+
+Read the full file to understand what is there.
+
+- [ ] **Step 2: Rewrite CLAUDE.md**
+
+Keep:
+- Project overview (first paragraph)
+- Key commands section
+- Pipeline overview (the one-liner: `parse -> SymbolTable.build -> ...`)
+- Pointers to deeper docs (new section replacing the detailed descriptions)
+- "CRITICAL: Handlers are safety infrastructure" section (verbatim)
+- "VERY IMPORTANT: Agency syntax rules" section (verbatim)
+- "General code Guidelines" section (verbatim)
+- "Guidance on writing commit messages" section (verbatim)
+- The note about file paths being relative to packages/agency-lang
+- Testing section (keep the short version: pointer to docs/TESTING.md + the key notes about LLM calls and saving output)
+- "Things that often confuse you" (keep this — it is short and important)
+
+Remove (replaced by pointers):
+- Detailed pipeline subsections (Parse, SymbolTable.build, buildCompilationUnit, preprocessor, build, Generate TypeScript code) — these are well-covered by docs/dev/ files
+- "Code generation and backends" section — this guidance moves to anti-patterns (#4: logic in the wrong layer)
+- "How to debug parser errors" section — keep a one-line pointer
+- "Parsers" section — keep a one-line pointer
+- "Typechecker" section — keep a one-line pointer to docs
+- "TypeScript IR" section — keep a one-line pointer to docs
+- "Templates (typestache)" section — keep a one-line pointer
+- "Runtime" section with component list — keep a one-line pointer
+- "Common Tasks" section — now in `docs/dev/adding-features.md`
+- "Other miscellaneous things to know about" section — keep one-line pointers
+- "Other docs and resources" section — fold into the new pointers section
+- "docs/dev/ reference" section — fold into the new pointers section
+
+Add a new "Deeper docs" section with pointers in this format:
+```
+- `docs/dev/coding-standards.md` — Banned patterns and style rules. Read before writing any new code.
+- `docs/dev/anti-patterns.md` — Common mistakes with before/after examples. Read before starting a task.
+- `docs/dev/adding-features.md` — Step-by-step guides for adding AST nodes, CLI commands, etc.
+```
+
+Also include pointers to the existing docs/dev/ files and top-level docs that were previously listed in the "Other docs and resources" and "docs/dev/ reference" sections.
+
+- [ ] **Step 3: Verify nothing critical was lost**
+
+Read the new CLAUDE.md. Check that all critical invariants (handlers, syntax rules, general guidelines) are still present. Check that every topic that was removed has a pointer to where it now lives.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: restructure CLAUDE.md as progressive disclosure map"
+```
+
+---
+
+### Task 7: Set Up ESLint with All Rules
+
+Install ESLint and configure all rules using built-in ESLint and @typescript-eslint rules. No custom rule files needed.
+
+**Files:**
+- Create: `packages/agency-lang/eslint.config.js`
+- Modify: `packages/agency-lang/package.json` (add devDependencies and script)
+
+- [ ] **Step 1: Install ESLint dependencies**
+
+```bash
+cd packages/agency-lang && pnpm add -D eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin typescript-eslint
+```
+
+- [ ] **Step 2: Create ESLint flat config with all rules**
+
+Create `packages/agency-lang/eslint.config.js`:
+
+```js
+import tseslint from "typescript-eslint";
+
+export default [
+  {
+    ignores: [
+      "dist/**",
+      "tests/**",
+      "templates/**/*.ts",
+      "stdlib/**/*.js",
+      "node_modules/**",
+    ],
+  },
+  ...tseslint.configs.recommended,
+  {
+    files: ["lib/**/*.ts"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    rules: {
+      // Disable rules from recommended that are too noisy for this codebase
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unused-vars": "off",
+
+      // --- Agency structural rules ---
+
+      // Use type, not interface
+      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+
+      // Prefer const over let when never reassigned
+      "prefer-const": "error",
+
+      // No dynamic imports
+      "no-restricted-syntax": ["error",
+        {
+          selector: "ImportExpression",
+          message: "Dynamic imports are not allowed. Use static import statements.",
+        },
+        {
+          selector: "NewExpression[callee.name='Map']",
+          message: "Use a plain object instead of Map.",
+        },
+        {
+          selector: "NewExpression[callee.name='Set']",
+          message: "Use a plain array instead of Set.",
+        },
+      ],
+
+      // Max nesting depth
+      "max-depth": ["error", { max: 4 }],
+
+      // Max function length
+      "max-lines-per-function": ["error", { max: 100, skipBlankLines: true, skipComments: true }],
+
+      // Max file length
+      "max-lines": ["error", { max: 600, skipBlankLines: true, skipComments: true }],
+    },
+  },
+  // Per-file overrides for legitimately large files
+  {
+    files: [
+      "lib/backends/typescriptBuilder.ts",
+      "lib/parser.ts",
+      // Add other legitimately large files here after running the linter
+    ],
+    rules: {
+      "max-lines": "off",
+      "max-lines-per-function": "off",
+    },
+  },
+];
+```
+
+- [ ] **Step 3: Add lint:structure script to package.json**
+
+Add to the `"scripts"` section of `packages/agency-lang/package.json`:
+
+```json
+"lint:structure": "eslint lib/"
+```
+
+- [ ] **Step 4: Run the linter and review output**
+
+```bash
+cd packages/agency-lang && pnpm run lint:structure 2>&1 | head -200 > /tmp/claude/lint-output.txt
+```
+
+Review the output. Expect violations in several categories:
+- `prefer-const` and `consistent-type-definitions` are auto-fixable
+- `max-lines`, `max-lines-per-function`, `max-depth` are not
+
+- [ ] **Step 5: Auto-fix what can be auto-fixed**
+
+```bash
+cd packages/agency-lang && pnpm run lint:structure --fix
+```
+
+This will fix `prefer-const` (let -> const) and `consistent-type-definitions` (interface -> type).
+
+- [ ] **Step 6: Handle remaining violations**
+
+Run the linter again to see what remains:
+
+```bash
+cd packages/agency-lang && pnpm run lint:structure 2>&1 > /tmp/claude/lint-output.txt
+```
+
+For each remaining violation:
+- Files over 600 lines: add to the per-file overrides list in `eslint.config.js`
+- Functions over 100 lines: add to per-file overrides if the file has many legitimately large functions, or add `// eslint-disable-next-line max-lines-per-function` for individual cases
+- Nesting depth over 4: add `// eslint-disable-next-line max-depth` for legitimate cases
+- `new Map()`/`new Set()` violations: fix manually (replace with objects/arrays)
+- Dynamic imports: fix manually (replace with static imports)
+
+- [ ] **Step 7: Verify linter passes cleanly**
+
+```bash
+cd packages/agency-lang && pnpm run lint:structure
+```
+
+Expected: 0 errors.
+
+- [ ] **Step 8: Run existing tests to make sure fixes did not break anything**
+
+```bash
+cd packages/agency-lang && pnpm test:run 2>&1 > /tmp/claude/test-output.txt
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/agency-lang/eslint.config.js packages/agency-lang/package.json packages/agency-lang/pnpm-lock.yaml
+git commit -m "feat: add ESLint structural linter with all rules"
+```
+
+If there were auto-fixed or manually fixed files:
+
+```bash
+git add -u packages/agency-lang/lib/
+git commit -m "fix: resolve all structural lint violations"
+```
+
+---
+
+### Task 8: Add GitHub Actions CI Workflow
+
+**Files:**
+- Create: `.github/workflows/lint.yml` (at monorepo root)
+
+- [ ] **Step 1: Create the workflow file**
+
+Create `.github/workflows/lint.yml`:
+
+```yaml
+name: Structural Lint
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run lint:structure
+        working-directory: packages/agency-lang
+```
+
+- [ ] **Step 2: Verify the linter still passes locally**
+
+```bash
+cd packages/agency-lang && pnpm run lint:structure
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/lint.yml
+git commit -m "ci: add structural lint workflow for PRs"
+```
+
+---
+
+### Task 9: Create `/review-changes` Command
+
+**Files:**
+- Create: `.claude/commands/review-changes.md` (at monorepo root, alongside existing commands)
+
+- [ ] **Step 1: Create the command file**
+
+Create `.claude/commands/review-changes.md`:
+
+```markdown
+Review the current changes in this branch for violations of the project's coding standards and anti-patterns.
+
+1. Run `git diff main` to get the full diff of changes in this branch.
+2. Read `packages/agency-lang/docs/dev/anti-patterns.md` — the anti-pattern catalog.
+3. Read `packages/agency-lang/docs/dev/coding-standards.md` — the coding standards.
+4. Review the diff against both documents. For each violation found, report:
+   - Which anti-pattern or coding standard was violated
+   - The file and approximate line number
+   - A specific suggested fix
+5. Focus ONLY on patterns documented in those two files. Do not invent new rules.
+6. Do not flag things that are clearly intentional or necessary for the context.
+7. If no violations are found, report that the changes look clean.
+```
+
+- [ ] **Step 2: Test the command**
+
+Make a small intentional violation (e.g., add a `let` that should be `const`) and run:
+
+```
+/review-changes
+```
+
+Verify it catches the violation and reports it clearly. Then revert the test change.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .claude/commands/review-changes.md
+git commit -m "feat: add /review-changes slash command"
+```
+
+---
+
+### Task 10: Final Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run the full linter**
+
+```bash
+cd packages/agency-lang && pnpm run lint:structure
+```
+
+Expected: passes cleanly with 0 errors.
+
+- [ ] **Step 2: Run the full test suite**
+
+```bash
+cd packages/agency-lang && pnpm test:run 2>&1 > /tmp/claude/test-output.txt
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 3: Verify CLAUDE.md is shorter and complete**
+
+Read `CLAUDE.md`. Verify:
+- It is significantly shorter than the original
+- All critical invariants are present (handlers, syntax rules, general guidelines)
+- Every removed section has a pointer to where it now lives
+- Pointers to `docs/dev/anti-patterns.md`, `docs/dev/coding-standards.md`, and `docs/dev/adding-features.md` are present
+
+- [ ] **Step 4: Verify anti-pattern catalog is complete**
+
+Read `docs/dev/anti-patterns.md`. Verify all 9 entries have concrete before/after examples.
+
+- [ ] **Step 5: Verify /review-changes works**
+
+Run `/review-changes` and verify it produces coherent output.

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-07-harness-engineering.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-07-harness-engineering.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Six independent components built in dependency order: doc audit first (so docs are accurate), then anti-pattern catalog and coding standards docs, then CLAUDE.md restructuring (which points to those docs), then ESLint structural linter, then CI workflow, then self-review slash command.
 
-**Tech Stack:** ESLint 9 (flat config), @typescript-eslint/parser, GitHub Actions, Claude Code custom commands (.claude/commands/)
+**Tech Stack:** ESLint 10 (flat config), typescript-eslint, GitHub Actions, Claude Code custom commands (.claude/commands/)
 
 **Spec:** `packages/agency-lang/docs/superpowers/specs/2026-05-06-harness-engineering-design.md`
 
@@ -198,7 +198,7 @@ git commit -m "docs: add adding-features guide"
 Slim down the monorepo-root CLAUDE.md to be a map that points to deeper docs.
 
 **Files:**
-- Modify: `CLAUDE.md` (at monorepo root: `/Users/adityabhargava/agency-lang/CLAUDE.md`)
+- Modify: `CLAUDE.md` (at monorepo root)
 
 - [ ] **Step 1: Read the current CLAUDE.md**
 

--- a/packages/agency-lang/eslint.config.js
+++ b/packages/agency-lang/eslint.config.js
@@ -64,7 +64,7 @@ export default [
       // Max file length
       "max-lines": [
         "error",
-        { max: 600, skipBlankLines: true, skipComments: true },
+        { max: 1000, skipBlankLines: true, skipComments: true },
       ],
     },
   },

--- a/packages/agency-lang/eslint.config.js
+++ b/packages/agency-lang/eslint.config.js
@@ -5,7 +5,7 @@ export default [
     ignores: [
       "dist/**",
       "tests/**",
-      "templates/**/*.ts",
+      "lib/templates/**/*.ts",
       "stdlib/**/*.js",
       "node_modules/**",
       "lib/agents/**",

--- a/packages/agency-lang/eslint.config.js
+++ b/packages/agency-lang/eslint.config.js
@@ -1,0 +1,82 @@
+import tseslint from "typescript-eslint";
+
+export default [
+  {
+    ignores: [
+      "dist/**",
+      "tests/**",
+      "templates/**/*.ts",
+      "stdlib/**/*.js",
+      "node_modules/**",
+      "lib/agents/**",
+    ],
+  },
+  ...tseslint.configs.recommended,
+  {
+    files: ["lib/**/*.ts"],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      },
+    },
+    rules: {
+      // Disable rules from recommended that are too noisy for this codebase
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unused-vars": "off",
+
+      // --- Agency structural rules ---
+
+      // Use type, not interface
+      "@typescript-eslint/consistent-type-definitions": ["error", "type"],
+
+      // Prefer const over let when never reassigned
+      "prefer-const": "error",
+
+      // No dynamic imports, no new Map(), no new Set()
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "ImportExpression",
+          message:
+            "Dynamic imports are not allowed. Use static import statements.",
+        },
+        {
+          selector: "NewExpression[callee.name='Map']",
+          message: "Use a plain object instead of Map.",
+        },
+        {
+          selector: "NewExpression[callee.name='Set']",
+          message: "Use a plain array instead of Set.",
+        },
+      ],
+
+      // Max nesting depth
+      "max-depth": ["error", { max: 4 }],
+
+      // Max function length
+      "max-lines-per-function": [
+        "error",
+        { max: 100, skipBlankLines: true, skipComments: true },
+      ],
+
+      // Max file length
+      "max-lines": [
+        "error",
+        { max: 600, skipBlankLines: true, skipComments: true },
+      ],
+    },
+  },
+  // Per-file overrides for legitimately large files
+  {
+    files: [
+      "lib/backends/typescriptBuilder.ts",
+      "lib/parser.ts",
+    ],
+    rules: {
+      "max-lines": "off",
+      "max-lines-per-function": "off",
+    },
+  },
+];

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -27,7 +27,8 @@
     "preprocess": "node ./dist/scripts/agency.js preprocess",
     "debug": "node ./dist/scripts/agency.js debug",
     "bundle": "node ./dist/scripts/agency.js bundle",
-    "circular-deps": "npx dpdm --circular lib/parser.ts"
+    "circular-deps": "npx dpdm --circular lib/parser.ts",
+    "lint:structure": "eslint lib/"
   },
   "bin": {
     "agency": "./dist/scripts/agency.js"
@@ -89,8 +90,10 @@
     "@types/node": "^25.0.3",
     "@types/picomatch": "^4.0.3",
     "@types/prompts": "^2.4.9",
+    "eslint": "^10.3.0",
     "tsc-alias": "^1.8.16",
     "typescript": "^5.9.3",
+    "typescript-eslint": "^8.59.2",
     "vitest": "^4.0.16"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,12 +77,18 @@ importers:
       '@types/prompts':
         specifier: ^2.4.9
         version: 2.4.9
+      eslint:
+        specifier: ^10.3.0
+        version: 10.3.0
       tsc-alias:
         specifier: ^1.8.16
         version: 1.8.16
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.59.2
+        version: 8.59.2(eslint@10.3.0)(typescript@5.9.3)
       vitest:
         specifier: ^4.0.16
         version: 4.0.17(@types/node@25.0.6)
@@ -634,6 +640,36 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.5.5':
+    resolution: {integrity: sha512-eIJYKTCECbP/nsKaaruF6LW967mtbQbsw4JTtSVkUQc9MneSkbrgPJAbKl9nWr0ZeowV8BfsarBmPpBzGelA2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.1':
+    resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@google/genai@1.50.1':
     resolution: {integrity: sha512-YbkX7H9+1Pt8wOt7DDREy8XSoiL6fRDzZQRyaVBarFf8MR3zHGqVdvM4cLbDXqPhxqvegZShgfxb8kw9C7YhAQ==}
     engines: {node: '>=20.0.0'}
@@ -652,6 +688,26 @@ packages:
   '@huggingface/jinja@0.5.6':
     resolution: {integrity: sha512-MyMWyLnjqo+KRJYSH7oWNbsOn5onuIvfXYPcc0WOGxU0eHUV7oAYUoQTl2BMdu7ml+ea/bu11UM+EshbeHwtIA==}
     engines: {node: '>=18'}
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@iconify-json/simple-icons@1.2.79':
     resolution: {integrity: sha512-aNyO7Fd1qej9oQfIyohYFRv0lhQLaZ+6UkK1c1qwax0MDPUOZOdq65MlU500kow97pD/W+b2u1And3e25eE24Q==}
@@ -1057,11 +1113,17 @@ packages:
   '@types/diff-match-patch@1.0.36':
     resolution: {integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/json-schema@7.0.15':
+    resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
@@ -1098,6 +1160,65 @@ packages:
 
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
+  '@typescript-eslint/eslint-plugin@8.59.2':
+    resolution: {integrity: sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.59.2
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.59.2':
+    resolution: {integrity: sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.59.2':
+    resolution: {integrity: sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.59.2':
+    resolution: {integrity: sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.59.2':
+    resolution: {integrity: sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.59.2':
+    resolution: {integrity: sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.59.2':
+    resolution: {integrity: sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.59.2':
+    resolution: {integrity: sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.59.2':
+    resolution: {integrity: sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.59.2':
+    resolution: {integrity: sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -1259,6 +1380,16 @@ packages:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
 
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
@@ -1270,6 +1401,9 @@ packages:
     peerDependenciesMeta:
       ajv:
         optional: true
+
+  ajv@6.15.0:
+    resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
@@ -1316,6 +1450,10 @@ packages:
   async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -1335,6 +1473,10 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1520,6 +1662,9 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
@@ -1621,11 +1766,57 @@ packages:
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
 
+  escape-string-regexp@4.0.0:
+    resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
+    engines: {node: '>=10'}
+
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.3.0:
+    resolution: {integrity: sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
+  esrecurse@4.3.0:
+    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
+    engines: {node: '>=4.0'}
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
+
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -1666,6 +1857,12 @@ packages:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
 
+  fast-json-stable-stringify@2.1.0:
+    resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -1685,6 +1882,10 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   filename-reserved-regex@3.0.0:
     resolution: {integrity: sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1700,6 +1901,17 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  find-up@5.0.0:
+    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
+    engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
@@ -1758,6 +1970,10 @@ packages:
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
 
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
@@ -1835,6 +2051,10 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -1909,15 +2129,24 @@ packages:
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
   json-schema-to-ts@3.1.1:
     resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
     engines: {node: '>=16'}
+
+  json-schema-traverse@0.4.1:
+    resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
@@ -1928,9 +2157,16 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lifecycle-utils@2.1.0:
     resolution: {integrity: sha512-AnrXnE2/OF9PHCyFg0RSqsnQTzV991XaZA/buhFDoc58xU7rhSCDgCz/09Lqpsn4MpoPHt7TRAXV1kWZypFVsA==}
@@ -1946,6 +2182,10 @@ packages:
     peerDependenciesMeta:
       canvas:
         optional: true
+
+  locate-path@6.0.0:
+    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
+    engines: {node: '>=10'}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -2020,6 +2260,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -2056,6 +2300,9 @@ packages:
     resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
     engines: {node: ^18 || >=20}
     hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -2144,9 +2391,21 @@ packages:
       zod:
         optional: true
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
   ora@9.3.0:
     resolution: {integrity: sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==}
     engines: {node: '>=20'}
+
+  p-limit@3.1.0:
+    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
+    engines: {node: '>=10'}
+
+  p-locate@5.0.0:
+    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
 
   p-retry@4.6.2:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
@@ -2172,6 +2431,10 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2228,6 +2491,10 @@ packages:
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
+
   pretty-bytes@6.1.1:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
@@ -2257,6 +2524,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.15.1:
     resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
@@ -2569,14 +2840,31 @@ packages:
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   tsc-alias@1.8.16:
     resolution: {integrity: sha512-QjCyu55NFyRSBAl6+MTFwplpFcnm2Pq01rR/uxfqJoLMm6X3O14KEGtaSDZpJYaE1bJBGDjD0eSuiIWPe2T58g==}
     engines: {node: '>=16.20.2'}
     hasBin: true
 
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
+
+  typescript-eslint@8.59.2:
+    resolution: {integrity: sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -2618,6 +2906,9 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  uri-js@4.4.1:
+    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
@@ -2833,6 +3124,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -2875,6 +3170,10 @@ packages:
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yocto-queue@0.1.0:
+    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
+    engines: {node: '>=10'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -3197,6 +3496,36 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.3.0)':
+    dependencies:
+      eslint: 10.3.0
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.5
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.5.5':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.1':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
   '@google/genai@1.50.1(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))':
     dependencies:
       google-auth-library: 10.6.2
@@ -3215,6 +3544,22 @@ snapshots:
       hono: 4.12.14
 
   '@huggingface/jinja@0.5.6': {}
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@iconify-json/simple-icons@1.2.79':
     dependencies:
@@ -3542,11 +3887,15 @@ snapshots:
 
   '@types/diff-match-patch@1.0.36': {}
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/hast@3.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/json-schema@7.0.15': {}
 
   '@types/linkify-it@5.0.0': {}
 
@@ -3585,6 +3934,97 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@types/web-bluetooth@0.0.21': {}
+
+  '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.59.2(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/type-utils': 8.59.2(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.2
+      eslint: 10.3.0
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.59.2(eslint@10.3.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
+      eslint: 10.3.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.59.2(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.2
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.59.2':
+    dependencies:
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/visitor-keys': 8.59.2
+
+  '@typescript-eslint/tsconfig-utils@8.59.2(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/type-utils@8.59.2(eslint@10.3.0)(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@10.3.0)(typescript@5.9.3)
+      debug: 4.4.3
+      eslint: 10.3.0
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.59.2': {}
+
+  '@typescript-eslint/typescript-estree@8.59.2(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/visitor-keys': 8.59.2
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.15
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.59.2(eslint@10.3.0)(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0)
+      '@typescript-eslint/scope-manager': 8.59.2
+      '@typescript-eslint/types': 8.59.2
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      eslint: 10.3.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.59.2':
+    dependencies:
+      '@typescript-eslint/types': 8.59.2
+      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -3778,11 +4218,24 @@ snapshots:
       mime-types: 3.0.2
       negotiator: 1.0.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
+  acorn@8.16.0: {}
+
   agent-base@7.1.4: {}
 
   ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
+
+  ajv@6.15.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-json-stable-stringify: 2.1.0
+      json-schema-traverse: 0.4.1
+      uri-js: 4.4.1
 
   ajv@8.18.0:
     dependencies:
@@ -3835,6 +4288,8 @@ snapshots:
     dependencies:
       retry: 0.13.1
 
+  balanced-match@4.0.4: {}
+
   base64-js@1.5.1: {}
 
   bignumber.js@9.3.1: {}
@@ -3858,6 +4313,10 @@ snapshots:
       - supports-color
 
   boolbase@1.0.0: {}
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -4030,6 +4489,8 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
+  deep-is@0.1.4: {}
+
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -4161,11 +4622,77 @@ snapshots:
 
   escape-html@1.0.3: {}
 
+  escape-string-regexp@4.0.0: {}
+
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.8
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.3.0:
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.3.0)
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.5.5
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.1
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  esrecurse@4.3.0:
+    dependencies:
+      estraverse: 5.3.0
+
+  estraverse@5.3.0: {}
+
   estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  esutils@2.0.3: {}
 
   etag@1.8.1: {}
 
@@ -4229,6 +4756,10 @@ snapshots:
       merge2: 1.4.1
       micromatch: 4.0.8
 
+  fast-json-stable-stringify@2.1.0: {}
+
+  fast-levenshtein@2.0.6: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -4243,6 +4774,10 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
 
   filename-reserved-regex@3.0.0: {}
 
@@ -4264,6 +4799,18 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  find-up@5.0.0:
+    dependencies:
+      locate-path: 6.0.0
+      path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.2
+      keyv: 4.5.4
+
+  flatted@3.4.2: {}
 
   focus-trap@7.8.0:
     dependencies:
@@ -4331,6 +4878,10 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
 
@@ -4426,6 +4977,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  imurmurhash@0.1.4: {}
+
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -4496,14 +5049,20 @@ snapshots:
     dependencies:
       bignumber.js: 9.3.1
 
+  json-buffer@3.0.1: {}
+
   json-schema-to-ts@3.1.1:
     dependencies:
       '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
 
+  json-schema-traverse@0.4.1: {}
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
 
   jsonfile@6.2.0:
     dependencies:
@@ -4522,7 +5081,16 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   kleur@3.0.3: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lifecycle-utils@2.1.0: {}
 
@@ -4535,6 +5103,10 @@ snapshots:
       html-escaper: 3.0.3
       htmlparser2: 10.1.0
       uhyphen: 0.2.0
+
+  locate-path@6.0.0:
+    dependencies:
+      p-locate: 5.0.0
 
   lodash.debounce@4.0.8: {}
 
@@ -4607,6 +5179,10 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
@@ -4632,6 +5208,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanoid@5.1.6: {}
+
+  natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
 
@@ -4744,6 +5322,15 @@ snapshots:
       ws: 8.20.0
       zod: 4.3.6
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
   ora@9.3.0:
     dependencies:
       chalk: 5.6.2
@@ -4754,6 +5341,14 @@ snapshots:
       log-symbols: 7.0.1
       stdin-discarder: 0.3.1
       string-width: 8.2.0
+
+  p-limit@3.1.0:
+    dependencies:
+      yocto-queue: 0.1.0
+
+  p-locate@5.0.0:
+    dependencies:
+      p-limit: 3.1.0
 
   p-retry@4.6.2:
     dependencies:
@@ -4773,6 +5368,8 @@ snapshots:
   parse5@6.0.1: {}
 
   parseurl@1.3.3: {}
+
+  path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
@@ -4813,6 +5410,8 @@ snapshots:
       source-map-js: 1.2.1
 
   preact@10.29.1: {}
+
+  prelude-ls@1.2.1: {}
 
   pretty-bytes@6.1.1: {}
 
@@ -4856,6 +5455,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  punycode@2.3.1: {}
 
   qs@6.15.1:
     dependencies:
@@ -5222,6 +5823,10 @@ snapshots:
 
   ts-algebra@2.0.0: {}
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   tsc-alias@1.8.16:
     dependencies:
       chokidar: 3.6.0
@@ -5232,11 +5837,26 @@ snapshots:
       normalize-path: 3.0.0
       plimit-lit: 1.6.1
 
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
       media-typer: 1.1.0
       mime-types: 3.0.2
+
+  typescript-eslint@8.59.2(eslint@10.3.0)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.3.0)(typescript@5.9.3))(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.59.2(eslint@10.3.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.59.2(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.59.2(eslint@10.3.0)(typescript@5.9.3)
+      eslint: 10.3.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
 
   typescript@5.9.3: {}
 
@@ -5279,6 +5899,10 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
+
+  uri-js@4.4.1:
+    dependencies:
+      punycode: 2.3.1
 
   url-join@4.0.1: {}
 
@@ -5507,6 +6131,8 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  word-wrap@1.2.5: {}
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -5544,6 +6170,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yocto-queue@0.1.0: {}
 
   yoctocolors@2.1.2: {}
 


### PR DESCRIPTION
## Summary

- Adds an ESLint structural linter (`pnpm run lint:structure`) with 7 rules using only built-in ESLint/@typescript-eslint rules — no custom rule files needed
- Creates anti-pattern catalog (`docs/dev/anti-patterns.md`) with 9 entries and concrete before/after examples
- Creates coding standards doc (`docs/dev/coding-standards.md`) documenting all mechanical rules
- Restructures CLAUDE.md from 225 to 119 lines as a progressive disclosure map pointing to deeper docs
- Adds `/review-changes` slash command for self-reviewing diffs against the anti-patterns and coding standards
- Adds GitHub Actions CI workflow to run structural lint on PRs
- Fixes stale references in TESTING.md (agency-ts -> agency-js) and typechecker.md

## Test plan

- [ ] Run `pnpm run lint:structure` — currently has violations that need `--fix` applied
- [ ] Run `pnpm run lint:structure --fix` to auto-fix prefer-const and consistent-type-definitions violations
- [ ] Add per-file overrides for legitimately large files
- [ ] Run `pnpm test:run` to verify auto-fixes did not break anything
- [ ] Review restructured CLAUDE.md for completeness
- [ ] Run `/review-changes` to verify it produces actionable output

Generated with [Claude Code](https://claude.com/claude-code)
