### PR TITLE
Add record() function to speech stdlib

### DIFF
--- a/packages/agency-lang/docs-new/stdlib/speech.md
+++ b/packages/agency-lang/docs-new/stdlib/speech.md
@@ -26,6 +26,34 @@ A tool for speaking text aloud using text-to-speech. Optionally specify a voice 
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/speech.agency#L3))
 
+### record
+
+```ts
+record(outputFile: string, silenceTimeout: number): string
+```
+
+Record audio from the microphone. Stops when the user presses Enter,
+  or after the specified silence timeout. Set silenceTimeout to 0 to
+  disable silence detection (recording stops only on Enter).
+
+  The silenceTimeout parameter is in milliseconds, so you can use
+  Agency's unit literals: record(silenceTimeout: 3s), record(silenceTimeout: 500ms).
+  Set to 0 for no timeout.
+
+  @param outputFile - File path to save audio to (auto-generated if empty)
+  @param silenceTimeout - Silence before auto-stopping in ms (0 to disable)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| outputFile | `string` | "" |
+| silenceTimeout | `number` | 2000 |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/speech.agency#L19))
+
 ### transcribe
 
 ```ts
@@ -46,4 +74,4 @@ A tool for transcribing an audio file to text using OpenAI's Whisper API. Option
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/speech.agency#L19))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/speech.agency#L37))

--- a/packages/agency-lang/stdlib/lib/speech.ts
+++ b/packages/agency-lang/stdlib/lib/speech.ts
@@ -1,4 +1,4 @@
-import { execFile } from "child_process";
+import { execFile, spawn } from "child_process";
 import { readFile, writeFile, unlink } from "fs/promises";
 import { promisify } from "util";
 import { nanoid } from "nanoid";
@@ -37,6 +37,40 @@ export async function _speak(text: string, voice: string, rate: number, outputFi
       `Supported platforms: macOS.`
     );
   }
+}
+
+export async function _record(outputFile: string, silenceTimeout: number): Promise<string> {
+  const outPath = outputFile || path.join(os.tmpdir(), `agency-rec-${nanoid()}.wav`);
+
+  const args = [outPath];
+  if (silenceTimeout > 0) {
+    const seconds = String(silenceTimeout / 1000);
+    args.push("silence", "1", "0.1", "3%", "1", seconds, "3%");
+  }
+
+  const proc = spawn("rec", args, { stdio: ["pipe", "pipe", "pipe"] });
+
+  await new Promise<void>((resolve, reject) => {
+    proc.on("error", (err) => {
+      reject(new Error(
+        `Failed to start 'rec' command: ${err.message}. ` +
+        `Make sure SoX is installed (e.g. 'brew install sox' on macOS, 'apt install sox' on Linux).`
+      ));
+    });
+    proc.on("close", () => resolve());
+
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+      process.stdin.resume();
+      process.stdin.once("data", () => {
+        process.stdin.setRawMode(false);
+        process.stdin.pause();
+        proc.kill("SIGTERM");
+      });
+    }
+  });
+
+  return outPath;
 }
 
 export async function _transcribe(filepath: string, language: string): Promise<string> {

--- a/packages/agency-lang/stdlib/lib/speech.ts
+++ b/packages/agency-lang/stdlib/lib/speech.ts
@@ -40,6 +40,15 @@ export async function _speak(text: string, voice: string, rate: number, outputFi
 }
 
 export async function _record(outputFile: string, silenceTimeout: number): Promise<string> {
+  const isTTY = process.stdin.isTTY;
+
+  if (silenceTimeout <= 0 && !isTTY) {
+    throw new Error(
+      "record() with silenceTimeout=0 requires an interactive terminal (TTY) " +
+      "so that Enter can stop the recording. Either run in a TTY or set a positive silenceTimeout."
+    );
+  }
+
   const outPath = outputFile
     ? path.resolve(process.cwd(), outputFile)
     : path.join(os.tmpdir(), `agency-rec-${nanoid()}.wav`);
@@ -52,18 +61,25 @@ export async function _record(outputFile: string, silenceTimeout: number): Promi
 
   const proc = spawn("rec", args, { stdio: ["pipe", "ignore", "ignore"] });
 
-  const cleanupStdin = (listener: (...args: unknown[]) => void) => {
-    if (process.stdin.isTTY) {
+  const cleanupStdin = (listener: (data: Buffer) => void) => {
+    if (isTTY) {
       process.stdin.removeListener("data", listener);
       process.stdin.setRawMode(false);
       process.stdin.pause();
     }
   };
 
+  let stoppedByUser = false;
+
   await new Promise<void>((resolve, reject) => {
-    const onData = () => {
-      cleanupStdin(onData);
-      proc.kill("SIGTERM");
+    const onData = (data: Buffer) => {
+      const key = data[0];
+      // Only stop on Enter (CR or LF) or Ctrl+C
+      if (key === 0x0d || key === 0x0a || key === 0x03) {
+        stoppedByUser = true;
+        cleanupStdin(onData);
+        proc.kill("SIGTERM");
+      }
     };
 
     proc.on("error", (err) => {
@@ -77,14 +93,18 @@ export async function _record(outputFile: string, silenceTimeout: number): Promi
 
     proc.on("close", (code) => {
       cleanupStdin(onData);
-      if (code !== 0 && !outputFile) unlink(outPath).catch(() => {});
-      resolve();
+      if (code !== 0 && code !== null && !stoppedByUser) {
+        if (!outputFile) unlink(outPath).catch(() => {});
+        reject(new Error(`'rec' exited with code ${code}`));
+      } else {
+        resolve();
+      }
     });
 
-    if (process.stdin.isTTY) {
+    if (isTTY) {
       process.stdin.setRawMode(true);
       process.stdin.resume();
-      process.stdin.once("data", onData);
+      process.stdin.on("data", onData);
     }
   });
 

--- a/packages/agency-lang/stdlib/lib/speech.ts
+++ b/packages/agency-lang/stdlib/lib/speech.ts
@@ -40,7 +40,9 @@ export async function _speak(text: string, voice: string, rate: number, outputFi
 }
 
 export async function _record(outputFile: string, silenceTimeout: number): Promise<string> {
-  const outPath = outputFile || path.join(os.tmpdir(), `agency-rec-${nanoid()}.wav`);
+  const outPath = outputFile
+    ? path.resolve(process.cwd(), outputFile)
+    : path.join(os.tmpdir(), `agency-rec-${nanoid()}.wav`);
 
   const args = [outPath];
   if (silenceTimeout > 0) {
@@ -48,25 +50,41 @@ export async function _record(outputFile: string, silenceTimeout: number): Promi
     args.push("silence", "1", "0.1", "3%", "1", seconds, "3%");
   }
 
-  const proc = spawn("rec", args, { stdio: ["pipe", "pipe", "pipe"] });
+  const proc = spawn("rec", args, { stdio: ["pipe", "ignore", "ignore"] });
+
+  const cleanupStdin = (listener: (...args: unknown[]) => void) => {
+    if (process.stdin.isTTY) {
+      process.stdin.removeListener("data", listener);
+      process.stdin.setRawMode(false);
+      process.stdin.pause();
+    }
+  };
 
   await new Promise<void>((resolve, reject) => {
+    const onData = () => {
+      cleanupStdin(onData);
+      proc.kill("SIGTERM");
+    };
+
     proc.on("error", (err) => {
+      cleanupStdin(onData);
+      if (!outputFile) unlink(outPath).catch(() => {});
       reject(new Error(
         `Failed to start 'rec' command: ${err.message}. ` +
         `Make sure SoX is installed (e.g. 'brew install sox' on macOS, 'apt install sox' on Linux).`
       ));
     });
-    proc.on("close", () => resolve());
+
+    proc.on("close", (code) => {
+      cleanupStdin(onData);
+      if (code !== 0 && !outputFile) unlink(outPath).catch(() => {});
+      resolve();
+    });
 
     if (process.stdin.isTTY) {
       process.stdin.setRawMode(true);
       process.stdin.resume();
-      process.stdin.once("data", () => {
-        process.stdin.setRawMode(false);
-        process.stdin.pause();
-        proc.kill("SIGTERM");
-      });
+      process.stdin.once("data", onData);
     }
   });
 

--- a/packages/agency-lang/stdlib/speech.agency
+++ b/packages/agency-lang/stdlib/speech.agency
@@ -1,4 +1,4 @@
-import { _speak, _transcribe } from "./lib/speech.js"
+import { _speak, _record, _transcribe } from "./lib/speech.js"
 
 export def speak(text: string, voice: string = "", rate: number = 0, outputFile: string = "") {
   """
@@ -14,6 +14,24 @@ export def speak(text: string, voice: string = "", rate: number = 0, outputFile:
   })
 
   _speak(text, voice, rate, outputFile)
+}
+
+export def record(outputFile: string = "", silenceTimeout: number = 2000): string {
+  """
+  Record audio from the microphone. Stops when the user presses Enter,
+  or after the specified silence timeout. Set silenceTimeout to 0 to
+  disable silence detection (recording stops only on Enter).
+
+  The silenceTimeout parameter is in milliseconds, so you can use
+  Agency's unit literals: record(silenceTimeout: 3s), record(silenceTimeout: 500ms).
+  Set to 0 for no timeout.
+
+  @param outputFile - File path to save audio to (auto-generated if empty)
+  @param silenceTimeout - Silence before auto-stopping in ms (0 to disable)
+  """
+  return interrupt std::record("Allow microphone recording?", {})
+
+  return _record(outputFile, silenceTimeout)
 }
 
 export def transcribe(filepath: string, language: string = ""): string {


### PR DESCRIPTION
## Summary
- Adds `record()` to `std::speech`, enabling microphone recording via the SoX `rec` command
- Recording stops on **Enter keypress** or after a configurable silence timeout (default 2s)
- Silence timeout supports Agency unit literals (e.g. `3s`, `500ms`); set to `0` for Enter-only mode
- Completes the voice pipeline: `record()` → `transcribe()` → agent acts → `speak()`

## Test plan
- [ ] Install SoX (`brew install sox`) and verify `record()` captures audio and returns a valid WAV path
- [ ] Verify Enter keypress stops recording immediately
- [ ] Verify `record(silenceTimeout: 0)` only stops on Enter (no silence detection)
- [ ] Verify custom timeout values work (e.g. `record(silenceTimeout: 5s)`)
- [ ] Verify helpful error message when SoX is not installed
- [ ] Verify interrupt fires before recording begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)