### PR TITLE
whisper-local: pin SHA-256 hashes for the remaining seven models

### DIFF
--- a/packages/agency-lang/docs/superpowers/specs/2026-05-11-whisper-local-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-11-whisper-local-design.md
@@ -7,9 +7,9 @@
 > and [`packages/whisper-local/docs/DEV.md`](../../../whisper-local/docs/DEV.md).**
 >
 > Notable differences from this spec as shipped:
-> - **Default model is `base.en`** (this spec says `base`); only `tiny`,
->   `tiny.en`, and `base.en` are in `KNOWN_MODELS` until the lockfile is
->   filled out for the larger models.
+> - **Default model is `base.en`** (this spec says `base`). All ten upstream
+>   whisper.cpp models (`tiny` through `large-v3-turbo`) are in
+>   `KNOWN_MODELS` and pinned in `models.lock.json` with verified SHAs.
 > - **No `install` / `postinstall` script.** Users explicitly run
 >   `npx agency-whisper build` after install. (This spec's "Build and
 >   install" section pre-dates that decision.)

--- a/packages/whisper-local/README.md
+++ b/packages/whisper-local/README.md
@@ -52,13 +52,22 @@ Returns the joined transcript text. Throws on missing ffmpeg, unknown model, cor
 
 ## Models
 
+All ten upstream whisper.cpp models are pinned in `models.lock.json` against HuggingFace commit [`5359861c…`](https://huggingface.co/ggerganov/whisper.cpp/tree/5359861c739e955e79d9a303bcbc70fb988958b1) with verified SHA-256 hashes.
+
 | Name | Size | English-only | Notes |
 |------|------|--------------|-------|
-| `tiny` | 75 MB | no | Fastest, lowest accuracy. Good for quick prototypes. |
-| `tiny.en` | 75 MB | yes | English-only variant of `tiny`; slightly more accurate. |
-| `base.en` | 142 MB | yes | Recommended default. Good accuracy/speed trade-off. |
+| `tiny`           | 75 MB  | no  | Fastest, lowest accuracy. Good for quick prototypes. |
+| `tiny.en`        | 75 MB  | yes | English-only variant of `tiny`; slightly more accurate. |
+| `base`           | 142 MB | no  | Multilingual base model. |
+| `base.en`        | 142 MB | yes | **Default.** Good accuracy/speed trade-off for English. |
+| `small`          | 466 MB | no  | Noticeable accuracy bump over `base`. |
+| `small.en`       | 466 MB | yes | English-only variant of `small`. |
+| `medium`         | 1.5 GB | no  | Slow on CPU; usable on Apple Silicon. |
+| `medium.en`      | 1.5 GB | yes | English-only variant of `medium`. |
+| `large-v3`       | 2.9 GB | no  | Best accuracy. Use only with adequate RAM (~5 GB peak). |
+| `large-v3-turbo` | 1.6 GB | no  | Approaches `large-v3` quality at ~half the size. |
 
-Other whisper.cpp models (`base`, `small`, `small.en`, `medium`, `medium.en`, `large-v3`, `large-v3-turbo`) are supported by the underlying engine but are not yet pinned in `models.lock.json`. They will be added as we verify each upstream release. To add one yourself, see [`docs/DEV.md`](./docs/DEV.md#adding-a-model).
+`.en` variants are slightly more accurate on English-only audio. To add a model from a newer upstream release, see [`docs/DEV.md`](./docs/DEV.md#adding-a-model).
 
 ## Pre-downloading models
 

--- a/packages/whisper-local/docs/DEV.md
+++ b/packages/whisper-local/docs/DEV.md
@@ -217,21 +217,27 @@ HF_COMMIT=<sha> MODELS="tiny tiny.en base.en" bash scripts/generate-lockfile.sh
 <a id="adding-a-model"></a>
 ### Adding a model
 
-The shipped lockfile and `KNOWN_MODELS` list (in `src/types.ts`) carry only
-the three models we have actually verified end-to-end: `tiny`, `tiny.en`,
-and `base.en`. To add another (e.g. `large-v3`):
+The shipped lockfile and `KNOWN_MODELS` list (in `src/types.ts`) carry all
+ten upstream whisper.cpp models, pinned to the HuggingFace commit recorded
+in `models.lock.json`. To add a model that ships in a newer upstream
+release (e.g. a hypothetical `large-v4`):
 
-1. Pick the upstream HuggingFace commit you want to pin to.
-2. Run `HF_COMMIT=<sha> MODELS="large-v3" bash scripts/generate-lockfile.sh`.
-3. Confirm the printed SHA against the upstream HuggingFace UI.
+1. Identify the new HuggingFace commit that includes the model.
+2. Run `HF_COMMIT=<sha> MODELS="large-v4" bash scripts/generate-lockfile.sh`.
+   The script downloads the file once to compute its SHA-256 and size.
+   Alternatively — much faster — fetch the LFS pointer directly:
+   `curl https://huggingface.co/ggerganov/whisper.cpp/raw/<sha>/ggml-large-v4.bin`
+   returns the `oid sha256:…` and `size` without downloading the model.
+3. Confirm the SHA against the HuggingFace UI (a separate browser session
+   guards against a compromised mirror).
 4. Add the model name to `KNOWN_MODELS` in `src/types.ts`.
 5. Add a row to the Models table in `README.md`.
 
 `ensureModel` retains a defensive guard: any lockfile entry with
 `sha256: "0".repeat(64)` is rejected with a clear "lockfile not populated
-yet" message. This is unreachable in shipped code (because such entries are
-not in `KNOWN_MODELS`) but stays as belt-and-suspenders against a future
-regression.
+yet" message. This is unreachable in shipped code today (every
+`KNOWN_MODELS` entry has a real hash) but stays as belt-and-suspenders
+against a future regression.
 
 ## 5. Vendoring procedure
 

--- a/packages/whisper-local/models.lock.json
+++ b/packages/whisper-local/models.lock.json
@@ -11,10 +11,45 @@
       "sha256": "921e4cf8686fdd993dcd081a5da5b6c365bfde1162e72b08d75ac75289920b1f",
       "sizeBytes": 77704715
     },
+    "base": {
+      "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/5359861c739e955e79d9a303bcbc70fb988958b1/ggml-base.bin",
+      "sha256": "60ed5bc3dd14eea856493d334349b405782ddcaf0028d4b5df4088345fba2efe",
+      "sizeBytes": 147951465
+    },
     "base.en": {
       "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/5359861c739e955e79d9a303bcbc70fb988958b1/ggml-base.en.bin",
       "sha256": "a03779c86df3323075f5e796cb2ce5029f00ec8869eee3fdfb897afe36c6d002",
       "sizeBytes": 147964211
+    },
+    "small": {
+      "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/5359861c739e955e79d9a303bcbc70fb988958b1/ggml-small.bin",
+      "sha256": "1be3a9b2063867b937e64e2ec7483364a79917e157fa98c5d94b5c1fffea987b",
+      "sizeBytes": 487601967
+    },
+    "small.en": {
+      "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/5359861c739e955e79d9a303bcbc70fb988958b1/ggml-small.en.bin",
+      "sha256": "c6138d6d58ecc8322097e0f987c32f1be8bb0a18532a3f88f734d1bbf9c41e5d",
+      "sizeBytes": 487614201
+    },
+    "medium": {
+      "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/5359861c739e955e79d9a303bcbc70fb988958b1/ggml-medium.bin",
+      "sha256": "6c14d5adee5f86394037b4e4e8b59f1673b6cee10e3cf0b11bbdbee79c156208",
+      "sizeBytes": 1533763059
+    },
+    "medium.en": {
+      "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/5359861c739e955e79d9a303bcbc70fb988958b1/ggml-medium.en.bin",
+      "sha256": "cc37e93478338ec7700281a7ac30a10128929eb8f427dda2e865faa8f6da4356",
+      "sizeBytes": 1533774781
+    },
+    "large-v3": {
+      "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/5359861c739e955e79d9a303bcbc70fb988958b1/ggml-large-v3.bin",
+      "sha256": "64d182b440b98d5203c4f9bd541544d84c605196c4f7b845dfa11fb23594d1e2",
+      "sizeBytes": 3095033483
+    },
+    "large-v3-turbo": {
+      "url": "https://huggingface.co/ggerganov/whisper.cpp/resolve/5359861c739e955e79d9a303bcbc70fb988958b1/ggml-large-v3-turbo.bin",
+      "sha256": "1fc70f774d38eb169993ac391eea357ef47c88757ef72ee5943879b7e8e2bc69",
+      "sizeBytes": 1624555275
     }
   }
 }

