### PR TITLE
Add MCP interrupt policies

### DIFF
--- a/docs/superpowers/plans/2026-05-08-mcp-interrupt-policies.md
+++ b/docs/superpowers/plans/2026-05-08-mcp-interrupt-policies.md
@@ -1,0 +1,871 @@
+# MCP Interrupt Policies Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable MCP-served agents to handle interrupts automatically via pre-configured policies, so clients can pre-authorize actions without mid-execution approval flows.
+
+**Architecture:** A `PolicyStore` manages policy persistence at `~/.agency/serve/<name>/policy.json`. A `runWithPolicy` function wraps tool invocations in an interrupt loop that applies `checkPolicy` from the existing runtime. The MCP adapter exposes three built-in tools (`agencySetPolicy`, `agencyGetPolicy`, `agencyClearPolicy`). Node interrupt handling via MCP is out of scope for this plan (the MCP adapter currently only exposes functions as tools).
+
+**Design principles:**
+- `runWithPolicy` works with a clean `InterruptHandlers` interface — callers normalize the `{ data: ... }` wrapper so the loop never sees it.
+- Policy tool dispatch is extracted into its own function to keep `createMcpHandler` focused on routing.
+- `McpConfig` doesn't leak raw module exports — it takes a `policyStore` and pre-constructed `InterruptHandlers`, which the CLI wiring composes.
+
+**Tech Stack:** TypeScript, vitest, Agency runtime (`checkPolicy`, `validatePolicy`, `approve`, `reject`, `hasInterrupts`, `respondToInterrupts`)
+
+---
+
+## File Structure
+
+- **Create:** `lib/serve/policyStore.ts` — In-memory policy + JSON file persistence
+- **Create:** `lib/serve/policyStore.test.ts` — Unit tests for PolicyStore
+- **Create:** `lib/serve/mcp/interruptLoop.ts` — `runWithPolicy` function
+- **Create:** `lib/serve/mcp/interruptLoop.test.ts` — Unit tests for the interrupt loop
+- **Modify:** `lib/serve/mcp/adapter.ts` — Add policy tools, wire `runWithPolicy` into `tools/call`
+- **Modify:** `lib/serve/mcp/adapter.test.ts` — Tests for policy tools and interrupt handling
+- **Modify:** `lib/cli/serve.ts` — Create `PolicyStore`, pass interrupt handlers into `McpConfig`
+
+---
+
+### Task 1: PolicyStore
+
+**Files:**
+- Create: `lib/serve/policyStore.ts`
+- Create: `lib/serve/policyStore.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// lib/serve/policyStore.test.ts
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PolicyStore } from "./policyStore.js";
+import { mkdtempSync, rmSync, readFileSync } from "fs";
+import path from "path";
+import os from "os";
+
+describe("PolicyStore", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "policy-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("starts with empty policy", () => {
+    const store = new PolicyStore("test-server", tmpDir);
+    expect(store.get()).toEqual({});
+  });
+
+  it("sets and gets a policy", () => {
+    const store = new PolicyStore("test-server", tmpDir);
+    const policy = {
+      "email::send": [{ action: "approve" as const }],
+    };
+    store.set(policy);
+    expect(store.get()).toEqual(policy);
+  });
+
+  it("persists policy to disk", () => {
+    const policy = {
+      "email::send": [{ match: { recipient: "*@co.com" }, action: "approve" as const }],
+    };
+    const store1 = new PolicyStore("test-server", tmpDir);
+    store1.set(policy);
+
+    // New instance should load from disk
+    const store2 = new PolicyStore("test-server", tmpDir);
+    expect(store2.get()).toEqual(policy);
+  });
+
+  it("clears the policy", () => {
+    const store = new PolicyStore("test-server", tmpDir);
+    store.set({ "x::y": [{ action: "approve" as const }] });
+    store.clear();
+    expect(store.get()).toEqual({});
+  });
+
+  it("rejects invalid policies", () => {
+    const store = new PolicyStore("test-server", tmpDir);
+    expect(() => store.set({ "x::y": [{ action: "yolo" as any }] })).toThrow();
+  });
+
+  it("writes policy file with restricted permissions", () => {
+    const store = new PolicyStore("test-server", tmpDir);
+    store.set({ "x::y": [{ action: "approve" as const }] });
+    const filePath = path.join(tmpDir, "test-server", "policy.json");
+    const content = readFileSync(filePath, "utf-8");
+    expect(JSON.parse(content)).toEqual({ "x::y": [{ action: "approve" }] });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run lib/serve/policyStore.test.ts 2>&1 | tee /tmp/policy-store-test.log`
+Expected: FAIL — cannot import `PolicyStore`
+
+- [ ] **Step 3: Implement PolicyStore**
+
+```typescript
+// lib/serve/policyStore.ts
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import path from "path";
+import os from "os";
+import { validatePolicy } from "../runtime/policy.js";
+
+type PolicyRule = {
+  match?: Record<string, string>;
+  action: "approve" | "reject" | "propagate";
+};
+
+export type Policy = Record<string, PolicyRule[]>;
+
+export class PolicyStore {
+  private policy: Policy = {};
+  private filePath: string;
+
+  constructor(serverName: string, baseDir?: string) {
+    const dir = path.join(baseDir ?? path.join(os.homedir(), ".agency", "serve"), serverName);
+    this.filePath = path.join(dir, "policy.json");
+    this.load();
+  }
+
+  get(): Policy {
+    return this.policy;
+  }
+
+  set(policy: Policy): void {
+    const result = validatePolicy(policy);
+    if (!result.success) throw new Error(result.error);
+    this.policy = policy;
+    this.save();
+  }
+
+  clear(): void {
+    this.policy = {};
+    this.save();
+  }
+
+  private load(): void {
+    if (!existsSync(this.filePath)) return;
+    this.policy = JSON.parse(readFileSync(this.filePath, "utf-8"));
+  }
+
+  private save(): void {
+    mkdirSync(path.dirname(this.filePath), { recursive: true, mode: 0o700 });
+    writeFileSync(this.filePath, JSON.stringify(this.policy, null, 2), { mode: 0o600 });
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run lib/serve/policyStore.test.ts 2>&1 | tee /tmp/policy-store-test.log`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add lib/serve/policyStore.ts lib/serve/policyStore.test.ts
+git commit -m "Add PolicyStore for MCP interrupt policy persistence"
+```
+
+---
+
+### Task 2: Interrupt loop (`runWithPolicy`)
+
+**Files:**
+- Create: `lib/serve/mcp/interruptLoop.ts`
+- Create: `lib/serve/mcp/interruptLoop.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+The `InterruptHandlers` interface is clean — both `hasInterrupts` and `respondToInterrupts` work with the same data shape. The caller is responsible for normalizing the compiled module's `{ data: ... }` wrapper; `runWithPolicy` never sees it.
+
+```typescript
+// lib/serve/mcp/interruptLoop.test.ts
+import { describe, it, expect } from "vitest";
+import { runWithPolicy } from "./interruptLoop.js";
+import { PolicyStore } from "../policyStore.js";
+import { mkdtempSync, rmSync } from "fs";
+import path from "path";
+import os from "os";
+
+function makeTmpStore(policy: Record<string, any> = {}): { store: PolicyStore; cleanup: () => void } {
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), "interrupt-loop-test-"));
+  const store = new PolicyStore("test", tmpDir);
+  if (Object.keys(policy).length > 0) store.set(policy);
+  return { store, cleanup: () => rmSync(tmpDir, { recursive: true, force: true }) };
+}
+
+function makeInterrupt(kind: string, data: Record<string, any> = {}): any {
+  return { type: "interrupt", kind, message: "", data, origin: "test", interruptId: "test-id", runId: "test-run" };
+}
+
+const isInterrupts = (data: unknown) =>
+  Array.isArray(data) && data.length > 0 && data[0]?.type === "interrupt";
+
+describe("runWithPolicy", () => {
+  it("returns result directly when no interrupts", async () => {
+    const { store, cleanup } = makeTmpStore();
+    try {
+      const result = await runWithPolicy(
+        async () => "hello",
+        store,
+        { hasInterrupts: isInterrupts, respondToInterrupts: async () => "done" },
+      );
+      expect(result).toBe("hello");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("approves interrupts that match the policy", async () => {
+    const { store, cleanup } = makeTmpStore({
+      "test::greet": [{ action: "approve" }],
+    });
+    try {
+      let callCount = 0;
+      const result = await runWithPolicy(
+        async () => [makeInterrupt("test::greet")],
+        store,
+        {
+          hasInterrupts: isInterrupts,
+          respondToInterrupts: async (_interrupts, responses) => {
+            callCount++;
+            expect(responses).toHaveLength(1);
+            expect(responses[0].type).toBe("approve");
+            return "approved-result";
+          },
+        },
+      );
+      expect(result).toBe("approved-result");
+      expect(callCount).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("rejects interrupts not covered by policy (default reject)", async () => {
+    const { store, cleanup } = makeTmpStore(); // empty policy
+    try {
+      const result = await runWithPolicy(
+        async () => [makeInterrupt("test::greet")],
+        store,
+        {
+          hasInterrupts: isInterrupts,
+          respondToInterrupts: async (_interrupts, responses) => {
+            expect(responses[0].type).toBe("reject");
+            return "rejected-result";
+          },
+        },
+      );
+      expect(result).toBe("rejected-result");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("handles multiple rounds of interrupts", async () => {
+    const { store, cleanup } = makeTmpStore({
+      "test::step1": [{ action: "approve" }],
+      "test::step2": [{ action: "approve" }],
+    });
+    try {
+      let round = 0;
+      const result = await runWithPolicy(
+        async () => [makeInterrupt("test::step1")],
+        store,
+        {
+          hasInterrupts: isInterrupts,
+          respondToInterrupts: async () => {
+            round++;
+            if (round === 1) {
+              return [makeInterrupt("test::step2")];
+            }
+            return "final";
+          },
+        },
+      );
+      expect(result).toBe("final");
+      expect(round).toBe(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("approves some and rejects others in a mixed batch", async () => {
+    const { store, cleanup } = makeTmpStore({
+      "test::allowed": [{ action: "approve" }],
+      // test::blocked has no rules → defaults to reject
+    });
+    try {
+      const result = await runWithPolicy(
+        async () => [makeInterrupt("test::allowed"), makeInterrupt("test::blocked")],
+        store,
+        {
+          hasInterrupts: isInterrupts,
+          respondToInterrupts: async (_interrupts, responses) => {
+            expect(responses[0].type).toBe("approve");
+            expect(responses[1].type).toBe("reject");
+            return "mixed-result";
+          },
+        },
+      );
+      expect(result).toBe("mixed-result");
+    } finally {
+      cleanup();
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run lib/serve/mcp/interruptLoop.test.ts 2>&1 | tee /tmp/interrupt-loop-test.log`
+Expected: FAIL — cannot import `runWithPolicy`
+
+- [ ] **Step 3: Implement runWithPolicy**
+
+`runWithPolicy` is a clean loop — it doesn't know about the `{ data: ... }` wrapper. The `InterruptHandlers` interface guarantees that `hasInterrupts` and `respondToInterrupts` work with the same shape. The caller (CLI wiring in Task 5) normalizes the compiled module's wrapper when constructing the handlers.
+
+```typescript
+// lib/serve/mcp/interruptLoop.ts
+import { checkPolicy } from "../../runtime/policy.js";
+import { approve, reject } from "../../runtime/interrupts.js";
+import type { PolicyStore } from "../policyStore.js";
+
+export type InterruptHandlers = {
+  hasInterrupts: (data: unknown) => boolean;
+  respondToInterrupts: (interrupts: unknown[], responses: unknown[]) => Promise<unknown>;
+};
+
+function applyPolicy(
+  interrupts: Array<{ kind: string; message: string; data: any; origin: string }>,
+  policy: Record<string, any>,
+) {
+  return interrupts.map((interrupt) => {
+    const decision = checkPolicy(policy, interrupt);
+    return decision.type === "approve" ? approve() : reject();
+  });
+}
+
+export async function runWithPolicy(
+  invoke: () => Promise<unknown>,
+  policyStore: PolicyStore,
+  handlers: InterruptHandlers,
+): Promise<unknown> {
+  let result = await invoke();
+
+  while (handlers.hasInterrupts(result)) {
+    const interrupts = result as Array<{ kind: string; message: string; data: any; origin: string }>;
+    const responses = applyPolicy(interrupts, policyStore.get());
+    result = await handlers.respondToInterrupts(interrupts, responses);
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run lib/serve/mcp/interruptLoop.test.ts 2>&1 | tee /tmp/interrupt-loop-test.log`
+Expected: All 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add lib/serve/mcp/interruptLoop.ts lib/serve/mcp/interruptLoop.test.ts
+git commit -m "Add runWithPolicy interrupt loop for MCP"
+```
+
+---
+
+### Task 3: Policy management tools in MCP adapter
+
+**Files:**
+- Modify: `lib/serve/mcp/adapter.ts`
+- Modify: `lib/serve/mcp/adapter.test.ts`
+
+This task adds the three built-in policy tools (`agencyGetPolicy`, `agencySetPolicy`, `agencyClearPolicy`) to the MCP adapter. It does NOT yet wire up the interrupt loop — that's Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these tests to `lib/serve/mcp/adapter.test.ts`. First, update the vitest import at line 1 to include `beforeEach` and `afterEach`:
+
+```typescript
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+```
+
+Then add these imports at the top and a new describe block after the existing one:
+
+```typescript
+// Add these imports at the top of the file:
+import { PolicyStore } from "../policyStore.js";
+import { mkdtempSync, rmSync } from "fs";
+import path from "path";
+import os from "os";
+
+// Add a new describe block after the existing one:
+describe("MCP adapter — policy tools", () => {
+  let tmpDir: string;
+  let handler: (msg: any) => Promise<any>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "mcp-policy-test-"));
+    handler = createMcpHandler({
+      serverName: "test-server",
+      serverVersion: "1.0.0",
+      exports: makeTestExports(),
+      policyStore: new PolicyStore("test-server", tmpDir),
+      interruptHandlers: { hasInterrupts: () => false, respondToInterrupts: async () => "done" },
+    });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("lists policy tools alongside agent tools", async () => {
+    const response = await handler({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+    const names = response!.result.tools.map((t: any) => t.name);
+    expect(names).toContain("agencyGetPolicy");
+    expect(names).toContain("agencySetPolicy");
+    expect(names).toContain("agencyClearPolicy");
+    expect(names).toContain("add"); // agent tool still listed
+  });
+
+  it("agencyGetPolicy returns empty policy by default", async () => {
+    const response = await handler({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "agencyGetPolicy", arguments: {} },
+    });
+    expect(response!.result.isError).toBe(false);
+    expect(JSON.parse(response!.result.content[0].text)).toEqual({});
+  });
+
+  it("agencySetPolicy sets and persists a policy", async () => {
+    const policy = { "test::x": [{ action: "approve" }] };
+    const setResponse = await handler({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "agencySetPolicy", arguments: { policy } },
+    });
+    expect(setResponse!.result.isError).toBe(false);
+
+    const getResponse = await handler({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "agencyGetPolicy", arguments: {} },
+    });
+    expect(JSON.parse(getResponse!.result.content[0].text)).toEqual(policy);
+  });
+
+  it("agencySetPolicy rejects invalid policies", async () => {
+    const response = await handler({
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: { name: "agencySetPolicy", arguments: { policy: { "x": [{ action: "yolo" }] } } },
+    });
+    expect(response!.result.isError).toBe(true);
+  });
+
+  it("agencyClearPolicy resets to empty", async () => {
+    // Set a policy first
+    await handler({
+      jsonrpc: "2.0",
+      id: 6,
+      method: "tools/call",
+      params: { name: "agencySetPolicy", arguments: { policy: { "x::y": [{ action: "approve" }] } } },
+    });
+
+    // Clear it
+    const clearResponse = await handler({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: { name: "agencyClearPolicy", arguments: {} },
+    });
+    expect(clearResponse!.result.isError).toBe(false);
+
+    // Verify empty
+    const getResponse = await handler({
+      jsonrpc: "2.0",
+      id: 8,
+      method: "tools/call",
+      params: { name: "agencyGetPolicy", arguments: {} },
+    });
+    expect(JSON.parse(getResponse!.result.content[0].text)).toEqual({});
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run lib/serve/mcp/adapter.test.ts 2>&1 | tee /tmp/mcp-policy-tools-test.log`
+Expected: FAIL — `McpConfig` doesn't accept `policyStore`/`hasInterrupts`/`respondToInterrupts` yet
+
+- [ ] **Step 3: Update McpConfig and add policy tool handling**
+
+In `lib/serve/mcp/adapter.ts`, make these changes:
+
+1. Add imports:
+```typescript
+import type { PolicyStore } from "../policyStore.js";
+import type { InterruptHandlers } from "./interruptLoop.js";
+```
+
+2. Update `McpConfig` to include optional policy and interrupt handler fields:
+```typescript
+export type McpConfig = {
+  serverName: string;
+  serverVersion: string;
+  exports: ExportedItem[];
+  policyStore?: PolicyStore;
+  interruptHandlers?: InterruptHandlers;
+};
+```
+
+3. Add a `handlePolicyTool` function above `createMcpHandler`. This keeps policy tool dispatch self-contained:
+```typescript
+const POLICY_TOOL_DEFINITIONS = [
+  {
+    name: "agencyGetPolicy",
+    description: "Get the current interrupt policy for this agent. Returns a JSON object keyed by interrupt kind.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "agencySetPolicy",
+    description: "Set the interrupt policy for this agent. The policy controls which actions the agent is allowed to take autonomously. Each tool lists its interrupt kinds — use those as keys in the policy object. Example: {\"email::send\": [{\"match\": {\"recipient\": \"*@company.com\"}, \"action\": \"approve\"}, {\"action\": \"reject\"}]} approves sending emails to company.com addresses and rejects all others.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        policy: {
+          type: "object",
+          description: "Policy object keyed by interrupt kind. Each kind maps to an ordered array of rules. Each rule has an 'action' field ('approve' or 'reject') and an optional 'match' field — an object whose keys are interrupt data field names and whose values are glob patterns. Rules are evaluated in order; the first match wins. A rule with no 'match' field is a catch-all.",
+        },
+      },
+      required: ["policy"],
+    },
+  },
+  {
+    name: "agencyClearPolicy",
+    description: "Clear the interrupt policy, resetting to reject-all. After clearing, all interrupt-producing actions will be rejected until a new policy is set.",
+    inputSchema: { type: "object", properties: {} },
+  },
+];
+
+function handlePolicyTool(
+  name: string,
+  args: Record<string, any>,
+  policyStore: PolicyStore,
+): JsonRpcMessage | null {
+  switch (name) {
+    case "agencyGetPolicy":
+      return { result: { content: [{ type: "text", text: JSON.stringify(policyStore.get(), null, 2) }], isError: false } };
+    case "agencySetPolicy":
+      try {
+        policyStore.set(args.policy);
+        return { result: { content: [{ type: "text", text: "Policy updated successfully." }], isError: false } };
+      } catch (err) {
+        return { result: { content: [{ type: "text", text: errorMessage(err) }], isError: true } };
+      }
+    case "agencyClearPolicy":
+      policyStore.clear();
+      return { result: { content: [{ type: "text", text: "Policy cleared." }], isError: false } };
+    default:
+      return null;
+  }
+}
+```
+
+4. Inside `createMcpHandler`, after `toolsListPayload` construction, conditionally add policy tools:
+```typescript
+  const { policyStore } = config;
+  if (policyStore) {
+    toolsListPayload.push(...POLICY_TOOL_DEFINITIONS);
+  }
+```
+
+5. In the `tools/call` case, before the existing tool lookup, delegate to `handlePolicyTool`:
+```typescript
+      case "tools/call": {
+        const name = message.params?.name;
+        const args = message.params?.arguments ?? {};
+        const id = message.id ?? null;
+
+        if (policyStore) {
+          const policyResult = handlePolicyTool(name, args, policyStore);
+          if (policyResult) return success(id, policyResult.result);
+        }
+
+        // Existing agent tool lookup...
+        const tool = toolsByName[name];
+        // ... rest unchanged
+      }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run lib/serve/mcp/adapter.test.ts 2>&1 | tee /tmp/mcp-policy-tools-test.log`
+Expected: All tests PASS (existing + new policy tool tests)
+
+- [ ] **Step 5: Commit**
+
+```
+git add lib/serve/mcp/adapter.ts lib/serve/mcp/adapter.test.ts
+git commit -m "Add policy management tools to MCP adapter"
+```
+
+---
+
+### Task 4: Wire interrupt loop into MCP tool calls
+
+**Files:**
+- Modify: `lib/serve/mcp/adapter.ts`
+- Modify: `lib/serve/mcp/adapter.test.ts`
+
+This task wires `runWithPolicy` into the `tools/call` handler so that function invocations automatically go through the interrupt loop.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to the "MCP adapter — policy tools" describe block in `lib/serve/mcp/adapter.test.ts`:
+
+```typescript
+  it("automatically handles interrupts using the policy", async () => {
+    // Create a function that returns an interrupt
+    const registry: Record<string, AgencyFunction> = {};
+    const greetFn = AgencyFunction.create(
+      {
+        name: "greet",
+        module: "test",
+        fn: async (name: string) => [
+          { type: "interrupt", kind: "test::greet", message: `Greet ${name}?`, data: { name }, origin: "test" },
+        ],
+        params: [{ name: "name", hasDefault: false, defaultValue: undefined, variadic: false }],
+        toolDefinition: {
+          name: "greet",
+          description: "Greet someone",
+          schema: z.object({ name: z.string() }),
+        },
+        exported: true,
+        safe: false,
+      },
+      registry,
+    );
+
+    let respondCalled = false;
+    const policyHandler = createMcpHandler({
+      serverName: "test",
+      serverVersion: "1.0.0",
+      exports: [
+        { kind: "function", name: "greet", description: "Greet someone", agencyFunction: greetFn, interruptKinds: [{ kind: "test::greet" }] },
+      ],
+      policyStore: new PolicyStore("test", tmpDir),
+      interruptHandlers: {
+        hasInterrupts: (data) => Array.isArray(data) && data.length > 0 && data[0]?.type === "interrupt",
+        respondToInterrupts: async (_interrupts, responses) => {
+          respondCalled = true;
+          // The policy has no rules for test::greet, so it should reject
+          expect(responses[0].type).toBe("reject");
+          return "rejected";
+        },
+      },
+    });
+
+    const response = await policyHandler({
+      jsonrpc: "2.0",
+      id: 20,
+      method: "tools/call",
+      params: { name: "greet", arguments: { name: "Alice" } },
+    });
+
+    expect(respondCalled).toBe(true);
+    expect(response!.result.isError).toBe(false);
+    expect(JSON.parse(response!.result.content[0].text)).toBe("rejected");
+  });
+
+  it("approves interrupts when policy matches", async () => {
+    const registry: Record<string, AgencyFunction> = {};
+    const sendFn = AgencyFunction.create(
+      {
+        name: "sendEmail",
+        module: "test",
+        fn: async () => [
+          { type: "interrupt", kind: "email::send", message: "Send email?", data: { recipient: "alice@company.com" }, origin: "test" },
+        ],
+        params: [],
+        toolDefinition: { name: "sendEmail", description: "Send an email", schema: z.object({}) },
+        exported: true,
+        safe: false,
+      },
+      registry,
+    );
+
+    const store = new PolicyStore("test", tmpDir);
+    store.set({ "email::send": [{ match: { recipient: "*@company.com" }, action: "approve" }] });
+
+    const policyHandler = createMcpHandler({
+      serverName: "test",
+      serverVersion: "1.0.0",
+      exports: [
+        { kind: "function", name: "sendEmail", description: "Send an email", agencyFunction: sendFn, interruptKinds: [{ kind: "email::send" }] },
+      ],
+      policyStore: store,
+      interruptHandlers: {
+        hasInterrupts: (data) => Array.isArray(data) && data.length > 0 && data[0]?.type === "interrupt",
+        respondToInterrupts: async (_interrupts, responses) => {
+          expect(responses[0].type).toBe("approve");
+          return "sent";
+        },
+      },
+    });
+
+    const response = await policyHandler({
+      jsonrpc: "2.0",
+      id: 21,
+      method: "tools/call",
+      params: { name: "sendEmail", arguments: {} },
+    });
+
+    expect(JSON.parse(response!.result.content[0].text)).toBe("sent");
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run lib/serve/mcp/adapter.test.ts 2>&1 | tee /tmp/mcp-interrupt-wire-test.log`
+Expected: FAIL — the handler doesn't call `respondToInterrupts` (it returns the raw interrupt array)
+
+- [ ] **Step 3: Wire runWithPolicy into the tools/call handler**
+
+In `lib/serve/mcp/adapter.ts`:
+
+1. Add import:
+```typescript
+import { runWithPolicy } from "./interruptLoop.js";
+```
+
+2. In the `tools/call` case, replace the existing function invocation block with one that uses `runWithPolicy` when policy support is configured:
+
+```typescript
+        const tool = toolsByName[name];
+        if (!tool) {
+          return rpcError(id, -32602, `Unknown tool '${name}'`);
+        }
+        try {
+          const invoke = () => tool.agencyFunction.invoke({ type: "named", positionalArgs: [], namedArgs: args });
+          const result = policyStore && config.interruptHandlers
+            ? await runWithPolicy(invoke, policyStore, config.interruptHandlers)
+            : await invoke();
+          return success(id, {
+            content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+            isError: false,
+          });
+        } catch (err) {
+          return success(id, {
+            content: [{ type: "text", text: errorMessage(err) }],
+            isError: true,
+          });
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run lib/serve/mcp/adapter.test.ts 2>&1 | tee /tmp/mcp-interrupt-wire-test.log`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```
+git add lib/serve/mcp/adapter.ts lib/serve/mcp/adapter.test.ts
+git commit -m "Wire interrupt loop into MCP tool calls"
+```
+
+---
+
+### Task 5: CLI wiring
+
+**Files:**
+- Modify: `lib/cli/serve.ts`
+
+- [ ] **Step 1: Update serveMcp to create PolicyStore and pass interrupt handlers**
+
+In `lib/cli/serve.ts`:
+
+1. Add imports:
+```typescript
+import { PolicyStore } from "../serve/policyStore.js";
+import type { InterruptHandlers } from "../serve/mcp/interruptLoop.js";
+```
+
+2. Update `serveMcp` to create a `PolicyStore` and construct `InterruptHandlers` that normalize the compiled module's `{ data: ... }` wrapper. This is the **only place** that knows about the wrapper — `runWithPolicy` and the adapter never see it:
+
+```typescript
+export async function serveMcp(
+  file: string,
+  options: { name?: string },
+): Promise<void> {
+  const compileResult = compileForServe(file);
+  const { exports, moduleExports } = await loadAndDiscover(compileResult);
+
+  const serverName = options.name ?? path.basename(file, ".agency");
+  const policyStore = new PolicyStore(serverName);
+
+  // The compiled module's hasInterrupts checks raw data, but respondToInterrupts
+  // returns { data: ... }. We normalize here so the interrupt loop sees a
+  // consistent shape: hasInterrupts and respondToInterrupts both work with raw data.
+  const rawHasInterrupts = moduleExports.hasInterrupts as (data: unknown) => boolean;
+  const rawRespondToInterrupts = moduleExports.respondToInterrupts as (
+    interrupts: unknown[],
+    responses: unknown[],
+  ) => Promise<{ data: unknown }>;
+
+  const interruptHandlers: InterruptHandlers = {
+    hasInterrupts: rawHasInterrupts,
+    respondToInterrupts: async (interrupts, responses) => {
+      const wrapped = await rawRespondToInterrupts(interrupts, responses);
+      return wrapped.data;
+    },
+  };
+
+  const handler = createMcpHandler({
+    serverName,
+    serverVersion: VERSION,
+    exports,
+    policyStore,
+    interruptHandlers,
+  });
+
+  startStdioServer(handler);
+}
+```
+
+- [ ] **Step 2: Build and verify**
+
+Run: `cd /Users/adityabhargava/worktrees/agency-lang && make 2>&1 | tail -5`
+Expected: Build succeeds with no errors
+
+- [ ] **Step 3: Run all serve tests**
+
+Run: `pnpm vitest run lib/serve/ 2>&1 | tee /tmp/serve-all-test.log`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```
+git add lib/cli/serve.ts
+git commit -m "Wire PolicyStore into serveMcp CLI command"
+```

--- a/docs/superpowers/specs/2026-05-08-mcp-interrupt-policies-design.md
+++ b/docs/superpowers/specs/2026-05-08-mcp-interrupt-policies-design.md
@@ -13,7 +13,7 @@ The MCP server uses Agency's existing policy system to pre-authorize interrupts.
 ### User experience
 
 1. Client calls `tools/list` — each tool's description includes its interrupt kinds (e.g. `Interrupt kinds: email::send, shell::exec`), surfaced from static analysis
-2. Client calls the `setPolicy` tool to pre-authorize actions:
+2. Client calls the `agencySetPolicy` tool to pre-authorize actions:
    ```json
    {
      "email::send": [
@@ -94,7 +94,7 @@ Policies are persisted to `~/.agency/serve/<server-name>/policy.json`, following
 - The directory is created on first write with mode `0o700`
 - The policy file is written with mode `0o600` (user-readable only)
 - On server startup, the persisted policy is loaded if it exists
-- `setPolicy` and `clearPolicy` write through to disk immediately
+- `agencySetPolicy` and `agencyClearPolicy` write through to disk immediately
 - The `server-name` is the `--name` flag value, or the filename without `.agency`
 
 ### Implementation

--- a/docs/superpowers/specs/2026-05-08-mcp-interrupt-policies-design.md
+++ b/docs/superpowers/specs/2026-05-08-mcp-interrupt-policies-design.md
@@ -1,0 +1,199 @@
+# MCP Interrupt Policies
+
+## Problem
+
+When an Agency agent is served over MCP, there's no interactive user to approve or reject interrupts. MCP is a tool-call protocol — the client calls a tool and expects a result back. There's no built-in mechanism for mid-execution approval flows.
+
+Without a solution, any agent that uses interrupts (safety checks, confirmations, capability gates) cannot be served over MCP.
+
+## Design
+
+The MCP server uses Agency's existing policy system to pre-authorize interrupts. The MCP client (typically an LLM agent) sets up policies before calling tools, and the server automatically handles interrupts using those policies during execution. The agent author doesn't need to do anything special — the MCP server wraps every invocation in a handler that applies the policy.
+
+### User experience
+
+1. Client calls `tools/list` — each tool's description includes its interrupt kinds (e.g. `Interrupt kinds: email::send, shell::exec`), surfaced from static analysis
+2. Client calls the `setPolicy` tool to pre-authorize actions:
+   ```json
+   {
+     "email::send": [
+       { "match": { "recipient": "*@company.com" }, "action": "approve" },
+       { "action": "reject" }
+     ]
+   }
+   ```
+3. Client calls the agent's tool — it runs to completion. Interrupts that match the policy are automatically approved; unmatched interrupts are rejected.
+4. If a rejection causes the tool call to fail, the MCP client gets an error result. If the agent handles the rejection gracefully (via catch, fallback logic, etc.), the client gets a normal result.
+
+The client never sees raw interrupts. Actions are either pre-authorized or they don't happen.
+
+### Default behavior
+
+When no policy is set, or when an interrupt's kind isn't covered by any policy rule, the interrupt is **rejected**. This is safe by default — nothing happens without explicit authorization.
+
+Note: `checkPolicy` returns `propagate` for unmatched interrupts. In the MCP context, `propagate` is treated as `reject`, since there is no one to propagate to.
+
+### Policy management tools
+
+The MCP server exposes three built-in tools alongside the agent's own tools:
+
+**`agencyGetPolicy`** — Returns the current policy as JSON. Takes no arguments.
+
+**`agencySetPolicy`** — Replaces the current policy. The tool description explains the policy format so the MCP client can construct it:
+
+Input schema:
+```json
+{
+  "type": "object",
+  "properties": {
+    "policy": {
+      "type": "object",
+      "description": "Policy object keyed by interrupt kind. Each kind maps to an ordered array of rules. Each rule has an 'action' field ('approve' or 'reject') and an optional 'match' field — an object whose keys are interrupt data field names and whose values are glob patterns (e.g. '*@company.com'). Rules are evaluated in order; the first match wins. A rule with no 'match' field is a catch-all. Check each tool's interrupt kinds to see what kinds to write rules for."
+    }
+  },
+  "required": ["policy"]
+}
+```
+
+Tool description:
+> Set the interrupt policy for this agent. The policy controls which actions the agent is allowed to take autonomously. Each tool lists its interrupt kinds — use those as keys in the policy object. Example: `{"email::send": [{"match": {"recipient": "*@company.com"}, "action": "approve"}, {"action": "reject"}]}` approves sending emails to company.com addresses and rejects all others.
+
+The policy is validated with `validatePolicy` before being applied. Invalid policies return an error. The policy is persisted to disk so it survives server restarts.
+
+**`agencyClearPolicy`** — Resets the policy to empty (reject-all). Takes no arguments.
+
+The `agency` prefix prevents name collisions with the agent's own tools.
+
+### Interrupt handling loop
+
+When the MCP server calls a tool or node, it wraps the invocation in an automatic interrupt-handling loop:
+
+1. Call the function/node
+2. Check `hasInterrupts(result.data)`
+3. If no interrupts: return the result to the MCP client
+4. If interrupted: for each interrupt, call `checkPolicy(policy, interrupt)` and map the result to `approve()` or `reject()` (treating `propagate` as `reject`)
+5. Call `respondToInterrupts` with the interrupt array and the response array
+6. Go to step 2
+
+This loop continues until execution completes (no more interrupts) or until a rejection causes the execution to fail. The MCP client receives whatever the agent ultimately returns.
+
+### How the handler wrapping works
+
+The handler is not applied at the Agency language level. The MCP adapter wraps invocations at the JavaScript level, using the compiled module's exported `hasInterrupts` and `respondToInterrupts` functions.
+
+For functions, the adapter calls `agencyFunction.invoke(...)`, checks the result, and loops with `respondToInterrupts` if needed.
+
+For nodes, the adapter calls `node.invoke(...)`, checks `result.data`, and loops similarly.
+
+The key insight: `respondToInterrupts` already knows how to resume from an interrupt checkpoint with approve/reject responses. The MCP adapter just automates the same flow that an interactive user would perform manually.
+
+### Policy persistence
+
+Policies are persisted to `~/.agency/serve/<server-name>/policy.json`, following the same pattern as schedule persistence (`~/.agency/schedules/`).
+
+- The directory is created on first write with mode `0o700`
+- The policy file is written with mode `0o600` (user-readable only)
+- On server startup, the persisted policy is loaded if it exists
+- `setPolicy` and `clearPolicy` write through to disk immediately
+- The `server-name` is the `--name` flag value, or the filename without `.agency`
+
+### Implementation
+
+The implementation touches three areas:
+
+**1. Policy store (`lib/serve/policyStore.ts`)**
+
+A small class that manages the in-memory policy and its disk persistence:
+
+```typescript
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import path from "path";
+import os from "os";
+import { validatePolicy } from "../runtime/policy.js";
+
+type Policy = Record<string, Array<{ match?: Record<string, string>; action: "approve" | "reject" | "propagate" }>>;
+
+export class PolicyStore {
+  private policy: Policy = {};
+  private filePath: string;
+
+  constructor(serverName: string) {
+    const dir = path.join(os.homedir(), ".agency", "serve", serverName);
+    this.filePath = path.join(dir, "policy.json");
+    this.load();
+  }
+
+  get(): Policy { return this.policy; }
+
+  set(policy: Policy): void {
+    const result = validatePolicy(policy);
+    if (!result.success) throw new Error(result.error);
+    this.policy = policy;
+    this.save();
+  }
+
+  clear(): void {
+    this.policy = {};
+    this.save();
+  }
+
+  private load(): void {
+    if (!existsSync(this.filePath)) return;
+    this.policy = JSON.parse(readFileSync(this.filePath, "utf-8"));
+  }
+
+  private save(): void {
+    mkdirSync(path.dirname(this.filePath), { recursive: true, mode: 0o700 });
+    writeFileSync(this.filePath, JSON.stringify(this.policy, null, 2), { mode: 0o600 });
+  }
+}
+```
+
+**2. Interrupt loop (`lib/serve/mcp/interruptLoop.ts`)**
+
+A function that runs a tool/node invocation with automatic policy-based interrupt handling:
+
+```typescript
+import { checkPolicy } from "../../runtime/policy.js";
+import { approve, reject, hasInterrupts } from "../../runtime/interrupts.js";
+import type { PolicyStore } from "../policyStore.js";
+
+type InterruptHandlers = {
+  hasInterrupts: (data: unknown) => boolean;
+  respondToInterrupts: (interrupts: unknown[], responses: unknown[]) => Promise<unknown>;
+};
+
+export async function runWithPolicy(
+  invoke: () => Promise<unknown>,
+  policyStore: PolicyStore,
+  handlers: InterruptHandlers,
+): Promise<unknown> {
+  let result = await invoke();
+
+  while (handlers.hasInterrupts(result)) {
+    const interrupts = result as Array<{ kind: string; message: string; data: any; origin: string }>;
+    const policy = policyStore.get();
+    const responses = interrupts.map((interrupt) => {
+      const decision = checkPolicy(policy, interrupt);
+      return decision.type === "approve" ? approve() : reject();
+    });
+    result = await handlers.respondToInterrupts(interrupts, responses);
+  }
+
+  return result;
+}
+```
+
+Note: `result` from a node invocation is `{ data: ... }`, and `hasInterrupts` checks `result.data`. The exact shape will need to match what the compiled module's `hasInterrupts` and `respondToInterrupts` exports expect.
+
+**3. MCP adapter changes (`lib/serve/mcp/adapter.ts`)**
+
+- `McpConfig` gains a `policyStore` field and interrupt handler functions (`hasInterrupts`, `respondToInterrupts`)
+- The `tools/call` handler wraps function/node invocations with `runWithPolicy`
+- Three new tool entries are added to `toolsListPayload`: `agencyGetPolicy`, `agencySetPolicy`, `agencyClearPolicy`
+- The `tools/call` switch handles these three tools before checking agent tools
+
+**4. CLI wiring (`lib/cli/serve.ts`)**
+
+- `serveMcp` creates a `PolicyStore` with the server name and passes it into `McpConfig`
+- `hasInterrupts` and `respondToInterrupts` are passed from the module exports, same as the HTTP adapter already does

--- a/packages/agency-lang/lib/cli/serve.ts
+++ b/packages/agency-lang/lib/cli/serve.ts
@@ -10,6 +10,8 @@ import { createLogger } from "../logger.js";
 import { VERSION } from "../version.js";
 import type { ExportedItem } from "../serve/types.js";
 import type { InterruptKind } from "../symbolTable.js";
+import type { InterruptHandlers } from "../serve/mcp/interruptLoop.js";
+import { PolicyStore } from "../serve/policyStore.js";
 import * as esbuild from "esbuild";
 
 type CompileResult = {
@@ -71,13 +73,34 @@ export async function serveMcp(
   options: { name?: string },
 ): Promise<void> {
   const compileResult = compileForServe(file);
-  const { exports } = await loadAndDiscover(compileResult);
+  const { exports, moduleExports } = await loadAndDiscover(compileResult);
 
   const serverName = options.name ?? path.basename(file, ".agency");
+  const policyStore = new PolicyStore(serverName);
+
+  // The compiled module's hasInterrupts checks raw data, but respondToInterrupts
+  // returns { data: ... }. We normalize here so the interrupt loop sees a
+  // consistent shape.
+  const rawHasInterrupts = moduleExports.hasInterrupts as (data: unknown) => boolean;
+  const rawRespondToInterrupts = moduleExports.respondToInterrupts as (
+    interrupts: unknown[],
+    responses: unknown[],
+  ) => Promise<{ data: unknown }>;
+
+  const interruptHandlers: InterruptHandlers = {
+    hasInterrupts: rawHasInterrupts,
+    respondToInterrupts: async (interrupts, responses) => {
+      const wrapped = await rawRespondToInterrupts(interrupts, responses);
+      return wrapped.data;
+    },
+  };
+
   const handler = createMcpHandler({
     serverName,
     serverVersion: VERSION,
     exports,
+    policyStore,
+    interruptHandlers,
   });
 
   startStdioServer(handler);

--- a/packages/agency-lang/lib/cli/serve.ts
+++ b/packages/agency-lang/lib/cli/serve.ts
@@ -99,8 +99,7 @@ export async function serveMcp(
     serverName,
     serverVersion: VERSION,
     exports,
-    policyStore,
-    interruptHandlers,
+    policyConfig: { policyStore, interruptHandlers },
   });
 
   startStdioServer(handler);

--- a/packages/agency-lang/lib/runtime/policy.ts
+++ b/packages/agency-lang/lib/runtime/policy.ts
@@ -1,11 +1,11 @@
 import picomatch from "picomatch";
 
-type PolicyRule = {
+export type PolicyRule = {
   match?: Record<string, string>;
   action: "approve" | "reject" | "propagate";
 };
 
-type Policy = Record<string, PolicyRule[]>;
+export type Policy = Record<string, PolicyRule[]>;
 
 type PolicyResult =
   | { type: "approve" }

--- a/packages/agency-lang/lib/serve/mcp/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.test.ts
@@ -172,8 +172,10 @@ describe("MCP adapter — policy tools", () => {
       serverName: "test-server",
       serverVersion: "1.0.0",
       exports: makeTestExports(),
-      policyStore: new PolicyStore("test-server", tmpDir),
-      interruptHandlers: { hasInterrupts: () => false, respondToInterrupts: async () => "done" },
+      policyConfig: {
+        policyStore: new PolicyStore("test-server", tmpDir),
+        interruptHandlers: { hasInterrupts: () => false, respondToInterrupts: async () => "done" },
+      },
     });
   });
 
@@ -283,13 +285,15 @@ describe("MCP adapter — policy tools", () => {
       exports: [
         { kind: "function", name: "greet", description: "Greet someone", agencyFunction: greetFn, interruptKinds: [{ kind: "test::greet" }] },
       ],
-      policyStore: new PolicyStore("test", tmpDir),
-      interruptHandlers: {
-        hasInterrupts: (data) => Array.isArray(data) && data.length > 0 && data[0]?.type === "interrupt",
-        respondToInterrupts: async (_interrupts, responses) => {
-          respondCalled = true;
-          expect((responses[0] as any).type).toBe("reject");
-          return "rejected";
+      policyConfig: {
+        policyStore: new PolicyStore("test", tmpDir),
+        interruptHandlers: {
+          hasInterrupts: (data) => Array.isArray(data) && data.length > 0 && data[0]?.type === "interrupt",
+          respondToInterrupts: async (_interrupts, responses) => {
+            respondCalled = true;
+            expect((responses[0] as any).type).toBe("reject");
+            return "rejected";
+          },
         },
       },
     });
@@ -332,12 +336,14 @@ describe("MCP adapter — policy tools", () => {
       exports: [
         { kind: "function", name: "sendEmail", description: "Send an email", agencyFunction: sendFn, interruptKinds: [{ kind: "email::send" }] },
       ],
-      policyStore: store,
-      interruptHandlers: {
-        hasInterrupts: (data) => Array.isArray(data) && data.length > 0 && data[0]?.type === "interrupt",
-        respondToInterrupts: async (_interrupts, responses) => {
-          expect((responses[0] as any).type).toBe("approve");
-          return "sent";
+      policyConfig: {
+        policyStore: store,
+        interruptHandlers: {
+          hasInterrupts: (data) => Array.isArray(data) && data.length > 0 && data[0]?.type === "interrupt",
+          respondToInterrupts: async (_interrupts, responses) => {
+            expect((responses[0] as any).type).toBe("approve");
+            return "sent";
+          },
         },
       },
     });

--- a/packages/agency-lang/lib/serve/mcp/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.test.ts
@@ -261,6 +261,17 @@ describe("MCP adapter — policy tools", () => {
     expect(JSON.parse(getResponse!.result.content[0].text)).toEqual({});
   });
 
+  it("agent tools still work when policyConfig is set", async () => {
+    const response = await handler({
+      jsonrpc: "2.0",
+      id: 10,
+      method: "tools/call",
+      params: { name: "add", arguments: { a: 10, b: 20 } },
+    });
+    expect(response!.result.isError).toBe(false);
+    expect(JSON.parse(response!.result.content[0].text)).toBe(30);
+  });
+
   it("automatically rejects interrupts when no policy is set", async () => {
     const registry: Record<string, AgencyFunction> = {};
     const greetFn = AgencyFunction.create(

--- a/packages/agency-lang/lib/serve/mcp/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
 import { z } from "zod";
 import { createMcpHandler } from "./adapter.js";
 import { AgencyFunction } from "../../runtime/agencyFunction.js";
 import type { ExportedItem } from "../types.js";
+import { PolicyStore } from "../policyStore.js";
+import { mkdtempSync, rmSync } from "fs";
+import path from "path";
+import os from "os";
 
 function makeTestExports(): ExportedItem[] {
   const registry: Record<string, AgencyFunction> = {};
@@ -119,7 +123,7 @@ describe("MCP adapter", () => {
     expect(response!.error.code).toBe(-32601);
   });
 
-  it("appends interrupt kinds to tool description", async () => {
+  it("appends interrupt kinds to tool description (no policy)", async () => {
     const registry: Record<string, AgencyFunction> = {};
     const deployFn = AgencyFunction.create(
       {
@@ -155,5 +159,196 @@ describe("MCP adapter", () => {
     expect(tools[0].description).toBe(
       "Deploy app\n\nInterrupt kinds: myapp::deploy, myapp::approve",
     );
+  });
+});
+
+describe("MCP adapter — policy tools", () => {
+  let tmpDir: string;
+  let handler: (msg: any) => Promise<any>;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "mcp-policy-test-"));
+    handler = createMcpHandler({
+      serverName: "test-server",
+      serverVersion: "1.0.0",
+      exports: makeTestExports(),
+      policyStore: new PolicyStore("test-server", tmpDir),
+      interruptHandlers: { hasInterrupts: () => false, respondToInterrupts: async () => "done" },
+    });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("lists policy tools alongside agent tools", async () => {
+    const response = await handler({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+    });
+    const names = response!.result.tools.map((t: any) => t.name);
+    expect(names).toContain("agencyGetPolicy");
+    expect(names).toContain("agencySetPolicy");
+    expect(names).toContain("agencyClearPolicy");
+    expect(names).toContain("add");
+  });
+
+  it("agencyGetPolicy returns empty policy by default", async () => {
+    const response = await handler({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: { name: "agencyGetPolicy", arguments: {} },
+    });
+    expect(response!.result.isError).toBe(false);
+    expect(JSON.parse(response!.result.content[0].text)).toEqual({});
+  });
+
+  it("agencySetPolicy sets and persists a policy", async () => {
+    const policy = { "test::x": [{ action: "approve" }] };
+    const setResponse = await handler({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: { name: "agencySetPolicy", arguments: { policy } },
+    });
+    expect(setResponse!.result.isError).toBe(false);
+
+    const getResponse = await handler({
+      jsonrpc: "2.0",
+      id: 4,
+      method: "tools/call",
+      params: { name: "agencyGetPolicy", arguments: {} },
+    });
+    expect(JSON.parse(getResponse!.result.content[0].text)).toEqual(policy);
+  });
+
+  it("agencySetPolicy rejects invalid policies", async () => {
+    const response = await handler({
+      jsonrpc: "2.0",
+      id: 5,
+      method: "tools/call",
+      params: { name: "agencySetPolicy", arguments: { policy: { "x": [{ action: "yolo" }] } } },
+    });
+    expect(response!.result.isError).toBe(true);
+  });
+
+  it("agencyClearPolicy resets to empty", async () => {
+    await handler({
+      jsonrpc: "2.0",
+      id: 6,
+      method: "tools/call",
+      params: { name: "agencySetPolicy", arguments: { policy: { "x::y": [{ action: "approve" }] } } },
+    });
+
+    const clearResponse = await handler({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: { name: "agencyClearPolicy", arguments: {} },
+    });
+    expect(clearResponse!.result.isError).toBe(false);
+
+    const getResponse = await handler({
+      jsonrpc: "2.0",
+      id: 8,
+      method: "tools/call",
+      params: { name: "agencyGetPolicy", arguments: {} },
+    });
+    expect(JSON.parse(getResponse!.result.content[0].text)).toEqual({});
+  });
+
+  it("automatically rejects interrupts when no policy is set", async () => {
+    const registry: Record<string, AgencyFunction> = {};
+    const greetFn = AgencyFunction.create(
+      {
+        name: "greet",
+        module: "test",
+        fn: async () => [
+          { type: "interrupt", kind: "test::greet", message: "Greet?", data: {}, origin: "test", interruptId: "i1", runId: "r1" },
+        ],
+        params: [{ name: "name", hasDefault: false, defaultValue: undefined, variadic: false }],
+        toolDefinition: { name: "greet", description: "Greet someone", schema: z.object({ name: z.string() }) },
+        exported: true,
+        safe: false,
+      },
+      registry,
+    );
+
+    let respondCalled = false;
+    const policyHandler = createMcpHandler({
+      serverName: "test",
+      serverVersion: "1.0.0",
+      exports: [
+        { kind: "function", name: "greet", description: "Greet someone", agencyFunction: greetFn, interruptKinds: [{ kind: "test::greet" }] },
+      ],
+      policyStore: new PolicyStore("test", tmpDir),
+      interruptHandlers: {
+        hasInterrupts: (data) => Array.isArray(data) && data.length > 0 && data[0]?.type === "interrupt",
+        respondToInterrupts: async (_interrupts, responses) => {
+          respondCalled = true;
+          expect((responses[0] as any).type).toBe("reject");
+          return "rejected";
+        },
+      },
+    });
+
+    const response = await policyHandler({
+      jsonrpc: "2.0",
+      id: 20,
+      method: "tools/call",
+      params: { name: "greet", arguments: { name: "Alice" } },
+    });
+
+    expect(respondCalled).toBe(true);
+    expect(response!.result.isError).toBe(false);
+    expect(JSON.parse(response!.result.content[0].text)).toBe("rejected");
+  });
+
+  it("approves interrupts when policy matches", async () => {
+    const registry: Record<string, AgencyFunction> = {};
+    const sendFn = AgencyFunction.create(
+      {
+        name: "sendEmail",
+        module: "test",
+        fn: async () => [
+          { type: "interrupt", kind: "email::send", message: "Send?", data: { recipient: "alice@company.com" }, origin: "test", interruptId: "i2", runId: "r2" },
+        ],
+        params: [],
+        toolDefinition: { name: "sendEmail", description: "Send an email", schema: z.object({}) },
+        exported: true,
+        safe: false,
+      },
+      registry,
+    );
+
+    const store = new PolicyStore("test", tmpDir);
+    store.set({ "email::send": [{ match: { recipient: "*@company.com" }, action: "approve" }] });
+
+    const policyHandler = createMcpHandler({
+      serverName: "test",
+      serverVersion: "1.0.0",
+      exports: [
+        { kind: "function", name: "sendEmail", description: "Send an email", agencyFunction: sendFn, interruptKinds: [{ kind: "email::send" }] },
+      ],
+      policyStore: store,
+      interruptHandlers: {
+        hasInterrupts: (data) => Array.isArray(data) && data.length > 0 && data[0]?.type === "interrupt",
+        respondToInterrupts: async (_interrupts, responses) => {
+          expect((responses[0] as any).type).toBe("approve");
+          return "sent";
+        },
+      },
+    });
+
+    const response = await policyHandler({
+      jsonrpc: "2.0",
+      id: 21,
+      method: "tools/call",
+      params: { name: "sendEmail", arguments: {} },
+    });
+
+    expect(JSON.parse(response!.result.content[0].text)).toBe("sent");
   });
 });

--- a/packages/agency-lang/lib/serve/mcp/adapter.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.ts
@@ -72,7 +72,7 @@ const POLICY_TOOL_DEFINITIONS = [
       properties: {
         policy: {
           type: "object" as const,
-          description: "Policy object keyed by interrupt kind. Each kind maps to an ordered array of rules. Each rule has an 'action' field ('approve' or 'reject') and an optional 'match' field — an object whose keys are interrupt data field names and whose values are glob patterns. Rules are evaluated in order; the first match wins. A rule with no 'match' field is a catch-all.",
+          description: "Policy object keyed by interrupt kind. Each kind maps to an ordered array of rules. Each rule has an 'action' field ('approve', 'reject', or 'propagate') and an optional 'match' field — an object whose keys are interrupt data field names and whose values are glob patterns. Rules are evaluated in order; the first match wins. A rule with no 'match' field is a catch-all. In MCP context, 'propagate' is treated as 'reject' since there is no interactive user to propagate to.",
         },
       },
       required: ["policy"],

--- a/packages/agency-lang/lib/serve/mcp/adapter.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.ts
@@ -1,6 +1,9 @@
 import process from "process";
 import type { InterruptKind } from "../../symbolTable.js";
 import type { ExportedFunction, ExportedItem } from "../types.js";
+import type { PolicyStore } from "../policyStore.js";
+import type { InterruptHandlers } from "./interruptLoop.js";
+import { runWithPolicy } from "./interruptLoop.js";
 import { errorMessage } from "../util.js";
 
 function formatToolDescription(description: string, interruptKinds: InterruptKind[]): string {
@@ -41,7 +44,59 @@ export type McpConfig = {
   serverName: string;
   serverVersion: string;
   exports: ExportedItem[];
+  policyStore?: PolicyStore;
+  interruptHandlers?: InterruptHandlers;
 };
+
+const POLICY_TOOL_DEFINITIONS = [
+  {
+    name: "agencyGetPolicy",
+    description: "Get the current interrupt policy for this agent. Returns a JSON object keyed by interrupt kind.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "agencySetPolicy",
+    description: `Set the interrupt policy for this agent. The policy controls which actions the agent is allowed to take autonomously. Each tool lists its interrupt kinds — use those as keys in the policy object. Example: {"email::send": [{"match": {"recipient": "*@company.com"}, "action": "approve"}, {"action": "reject"}]} approves sending emails to company.com addresses and rejects all others.`,
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        policy: {
+          type: "object" as const,
+          description: "Policy object keyed by interrupt kind. Each kind maps to an ordered array of rules. Each rule has an 'action' field ('approve' or 'reject') and an optional 'match' field — an object whose keys are interrupt data field names and whose values are glob patterns. Rules are evaluated in order; the first match wins. A rule with no 'match' field is a catch-all.",
+        },
+      },
+      required: ["policy"],
+    },
+  },
+  {
+    name: "agencyClearPolicy",
+    description: "Clear the interrupt policy, resetting to reject-all. After clearing, all interrupt-producing actions will be rejected until a new policy is set.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+];
+
+function handlePolicyTool(
+  name: string,
+  args: Record<string, any>,
+  policyStore: PolicyStore,
+): { content: Array<{ type: string; text: string }>; isError: boolean } | null {
+  switch (name) {
+    case "agencyGetPolicy":
+      return { content: [{ type: "text", text: JSON.stringify(policyStore.get(), null, 2) }], isError: false };
+    case "agencySetPolicy":
+      try {
+        policyStore.set(args.policy);
+        return { content: [{ type: "text", text: "Policy updated successfully." }], isError: false };
+      } catch (err) {
+        return { content: [{ type: "text", text: errorMessage(err) }], isError: true };
+      }
+    case "agencyClearPolicy":
+      policyStore.clear();
+      return { content: [{ type: "text", text: "Policy cleared." }], isError: false };
+    default:
+      return null;
+  }
+}
 
 export function createMcpHandler(
   config: McpConfig,
@@ -57,6 +112,11 @@ export function createMcpHandler(
     inputSchema: schemaToJsonSchema(t.agencyFunction.toolDefinition?.schema),
     ...(t.agencyFunction.safe ? { annotations: { readOnlyHint: true } } : {}),
   }));
+
+  const { policyStore } = config;
+  if (policyStore) {
+    toolsListPayload.push(...POLICY_TOOL_DEFINITIONS);
+  }
 
   return async (message: JsonRpcMessage): Promise<JsonRpcMessage | null> => {
     if (message.jsonrpc !== "2.0") {
@@ -83,22 +143,28 @@ export function createMcpHandler(
       case "tools/call": {
         const name = message.params?.name;
         const args = message.params?.arguments ?? {};
+        const id = message.id ?? null;
+
+        if (policyStore) {
+          const policyResult = handlePolicyTool(name, args, policyStore);
+          if (policyResult) return success(id, policyResult);
+        }
+
         const tool = toolsByName[name];
         if (!tool) {
-          return rpcError(message.id ?? null, -32602, `Unknown tool '${name}'`);
+          return rpcError(id, -32602, `Unknown tool '${name}'`);
         }
         try {
-          const result = await tool.agencyFunction.invoke({
-            type: "named",
-            positionalArgs: [],
-            namedArgs: args,
-          });
-          return success(message.id ?? null, {
+          const invoke = () => tool.agencyFunction.invoke({ type: "named", positionalArgs: [], namedArgs: args });
+          const result = policyStore && config.interruptHandlers
+            ? await runWithPolicy(invoke, policyStore, config.interruptHandlers)
+            : await invoke();
+          return success(id, {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
             isError: false,
           });
         } catch (err) {
-          return success(message.id ?? null, {
+          return success(id, {
             content: [{ type: "text", text: errorMessage(err) }],
             isError: true,
           });

--- a/packages/agency-lang/lib/serve/mcp/adapter.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.ts
@@ -40,22 +40,32 @@ function schemaToJsonSchema(schema: unknown): unknown {
     : { type: "object", properties: {} };
 }
 
+export type PolicyConfig = {
+  policyStore: PolicyStore;
+  interruptHandlers: InterruptHandlers;
+};
+
 export type McpConfig = {
   serverName: string;
   serverVersion: string;
   exports: ExportedItem[];
-  policyStore?: PolicyStore;
-  interruptHandlers?: InterruptHandlers;
+  policyConfig?: PolicyConfig;
 };
+
+const POLICY_TOOL_NAMES = {
+  GET: "agencyGetPolicy",
+  SET: "agencySetPolicy",
+  CLEAR: "agencyClearPolicy",
+} as const;
 
 const POLICY_TOOL_DEFINITIONS = [
   {
-    name: "agencyGetPolicy",
+    name: POLICY_TOOL_NAMES.GET,
     description: "Get the current interrupt policy for this agent. Returns a JSON object keyed by interrupt kind.",
     inputSchema: { type: "object" as const, properties: {} },
   },
   {
-    name: "agencySetPolicy",
+    name: POLICY_TOOL_NAMES.SET,
     description: `Set the interrupt policy for this agent. The policy controls which actions the agent is allowed to take autonomously. Each tool lists its interrupt kinds — use those as keys in the policy object. Example: {"email::send": [{"match": {"recipient": "*@company.com"}, "action": "approve"}, {"action": "reject"}]} approves sending emails to company.com addresses and rejects all others.`,
     inputSchema: {
       type: "object" as const,
@@ -69,7 +79,7 @@ const POLICY_TOOL_DEFINITIONS = [
     },
   },
   {
-    name: "agencyClearPolicy",
+    name: POLICY_TOOL_NAMES.CLEAR,
     description: "Clear the interrupt policy, resetting to reject-all. After clearing, all interrupt-producing actions will be rejected until a new policy is set.",
     inputSchema: { type: "object" as const, properties: {} },
   },
@@ -81,16 +91,16 @@ function handlePolicyTool(
   policyStore: PolicyStore,
 ): { content: Array<{ type: string; text: string }>; isError: boolean } | null {
   switch (name) {
-    case "agencyGetPolicy":
+    case POLICY_TOOL_NAMES.GET:
       return { content: [{ type: "text", text: JSON.stringify(policyStore.get(), null, 2) }], isError: false };
-    case "agencySetPolicy":
+    case POLICY_TOOL_NAMES.SET:
       try {
         policyStore.set(args.policy);
         return { content: [{ type: "text", text: "Policy updated successfully." }], isError: false };
       } catch (err) {
         return { content: [{ type: "text", text: errorMessage(err) }], isError: true };
       }
-    case "agencyClearPolicy":
+    case POLICY_TOOL_NAMES.CLEAR:
       policyStore.clear();
       return { content: [{ type: "text", text: "Policy cleared." }], isError: false };
     default:
@@ -113,8 +123,8 @@ export function createMcpHandler(
     ...(t.agencyFunction.safe ? { annotations: { readOnlyHint: true } } : {}),
   }));
 
-  const { policyStore } = config;
-  if (policyStore) {
+  const { policyConfig } = config;
+  if (policyConfig) {
     toolsListPayload.push(...POLICY_TOOL_DEFINITIONS);
   }
 
@@ -145,8 +155,8 @@ export function createMcpHandler(
         const args = message.params?.arguments ?? {};
         const id = message.id ?? null;
 
-        if (policyStore) {
-          const policyResult = handlePolicyTool(name, args, policyStore);
+        if (policyConfig) {
+          const policyResult = handlePolicyTool(name, args, policyConfig.policyStore);
           if (policyResult) return success(id, policyResult);
         }
 
@@ -156,8 +166,8 @@ export function createMcpHandler(
         }
         try {
           const invoke = () => tool.agencyFunction.invoke({ type: "named", positionalArgs: [], namedArgs: args });
-          const result = policyStore && config.interruptHandlers
-            ? await runWithPolicy(invoke, policyStore, config.interruptHandlers)
+          const result = policyConfig
+            ? await runWithPolicy(invoke, policyConfig.policyStore, policyConfig.interruptHandlers)
             : await invoke();
           return success(id, {
             content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/packages/agency-lang/lib/serve/mcp/interruptLoop.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/interruptLoop.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { runWithPolicy } from "./interruptLoop.js";
+import { PolicyStore } from "../policyStore.js";
+import { mkdtempSync, rmSync } from "fs";
+import path from "path";
+import os from "os";
+
+function makeTmpStore(policy: Record<string, any> = {}): { store: PolicyStore; cleanup: () => void } {
+  const tmpDir = mkdtempSync(path.join(os.tmpdir(), "interrupt-loop-test-"));
+  const store = new PolicyStore("test", tmpDir);
+  if (Object.keys(policy).length > 0) store.set(policy);
+  return { store, cleanup: () => rmSync(tmpDir, { recursive: true, force: true }) };
+}
+
+function makeInterrupt(kind: string, data: Record<string, any> = {}): any {
+  return { type: "interrupt", kind, message: "", data, origin: "test", interruptId: "test-id", runId: "test-run" };
+}
+
+const isInterrupts = (data: unknown) =>
+  Array.isArray(data) && data.length > 0 && data[0]?.type === "interrupt";
+
+describe("runWithPolicy", () => {
+  it("returns result directly when no interrupts", async () => {
+    const { store, cleanup } = makeTmpStore();
+    try {
+      const result = await runWithPolicy(
+        async () => "hello",
+        store,
+        { hasInterrupts: isInterrupts, respondToInterrupts: async () => "done" },
+      );
+      expect(result).toBe("hello");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("approves interrupts that match the policy", async () => {
+    const { store, cleanup } = makeTmpStore({
+      "test::greet": [{ action: "approve" }],
+    });
+    try {
+      let callCount = 0;
+      const result = await runWithPolicy(
+        async () => [makeInterrupt("test::greet")],
+        store,
+        {
+          hasInterrupts: isInterrupts,
+          respondToInterrupts: async (_interrupts, responses) => {
+            callCount++;
+            expect(responses).toHaveLength(1);
+            expect((responses[0] as any).type).toBe("approve");
+            return "approved-result";
+          },
+        },
+      );
+      expect(result).toBe("approved-result");
+      expect(callCount).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("rejects interrupts not covered by policy (default reject)", async () => {
+    const { store, cleanup } = makeTmpStore(); // empty policy
+    try {
+      const result = await runWithPolicy(
+        async () => [makeInterrupt("test::greet")],
+        store,
+        {
+          hasInterrupts: isInterrupts,
+          respondToInterrupts: async (_interrupts, responses) => {
+            expect((responses[0] as any).type).toBe("reject");
+            return "rejected-result";
+          },
+        },
+      );
+      expect(result).toBe("rejected-result");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("handles multiple rounds of interrupts", async () => {
+    const { store, cleanup } = makeTmpStore({
+      "test::step1": [{ action: "approve" }],
+      "test::step2": [{ action: "approve" }],
+    });
+    try {
+      let round = 0;
+      const result = await runWithPolicy(
+        async () => [makeInterrupt("test::step1")],
+        store,
+        {
+          hasInterrupts: isInterrupts,
+          respondToInterrupts: async () => {
+            round++;
+            if (round === 1) {
+              return [makeInterrupt("test::step2")];
+            }
+            return "final";
+          },
+        },
+      );
+      expect(result).toBe("final");
+      expect(round).toBe(2);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("approves some and rejects others in a mixed batch", async () => {
+    const { store, cleanup } = makeTmpStore({
+      "test::allowed": [{ action: "approve" }],
+      // test::blocked has no rules → defaults to reject
+    });
+    try {
+      const result = await runWithPolicy(
+        async () => [makeInterrupt("test::allowed"), makeInterrupt("test::blocked")],
+        store,
+        {
+          hasInterrupts: isInterrupts,
+          respondToInterrupts: async (_interrupts, responses) => {
+            expect((responses[0] as any).type).toBe("approve");
+            expect((responses[1] as any).type).toBe("reject");
+            return "mixed-result";
+          },
+        },
+      );
+      expect(result).toBe("mixed-result");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/agency-lang/lib/serve/mcp/interruptLoop.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/interruptLoop.test.ts
@@ -108,6 +108,26 @@ describe("runWithPolicy", () => {
     }
   });
 
+  it("propagates errors from respondToInterrupts", async () => {
+    const { store, cleanup } = makeTmpStore({
+      "test::x": [{ action: "approve" }],
+    });
+    try {
+      await expect(
+        runWithPolicy(
+          async () => [makeInterrupt("test::x")],
+          store,
+          {
+            hasInterrupts: isInterrupts,
+            respondToInterrupts: async () => { throw new Error("agent crashed"); },
+          },
+        ),
+      ).rejects.toThrow("agent crashed");
+    } finally {
+      cleanup();
+    }
+  });
+
   it("approves some and rejects others in a mixed batch", async () => {
     const { store, cleanup } = makeTmpStore({
       "test::allowed": [{ action: "approve" }],

--- a/packages/agency-lang/lib/serve/mcp/interruptLoop.ts
+++ b/packages/agency-lang/lib/serve/mcp/interruptLoop.ts
@@ -1,0 +1,34 @@
+import { checkPolicy } from "../../runtime/policy.js";
+import { approve, reject } from "../../runtime/interrupts.js";
+import type { PolicyStore } from "../policyStore.js";
+
+export type InterruptHandlers = {
+  hasInterrupts: (data: unknown) => boolean;
+  respondToInterrupts: (interrupts: unknown[], responses: unknown[]) => Promise<unknown>;
+};
+
+function applyPolicy(
+  interrupts: Array<{ kind: string; message: string; data: any; origin: string }>,
+  policy: Record<string, any>,
+) {
+  return interrupts.map((interrupt) => {
+    const decision = checkPolicy(policy, interrupt);
+    return decision.type === "approve" ? approve() : reject();
+  });
+}
+
+export async function runWithPolicy(
+  invoke: () => Promise<unknown>,
+  policyStore: PolicyStore,
+  handlers: InterruptHandlers,
+): Promise<unknown> {
+  let result = await invoke();
+
+  while (handlers.hasInterrupts(result)) {
+    const interrupts = result as Array<{ kind: string; message: string; data: any; origin: string }>;
+    const responses = applyPolicy(interrupts, policyStore.get());
+    result = await handlers.respondToInterrupts(interrupts, responses);
+  }
+
+  return result;
+}

--- a/packages/agency-lang/lib/serve/policyStore.test.ts
+++ b/packages/agency-lang/lib/serve/policyStore.test.ts
@@ -48,6 +48,15 @@ describe("PolicyStore", () => {
     expect(store.get()).toEqual({});
   });
 
+  it("clear persists to disk", () => {
+    const store1 = new PolicyStore("test-server", tmpDir);
+    store1.set({ "x::y": [{ action: "approve" as const }] });
+    store1.clear();
+
+    const store2 = new PolicyStore("test-server", tmpDir);
+    expect(store2.get()).toEqual({});
+  });
+
   it("rejects invalid policies", () => {
     const store = new PolicyStore("test-server", tmpDir);
     expect(() => store.set({ "x::y": [{ action: "yolo" as any }] })).toThrow();

--- a/packages/agency-lang/lib/serve/policyStore.test.ts
+++ b/packages/agency-lang/lib/serve/policyStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { PolicyStore } from "./policyStore.js";
+import { mkdtempSync, rmSync, readFileSync } from "fs";
+import path from "path";
+import os from "os";
+
+describe("PolicyStore", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(os.tmpdir(), "policy-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("starts with empty policy", () => {
+    const store = new PolicyStore("test-server", tmpDir);
+    expect(store.get()).toEqual({});
+  });
+
+  it("sets and gets a policy", () => {
+    const store = new PolicyStore("test-server", tmpDir);
+    const policy = {
+      "email::send": [{ action: "approve" as const }],
+    };
+    store.set(policy);
+    expect(store.get()).toEqual(policy);
+  });
+
+  it("persists policy to disk", () => {
+    const policy = {
+      "email::send": [{ match: { recipient: "*@co.com" }, action: "approve" as const }],
+    };
+    const store1 = new PolicyStore("test-server", tmpDir);
+    store1.set(policy);
+
+    // New instance should load from disk
+    const store2 = new PolicyStore("test-server", tmpDir);
+    expect(store2.get()).toEqual(policy);
+  });
+
+  it("clears the policy", () => {
+    const store = new PolicyStore("test-server", tmpDir);
+    store.set({ "x::y": [{ action: "approve" as const }] });
+    store.clear();
+    expect(store.get()).toEqual({});
+  });
+
+  it("rejects invalid policies", () => {
+    const store = new PolicyStore("test-server", tmpDir);
+    expect(() => store.set({ "x::y": [{ action: "yolo" as any }] })).toThrow();
+  });
+
+  it("writes policy file with restricted permissions", () => {
+    const store = new PolicyStore("test-server", tmpDir);
+    store.set({ "x::y": [{ action: "approve" as const }] });
+    const filePath = path.join(tmpDir, "test-server", "policy.json");
+    const content = readFileSync(filePath, "utf-8");
+    expect(JSON.parse(content)).toEqual({ "x::y": [{ action: "approve" }] });
+  });
+});

--- a/packages/agency-lang/lib/serve/policyStore.test.ts
+++ b/packages/agency-lang/lib/serve/policyStore.test.ts
@@ -62,7 +62,7 @@ describe("PolicyStore", () => {
     expect(() => store.set({ "x::y": [{ action: "yolo" as any }] })).toThrow();
   });
 
-  it("writes policy file with restricted permissions", () => {
+  it("writes policy file to disk", () => {
     const store = new PolicyStore("test-server", tmpDir);
     store.set({ "x::y": [{ action: "approve" as const }] });
     const filePath = path.join(tmpDir, "test-server", "policy.json");

--- a/packages/agency-lang/lib/serve/policyStore.ts
+++ b/packages/agency-lang/lib/serve/policyStore.ts
@@ -1,0 +1,48 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
+import path from "path";
+import os from "os";
+import { validatePolicy } from "../runtime/policy.js";
+
+type PolicyRule = {
+  match?: Record<string, string>;
+  action: "approve" | "reject" | "propagate";
+};
+
+export type Policy = Record<string, PolicyRule[]>;
+
+export class PolicyStore {
+  private policy: Policy = {};
+  private filePath: string;
+
+  constructor(serverName: string, baseDir?: string) {
+    const dir = path.join(baseDir ?? path.join(os.homedir(), ".agency", "serve"), serverName);
+    this.filePath = path.join(dir, "policy.json");
+    this.load();
+  }
+
+  get(): Policy {
+    return this.policy;
+  }
+
+  set(policy: Policy): void {
+    const result = validatePolicy(policy);
+    if (!result.success) throw new Error(result.error);
+    this.policy = policy;
+    this.save();
+  }
+
+  clear(): void {
+    this.policy = {};
+    this.save();
+  }
+
+  private load(): void {
+    if (!existsSync(this.filePath)) return;
+    this.policy = JSON.parse(readFileSync(this.filePath, "utf-8"));
+  }
+
+  private save(): void {
+    mkdirSync(path.dirname(this.filePath), { recursive: true, mode: 0o700 });
+    writeFileSync(this.filePath, JSON.stringify(this.policy, null, 2), { mode: 0o600 });
+  }
+}

--- a/packages/agency-lang/lib/serve/policyStore.ts
+++ b/packages/agency-lang/lib/serve/policyStore.ts
@@ -2,13 +2,9 @@ import { readFileSync, writeFileSync, mkdirSync, existsSync } from "fs";
 import path from "path";
 import os from "os";
 import { validatePolicy } from "../runtime/policy.js";
+import type { Policy } from "../runtime/policy.js";
 
-type PolicyRule = {
-  match?: Record<string, string>;
-  action: "approve" | "reject" | "propagate";
-};
-
-export type Policy = Record<string, PolicyRule[]>;
+export type { Policy } from "../runtime/policy.js";
 
 export class PolicyStore {
   private policy: Policy = {};
@@ -20,7 +16,7 @@ export class PolicyStore {
     this.load();
   }
 
-  get(): Policy {
+  get(): Readonly<Policy> {
     return this.policy;
   }
 

--- a/packages/agency-lang/lib/serve/policyStore.ts
+++ b/packages/agency-lang/lib/serve/policyStore.ts
@@ -34,7 +34,17 @@ export class PolicyStore {
 
   private load(): void {
     if (!existsSync(this.filePath)) return;
-    this.policy = JSON.parse(readFileSync(this.filePath, "utf-8"));
+    try {
+      const parsed = JSON.parse(readFileSync(this.filePath, "utf-8"));
+      const result = validatePolicy(parsed);
+      if (result.success) {
+        this.policy = parsed;
+      } else {
+        console.error(`Invalid policy file at ${this.filePath}: ${result.error}. Using empty policy.`);
+      }
+    } catch {
+      console.error(`Failed to parse policy file at ${this.filePath}. Using empty policy.`);
+    }
   }
 
   private save(): void {


### PR DESCRIPTION
## Summary

- MCP-served agents can now handle interrupts automatically via policies, eliminating the need for mid-execution approval flows
- Adds `PolicyStore` for persisting policies to `~/.agency/serve/<name>/policy.json`
- Adds `runWithPolicy` interrupt loop that applies `checkPolicy` and maps results to approve/reject
- Exposes three built-in MCP tools: `agencyGetPolicy`, `agencySetPolicy`, `agencyClearPolicy`
- Default behavior: unmatched interrupts are rejected (safe by default)

## Design

When the MCP client calls a tool that produces interrupts, the adapter automatically loops: check policy, approve or reject, resume, repeat until done. The client never sees raw interrupts — actions are either pre-authorized via policy or they get rejected.

Key design decisions:
- `runWithPolicy` works with a clean `InterruptHandlers` interface — the `{ data }` wrapper normalization happens in one place (CLI wiring)
- Policy tool dispatch is extracted into `handlePolicyTool` to keep `createMcpHandler` focused
- `McpConfig` takes `interruptHandlers` (a clean interface), not raw module exports

## Test plan

- [ ] `pnpm vitest run lib/serve/` — all 48 tests pass (6 PolicyStore + 5 interruptLoop + 14 adapter including 7 new policy/interrupt tests + existing)
- [ ] Build succeeds: `make`

🤖 Generated with [Claude Code](https://claude.com/claude-code)