### PR TITLE
Add stdlib coverage report to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,10 @@ on:
 
 permissions:
   contents: read
+  # Required so the coverage step can post a sticky comment on PRs.
+  # `pull_request` events from forks still receive a read-only token, in which
+  # case the post step degrades to "log only" via continue-on-error.
+  pull-requests: write
 
 jobs:
   build:
@@ -63,12 +67,65 @@ jobs:
       working-directory: packages/agency-lang
       env:
         AGENCY_USE_TEST_LLM_PROVIDER: "1"
-      run: pnpm run test:agency
+      # On node 22 we collect step coverage so the next step can report on
+      # stdlib. `--coverage` (without `--accumulate`) cleans `.coverage/` first,
+      # so the runner does not need to be otherwise prepared.
+      run: |
+        if [ "${{ matrix.node-version }}" = "22.x" ]; then
+          time node ./dist/scripts/agency.js test tests/agency -p 12 --coverage
+        else
+          pnpm run test:agency
+        fi
     - name: Agency-JS integration tests
       working-directory: packages/agency-lang
       env:
         AGENCY_USE_TEST_LLM_PROVIDER: "1"
-      run: pnpm run test:agency-js
+      run: |
+        if [ "${{ matrix.node-version }}" = "22.x" ]; then
+          time node ./dist/scripts/agency.js test js tests/agency-js -p 12 --coverage --accumulate
+        else
+          pnpm run test:agency-js
+        fi
+    - name: Generate stdlib coverage report
+      if: matrix.node-version == '22.x' && always() && !cancelled()
+      working-directory: packages/agency-lang
+      # `coverage report` triggers a recompile of every target .agency file:
+      # type warnings go to stderr (silenced) and "file.agency → file.js"
+      # progress lines go to stdout interleaved with the report itself
+      # (filtered out with grep).
+      run: |
+        node ./dist/scripts/agency.js coverage report stdlib 2>/dev/null \
+          | grep -v ' → ' \
+          | tee coverage-summary.txt
+        node ./dist/scripts/agency.js coverage report --detail stdlib 2>/dev/null \
+          | grep -v ' → ' \
+          | tee coverage-detail.txt
+    - name: Post stdlib coverage comment
+      if: matrix.node-version == '22.x' && github.event_name == 'pull_request' && always() && !cancelled()
+      continue-on-error: true
+      uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+      with:
+        script: |
+          const fs = require('fs');
+          const summary = fs.readFileSync('packages/agency-lang/coverage-summary.txt', 'utf8');
+          const detail = fs.readFileSync('packages/agency-lang/coverage-detail.txt', 'utf8');
+          const marker = '<!-- agency-stdlib-coverage -->';
+          const body = `${marker}\n## Standard Library Coverage\n\nFrom \`agency test\` + \`agency test js\` (run \`${context.runId}\`).\n\n<details open><summary>Summary</summary>\n\n\`\`\`\n${summary}\n\`\`\`\n\n</details>\n\n<details><summary>Per-file uncovered ranges</summary>\n\n\`\`\`\n${detail}\n\`\`\`\n\n</details>\n`;
+          const { owner, repo } = context.repo;
+          const issue_number = context.issue.number;
+          const { data: comments } = await github.rest.issues.listComments({
+            owner, repo, issue_number, per_page: 100,
+          });
+          const existing = comments.find((c) => c.body && c.body.includes(marker));
+          if (existing) {
+            await github.rest.issues.updateComment({
+              owner, repo, comment_id: existing.id, body,
+            });
+          } else {
+            await github.rest.issues.createComment({
+              owner, repo, issue_number, body,
+            });
+          }
     - name: github stdlib smoke test
       # Only run on `push` to main, NEVER on `pull_request` events.
       #

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,15 +7,28 @@ on:
   pull_request:
     branches: [ "main" ]
 
+# Workflow-level permissions are read-only by default. Each job opts into
+# additional scopes only when it needs them.
 permissions:
   contents: read
-  # Required so the coverage step can post a sticky comment on PRs.
-  # `pull_request` events from forks still receive a read-only token, in which
-  # case the post step degrades to "log only" via continue-on-error.
-  pull-requests: write
 
 jobs:
   build:
