### PR TITLE
Add per-test and suite-wide timeouts to the agency test runner

### DIFF
--- a/packages/agency-lang/docs-new/stdlib/agency.md
+++ b/packages/agency-lang/docs-new/stdlib/agency.md
@@ -45,7 +45,7 @@ Execute a compiled Agency program in a subprocess. The parent's handler chain ex
 
   @param compiled - A CompiledProgram from compile()
   @param node - Which exported node to run
-  @param args - Arguments to pass to the node
+  @param args - Arguments to pass to the node (defaults to no args)
   @param wallClock - Max wall-clock time before SIGKILL (default 60s, max 1h)
   @param memory - Max V8 heap size (default 512mb, max 4gb)
   @param ipcPayload - Max single IPC message size (default 100mb, max 1gb)
@@ -57,7 +57,7 @@ Execute a compiled Agency program in a subprocess. The parent's handler chain ex
 |---|---|---|
 | compiled | [CompiledProgram](#compiledprogram) |  |
 | node | `string` |  |
-| args | `Record<string, any>` |  |
+| args | `Record<string, any>` | {} |
 | wallClock | `number` | 60s |
 | memory | `number` | 512mb |
 | ipcPayload | `number` | 100mb |

--- a/packages/agency-lang/lib/cli/test.ts
+++ b/packages/agency-lang/lib/cli/test.ts
@@ -36,6 +36,10 @@ type TestCase = {
   description?: string;
   retry?: number;
   skip?: boolean;
+  // Per-test timeout in milliseconds. Overrides the file-level
+  // `defaultTimeoutMs`. Falls back to DEFAULT_PER_TEST_MS when unset.
+  // Clamped to TIMEOUT_CEILINGS.perTestMs.
+  timeoutMs?: number;
 };
 type Tests = {
   sourceFile?: string;
@@ -46,7 +50,97 @@ type Tests = {
   // Optional human-readable reason for the skip; printed when the file is
   // skipped. No semantic effect.
   skipReason?: string;
+  // File-level default timeout (ms) applied to every test in this file
+  // unless the individual TestCase sets its own `timeoutMs`. Falls back
+  // to DEFAULT_PER_TEST_MS when unset.
+  defaultTimeoutMs?: number;
 };
+
+// ── Test runner timeout limits ──
+// Pattern mirrors LIMIT_CEILINGS in lib/runtime/ipc.ts: hardcoded ceilings
+// clamp any user-supplied value so a stray `"timeoutMs": 9999999999` in a
+// fixture cannot exceed our per-test or suite-wide caps.
+const TIMEOUT_CEILINGS = {
+  // A single test cannot consume more than the entire suite budget.
+  perTestMs: 30 * 60 * 1000, // 30 minutes
+  // Suite-wide ceiling. Not currently user-configurable.
+  suiteMs: 30 * 60 * 1000, // 30 minutes
+} as const;
+
+const DEFAULT_PER_TEST_MS = 2 * 60 * 1000; // 2 minutes
+
+function resolveTimeoutMs(testCase: TestCase, fileDefaults: Tests): number {
+  const requested =
+    testCase.timeoutMs ?? fileDefaults.defaultTimeoutMs ?? DEFAULT_PER_TEST_MS;
+  return Math.min(requested, TIMEOUT_CEILINGS.perTestMs);
+}
+
+// Format a millisecond duration as the largest unit that yields an integer.
+// 120000 → "2 minutes", 90000 → "90 seconds", 500 → "500 milliseconds".
+function formatTimeout(ms: number): string {
+  if (ms % 60000 === 0) {
+    const m = ms / 60000;
+    return `${m} minute${m === 1 ? "" : "s"}`;
+  }
+  if (ms % 1000 === 0) {
+    const s = ms / 1000;
+    return `${s} second${s === 1 ? "" : "s"}`;
+  }
+  return `${ms} millisecond${ms === 1 ? "" : "s"}`;
+}
+
+// Detect the rejection shape produced when execFile kills the child due to
+// our `timeout` option. Promisified execFile attaches `killed` and `signal`
+// to the error.
+function isTimeoutError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  const err = e as any;
+  return err.killed === true && err.signal === "SIGKILL";
+}
+
+// Detect the rejection shape produced when execFile is killed via the
+// AbortSignal (suite ceiling or SIGINT). Node sets `code === "ABORT_ERR"`
+// or surfaces the abort via `signal`.
+function isAbortError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false;
+  const err = e as any;
+  return err.name === "AbortError" || err.code === "ABORT_ERR";
+}
+
+// ── Suite-wide context ──
+// Bundled per the RunSession pattern in lib/runtime/ipc.ts so helpers can
+// be passed one object instead of N closure parameters.
+type AbortReason = "sigint" | "ceiling";
+type SuiteContext = {
+  aborted: boolean;
+  abortReason: AbortReason | null;
+  abortController: AbortController;
+  // Files that started running and whose runTestFile() returned normally.
+  completed: string[];
+  // Files currently being processed by a worker.
+  inFlight: Set<string>;
+  // Files that exist in the input set but have not yet been picked up.
+  // Mutated by workers as they pull items.
+  pending: Set<string>;
+};
+
+function createSuiteContext(allFiles: string[]): SuiteContext {
+  return {
+    aborted: false,
+    abortReason: null,
+    abortController: new AbortController(),
+    completed: [],
+    inFlight: new Set(),
+    pending: new Set(allFiles),
+  };
+}
+
+function triggerSuiteAbort(suite: SuiteContext, reason: AbortReason): void {
+  if (suite.aborted) return;
+  suite.aborted = true;
+  suite.abortReason = reason;
+  suite.abortController.abort();
+}
 
 function readFile(filename: string): string {
   console.log("Trying to read file", filename, "...");
@@ -381,6 +475,7 @@ async function runWithConcurrency<T, R>(
   concurrency: number,
   fn: (item: T) => Promise<R>,
   onError: (item: T, error: unknown) => R,
+  shouldAbort?: () => boolean,
 ): Promise<R[]> {
   const results: R[] = new Array(items.length);
   let nextIndex = 0;
@@ -390,6 +485,10 @@ async function runWithConcurrency<T, R>(
       // Safe: nextIndex++ is synchronous and JS is single-threaded,
       // so no two workers can read the same value before the increment.
       const index = nextIndex++;
+      // Suite abort: stop pulling new items. Items already in flight
+      // continue to settle (via their own AbortSignal-killed children),
+      // but no new files start.
+      if (shouldAbort && shouldAbort()) return;
       try {
         results[index] = await fn(items[index]);
       } catch (e) {
@@ -406,12 +505,20 @@ async function runWithConcurrency<T, R>(
   return results;
 }
 
+// Outcome of a single test attempt. "aborted" means the suite-wide
+// AbortSignal fired (ceiling or SIGINT) — distinct from a per-test
+// timeout, because the runner shouldn't keep retrying or print a per-test
+// failure message in that case.
+type SingleTestOutcome = "passed" | "failed" | "aborted";
+
 async function runSingleTest(
   config: AgencyConfig,
   testFile: string,
   testCase: TestCase,
+  timeoutMs: number,
+  signal: AbortSignal,
   log: Logger,
-): Promise<boolean> {
+): Promise<SingleTestOutcome> {
   const hasArgs = testCase.input !== "";
   const relativeSourceFilePath = testFile.replace(".test.json", ".agency");
   let result: { data: any; stdout: string; stderr: string };
@@ -423,13 +530,23 @@ async function runSingleTest(
       hasArgs,
       argsString: testCase.input,
       interruptHandlers: testCase.interruptHandlers,
+      timeoutMs,
+      signal,
     });
     if (result.stdout) log(result.stdout.trimEnd());
     if (result.stderr) log(result.stderr.trimEnd(), "stderr");
   } catch (e) {
+    if (isAbortError(e)) {
+      // Don't print a failure — the suite-abort summary will explain.
+      return "aborted";
+    }
+    if (isTimeoutError(e)) {
+      log(color.red(`  ✗ Test exceeded ${formatTimeout(timeoutMs)} timeout`));
+      return "failed";
+    }
     exitIfSignal(e);
     log(color.red(`  ✗ Test execution error: ${e}`));
-    return false;
+    return "failed";
   }
 
   let testPassed = true;
@@ -478,7 +595,7 @@ async function runSingleTest(
       }
     }
   }
-  return testPassed;
+  return testPassed ? "passed" : "failed";
 }
 
 function collectTestFiles(inputPath: string): string[] {
@@ -501,12 +618,45 @@ function collectTestFiles(inputPath: string): string[] {
   return files;
 }
 
+// Run a single test through its retry loop. Returns the final outcome.
+// "aborted" short-circuits the retry loop — no point retrying when the
+// suite is shutting down.
+async function runTestWithRetries(
+  config: AgencyConfig,
+  testFile: string,
+  testCase: TestCase,
+  timeoutMs: number,
+  signal: AbortSignal,
+  log: Logger,
+): Promise<SingleTestOutcome> {
+  const maxAttempts = (testCase.retry ?? 0) + 1;
+  let outcome: SingleTestOutcome = "failed";
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    if (attempt > 1) {
+      log(color.yellow(`  Retry ${attempt - 1}/${testCase.retry}...`));
+    }
+    try {
+      outcome = await runSingleTest(config, testFile, testCase, timeoutMs, signal, log);
+      if (outcome === "passed" || outcome === "aborted") break;
+    } catch (e) {
+      exitIfSignal(e);
+      log(color.red(`  ✗ Test error: ${e}`));
+      outcome = "failed";
+    }
+  }
+  return outcome;
+}
+
 async function runTestFile(
   config: AgencyConfig,
   testFile: string,
+  suite: SuiteContext,
 ): Promise<TestStats> {
   const logger = createBufferedLogger();
   const log = logger.log;
+
+  suite.inFlight.add(testFile);
+  suite.pending.delete(testFile);
 
   try {
     log(color.yellow(`Running tests for ${testFile}...`));
@@ -535,8 +685,16 @@ async function runTestFile(
 
     let skipped = 0;
     const slowTests: SlowTest[] = [];
+    let aborted = false;
 
     for (let i = 0; i < total; i++) {
+      // Bail between test cases if the suite is aborting. The currently
+      // in-flight execFile (if any) is killed via its AbortSignal.
+      if (suite.aborted) {
+        aborted = true;
+        break;
+      }
+
       const testCase = tests.tests[i];
       const interruptInfo = testCase.interruptHandlers
         ? ` interrupts=${testCase.interruptHandlers.length}`
@@ -555,37 +713,40 @@ async function runTestFile(
         continue;
       }
 
-      const maxAttempts = (testCase.retry ?? 0) + 1;
-      let testPassed = false;
-
+      const timeoutMs = resolveTimeoutMs(testCase, tests);
       const startTime = performance.now();
-      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-        if (attempt > 1) {
-          log(color.yellow(`  Retry ${attempt - 1}/${testCase.retry}...`));
-        }
-        try {
-          testPassed = await runSingleTest(config, testFile, testCase, log);
-          if (testPassed) break;
-        } catch (e) {
-          exitIfSignal(e);
-          log(color.red(`  ✗ Test error: ${e}`));
-          testPassed = false;
-        }
-      }
+      const outcome = await runTestWithRetries(
+        config,
+        testFile,
+        testCase,
+        timeoutMs,
+        suite.abortController.signal,
+        log,
+      );
       const durationMs = performance.now() - startTime;
+
+      if (outcome === "aborted") {
+        aborted = true;
+        break;
+      }
 
       const testName = testCase.description
         ? `${testFile} > ${testCase.nodeName} > ${testCase.description}`
         : `${testFile} > ${testCase.nodeName}(${testCase.input || ""})`;
       slowTests.push({ name: testName, durationMs });
 
-      if (testPassed) passed++;
+      if (outcome === "passed") passed++;
     }
 
     const ran = total - skipped;
     const failed = ran - passed;
     const skipMsg = skipped > 0 ? ` (${skipped} skipped)` : "";
-    log(`\n${passed}/${ran} tests passed${skipMsg}`);
+    if (!aborted) {
+      log(`\n${passed}/${ran} tests passed${skipMsg}`);
+      suite.completed.push(testFile);
+    } else {
+      log(color.yellow(`\n  ⚠️  ${testFile} aborted (${passed}/${ran} tests passed before abort)`));
+    }
 
     return {
       passed,
@@ -596,7 +757,31 @@ async function runTestFile(
       slowTests,
     };
   } finally {
+    suite.inFlight.delete(testFile);
     logger.flush();
+  }
+}
+
+// Print the suite-abort summary after the runner has drained.
+// Three categories: completed, in-flight when abort fired, never started.
+function printSuiteAbortSummary(suite: SuiteContext): void {
+  const header =
+    suite.abortReason === "sigint"
+      ? "⚠️  Interrupted by user"
+      : `⚠️  Suite-wide timeout of ${formatTimeout(TIMEOUT_CEILINGS.suiteMs)} exceeded`;
+  console.log(color.yellow(`\n${header}. Aborting.\n`));
+
+  if (suite.completed.length > 0) {
+    console.log("Completed test files:");
+    for (const f of suite.completed) console.log(`  ✓ ${f}`);
+  }
+  if (suite.inFlight.size > 0) {
+    console.log("\nTest files in flight when aborted:");
+    for (const f of suite.inFlight) console.log(color.yellow(`  - ${f}`));
+  }
+  if (suite.pending.size > 0) {
+    console.log("\nTest files that did not start:");
+    for (const f of suite.pending) console.log(color.yellow(`  - ${f}`));
   }
 }
 
@@ -610,27 +795,58 @@ export async function test(
     testFiles.push(...collectTestFiles(inputPath));
   }
 
-  const results = await runWithConcurrency(
-    testFiles,
-    sanitizeParallel(parallel),
-    (testFile) => runTestFile(config, testFile),
-    (testFile, error) => {
-      console.error(color.red(`  ✗ Test file error: ${testFile}: ${error}`));
-      return {
-        passed: 0,
-        failed: 1,
-        filesPassed: 0,
-        filesFailed: 1,
-        failedFiles: [testFile],
-        slowTests: [],
-      };
-    },
-  );
+  const suite = createSuiteContext(testFiles);
+
+  // Suite-wide ceiling. When fired, flips the abort flag, which causes:
+  //   - workers to stop pulling new files (runWithConcurrency check)
+  //   - in-flight execFile children to be SIGKILL'd (AbortSignal)
+  //   - runTestFile loops to break between cases
+  const ceilingTimer = setTimeout(() => {
+    triggerSuiteAbort(suite, "ceiling");
+  }, TIMEOUT_CEILINGS.suiteMs);
+  // Don't keep the process alive just for this timer.
+  ceilingTimer.unref?.();
+
+  // Graceful Ctrl+C: first SIGINT triggers the same drain-and-summarize
+  // flow as the ceiling. A SECOND SIGINT falls through to Node's default
+  // handler (immediate exit) — critical safety valve so the user can
+  // always escape if our drain logic itself hangs.
+  const sigintHandler = () => {
+    triggerSuiteAbort(suite, "sigint");
+  };
+  process.once("SIGINT", sigintHandler);
+
+  let results: TestStats[] = [];
+  try {
+    results = await runWithConcurrency(
+      testFiles,
+      sanitizeParallel(parallel),
+      (testFile) => runTestFile(config, testFile, suite),
+      (testFile, error) => {
+        console.error(color.red(`  ✗ Test file error: ${testFile}: ${error}`));
+        return {
+          passed: 0,
+          failed: 1,
+          filesPassed: 0,
+          filesFailed: 1,
+          failedFiles: [testFile],
+          slowTests: [],
+        };
+      },
+      () => suite.aborted,
+    );
+  } finally {
+    clearTimeout(ceilingTimer);
+    process.removeListener("SIGINT", sigintHandler);
+  }
 
   let stats = emptyStats();
   for (const result of results) {
-    stats = mergeStats(stats, result);
+    if (result) stats = mergeStats(stats, result);
   }
+
+  if (suite.aborted) printSuiteAbortSummary(suite);
+
   return stats;
 }
 

