### PR TITLE
Add agency policy gen command

### DIFF
--- a/packages/agency-lang/docs-new/stdlib/policy.md
+++ b/packages/agency-lang/docs-new/stdlib/policy.md
@@ -34,3 +34,20 @@ Validate that a policy object is well-formed. Returns { success: true } if valid
 | policy | `Record<string, any>` |  |
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L10))
+
+### writePolicyFile
+
+```ts
+writePolicyFile(path: string, policy: Record<string, any>)
+```
+
+Validate and write a policy to a JSON file. Throws if the policy is invalid.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| path | `string` |  |
+| policy | `Record<string, any>` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L17))

--- a/packages/agency-lang/lib/agents/policy/agent.agency
+++ b/packages/agency-lang/lib/agents/policy/agent.agency
@@ -26,11 +26,13 @@ node main() {
 
   let contextMessage = "This agent can produce the following interrupts:\n"
   for (kind in interruptKinds) {
-    contextMessage = contextMessage + "- `${kind}`\n"
+    contextMessage = contextMessage + "- ${kind}\n"
   }
 
   if (existingPolicy != null) {
-    contextMessage = contextMessage + "\nCurrent policy:\n```json\n${printJSON(existingPolicy)}\n```\n\nWhat would you like to change?"
+    contextMessage = contextMessage + """
+    Current policy:\n```json\n${printJSON(existingPolicy)}\n```\n\nWhat would you like to change?
+    """
   } else {
     contextMessage = contextMessage + "\nWhat actions would you like to allow?"
   }
@@ -46,7 +48,9 @@ node main() {
 
     thread {
       system(systemPrompt)
-      let step: NextStep = llm("${conversationHistory}\n\nCurrent policy: ${printJSON(policy)}\n\nDecide the next step. If the user is describing what they want, build or update the policy and use showPolicy. If the user approves the shown policy, use writePolicy. If you need clarification, use askQuestion.")
+      let step: NextStep = llm("""
+      ${conversationHistory}\n\nCurrent policy: ${printJSON(policy)}\n\nDecide the next step. If the user is describing what they want, build or update the policy and use showPolicy. If the user approves the shown policy, use writePolicy. If you need clarification, use askQuestion.
+      """)
     }
 
     if (step.type == "showPolicy") {

--- a/packages/agency-lang/lib/agents/policy/agent.agency
+++ b/packages/agency-lang/lib/agents/policy/agent.agency
@@ -1,0 +1,73 @@
+import { writePolicyFile } from "std::policy"
+import { args } from "std::system"
+
+systemPrompt = read("./prompts/system.md")
+
+type NextStep = { type: "showPolicy"; policy: object } | { type: "writePolicy"; policy: object } | { type: "askQuestion"; question: string }
+
+node main() {
+  let cliArgs = args()
+  if (cliArgs.length < 2) {
+    print("Usage: agency policy gen <file>")
+    return end()
+  }
+  let interruptKindsJson = cliArgs[0]
+  let outputPath = cliArgs[1]
+  let existingPolicyJson = ""
+  if (cliArgs.length >= 3) {
+    existingPolicyJson = cliArgs[2]
+  }
+
+  let interruptKinds = parseJSON(interruptKindsJson)
+  let existingPolicy = null
+  if (existingPolicyJson != "") {
+    existingPolicy = parseJSON(existingPolicyJson)
+  }
+
+  let contextMessage = "This agent can produce the following interrupts:\n"
+  for (kind in interruptKinds) {
+    contextMessage = contextMessage + "- `${kind}`\n"
+  }
+
+  if (existingPolicy != null) {
+    contextMessage = contextMessage + "\nCurrent policy:\n```json\n${printJSON(existingPolicy)}\n```\n\nWhat would you like to change?"
+  } else {
+    contextMessage = contextMessage + "\nWhat actions would you like to allow?"
+  }
+
+  print(contextMessage)
+
+  let done = false
+  let policy = {}
+  let conversationHistory = contextMessage
+  while (!done) {
+    let userInput = input("> ")
+    conversationHistory = conversationHistory + "\nUser: ${userInput}"
+
+    thread {
+      system(systemPrompt)
+      let step: NextStep = llm("${conversationHistory}\n\nCurrent policy: ${printJSON(policy)}\n\nDecide the next step. If the user is describing what they want, build or update the policy and use showPolicy. If the user approves the shown policy, use writePolicy. If you need clarification, use askQuestion.")
+    }
+
+    if (step.type == "showPolicy") {
+      policy = step.policy
+      let policyStr = printJSON(policy)
+      print("\nProposed policy:\n```json\n${policyStr}\n```\n")
+      print("Does this look right? (say 'yes' to save, or describe changes)")
+      conversationHistory = conversationHistory + "\nAssistant: Here is the proposed policy:\n${policyStr}\nDoes this look right?"
+    } else if (step.type == "writePolicy") {
+      policy = step.policy
+      writePolicyFile(outputPath, policy)
+      print("\nPolicy written to ${outputPath}")
+      done = true
+    } else if (step.type == "askQuestion") {
+      print(step.question)
+      conversationHistory = conversationHistory + "\nAssistant: ${step.question}"
+    }
+  }
+  return end()
+}
+
+node end() {
+
+}

--- a/packages/agency-lang/lib/agents/policy/prompts/system.md
+++ b/packages/agency-lang/lib/agents/policy/prompts/system.md
@@ -1,0 +1,39 @@
+You are a policy configuration assistant for Agency agents. Your job is to help users create interrupt policies that control what actions their agent can take autonomously.
+
+## What is a policy?
+
+A policy is a JSON object that maps interrupt kinds to ordered arrays of rules. When an agent tries to perform an action that produces an interrupt, the policy is checked. The first matching rule determines whether the action is approved or rejected.
+
+## Policy format
+
+```json
+{
+  "email::send": [
+    { "match": { "recipient": "*@company.com" }, "action": "approve" },
+    { "action": "reject" }
+  ]
+}
+```
+
+Each rule has:
+- `action`: either `"approve"` or `"reject"`
+- `match` (optional): an object where keys are interrupt data field names and values are glob patterns (using `*` for wildcards, `**` for path matching). If omitted, the rule is a catch-all.
+
+## Important rules
+
+- Rules are evaluated **in order** — the first match wins
+- Put specific rules **before** catch-all rules
+- If no rule matches an interrupt kind, the interrupt is **rejected** by default
+- Glob patterns use picomatch syntax: `*` matches anything except path separators, `**` matches anything including path separators
+
+## Your workflow
+
+1. You will be given a list of interrupt kinds that the agent can produce
+2. If an existing policy was provided, present it and ask what the user wants to change
+3. Otherwise, present the interrupt kinds and ask the user what they want to allow
+4. Build the policy based on the user's intent
+5. Show the complete policy JSON and ask for confirmation
+6. If the user approves, write the policy file using the writePolicyFile tool
+7. If the user wants changes, refine and show again
+
+Be concise. Don't over-explain the policy format unless the user asks. Focus on understanding what they want to allow or deny, then build the policy for them.

--- a/packages/agency-lang/lib/cli/policy.ts
+++ b/packages/agency-lang/lib/cli/policy.ts
@@ -1,0 +1,66 @@
+import { AgencyConfig } from "@/config.js";
+import { runBundledAgent } from "./runBundledAgent.js";
+import { SymbolTable } from "../symbolTable.js";
+import { existsSync, readFileSync } from "fs";
+import { validatePolicy } from "../runtime/policy.js";
+import path from "path";
+
+export function policyGen(
+  config: AgencyConfig,
+  file: string,
+  options: { output?: string; existing?: string },
+): void {
+  const absoluteFile = path.resolve(file);
+  if (!existsSync(absoluteFile)) {
+    console.error(`File not found: ${file}`);
+    process.exit(1);
+  }
+
+  const outputPath = path.resolve(options.output ?? "policy.json");
+  if (existsSync(outputPath) && outputPath !== path.resolve(options.existing ?? "")) {
+    console.error(`Output file already exists: ${outputPath}. Use -p to edit an existing policy, or -o to specify a different output path.`);
+    process.exit(1);
+  }
+
+  const symbolTable = SymbolTable.build(absoluteFile, config);
+  const fileSymbols = symbolTable.getFile(absoluteFile);
+  const interruptKinds: string[] = [];
+  for (const sym of Object.values(fileSymbols ?? {})) {
+    if ((sym.kind === "function" || sym.kind === "node") && sym.interruptKinds) {
+      for (const ik of sym.interruptKinds) {
+        if (!interruptKinds.includes(ik.kind)) {
+          interruptKinds.push(ik.kind);
+        }
+      }
+    }
+  }
+
+  if (interruptKinds.length === 0) {
+    console.log("No interrupt kinds found in this agent. No policy needed.");
+    return;
+  }
+
+  let existingPolicyJson = "";
+  if (options.existing) {
+    const existingPath = path.resolve(options.existing);
+    if (!existsSync(existingPath)) {
+      console.error(`Existing policy file not found: ${options.existing}`);
+      process.exit(1);
+    }
+    const parsed = JSON.parse(readFileSync(existingPath, "utf-8"));
+    const result = validatePolicy(parsed);
+    if (!result.success) {
+      console.error(`Invalid existing policy: ${result.error}`);
+      process.exit(1);
+    }
+    existingPolicyJson = JSON.stringify(parsed);
+  }
+
+  const agentArgs = [
+    JSON.stringify(interruptKinds),
+    outputPath,
+    ...(existingPolicyJson ? [existingPolicyJson] : []),
+  ];
+
+  runBundledAgent(config, "policy", agentArgs);
+}

--- a/packages/agency-lang/lib/cli/policy.ts
+++ b/packages/agency-lang/lib/cli/policy.ts
@@ -1,9 +1,20 @@
 import { AgencyConfig } from "@/config.js";
 import { runBundledAgent } from "./runBundledAgent.js";
 import { SymbolTable } from "../symbolTable.js";
+import type { FileSymbols } from "../symbolTable.js";
 import { existsSync, readFileSync } from "fs";
 import { validatePolicy } from "../runtime/policy.js";
 import path from "path";
+
+function uniqueInterruptKinds(fileSymbols: FileSymbols | undefined): string[] {
+  const kinds = Object.values(fileSymbols ?? {})
+    .flatMap((sym) =>
+      (sym.kind === "function" || sym.kind === "node") && sym.interruptKinds
+        ? sym.interruptKinds.map((ik) => ik.kind)
+        : [],
+    );
+  return [...new Set(kinds)];
+}
 
 export function policyGen(
   config: AgencyConfig,
@@ -24,16 +35,7 @@ export function policyGen(
 
   const symbolTable = SymbolTable.build(absoluteFile, config);
   const fileSymbols = symbolTable.getFile(absoluteFile);
-  const interruptKinds: string[] = [];
-  for (const sym of Object.values(fileSymbols ?? {})) {
-    if ((sym.kind === "function" || sym.kind === "node") && sym.interruptKinds) {
-      for (const ik of sym.interruptKinds) {
-        if (!interruptKinds.includes(ik.kind)) {
-          interruptKinds.push(ik.kind);
-        }
-      }
-    }
-  }
+  const interruptKinds = uniqueInterruptKinds(fileSymbols);
 
   if (interruptKinds.length === 0) {
     console.log("No interrupt kinds found in this agent. No policy needed.");
@@ -47,13 +49,12 @@ export function policyGen(
       console.error(`Existing policy file not found: ${options.existing}`);
       process.exit(1);
     }
-    const parsed = JSON.parse(readFileSync(existingPath, "utf-8"));
-    const result = validatePolicy(parsed);
+    existingPolicyJson = readFileSync(existingPath, "utf-8");
+    const result = validatePolicy(JSON.parse(existingPolicyJson));
     if (!result.success) {
       console.error(`Invalid existing policy: ${result.error}`);
       process.exit(1);
     }
-    existingPolicyJson = JSON.stringify(parsed);
   }
 
   const agentArgs = [

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -27,6 +27,7 @@ import { TarsecError } from "tarsec";
 import process from "process";
 import { agent } from "@/cli/agent.js";
 import { review } from "@/cli/review.js";
+import { policyGen } from "@/cli/policy.js";
 import {
   scheduleAdd,
   scheduleList,
@@ -809,6 +810,21 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .option("--standalone", "Generate a standalone server.js file")
     .action(async (file: string, options: { port?: string; apiKey?: string; standalone?: boolean }) => {
       await serveHttp(file, options);
+    });
+
+  const policyCmd = program
+    .command("policy")
+    .description("Policy management tools");
+
+  policyCmd
+    .command("gen")
+    .description("Generate an interrupt policy for an Agency agent")
+    .argument("<file>", "The .agency file to analyze")
+    .option("-o, --output <path>", "Output path for the policy file (default: policy.json)")
+    .option("-p, --existing <path>", "Existing policy file to modify")
+    .action((file: string, options: { output?: string; existing?: string }) => {
+      const config = getConfig();
+      policyGen(config, file, options);
     });
 
   addRunOptions(

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -1,4 +1,4 @@
-import { _checkPolicy, _validatePolicy } from "agency-lang/stdlib-lib/policy.js"
+import { _checkPolicy, _validatePolicy, _writePolicyFile } from "agency-lang/stdlib-lib/policy.js"
 
 export def checkPolicy(policy: object, interrupt: object) {
   """
@@ -12,4 +12,11 @@ export def validatePolicy(policy: object) {
   Validate that a policy object is well-formed. Returns { success: true } if valid, or { success: false, error: "..." } with a description of the problem.
   """
   return _validatePolicy(policy)
+}
+
+export def writePolicyFile(path: string, policy: object) {
+  """
+  Validate and write a policy to a JSON file. Throws if the policy is invalid.
+  """
+  return _writePolicyFile(path, policy)
 }


### PR DESCRIPTION
## Summary

- Add `agency policy gen <file>` CLI command that helps users create interrupt policies interactively
- A conversational agent analyzes the file's interrupt kinds (via static analysis) and guides the user through policy creation
- Adds `writePolicyFile` to `std::policy` for validated policy file writing

## How it works

1. `agency policy gen myagent.agency` compiles the file and extracts interrupt kinds from the symbol table
2. Launches a conversational agent that lists the interrupt kinds and asks what the user wants to allow
3. The agent builds the policy, shows it for approval, refines on request
4. On approval, writes `policy.json` (or custom path via `-o`)
5. `-p` flag loads an existing policy for modification

## Files

- `stdlib/policy.agency` — added `writePolicyFile(path, policy)`
- `stdlib/lib/policy.js` — backing `_writePolicyFile` implementation
- `lib/agents/policy/agent.agency` — the policy generation agent
- `lib/agents/policy/run.js` — agent runner
- `lib/agents/policy/prompts/system.md` — system prompt
- `lib/cli/policy.ts` — CLI command implementation
- `scripts/agency.ts` — wired `policy gen` subcommand

## Test plan

- [ ] `make` — build succeeds
- [ ] `pnpm run agency policy gen --help` — shows correct usage
- [ ] Manual test: run against an agent with interrupts, verify conversational flow and policy output

🤖 Generated with [Claude Code](https://claude.com/claude-code)