+    # `pull-requests: write` is required so the coverage reporter can post
+    # a sticky comment on PRs.
+    #
+    # Security notes:
+    #   * This workflow uses `pull_request`, NOT `pull_request_target`. PRs
+    #     from forks therefore receive a read-only `GITHUB_TOKEN` regardless
+    #     of the `permissions:` block, so a fork cannot abuse this scope.
+    #   * For same-repo PRs the author already has push access, so the
+    #     incremental risk of granting comment-write to that PR's workflow
+    #     run is minimal.
+    #   * The post step is wrapped with `continue-on-error: true` so that a
+    #     missing/restricted token never fails the build.
+    permissions:
+      contents: read
+      pull-requests: write
 
     runs-on: ubuntu-latest
 
@@ -136,7 +149,16 @@ jobs:
       # `main` means only commits already on the protected branch can
       # exercise this step (so the token is only readable by code that
       # has already been merged).
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.node-version == '22.x' && secrets.GITHUB_TEST_TOKEN != ''
+      #
+      # `secrets.*` cannot be referenced inside step-level `if:` expressions,
+      # so we gate on the event/ref here and skip inside the script when
+      # `GITHUB_TOKEN` is empty (e.g. on forks of this repo).
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.node-version == '22.x'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TEST_TOKEN }}
-      run: pnpm -F @agency-lang/github test:agency
+      run: |
+        if [ -z "$GITHUB_TOKEN" ]; then
+          echo "GITHUB_TEST_TOKEN secret not set; skipping github stdlib smoke test."
+          exit 0
+        fi
+        pnpm -F @agency-lang/github test:agency


### PR DESCRIPTION
After the agency + agency-js test suites run on CI, generate a stdlib coverage report and post it as a sticky comment on the PR.

## How it works

- `Agency execution tests` step now runs with `--coverage` (only on the node 22 matrix slot). `--coverage` (without `--accumulate`) cleans `.coverage/` first, so a fresh CI runner needs no setup.
- `Agency-JS integration tests` step runs with `--coverage --accumulate` so its hits merge into the dataset from the previous step.
- A new `Generate stdlib coverage report` step runs `agency coverage report stdlib` (summary) and `agency coverage report --detail stdlib` (per-file uncovered line ranges), capturing both into files. Type warnings (stderr) are silenced and `file.agency → file.js` recompile lines are stripped so the captured text contains only the table.
- A new `Post stdlib coverage comment` step uses `actions/github-script@v7.0.1` (SHA-pinned) to find an existing coverage comment by HTML marker and either update it in place or create a new one. This means re-runs and force-pushes do not spam the PR with duplicate comments.

## What the comment looks like

```
## Standard Library Coverage

From `agency test` + `agency test js` (run `12345678`).

▸ Summary
  stdlib/array.agency  100.0%  (76/76 steps)
  stdlib/math.agency    33.3%   (2/6 steps)
  ...
  Total                 53.8%  (162/301 steps)

▸ Per-file uncovered ranges
  stdlib/math.agency   33.3%  (2/6)  uncovered: 14-15, 22
  ...
```

(Both sections are collapsible `<details>` blocks; the summary is open by default.)

## Behavior matrix

| Trigger | Node 22 | Node 23 | Comment posted? |
|---|---|---|---|
| `push` to main | tests + report (logs only) | tests only | No |
| `pull_request` (same-repo) | tests + report + comment | tests only | Yes |
| `pull_request` (fork) | tests + report (logs only) | tests only | No (token read-only) |

The post step is `continue-on-error: true` so a failed comment post never breaks CI; for forks, the report still lands in the workflow logs.

The report runs with `if: always() && !cancelled()` so a partial test failure still produces a coverage view (useful for diagnosing why coverage dropped on a PR).

## Notes / things you might want to tweak

- I run coverage only on node 22, not on both matrix slots, since they would produce the same result and double the runtime.
- The comment uses a HTML marker `<!-- agency-stdlib-coverage -->` to find itself for updates; safe to change later if you want a different identifier.
- The `pull-requests: write` permission was added to the job — required for posting comments. The existing `contents: read` is unchanged.
- For PRs from forks, the comment will silently fail to post (read-only token). The report still appears in the workflow run logs. If you want comments on fork PRs you would need a separate `workflow_run`-triggered job that downloads an artifact and posts with elevated perms — happy to add that as a follow-up.
- If you would prefer this to run on every push to main as well (so main's coverage is always logged), let me know and I can drop the `pull_request` event guard on the comment step (it would still try to post, but `context.issue.number` is undefined on push events so it would no-op).
