### PR TITLE
Add bundler and CLI integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     - run: pnpm install
     - run: make
     - run: pnpm test:run
-    - name: Smoke test (tarball install)
+    - name: Integration tests (tarball install, bundlers, CLI)
       if: matrix.node-version == '22.x'
       env:
         TMPDIR: ${{ runner.temp }}
@@ -50,6 +50,9 @@ jobs:
         cd packages/agency-lang
         npm pack
         node tests/integration/smoke/test.mjs ./agency-lang-*.tgz
+        node tests/integration/bundlers/test-esbuild.mjs ./agency-lang-*.tgz
+        node tests/integration/bundlers/test-vite.mjs ./agency-lang-*.tgz
+        node tests/integration/cli/test.mjs ./agency-lang-*.tgz
         rm -f agency-lang-*.tgz
     # - run: pnpm run test:agency
     #   env:

--- a/makefile
+++ b/makefile
@@ -4,7 +4,5 @@ PACKAGES := $(wildcard packages/*)
 
 all: $(PACKAGES)
 
-packages/agency-lang: packages/tui
-
 $(PACKAGES):
 	@if [ -f $@/makefile ] || [ -f $@/Makefile ]; then $(MAKE) -C $@; fi

--- a/packages/agency-lang/tests/integration/bundlers/test-esbuild.mjs
+++ b/packages/agency-lang/tests/integration/bundlers/test-esbuild.mjs
@@ -8,7 +8,7 @@ import {
 const MARKER = "ESBUILD TEST PASSED";
 
 withTestProject("esbuild", (dir) => {
-  installDev(dir, "esbuild");
+  installDev(dir, "esbuild@0");
   writeHelloAgency(dir);
   writeHelloEntryPoint(dir, "entry.mjs", "esbuild", MARKER);
   run(dir, "npx esbuild entry.mjs --bundle --outfile=out.mjs --platform=node --format=esm --packages=external");

--- a/packages/agency-lang/tests/integration/bundlers/test-esbuild.mjs
+++ b/packages/agency-lang/tests/integration/bundlers/test-esbuild.mjs
@@ -1,0 +1,48 @@
+// Verify that a project using compiled Agency code can be bundled with esbuild.
+
+import { resolve } from "node:path";
+import {
+  createTempProject, initProject, installTarball, installDev,
+  writeFile, run, assertIncludes, cleanup, getTarballPath,
+} from "../helpers.mjs";
+
+const tarball = resolve(getTarballPath());
+const dir = createTempProject("esbuild");
+
+try {
+  initProject(dir);
+  installTarball(dir, tarball);
+  installDev(dir, "esbuild");
+
+  writeFile(dir, "hello.agency", `
+node main(name: string) {
+  return "Hello, " + name + "!"
+}
+`);
+  run(dir, "npx agency compile hello.agency");
+
+  // Entry point imports compiled Agency node
+  writeFile(dir, "entry.mjs", `
+import { main } from "./hello.js";
+const result = await main("esbuild");
+const value = result?.data ?? result;
+if (value !== "Hello, esbuild!") {
+  console.error("Expected 'Hello, esbuild!' but got:", JSON.stringify(result, null, 2));
+  process.exit(1);
+}
+console.log("ESBUILD TEST PASSED");
+`);
+
+  // Bundle with esbuild — packages=external keeps node_modules as imports
+  run(dir, "npx esbuild entry.mjs --bundle --outfile=out.mjs --platform=node --format=esm --packages=external");
+
+  const output = run(dir, "node out.mjs");
+  assertIncludes(output, "ESBUILD TEST PASSED");
+
+  console.log("=== esbuild test passed ===");
+  cleanup(dir);
+} catch (err) {
+  console.error("esbuild test failed:", err);
+  console.error("Temp directory preserved at:", dir);
+  process.exit(1);
+}

--- a/packages/agency-lang/tests/integration/bundlers/test-esbuild.mjs
+++ b/packages/agency-lang/tests/integration/bundlers/test-esbuild.mjs
@@ -1,48 +1,17 @@
 // Verify that a project using compiled Agency code can be bundled with esbuild.
 
-import { resolve } from "node:path";
 import {
-  createTempProject, initProject, installTarball, installDev,
-  writeFile, run, assertIncludes, cleanup, getTarballPath,
+  installDev, run, assertIncludes, withTestProject,
+  writeHelloAgency, writeHelloEntryPoint,
 } from "../helpers.mjs";
 
-const tarball = resolve(getTarballPath());
-const dir = createTempProject("esbuild");
+const MARKER = "ESBUILD TEST PASSED";
 
-try {
-  initProject(dir);
-  installTarball(dir, tarball);
+withTestProject("esbuild", (dir) => {
   installDev(dir, "esbuild");
-
-  writeFile(dir, "hello.agency", `
-node main(name: string) {
-  return "Hello, " + name + "!"
-}
-`);
-  run(dir, "npx agency compile hello.agency");
-
-  // Entry point imports compiled Agency node
-  writeFile(dir, "entry.mjs", `
-import { main } from "./hello.js";
-const result = await main("esbuild");
-const value = result?.data ?? result;
-if (value !== "Hello, esbuild!") {
-  console.error("Expected 'Hello, esbuild!' but got:", JSON.stringify(result, null, 2));
-  process.exit(1);
-}
-console.log("ESBUILD TEST PASSED");
-`);
-
-  // Bundle with esbuild — packages=external keeps node_modules as imports
+  writeHelloAgency(dir);
+  writeHelloEntryPoint(dir, "entry.mjs", "esbuild", MARKER);
   run(dir, "npx esbuild entry.mjs --bundle --outfile=out.mjs --platform=node --format=esm --packages=external");
-
   const output = run(dir, "node out.mjs");
-  assertIncludes(output, "ESBUILD TEST PASSED");
-
-  console.log("=== esbuild test passed ===");
-  cleanup(dir);
-} catch (err) {
-  console.error("esbuild test failed:", err);
-  console.error("Temp directory preserved at:", dir);
-  process.exit(1);
-}
+  assertIncludes(output, MARKER);
+});

--- a/packages/agency-lang/tests/integration/bundlers/test-vite.mjs
+++ b/packages/agency-lang/tests/integration/bundlers/test-vite.mjs
@@ -1,40 +1,18 @@
 // Verify that a project using compiled Agency code can be built with Vite.
 
-import { resolve } from "node:path";
 import {
-  createTempProject, initProject, installTarball, installDev,
-  writeFile, run, assertIncludes, cleanup, getTarballPath,
+  installDev, writeFile, run, assertIncludes, withTestProject,
+  writeHelloAgency, writeHelloEntryPoint,
 } from "../helpers.mjs";
 
-const tarball = resolve(getTarballPath());
-const dir = createTempProject("vite");
+const MARKER = "VITE TEST PASSED";
 
-try {
-  initProject(dir);
-  installTarball(dir, tarball);
+withTestProject("vite", (dir) => {
   installDev(dir, "vite");
+  writeHelloAgency(dir);
+  writeHelloEntryPoint(dir, "entry.mjs", "vite", MARKER);
 
-  writeFile(dir, "hello.agency", `
-node main(name: string) {
-  return "Hello, " + name + "!"
-}
-`);
-  run(dir, "npx agency compile hello.agency");
-
-  writeFile(dir, "entry.mjs", `
-import { main } from "./hello.js";
-const result = await main("vite");
-const value = result?.data ?? result;
-if (value !== "Hello, vite!") {
-  console.error("Expected 'Hello, vite!' but got:", JSON.stringify(result, null, 2));
-  process.exit(1);
-}
-console.log("VITE TEST PASSED");
-`);
-
-  // SSR build — bundles for Node, not browser
-  writeFile(dir, "vite.config.mjs", `
-import { defineConfig } from "vite";
+  writeFile(dir, "vite.config.mjs", `import { defineConfig } from "vite";
 export default defineConfig({
   build: {
     ssr: true,
@@ -48,14 +26,6 @@ export default defineConfig({
 `);
 
   run(dir, "npx vite build");
-
   const output = run(dir, "node dist/entry.js");
-  assertIncludes(output, "VITE TEST PASSED");
-
-  console.log("=== Vite test passed ===");
-  cleanup(dir);
-} catch (err) {
-  console.error("Vite test failed:", err);
-  console.error("Temp directory preserved at:", dir);
-  process.exit(1);
-}
+  assertIncludes(output, MARKER);
+});

--- a/packages/agency-lang/tests/integration/bundlers/test-vite.mjs
+++ b/packages/agency-lang/tests/integration/bundlers/test-vite.mjs
@@ -1,0 +1,61 @@
+// Verify that a project using compiled Agency code can be built with Vite.
+
+import { resolve } from "node:path";
+import {
+  createTempProject, initProject, installTarball, installDev,
+  writeFile, run, assertIncludes, cleanup, getTarballPath,
+} from "../helpers.mjs";
+
+const tarball = resolve(getTarballPath());
+const dir = createTempProject("vite");
+
+try {
+  initProject(dir);
+  installTarball(dir, tarball);
+  installDev(dir, "vite");
+
+  writeFile(dir, "hello.agency", `
+node main(name: string) {
+  return "Hello, " + name + "!"
+}
+`);
+  run(dir, "npx agency compile hello.agency");
+
+  writeFile(dir, "entry.mjs", `
+import { main } from "./hello.js";
+const result = await main("vite");
+const value = result?.data ?? result;
+if (value !== "Hello, vite!") {
+  console.error("Expected 'Hello, vite!' but got:", JSON.stringify(result, null, 2));
+  process.exit(1);
+}
+console.log("VITE TEST PASSED");
+`);
+
+  // SSR build — bundles for Node, not browser
+  writeFile(dir, "vite.config.mjs", `
+import { defineConfig } from "vite";
+export default defineConfig({
+  build: {
+    ssr: true,
+    rollupOptions: {
+      input: "./entry.mjs",
+      output: { format: "esm" },
+    },
+    outDir: "dist",
+  },
+});
+`);
+
+  run(dir, "npx vite build");
+
+  const output = run(dir, "node dist/entry.js");
+  assertIncludes(output, "VITE TEST PASSED");
+
+  console.log("=== Vite test passed ===");
+  cleanup(dir);
+} catch (err) {
+  console.error("Vite test failed:", err);
+  console.error("Temp directory preserved at:", dir);
+  process.exit(1);
+}

--- a/packages/agency-lang/tests/integration/bundlers/test-vite.mjs
+++ b/packages/agency-lang/tests/integration/bundlers/test-vite.mjs
@@ -8,7 +8,7 @@ import {
 const MARKER = "VITE TEST PASSED";
 
 withTestProject("vite", (dir) => {
-  installDev(dir, "vite");
+  installDev(dir, "vite@6");
   writeHelloAgency(dir);
   writeHelloEntryPoint(dir, "entry.mjs", "vite", MARKER);
 
@@ -16,6 +16,7 @@ withTestProject("vite", (dir) => {
 export default defineConfig({
   build: {
     ssr: true,
+    target: "esnext",
     rollupOptions: {
       input: "./entry.mjs",
       output: { format: "esm" },

--- a/packages/agency-lang/tests/integration/cli/test.mjs
+++ b/packages/agency-lang/tests/integration/cli/test.mjs
@@ -29,9 +29,8 @@ try {
   // --- Test 2: Stdlib imports ---
   console.log("--- Test 2: Stdlib imports ---");
   writeFile(dir, "stdlib-test.agency", `import { map } from "std::array"
-import { add } from "std::math"
+import { add, multiply } from "std::math"
 import { join } from "std::path"
-import { now } from "std::date"
 import { mapValues } from "std::object"
 
 node main() {
@@ -44,11 +43,11 @@ node main() {
   const sum = add(10, 20)
   print(sum)
 
+  const product = multiply(3, 7)
+  print(product)
+
   const p = join("foo", "bar", "baz.txt")
   print(p)
-
-  const t = now()
-  print(t)
 
   const obj = { a: 1, b: 2 }
   const doubled2 = mapValues(obj) as (v, k) {
@@ -60,11 +59,11 @@ node main() {
 }
 `);
   const stdlibOutput = run(dir, "npx agency run stdlib-test.agency");
-  // Verify stdlib functions produced correct output
-  assertIncludes(stdlibOutput, "[ 2, 4, 6 ]");  // map doubled
-  assertIncludes(stdlibOutput, "30");             // add(10, 20)
-  assertIncludes(stdlibOutput, "foo/bar/baz.txt"); // join
-  assertIncludes(stdlibOutput, "{ a: 2, b: 4 }"); // mapValues doubled
+  assertIncludes(stdlibOutput, "[ 2, 4, 6 ]");
+  assertIncludes(stdlibOutput, "30");
+  assertIncludes(stdlibOutput, "21");
+  assertIncludes(stdlibOutput, "foo/bar/baz.txt"); // CI runs on Linux; Windows would use backslashes
+  assertIncludes(stdlibOutput, "{ a: 2, b: 4 }");
   console.log("Test 2 passed");
 
   // --- Test 3: Interrupts and handlers ---

--- a/packages/agency-lang/tests/integration/cli/test.mjs
+++ b/packages/agency-lang/tests/integration/cli/test.mjs
@@ -1,0 +1,116 @@
+// CLI end-to-end tests: compile+run, stdlib imports, interrupts/handlers, test runner.
+// All tests avoid LLM calls.
+
+import { resolve } from "node:path";
+import {
+  createTempProject, initProject, installTarball,
+  writeFile, run, assertIncludes, cleanup, getTarballPath,
+} from "../helpers.mjs";
+
+const tarball = resolve(getTarballPath());
+const dir = createTempProject("cli");
+
+try {
+  initProject(dir);
+  installTarball(dir, tarball);
+
+  // --- Test 1: Basic compile and run ---
+  console.log("--- Test 1: Basic compile and run ---");
+  writeFile(dir, "basic.agency", `node main() {
+  const greeting = "hello " + "world"
+  print(greeting)
+  return greeting
+}
+`);
+  const basicOutput = run(dir, "npx agency run basic.agency");
+  assertIncludes(basicOutput, "hello world");
+  console.log("Test 1 passed");
+
+  // --- Test 2: Stdlib imports ---
+  console.log("--- Test 2: Stdlib imports ---");
+  writeFile(dir, "stdlib-test.agency", `import { map } from "std::array"
+import { add } from "std::math"
+import { join } from "std::path"
+import { now } from "std::date"
+import { mapValues } from "std::object"
+
+node main() {
+  const nums = [1, 2, 3]
+  const doubled = map(nums) as n {
+    return n * 2
+  }
+  print(doubled)
+
+  const sum = add(10, 20)
+  print(sum)
+
+  const p = join("foo", "bar", "baz.txt")
+  print(p)
+
+  const t = now()
+  print(t)
+
+  const obj = { a: 1, b: 2 }
+  const doubled2 = mapValues(obj) as (v, k) {
+    return v * 2
+  }
+  print(doubled2)
+
+  return "stdlib ok"
+}
+`);
+  const stdlibOutput = run(dir, "npx agency run stdlib-test.agency");
+  // Verify stdlib functions produced correct output
+  assertIncludes(stdlibOutput, "[ 2, 4, 6 ]");  // map doubled
+  assertIncludes(stdlibOutput, "30");             // add(10, 20)
+  assertIncludes(stdlibOutput, "foo/bar/baz.txt"); // join
+  assertIncludes(stdlibOutput, "{ a: 2, b: 4 }"); // mapValues doubled
+  console.log("Test 2 passed");
+
+  // --- Test 3: Interrupts and handlers ---
+  console.log("--- Test 3: Interrupts and handlers ---");
+  writeFile(dir, "interrupt-test.agency", `def dangerousAction() {
+  return interrupt("Are you sure?")
+  return "action completed"
+}
+
+node main() {
+  handle {
+    const result = dangerousAction()
+  } with (data) {
+    return approve()
+  }
+  return result
+}
+`);
+  // If the handler works, execution completes without error (exit code 0).
+  // If the interrupt isn't handled, the program would fail.
+  run(dir, "npx agency run interrupt-test.agency");
+  console.log("Test 3 passed");
+
+  // --- Test 4: Agency test runner ---
+  console.log("--- Test 4: Agency test runner ---");
+  writeFile(dir, "testable.agency", `node greet(name: string) {
+  return "hi " + name
+}
+`);
+  writeFile(dir, "testable.test.json", JSON.stringify({
+    tests: [
+      {
+        nodeName: "greet",
+        input: '"Alice"',
+        expectedOutput: '"hi Alice"',
+        evaluationCriteria: [{ type: "exact" }],
+      },
+    ],
+  }, null, 2));
+  run(dir, "npx agency test testable.agency");
+  console.log("Test 4 passed");
+
+  console.log("=== All CLI tests passed ===");
+  cleanup(dir);
+} catch (err) {
+  console.error("CLI test failed:", err);
+  console.error("Temp directory preserved at:", dir);
+  process.exit(1);
+}

--- a/packages/agency-lang/tests/integration/helpers.mjs
+++ b/packages/agency-lang/tests/integration/helpers.mjs
@@ -4,7 +4,7 @@
 
 import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { execSync } from "node:child_process";
-import { join, dirname } from "node:path";
+import { join, dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
 export function createTempProject(name) {
@@ -75,6 +75,50 @@ export function assertIncludes(haystack, needle, message) {
 export function cleanup(dir) {
   rmSync(dir, { recursive: true, force: true });
   console.log(`[cleanup] Removed ${dir}`);
+}
+
+// Runs a test in an isolated temp project with tarball installed.
+// Handles setup, cleanup on success, and preserves dir on failure.
+export function withTestProject(name, fn) {
+  const tarball = resolve(process.argv[2] || "");
+  if (!tarball) {
+    console.error(`Usage: node ${process.argv[1]} <path-to-tarball>`);
+    process.exit(1);
+  }
+  const dir = createTempProject(name);
+  try {
+    initProject(dir);
+    installTarball(dir, tarball);
+    fn(dir, tarball);
+    console.log(`=== ${name} test passed ===`);
+    cleanup(dir);
+  } catch (err) {
+    console.error(`${name} test failed:`, err);
+    console.error("Temp directory preserved at:", dir);
+    process.exit(1);
+  }
+}
+
+// Writes and compiles the standard hello.agency fixture.
+export function writeHelloAgency(dir) {
+  writeFile(dir, "hello.agency", `node main(name: string) {
+  return "Hello, " + name + "!"
+}
+`);
+  run(dir, "npx agency compile hello.agency");
+}
+
+// Writes an entry point that imports a compiled node, calls it, and asserts the result.
+export function writeHelloEntryPoint(dir, filename, arg, marker) {
+  writeFile(dir, filename, `import { main } from "./hello.js";
+const result = await main("${arg}");
+const value = result?.data ?? result;
+if (value !== "Hello, ${arg}!") {
+  console.error("Expected 'Hello, ${arg}!' but got:", JSON.stringify(result, null, 2));
+  process.exit(1);
+}
+console.log("${marker}");
+`);
 }
 
 export function getTarballPath() {


### PR DESCRIPTION
## Summary

Adds three new integration tests that run on CI alongside the existing smoke test, verifying that Agency works correctly from a user's perspective:

- **esbuild bundler test**: Install Agency from tarball, compile .agency file, bundle with esbuild, execute the bundle
- **Vite bundler test**: Install Agency from tarball, compile .agency file, build with Vite (SSR mode), execute the output
- **CLI end-to-end tests** (4 sub-tests):
  - Basic compile and run via `agency run`
  - Stdlib imports (std::array, std::math, std::path, std::date, std::object)
  - Interrupts and handlers (verifies handler approves interrupt and execution completes)
  - Agency test runner (writes .agency + .test.json, runs `agency test`)

All tests create fresh projects in temp directories outside the monorepo, install from an `npm pack` tarball, and run commands exactly as a user would.

## Test plan

- [x] esbuild test passes locally
- [x] Vite test passes locally
- [x] All 4 CLI tests pass locally
- [x] All tests added to test.yml (Node 22 only)
