### PR TITLE
Add std::agency compile() function

### DIFF
--- a/packages/agency-lang/lib/compiler/compile.test.ts
+++ b/packages/agency-lang/lib/compiler/compile.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { compileSource } from "./compile.js";
+
+describe("compileSource", () => {
+  it("compiles valid Agency source to JavaScript", () => {
+    const source = `node main() { return "hello" }`;
+    const result = compileSource(source, {});
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.code).toContain("function");
+      expect(result.moduleId).toBeTruthy();
+    }
+  });
+
+  it("returns errors for invalid syntax", () => {
+    const source = `node main( { return "hello" }`;
+    const result = compileSource(source, {});
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("returns errors for type check failures when typeCheck is enabled", () => {
+    const source = `
+def foo(x: number): string { return x }
+node main() { return foo(42) }
+`;
+    const result = compileSource(source, { typeCheck: true });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects local relative imports when restrictImports is set", () => {
+    const source = `
+import { foo } from "./bar.agency"
+node main() { return foo() }
+`;
+    const result = compileSource(source, { restrictImports: true });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors[0].toLowerCase()).toContain("import");
+    }
+  });
+
+  it("allows stdlib imports with restrictImports", () => {
+    const source = `
+import { exists } from "std::shell"
+node main() { return exists("/tmp") }
+`;
+    const result = compileSource(source, { restrictImports: true });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/compiler/compile.ts
+++ b/packages/agency-lang/lib/compiler/compile.ts
@@ -1,0 +1,149 @@
+/**
+ * Pure compilation pipeline for Agency source strings.
+ * No process.exit(), no console.log(). Returns errors as data.
+ */
+import { AgencyConfig } from "@/config.js";
+import { AgencyProgram, generateTypeScript } from "@/index.js";
+import { resolveImports } from "@/preprocessors/importResolver.js";
+import { buildCompilationUnit } from "@/compilationUnit.js";
+import { SymbolTable } from "@/symbolTable.js";
+import { formatErrors, typeCheck } from "@/typeChecker/index.js";
+import { transformSync } from "esbuild";
+import { nanoid } from "nanoid";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { parseAgency } from "@/parser.js";
+import {
+  isStdlibImport,
+  isPkgImport,
+} from "../importPaths.js";
+import { CompileStrategy } from "../importStrategy.js";
+import { getImports } from "../cli/util.js";
+
+type CompileSuccess = {
+  success: true;
+  code: string;
+  moduleId: string;
+};
+
+type CompileFailure = {
+  success: false;
+  errors: string[];
+};
+
+export type CompileResult = CompileSuccess | CompileFailure;
+
+export function compileSource(
+  source: string,
+  config: AgencyConfig,
+): CompileResult {
+  const moduleId = `agency_${nanoid()}`;
+  // Write source to a temp file so SymbolTable.build() can read it.
+  // The symbol table walks the file system to resolve imports and find builtins.
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-compile-"));
+  const syntheticPath = path.join(tempDir, `${moduleId}.agency`);
+  fs.writeFileSync(syntheticPath, source, "utf-8");
+
+  try {
+    // 1. Parse
+    const parseResult = parseAgency(source, config, true);
+    if (!parseResult.success) {
+      return {
+        success: false,
+        errors: [parseResult.message ?? "Failed to parse Agency source"],
+      };
+    }
+    const program: AgencyProgram = parseResult.result;
+
+    // 2. Check for restricted imports — only stdlib allowed
+    if (config.restrictImports) {
+      const imports = getImports(program);
+      for (const importPath of imports) {
+        if (!isStdlibImport(importPath)) {
+          return {
+            success: false,
+            errors: [`Import '${importPath}' is not allowed. Only standard library (std::) imports are permitted.`],
+          };
+        }
+      }
+    }
+
+    // 3. Build symbol table and resolve imports
+    const symbolTable = SymbolTable.build(syntheticPath, config);
+    const resolvedProgram = resolveImports(program, symbolTable, syntheticPath);
+
+    // 4. Build compilation unit
+    const info = buildCompilationUnit(
+      resolvedProgram,
+      symbolTable,
+      syntheticPath,
+      source,
+    );
+
+    // 5. Type check
+    if (config.typeCheck || config.typeCheckStrict) {
+      const { errors } = typeCheck(resolvedProgram, config, info);
+      if (errors.length > 0) {
+        const hasFatal = errors.some(
+          (e) => (e.severity ?? "error") === "error",
+        );
+        if (hasFatal) {
+          return {
+            success: false,
+            errors: [formatErrors(errors)],
+          };
+        }
+      }
+    }
+
+    // 6. Rewrite import paths
+    const strategy = new CompileStrategy({ targetExt: ".js" });
+    resolvedProgram.nodes.forEach((node) => {
+      if (node.type !== "importStatement") return;
+      if (isStdlibImport(node.modulePath) || isPkgImport(node.modulePath))
+        return;
+      node.modulePath = strategy.rewriteImport(
+        node.modulePath,
+        syntheticPath,
+      );
+    });
+
+    // 7. Generate TypeScript
+    const outputPath = path.join(os.tmpdir(), `${moduleId}.js`);
+    const generatedCode = generateTypeScript(
+      resolvedProgram,
+      config,
+      info,
+      moduleId,
+      outputPath,
+    );
+
+    // 8. Transpile TS → JS
+    const result = transformSync(generatedCode, {
+      loader: "ts",
+      format: "esm",
+      supported: { "top-level-await": true },
+    });
+
+    return {
+      success: true,
+      code: result.code,
+      moduleId,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      errors: [error instanceof Error ? error.message : String(error)],
+    };
+  } finally {
+    // Clean up temp source file (best-effort — OS cleans tmpdir eventually)
+    if (tempDir.startsWith(os.tmpdir())) {
+      try {
+        fs.rmSync(tempDir, { recursive: true });
+      } catch (_) {
+        // Ignore cleanup failures — temp files in os.tmpdir() are ephemeral
+      }
+    }
+  }
+}

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -55,6 +55,11 @@
       "import": "./dist/lib/runtime/index.js",
       "require": "./dist/lib/runtime/index.js"
     },
+    "./compiler": {
+      "types": "./dist/lib/compiler/compile.d.ts",
+      "import": "./dist/lib/compiler/compile.js",
+      "require": "./dist/lib/compiler/compile.js"
+    },
     "./stdlib/*": "./stdlib/*"
   },
   "type": "module",

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -1,0 +1,13 @@
+import { _compile } from "./lib/agency.js"
+
+type CompiledProgram = {
+  moduleId: string
+}
+
+export def compile(source: string): Result {
+  """
+  Compile Agency source code. Returns a CompiledProgram on success, or a failure with compilation errors. Only standard library (std::) imports are allowed in the compiled code.
+  @param source - Agency source code as a string
+  """
+  return try _compile(source)
+}

