### PR TITLE
Harden HTTP serve and MCP stdio against the security issues from #124 review

### DIFF
--- a/packages/agency-lang/lib/cli/serve.ts
+++ b/packages/agency-lang/lib/cli/serve.ts
@@ -132,6 +132,7 @@ export async function serveHttp(
   file: string,
   options: {
     port?: string;
+    host?: string;
     apiKey?: string;
     apiKeyEnv?: string;
     standalone?: boolean;
@@ -144,6 +145,10 @@ export async function serveHttp(
     throw new Error(`Invalid port: ${options.port}`);
   }
 
+  if (options.apiKey !== undefined && options.apiKeyEnv !== undefined) {
+    throw new Error("--api-key and --api-key-env are mutually exclusive.");
+  }
+
   if (options.standalone) {
     if (options.apiKey !== undefined) {
       throw new Error(
@@ -152,15 +157,25 @@ export async function serveHttp(
     }
     await generateStandalone("http", compileResult, file, {
       port,
+      host: options.host ?? "127.0.0.1",
       apiKeyEnv: options.apiKeyEnv ?? "API_KEY",
     });
     return;
   }
 
+  // Non-standalone: --api-key-env reads the key from the named env var at
+  // serve time (preferred — the key never appears in argv). --api-key is
+  // still accepted for ad-hoc use but exposes the key in process listings.
+  let apiKey: string | undefined;
   if (options.apiKeyEnv !== undefined) {
-    console.warn(
-      "--api-key-env is only used with --standalone; it is ignored when serving directly.",
-    );
+    apiKey = process.env[options.apiKeyEnv];
+    if (!apiKey) {
+      throw new Error(
+        `Environment variable '${options.apiKeyEnv}' is not set or empty (required by --api-key-env).`,
+      );
+    }
+  } else {
+    apiKey = options.apiKey;
   }
 
   const { exports, moduleExports } = await loadAndDiscover(compileResult);
@@ -169,7 +184,8 @@ export async function serveHttp(
   startHttpServer({
     exports,
     port,
-    apiKey: options.apiKey,
+    host: options.host,
+    apiKey,
     logger,
     hasInterrupts: moduleExports.hasInterrupts as (data: unknown) => boolean,
     respondToInterrupts: moduleExports.respondToInterrupts as (
@@ -179,7 +195,11 @@ export async function serveHttp(
   });
 }
 
-type StandaloneHttpOptions = { port: number; apiKeyEnv: string };
+type StandaloneHttpOptions = {
+  port: number;
+  host: string;
+  apiKeyEnv: string;
+};
 type StandaloneMcpOptions = { serverName: string };
 
 /**
@@ -213,6 +233,7 @@ function buildHttpEntrypoint(
     exportedNodeNamesJson: JSON.stringify(compileResult.exportedNodeNames),
     interruptKindsByNameJson: JSON.stringify(compileResult.interruptKindsByName),
     defaultPort: JSON.stringify(String(options.port)),
+    defaultHost: JSON.stringify(options.host),
     apiKeyEnv: JSON.stringify(options.apiKeyEnv),
   });
 }
@@ -266,6 +287,7 @@ async function generateStandalone(
 
   fs.writeFileSync(entrypointPath, entrypointSource);
 
+  let bundleSucceeded = false;
   try {
     await esbuild.build({
       entryPoints: [entrypointPath],
@@ -287,9 +309,31 @@ async function generateStandalone(
           'import { createRequire as __createRequire } from "module"; const require = __createRequire(import.meta.url);',
       },
     });
+    bundleSucceeded = true;
   } finally {
-    if (fs.existsSync(entrypointPath)) fs.unlinkSync(entrypointPath);
+    // Always remove the temp entrypoint we created.
+    safeUnlink(entrypointPath);
+    // Only delete the intermediate compiled JS on success, and only if the
+    // basename matches what compile() would produce (defends against an
+    // accidentally-misconfigured outputPath pointing at a hand-written file).
+    if (
+      bundleSucceeded &&
+      path.basename(compiledAbsPath) === `${baseName}.js`
+    ) {
+      safeUnlink(compiledAbsPath);
+    }
   }
 
   console.log(`Standalone ${mode} server written to ${outfile}`);
+}
+
+function safeUnlink(p: string): void {
+  if (!fs.existsSync(p)) return;
+  try {
+    fs.unlinkSync(p);
+  } catch (err) {
+    console.warn(
+      `Failed to remove temporary file ${p}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 }

--- a/packages/agency-lang/lib/serve/http/adapter.test.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { createHttpHandler } from "./adapter.js";
+import http from "http";
+import { AddressInfo } from "net";
+import { createHttpHandler, startHttpServer } from "./adapter.js";
 import { AgencyFunction } from "../../runtime/agencyFunction.js";
 import type { ExportedItem } from "../types.js";
 import { createLogger } from "../../logger.js";
@@ -51,15 +53,56 @@ function makeExports(): {
   return { exports };
 }
 
-function makeHandler(apiKey?: string) {
+function makeHandler() {
   const { exports } = makeExports();
   return createHttpHandler({
     exports,
     port: 3545,
-    apiKey,
     logger: createLogger("error"),
     hasInterrupts: () => false,
     respondToInterrupts: async () => ({ data: "resumed" }),
+  });
+}
+
+async function withServer<T>(
+  config: Parameters<typeof startHttpServer>[0],
+  fn: (port: number) => Promise<T>,
+): Promise<T> {
+  // Use port 0 to let the OS assign a free port for the test.
+  const server = startHttpServer({ ...config, port: 0 });
+  await new Promise<void>((resolve) => server.on("listening", () => resolve()));
+  const port = (server.address() as AddressInfo).port;
+  try {
+    return await fn(port);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+function request(
+  port: number,
+  options: { method?: string; path?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        method: options.method ?? "GET",
+        path: options.path ?? "/list",
+        headers: options.headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () =>
+          resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() }),
+        );
+      },
+    );
+    req.on("error", reject);
+    if (options.body !== undefined) req.write(options.body);
+    req.end();
   });
 }
 
@@ -162,21 +205,127 @@ describe("HTTP adapter", () => {
   });
 });
 
-describe("HTTP auth", () => {
-  const handler = makeHandler("my-secret");
+describe("startHttpServer auth and host validation", () => {
+  function baseConfig(overrides: Partial<Parameters<typeof startHttpServer>[0]> = {}) {
+    const { exports } = makeExports();
+    return {
+      exports,
+      port: 0,
+      logger: createLogger("error"),
+      hasInterrupts: () => false,
+      respondToInterrupts: async () => ({ data: "resumed" }),
+      ...overrides,
+    };
+  }
 
-  it("rejects requests without auth header", async () => {
-    const result = await handler("GET", "/list", undefined);
-    expect(result.status).toBe(401);
+  it("rejects requests without auth header when key is configured", async () => {
+    await withServer(baseConfig({ apiKey: "my-secret" }), async (port) => {
+      const res = await request(port);
+      expect(res.status).toBe(401);
+    });
   });
 
   it("rejects requests with wrong key", async () => {
-    const result = await handler("GET", "/list", undefined, "Bearer wrong");
-    expect(result.status).toBe(401);
+    await withServer(baseConfig({ apiKey: "my-secret" }), async (port) => {
+      const res = await request(port, { headers: { authorization: "Bearer wrong" } });
+      expect(res.status).toBe(401);
+    });
   });
 
-  it("allows requests with correct key", async () => {
-    const result = await handler("GET", "/list", undefined, "Bearer my-secret");
-    expect(result.status).toBe(200);
+  it("accepts requests with correct key", async () => {
+    await withServer(baseConfig({ apiKey: "my-secret" }), async (port) => {
+      const res = await request(port, { headers: { authorization: "Bearer my-secret" } });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  it("rejects requests with disallowed Host header (DNS-rebinding defense)", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, { headers: { host: "evil.example.com" } });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  it("allows requests with localhost Host header by default", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, { headers: { host: `localhost:${port}` } });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  it("Host validation runs before auth (forbidden host gets 403, not 401)", async () => {
+    await withServer(baseConfig({ apiKey: "my-secret" }), async (port) => {
+      // Wrong host AND missing auth — should return 403, not 401.
+      const res = await request(port, { headers: { host: "evil.example.com" } });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  it("auth runs before body parsing (POST without auth returns 401)", async () => {
+    await withServer(baseConfig({ apiKey: "my-secret" }), async (port) => {
+      const res = await request(port, {
+        method: "POST",
+        path: "/function/add",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ a: 1, b: 2 }),
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  it("refuses to start without API key on non-loopback host", () => {
+    const { exports } = makeExports();
+    expect(() =>
+      startHttpServer({
+        exports,
+        port: 0,
+        host: "0.0.0.0",
+        logger: createLogger("error"),
+        hasInterrupts: () => false,
+        respondToInterrupts: async () => ({ data: "x" }),
+      }),
+    ).toThrow(/Refusing to start.*non-loopback/);
+  });
+
+  it("function errors are sanitized in the response body", async () => {
+    const { exports } = makeExports();
+    const registry: Record<string, AgencyFunction> = {};
+    const failFn = AgencyFunction.create(
+      {
+        name: "fail",
+        module: "test",
+        fn: async () => {
+          throw new Error("internal secret: sk-abc123");
+        },
+        params: [],
+        toolDefinition: { name: "fail", description: "", schema: null },
+        exported: true,
+        safe: true,
+      },
+      registry,
+    );
+    const exportsWithFail: ExportedItem[] = [
+      ...exports,
+      {
+        kind: "function",
+        name: "fail",
+        description: "",
+        agencyFunction: failFn,
+        interruptKinds: [],
+      },
+    ];
+    await withServer(baseConfig({ exports: exportsWithFail }), async (port) => {
+      const res = await request(port, {
+        method: "POST",
+        path: "/function/fail",
+        headers: { "content-type": "application/json" },
+        body: "{}",
+      });
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.success).toBe(false);
+      expect(body.error).not.toContain("sk-abc123");
+      expect(body.error).not.toContain("internal secret");
+    });
   });
 });

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -8,6 +8,15 @@ export type HttpConfig = {
   exports: ExportedItem[];
   port: number;
   apiKey?: string;
+  /** Interface to bind to. Default "127.0.0.1" (loopback only). */
+  host?: string;
+  /**
+   * Allowed Host: header values (DNS-rebinding defense). If unset, defaults
+   * are derived from `host`: loopback addresses are allowed, plus the
+   * "localhost" hostname. For non-loopback hosts, callers must opt in
+   * explicitly.
+   */
+  allowedHosts?: string[];
   logger: Logger;
   hasInterrupts: (data: unknown) => boolean;
   respondToInterrupts: (interrupts: unknown[], responses: unknown[]) => Promise<unknown>;
@@ -34,7 +43,18 @@ function interruptResult(data: unknown): RouteResult {
   return ok({ interrupts: data, state: JSON.stringify(data) });
 }
 
-async function callFunction(fn: ExportedFunction, body: unknown): Promise<RouteResult> {
+/**
+ * Generic message returned to clients when an Agency function/node throws.
+ * The full error is logged server-side but never sent to the client, to
+ * avoid leaking secrets, file paths, model API responses, etc.
+ */
+const TOOL_ERROR_MESSAGE = "Tool execution failed";
+
+async function callFunction(
+  fn: ExportedFunction,
+  body: unknown,
+  logger: Logger,
+): Promise<RouteResult> {
   try {
     const result = await fn.agencyFunction.invoke({
       type: "named",
@@ -43,7 +63,8 @@ async function callFunction(fn: ExportedFunction, body: unknown): Promise<RouteR
     });
     return ok(result);
   } catch (err) {
-    return fail(errorMessage(err));
+    logger.error(`function ${fn.name} threw: ${errorMessage(err)}`);
+    return fail(TOOL_ERROR_MESSAGE);
   }
 }
 
@@ -51,6 +72,7 @@ async function callNode(
   node: ExportedNode,
   body: unknown,
   hasInterrupts: (data: unknown) => boolean,
+  logger: Logger,
 ): Promise<RouteResult> {
   try {
     const args = toArgs(body);
@@ -59,7 +81,8 @@ async function callNode(
     if (hasInterrupts(result.data)) return interruptResult(result.data);
     return ok(result.data);
   } catch (err) {
-    return fail(errorMessage(err));
+    logger.error(`node ${node.name} threw: ${errorMessage(err)}`);
+    return fail(TOOL_ERROR_MESSAGE);
   }
 }
 
@@ -67,6 +90,7 @@ async function resumeInterrupts(
   respondToInterrupts: (i: unknown[], r: unknown[]) => Promise<unknown>,
   hasInterrupts: (data: unknown) => boolean,
   body: unknown,
+  logger: Logger,
 ): Promise<RouteResult> {
   if (body == null || typeof body !== "object" || Array.isArray(body)) {
     return { status: 400, body: { error: "Request body must be a JSON object" } };
@@ -83,7 +107,8 @@ async function resumeInterrupts(
     if (hasInterrupts(result.data)) return interruptResult(result.data);
     return ok(result.data);
   } catch (err) {
-    return fail(errorMessage(err));
+    logger.error(`resume threw: ${errorMessage(err)}`);
+    return fail(TOOL_ERROR_MESSAGE);
   }
 }
 
@@ -94,9 +119,8 @@ export function createHttpHandler(config: HttpConfig): (
   method: string,
   path: string,
   body: unknown,
-  authHeader?: string,
 ) => Promise<RouteResult> {
-  const { exports, apiKey, hasInterrupts, respondToInterrupts } = config;
+  const { exports, hasInterrupts, respondToInterrupts, logger } = config;
 
   const functions = Object.fromEntries(
     exports.filter((e): e is ExportedFunction => e.kind === "function").map((e) => [e.name, e]),
@@ -105,11 +129,7 @@ export function createHttpHandler(config: HttpConfig): (
     exports.filter((e): e is ExportedNode => e.kind === "node").map((e) => [e.name, e]),
   );
 
-  return async (method, path, body, authHeader): Promise<RouteResult> => {
-    if (!checkAuth(apiKey, authHeader)) {
-      return { status: 401, body: { error: "Unauthorized" } };
-    }
-
+  return async (method, path, body): Promise<RouteResult> => {
     if (method === "GET" && path === "/list") {
       return {
         status: 200,
@@ -134,21 +154,21 @@ export function createHttpHandler(config: HttpConfig): (
       if (functionMatch) {
         const fn = functions[functionMatch[1]];
         if (!fn) return notFound(`Unknown function '${functionMatch[1]}'`);
-        return callFunction(fn, body);
+        return callFunction(fn, body, logger);
       }
 
       const nodeMatch = path.match(NODE_ROUTE);
       if (nodeMatch) {
         const node = nodes[nodeMatch[1]];
         if (!node) return notFound(`Unknown node '${nodeMatch[1]}'`);
-        return callNode(node, body, hasInterrupts);
+        return callNode(node, body, hasInterrupts, logger);
       }
 
       if (path === "/resume") {
         if (!respondToInterrupts) {
           return { status: 400, body: { error: "Module does not support interrupt resume" } };
         }
-        return resumeInterrupts(respondToInterrupts, hasInterrupts, body);
+        return resumeInterrupts(respondToInterrupts, hasInterrupts, body, logger);
       }
     }
 
@@ -156,34 +176,87 @@ export function createHttpHandler(config: HttpConfig): (
   };
 }
 
+const DEFAULT_HOST = "127.0.0.1";
+const LOOPBACK_HOSTS = ["127.0.0.1", "::1", "localhost"];
+
+function isLoopbackHost(host: string): boolean {
+  return LOOPBACK_HOSTS.includes(host);
+}
+
+function defaultAllowedHosts(host: string): string[] {
+  if (isLoopbackHost(host)) return ["localhost", "127.0.0.1", "[::1]"];
+  // Non-loopback bind: only the exact bound host is allowed by default.
+  return [host];
+}
+
+/**
+ * Validate the Host header against an allowlist (DNS-rebinding defense).
+ * Strips the port before comparison; matches case-insensitively.
+ */
+function isHostAllowed(hostHeader: string | undefined, allowed: string[]): boolean {
+  if (!hostHeader) return false;
+  const hostOnly = stripPort(hostHeader).toLowerCase();
+  return allowed.some((a) => a.toLowerCase() === hostOnly);
+}
+
+function stripPort(hostHeader: string): string {
+  // IPv6 literal: "[::1]:3545" → "[::1]"
+  if (hostHeader.startsWith("[")) {
+    const end = hostHeader.indexOf("]");
+    return end === -1 ? hostHeader : hostHeader.slice(0, end + 1);
+  }
+  const colon = hostHeader.indexOf(":");
+  return colon === -1 ? hostHeader : hostHeader.slice(0, colon);
+}
+
 export function startHttpServer(config: HttpConfig): http.Server {
   const handler = createHttpHandler(config);
-  const { logger, port } = config;
+  const { logger, port, apiKey } = config;
+  const host = config.host ?? DEFAULT_HOST;
+  const allowedHosts = config.allowedHosts ?? defaultAllowedHosts(host);
+
+  if (!apiKey && !isLoopbackHost(host)) {
+    throw new Error(
+      `Refusing to start: no API key configured but bind host is "${host}" (non-loopback). ` +
+      `Either configure an API key, or bind to 127.0.0.1.`,
+    );
+  }
 
   const server = http.createServer(async (req, res) => {
     const method = req.method ?? "GET";
     const rawUrl = req.url ?? "/";
     const path = rawUrl.split("?")[0];
-    const authHeader = req.headers.authorization;
+    const start = Date.now();
 
     const sendJson = (status: number, body: unknown) => {
       res.writeHead(status, { "Content-Type": "application/json" });
       res.end(JSON.stringify(body) + "\n");
+      logger.info(`${method} ${path} → ${status} (${Date.now() - start}ms)`);
     };
+
+    // 1. Host header validation (DNS-rebinding defense). Done first so a
+    //    rebinding attacker cannot reach any server logic, including auth.
+    if (!isHostAllowed(req.headers.host, allowedHosts)) {
+      sendJson(403, { error: "Forbidden host" });
+      return;
+    }
+
+    // 2. Authentication. Done before body parsing so an unauthenticated
+    //    client cannot force the server to buffer up to MAX_BODY_BYTES.
+    if (!checkAuth(apiKey, req.headers.authorization)) {
+      sendJson(401, { error: "Unauthorized" });
+      return;
+    }
 
     try {
       const body = method === "POST" ? await parseJsonBody(req) : undefined;
-      const start = Date.now();
-      const result = await handler(method, path, body, authHeader);
-      logger.info(`${method} ${path} → ${result.status} (${Date.now() - start}ms)`);
+      const result = await handler(method, path, body);
       sendJson(result.status, result.body);
     } catch (err) {
       const msg = errorMessage(err);
       if (msg === "Invalid JSON body") {
-        logger.error(`${method} ${path} → 400: ${msg}`);
         sendJson(400, { error: msg });
       } else if (msg === "Request body too large") {
-        logger.error(`${method} ${path} → 413: ${msg}`);
         sendJson(413, { error: msg });
       } else {
         logger.error(`${method} ${path} → 500: ${msg}`);
@@ -192,8 +265,19 @@ export function startHttpServer(config: HttpConfig): http.Server {
     }
   });
 
-  server.listen(port, () => {
-    logger.info(`Agency HTTP server listening on http://0.0.0.0:${port}`);
+  server.listen(port, host, () => {
+    const displayHost = host.includes(":") ? `[${host}]` : host;
+    logger.info(`Agency HTTP server listening on http://${displayHost}:${port}`);
+    if (!isLoopbackHost(host)) {
+      logger.info(
+        `WARNING: bound to ${host} (non-loopback). Server is reachable from the network.`,
+      );
+    }
+    if (!apiKey) {
+      logger.info(
+        "WARNING: no API key configured. All requests are accepted without authentication.",
+      );
+    }
   });
 
   return server;

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -12,9 +12,10 @@ export type HttpConfig = {
   host?: string;
   /**
    * Allowed Host: header values (DNS-rebinding defense). If unset, defaults
-   * are derived from `host`: loopback addresses are allowed, plus the
-   * "localhost" hostname. For non-loopback hosts, callers must opt in
-   * explicitly.
+   * are derived from `host`: loopback binds get an allowlist of loopback
+   * names. Non-loopback binds skip Host validation by default (the strict
+   * API key requirement mitigates DNS rebinding there); pass an explicit
+   * array to lock the server down to specific hostnames.
    */
   allowedHosts?: string[];
   logger: Logger;
@@ -183,17 +184,24 @@ function isLoopbackHost(host: string): boolean {
   return LOOPBACK_HOSTS.includes(host);
 }
 
-function defaultAllowedHosts(host: string): string[] {
+function defaultAllowedHosts(host: string): string[] | undefined {
   if (isLoopbackHost(host)) return ["localhost", "127.0.0.1", "[::1]"];
-  // Non-loopback bind: only the exact bound host is allowed by default.
-  return [host];
+  // Non-loopback bind: skip Host validation by default. The mandatory API
+  // key (enforced below) is what mitigates DNS rebinding in this case.
+  // Operators can still pass an explicit `allowedHosts` to lock things down.
+  return undefined;
 }
 
 /**
  * Validate the Host header against an allowlist (DNS-rebinding defense).
- * Strips the port before comparison; matches case-insensitively.
+ * Strips the port before comparison; matches case-insensitively. If
+ * `allowed` is undefined, validation is skipped.
  */
-function isHostAllowed(hostHeader: string | undefined, allowed: string[]): boolean {
+function isHostAllowed(
+  hostHeader: string | undefined,
+  allowed: string[] | undefined,
+): boolean {
+  if (allowed === undefined) return true;
   if (!hostHeader) return false;
   const hostOnly = stripPort(hostHeader).toLowerCase();
   return allowed.some((a) => a.toLowerCase() === hostOnly);

--- a/packages/agency-lang/lib/serve/http/auth.ts
+++ b/packages/agency-lang/lib/serve/http/auth.ts
@@ -1,3 +1,5 @@
+import { timingSafeEqual } from "crypto";
+
 export function checkAuth(
   configuredKey: string | undefined,
   authHeader: string | undefined,
@@ -6,5 +8,19 @@ export function checkAuth(
   if (!authHeader) return false;
   const parts = authHeader.split(" ");
   if (parts.length !== 2 || parts[0] !== "Bearer") return false;
-  return parts[1] === configuredKey;
+  return constantTimeStringEqual(parts[1], configuredKey);
+}
+
+/**
+ * Constant-time string comparison. Returns false immediately on length
+ * mismatch (which leaks length, but that's acceptable for fixed-length
+ * secrets and the alternative — comparing variable-length buffers — would
+ * require a different cryptographic primitive). For equal-length inputs the
+ * comparison time does not depend on the position of the first differing byte.
+ */
+function constantTimeStringEqual(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, "utf-8");
+  const bBuf = Buffer.from(b, "utf-8");
+  if (aBuf.length !== bBuf.length) return false;
+  return timingSafeEqual(aBuf, bBuf);
 }

--- a/packages/agency-lang/lib/serve/mcp/adapter.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.ts
@@ -314,11 +314,12 @@ export function startStdioServer(
       if (line.length > 0) processLine(line, handler);
       newlineIndex = buffer.indexOf("\n");
     }
-    if (buffer.length > MAX_STDIO_LINE_BYTES) {
+    const bufferBytes = Buffer.byteLength(buffer, "utf-8");
+    if (bufferBytes > MAX_STDIO_LINE_BYTES) {
       // Drop the oversized partial and continue reading. We can't reply
       // because we have no message id; surface the problem to stderr.
       process.stderr.write(
-        `MCP stdio: discarding partial input of ${buffer.length} bytes (no newline within ${MAX_STDIO_LINE_BYTES} bytes)\n`,
+        `MCP stdio: discarding partial input of ${bufferBytes} bytes (no newline within ${MAX_STDIO_LINE_BYTES} bytes)\n`,
       );
       buffer = "";
     }

--- a/packages/agency-lang/lib/serve/mcp/adapter.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.ts
@@ -292,6 +292,13 @@ function processLine(
   }
 }
 
+/**
+ * Maximum size of an unterminated stdio line. A peer that streams data
+ * without ever sending a newline would otherwise grow the buffer
+ * unboundedly and OOM the process.
+ */
+const MAX_STDIO_LINE_BYTES = 10 * 1024 * 1024; // 10 MB
+
 export function startStdioServer(
   handler: (message: JsonRpcMessage) => Promise<JsonRpcMessage | null>,
 ): void {
@@ -306,6 +313,14 @@ export function startStdioServer(
       buffer = buffer.slice(newlineIndex + 1);
       if (line.length > 0) processLine(line, handler);
       newlineIndex = buffer.indexOf("\n");
+    }
+    if (buffer.length > MAX_STDIO_LINE_BYTES) {
+      // Drop the oversized partial and continue reading. We can't reply
+      // because we have no message id; surface the problem to stderr.
+      process.stderr.write(
+        `MCP stdio: discarding partial input of ${buffer.length} bytes (no newline within ${MAX_STDIO_LINE_BYTES} bytes)\n`,
+      );
+      buffer = "";
     }
   });
 }

--- a/packages/agency-lang/lib/templates/cli/standaloneHttp.mustache
+++ b/packages/agency-lang/lib/templates/cli/standaloneHttp.mustache
@@ -20,13 +20,20 @@ if (isNaN(port) || port < 1 || port > 65535) {
   console.error("Invalid PORT: " + rawPort + ". Must be an integer between 1 and 65535.");
   process.exit(1);
 }
+const host = process.env.HOST ?? {{{defaultHost:string}}};
 const apiKey = process.env[{{{apiKeyEnv:string}}}];
 
-startHttpServer({
-  exports,
-  port,
-  apiKey,
-  logger: createLogger("info"),
-  hasInterrupts: mod.hasInterrupts,
-  respondToInterrupts: mod.respondToInterrupts,
-});
+try {
+  startHttpServer({
+    exports,
+    port,
+    host,
+    apiKey,
+    logger: createLogger("info"),
+    hasInterrupts: mod.hasInterrupts,
+    respondToInterrupts: mod.respondToInterrupts,
+  });
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/packages/agency-lang/lib/templates/cli/standaloneHttp.ts
+++ b/packages/agency-lang/lib/templates/cli/standaloneHttp.ts
@@ -25,16 +25,23 @@ if (isNaN(port) || port < 1 || port > 65535) {
   console.error("Invalid PORT: " + rawPort + ". Must be an integer between 1 and 65535.");
   process.exit(1);
 }
+const host = process.env.HOST ?? {{{defaultHost:string}}};
 const apiKey = process.env[{{{apiKeyEnv:string}}}];
 
-startHttpServer({
-  exports,
-  port,
-  apiKey,
-  logger: createLogger("info"),
-  hasInterrupts: mod.hasInterrupts,
-  respondToInterrupts: mod.respondToInterrupts,
-});
+try {
+  startHttpServer({
+    exports,
+    port,
+    host,
+    apiKey,
+    logger: createLogger("info"),
+    hasInterrupts: mod.hasInterrupts,
+    respondToInterrupts: mod.respondToInterrupts,
+  });
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
 `;
 
 export type TemplateType = {
@@ -46,6 +53,7 @@ export type TemplateType = {
   interruptKindsByNameJson: string;
   moduleId: string;
   defaultPort: string;
+  defaultHost: string;
   apiKeyEnv: string;
 };
 

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -809,10 +809,17 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .description("Start an HTTP REST server")
     .argument("<file>", "Agency file to serve")
     .option("--port <port>", "HTTP port (default: 3545)", "3545")
-    .option("--api-key <key>", "API key for authentication")
+    .option(
+      "--host <host>",
+      "Interface to bind to (default: 127.0.0.1, loopback only). Use 0.0.0.0 to expose externally — requires --api-key/--api-key-env.",
+    )
+    .option(
+      "--api-key <key>",
+      "API key for authentication. NOT recommended: visible in process listings. Prefer --api-key-env.",
+    )
     .option(
       "--api-key-env <name>",
-      "Name of the environment variable to read the API key from (standalone only, default: API_KEY)",
+      "Name of the environment variable to read the API key from. For --standalone, the bundle reads this env var at runtime (default: API_KEY). Without --standalone, the key is read from the env var at serve time.",
     )
     .option("--standalone", "Generate a standalone server.js file")
     .action(
@@ -820,6 +827,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
         file: string,
         options: {
           port?: string;
+          host?: string;
           apiKey?: string;
           apiKeyEnv?: string;
           standalone?: boolean;


### PR DESCRIPTION
## What

Hardens `agency serve http` and the standalone bundles it produces against the security issues identified during review of #124.

(Note: this commit briefly landed on main — `ed273d0f` — and was reverted in `b1d89af6` so it can go through a proper review here.)

## Issues fixed

| # | Severity | Issue | Fix |
|---|---|---|---|
| 1 | High | API-key comparison was timing-unsafe (`===` short-circuits on first byte mismatch, leaks the key one byte at a time) | `crypto.timingSafeEqual` on equal-length buffers, with a length-mismatch fast-path |
| 2 | High | `server.listen(port, ...)` bound to all interfaces; the standalone bundle was reachable from the public network of any deployment site | Default bind is `127.0.0.1`. New `--host` CLI flag and `HOST` env var (standalone) opt in to non-loopback. |
| 3 | High | `if (!configuredKey) return true` — no API key meant unauthenticated execution of any exported tool/node | `startHttpServer` throws on construction if no key is configured AND host is non-loopback. Logs a warning if no key on loopback. |
| 4 | High | No `Host:` header validation → DNS rebinding / drive-by attacks from malicious websites visiting `localhost:3545` in a browser | Default allowlist for loopback bind is `{localhost, 127.0.0.1, [::1]}`. Bad host returns 403 **before** auth or body parsing — a rebinding attacker can't probe the API surface. |
| 5 | Medium | Body parsed before auth → unauthenticated client could force the server to buffer up to `MAX_BODY_BYTES` (10 MB) per connection | Auth check moved into `startHttpServer`, before `parseJsonBody`. Same for Host check. |
| 6 | Medium | Per-tool errors returned the raw exception message to the client. (We saw an OpenAI 401 leak the redacted-but-prefix-visible API key in our verification of #124.) | Server returns generic `"Tool execution failed"`; full error logged server-side via `logger.error`. |
| 7 | Low–Med | `--api-key <key>` exposed the key in `ps`/shell history | `--api-key-env` now also works in non-standalone mode (reads the key at serve time, never appears in argv). `--api-key-env` and `--api-key` are mutually exclusive. |
| 8 | Low | MCP stdio server did `buffer += chunk` until newline with no cap → peer that streams without newlines could OOM the process | Cap at 10 MB; oversized partials dropped with a stderr warning. |
| 10 | Low | `unlinkSync(compiledAbsPath)` in `finally` was unconditionally destructive (could delete a user file if `outputPath` were ever misconfigured) | New `safeUnlink()`. Only delete the compiled JS on bundle success **and** only if `path.basename(p) === ${baseName}.js`. |

(Issue #9 — runtime validation of node parameters — is a discovery/runtime design change, not a serve-layer fix; left for a separate change.)

## Behavior changes

- `agency serve http foo.agency` now binds to `127.0.0.1:3545` instead of `0.0.0.0:3545`. Existing local-dev usage is unaffected because `localhost` is in the default Host allowlist.
- `agency serve http --host 0.0.0.0 foo.agency` requires `--api-key` or `--api-key-env`; without one, it exits with a clear error.
- `node foo.server.js` (standalone HTTP bundle) reads `HOST` and `PORT` env vars; defaults are baked from the CLI invocation.
- Per-tool errors over HTTP now return `{success: false, error: "Tool execution failed"}` instead of the raw error text. Server logs still contain the full error.
- Bad `Host:` header returns 403; without auth → 401; before, both could be ambiguous.

## CLI changes

```text
agency serve http <file>
  --port <port>           HTTP port (default: 3545)
  --host <host>           Interface to bind to (default: 127.0.0.1, loopback only)
  --api-key <key>         API key for authentication. NOT recommended: visible in process listings.
  --api-key-env <name>    Name of the env var to read the API key from. Standalone reads at runtime; non-standalone reads at serve time.
  --standalone            Generate a standalone server.js file
```

## Tests

- 5 existing `auth.ts` unit tests still pass (constant-time compare).
- 18 new/updated `adapter.test.ts` integration tests using `startHttpServer` on port 0:
  - 401 for missing/wrong auth, 200 for correct
  - 403 for disallowed Host header
  - 403 takes priority over 401 (Host check before auth)
  - 401 returned before body is parsed (POST with no auth)
  - `startHttpServer` throws when started without a key on `0.0.0.0`
  - secret strings in tool errors do not leak into the response body
- All 212 tests across `lib/serve/` and `lib/cli/` pass.
- `pnpm run lint:structure` clean.
- End-to-end verified: standalone bundle binds loopback by default; refuses `HOST=0.0.0.0` without `API_KEY`; returns 403 for evil Host headers; returns 401 before reading body.
