### PR TITLE
Add Streamable HTTP transport for the MCP server

### DIFF
--- a/packages/agency-lang/lib/cli/serve.ts
+++ b/packages/agency-lang/lib/cli/serve.ts
@@ -9,6 +9,7 @@ import { buildCompilationUnit } from "../compilationUnit.js";
 import { typeCheck, formatErrors } from "../typeChecker/index.js";
 import { discoverExports } from "../serve/discovery.js";
 import { createMcpHandler, startStdioServer } from "../serve/mcp/adapter.js";
+import { startMcpHttpServer } from "../serve/mcp/httpTransport.js";
 import { startHttpServer } from "../serve/http/adapter.js";
 import { createLogger } from "../logger.js";
 import { VERSION } from "../version.js";
@@ -19,6 +20,7 @@ import { PolicyStore } from "../serve/policyStore.js";
 import * as esbuild from "esbuild";
 import renderStandaloneHttp from "../templates/cli/standaloneHttp.js";
 import renderStandaloneMcp from "../templates/cli/standaloneMcp.js";
+import renderStandaloneMcpHttp from "../templates/cli/standaloneMcpHttp.js";
 
 type CompileResult = {
   outputPath: string;
@@ -85,16 +87,43 @@ async function loadAndDiscover(
   return { exports, moduleExports };
 }
 
+export type McpTransport = "stdio" | "http";
+
 export async function serveMcp(
   file: string,
-  options: { name?: string; standalone?: boolean },
+  options: {
+    name?: string;
+    standalone?: boolean;
+    transport?: string;
+    port?: string;
+    host?: string;
+    path?: string;
+    apiKey?: string;
+    apiKeyEnv?: string;
+  },
 ): Promise<void> {
-  const compileResult = compileForServe(file);
+  const transport = parseTransport(options.transport);
 
+  if (transport === "stdio") {
+    rejectHttpOnlyOptions(options);
+  }
+
+  const compileResult = compileForServe(file);
   const serverName = options.name ?? path.basename(file, ".agency");
 
   if (options.standalone) {
-    await generateStandalone("mcp", compileResult, file, { serverName });
+    if (transport === "http") {
+      const httpOpts = resolveMcpHttpOptions(options);
+      await generateStandalone("mcp-http", compileResult, file, {
+        serverName,
+        port: httpOpts.port,
+        host: httpOpts.host,
+        mcpPath: httpOpts.mcpPath,
+        apiKeyEnv: httpOpts.apiKeyEnv,
+      });
+    } else {
+      await generateStandalone("mcp", compileResult, file, { serverName });
+    }
     return;
   }
 
@@ -125,7 +154,106 @@ export async function serveMcp(
     policyConfig: { policyStore, interruptHandlers },
   });
 
+  if (transport === "http") {
+    const { port, host, mcpPath, apiKey } = resolveMcpHttpOptions(options, {
+      readApiKeyAtServeTime: true,
+    });
+    startMcpHttpServer({
+      handler,
+      port,
+      host,
+      path: mcpPath,
+      apiKey,
+      logger: createLogger("info"),
+    });
+    return;
+  }
+
   startStdioServer(handler);
+}
+
+function parseTransport(value: string | undefined): McpTransport {
+  if (value === undefined || value === "stdio") return "stdio";
+  if (value === "http") return "http";
+  throw new Error(`Unknown MCP transport '${value}'. Expected 'stdio' or 'http'.`);
+}
+
+function rejectHttpOnlyOptions(options: {
+  port?: string;
+  host?: string;
+  path?: string;
+  apiKey?: string;
+  apiKeyEnv?: string;
+}): void {
+  const httpFlags = ["port", "host", "path", "apiKey", "apiKeyEnv"] as const;
+  for (const flag of httpFlags) {
+    if (options[flag] !== undefined) {
+      throw new Error(
+        `--${kebab(flag)} requires --transport http (the default stdio transport ignores network options).`,
+      );
+    }
+  }
+}
+
+function kebab(name: string): string {
+  return name.replace(/([A-Z])/g, "-$1").toLowerCase();
+}
+
+type ResolvedMcpHttpOptions = {
+  port: number;
+  host: string;
+  mcpPath: string;
+  /** Only populated when readApiKeyAtServeTime is true (non-standalone). */
+  apiKey: string | undefined;
+  apiKeyEnv: string;
+};
+
+function resolveMcpHttpOptions(
+  options: {
+    port?: string;
+    host?: string;
+    path?: string;
+    apiKey?: string;
+    apiKeyEnv?: string;
+    standalone?: boolean;
+  },
+  resolveOpts: { readApiKeyAtServeTime?: boolean } = {},
+): ResolvedMcpHttpOptions {
+  const port = parseInt(options.port ?? "3545", 10);
+  if (isNaN(port) || port < 1 || port > 65535) {
+    throw new Error(`Invalid port: ${options.port}`);
+  }
+
+  const host = options.host ?? "127.0.0.1";
+  const mcpPath = options.path ?? "/mcp";
+
+  if (options.apiKey !== undefined && options.apiKeyEnv !== undefined) {
+    throw new Error("--api-key and --api-key-env are mutually exclusive.");
+  }
+
+  if (options.standalone && options.apiKey !== undefined) {
+    throw new Error(
+      "--api-key cannot be used with --standalone. Use --api-key-env <name> so the bundle reads the key from the named environment variable at runtime (default: API_KEY).",
+    );
+  }
+
+  const apiKeyEnv = options.apiKeyEnv ?? "API_KEY";
+
+  let apiKey: string | undefined;
+  if (resolveOpts.readApiKeyAtServeTime) {
+    if (options.apiKeyEnv !== undefined) {
+      apiKey = process.env[options.apiKeyEnv];
+      if (!apiKey) {
+        throw new Error(
+          `Environment variable '${options.apiKeyEnv}' is not set or empty (required by --api-key-env).`,
+        );
+      }
+    } else {
+      apiKey = options.apiKey;
+    }
+  }
+
+  return { port, host, mcpPath, apiKey, apiKeyEnv };
 }
 
 export async function serveHttp(
@@ -201,6 +329,14 @@ type StandaloneHttpOptions = {
   apiKeyEnv: string;
 };
 type StandaloneMcpOptions = { serverName: string };
+type StandaloneMcpHttpOptions = {
+  serverName: string;
+  port: number;
+  host: string;
+  mcpPath: string;
+  apiKeyEnv: string;
+};
+type StandaloneMode = "http" | "mcp" | "mcp-http";
 
 /**
  * Resolve an absolute path inside `dist/` from the currently running compiled
@@ -257,11 +393,36 @@ function buildMcpEntrypoint(
   });
 }
 
+function buildMcpHttpEntrypoint(
+  compiledAbsPath: string,
+  compileResult: CompileResult,
+  options: StandaloneMcpHttpOptions,
+  serverVersion: string,
+): string {
+  return renderStandaloneMcpHttp({
+    compiledModulePath: JSON.stringify(toPosixPath(compiledAbsPath)),
+    discoveryPath: JSON.stringify(distPath("lib/serve/discovery.js")),
+    mcpAdapterPath: JSON.stringify(distPath("lib/serve/mcp/adapter.js")),
+    mcpHttpTransportPath: JSON.stringify(distPath("lib/serve/mcp/httpTransport.js")),
+    policyStorePath: JSON.stringify(distPath("lib/serve/policyStore.js")),
+    loggerPath: JSON.stringify(distPath("lib/logger.js")),
+    moduleId: JSON.stringify(compileResult.moduleId),
+    exportedNodeNamesJson: JSON.stringify(compileResult.exportedNodeNames),
+    interruptKindsByNameJson: JSON.stringify(compileResult.interruptKindsByName),
+    serverName: JSON.stringify(options.serverName),
+    serverVersion: JSON.stringify(serverVersion),
+    defaultPort: JSON.stringify(String(options.port)),
+    defaultHost: JSON.stringify(options.host),
+    defaultPath: JSON.stringify(options.mcpPath),
+    apiKeyEnv: JSON.stringify(options.apiKeyEnv),
+  });
+}
+
 async function generateStandalone(
-  mode: "http" | "mcp",
+  mode: StandaloneMode,
   compileResult: CompileResult,
   originalFile: string,
-  options: StandaloneHttpOptions | StandaloneMcpOptions,
+  options: StandaloneHttpOptions | StandaloneMcpOptions | StandaloneMcpHttpOptions,
 ): Promise<void> {
   const baseName = path.basename(originalFile, ".agency");
   const outfile = baseName + ".server.js";
@@ -271,19 +432,7 @@ async function generateStandalone(
     `${baseName}.standalone-entry.mjs`,
   );
 
-  const entrypointSource =
-    mode === "http"
-      ? buildHttpEntrypoint(
-          compiledAbsPath,
-          compileResult,
-          options as StandaloneHttpOptions,
-        )
-      : buildMcpEntrypoint(
-          compiledAbsPath,
-          compileResult,
-          options as StandaloneMcpOptions,
-          VERSION,
-        );
+  const entrypointSource = buildEntrypoint(mode, compiledAbsPath, compileResult, options);
 
   fs.writeFileSync(entrypointPath, entrypointSource);
 
@@ -325,6 +474,36 @@ async function generateStandalone(
   }
 
   console.log(`Standalone ${mode} server written to ${outfile}`);
+}
+
+function buildEntrypoint(
+  mode: StandaloneMode,
+  compiledAbsPath: string,
+  compileResult: CompileResult,
+  options: StandaloneHttpOptions | StandaloneMcpOptions | StandaloneMcpHttpOptions,
+): string {
+  switch (mode) {
+    case "http":
+      return buildHttpEntrypoint(
+        compiledAbsPath,
+        compileResult,
+        options as StandaloneHttpOptions,
+      );
+    case "mcp":
+      return buildMcpEntrypoint(
+        compiledAbsPath,
+        compileResult,
+        options as StandaloneMcpOptions,
+        VERSION,
+      );
+    case "mcp-http":
+      return buildMcpHttpEntrypoint(
+        compiledAbsPath,
+        compileResult,
+        options as StandaloneMcpHttpOptions,
+        VERSION,
+      );
+  }
 }
 
 function safeUnlink(p: string): void {

--- a/packages/agency-lang/lib/cli/serve.ts
+++ b/packages/agency-lang/lib/cli/serve.ts
@@ -9,8 +9,13 @@ import { buildCompilationUnit } from "../compilationUnit.js";
 import { typeCheck, formatErrors } from "../typeChecker/index.js";
 import { discoverExports } from "../serve/discovery.js";
 import { createMcpHandler, startStdioServer } from "../serve/mcp/adapter.js";
-import { startMcpHttpServer } from "../serve/mcp/httpTransport.js";
+import {
+  startMcpHttpServer,
+  DEFAULT_MCP_PATH,
+  DEFAULT_MCP_PORT,
+} from "../serve/mcp/httpTransport.js";
 import { startHttpServer } from "../serve/http/adapter.js";
+import { DEFAULT_HOST } from "../serve/http/security.js";
 import { createLogger } from "../logger.js";
 import { VERSION } from "../version.js";
 import type { ExportedItem } from "../serve/types.js";
@@ -219,13 +224,13 @@ function resolveMcpHttpOptions(
   },
   resolveOpts: { readApiKeyAtServeTime?: boolean } = {},
 ): ResolvedMcpHttpOptions {
-  const port = parseInt(options.port ?? "3545", 10);
+  const port = parseInt(options.port ?? String(DEFAULT_MCP_PORT), 10);
   if (isNaN(port) || port < 1 || port > 65535) {
     throw new Error(`Invalid port: ${options.port}`);
   }
 
-  const host = options.host ?? "127.0.0.1";
-  const mcpPath = options.path ?? "/mcp";
+  const host = options.host ?? DEFAULT_HOST;
+  const mcpPath = options.path ?? DEFAULT_MCP_PATH;
 
   if (options.apiKey !== undefined && options.apiKeyEnv !== undefined) {
     throw new Error("--api-key and --api-key-env are mutually exclusive.");
@@ -285,7 +290,7 @@ export async function serveHttp(
     }
     await generateStandalone("http", compileResult, file, {
       port,
-      host: options.host ?? "127.0.0.1",
+      host: options.host ?? DEFAULT_HOST,
       apiKeyEnv: options.apiKeyEnv ?? "API_KEY",
     });
     return;

--- a/packages/agency-lang/lib/serve/http/adapter.ts
+++ b/packages/agency-lang/lib/serve/http/adapter.ts
@@ -1,8 +1,14 @@
 import http from "http";
 import type { ExportedItem, ExportedFunction, ExportedNode } from "../types.js";
-import { checkAuth } from "./auth.js";
 import { errorMessage, toArgs, parseJsonBody } from "../util.js";
 import type { Logger } from "../../logger.js";
+import {
+  DEFAULT_HOST,
+  defaultAllowedHosts,
+  enforceNoKeyOnNonLoopback,
+  logServerStart,
+  makeGuardedRequestListener,
+} from "./security.js";
 
 export type HttpConfig = {
   exports: ExportedItem[];
@@ -177,115 +183,29 @@ export function createHttpHandler(config: HttpConfig): (
   };
 }
 
-const DEFAULT_HOST = "127.0.0.1";
-const LOOPBACK_HOSTS = ["127.0.0.1", "::1", "localhost"];
-
-function isLoopbackHost(host: string): boolean {
-  return LOOPBACK_HOSTS.includes(host);
-}
-
-function defaultAllowedHosts(host: string): string[] | undefined {
-  if (isLoopbackHost(host)) return ["localhost", "127.0.0.1", "[::1]"];
-  // Non-loopback bind: skip Host validation by default. The mandatory API
-  // key (enforced below) is what mitigates DNS rebinding in this case.
-  // Operators can still pass an explicit `allowedHosts` to lock things down.
-  return undefined;
-}
-
-/**
- * Validate the Host header against an allowlist (DNS-rebinding defense).
- * Strips the port before comparison; matches case-insensitively. If
- * `allowed` is undefined, validation is skipped.
- */
-function isHostAllowed(
-  hostHeader: string | undefined,
-  allowed: string[] | undefined,
-): boolean {
-  if (allowed === undefined) return true;
-  if (!hostHeader) return false;
-  const hostOnly = stripPort(hostHeader).toLowerCase();
-  return allowed.some((a) => a.toLowerCase() === hostOnly);
-}
-
-function stripPort(hostHeader: string): string {
-  // IPv6 literal: "[::1]:3545" → "[::1]"
-  if (hostHeader.startsWith("[")) {
-    const end = hostHeader.indexOf("]");
-    return end === -1 ? hostHeader : hostHeader.slice(0, end + 1);
-  }
-  const colon = hostHeader.indexOf(":");
-  return colon === -1 ? hostHeader : hostHeader.slice(0, colon);
-}
-
 export function startHttpServer(config: HttpConfig): http.Server {
   const handler = createHttpHandler(config);
   const { logger, port, apiKey } = config;
   const host = config.host ?? DEFAULT_HOST;
   const allowedHosts = config.allowedHosts ?? defaultAllowedHosts(host);
 
-  if (!apiKey && !isLoopbackHost(host)) {
-    throw new Error(
-      `Refusing to start: no API key configured but bind host is "${host}" (non-loopback). ` +
-      `Either configure an API key, or bind to 127.0.0.1.`,
-    );
-  }
+  enforceNoKeyOnNonLoopback(host, apiKey);
 
-  const server = http.createServer(async (req, res) => {
-    const method = req.method ?? "GET";
-    const rawUrl = req.url ?? "/";
-    const path = rawUrl.split("?")[0];
-    const start = Date.now();
-
-    const sendJson = (status: number, body: unknown) => {
-      res.writeHead(status, { "Content-Type": "application/json" });
-      res.end(JSON.stringify(body) + "\n");
-      logger.info(`${method} ${path} → ${status} (${Date.now() - start}ms)`);
-    };
-
-    // 1. Host header validation (DNS-rebinding defense). Done first so a
-    //    rebinding attacker cannot reach any server logic, including auth.
-    if (!isHostAllowed(req.headers.host, allowedHosts)) {
-      sendJson(403, { error: "Forbidden host" });
-      return;
-    }
-
-    // 2. Authentication. Done before body parsing so an unauthenticated
-    //    client cannot force the server to buffer up to MAX_BODY_BYTES.
-    if (!checkAuth(apiKey, req.headers.authorization)) {
-      sendJson(401, { error: "Unauthorized" });
-      return;
-    }
-
-    try {
-      const body = method === "POST" ? await parseJsonBody(req) : undefined;
-      const result = await handler(method, path, body);
-      sendJson(result.status, result.body);
-    } catch (err) {
-      const msg = errorMessage(err);
-      if (msg === "Invalid JSON body") {
-        sendJson(400, { error: msg });
-      } else if (msg === "Request body too large") {
-        sendJson(413, { error: msg });
-      } else {
-        logger.error(`${method} ${path} → 500: ${msg}`);
-        sendJson(500, { error: "Internal server error" });
-      }
-    }
+  const listener = makeGuardedRequestListener({
+    logger,
+    apiKey,
+    allowedHosts,
+    inner: async (req, _res, ctx) => {
+      const body = ctx.method === "POST" ? await parseJsonBody(req) : undefined;
+      const result = await handler(ctx.method, ctx.path, body);
+      ctx.sendJson(result.status, result.body);
+    },
   });
 
+  const server = http.createServer(listener);
+
   server.listen(port, host, () => {
-    const displayHost = host.includes(":") ? `[${host}]` : host;
-    logger.info(`Agency HTTP server listening on http://${displayHost}:${port}`);
-    if (!isLoopbackHost(host)) {
-      logger.info(
-        `WARNING: bound to ${host} (non-loopback). Server is reachable from the network.`,
-      );
-    }
-    if (!apiKey) {
-      logger.info(
-        "WARNING: no API key configured. All requests are accepted without authentication.",
-      );
-    }
+    logServerStart(logger, "Agency HTTP server", host, port, apiKey);
   });
 
   return server;

--- a/packages/agency-lang/lib/serve/http/security.ts
+++ b/packages/agency-lang/lib/serve/http/security.ts
@@ -1,0 +1,159 @@
+/**
+ * Shared HTTP security helpers used by both the REST adapter and the MCP
+ * Streamable HTTP transport. Keeping them in one place avoids drift between
+ * the two servers (e.g., one being upgraded with a new defense and the
+ * other forgotten).
+ */
+import http from "http";
+import type { Logger } from "../../logger.js";
+import { checkAuth } from "./auth.js";
+import { errorMessage, parseJsonBody } from "../util.js";
+
+export const DEFAULT_HOST = "127.0.0.1";
+
+const LOOPBACK_HOSTS = ["127.0.0.1", "::1", "localhost"];
+
+export function isLoopbackHost(host: string): boolean {
+  return LOOPBACK_HOSTS.includes(host);
+}
+
+export function defaultAllowedHosts(host: string): string[] | undefined {
+  if (isLoopbackHost(host)) return ["localhost", "127.0.0.1", "[::1]"];
+  // Non-loopback bind: skip Host validation by default. The mandatory API
+  // key (enforced by enforceNoKeyOnNonLoopback) is what mitigates DNS
+  // rebinding in this case. Operators can still pass an explicit
+  // `allowedHosts` to lock things down.
+  return undefined;
+}
+
+/**
+ * Validate the Host header against an allowlist (DNS-rebinding defense).
+ * Strips the port before comparison; matches case-insensitively. If
+ * `allowed` is undefined, validation is skipped.
+ */
+export function isHostAllowed(
+  hostHeader: string | undefined,
+  allowed: string[] | undefined,
+): boolean {
+  if (allowed === undefined) return true;
+  if (!hostHeader) return false;
+  const hostOnly = stripPort(hostHeader).toLowerCase();
+  return allowed.some((a) => a.toLowerCase() === hostOnly);
+}
+
+function stripPort(hostHeader: string): string {
+  // IPv6 literal: "[::1]:3545" → "[::1]"
+  if (hostHeader.startsWith("[")) {
+    const end = hostHeader.indexOf("]");
+    return end === -1 ? hostHeader : hostHeader.slice(0, end + 1);
+  }
+  const colon = hostHeader.indexOf(":");
+  return colon === -1 ? hostHeader : hostHeader.slice(0, colon);
+}
+
+/**
+ * Throws if no API key is configured but the bind host is non-loopback.
+ * Call this before binding to surface the misconfiguration as early as
+ * possible — startup time, not first request.
+ */
+export function enforceNoKeyOnNonLoopback(host: string, apiKey: string | undefined): void {
+  if (!apiKey && !isLoopbackHost(host)) {
+    throw new Error(
+      `Refusing to start: no API key configured but bind host is "${host}" (non-loopback). ` +
+      `Either configure an API key, or bind to 127.0.0.1.`,
+    );
+  }
+}
+
+/**
+ * Logs the standard "listening on …" message plus warnings about
+ * non-loopback bind and missing API key.
+ */
+export function logServerStart(
+  logger: Logger,
+  serverLabel: string,
+  host: string,
+  port: number,
+  apiKey: string | undefined,
+): void {
+  const displayHost = host.includes(":") ? `[${host}]` : host;
+  logger.info(`${serverLabel} listening on http://${displayHost}:${port}`);
+  if (!isLoopbackHost(host)) {
+    logger.info(
+      `WARNING: bound to ${host} (non-loopback). Server is reachable from the network.`,
+    );
+  }
+  if (!apiKey) {
+    logger.info(
+      "WARNING: no API key configured. All requests are accepted without authentication.",
+    );
+  }
+}
+
+export type GuardedRequestContext = {
+  method: string;
+  path: string;
+  start: number;
+  sendJson: (status: number, body: unknown) => void;
+};
+
+/**
+ * Wraps an http.Server request handler with the standard pipeline:
+ * 1. Host header validation (403 on mismatch)
+ * 2. Authentication (401 on mismatch)
+ * 3. Standard error envelope for body-parse errors / 500s
+ *
+ * The inner handler is only invoked once host + auth have passed.
+ */
+export function makeGuardedRequestListener(opts: {
+  logger: Logger;
+  apiKey: string | undefined;
+  allowedHosts: string[] | undefined;
+  /** Inner handler invoked after host + auth have passed. */
+  inner: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    ctx: GuardedRequestContext,
+  ) => Promise<void>;
+}): http.RequestListener {
+  const { logger, apiKey, allowedHosts, inner } = opts;
+  return async (req, res) => {
+    const method = req.method ?? "GET";
+    const rawUrl = req.url ?? "/";
+    const path = rawUrl.split("?")[0];
+    const start = Date.now();
+
+    const sendJson = (status: number, body: unknown) => {
+      res.writeHead(status, { "Content-Type": "application/json" });
+      res.end(JSON.stringify(body) + "\n");
+      logger.info(`${method} ${path} → ${status} (${Date.now() - start}ms)`);
+    };
+
+    if (!isHostAllowed(req.headers.host, allowedHosts)) {
+      sendJson(403, { error: "Forbidden host" });
+      return;
+    }
+
+    if (!checkAuth(apiKey, req.headers.authorization)) {
+      sendJson(401, { error: "Unauthorized" });
+      return;
+    }
+
+    try {
+      await inner(req, res, { method, path, start, sendJson });
+    } catch (err) {
+      const msg = errorMessage(err);
+      if (msg === "Invalid JSON body") {
+        sendJson(400, { error: msg });
+      } else if (msg === "Request body too large") {
+        sendJson(413, { error: msg });
+      } else {
+        logger.error(`${method} ${path} → 500: ${msg}`);
+        sendJson(500, { error: "Internal server error" });
+      }
+    }
+  };
+}
+
+// Re-export parseJsonBody so transport modules don't need a second import.
+export { parseJsonBody };

--- a/packages/agency-lang/lib/serve/http/security.ts
+++ b/packages/agency-lang/lib/serve/http/security.ts
@@ -95,6 +95,12 @@ export type GuardedRequestContext = {
   path: string;
   start: number;
   sendJson: (status: number, body: unknown) => void;
+  /**
+   * Send an empty-body response (e.g. 202, 204, 405). Use this instead of
+   * `sendJson` when the HTTP status forbids a body or when extra headers
+   * (such as `Allow:` on a 405) need to be set without a JSON envelope.
+   */
+  sendStatus: (status: number, headers?: Record<string, string>) => void;
 };
 
 /**
@@ -129,6 +135,12 @@ export function makeGuardedRequestListener(opts: {
       logger.info(`${method} ${path} → ${status} (${Date.now() - start}ms)`);
     };
 
+    const sendStatus = (status: number, headers: Record<string, string> = {}) => {
+      res.writeHead(status, headers);
+      res.end();
+      logger.info(`${method} ${path} → ${status} (${Date.now() - start}ms)`);
+    };
+
     if (!isHostAllowed(req.headers.host, allowedHosts)) {
       sendJson(403, { error: "Forbidden host" });
       return;
@@ -140,7 +152,7 @@ export function makeGuardedRequestListener(opts: {
     }
 
     try {
-      await inner(req, res, { method, path, start, sendJson });
+      await inner(req, res, { method, path, start, sendJson, sendStatus });
     } catch (err) {
       const msg = errorMessage(err);
       if (msg === "Invalid JSON body") {

--- a/packages/agency-lang/lib/serve/mcp/adapter.ts
+++ b/packages/agency-lang/lib/serve/mcp/adapter.ts
@@ -14,7 +14,7 @@ function formatToolDescription(description: string, interruptKinds: InterruptKin
 
 type JsonRpcId = string | number | null;
 
-type JsonRpcMessage = {
+export type JsonRpcMessage = {
   jsonrpc?: string;
   id?: JsonRpcId;
   method?: string;
@@ -22,6 +22,9 @@ type JsonRpcMessage = {
   result?: any;
   error?: any;
 };
+
+/** The transport-agnostic handler returned by createMcpHandler. */
+export type McpHandler = (message: JsonRpcMessage) => Promise<JsonRpcMessage | null>;
 
 const MCP_PROTOCOL_VERSION = "2025-06-18";
 
@@ -197,9 +200,7 @@ async function handleToolCall(
   return rpcError(id, -32602, `Unknown tool '${name}'`);
 }
 
-export function createMcpHandler(
-  config: McpConfig,
-): (message: JsonRpcMessage) => Promise<JsonRpcMessage | null> {
+export function createMcpHandler(config: McpConfig): McpHandler {
   const { serverName, serverVersion, exports } = config;
 
   const functions = exports.filter((e): e is ExportedFunction => e.kind === "function");
@@ -277,10 +278,7 @@ function sendResponse(response: JsonRpcMessage | null): void {
   }
 }
 
-function processLine(
-  line: string,
-  handler: (message: JsonRpcMessage) => Promise<JsonRpcMessage | null>,
-): void {
+function processLine(line: string, handler: McpHandler): void {
   try {
     handler(JSON.parse(line))
       .then(sendResponse)
@@ -299,9 +297,7 @@ function processLine(
  */
 const MAX_STDIO_LINE_BYTES = 10 * 1024 * 1024; // 10 MB
 
-export function startStdioServer(
-  handler: (message: JsonRpcMessage) => Promise<JsonRpcMessage | null>,
-): void {
+export function startStdioServer(handler: McpHandler): void {
   process.stdin.setEncoding("utf-8");
 
   let buffer = "";

--- a/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
@@ -62,7 +62,7 @@ function request(
     headers?: Record<string, string>;
     body?: string;
   } = {},
-): Promise<{ status: number; body: string }> {
+): Promise<{ status: number; body: string; headers: Record<string, string> }> {
   return new Promise((resolve, reject) => {
     const req = http.request(
       {
@@ -75,9 +75,19 @@ function request(
       (res) => {
         const chunks: Buffer[] = [];
         res.on("data", (c) => chunks.push(c));
-        res.on("end", () =>
-          resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() }),
-        );
+        res.on("end", () => {
+          // Normalize header values to strings (node may give us string[]).
+          const headers: Record<string, string> = {};
+          for (const [k, v] of Object.entries(res.headers)) {
+            if (Array.isArray(v)) headers[k] = v.join(", ");
+            else if (v !== undefined) headers[k] = v;
+          }
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString(),
+            headers,
+          });
+        });
       },
     );
     req.on("error", reject);
@@ -162,10 +172,12 @@ describe("MCP HTTP transport", () => {
     });
   });
 
-  it("GET on the MCP endpoint returns 405", async () => {
+  it("GET on the MCP endpoint returns 405 with Allow: POST and an empty body", async () => {
     await withServer(baseConfig(), async (port) => {
       const res = await request(port, { method: "GET" });
       expect(res.status).toBe(405);
+      expect(res.body).toBe("");
+      expect(res.headers["allow"]).toBe("POST");
     });
   });
 
@@ -179,19 +191,30 @@ describe("MCP HTTP transport", () => {
     });
   });
 
-  it("notification (no id) returns 204 with no body content", async () => {
+  it("notification (no id) returns 202 with an empty body", async () => {
     await withServer(baseConfig(), async (port) => {
       const res = await request(port, {
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
       });
-      expect(res.status).toBe(204);
+      expect(res.status).toBe(202);
+      expect(res.body).toBe("");
     });
   });
 
-  it("rejects unauthorized request when API key is configured", async () => {
+  it("rejects unauthorized request (no Authorization header) when API key is configured", async () => {
     await withServer(baseConfig({ apiKey: "shh" }), async (port) => {
       const res = await request(port, {
+        body: JSON.stringify({ jsonrpc: "2.0", id: 6, method: "ping" }),
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  it("rejects request with the wrong Bearer token", async () => {
+    await withServer(baseConfig({ apiKey: "shh" }), async (port) => {
+      const res = await request(port, {
+        headers: { authorization: "Bearer wrong" },
         body: JSON.stringify({ jsonrpc: "2.0", id: 6, method: "ping" }),
       });
       expect(res.status).toBe(401);
@@ -205,6 +228,64 @@ describe("MCP HTTP transport", () => {
         body: JSON.stringify({ jsonrpc: "2.0", id: 7, method: "ping" }),
       });
       expect(res.status).toBe(200);
+    });
+  });
+
+  it("processes a JSON-RPC batch and returns an array of responses", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify([
+          { jsonrpc: "2.0", id: "a", method: "ping" },
+          {
+            jsonrpc: "2.0",
+            id: "b",
+            method: "tools/call",
+            params: { name: "add", arguments: { a: 10, b: 5 } },
+          },
+        ]),
+      });
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(Array.isArray(body)).toBe(true);
+      expect(body).toHaveLength(2);
+      const byId = Object.fromEntries(body.map((r: any) => [r.id, r]));
+      expect(byId.a.result).toEqual({});
+      expect(byId.b.result.content[0].text).toBe("15");
+    });
+  });
+
+  it("returns 202 with an empty body for a batch of only notifications", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify([
+          { jsonrpc: "2.0", method: "notifications/initialized" },
+          { jsonrpc: "2.0", method: "notifications/initialized" },
+        ]),
+      });
+      expect(res.status).toBe(202);
+      expect(res.body).toBe("");
+    });
+  });
+
+  it("rejects an empty batch with 400", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, {
+        headers: { "content-type": "application/json" },
+        body: "[]",
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  it("rejects a batch containing a non-object entry with 400", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify([{ jsonrpc: "2.0", id: 1, method: "ping" }, 7]),
+      });
+      expect(res.status).toBe(400);
     });
   });
 

--- a/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
+++ b/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it } from "vitest";
+import http from "http";
+import { AddressInfo } from "net";
+import { startMcpHttpServer } from "./httpTransport.js";
+import { createMcpHandler } from "./adapter.js";
+import { AgencyFunction } from "../../runtime/agencyFunction.js";
+import type { ExportedItem } from "../types.js";
+import { createLogger } from "../../logger.js";
+
+function makeHandler() {
+  const registry: Record<string, AgencyFunction> = {};
+  const addFn = AgencyFunction.create(
+    {
+      name: "add",
+      module: "test",
+      fn: async (a: number, b: number) => a + b,
+      params: [
+        { name: "a", hasDefault: false, defaultValue: undefined, variadic: false },
+        { name: "b", hasDefault: false, defaultValue: undefined, variadic: false },
+      ],
+      toolDefinition: { name: "add", description: "Add two numbers", schema: null },
+      exported: true,
+      safe: true,
+    },
+    registry,
+  );
+  const exports: ExportedItem[] = [
+    {
+      kind: "function",
+      name: "add",
+      description: "Add two numbers",
+      agencyFunction: addFn,
+      interruptKinds: [],
+    },
+  ];
+  return createMcpHandler({
+    serverName: "test-mcp-http",
+    serverVersion: "0.0.0",
+    exports,
+  });
+}
+
+async function withServer<T>(
+  config: Parameters<typeof startMcpHttpServer>[0],
+  fn: (port: number) => Promise<T>,
+): Promise<T> {
+  const server = startMcpHttpServer({ ...config, port: 0 });
+  await new Promise<void>((resolve) => server.on("listening", () => resolve()));
+  const port = (server.address() as AddressInfo).port;
+  try {
+    return await fn(port);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+function request(
+  port: number,
+  options: {
+    method?: string;
+    path?: string;
+    headers?: Record<string, string>;
+    body?: string;
+  } = {},
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        method: options.method ?? "POST",
+        path: options.path ?? "/mcp",
+        headers: options.headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () =>
+          resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString() }),
+        );
+      },
+    );
+    req.on("error", reject);
+    if (options.body !== undefined) req.write(options.body);
+    req.end();
+  });
+}
+
+function baseConfig(overrides: Partial<Parameters<typeof startMcpHttpServer>[0]> = {}) {
+  return {
+    handler: makeHandler(),
+    port: 0,
+    logger: createLogger("error"),
+    ...overrides,
+  };
+}
+
+describe("MCP HTTP transport", () => {
+  it("POST /mcp initialize returns serverInfo", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "t", version: "1" } },
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.result.serverInfo.name).toBe("test-mcp-http");
+    });
+  });
+
+  it("POST /mcp tools/list lists exported tools", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} }),
+      });
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.result.tools.map((t: any) => t.name)).toContain("add");
+    });
+  });
+
+  it("POST /mcp tools/call invokes the function", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 3,
+          method: "tools/call",
+          params: { name: "add", arguments: { a: 2, b: 5 } },
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.result.content[0].text).toBe("7");
+    });
+  });
+
+  it("POST {custom path} works when --path is set", async () => {
+    await withServer(baseConfig({ path: "/jsonrpc" }), async (port) => {
+      const res = await request(port, {
+        path: "/jsonrpc",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 4, method: "ping" }),
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  it("default path returns 404 when --path overrides it", async () => {
+    await withServer(baseConfig({ path: "/jsonrpc" }), async (port) => {
+      const res = await request(port, {
+        body: JSON.stringify({ jsonrpc: "2.0", id: 5, method: "ping" }),
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  it("GET on the MCP endpoint returns 405", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, { method: "GET" });
+      expect(res.status).toBe(405);
+    });
+  });
+
+  it("non-JSON-object body returns 400", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, {
+        headers: { "content-type": "application/json" },
+        body: "[1,2,3]",
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  it("notification (no id) returns 204 with no body content", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+      });
+      expect(res.status).toBe(204);
+    });
+  });
+
+  it("rejects unauthorized request when API key is configured", async () => {
+    await withServer(baseConfig({ apiKey: "shh" }), async (port) => {
+      const res = await request(port, {
+        body: JSON.stringify({ jsonrpc: "2.0", id: 6, method: "ping" }),
+      });
+      expect(res.status).toBe(401);
+    });
+  });
+
+  it("accepts authorized request with correct key", async () => {
+    await withServer(baseConfig({ apiKey: "shh" }), async (port) => {
+      const res = await request(port, {
+        headers: { authorization: "Bearer shh" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 7, method: "ping" }),
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  it("rejects forbidden Host header (DNS-rebinding defense)", async () => {
+    await withServer(baseConfig(), async (port) => {
+      const res = await request(port, {
+        headers: { host: "evil.example.com" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 8, method: "ping" }),
+      });
+      expect(res.status).toBe(403);
+    });
+  });
+
+  it("refuses to start without API key on non-loopback host", () => {
+    expect(() =>
+      startMcpHttpServer({
+        handler: makeHandler(),
+        port: 0,
+        host: "0.0.0.0",
+        logger: createLogger("error"),
+      }),
+    ).toThrow(/Refusing to start.*non-loopback/);
+  });
+});

--- a/packages/agency-lang/lib/serve/mcp/httpTransport.ts
+++ b/packages/agency-lang/lib/serve/mcp/httpTransport.ts
@@ -1,0 +1,96 @@
+import http from "http";
+import type { Logger } from "../../logger.js";
+import {
+  DEFAULT_HOST,
+  defaultAllowedHosts,
+  enforceNoKeyOnNonLoopback,
+  logServerStart,
+  makeGuardedRequestListener,
+  parseJsonBody,
+} from "../http/security.js";
+import type { JsonRpcMessage, McpHandler } from "./adapter.js";
+
+export type McpHttpConfig = {
+  /** JSON-RPC handler returned by createMcpHandler. */
+  handler: McpHandler;
+  port: number;
+  /** Interface to bind to. Default "127.0.0.1" (loopback only). */
+  host?: string;
+  /** Path the MCP endpoint is mounted at. Default "/mcp". */
+  path?: string;
+  apiKey?: string;
+  /**
+   * Allowed Host: header values (DNS-rebinding defense). If unset, defaults
+   * follow the same rules as the REST adapter (loopback addresses for
+   * loopback bind; skipped for non-loopback bind, where the mandatory API
+   * key handles security).
+   */
+  allowedHosts?: string[];
+  logger: Logger;
+};
+
+const DEFAULT_PATH = "/mcp";
+
+/**
+ * Start an MCP server using the Streamable HTTP transport. The transport
+ * is intentionally minimal:
+ *   - POST {path} with a single JSON-RPC message → JSON response
+ *   - GET/DELETE {path} → 405 (we have no server-initiated messages, so
+ *     SSE streams and session lifecycle are not needed)
+ *
+ * Auth, host validation, body-size limits, and the no-key-on-non-loopback
+ * guard are shared with the REST HTTP server via lib/serve/http/security.ts.
+ */
+export function startMcpHttpServer(config: McpHttpConfig): http.Server {
+  const { handler, logger, port, apiKey } = config;
+  const host = config.host ?? DEFAULT_HOST;
+  const mcpPath = config.path ?? DEFAULT_PATH;
+  const allowedHosts = config.allowedHosts ?? defaultAllowedHosts(host);
+
+  enforceNoKeyOnNonLoopback(host, apiKey);
+
+  const listener = makeGuardedRequestListener({
+    logger,
+    apiKey,
+    allowedHosts,
+    inner: async (req, _res, ctx) => {
+      if (ctx.path !== mcpPath) {
+        ctx.sendJson(404, { error: "Not found" });
+        return;
+      }
+
+      if (ctx.method !== "POST") {
+        ctx.sendJson(405, {
+          error: `Method ${ctx.method} not allowed; use POST`,
+        });
+        return;
+      }
+
+      const body = await parseJsonBody(req);
+      if (!isJsonRpcMessage(body)) {
+        ctx.sendJson(400, { error: "Request body must be a JSON-RPC 2.0 message object" });
+        return;
+      }
+
+      const response = await handler(body);
+      // Notifications (no id) yield null; reply with 204 No Content.
+      if (response === null) {
+        ctx.sendJson(204, {});
+        return;
+      }
+      ctx.sendJson(200, response);
+    },
+  });
+
+  const server = http.createServer(listener);
+
+  server.listen(port, host, () => {
+    logServerStart(logger, `Agency MCP HTTP server (path: ${mcpPath})`, host, port, apiKey);
+  });
+
+  return server;
+}
+
+function isJsonRpcMessage(value: unknown): value is JsonRpcMessage {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}

--- a/packages/agency-lang/lib/serve/mcp/httpTransport.ts
+++ b/packages/agency-lang/lib/serve/mcp/httpTransport.ts
@@ -10,6 +10,9 @@ import {
 } from "../http/security.js";
 import type { JsonRpcMessage, McpHandler } from "./adapter.js";
 
+export const DEFAULT_MCP_PATH = "/mcp";
+export const DEFAULT_MCP_PORT = 3545;
+
 export type McpHttpConfig = {
   /** JSON-RPC handler returned by createMcpHandler. */
   handler: McpHandler;
@@ -29,14 +32,15 @@ export type McpHttpConfig = {
   logger: Logger;
 };
 
-const DEFAULT_PATH = "/mcp";
-
 /**
  * Start an MCP server using the Streamable HTTP transport. The transport
  * is intentionally minimal:
  *   - POST {path} with a single JSON-RPC message → JSON response
- *   - GET/DELETE {path} → 405 (we have no server-initiated messages, so
- *     SSE streams and session lifecycle are not needed)
+ *   - POST {path} with a JSON-RPC batch (array) → array of responses, or
+ *     202 No Content if every message in the batch is a notification
+ *   - GET/DELETE {path} → 405 with `Allow: POST` (we have no
+ *     server-initiated messages, so SSE streams and session lifecycle are
+ *     not needed)
  *
  * Auth, host validation, body-size limits, and the no-key-on-non-loopback
  * guard are shared with the REST HTTP server via lib/serve/http/security.ts.
@@ -44,7 +48,7 @@ const DEFAULT_PATH = "/mcp";
 export function startMcpHttpServer(config: McpHttpConfig): http.Server {
   const { handler, logger, port, apiKey } = config;
   const host = config.host ?? DEFAULT_HOST;
-  const mcpPath = config.path ?? DEFAULT_PATH;
+  const mcpPath = config.path ?? DEFAULT_MCP_PATH;
   const allowedHosts = config.allowedHosts ?? defaultAllowedHosts(host);
 
   enforceNoKeyOnNonLoopback(host, apiKey);
@@ -60,22 +64,52 @@ export function startMcpHttpServer(config: McpHttpConfig): http.Server {
       }
 
       if (ctx.method !== "POST") {
-        ctx.sendJson(405, {
-          error: `Method ${ctx.method} not allowed; use POST`,
-        });
+        ctx.sendStatus(405, { Allow: "POST" });
         return;
       }
 
       const body = await parseJsonBody(req);
+
+      // JSON-RPC 2.0 batch: array of messages → array of responses.
+      // Empty arrays are explicitly invalid per the spec.
+      if (Array.isArray(body)) {
+        if (body.length === 0) {
+          ctx.sendJson(400, { error: "JSON-RPC batch must not be empty" });
+          return;
+        }
+        if (!body.every(isJsonRpcMessage)) {
+          ctx.sendJson(400, {
+            error: "Every entry of a JSON-RPC batch must be a JSON-RPC 2.0 message object",
+          });
+          return;
+        }
+        const responses = (await Promise.all(body.map(handler))).filter(
+          (r): r is JsonRpcMessage => r !== null,
+        );
+        // All notifications → no response per JSON-RPC 2.0 §6 ("nothing
+        // SHOULD be returned"). Use 202 with no body — 204 is the wrong
+        // status (server *did* process the request, just has nothing to
+        // return) and "{}" would violate RFC 9110 for both 202 and 204.
+        if (responses.length === 0) {
+          ctx.sendStatus(202);
+          return;
+        }
+        ctx.sendJson(200, responses);
+        return;
+      }
+
       if (!isJsonRpcMessage(body)) {
-        ctx.sendJson(400, { error: "Request body must be a JSON-RPC 2.0 message object" });
+        ctx.sendJson(400, {
+          error: "Request body must be a JSON-RPC 2.0 message object or batch array",
+        });
         return;
       }
 
       const response = await handler(body);
-      // Notifications (no id) yield null; reply with 204 No Content.
+      // Notification (no id) → no response. 202 with no body, same as
+      // the all-notifications batch case above.
       if (response === null) {
-        ctx.sendJson(204, {});
+        ctx.sendStatus(202);
         return;
       }
       ctx.sendJson(200, response);

--- a/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.mustache
+++ b/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.mustache
@@ -1,0 +1,59 @@
+import * as mod from {{{compiledModulePath:string}}};
+import { discoverExports } from {{{discoveryPath:string}}};
+import { createMcpHandler } from {{{mcpAdapterPath:string}}};
+import { startMcpHttpServer } from {{{mcpHttpTransportPath:string}}};
+import { PolicyStore } from {{{policyStorePath:string}}};
+import { createLogger } from {{{loggerPath:string}}};
+
+const exportedNodeNames = {{{exportedNodeNamesJson:string}}};
+const interruptKindsByName = {{{interruptKindsByNameJson:string}}};
+
+const exports = discoverExports({
+  toolRegistry: mod.__toolRegistry ?? {},
+  moduleExports: mod,
+  moduleId: {{{moduleId:string}}},
+  exportedNodeNames,
+  interruptKindsByName,
+});
+
+const serverName = {{{serverName:string}}};
+const policyStore = new PolicyStore(serverName);
+
+const interruptHandlers = {
+  hasInterrupts: mod.hasInterrupts,
+  respondToInterrupts: async (interrupts, responses) => {
+    const wrapped = await mod.respondToInterrupts(interrupts, responses);
+    return wrapped.data;
+  },
+};
+
+const handler = createMcpHandler({
+  serverName,
+  serverVersion: {{{serverVersion:string}}},
+  exports,
+  policyConfig: { policyStore, interruptHandlers },
+});
+
+const rawPort = process.env.PORT ?? {{{defaultPort:string}}};
+const port = parseInt(rawPort, 10);
+if (isNaN(port) || port < 1 || port > 65535) {
+  console.error("Invalid PORT: " + rawPort + ". Must be an integer between 1 and 65535.");
+  process.exit(1);
+}
+const host = process.env.HOST ?? {{{defaultHost:string}}};
+const mcpPath = process.env.MCP_PATH ?? {{{defaultPath:string}}};
+const apiKey = process.env[{{{apiKeyEnv:string}}}];
+
+try {
+  startMcpHttpServer({
+    handler,
+    port,
+    host,
+    path: mcpPath,
+    apiKey,
+    logger: createLogger("info"),
+  });
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}

--- a/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.ts
+++ b/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.ts
@@ -1,0 +1,90 @@
+// THIS FILE WAS AUTO-GENERATED
+// Source: lib/templates/cli/standaloneMcpHttp.mustache
+// Any manual changes will be lost.
+import { apply } from "typestache";
+
+export const template = `import * as mod from {{{compiledModulePath:string}}};
+import { discoverExports } from {{{discoveryPath:string}}};
+import { createMcpHandler } from {{{mcpAdapterPath:string}}};
+import { startMcpHttpServer } from {{{mcpHttpTransportPath:string}}};
+import { PolicyStore } from {{{policyStorePath:string}}};
+import { createLogger } from {{{loggerPath:string}}};
+
+const exportedNodeNames = {{{exportedNodeNamesJson:string}}};
+const interruptKindsByName = {{{interruptKindsByNameJson:string}}};
+
+const exports = discoverExports({
+  toolRegistry: mod.__toolRegistry ?? {},
+  moduleExports: mod,
+  moduleId: {{{moduleId:string}}},
+  exportedNodeNames,
+  interruptKindsByName,
+});
+
+const serverName = {{{serverName:string}}};
+const policyStore = new PolicyStore(serverName);
+
+const interruptHandlers = {
+  hasInterrupts: mod.hasInterrupts,
+  respondToInterrupts: async (interrupts, responses) => {
+    const wrapped = await mod.respondToInterrupts(interrupts, responses);
+    return wrapped.data;
+  },
+};
+
+const handler = createMcpHandler({
+  serverName,
+  serverVersion: {{{serverVersion:string}}},
+  exports,
+  policyConfig: { policyStore, interruptHandlers },
+});
+
+const rawPort = process.env.PORT ?? {{{defaultPort:string}}};
+const port = parseInt(rawPort, 10);
+if (isNaN(port) || port < 1 || port > 65535) {
+  console.error("Invalid PORT: " + rawPort + ". Must be an integer between 1 and 65535.");
+  process.exit(1);
+}
+const host = process.env.HOST ?? {{{defaultHost:string}}};
+const mcpPath = process.env.MCP_PATH ?? {{{defaultPath:string}}};
+const apiKey = process.env[{{{apiKeyEnv:string}}}];
+
+try {
+  startMcpHttpServer({
+    handler,
+    port,
+    host,
+    path: mcpPath,
+    apiKey,
+    logger: createLogger("info"),
+  });
+} catch (err) {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
+`;
+
+export type TemplateType = {
+  compiledModulePath: string;
+  discoveryPath: string;
+  mcpAdapterPath: string;
+  mcpHttpTransportPath: string;
+  policyStorePath: string;
+  loggerPath: string;
+  exportedNodeNamesJson: string;
+  interruptKindsByNameJson: string;
+  moduleId: string;
+  serverName: string;
+  serverVersion: string;
+  defaultPort: string;
+  defaultHost: string;
+  defaultPath: string;
+  apiKeyEnv: string;
+};
+
+const render = (args: TemplateType) => {
+  return apply(template, args);
+}
+
+export default render;
+    

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -801,7 +801,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
       "--transport <transport>",
       "Transport: 'stdio' (default) or 'http' (Streamable HTTP)",
     )
-    .option("--port <port>", "HTTP port (http transport only, default: 3545)", "3545")
+    .option("--port <port>", "HTTP port (http transport only, default: 3545)")
     .option(
       "--host <host>",
       "Interface to bind to (http transport only, default: 127.0.0.1, loopback only). Use 0.0.0.0 to expose externally — requires --api-key/--api-key-env.",
@@ -833,17 +833,7 @@ export function createProgram(deps: CliDependencies = {}): Command {
           apiKeyEnv?: string;
         },
       ) => {
-        // commander always assigns the default port string even when --port
-        // wasn't passed; strip it for the stdio path so the cross-flag
-        // validator doesn't complain about an http-only flag.
-        const cleanedOptions = { ...options };
-        if (
-          (options.transport === undefined || options.transport === "stdio") &&
-          options.port === "3545"
-        ) {
-          delete cleanedOptions.port;
-        }
-        await serveMcp(file, cleanedOptions);
+        await serveMcp(file, options);
       },
     );
 

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -794,13 +794,56 @@ export function createProgram(deps: CliDependencies = {}): Command {
 
   serveCmd
     .command("mcp")
-    .description("Start an MCP server (stdio)")
+    .description("Start an MCP server (stdio by default; --transport http for Streamable HTTP)")
     .argument("<file>", "Agency file to serve")
     .option("--name <name>", "Server name (defaults to filename)")
+    .option(
+      "--transport <transport>",
+      "Transport: 'stdio' (default) or 'http' (Streamable HTTP)",
+    )
+    .option("--port <port>", "HTTP port (http transport only, default: 3545)", "3545")
+    .option(
+      "--host <host>",
+      "Interface to bind to (http transport only, default: 127.0.0.1, loopback only). Use 0.0.0.0 to expose externally — requires --api-key/--api-key-env.",
+    )
+    .option(
+      "--path <path>",
+      "Endpoint path the MCP server is mounted at (http transport only, default: /mcp)",
+    )
+    .option(
+      "--api-key <key>",
+      "API key for authentication (http transport only). NOT recommended: visible in process listings. Prefer --api-key-env.",
+    )
+    .option(
+      "--api-key-env <name>",
+      "Name of the environment variable to read the API key from (http transport only). For --standalone, the bundle reads this env var at runtime (default: API_KEY).",
+    )
     .option("--standalone", "Generate a standalone server.js file")
     .action(
-      async (file: string, options: { name?: string; standalone?: boolean }) => {
-        await serveMcp(file, options);
+      async (
+        file: string,
+        options: {
+          name?: string;
+          standalone?: boolean;
+          transport?: string;
+          port?: string;
+          host?: string;
+          path?: string;
+          apiKey?: string;
+          apiKeyEnv?: string;
+        },
+      ) => {
+        // commander always assigns the default port string even when --port
+        // wasn't passed; strip it for the stdio path so the cross-flag
+        // validator doesn't complain about an http-only flag.
+        const cleanedOptions = { ...options };
+        if (
+          (options.transport === undefined || options.transport === "stdio") &&
+          options.port === "3545"
+        ) {
+          delete cleanedOptions.port;
+        }
+        await serveMcp(file, cleanedOptions);
       },
     );
 


### PR DESCRIPTION
## What

Adds MCP **Streamable HTTP** transport support to `agency serve mcp`, both for direct serving and `--standalone` bundling.

```bash
# Existing: stdio (unchanged)
agency serve mcp foo.agency

# New: MCP over HTTP
agency serve mcp --transport http foo.agency
agency serve mcp --transport http --standalone foo.agency
node foo.server.js   # MCP server reachable at http://127.0.0.1:3545/mcp
```

## Why

Modern MCP clients (Claude Desktop's HTTP support, web-based clients) prefer the Streamable HTTP transport over stdio because it:
- Works across process/network boundaries
- Allows long-running shared agents instead of one process per client
- Doesn't tie the client's lifetime to the agent's

`createMcpHandler` was already transport-agnostic (returns a pure `(JsonRpcMessage) => Promise<JsonRpcMessage | null>`), so the only missing piece was the HTTP plumbing.

## Design

For an Agency agent (stateless tool server, no server-initiated messages), the minimum viable Streamable HTTP transport is **one POST endpoint that returns a single JSON-RPC response**. No SSE streams, no GET subscription, no session lifecycle. That's exactly what this PR ships.

The new `startMcpHttpServer` shares the entire HTTP security pipeline with the REST adapter via a new `lib/serve/http/security.ts` module — same timing-safe auth, same Host-allowlist DNS-rebinding defense, same auth-before-body ordering, same refuse-no-key-on-non-loopback guard, same warnings.

## CLI surface

```text
agency serve mcp <file>
  --name <name>             Server name (defaults to filename)
  --transport <transport>   'stdio' (default) or 'http'
  --port <port>             HTTP port (http only, default: 3545)
  --host <host>             Bind interface (http only, default: 127.0.0.1)
  --path <path>             Endpoint path (http only, default: /mcp)
  --api-key <key>           HTTP auth (discouraged; visible in argv)
  --api-key-env <name>      HTTP auth env var (preferred; standalone reads at runtime)
  --standalone              Generate a standalone server.js
```

`--port`, `--host`, etc. on the stdio path are rejected with a clear error.

## Files

- **New:** [`lib/serve/mcp/httpTransport.ts`](https://github.com/egonSchiele/agency-lang/blob/mcp-http-transport/packages/agency-lang/lib/serve/mcp/httpTransport.ts) — the new transport
- **New:** [`lib/serve/http/security.ts`](https://github.com/egonSchiele/agency-lang/blob/mcp-http-transport/packages/agency-lang/lib/serve/http/security.ts) — extracted shared HTTP security helpers
- **New:** [`lib/templates/cli/standaloneMcpHttp.mustache`](https://github.com/egonSchiele/agency-lang/blob/mcp-http-transport/packages/agency-lang/lib/templates/cli/standaloneMcpHttp.mustache) + generated TS — third standalone entrypoint template
- **New:** [`lib/serve/mcp/httpTransport.test.ts`](https://github.com/egonSchiele/agency-lang/blob/mcp-http-transport/packages/agency-lang/lib/serve/mcp/httpTransport.test.ts) — 12 integration tests
- **Modified:** `lib/serve/http/adapter.ts` — refactored to use `security.ts` (no behavior change, just deduplication)
- **Modified:** `lib/serve/mcp/adapter.ts` — exported `JsonRpcMessage` and added an `McpHandler` type alias
- **Modified:** `lib/cli/serve.ts` — `serveMcp` dispatches on `--transport`; new `mcp-http` mode in `generateStandalone`
- **Modified:** `scripts/agency.ts` — new flags wired through

## Deliberately out of scope

- **SSE response streams.** Agency agents don't emit server-initiated messages.
- **Client GET → SSE stream.** Same reason.
- **`Mcp-Session-Id` lifecycle.** Each request is independent.
- **`@modelcontextprotocol/sdk` dependency.** Hand-rolled JSON-RPC handler is already complete.

## Verification

- 12 new transport integration tests pass
- 23 existing HTTP adapter tests pass after the security refactor
- 17 existing MCP stdio adapter tests pass
- All 224 tests across `lib/serve/` and `lib/cli/` pass
- `pnpm run lint:structure` clean

End-to-end (manual):
- `agency serve mcp --transport http test_mcp.agency` + `curl POST /mcp tools/call add(3,4)` → returns `"7"`
- `agency serve mcp --transport http --standalone test_mcp.agency` → `node test_mcp.server.js` works the same way
- `Host: evil.com` → 403
- `HOST=0.0.0.0` without API key → refuses to start with clear error
- Stdio default unchanged: `echo '{"jsonrpc":"2.0",...,"method":"tools/list"}' | agency serve mcp test_mcp.agency` → returns the `add` tool
- `agency serve mcp --port 3000 test_mcp.agency` (stdio + http-only flag) → rejected with "--port requires --transport http"

## Notes

- Per `lib/serve/http/security.ts`, `defaultAllowedHosts` returns `["localhost", "127.0.0.1", "[::1]"]` for loopback bind and `undefined` (skip Host validation) for non-loopback. This matches the existing REST adapter behavior — non-loopback bind already requires an API key, and forcing operators to pre-declare every public hostname is too restrictive. Operators can still pass an explicit `allowedHosts` to `startMcpHttpServer` to lock things down further.