--- a/packages/whisper-local/src/types.ts
+++ b/packages/whisper-local/src/types.ts
@@ -1,10 +1,19 @@
-// Only models with a real pinned URL + SHA-256 in models.lock.json are
-// advertised here. Additional models (small, medium, large-v3, etc.) can be
-// added once the lockfile entry is verified — see scripts/generate-lockfile.sh.
+// Every entry here must have a real pinned URL + SHA-256 in
+// models.lock.json. To add another upstream model, run
+// `HF_COMMIT=<sha> MODELS="<name>" bash scripts/generate-lockfile.sh`,
+// confirm the printed SHA against the HuggingFace UI, then add the name
+// to this list and a row to README.md's Models table.
 export const KNOWN_MODELS = [
   "tiny",
   "tiny.en",
+  "base",
   "base.en",
+  "small",
+  "small.en",
+  "medium",
+  "medium.en",
+  "large-v3",
+  "large-v3-turbo",
 ] as const;
 
 export type ModelName = (typeof KNOWN_MODELS)[number];

--- a/packages/whisper-local/tests/cli.test.ts
+++ b/packages/whisper-local/tests/cli.test.ts
@@ -98,9 +98,20 @@ describe("CLI", () => {
       const r = await runCli(["list"], { AGENCY_WHISPER_MODELS_DIR: tmp });
       expect(r.code).toBe(0);
       expect(r.stdout).toMatch(/Models directory:/);
-      // Every model in the shipped lockfile should appear. Currently we only
-      // ship the three with verified hashes; see types.ts KNOWN_MODELS.
-      for (const name of ["tiny", "tiny.en", "base.en"]) {
+      // Every model in the shipped lockfile should appear; see KNOWN_MODELS
+      // in src/types.ts (the lockfile and KNOWN_MODELS are kept in sync).
+      for (const name of [
+        "tiny",
+        "tiny.en",
+        "base",
+        "base.en",
+        "small",
+        "small.en",
+        "medium",
+        "medium.en",
+        "large-v3",
+        "large-v3-turbo",
+      ]) {
         expect(r.stdout).toContain(name);
       }
     });

--- a/packages/whisper-local/tests/ensureModel.test.ts
+++ b/packages/whisper-local/tests/ensureModel.test.ts
@@ -36,13 +36,14 @@ describe("ensureModel", () => {
   });
 
   it("rejects with ModelManagerError for a model not in KNOWN_MODELS", async () => {
-    // "small" was removed from KNOWN_MODELS until its lockfile entry is
-    // populated. resolveModelPath rejects unknown names up front.
+    // resolveModelPath rejects unknown names up front (before the file
+    // existence check or the lockfile lookup), so ensureModel inherits
+    // that rejection. Use a name that cannot ever be a real whisper model.
     await expect(
-      ensureModel("small" as never, tmp),
+      ensureModel("definitely-not-a-real-whisper-model" as never, tmp),
     ).rejects.toBeInstanceOf(ModelManagerError);
     await expect(
-      ensureModel("small" as never, tmp),
+      ensureModel("definitely-not-a-real-whisper-model" as never, tmp),
     ).rejects.toThrow(/unknown model/);
   });
 });