--- a/packages/agency-lang/stdlib/lib/agency.ts
+++ b/packages/agency-lang/stdlib/lib/agency.ts
@@ -1,0 +1,23 @@
+import { compileSource } from "agency-lang/compiler";
+import { writeFileSync, mkdtempSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+export function _compile(source: string): { moduleId: string; path: string } {
+  const result = compileSource(source, {
+    typeCheck: true,
+    restrictImports: true,
+  });
+
+  if (!result.success) {
+    throw new Error(result.errors.join("\n"));
+  }
+
+  // Write compiled JS to a temp file for subprocess execution.
+  // Cleanup is the caller's responsibility (e.g., _run() cleans up after execution).
+  const tempDir = mkdtempSync(join(tmpdir(), "agency-"));
+  const tempPath = join(tempDir, `${result.moduleId}.js`);
+  writeFileSync(tempPath, result.code, "utf-8");
+
+  return { moduleId: result.moduleId, path: tempPath };
+}

--- a/packages/agency-lang/tests/agency/subprocess/compile-failure.agency
+++ b/packages/agency-lang/tests/agency/subprocess/compile-failure.agency
@@ -1,0 +1,10 @@
+import { compile } from "std::agency"
+
+node main() {
+  const source = "node main( { return 42 }"
+  const result = compile(source)
+  if (isFailure(result)) {
+    return "correctly failed"
+  }
+  return "unexpected success"
+}

--- a/packages/agency-lang/tests/agency/subprocess/compile-failure.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/compile-failure.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "compile() returns failure for invalid Agency source",
+      "input": "",
+      "expectedOutput": "\"correctly failed\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/subprocess/compile-success.agency
+++ b/packages/agency-lang/tests/agency/subprocess/compile-success.agency
@@ -1,0 +1,10 @@
+import { compile } from "std::agency"
+
+node main() {
+  const source = "node main() { return 42 }"
+  const result = compile(source)
+  if (isSuccess(result)) {
+    return "compiled"
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/subprocess/compile-success.test.json
+++ b/packages/agency-lang/tests/agency/subprocess/compile-success.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "compile() returns success for valid Agency source",
+      "input": "",
+      "expectedOutput": "\"compiled\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Extract the compilation pipeline into a reusable `compileSource()` function that takes a source string and config, returns compiled JS or errors. No `process.exit`, no `console.log`.
- Expose it as `std::agency` `compile()` in the stdlib, so agents can generate Agency code, compile it, and check for errors at runtime.
- Add `agency-lang/compiler` package export so the stdlib can import `compileSource` cleanly.

## What this enables

```
import { compile } from "std::agency"

const source = llm("Write an Agency program that...")
const compiled = compile(source)
if (isFailure(compiled)) {
  // feed errors back to LLM, retry
}
// compiled is a CompiledProgram ready for run() (coming in a follow-up PR)
```

This is the first half of the subprocess IPC + handler propagation feature. The `run()` function (which executes compiled code in a subprocess with handler propagation) will come in a follow-up PR.

## Test plan

- [x] 5 unit tests for `compileSource()` (valid source, syntax errors, type errors, restricted imports, stdlib imports allowed)
- [x] 2 Agency execution tests for `std::agency compile()` (success and failure cases)
- [x] Full test suite passes (2910 tests, 0 regressions)

Generated with [Claude Code](https://claude.com/claude-code)
