### PR TITLE
Add .preapprove() to AgencyFunction

### DIFF
--- a/packages/agency-lang/docs/site/guide/partial-application.md
+++ b/packages/agency-lang/docs/site/guide/partial-application.md
@@ -123,6 +123,33 @@ const result = success(10) |> half |> multiply.partial(a: 3)
 
 The piped value fills the remaining unbound parameter.
 
+## Auto-approving interrupts with `.preapprove()`
+
+If you trust a function and want to auto-approve all its interrupts, use `.preapprove()`:
+
+```ts
+const tool = readFile.preapprove()
+llm("Read the config", { tools: [tool] })
+```
+
+This is equivalent to wrapping every call in a handler that approves:
+
+```ts
+handle {
+  readFile(filename)
+} with (data) {
+  return approve()
+}
+```
+
+`.preapprove()` works on any function, not just PFAs, and chains with `.partial()` and `.describe()` in any order:
+
+```ts
+const safeTool = readFile.partial(dir: "/tmp").preapprove().describe("Read temp files")
+```
+
+Outer handlers still take precedence. If a handler further up the chain rejects the interrupt, it stays rejected — `.preapprove()` can't override an outer rejection. This follows the normal [handler rules](./handlers).
+
 ## Rules and restrictions
 
 - You can only bind parameters by name: `fn.partial(x: 5)`, not by position.

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { stripBoundParams } from "./stripBoundParams.js";
+import { approve } from "./interrupts.js";
 
 export const UNSET: unique symbol = Symbol("UNSET");
 
@@ -30,6 +31,7 @@ export type AgencyFunctionOpts = {
   toolDefinition: ToolDefinition | null;
   exported?: boolean;
   safe?: boolean;
+  isPreapproved?: boolean;
 };
 
 export class AgencyFunction {
@@ -45,6 +47,7 @@ export class AgencyFunction {
   private readonly _isBound: boolean;
   readonly exported: boolean;
   readonly safe: boolean;
+  private readonly _isPreapproved: boolean;
 
   constructor(opts: AgencyFunctionOpts) {
     this.name = opts.name;
@@ -54,10 +57,15 @@ export class AgencyFunction {
     this.toolDefinition = opts.toolDefinition;
     this.exported = opts.exported ?? false;
     this.safe = opts.safe ?? false;
+    this._isPreapproved = opts.isPreapproved ?? false;
     this._unboundParams = opts.params.filter(p => !p.isBound);
     this._nonVariadicUnbound = this._unboundParams.filter(p => !p.variadic);
     this._hasVariadic = this._unboundParams.length > 0 && this._unboundParams[this._unboundParams.length - 1].variadic;
     this._isBound = opts.params.some(p => p.isBound);
+  }
+
+  get isPreapproved(): boolean {
+    return this._isPreapproved;
   }
 
   get boundArgs(): { indices: number[]; values: unknown[]; originalParams: FuncParam[] } | null {
@@ -82,6 +90,7 @@ export class AgencyFunction {
       toolDefinition,
       exported: this.exported,
       safe: this.safe,
+      isPreapproved: this._isPreapproved,
     });
   }
 
@@ -94,6 +103,19 @@ export class AgencyFunction {
   }
 
   async invoke(descriptor: CallType, state?: unknown): Promise<unknown> {
+    const ctx = (state as any)?.ctx;
+    if (this._isPreapproved && ctx) {
+      ctx.pushHandler(async () => approve());
+      try {
+        return await this._invokeInner(descriptor, state);
+      } finally {
+        ctx.popHandler();
+      }
+    }
+    return this._invokeInner(descriptor, state);
+  }
+
+  private async _invokeInner(descriptor: CallType, state?: unknown): Promise<unknown> {
     if (this._isBound) {
       const callArgs = this.resolveArgs(descriptor);
       const fullArgs = this.mergeWithBound(callArgs);
@@ -148,6 +170,21 @@ export class AgencyFunction {
       toolDefinition: newToolDef,
       exported: this.exported,
       safe: this.safe,
+      isPreapproved: this._isPreapproved,
+    });
+  }
+
+  preapprove(): AgencyFunction {
+    if (this._isPreapproved) return this;
+    return new AgencyFunction({
+      name: this.name,
+      module: this.module,
+      fn: this._fn,
+      params: this.params,
+      toolDefinition: this.toolDefinition,
+      exported: this.exported,
+      safe: this.safe,
+      isPreapproved: true,
     });
   }
 

--- a/packages/agency-lang/lib/runtime/call.test.ts
+++ b/packages/agency-lang/lib/runtime/call.test.ts
@@ -82,4 +82,25 @@ describe("__callMethod", () => {
       __callMethod(obj, "fn", { type: "named", positionalArgs: [], namedArgs: { a: 1 } }),
     ).rejects.toThrow("Named arguments are not supported");
   });
+
+  it("dispatches .preapprove() with no args", async () => {
+    const fn = makeAgencyFn(async (x: number) => x);
+    const result = await __callMethod(fn, "preapprove", { type: "positional", args: [] });
+    expect(AgencyFunction.isAgencyFunction(result)).toBe(true);
+    expect((result as AgencyFunction).isPreapproved).toBe(true);
+  });
+
+  it("throws when .preapprove() is called with positional args", async () => {
+    const fn = makeAgencyFn(async (x: number) => x);
+    await expect(
+      __callMethod(fn, "preapprove", { type: "positional", args: ["bad"] }),
+    ).rejects.toThrow(".preapprove() takes no arguments");
+  });
+
+  it("throws when .preapprove() is called with named args", async () => {
+    const fn = makeAgencyFn(async (x: number) => x);
+    await expect(
+      __callMethod(fn, "preapprove", { type: "named", positionalArgs: [], namedArgs: { foo: 1 } }),
+    ).rejects.toThrow(".preapprove() takes no arguments");
+  });
 });

