### PR TITLE
Surface interrupt kinds in serve and LSP hover

### DIFF
--- a/packages/agency-lang/lib/cli/serve.ts
+++ b/packages/agency-lang/lib/cli/serve.ts
@@ -9,12 +9,14 @@ import { startHttpServer } from "../serve/http/adapter.js";
 import { createLogger } from "../logger.js";
 import { VERSION } from "../version.js";
 import type { ExportedItem } from "../serve/types.js";
+import type { InterruptKind } from "../symbolTable.js";
 import * as esbuild from "esbuild";
 
 type CompileResult = {
   outputPath: string;
   moduleId: string;
   exportedNodeNames: string[];
+  interruptKindsByName: Record<string, InterruptKind[]>;
 };
 
 function compileForServe(file: string): CompileResult {
@@ -32,8 +34,15 @@ function compileForServe(file: string): CompileResult {
     .filter((sym) => sym.kind === "node" && sym.exported)
     .map((sym) => sym.name);
 
+  const interruptKindsByName: Record<string, InterruptKind[]> = {};
+  for (const [name, sym] of Object.entries(fileSymbols ?? {})) {
+    if ((sym.kind === "function" || sym.kind === "node") && sym.interruptKinds) {
+      interruptKindsByName[name] = sym.interruptKinds;
+    }
+  }
+
   const moduleId = path.relative(process.cwd(), absoluteFile);
-  return { outputPath, moduleId, exportedNodeNames };
+  return { outputPath, moduleId, exportedNodeNames, interruptKindsByName };
 }
 
 async function loadAndDiscover(
@@ -51,6 +60,7 @@ async function loadAndDiscover(
     moduleExports,
     moduleId: compileResult.moduleId,
     exportedNodeNames: compileResult.exportedNodeNames,
+    interruptKindsByName: compileResult.interruptKindsByName,
   });
 
   return { exports, moduleExports };

--- a/packages/agency-lang/lib/lsp/hover.test.ts
+++ b/packages/agency-lang/lib/lsp/hover.test.ts
@@ -109,6 +109,40 @@ greet("world")`;
     expect(value).toContain("name");
   });
 
+  it("shows interrupt kinds in hover for function with interrupts", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-hover-int-"));
+    try {
+      const mainFile = path.join(tmpDir, "main.agency");
+      const source = [
+        "def deploy() {",
+        '  interrupt myapp::deploy("Deploy?")',
+        "}",
+        "",
+        "node main() {",
+        "  deploy()",
+        "}",
+        "",
+      ].join("\n");
+      fs.writeFileSync(mainFile, source);
+
+      const doc = makeDoc(source, `file://${mainFile}`);
+      const symbolTable = SymbolTable.build(mainFile, {});
+      const { semanticIndex } = runDiagnostics(doc, mainFile, {}, symbolTable);
+      const result = handleHover(
+        { textDocument: { uri: doc.uri }, position: { line: 5, character: 2 } },
+        doc,
+        semanticIndex,
+      );
+
+      const value = (result?.contents as any)?.value ?? "";
+      expect(value).toContain("def deploy()");
+      expect(value).toContain("**Interrupts:**");
+      expect(value).toContain("`myapp::deploy`");
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
   it("returns null when not on an identifier", () => {
     const doc = makeDoc("let x: number = 5");
     const { semanticIndex } = runDiagnostics(

--- a/packages/agency-lang/lib/lsp/semantics.ts
+++ b/packages/agency-lang/lib/lsp/semantics.ts
@@ -1,6 +1,6 @@
 import { getWordAtPosition } from "../cli/definition.js";
 import { formatTypeHint } from "../cli/util.js";
-import type { InterruptKind, SymbolInfo, SymbolKind, SymbolTable } from "../symbolTable.js";
+import type { FileSymbols, InterruptKind, SymbolInfo, SymbolKind, SymbolTable } from "../symbolTable.js";
 import type {
   AgencyProgram,
   ClassDefinition,
@@ -31,16 +31,20 @@ function addSymbol(index: SemanticIndex, symbol: SemanticSymbol): void {
   index[symbol.name] = symbol;
 }
 
+function interruptKindsFor(fileSymbols: FileSymbols | undefined, name: string): InterruptKind[] | undefined {
+  const sym = fileSymbols?.[name];
+  if (sym?.kind === "function" || sym?.kind === "node") return sym.interruptKinds;
+  return undefined;
+}
+
 function addLocalDefinition(
   index: SemanticIndex,
   fsPath: string,
   node: FunctionDefinition | GraphNodeDefinition | TypeAlias | ClassDefinition,
-  symbolTable: SymbolTable,
+  fileSymbols: FileSymbols | undefined,
 ): void {
-  const fileSymbols = symbolTable.getFile(fsPath);
   switch (node.type) {
-    case "function": {
-      const sym = fileSymbols?.[node.functionName];
+    case "function":
       addSymbol(index, {
         name: node.functionName,
         originalName: node.functionName,
@@ -50,12 +54,10 @@ function addLocalDefinition(
         loc: node.loc,
         parameters: node.parameters,
         returnType: node.returnType,
-        interruptKinds: sym?.kind === "function" ? sym.interruptKinds : undefined,
+        interruptKinds: interruptKindsFor(fileSymbols, node.functionName),
       });
       break;
-    }
-    case "graphNode": {
-      const sym = fileSymbols?.[node.nodeName];
+    case "graphNode":
       addSymbol(index, {
         name: node.nodeName,
         originalName: node.nodeName,
@@ -65,10 +67,9 @@ function addLocalDefinition(
         loc: node.loc,
         parameters: node.parameters,
         returnType: node.returnType,
-        interruptKinds: sym?.kind === "node" ? sym.interruptKinds : undefined,
+        interruptKinds: interruptKindsFor(fileSymbols, node.nodeName),
       });
       break;
-    }
     case "typeAlias":
       addSymbol(index, {
         name: node.aliasName,
@@ -172,6 +173,7 @@ export function buildSemanticIndex(
   symbolTable: SymbolTable,
 ): SemanticIndex {
   const index: SemanticIndex = {};
+  const fileSymbols = symbolTable.getFile(fsPath);
 
   for (const node of program.nodes) {
     if (
@@ -180,7 +182,7 @@ export function buildSemanticIndex(
       node.type === "typeAlias" ||
       node.type === "classDefinition"
     ) {
-      addLocalDefinition(index, fsPath, node, symbolTable);
+      addLocalDefinition(index, fsPath, node, fileSymbols);
     }
   }
 

--- a/packages/agency-lang/lib/lsp/semantics.ts
+++ b/packages/agency-lang/lib/lsp/semantics.ts
@@ -1,6 +1,6 @@
 import { getWordAtPosition } from "../cli/definition.js";
 import { formatTypeHint } from "../cli/util.js";
-import type { SymbolInfo, SymbolKind, SymbolTable } from "../symbolTable.js";
+import type { InterruptKind, SymbolInfo, SymbolKind, SymbolTable } from "../symbolTable.js";
 import type {
   AgencyProgram,
   ClassDefinition,
@@ -22,6 +22,7 @@ export type SemanticSymbol = {
   returnType?: VariableType | null;
   aliasedType?: VariableType;
   importPath?: string;
+  interruptKinds?: InterruptKind[];
 };
 
 export type SemanticIndex = Record<string, SemanticSymbol>;
@@ -34,9 +35,12 @@ function addLocalDefinition(
   index: SemanticIndex,
   fsPath: string,
   node: FunctionDefinition | GraphNodeDefinition | TypeAlias | ClassDefinition,
+  symbolTable: SymbolTable,
 ): void {
+  const fileSymbols = symbolTable.getFile(fsPath);
   switch (node.type) {
-    case "function":
+    case "function": {
+      const sym = fileSymbols?.[node.functionName];
       addSymbol(index, {
         name: node.functionName,
         originalName: node.functionName,
@@ -46,9 +50,12 @@ function addLocalDefinition(
         loc: node.loc,
         parameters: node.parameters,
         returnType: node.returnType,
+        interruptKinds: sym?.kind === "function" ? sym.interruptKinds : undefined,
       });
       break;
-    case "graphNode":
+    }
+    case "graphNode": {
+      const sym = fileSymbols?.[node.nodeName];
       addSymbol(index, {
         name: node.nodeName,
         originalName: node.nodeName,
@@ -58,8 +65,10 @@ function addLocalDefinition(
         loc: node.loc,
         parameters: node.parameters,
         returnType: node.returnType,
+        interruptKinds: sym?.kind === "node" ? sym.interruptKinds : undefined,
       });
       break;
+    }
     case "typeAlias":
       addSymbol(index, {
         name: node.aliasName,
@@ -107,6 +116,7 @@ function addImportedSymbol(
     returnType: isCallable ? sym.returnType : undefined,
     aliasedType: sym.kind === "type" ? sym.aliasedType : undefined,
     importPath: opts.importPath,
+    interruptKinds: isCallable ? sym.interruptKinds : undefined,
   });
 }
 
@@ -170,7 +180,7 @@ export function buildSemanticIndex(
       node.type === "typeAlias" ||
       node.type === "classDefinition"
     ) {
-      addLocalDefinition(index, fsPath, node);
+      addLocalDefinition(index, fsPath, node, symbolTable);
     }
   }
 
@@ -233,15 +243,22 @@ function formatSignature(symbol: SemanticSymbol): string {
   }
 }
 
+function formatInterruptKinds(interruptKinds: InterruptKind[] | undefined): string {
+  if (!interruptKinds || interruptKinds.length === 0) return "";
+  const kinds = interruptKinds.map((ik) => `\`${ik.kind}\``).join(", ");
+  return `\n\n**Interrupts:** ${kinds}`;
+}
+
 export function formatSemanticHover(symbol: SemanticSymbol): string {
   const signature = formatSignature(symbol);
   const codeBlock = `\`\`\`typescript\n${signature}\n\`\`\``;
+  const interrupts = formatInterruptKinds(symbol.interruptKinds);
   if (symbol.source === "local") {
-    return codeBlock;
+    return `${codeBlock}${interrupts}`;
   }
 
   const aliasNote = symbol.originalName !== symbol.name
     ? ` as \`${symbol.originalName}\``
     : "";
-  return `${codeBlock}\n\nImported from \`${symbol.importPath}\`${aliasNote}`;
+  return `${codeBlock}\n\nImported from \`${symbol.importPath}\`${aliasNote}${interrupts}`;
 }

--- a/packages/agency-lang/lib/serve/discovery.test.ts
+++ b/packages/agency-lang/lib/serve/discovery.test.ts
@@ -99,6 +99,7 @@ describe("discoverExports", () => {
     expect(nodes[0].name).toBe("main");
     if (nodes[0].kind === "node") {
       expect(nodes[0].parameters).toEqual([{ name: "message" }]);
+      expect(nodes[0].interruptKinds).toEqual([]);
     }
   });
 

--- a/packages/agency-lang/lib/serve/discovery.test.ts
+++ b/packages/agency-lang/lib/serve/discovery.test.ts
@@ -126,4 +126,43 @@ describe("discoverExports", () => {
       discoverExports({ toolRegistry: {}, moduleExports: {}, moduleId: "test" }),
     ).toEqual([]);
   });
+
+  it("attaches interruptKinds from interruptKindsByName", () => {
+    const registry: Record<string, AgencyFunction> = {};
+    AgencyFunction.create(
+      {
+        name: "deploy",
+        module: "test",
+        fn: async () => {},
+        params: [],
+        toolDefinition: { name: "deploy", description: "Deploy", schema: null },
+        exported: true,
+        safe: false,
+      },
+      registry,
+    );
+
+    const exports = discoverExports({
+      toolRegistry: registry,
+      moduleExports: {
+        checkout: async () => ({ data: "ok" }),
+        __checkoutNodeParams: [],
+      },
+      moduleId: "test",
+      exportedNodeNames: ["checkout"],
+      interruptKindsByName: {
+        deploy: [{ kind: "myapp::deploy" }],
+        checkout: [{ kind: "payment::charge" }, { kind: "payment::refund" }],
+      },
+    });
+
+    const fn = exports.find((e) => e.name === "deploy")!;
+    expect(fn.interruptKinds).toEqual([{ kind: "myapp::deploy" }]);
+
+    const node = exports.find((e) => e.name === "checkout")!;
+    expect(node.interruptKinds).toEqual([
+      { kind: "payment::charge" },
+      { kind: "payment::refund" },
+    ]);
+  });
 });

--- a/packages/agency-lang/lib/serve/discovery.ts
+++ b/packages/agency-lang/lib/serve/discovery.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import type { AgencyFunction } from "../runtime/agencyFunction.js";
+import type { InterruptKind } from "../symbolTable.js";
 import type { ExportedFunction, ExportedNode, ExportedItem } from "./types.js";
 
 export type DiscoverOptions = {
@@ -7,24 +8,27 @@ export type DiscoverOptions = {
   moduleExports: Record<string, unknown>;
   moduleId: string;
   exportedNodeNames?: string[];
+  interruptKindsByName?: Record<string, InterruptKind[]>;
 };
 
 function isExportedFromModule(fn: AgencyFunction, moduleId: string): boolean {
   return !!fn.exported && !!fn.toolDefinition && fn.module === moduleId;
 }
 
-function toExportedFunction(fn: AgencyFunction): ExportedFunction {
+function toExportedFunction(fn: AgencyFunction, interruptKinds: InterruptKind[]): ExportedFunction {
   return {
     kind: "function",
     name: fn.name,
     description: fn.toolDefinition!.description,
     agencyFunction: fn,
+    interruptKinds,
   };
 }
 
 function toExportedNode(
   nodeName: string,
   moduleExports: Record<string, unknown>,
+  interruptKinds: InterruptKind[],
 ): ExportedNode | null {
   const nodeFn = moduleExports[nodeName];
   if (typeof nodeFn !== "function") return null;
@@ -35,18 +39,19 @@ function toExportedNode(
     name: nodeName,
     parameters: params.map((name) => ({ name })),
     invoke: nodeFn as (...args: unknown[]) => Promise<unknown>,
+    interruptKinds,
   };
 }
 
 export function discoverExports(options: DiscoverOptions): ExportedItem[] {
-  const { toolRegistry, moduleExports, moduleId, exportedNodeNames = [] } = options;
+  const { toolRegistry, moduleExports, moduleId, exportedNodeNames = [], interruptKindsByName = {} } = options;
 
   const functions = Object.values(toolRegistry)
     .filter((fn) => isExportedFromModule(fn, moduleId))
-    .map(toExportedFunction);
+    .map((fn) => toExportedFunction(fn, interruptKindsByName[fn.name] ?? []));
 
   const nodes = exportedNodeNames
-    .map((name) => toExportedNode(name, moduleExports))
+    .map((name) => toExportedNode(name, moduleExports, interruptKindsByName[name] ?? []))
     .filter((n): n is ExportedNode => n !== null);
 
   return [...functions, ...nodes];

--- a/packages/agency-lang/lib/serve/http/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.test.ts
@@ -34,6 +34,7 @@ function makeExports(): {
       name: "add",
       description: "Add two numbers",
       agencyFunction: addFn,
+      interruptKinds: [],
     },
     {
       kind: "node",
@@ -43,6 +44,7 @@ function makeExports(): {
         data: { echo: message },
         messages: {},
       }),
+      interruptKinds: [],
     },
   ];
 

--- a/packages/agency-lang/lib/serve/http/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.test.ts
@@ -72,8 +72,10 @@ describe("HTTP adapter", () => {
     const body = result.body as any;
     expect(body.functions).toHaveLength(1);
     expect(body.functions[0].name).toBe("add");
+    expect(body.functions[0].interruptKinds).toEqual([]);
     expect(body.nodes).toHaveLength(1);
     expect(body.nodes[0].name).toBe("main");
+    expect(body.nodes[0].interruptKinds).toEqual([]);
   });
 
   it("POST /function/:name calls function", async () => {
@@ -123,6 +125,40 @@ describe("HTTP adapter", () => {
   it("returns 404 for unknown routes", async () => {
     const result = await handler("GET", "/unknown", undefined);
     expect(result.status).toBe(404);
+  });
+
+  it("GET /list includes interruptKinds as string arrays", async () => {
+    const registry: Record<string, AgencyFunction> = {};
+    const deployFn = AgencyFunction.create(
+      {
+        name: "deploy",
+        module: "test",
+        fn: async () => {},
+        params: [],
+        toolDefinition: { name: "deploy", description: "Deploy", schema: null },
+        exported: true,
+        safe: false,
+      },
+      registry,
+    );
+    const h = createHttpHandler({
+      exports: [
+        {
+          kind: "function",
+          name: "deploy",
+          description: "Deploy",
+          agencyFunction: deployFn,
+          interruptKinds: [{ kind: "myapp::deploy" }],
+        },
+      ],
+      port: 3545,
+      logger: createLogger("error"),
+      hasInterrupts: () => false,
+      respondToInterrupts: async () => ({ data: "ok" }),
+    });
+    const result = await h("GET", "/list", undefined);
+    const body = result.body as any;
+    expect(body.functions[0].interruptKinds).toEqual(["myapp::deploy"]);
   });
 });
 

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -118,10 +118,12 @@ export function createHttpHandler(config: HttpConfig): (
             name: f.name,
             description: f.description,
             safe: f.agencyFunction.safe,
+            interruptKinds: f.interruptKinds.map((ik) => ik.kind),
           })),
           nodes: Object.values(nodes).map((n) => ({
             name: n.name,
             parameters: n.parameters.map((p) => p.name),
+            interruptKinds: n.interruptKinds.map((ik) => ik.kind),
           })),
         },
       };

--- a/packages/agency-lang/lib/serve/mcp/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.test.ts
@@ -32,6 +32,7 @@ function makeTestExports(): ExportedItem[] {
       name: "add",
       description: "Add two numbers",
       agencyFunction: addFn,
+      interruptKinds: [],
     },
   ];
 }

--- a/packages/agency-lang/lib/serve/mcp/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.test.ts
@@ -118,4 +118,42 @@ describe("MCP adapter", () => {
     expect(response).toBeTruthy();
     expect(response!.error.code).toBe(-32601);
   });
+
+  it("appends interrupt kinds to tool description", async () => {
+    const registry: Record<string, AgencyFunction> = {};
+    const deployFn = AgencyFunction.create(
+      {
+        name: "deploy",
+        module: "test",
+        fn: async () => {},
+        params: [],
+        toolDefinition: { name: "deploy", description: "Deploy app", schema: null },
+        exported: true,
+        safe: false,
+      },
+      registry,
+    );
+    const interruptHandler = createMcpHandler({
+      serverName: "test",
+      serverVersion: "1.0.0",
+      exports: [
+        {
+          kind: "function",
+          name: "deploy",
+          description: "Deploy app",
+          agencyFunction: deployFn,
+          interruptKinds: [{ kind: "myapp::deploy" }, { kind: "myapp::approve" }],
+        },
+      ],
+    });
+    const response = await interruptHandler({
+      jsonrpc: "2.0",
+      id: 10,
+      method: "tools/list",
+    });
+    const tools = response!.result.tools;
+    expect(tools[0].description).toBe(
+      "Deploy app\n\nInterrupt kinds: myapp::deploy, myapp::approve",
+    );
+  });
 });

--- a/packages/agency-lang/lib/serve/mcp/adapter.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.ts
@@ -1,6 +1,13 @@
 import process from "process";
+import type { InterruptKind } from "../../symbolTable.js";
 import type { ExportedFunction, ExportedItem } from "../types.js";
 import { errorMessage } from "../util.js";
+
+function formatToolDescription(description: string, interruptKinds: InterruptKind[]): string {
+  if (interruptKinds.length === 0) return description;
+  const kinds = interruptKinds.map((ik) => ik.kind).join(", ");
+  return `${description}\n\nInterrupt kinds: ${kinds}`;
+}
 
 type JsonRpcId = string | number | null;
 
@@ -46,7 +53,7 @@ export function createMcpHandler(
 
   const toolsListPayload = tools.map((t) => ({
     name: t.name,
-    description: t.description,
+    description: formatToolDescription(t.description, t.interruptKinds),
     inputSchema: schemaToJsonSchema(t.agencyFunction.toolDefinition?.schema),
     ...(t.agencyFunction.safe ? { annotations: { readOnlyHint: true } } : {}),
   }));

--- a/packages/agency-lang/lib/serve/types.ts
+++ b/packages/agency-lang/lib/serve/types.ts
@@ -1,10 +1,12 @@
 import type { AgencyFunction } from "../runtime/agencyFunction.js";
+import type { InterruptKind } from "../symbolTable.js";
 
 export type ExportedFunction = {
   kind: "function";
   name: string;
   description: string;
   agencyFunction: AgencyFunction;
+  interruptKinds: InterruptKind[];
 };
 
 export type ExportedNode = {
@@ -12,6 +14,7 @@ export type ExportedNode = {
   name: string;
   parameters: Array<{ name: string }>;
   invoke: (...args: unknown[]) => Promise<unknown>;
+  interruptKinds: InterruptKind[];
 };
 
 export type ExportedItem = ExportedFunction | ExportedNode;


### PR DESCRIPTION
## Summary

- Threads static interrupt analysis results (from PR #109) through the serve pipeline and LSP semantic index
- MCP tool descriptions now include interrupt kinds (e.g. `Interrupt kinds: myapp::deploy`)
- HTTP `/list` endpoint includes `interruptKinds` arrays on functions and nodes
- LSP hover tooltips show **Interrupts:** for functions/nodes that can throw interrupts
- All 2905 tests passing

## Test plan

- [x] Existing serve tests updated with `interruptKinds` field and passing
- [x] MCP adapter test passes with interrupt-aware descriptions
- [x] HTTP adapter `/list` test passes with interrupt kinds in response
- [x] Full test suite passes (2905 tests)