--- a/packages/agency-lang/lib/cli/test.ts
+++ b/packages/agency-lang/lib/cli/test.ts
@@ -61,8 +61,11 @@ type Tests = {
 // clamp any user-supplied value so a stray `"timeoutMs": 9999999999` in a
 // fixture cannot exceed our per-test or suite-wide caps.
 const TIMEOUT_CEILINGS = {
-  // A single test cannot consume more than the entire suite budget.
-  perTestMs: 30 * 60 * 1000, // 30 minutes
+  // A single test cannot consume more than 5 minutes — keeps a single
+  // misconfigured test from monopolizing the suite budget. The default
+  // (DEFAULT_PER_TEST_MS) sits well under this so most fixtures are
+  // untouched.
+  perTestMs: 5 * 60 * 1000, // 5 minutes
   // Suite-wide ceiling. Not currently user-configurable.
   suiteMs: 30 * 60 * 1000, // 30 minutes
 } as const;
@@ -72,7 +75,10 @@ const DEFAULT_PER_TEST_MS = 2 * 60 * 1000; // 2 minutes
 function resolveTimeoutMs(testCase: TestCase, fileDefaults: Tests): number {
   const requested =
     testCase.timeoutMs ?? fileDefaults.defaultTimeoutMs ?? DEFAULT_PER_TEST_MS;
-  return Math.min(requested, TIMEOUT_CEILINGS.perTestMs);
+  // Clamp to >= 1ms: Node treats `timeout: 0` (and negative) as "no
+  // timeout", which would defeat the entire defensive-timeout goal.
+  // Clamp to <= ceiling so a stray huge value can't escape the cap.
+  return Math.min(Math.max(1, requested), TIMEOUT_CEILINGS.perTestMs);
 }
 
 // Format a millisecond duration as the largest unit that yields an integer.
@@ -122,6 +128,11 @@ type SuiteContext = {
   // Files that exist in the input set but have not yet been picked up.
   // Mutated by workers as they pull items.
   pending: Set<string>;
+  // Snapshot of `inFlight` taken at the moment of abort. Needed for the
+  // summary because `runTestFile` removes itself from `inFlight` in its
+  // `finally` — so by the time the summary prints (after the runner has
+  // drained), `inFlight` is empty.
+  inFlightAtAbort: string[];
 };
 
 function createSuiteContext(allFiles: string[]): SuiteContext {
@@ -132,6 +143,7 @@ function createSuiteContext(allFiles: string[]): SuiteContext {
     completed: [],
     inFlight: new Set(),
     pending: new Set(allFiles),
+    inFlightAtAbort: [],
   };
 }
 
@@ -139,6 +151,8 @@ function triggerSuiteAbort(suite: SuiteContext, reason: AbortReason): void {
   if (suite.aborted) return;
   suite.aborted = true;
   suite.abortReason = reason;
+  // Snapshot in-flight files NOW, before workers' `finally` blocks drain.
+  suite.inFlightAtAbort = [...suite.inFlight];
   suite.abortController.abort();
 }
 
@@ -470,14 +484,18 @@ function sanitizeParallel(parallel: number): number {
     : 1;
 }
 
+// Returns `(R | undefined)[]` (not `R[]`) because workers can exit
+// early when `shouldAbort()` becomes true, leaving holes in the result
+// array. Callers must handle `undefined` entries (typically: skip them
+// during result aggregation).
 async function runWithConcurrency<T, R>(
   items: T[],
   concurrency: number,
   fn: (item: T) => Promise<R>,
   onError: (item: T, error: unknown) => R,
   shouldAbort?: () => boolean,
-): Promise<R[]> {
-  const results: R[] = new Array(items.length);
+): Promise<(R | undefined)[]> {
+  const results: (R | undefined)[] = new Array(items.length);
   let nextIndex = 0;
 
   async function worker() {
@@ -775,9 +793,9 @@ function printSuiteAbortSummary(suite: SuiteContext): void {
     console.log("Completed test files:");
     for (const f of suite.completed) console.log(`  ✓ ${f}`);
   }
-  if (suite.inFlight.size > 0) {
+  if (suite.inFlightAtAbort.length > 0) {
     console.log("\nTest files in flight when aborted:");
-    for (const f of suite.inFlight) console.log(color.yellow(`  - ${f}`));
+    for (const f of suite.inFlightAtAbort) console.log(color.yellow(`  - ${f}`));
   }
   if (suite.pending.size > 0) {
     console.log("\nTest files that did not start:");
@@ -816,7 +834,7 @@ export async function test(
   };
   process.once("SIGINT", sigintHandler);
 
-  let results: TestStats[] = [];
+  let results: (TestStats | undefined)[] = [];
   try {
     results = await runWithConcurrency(
       testFiles,
@@ -985,7 +1003,9 @@ export async function testTs(config: AgencyConfig, inputPaths: string[], paralle
     }
   }
 
-  const results = await runWithConcurrency(
+  // testTs doesn't pass `shouldAbort`, so no entries can be undefined,
+  // but `runWithConcurrency`'s type allows for it — drop them defensively.
+  const rawResults = await runWithConcurrency(
     allDirs,
     sanitizeParallel(parallel),
     (dir) => runTsTestDir(config, dir),
@@ -994,6 +1014,7 @@ export async function testTs(config: AgencyConfig, inputPaths: string[], paralle
       return { success: false, dir };
     },
   );
+  const results = rawResults.filter((r): r is { success: boolean; dir: string } => r !== undefined);
 
   const successes = results.filter((r) => r.success);
   const failures = results.filter((r) => !r.success);

--- a/packages/agency-lang/lib/cli/util.ts
+++ b/packages/agency-lang/lib/cli/util.ts
@@ -188,6 +188,14 @@ type ExecuteNodeArgs = {
   hasArgs: boolean;
   argsString: string;
   interruptHandlers?: InterruptHandler[];
+  // Per-call timeout (ms). When exceeded, execFile sends `killSignal` to
+  // the child (we use SIGKILL — these are spinning subprocesses we want
+  // dead, not given a chance to handle SIGTERM).
+  timeoutMs?: number;
+  // Suite-wide AbortSignal. When aborted (suite ceiling hit, or SIGINT
+  // from user), the in-flight child is killed via execFile's signal
+  // handling. Used by the test runner; safe to omit elsewhere.
+  signal?: AbortSignal;
 };
 
 export async function executeNodeAsync({
@@ -197,6 +205,8 @@ export async function executeNodeAsync({
   hasArgs,
   argsString,
   interruptHandlers,
+  timeoutMs,
+  signal,
 }: ExecuteNodeArgs): Promise<{ data: any; stdout: string; stderr: string }> {
   let evaluateFile = "";
   let resultsFile = "";
@@ -235,8 +245,12 @@ export async function executeNodeAsync({
       resultsFilename: resultsFile,
     });
     fs.writeFileSync(evaluateFile, evaluateScript);
+    // SIGKILL (not SIGTERM) for timeout: these can be spinning subprocesses
+    // (`while(true)`) where SIGTERM might be ignored. SIGKILL is uncatchable.
     const { stdout, stderr } = await execFileAsync("node", [evaluateFile], {
       maxBuffer: 10 * 1024 * 1024,
+      ...(timeoutMs !== undefined ? { timeout: timeoutMs, killSignal: "SIGKILL" as const } : {}),
+      ...(signal !== undefined ? { signal } : {}),
     });
     const results = readFileSync(resultsFile, "utf-8");
     return { data: JSON.parse(results).data, stdout, stderr };

--- a/packages/agency-lang/lib/cli/util.ts
+++ b/packages/agency-lang/lib/cli/util.ts
@@ -245,12 +245,17 @@ export async function executeNodeAsync({
       resultsFilename: resultsFile,
     });
     fs.writeFileSync(evaluateFile, evaluateScript);
-    // SIGKILL (not SIGTERM) for timeout: these can be spinning subprocesses
-    // (`while(true)`) where SIGTERM might be ignored. SIGKILL is uncatchable.
+    // SIGKILL (not SIGTERM) for both the `timeout` AND `signal` paths:
+    // these can be spinning subprocesses (`while(true)`) where SIGTERM
+    // might be ignored. SIGKILL is uncatchable. Setting `killSignal`
+    // covers both the per-call `timeout` option and the AbortSignal
+    // (suite-ceiling/SIGINT) path, which otherwise default to SIGTERM.
+    const wantsKill = timeoutMs !== undefined || signal !== undefined;
     const { stdout, stderr } = await execFileAsync("node", [evaluateFile], {
       maxBuffer: 10 * 1024 * 1024,
-      ...(timeoutMs !== undefined ? { timeout: timeoutMs, killSignal: "SIGKILL" as const } : {}),
+      ...(timeoutMs !== undefined ? { timeout: timeoutMs } : {}),
       ...(signal !== undefined ? { signal } : {}),
+      ...(wantsKill ? { killSignal: "SIGKILL" as const } : {}),
     });
     const results = readFileSync(resultsFile, "utf-8");
     return { data: JSON.parse(results).data, stdout, stderr };

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -15,7 +15,7 @@ export def compile(source: string): Result {
 export def run(
   compiled: CompiledProgram,
   node: string,
-  args: object,
+  args: object = {},
   wallClock: number = 60s,
   memory: number = 512mb,
   ipcPayload: number = 100mb,
@@ -28,7 +28,7 @@ export def run(
 
   @param compiled - A CompiledProgram from compile()
   @param node - Which exported node to run
-  @param args - Arguments to pass to the node
+  @param args - Arguments to pass to the node (defaults to no args)
   @param wallClock - Max wall-clock time before SIGKILL (default 60s, max 1h)
   @param memory - Max V8 heap size (default 512mb, max 4gb)
   @param ipcPayload - Max single IPC message size (default 100mb, max 1gb)

--- a/packages/agency-lang/tests/agency-js/subprocess-no-handler/agent.agency
+++ b/packages/agency-lang/tests/agency-js/subprocess-no-handler/agent.agency
@@ -6,6 +6,6 @@ node main() {
     return "compile failed"
   }
   const compiled = compileResult.value
-  const result = run(compiled, "main", {})
+  const result = run(compiled: compiled, node: "main", args: {})
   return result
 }

--- a/packages/agency-lang/tests/agency-js/subprocess-no-handler/agent.agency
+++ b/packages/agency-lang/tests/agency-js/subprocess-no-handler/agent.agency
@@ -6,6 +6,6 @@ node main() {
     return "compile failed"
   }
   const compiled = compileResult.value
-  const result = run(compiled, { node: "main", args: {} })
+  const result = run(compiled, "main", {})
   return result
 }

--- a/packages/agency-lang/tests/agency-js/subprocess-no-handler/agent.agency
+++ b/packages/agency-lang/tests/agency-js/subprocess-no-handler/agent.agency
@@ -6,6 +6,6 @@ node main() {
     return "compile failed"
   }
   const compiled = compileResult.value
-  const result = run(compiled: compiled, node: "main", args: {})
+  const result = run(compiled: compiled, node: "main")
   return result
 }


### PR DESCRIPTION
## Motivation

Defensive timeouts for `pnpm run agency test ...` so a busted fixture (especially the new subprocess `limit-*` fixtures from #119) cannot hang the runner indefinitely.

This came up as PR review feedback on #119: several of the new subprocess limit fixtures can run for an hour or longer if their assertion logic regresses, and there was no defensive timeout in the test framework itself.

## Spec

- **Per-test default**: 2 minutes, configurable per-test via `timeoutMs` in `.test.json` or per-file via `defaultTimeoutMs`. Hard-clamped to 30 minutes.
- **Suite-wide ceiling**: 30 minutes. On expiry, abort cleanly and print a summary of which tests had completed.
- **Per-test timeout**: mark the failing test as failed with a clear "exceeded N timeout" message, then **continue** to the next test. Do NOT abort the suite.
- **SIGINT (Ctrl+C)**: same drain-and-summarize flow. Second Ctrl+C falls through to Node's default handler so the user can always escape.

## Implementation

Hardcoded ceilings + clamping mirror the `LIMIT_CEILINGS` / `clampLimits` pattern in `lib/runtime/ipc.ts`. State threading uses a `SuiteContext` bundle, mirroring the `RunSession` refactor in the same file.

**`lib/cli/util.ts`**
- `ExecuteNodeArgs` gains optional `timeoutMs` and `signal` fields, piped into `execFile`'s built-in `timeout` and `signal` options. `killSignal: "SIGKILL"` (uncatchable) because spinning subprocesses can ignore SIGTERM.

**`lib/cli/test.ts`**
- New schema fields: `TestCase.timeoutMs?`, `Tests.defaultTimeoutMs?`.
- New constants: `TIMEOUT_CEILINGS = { perTestMs: 30min, suiteMs: 30min }`, `DEFAULT_PER_TEST_MS = 2min`.
- New `SuiteContext` type with `aborted`, `abortReason`, `abortController`, plus `completed` / `inFlight` / `pending` file lists for the abort summary.
- `runWithConcurrency` gains an optional `shouldAbort` predicate so workers stop pulling new items after abort.
- `runSingleTest` returns `SingleTestOutcome` (`"passed" | "failed" | "aborted"`) instead of `bool`. `aborted` short-circuits retries and skips the per-test failure print (the suite summary explains).
- `runTestWithRetries` extracted from `runTestFile`.
- `runTestFile` registers itself in `inFlight`, checks the abort flag between cases, joins `completed` on normal return.
- `test()` starts a `setTimeout(suiteMs)` ceiling timer (`unref`'d) and installs `process.once("SIGINT", ...)`. Both cleared in `finally`. Prints the three-category abort summary if `suite.aborted`.

## Verification

- **Per-test timeout**: spinning `while(true)` fixture with `"timeoutMs": 1500` killed at 1.55s with `"✗ Test exceeded 1500 milliseconds timeout"`; subsequent test in the same file ran and passed.
- **SIGINT graceful abort**: SIGINT during a spinning test → child SIGKILL'd, `"⚠️  Interrupted by user. Aborting."` summary printed, exit code 1.
- **Full agency suite** (`pnpm run test:agency`): 523/523 tests pass, no regressions.
- **Unit suite** (`pnpm test:run`): 2963/2963 tests pass.
- **`make`**: clean build.

## Notes

- Suite-wide ceiling is currently hardcoded (not user-configurable); the `30 minute` value matches the per-test ceiling deliberately so a single test cannot exceed the whole suite's budget.
- `process.once` (not `on`) for SIGINT is intentional: a second Ctrl+C must always be able to hard-kill the runner if our drain logic itself hangs.