--- a/packages/agency-lang/lib/runtime/call.ts
+++ b/packages/agency-lang/lib/runtime/call.ts
@@ -49,6 +49,9 @@ export async function __callMethod(
       }
       return obj.describe(descriptor.args[0] as string);
     }
+    if (prop === "preapprove") {
+      return obj.preapprove();
+    }
   }
 
   const target = (obj as any)[prop];

--- a/packages/agency-lang/lib/runtime/call.ts
+++ b/packages/agency-lang/lib/runtime/call.ts
@@ -50,6 +50,14 @@ export async function __callMethod(
       return obj.describe(descriptor.args[0] as string);
     }
     if (prop === "preapprove") {
+      const hasArgs =
+        descriptor.type === "named"
+          ? descriptor.positionalArgs.length > 0 ||
+            Object.keys(descriptor.namedArgs).length > 0
+          : descriptor.args.length > 0;
+      if (hasArgs) {
+        throw new Error(".preapprove() takes no arguments");
+      }
       return obj.preapprove();
     }
   }

--- a/packages/agency-lang/lib/runtime/revivers/functionRefReviver.ts
+++ b/packages/agency-lang/lib/runtime/revivers/functionRefReviver.ts
@@ -29,6 +29,9 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
     if (value.toolDefinition) {
       result.toolDescription = value.toolDefinition.description;
     }
+    if (value.isPreapproved) {
+      result.isPreapproved = true;
+    }
     return result;
   }
 
@@ -47,6 +50,8 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
 
     const original = this.findInRegistry(name, module);
 
+    let result: AgencyFunction;
+
     // If serialized params have bound values, reconstruct the bound function
     if (Array.isArray(value.params) && value.params.some((p: any) => p.isBound)) {
       const params = value.params as FuncParam[];
@@ -57,28 +62,32 @@ export class FunctionRefReviver implements BaseReviver<AgencyFunction> {
           bindings[p.name] = p.boundValue;
         }
       }
-      let revived = original.partial(bindings);
+      result = original.partial(bindings);
 
       // Restore tool description if it was customized via .describe()
