### PR TITLE
Add standalone server bundling for serve http and serve mcp

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -17,7 +17,7 @@ import {
   VariableType,
 } from "../types.js";
 import path from "path";
-import { formatTypeHint, formatTypeHintTs } from "@/cli/util.js";
+import { formatTypeHint, formatTypeHintTs } from "@/utils/formatType.js";
 import {
   BUILTIN_FUNCTIONS,
   BUILTIN_TOOLS,

--- a/packages/agency-lang/lib/cli/serve.ts
+++ b/packages/agency-lang/lib/cli/serve.ts
@@ -1,7 +1,7 @@
 import fs from "fs";
 import path from "path";
 import process from "process";
-import { pathToFileURL } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import { compile, loadConfig } from "./commands.js";
 import { SymbolTable } from "../symbolTable.js";
 import { parseAgency } from "../parser.js";
@@ -85,12 +85,18 @@ async function loadAndDiscover(
 
 export async function serveMcp(
   file: string,
-  options: { name?: string },
+  options: { name?: string; standalone?: boolean },
 ): Promise<void> {
   const compileResult = compileForServe(file);
-  const { exports, moduleExports } = await loadAndDiscover(compileResult);
 
   const serverName = options.name ?? path.basename(file, ".agency");
+
+  if (options.standalone) {
+    await generateStandalone("mcp", compileResult, file, { serverName });
+    return;
+  }
+
+  const { exports, moduleExports } = await loadAndDiscover(compileResult);
   const policyStore = new PolicyStore(serverName);
 
   // The compiled module's hasInterrupts checks raw data, but respondToInterrupts
@@ -122,20 +128,29 @@ export async function serveMcp(
 
 export async function serveHttp(
   file: string,
-  options: { port?: string; apiKey?: string; standalone?: boolean },
+  options: {
+    port?: string;
+    apiKey?: string;
+    apiKeyEnv?: string;
+    standalone?: boolean;
+  },
 ): Promise<void> {
   const compileResult = compileForServe(file);
 
-  if (options.standalone) {
-    await generateStandalone(compileResult.outputPath, file);
-    return;
-  }
-
-  const { exports, moduleExports } = await loadAndDiscover(compileResult);
   const port = parseInt(options.port ?? "3545", 10);
   if (isNaN(port) || port < 1 || port > 65535) {
     throw new Error(`Invalid port: ${options.port}`);
   }
+
+  if (options.standalone) {
+    await generateStandalone("http", compileResult, file, {
+      port,
+      apiKeyEnv: options.apiKeyEnv ?? "API_KEY",
+    });
+    return;
+  }
+
+  const { exports, moduleExports } = await loadAndDiscover(compileResult);
   const logger = createLogger("info");
 
   startHttpServer({
@@ -151,22 +166,162 @@ export async function serveHttp(
   });
 }
 
+type StandaloneHttpOptions = { port: number; apiKeyEnv: string };
+type StandaloneMcpOptions = { serverName: string };
+
+/**
+ * Resolve an absolute path inside `dist/` from the currently running compiled
+ * file. At runtime this file lives at `dist/lib/cli/serve.js`, so we go up two
+ * levels to reach `dist/` and then join the requested path.
+ */
+function distPath(relativeToDist: string): string {
+  const here = fileURLToPath(import.meta.url);
+  const distDir = path.resolve(path.dirname(here), "..", "..");
+  return path.join(distDir, relativeToDist);
+}
+
+function buildHttpEntrypoint(
+  compiledAbsPath: string,
+  compileResult: CompileResult,
+  options: StandaloneHttpOptions,
+): string {
+  const discoveryPath = distPath("lib/serve/discovery.js");
+  const httpAdapterPath = distPath("lib/serve/http/adapter.js");
+  const loggerPath = distPath("lib/logger.js");
+
+  return `import * as mod from ${JSON.stringify(compiledAbsPath)};
+import { discoverExports } from ${JSON.stringify(discoveryPath)};
+import { startHttpServer } from ${JSON.stringify(httpAdapterPath)};
+import { createLogger } from ${JSON.stringify(loggerPath)};
+
+const exportedNodeNames = ${JSON.stringify(compileResult.exportedNodeNames)};
+const interruptKindsByName = ${JSON.stringify(compileResult.interruptKindsByName)};
+
+const exports = discoverExports({
+  toolRegistry: mod.__toolRegistry ?? {},
+  moduleExports: mod,
+  moduleId: ${JSON.stringify(compileResult.moduleId)},
+  exportedNodeNames,
+  interruptKindsByName,
+});
+
+const port = parseInt(process.env.PORT ?? ${JSON.stringify(String(options.port))}, 10);
+const apiKey = process.env[${JSON.stringify(options.apiKeyEnv)}];
+
+startHttpServer({
+  exports,
+  port,
+  apiKey,
+  logger: createLogger("info"),
+  hasInterrupts: mod.hasInterrupts,
+  respondToInterrupts: mod.respondToInterrupts,
+});
+`;
+}
+
+function buildMcpEntrypoint(
+  compiledAbsPath: string,
+  compileResult: CompileResult,
+  options: StandaloneMcpOptions,
+  serverVersion: string,
+): string {
+  const discoveryPath = distPath("lib/serve/discovery.js");
+  const mcpAdapterPath = distPath("lib/serve/mcp/adapter.js");
+  const policyStorePath = distPath("lib/serve/policyStore.js");
+
+  return `import * as mod from ${JSON.stringify(compiledAbsPath)};
+import { discoverExports } from ${JSON.stringify(discoveryPath)};
+import { createMcpHandler, startStdioServer } from ${JSON.stringify(mcpAdapterPath)};
+import { PolicyStore } from ${JSON.stringify(policyStorePath)};
+
+const exportedNodeNames = ${JSON.stringify(compileResult.exportedNodeNames)};
+const interruptKindsByName = ${JSON.stringify(compileResult.interruptKindsByName)};
+
+const exports = discoverExports({
+  toolRegistry: mod.__toolRegistry ?? {},
+  moduleExports: mod,
+  moduleId: ${JSON.stringify(compileResult.moduleId)},
+  exportedNodeNames,
+  interruptKindsByName,
+});
+
+const serverName = ${JSON.stringify(options.serverName)};
+const policyStore = new PolicyStore(serverName);
+
+const interruptHandlers = {
+  hasInterrupts: mod.hasInterrupts,
+  respondToInterrupts: async (interrupts, responses) => {
+    const wrapped = await mod.respondToInterrupts(interrupts, responses);
+    return wrapped.data;
+  },
+};
+
+const handler = createMcpHandler({
+  serverName,
+  serverVersion: ${JSON.stringify(serverVersion)},
+  exports,
+  policyConfig: { policyStore, interruptHandlers },
+});
+
+startStdioServer(handler);
+`;
+}
+
 async function generateStandalone(
-  compiledPath: string,
+  mode: "http" | "mcp",
+  compileResult: CompileResult,
   originalFile: string,
+  options: StandaloneHttpOptions | StandaloneMcpOptions,
 ): Promise<void> {
-  const outfile = path.basename(originalFile, ".agency") + ".server.js";
+  const baseName = path.basename(originalFile, ".agency");
+  const outfile = baseName + ".server.js";
+  const compiledAbsPath = path.resolve(compileResult.outputPath);
+  const entrypointPath = path.join(
+    path.dirname(compiledAbsPath),
+    `${baseName}.standalone-entry.mjs`,
+  );
 
-  await esbuild.build({
-    entryPoints: [compiledPath],
-    bundle: true,
-    platform: "node",
-    format: "esm",
-    outfile,
-    banner: {
-      js: "// Generated by Agency — standalone HTTP server\n",
-    },
-  });
+  const entrypointSource =
+    mode === "http"
+      ? buildHttpEntrypoint(
+          compiledAbsPath,
+          compileResult,
+          options as StandaloneHttpOptions,
+        )
+      : buildMcpEntrypoint(
+          compiledAbsPath,
+          compileResult,
+          options as StandaloneMcpOptions,
+          VERSION,
+        );
 
-  console.log(`Standalone server written to ${outfile}`);
+  fs.writeFileSync(entrypointPath, entrypointSource);
+
+  try {
+    await esbuild.build({
+      entryPoints: [entrypointPath],
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      outfile,
+      external: [
+        "node-llama-cpp",
+        "node-llama-cpp/*",
+        "@node-llama-cpp/*",
+        "@reflink/*",
+      ],
+      banner: {
+        js:
+          '// Generated by Agency — standalone ' +
+          mode +
+          ' server\n' +
+          'import { createRequire as __createRequire } from "module"; const require = __createRequire(import.meta.url);',
+      },
+    });
+  } finally {
+    if (fs.existsSync(entrypointPath)) fs.unlinkSync(entrypointPath);
+    if (fs.existsSync(compiledAbsPath)) fs.unlinkSync(compiledAbsPath);
+  }
+
+  console.log(`Standalone ${mode} server written to ${outfile}`);
 }

--- a/packages/agency-lang/lib/cli/serve.ts
+++ b/packages/agency-lang/lib/cli/serve.ts
@@ -17,6 +17,8 @@ import type { InterruptKind } from "../symbolTable.js";
 import type { InterruptHandlers } from "../serve/mcp/interruptLoop.js";
 import { PolicyStore } from "../serve/policyStore.js";
 import * as esbuild from "esbuild";
+import renderStandaloneHttp from "../templates/cli/standaloneHttp.js";
+import renderStandaloneMcp from "../templates/cli/standaloneMcp.js";
 
 type CompileResult = {
   outputPath: string;
@@ -143,11 +145,22 @@ export async function serveHttp(
   }
 
   if (options.standalone) {
+    if (options.apiKey !== undefined) {
+      throw new Error(
+        "--api-key cannot be used with --standalone. The standalone bundle reads the key from an environment variable at runtime; use --api-key-env <name> to choose which one (default: API_KEY).",
+      );
+    }
     await generateStandalone("http", compileResult, file, {
       port,
       apiKeyEnv: options.apiKeyEnv ?? "API_KEY",
     });
     return;
+  }
+
+  if (options.apiKeyEnv !== undefined) {
+    console.warn(
+      "--api-key-env is only used with --standalone; it is ignored when serving directly.",
+    );
   }
 
   const { exports, moduleExports } = await loadAndDiscover(compileResult);
@@ -172,12 +185,18 @@ type StandaloneMcpOptions = { serverName: string };
 /**
  * Resolve an absolute path inside `dist/` from the currently running compiled
  * file. At runtime this file lives at `dist/lib/cli/serve.js`, so we go up two
- * levels to reach `dist/` and then join the requested path.
+ * levels to reach `dist/` and then join the requested path. The result is
+ * normalized to forward slashes so it works as an import specifier on Windows
+ * (esbuild does not accept backslash-separated import paths).
  */
 function distPath(relativeToDist: string): string {
   const here = fileURLToPath(import.meta.url);
   const distDir = path.resolve(path.dirname(here), "..", "..");
-  return path.join(distDir, relativeToDist);
+  return toPosixPath(path.join(distDir, relativeToDist));
+}
+
+function toPosixPath(p: string): string {
+  return p.replace(/\\/g, "/");
 }
 
 function buildHttpEntrypoint(
@@ -185,38 +204,17 @@ function buildHttpEntrypoint(
   compileResult: CompileResult,
   options: StandaloneHttpOptions,
 ): string {
-  const discoveryPath = distPath("lib/serve/discovery.js");
-  const httpAdapterPath = distPath("lib/serve/http/adapter.js");
-  const loggerPath = distPath("lib/logger.js");
-
-  return `import * as mod from ${JSON.stringify(compiledAbsPath)};
-import { discoverExports } from ${JSON.stringify(discoveryPath)};
-import { startHttpServer } from ${JSON.stringify(httpAdapterPath)};
-import { createLogger } from ${JSON.stringify(loggerPath)};
-
-const exportedNodeNames = ${JSON.stringify(compileResult.exportedNodeNames)};
-const interruptKindsByName = ${JSON.stringify(compileResult.interruptKindsByName)};
-
-const exports = discoverExports({
-  toolRegistry: mod.__toolRegistry ?? {},
-  moduleExports: mod,
-  moduleId: ${JSON.stringify(compileResult.moduleId)},
-  exportedNodeNames,
-  interruptKindsByName,
-});
-
-const port = parseInt(process.env.PORT ?? ${JSON.stringify(String(options.port))}, 10);
-const apiKey = process.env[${JSON.stringify(options.apiKeyEnv)}];
-
-startHttpServer({
-  exports,
-  port,
-  apiKey,
-  logger: createLogger("info"),
-  hasInterrupts: mod.hasInterrupts,
-  respondToInterrupts: mod.respondToInterrupts,
-});
-`;
+  return renderStandaloneHttp({
+    compiledModulePath: JSON.stringify(toPosixPath(compiledAbsPath)),
+    discoveryPath: JSON.stringify(distPath("lib/serve/discovery.js")),
+    httpAdapterPath: JSON.stringify(distPath("lib/serve/http/adapter.js")),
+    loggerPath: JSON.stringify(distPath("lib/logger.js")),
+    moduleId: JSON.stringify(compileResult.moduleId),
+    exportedNodeNamesJson: JSON.stringify(compileResult.exportedNodeNames),
+    interruptKindsByNameJson: JSON.stringify(compileResult.interruptKindsByName),
+    defaultPort: JSON.stringify(String(options.port)),
+    apiKeyEnv: JSON.stringify(options.apiKeyEnv),
+  });
 }
 
 function buildMcpEntrypoint(
@@ -225,46 +223,17 @@ function buildMcpEntrypoint(
   options: StandaloneMcpOptions,
   serverVersion: string,
 ): string {
-  const discoveryPath = distPath("lib/serve/discovery.js");
-  const mcpAdapterPath = distPath("lib/serve/mcp/adapter.js");
-  const policyStorePath = distPath("lib/serve/policyStore.js");
-
-  return `import * as mod from ${JSON.stringify(compiledAbsPath)};
-import { discoverExports } from ${JSON.stringify(discoveryPath)};
-import { createMcpHandler, startStdioServer } from ${JSON.stringify(mcpAdapterPath)};
-import { PolicyStore } from ${JSON.stringify(policyStorePath)};
-
-const exportedNodeNames = ${JSON.stringify(compileResult.exportedNodeNames)};
-const interruptKindsByName = ${JSON.stringify(compileResult.interruptKindsByName)};
-
-const exports = discoverExports({
-  toolRegistry: mod.__toolRegistry ?? {},
-  moduleExports: mod,
-  moduleId: ${JSON.stringify(compileResult.moduleId)},
-  exportedNodeNames,
-  interruptKindsByName,
-});
-
-const serverName = ${JSON.stringify(options.serverName)};
-const policyStore = new PolicyStore(serverName);
-
-const interruptHandlers = {
-  hasInterrupts: mod.hasInterrupts,
-  respondToInterrupts: async (interrupts, responses) => {
-    const wrapped = await mod.respondToInterrupts(interrupts, responses);
-    return wrapped.data;
-  },
-};
-
-const handler = createMcpHandler({
-  serverName,
-  serverVersion: ${JSON.stringify(serverVersion)},
-  exports,
-  policyConfig: { policyStore, interruptHandlers },
-});
-
-startStdioServer(handler);
-`;
+  return renderStandaloneMcp({
+    compiledModulePath: JSON.stringify(toPosixPath(compiledAbsPath)),
+    discoveryPath: JSON.stringify(distPath("lib/serve/discovery.js")),
+    mcpAdapterPath: JSON.stringify(distPath("lib/serve/mcp/adapter.js")),
+    policyStorePath: JSON.stringify(distPath("lib/serve/policyStore.js")),
+    moduleId: JSON.stringify(compileResult.moduleId),
+    exportedNodeNamesJson: JSON.stringify(compileResult.exportedNodeNames),
+    interruptKindsByNameJson: JSON.stringify(compileResult.interruptKindsByName),
+    serverName: JSON.stringify(options.serverName),
+    serverVersion: JSON.stringify(serverVersion),
+  });
 }
 
 async function generateStandalone(
@@ -320,7 +289,6 @@ async function generateStandalone(
     });
   } finally {
     if (fs.existsSync(entrypointPath)) fs.unlinkSync(entrypointPath);
-    if (fs.existsSync(compiledAbsPath)) fs.unlinkSync(compiledAbsPath);
   }
 
   console.log(`Standalone ${mode} server written to ${outfile}`);

--- a/packages/agency-lang/lib/cli/util.ts
+++ b/packages/agency-lang/lib/cli/util.ts
@@ -334,66 +334,15 @@ export function executeNode(args: ExecuteNodeArgs): {
   return JSON.parse(results);
 }
 
-/** Maps Agency primitive type names to their TypeScript equivalents. */
-const TS_PRIMITIVE_ALIASES: Record<string, string> = {
-  regex: "RegExp",
-};
-
-/**
- * Format a VariableType for display.
- *
- * Pass `primitiveAliases` (e.g. for codegen) to substitute Agency-only
- * primitive names with target-language equivalents. Default omits the map
- * so diagnostics, LSP hover, and CLI prompts show source-level keywords.
- */
-export function formatTypeHint(
-  vt: VariableType,
-  primitiveAliases?: Record<string, string>,
-): string {
-  const recurse = (v: VariableType) => formatTypeHint(v, primitiveAliases);
-  switch (vt.type) {
-    case "primitiveType":
-      return primitiveAliases?.[vt.value] ?? vt.value;
-    case "arrayType":
-      return `${recurse(vt.elementType)}[]`;
-    case "stringLiteralType":
-      return `"${vt.value}"`;
-    case "numberLiteralType":
-      return vt.value;
-    case "booleanLiteralType":
-      return vt.value;
-    case "unionType":
-      return vt.types.map(recurse).join(" | ");
-    case "objectType":
-      return `{ ${vt.properties.map((p) => `${p.key}: ${recurse(p.value)}`).join(", ")} }`;
-    case "typeAliasVariable":
-      return vt.aliasName;
-    case "blockType": {
-      const params = vt.params.map((p) => recurse(p.typeAnnotation)).join(", ");
-      return `(${params}) => ${recurse(vt.returnType)}`;
-    }
-    case "resultType": {
-      const s = recurse(vt.successType);
-      const f = recurse(vt.failureType);
-      if (s === "any" && f === "any") return "Result";
-      return `Result<${s}, ${f}>`;
-    }
-    case "functionRefType": {
-      const params = vt.params
-        .map((p) => `${p.name}${p.typeHint ? `: ${recurse(p.typeHint)}` : ""}`)
-        .join(", ");
-      const ret = vt.returnType ? `: ${recurse(vt.returnType)}` : "";
-      return `function ${vt.name}(${params})${ret}`;
-    }
-    default:
-      throw new Error(`Unknown variable type: ${(vt as any).type}`);
-  }
-}
-
-/** Convenience wrapper for codegen contexts. */
-export function formatTypeHintTs(vt: VariableType): string {
-  return formatTypeHint(vt, TS_PRIMITIVE_ALIASES);
-}
+// Re-exported for backward compatibility. The implementation lives in
+// lib/utils/formatType.ts to avoid pulling in `prompts` (and its CJS
+// readline dependency) when only the typechecker/LSP/codegen need it.
+export {
+  formatTypeHint,
+  formatTypeHintTs,
+  TS_PRIMITIVE_ALIASES,
+} from "../utils/formatType.js";
+import { formatTypeHint } from "../utils/formatType.js";
 
 function serializeArgValue(value: string): string {
   const num = Number(value);

--- a/packages/agency-lang/lib/debugger/ui.ts
+++ b/packages/agency-lang/lib/debugger/ui.ts
@@ -10,7 +10,7 @@ import {
   type KeyEvent,
 } from "@/tui/index.js";
 import { readFileSync } from "fs";
-import { formatTypeHint } from "../cli/util.js";
+import { formatTypeHint } from "../utils/formatType.js";
 import type { Checkpoint } from "../runtime/state/checkpointStore.js";
 import type { FunctionParameter } from "../types.js";
 import type { DebuggerCommand, DebuggerIO } from "./types.js";

--- a/packages/agency-lang/lib/lsp/completion.ts
+++ b/packages/agency-lang/lib/lsp/completion.ts
@@ -2,7 +2,7 @@ import path from "path";
 import fs from "fs";
 import { CompletionItem, CompletionItemKind, InsertTextFormat } from "vscode-languageserver-protocol";
 import { CompilationUnit, GLOBAL_SCOPE_KEY } from "../compilationUnit.js";
-import { formatTypeHint } from "../cli/util.js";
+import { formatTypeHint } from "../utils/formatType.js";
 import { resolveType } from "../typeChecker/assignability.js";
 import type { AgencyProgram, FunctionParameter, VariableType } from "../types.js";
 import type { ScopeInfo } from "../typeChecker/types.js";

--- a/packages/agency-lang/lib/lsp/hover.ts
+++ b/packages/agency-lang/lib/lsp/hover.ts
@@ -2,7 +2,7 @@ import { Hover, HoverParams } from "vscode-languageserver-protocol";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { formatSemanticHover, lookupSemanticSymbol, type SemanticIndex } from "./semantics.js";
 import { resolveTypeAtPosition } from "./typeResolution.js";
-import { formatTypeHint } from "../cli/util.js";
+import { formatTypeHint } from "../utils/formatType.js";
 import { getWordAtPosition } from "../cli/definition.js";
 import type { AgencyProgram } from "../types.js";
 import type { ScopeInfo } from "../typeChecker/types.js";

--- a/packages/agency-lang/lib/lsp/inlayHint.ts
+++ b/packages/agency-lang/lib/lsp/inlayHint.ts
@@ -2,7 +2,7 @@ import { InlayHint, InlayHintKind } from "vscode-languageserver-protocol";
 import type { AgencyProgram } from "../types.js";
 import type { ScopeInfo } from "../typeChecker/types.js";
 import { walkNodes } from "../utils/node.js";
-import { formatTypeHint } from "../cli/util.js";
+import { formatTypeHint } from "../utils/formatType.js";
 import { findContainingScope } from "./scopeResolution.js";
 
 export function getInlayHints(

--- a/packages/agency-lang/lib/lsp/semantics.ts
+++ b/packages/agency-lang/lib/lsp/semantics.ts
@@ -1,5 +1,5 @@
 import { getWordAtPosition } from "../cli/definition.js";
-import { formatTypeHint } from "../cli/util.js";
+import { formatTypeHint } from "../utils/formatType.js";
 import type { FileSymbols, InterruptKind, SymbolInfo, SymbolKind, SymbolTable } from "../symbolTable.js";
 import type {
   AgencyProgram,

--- a/packages/agency-lang/lib/lsp/signatureHelp.ts
+++ b/packages/agency-lang/lib/lsp/signatureHelp.ts
@@ -6,7 +6,7 @@ import {
 } from "vscode-languageserver-protocol";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import type { SemanticIndex } from "./semantics.js";
-import { formatTypeHint } from "../cli/util.js";
+import { formatTypeHint } from "../utils/formatType.js";
 
 export function handleSignatureHelp(
   params: SignatureHelpParams,

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -193,7 +193,7 @@ export function startHttpServer(config: HttpConfig): http.Server {
   });
 
   server.listen(port, () => {
-    logger.info(`Agency HTTP server listening on http://localhost:${port}`);
+    logger.info(`Agency HTTP server listening on http://0.0.0.0:${port}`);
   });
 
   return server;

--- a/packages/agency-lang/lib/templates/cli/standaloneHttp.mustache
+++ b/packages/agency-lang/lib/templates/cli/standaloneHttp.mustache
@@ -1,0 +1,32 @@
+import * as mod from {{{compiledModulePath:string}}};
+import { discoverExports } from {{{discoveryPath:string}}};
+import { startHttpServer } from {{{httpAdapterPath:string}}};
+import { createLogger } from {{{loggerPath:string}}};
+
+const exportedNodeNames = {{{exportedNodeNamesJson:string}}};
+const interruptKindsByName = {{{interruptKindsByNameJson:string}}};
+
+const exports = discoverExports({
+  toolRegistry: mod.__toolRegistry ?? {},
+  moduleExports: mod,
+  moduleId: {{{moduleId:string}}},
+  exportedNodeNames,
+  interruptKindsByName,
+});
+
+const rawPort = process.env.PORT ?? {{{defaultPort:string}}};
+const port = parseInt(rawPort, 10);
+if (isNaN(port) || port < 1 || port > 65535) {
+  console.error("Invalid PORT: " + rawPort + ". Must be an integer between 1 and 65535.");
+  process.exit(1);
+}
+const apiKey = process.env[{{{apiKeyEnv:string}}}];
+
+startHttpServer({
+  exports,
+  port,
+  apiKey,
+  logger: createLogger("info"),
+  hasInterrupts: mod.hasInterrupts,
+  respondToInterrupts: mod.respondToInterrupts,
+});

--- a/packages/agency-lang/lib/templates/cli/standaloneHttp.ts
+++ b/packages/agency-lang/lib/templates/cli/standaloneHttp.ts
@@ -1,0 +1,57 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/cli/standaloneHttp.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `import * as mod from {{{compiledModulePath:string}}};
+import { discoverExports } from {{{discoveryPath:string}}};
+import { startHttpServer } from {{{httpAdapterPath:string}}};
+import { createLogger } from {{{loggerPath:string}}};
+
+const exportedNodeNames = {{{exportedNodeNamesJson:string}}};
+const interruptKindsByName = {{{interruptKindsByNameJson:string}}};
+
+const exports = discoverExports({
+  toolRegistry: mod.__toolRegistry ?? {},
+  moduleExports: mod,
+  moduleId: {{{moduleId:string}}},
+  exportedNodeNames,
+  interruptKindsByName,
+});
+
+const rawPort = process.env.PORT ?? {{{defaultPort:string}}};
+const port = parseInt(rawPort, 10);
+if (isNaN(port) || port < 1 || port > 65535) {
+  console.error("Invalid PORT: " + rawPort + ". Must be an integer between 1 and 65535.");
+  process.exit(1);
+}
+const apiKey = process.env[{{{apiKeyEnv:string}}}];
+
+startHttpServer({
+  exports,
+  port,
+  apiKey,
+  logger: createLogger("info"),
+  hasInterrupts: mod.hasInterrupts,
+  respondToInterrupts: mod.respondToInterrupts,
+});
+`;
+
+export type TemplateType = {
+  compiledModulePath: string;
+  discoveryPath: string;
+  httpAdapterPath: string;
+  loggerPath: string;
+  exportedNodeNamesJson: string;
+  interruptKindsByNameJson: string;
+  moduleId: string;
+  defaultPort: string;
+  apiKeyEnv: string;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/templates/cli/standaloneMcp.mustache
+++ b/packages/agency-lang/lib/templates/cli/standaloneMcp.mustache
@@ -1,0 +1,35 @@
+import * as mod from {{{compiledModulePath:string}}};
+import { discoverExports } from {{{discoveryPath:string}}};
+import { createMcpHandler, startStdioServer } from {{{mcpAdapterPath:string}}};
+import { PolicyStore } from {{{policyStorePath:string}}};
+
+const exportedNodeNames = {{{exportedNodeNamesJson:string}}};
+const interruptKindsByName = {{{interruptKindsByNameJson:string}}};
+
+const exports = discoverExports({
+  toolRegistry: mod.__toolRegistry ?? {},
+  moduleExports: mod,
+  moduleId: {{{moduleId:string}}},
+  exportedNodeNames,
+  interruptKindsByName,
+});
+
+const serverName = {{{serverName:string}}};
+const policyStore = new PolicyStore(serverName);
+
+const interruptHandlers = {
+  hasInterrupts: mod.hasInterrupts,
+  respondToInterrupts: async (interrupts, responses) => {
+    const wrapped = await mod.respondToInterrupts(interrupts, responses);
+    return wrapped.data;
+  },
+};
+
+const handler = createMcpHandler({
+  serverName,
+  serverVersion: {{{serverVersion:string}}},
+  exports,
+  policyConfig: { policyStore, interruptHandlers },
+});
+
+startStdioServer(handler);

--- a/packages/agency-lang/lib/templates/cli/standaloneMcp.ts
+++ b/packages/agency-lang/lib/templates/cli/standaloneMcp.ts
@@ -1,0 +1,60 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/cli/standaloneMcp.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `import * as mod from {{{compiledModulePath:string}}};
+import { discoverExports } from {{{discoveryPath:string}}};
+import { createMcpHandler, startStdioServer } from {{{mcpAdapterPath:string}}};
+import { PolicyStore } from {{{policyStorePath:string}}};
+
+const exportedNodeNames = {{{exportedNodeNamesJson:string}}};
+const interruptKindsByName = {{{interruptKindsByNameJson:string}}};
+
+const exports = discoverExports({
+  toolRegistry: mod.__toolRegistry ?? {},
+  moduleExports: mod,
+  moduleId: {{{moduleId:string}}},
+  exportedNodeNames,
+  interruptKindsByName,
+});
+
+const serverName = {{{serverName:string}}};
+const policyStore = new PolicyStore(serverName);
+
+const interruptHandlers = {
+  hasInterrupts: mod.hasInterrupts,
+  respondToInterrupts: async (interrupts, responses) => {
+    const wrapped = await mod.respondToInterrupts(interrupts, responses);
+    return wrapped.data;
+  },
+};
+
+const handler = createMcpHandler({
+  serverName,
+  serverVersion: {{{serverVersion:string}}},
+  exports,
+  policyConfig: { policyStore, interruptHandlers },
+});
+
+startStdioServer(handler);
+`;
+
+export type TemplateType = {
+  compiledModulePath: string;
+  discoveryPath: string;
+  mcpAdapterPath: string;
+  policyStorePath: string;
+  exportedNodeNamesJson: string;
+  interruptKindsByNameJson: string;
+  moduleId: string;
+  serverName: string;
+  serverVersion: string;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -5,7 +5,7 @@ import {
   VariableType,
 } from "../types.js";
 import { walkNodes, isInsideBlock, type WalkAncestor } from "../utils/node.js";
-import { formatTypeHint } from "../cli/util.js";
+import { formatTypeHint } from "../utils/formatType.js";
 import { BUILTIN_FUNCTION_TYPES } from "./builtins.js";
 import { isAssignable } from "./assignability.js";
 import { synthType } from "./synthesizer.js";

--- a/packages/agency-lang/lib/typeChecker/scopes.ts
+++ b/packages/agency-lang/lib/typeChecker/scopes.ts
@@ -15,7 +15,7 @@ import { resultTypeForValidation } from "./validation.js";
 import { validateTypeReferences } from "./validate.js";
 import { ScopeInfo, TypeCheckerContext } from "./types.js";
 import { Scope } from "./scope.js";
-import { formatTypeHint } from "../cli/util.js";
+import { formatTypeHint } from "../utils/formatType.js";
 import { checkType, getBlockSlot } from "./utils.js";
 import { NUMBER_T } from "./primitives.js";
 

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -3,7 +3,7 @@ import type {
   NamedArgument,
   SplatExpression,
 } from "../types/dataStructures.js";
-import { formatTypeHint } from "../cli/util.js";
+import { formatTypeHint } from "../utils/formatType.js";
 import { BUILTIN_FUNCTION_TYPES } from "./builtins.js";
 import { isAssignable, resolveType } from "./assignability.js";
 import { resultTypeForValidation } from "./validation.js";

--- a/packages/agency-lang/lib/typeChecker/utils.ts
+++ b/packages/agency-lang/lib/typeChecker/utils.ts
@@ -1,6 +1,6 @@
 import { AgencyNode, FunctionParameter, VariableType } from "../types.js";
 import type { BlockType } from "../types/typeHints.js";
-import { formatTypeHint } from "../cli/util.js";
+import { formatTypeHint } from "../utils/formatType.js";
 import { isAssignable, resolveType } from "./assignability.js";
 import { synthType } from "./synthesizer.js";
 import { TypeCheckerContext } from "./types.js";

--- a/packages/agency-lang/lib/utils/formatType.ts
+++ b/packages/agency-lang/lib/utils/formatType.ts
@@ -1,0 +1,62 @@
+import { VariableType } from "@/types.js";
+
+/** Maps Agency primitive type names to their TypeScript equivalents. */
+export const TS_PRIMITIVE_ALIASES: Record<string, string> = {
+  regex: "RegExp",
+};
+
+/**
+ * Format a VariableType for display.
+ *
+ * Pass `primitiveAliases` (e.g. for codegen) to substitute Agency-only
+ * primitive names with target-language equivalents. Default omits the map
+ * so diagnostics, LSP hover, and CLI prompts show source-level keywords.
+ */
+export function formatTypeHint(
+  vt: VariableType,
+  primitiveAliases?: Record<string, string>,
+): string {
+  const recurse = (v: VariableType) => formatTypeHint(v, primitiveAliases);
+  switch (vt.type) {
+    case "primitiveType":
+      return primitiveAliases?.[vt.value] ?? vt.value;
+    case "arrayType":
+      return `${recurse(vt.elementType)}[]`;
+    case "stringLiteralType":
+      return `"${vt.value}"`;
+    case "numberLiteralType":
+      return vt.value;
+    case "booleanLiteralType":
+      return vt.value;
+    case "unionType":
+      return vt.types.map(recurse).join(" | ");
+    case "objectType":
+      return `{ ${vt.properties.map((p) => `${p.key}: ${recurse(p.value)}`).join(", ")} }`;
+    case "typeAliasVariable":
+      return vt.aliasName;
+    case "blockType": {
+      const params = vt.params.map((p) => recurse(p.typeAnnotation)).join(", ");
+      return `(${params}) => ${recurse(vt.returnType)}`;
+    }
+    case "resultType": {
+      const s = recurse(vt.successType);
+      const f = recurse(vt.failureType);
+      if (s === "any" && f === "any") return "Result";
+      return `Result<${s}, ${f}>`;
+    }
+    case "functionRefType": {
+      const params = vt.params
+        .map((p) => `${p.name}${p.typeHint ? `: ${recurse(p.typeHint)}` : ""}`)
+        .join(", ");
+      const ret = vt.returnType ? `: ${recurse(vt.returnType)}` : "";
+      return `function ${vt.name}(${params})${ret}`;
+    }
+    default:
+      throw new Error(`Unknown variable type: ${(vt as any).type}`);
+  }
+}
+
+/** Convenience wrapper for codegen contexts. */
+export function formatTypeHintTs(vt: VariableType): string {
+  return formatTypeHint(vt, TS_PRIMITIVE_ALIASES);
+}

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -797,9 +797,12 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .description("Start an MCP server (stdio)")
     .argument("<file>", "Agency file to serve")
     .option("--name <name>", "Server name (defaults to filename)")
-    .action(async (file: string, options: { name?: string }) => {
-      await serveMcp(file, options);
-    });
+    .option("--standalone", "Generate a standalone server.js file")
+    .action(
+      async (file: string, options: { name?: string; standalone?: boolean }) => {
+        await serveMcp(file, options);
+      },
+    );
 
   serveCmd
     .command("http")
@@ -807,10 +810,24 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .argument("<file>", "Agency file to serve")
     .option("--port <port>", "HTTP port (default: 3545)", "3545")
     .option("--api-key <key>", "API key for authentication")
+    .option(
+      "--api-key-env <name>",
+      "Name of the environment variable to read the API key from (standalone only, default: API_KEY)",
+    )
     .option("--standalone", "Generate a standalone server.js file")
-    .action(async (file: string, options: { port?: string; apiKey?: string; standalone?: boolean }) => {
-      await serveHttp(file, options);
-    });
+    .action(
+      async (
+        file: string,
+        options: {
+          port?: string;
+          apiKey?: string;
+          apiKeyEnv?: string;
+          standalone?: boolean;
+        },
+      ) => {
+        await serveHttp(file, options);
+      },
+    );
 
   const policyCmd = program
     .command("policy")


### PR DESCRIPTION
## What

Adds `--standalone` support to `agency serve http` and `agency serve mcp`, so users can compile an Agency program into a single, self-contained `server.js` bundle that can be deployed and run with just `node server.js` — no Agency CLI or source files required at the deployment site.

```bash
agency serve http --standalone myagent.agency
node myagent.server.js   # listens on :3545

agency serve mcp --standalone myagent.agency
node myagent.server.js   # MCP server over stdio
```

## Why

Two problems are solved together:

1. **Bundling broke on the `prompts` package.** The typechecker imports `formatTypeHint` from `lib/cli/util.ts`, which top-level imports the `prompts` npm package. `prompts` uses CJS `require("readline")`, which fails inside an esbuild ESM bundle.
2. **The previous `generateStandalone` only emitted the compiled module — it never wired up discovery or started a server.** The output was unrunnable.

## How

### 1. Cut the bad dependency edge

- New file `lib/utils/formatType.ts` containing `formatTypeHint`, `formatTypeHintTs`, and `TS_PRIMITIVE_ALIASES`.
- All 11 importers (typeChecker x4, lsp x5, debugger, backends) now import from the new path.
- `lib/cli/util.ts` re-exports the same symbols for backward compatibility with anything still importing from there.

### 2. Real `generateStandalone`

- New signature `(mode, compileResult, originalFile, options)`.
- Helper `distPath()` resolves dist files via `import.meta.url` (no `package.json` exports entries needed).
- `buildHttpEntrypoint` / `buildMcpEntrypoint` generate a temp `.mjs` that imports the compiled module + `dist/lib/serve/...` adapters by absolute path.
- The MCP entrypoint mirrors `serveMcp`'s wiring (PolicyStore + interrupt-handler shape normalization + `createMcpHandler` + `startStdioServer`).
- esbuild config: `platform: node`, `format: esm`, externals for `node-llama-cpp`/`@reflink/*` (native bindings can't be ESM bundled), and a `__createRequire` banner so any CJS dependency that uses `require()` still works inside the ESM bundle.
- Temp entrypoint and intermediate compiled JS are deleted in a `finally` block.

### 3. CLI flags

- `serve mcp` gains `--standalone`.
- `serve http` gains `--api-key-env <name>` (default `API_KEY`). The key is never baked into the bundle; the bundle reads it from the named env var at runtime. `--port` similarly bakes a default; `PORT` env var overrides at runtime.

## Verification

- `agency serve http --standalone foo.agency` → `node foo.server.js` → `curl http://localhost:3545/list` returns the agent's exported functions and nodes.
- `agency serve mcp --standalone test_agent.agency` → bundle responds to `initialize` (returns `serverInfo: {name: "test_agent", ...}`) and `tools/list` (returns the exported `add` function plus the agency policy tools) over stdio.
- `grep "readline" foo.server.js` shows no CJS `require("readline")` from `prompts`. Only the legitimate ESM `import * as readline from "readline"` from the Agency runtime remains.

## Notes

- `node-llama-cpp` is externalized because the package has top-level native side effects that can't be ESM bundled. As of `smoltalk@0.0.67` the package is statically imported by smoltalk's client module, so the deployment site must currently have `node-llama-cpp` installed (e.g. as a peer dependency) for the bundle to start. Once smoltalk lazy-loads its llama-cpp client, the bundle will start without it being installed for users who only use OpenAI/Anthropic/etc.
- The previous attempt at this feature was never committed; this PR re-implements it from scratch on top of the resolved smoltalk/node-llama-cpp blocker.