### PR DESCRIPTION
Pins SHA-256 hashes for the remaining seven whisper.cpp models so the package now ships with all ten upstream models usable out of the box: `tiny`, `tiny.en`, `base`, `base.en`, `small`, `small.en`, `medium`, `medium.en`, `large-v3`, `large-v3-turbo`.

All entries pin to the same HuggingFace commit (`5359861c…`) that the existing three entries use. No upstream version bump.

## How the SHAs were obtained

HuggingFace serves the LFS pointer file at `/raw/<commit>/<file>`, which contains the file's SHA-256 OID and size — no need to download the actual ~8 GB of model data:

```
$ curl https://huggingface.co/ggerganov/whisper.cpp/raw/5359861c…/ggml-large-v3.bin
version https://git-lfs.github.com/spec/v1
oid sha256:64d182b440b98d5203c4f9bd541544d84c605196c4f7b845dfa11fb23594d1e2
size 3095033483
```

I verified the mechanism by re-fetching `base.en`'s LFS OID and confirming it matches the SHA already in the lockfile from when we downloaded that file directly (`a03779c…`). LFS OID = file SHA-256 by spec, so this is sound.

## Doc + test updates

- `README.md`: full ten-row Models table with size / English-only / notes.
- `docs/DEV.md` "Adding a model" section rewritten to describe the faster `/raw/` LFS-pointer workflow.
- Historical design spec note updated to reflect the full set.
- `tests/cli.test.ts`: `list` test now expects all ten models.
- `tests/ensureModel.test.ts`: unknown-model test now uses a name that cannot ever be a real whisper model.

## Tests

`62 passed | 3 skipped` (unchanged from main).