-      if (typeof value.toolDescription === "string" && revived.toolDefinition) {
-        revived = revived.withToolDefinition({
-          ...revived.toolDefinition,
+      if (typeof value.toolDescription === "string" && result.toolDefinition) {
+        result = result.withToolDefinition({
+          ...result.toolDefinition,
           description: value.toolDescription,
         });
       }
-      return revived;
-    }
-
-    // Restore tool description for non-bound functions that used .describe()
-    if (typeof value.toolDescription === "string" && original.toolDefinition &&
+    } else if (typeof value.toolDescription === "string" && original.toolDefinition &&
         value.toolDescription !== original.toolDefinition.description) {
-      return original.withToolDefinition({
+      // Restore tool description for non-bound functions that used .describe()
+      result = original.withToolDefinition({
         ...original.toolDefinition,
         description: value.toolDescription,
       });
+    } else {
+      result = original;
     }
 
-    return original;
+    // Restore preapproved state
+    if (value.isPreapproved) {
+      result = result.preapprove();
+    }
+
+    return result;
   }
 
   private findInRegistry(name: string, module: string): AgencyFunction {

--- a/packages/agency-lang/lib/typeChecker/interruptWarnings.test.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptWarnings.test.ts
@@ -240,4 +240,58 @@ describe("interrupt kind warnings", () => {
       unlinkSync(libFile);
     }
   });
+
+  it("does not warn when function is called via .preapprove()", () => {
+    const warnings = warningsFrom(`
+      def deploy() {
+        interrupt myapp::deploy("Deploy?")
+      }
+      node main() {
+        const fn = deploy.preapprove()
+        fn()
+      }
+    `);
+    // fn() is a dynamic call to a variable, not a direct call to deploy,
+    // so no warning is expected
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("does not warn when preapproved function is in tools array", () => {
+    const warnings = warningsFrom(`
+      def deploy() {
+        interrupt myapp::deploy("Deploy?")
+      }
+      node main() {
+        llm("do it", { tools: [deploy.preapprove()] })
+      }
+    `);
+    // deploy.preapprove() synthesizes as "any", so the function ref
+    // is not extracted and no warning is generated
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("produces error when .preapprove() is called with arguments", () => {
+    const file = path.join(os.tmpdir(), `tc-preapprove-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`);
+    const source = `
+      def deploy() {
+        interrupt myapp::deploy("Deploy?")
+      }
+      node main() {
+        const fn = deploy.preapprove("bad")
+      }
+    `;
+    writeFileSync(file, source);
+    try {
+      const absPath = path.resolve(file);
+      const symbolTable = SymbolTable.build(absPath);
+      const parseResult = parseAgency(source, {});
+      if (!parseResult.success) throw new Error("Parse failed");
+      const info = buildCompilationUnit(parseResult.result, symbolTable, absPath, source);
+      const { errors } = typeCheck(parseResult.result, {}, info);
+      const errs = errors.filter((e) => !e.severity || e.severity === "error");
+      expect(errs.some((e) => e.message.includes(".preapprove()"))).toBe(true);
+    } finally {
+      unlinkSync(file);
+    }
+  });
 });

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -358,7 +358,7 @@ function synthObject(
   };
 }
 
-function validatePartialOrDescribe(
+function validateAgencyFunctionMethod(
   expr: ValueAccess,
   element: { kind: "methodCall"; functionCall: { type: "functionCall"; functionName: string; arguments: any[] } },
   methodName: string,
@@ -427,6 +427,16 @@ function validatePartialOrDescribe(
       });
     }
   }
+
+  if (methodName === "preapprove") {
+    const args = element.functionCall.arguments;
+    if (args.length > 0) {
+      ctx.errors.push({
+        message: `.preapprove() takes no arguments.`,
+        loc: expr.loc,
+      });
+    }
+  }
 }
 
 export function synthValueAccess(
@@ -443,8 +453,8 @@ export function synthValueAccess(
     // Use continue (not return) so chained calls like fn.partial(a: 1).describe("x") are all validated.
     if (element.kind === "methodCall") {
       const methodName = element.functionCall.functionName;
-      if (methodName === "partial" || methodName === "describe") {
-        validatePartialOrDescribe(expr, element, methodName, ctx);
+      if (methodName === "partial" || methodName === "describe" || methodName === "preapprove") {
+        validateAgencyFunctionMethod(expr, element, methodName, ctx);
         currentType = "any";
         continue;
       }

--- a/packages/agency-lang/tests/agency/preapprove-global.agency
+++ b/packages/agency-lang/tests/agency/preapprove-global.agency
@@ -1,0 +1,10 @@
+def guardedAdd(a: number, b: number): number {
+  const check = interrupt("Confirm ${a} + ${b}?")
+  return a + b
+}
+
+const safeAdd5 = guardedAdd.partial(a: 5).preapprove()
+
+node testGlobalPreapprovedPFA() {
+  return safeAdd5(7)
+}

--- a/packages/agency-lang/tests/agency/preapprove-global.test.json
+++ b/packages/agency-lang/tests/agency/preapprove-global.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "testGlobalPreapprovedPFA",
+      "input": "",
+      "expectedOutput": "12",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "PFA constructed and preapproved in global scope auto-approves interrupts"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/preapprove-helpers.agency
+++ b/packages/agency-lang/tests/agency/preapprove-helpers.agency
@@ -1,0 +1,4 @@
+export def guardedAdd(a: number, b: number): number {
+  const check = interrupt("Confirm ${a} + ${b}?")
+  return a + b
+}

--- a/packages/agency-lang/tests/agency/preapprove-import.agency
+++ b/packages/agency-lang/tests/agency/preapprove-import.agency
@@ -1,0 +1,11 @@
+import { guardedAdd } from "./preapprove-helpers.agency"
+
+node testImportedPreapprove() {
+  const fn = guardedAdd.preapprove()
+  return fn(3, 4)
+}
+
+node testImportedPartialThenPreapprove() {
+  const fn = guardedAdd.partial(a: 10).preapprove()
+  return fn(5)
+}

--- a/packages/agency-lang/tests/agency/preapprove-import.test.json
+++ b/packages/agency-lang/tests/agency/preapprove-import.test.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "nodeName": "testImportedPreapprove",
+      "input": "",
+      "expectedOutput": "7",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "imported function with .preapprove() auto-approves interrupts"
+    },
+    {
+      "nodeName": "testImportedPartialThenPreapprove",
+      "input": "",
+      "expectedOutput": "15",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "imported function with .partial().preapprove() auto-approves interrupts"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/preapprove-interrupt.agency
+++ b/packages/agency-lang/tests/agency/preapprove-interrupt.agency
@@ -1,0 +1,16 @@
+def guardedAction(x: number): number {
+  const check = interrupt("Confirm action on ${x}?")
+  return x * 2
+}
+
+def otherInterrupt(): number {
+  const check = interrupt("Other interrupt")
+  return 42
+}
+
+node main() {
+  const fn = guardedAction.preapprove()
+  const other = otherInterrupt()
+  const result = fn(5)
+  return [other, result]
+}

--- a/packages/agency-lang/tests/agency/preapprove-interrupt.test.json
+++ b/packages/agency-lang/tests/agency/preapprove-interrupt.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[42,10]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "preapproved function survives interrupt serialization cycle",
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "Other interrupt"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/preapprove-outer-reject.agency
+++ b/packages/agency-lang/tests/agency/preapprove-outer-reject.agency
@@ -1,0 +1,17 @@
+def guardedAction(x: number): number {
+  const check = interrupt("Confirm action on ${x}?")
+  return x * 2
+}
+
+node main() {
+  const fn = guardedAction.preapprove()
+  handle {
+    const result = fn(5)
+    if (isFailure(result)) {
+      return "rejected"
+    }
+    return "approved"
+  } with (data) {
+    return reject()
+  }
+}

--- a/packages/agency-lang/tests/agency/preapprove-outer-reject.test.json
+++ b/packages/agency-lang/tests/agency/preapprove-outer-reject.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"rejected\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "outer handler reject overrides preapprove"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/preapprove-tool.agency
+++ b/packages/agency-lang/tests/agency/preapprove-tool.agency
@@ -1,0 +1,10 @@
+export def guardedAdd(a: number, b: number): number {
+  const check = interrupt("Confirm adding ${a} + ${b}?")
+  return a + b
+}
+
+node main() {
+  const tool = guardedAdd.partial(a: 5).preapprove()
+  const result: number = llm("Use the guardedAdd tool to add 5 and 7. Return ONLY the number.", { tools: [tool] })
+  return result
+}

--- a/packages/agency-lang/tests/agency/preapprove-tool.test.json
+++ b/packages/agency-lang/tests/agency/preapprove-tool.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "12",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "preapproved partial function as LLM tool auto-approves interrupt",
+      "llmMocks": [
+        { "toolCall": { "name": "guardedAdd", "args": { "b": 7 } } },
+        { "return": 12 }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/preapprove.agency
+++ b/packages/agency-lang/tests/agency/preapprove.agency
@@ -1,0 +1,34 @@
+def guardedAction(x: number): number {
+  const check = interrupt("Confirm action on ${x}?")
+  return x * 2
+}
+
+def guardedAdd(a: number, b: number): number {
+  const check = interrupt("Confirm ${a} + ${b}?")
+  return a + b
+}
+
+node testBasic() {
+  const fn = guardedAction.preapprove()
+  return fn(5)
+}
+
+node testChainPartialThenPreapprove() {
+  const fn = guardedAdd.partial(a: 10).preapprove()
+  return fn(3)
+}
+
+node testChainPreapproveThenPartial() {
+  const fn = guardedAdd.preapprove().partial(a: 10)
+  return fn(3)
+}
+
+node testChainPreapproveThenDescribe() {
+  const fn = guardedAction.preapprove().describe("A safe action")
+  return fn(5)
+}
+
+node testIdempotent() {
+  const fn = guardedAction.preapprove().preapprove()
+  return fn(5)
+}

--- a/packages/agency-lang/tests/agency/preapprove.test.json
+++ b/packages/agency-lang/tests/agency/preapprove.test.json
@@ -1,0 +1,39 @@
+{
+  "tests": [
+    {
+      "nodeName": "testBasic",
+      "input": "",
+      "expectedOutput": "10",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "preapprove auto-approves interrupt"
+    },
+    {
+      "nodeName": "testChainPartialThenPreapprove",
+      "input": "",
+      "expectedOutput": "13",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "partial then preapprove chains correctly"
+    },
+    {
+      "nodeName": "testChainPreapproveThenPartial",
+      "input": "",
+      "expectedOutput": "13",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "preapprove then partial chains correctly"
+    },
+    {
+      "nodeName": "testChainPreapproveThenDescribe",
+      "input": "",
+      "expectedOutput": "10",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "preapprove then describe chains correctly"
+    },
+    {
+      "nodeName": "testIdempotent",
+      "input": "",
+      "expectedOutput": "10",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "calling preapprove twice is idempotent"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `.preapprove()` to `AgencyFunction` — a method that returns a new function which auto-approves all interrupts thrown during invocation, by wrapping the call in an approve handler using the same `pushHandler`/`popHandler` infrastructure as `handle` blocks.

```ts
const tool = readFile.preapprove()
llm("Read the config", { tools: [tool] })
```

This is equivalent to wrapping every call in `handle { ... } with (data) { return approve() }` but is surgical (only affects the specific function) and chains with `.partial()` and `.describe()` in any order.

## Design

- **Runtime-only.** No compiler changes — purely a method on `AgencyFunction`.
- **Same handler stack as `handle` blocks.** `invoke()` pushes an approve handler before calling `_fn` and pops it after, in a try/finally — identical pattern to `runner.handle()`.
- **Outer handlers still win.** `interruptWithHandlers` walks innermost-first but continues past `approve` and short-circuits on `reject`, so an outer rejecting handler overrides the inner preapprove. Verified by test.
- **Idempotent.** `.preapprove().preapprove()` returns `this`.
- **Serializable.** `isPreapproved` is serialized in `FunctionRefReviver` and re-applied on revival.
- **Works everywhere `invoke()` is called** — direct calls, LLM tool loop ([prompt.ts](https://github.com/egonSchiele/agency-lang/blob/preapprove/packages/agency-lang/lib/runtime/prompt.ts#L369)), callbacks ([context.ts](https://github.com/egonSchiele/agency-lang/blob/preapprove/packages/agency-lang/lib/runtime/state/context.ts#L271)), forks (share same `ctx`).

## Files

| File | Change |
|------|--------|
| `lib/runtime/agencyFunction.ts` | `_isPreapproved` flag, `.preapprove()` method, `invoke()` wraps `_invokeInner()` with handler push/pop |
| `lib/runtime/call.ts` | Dispatch `"preapprove"` in `__callMethod()` |
| `lib/runtime/revivers/functionRefReviver.ts` | Serialize/deserialize `isPreapproved` |
| `lib/typeChecker/synthesizer.ts` | Validate `.preapprove()` takes no args; rename `validatePartialOrDescribe` → `validateAgencyFunctionMethod` |
| `docs/site/guide/partial-application.md` | New `.preapprove()` section |
| `tests/agency/preapprove*.agency` (×4) | Basic chaining/idempotent, outer-reject overrides, LLM tool, interrupt serialization round-trip |
| `lib/typeChecker/interruptWarnings.test.ts` | Warning suppression + argument validation tests |

## Verification

- `make` — build succeeds
- `pnpm test:run` — 3075 / 3075 tests pass (3 skipped pre-existing)
- `pnpm run lint:structure` — clean
- 4 new agency runtime tests pass; 3 new typechecker tests pass
- Existing `partial-application-*` interrupt tests still pass
