### PR TITLE
trace: fix multi-writer lifecycle, un-skip trace + thread debugger tests

### DIFF
--- a/packages/agency-lang/lib/debugger/thread.test.ts
+++ b/packages/agency-lang/lib/debugger/thread.test.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import * as path from "path";
 import type { DebuggerCommand } from "./types.js";
 import { compile } from "../cli/commands.js";
-import { isInterrupt } from "@/runtime/interrupts.js";
+import { hasInterrupts } from "@/runtime/interrupts.js";
 import { TestDebuggerIO, freshImport, makeDriver, fixtureDir } from "./testHelpers.js";
 
 // Queue of canned responses for the mock runPrompt
@@ -42,7 +42,7 @@ vi.mock("agency-lang/runtime", async (importOriginal) => {
 const threadTestAgency = path.join(fixtureDir, "thread-test.agency");
 const threadTestCompiled = path.join(fixtureDir, "thread-test.ts");
 
-describe.skip("Debugger threads panel", () => {
+describe("Debugger threads panel", () => {
   beforeAll(() => {
     compile({ debugger: true }, threadTestAgency, threadTestCompiled, { ts: true });
   });
@@ -61,7 +61,7 @@ describe.skip("Debugger threads panel", () => {
     const driver = makeDriver(mod, testUI);
     const callbacks = driver.getCallbacks();
     const initialResult = await mod.main({ callbacks });
-    expect(isInterrupt(initialResult?.data)).toBe(true);
+    expect(hasInterrupts(initialResult?.data)).toBe(true);
 
     await driver.run(initialResult, { interceptConsole: false });
 

--- a/packages/agency-lang/lib/debugger/trace.test.ts
+++ b/packages/agency-lang/lib/debugger/trace.test.ts
@@ -3,18 +3,15 @@ import * as fs from "fs";
 import * as path from "path";
 import { compile } from "../cli/commands.js";
 import { TraceReader } from "../runtime/trace/traceReader.js";
-import { TraceWriter } from "../runtime/trace/traceWriter.js";
-import { FileSink } from "../runtime/trace/sinks.js";
 import { Checkpoint } from "../runtime/state/checkpointStore.js";
 import { DebuggerDriver } from "./driver.js";
 import type { DebuggerCommand } from "./types.js";
-import { isInterrupt } from "../runtime/interrupts.js";
-import { TestDebuggerIO, fixtureDir } from "./testHelpers.js";
+import { hasInterrupts } from "../runtime/interrupts.js";
+import { TestDebuggerIO, fixtureDir, freshImport } from "./testHelpers.js";
+
 const traceTestAgency = path.join(fixtureDir, "trace-test.agency");
 const traceTestCompiled = path.join(fixtureDir, "trace-test.ts");
 const traceFile = path.join(fixtureDir, "trace-test.agencytrace");
-
-const RUN_ID = "trace-test-run-id";
 
 describe("Trace integration with debugger", () => {
   let mod: any;
@@ -23,7 +20,7 @@ describe("Trace integration with debugger", () => {
     compile({ debugger: true }, traceTestAgency, traceTestCompiled, {
       ts: true,
     });
-    mod = await import(traceTestCompiled);
+    mod = await freshImport(traceTestCompiled);
   });
 
   afterAll(() => {
@@ -34,25 +31,22 @@ describe("Trace integration with debugger", () => {
     }
   });
 
-  it.skip(
+  it(
     "produces a trace file when running with trace enabled",
     { timeout: 15000 },
     async () => {
-      console.log("[trace-test] Step 1: Creating TraceWriter");
-      const traceWriter = new TraceWriter(RUN_ID, "trace-test.agency", [
-        new FileSink(traceFile),
-      ]);
-      console.log("[trace-test] Step 2: Setting traceWriter on module");
-      mod.__setTraceWriter(traceWriter);
+      // Reconfigure the global traceConfig.traceFile so each per-execCtx
+      // TraceWriter created during the run will write (in append mode)
+      // to this file. __setTraceFile truncates the file so the run starts
+      // clean.
+      mod.__setTraceFile(traceFile);
 
-      console.log("[trace-test] Step 3: Creating commands and TestDebuggerIO");
       const commands: DebuggerCommand[] = [
         ...Array(20).fill({ type: "step" }),
         { type: "continue" },
       ];
       const testUI = new TestDebuggerIO(commands);
 
-      console.log("[trace-test] Step 4: Creating DebuggerDriver");
       const driver = new DebuggerDriver({
         mod: {
           respondToInterrupts: mod.respondToInterrupts,
@@ -64,36 +58,19 @@ describe("Trace integration with debugger", () => {
         rewindSize: 30,
         ui: testUI,
       });
-      console.log("[trace-test] Step 5: Setting debugger on module");
       mod.__setDebugger(driver.debuggerState);
 
-      console.log("[trace-test] Step 6: Getting callbacks");
       const callbacks = driver.getCallbacks();
-      console.log("[trace-test] Step 7: Calling mod.main()");
       const initialResult = await mod.main({ callbacks });
-      console.log(
-        "[trace-test] Step 8: mod.main() returned, checking interrupt",
-      );
-      expect(isInterrupt(initialResult.data)).toBe(true);
+      expect(hasInterrupts(initialResult.data)).toBe(true);
 
-      console.log("[trace-test] Step 9: Starting driver.run()");
       await driver.run(initialResult, { interceptConsole: false });
-      console.log("[trace-test] Step 10: driver.run() completed");
-
-      console.log("[trace-test] Step 11: Closing traceWriter");
-      await traceWriter.close();
-      console.log("[trace-test] Step 12: traceWriter closed");
 
       // Verify trace file was created
       expect(fs.existsSync(traceFile)).toBe(true);
-      console.log("[trace-test] Step 13: Trace file exists");
 
       // Read and validate the trace
       const reader = TraceReader.fromFile(traceFile);
-      console.log(
-        "[trace-test] Step 14: Read trace, checkpoints: " +
-          reader.checkpoints.length,
-      );
       expect(reader.checkpoints.length).toBeGreaterThan(0);
 
       // Verify each checkpoint is a valid Checkpoint instance
@@ -101,7 +78,6 @@ describe("Trace integration with debugger", () => {
         expect(cp).toBeInstanceOf(Checkpoint);
         expect(cp.stack.stack.length).toBeGreaterThan(0);
       }
-      console.log("[trace-test] Step 15: All checkpoints valid");
 
       // Verify state progresses: later checkpoints should have more locals
       const firstCp = reader.checkpoints[0];
@@ -111,25 +87,15 @@ describe("Trace integration with debugger", () => {
       const lastLocals =
         lastCp.stack.stack[lastCp.stack.stack.length - 1].locals;
 
-      console.log(
-        "[trace-test] Step 16: firstLocals:",
-        JSON.stringify(firstLocals),
-      );
-      console.log(
-        "[trace-test] Step 17: lastLocals:",
-        JSON.stringify(lastLocals),
-      );
-
       // The last checkpoint should have c = 30 (a=10, b=20, c=a+b)
       expect(lastLocals.c).toBe(30);
       expect(Object.keys(lastLocals).length).toBeGreaterThanOrEqual(
         Object.keys(firstLocals).length,
       );
-      console.log("[trace-test] Step 18: All assertions passed");
     },
   );
 
-  it.skip("deduplicates globals across trace checkpoints", () => {
+  it("deduplicates globals across trace checkpoints", () => {
     // Read the trace file from the previous test
     const content = fs.readFileSync(traceFile, "utf-8");
     const lines = content

--- a/packages/agency-lang/lib/debugger/trace.test.ts
+++ b/packages/agency-lang/lib/debugger/trace.test.ts
@@ -92,20 +92,6 @@ describe("Trace integration with debugger", () => {
       expect(Object.keys(lastLocals).length).toBeGreaterThanOrEqual(
         Object.keys(firstLocals).length,
       );
-
-      // Verify CAS dedup across per-execCtx writer segments: with the
-      // shared store on RuntimeContext, chunks should not be re-emitted
-      // for every segment that references them. Asserted in this same
-      // test (rather than a separate `it` reading the produced file) to
-      // keep the suite order-independent.
-      const lines = fs
-        .readFileSync(traceFile, "utf-8")
-        .trim()
-        .split("\n")
-        .map((l: string) => JSON.parse(l));
-      const chunks = lines.filter((l: any) => l.type === "chunk");
-      const manifests = lines.filter((l: any) => l.type === "manifest");
-      expect(chunks.length).toBeLessThan(manifests.length * 2);
     },
   );
 });

--- a/packages/agency-lang/lib/debugger/trace.test.ts
+++ b/packages/agency-lang/lib/debugger/trace.test.ts
@@ -92,20 +92,20 @@ describe("Trace integration with debugger", () => {
       expect(Object.keys(lastLocals).length).toBeGreaterThanOrEqual(
         Object.keys(firstLocals).length,
       );
+
+      // Verify CAS dedup across per-execCtx writer segments: with the
+      // shared store on RuntimeContext, chunks should not be re-emitted
+      // for every segment that references them. Asserted in this same
+      // test (rather than a separate `it` reading the produced file) to
+      // keep the suite order-independent.
+      const lines = fs
+        .readFileSync(traceFile, "utf-8")
+        .trim()
+        .split("\n")
+        .map((l: string) => JSON.parse(l));
+      const chunks = lines.filter((l: any) => l.type === "chunk");
+      const manifests = lines.filter((l: any) => l.type === "manifest");
+      expect(chunks.length).toBeLessThan(manifests.length * 2);
     },
   );
-
-  it("deduplicates globals across trace checkpoints", () => {
-    // Read the trace file from the previous test
-    const content = fs.readFileSync(traceFile, "utf-8");
-    const lines = content
-      .trim()
-      .split("\n")
-      .map((l: string) => JSON.parse(l));
-    const chunks = lines.filter((l: any) => l.type === "chunk");
-    const manifests = lines.filter((l: any) => l.type === "manifest");
-
-    // With deduplication, should have fewer chunks than manifests * 2
-    expect(chunks.length).toBeLessThan(manifests.length * 2);
-  });
 });

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -6,7 +6,7 @@ export type {
   HandlerFn,
 } from "./types.js";
 export type { Interrupt, InterruptResponse } from "./interrupts.js";
-export { RuntimeContext, truncateTraceFile } from "./state/context.js";
+export { RuntimeContext } from "./state/context.js";
 export { StateStack, State } from "./state/stateStack.js";
 export { GlobalStore } from "./state/globalStore.js";
 export { MessageThread } from "./state/messageThread.js";

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -6,7 +6,7 @@ export type {
   HandlerFn,
 } from "./types.js";
 export type { Interrupt, InterruptResponse } from "./interrupts.js";
-export { RuntimeContext } from "./state/context.js";
+export { RuntimeContext, truncateTraceFile } from "./state/context.js";
 export { StateStack, State } from "./state/stateStack.js";
 export { GlobalStore } from "./state/globalStore.js";
 export { MessageThread } from "./state/messageThread.js";

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as path from "path";
 import { MessageJSON } from "smoltalk";
 import { callHook } from "./hooks.js";
 import type { AgencyCallbacks } from "./hooks.js";
@@ -9,6 +11,7 @@ import {
 } from "./errors.js";
 import { State, StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
+import { resolveTraceFilePath } from "./trace/traceWriter.js";
 import { GraphState, InternalFunctionState, RunNodeResult } from "./types.js";
 import { createReturnObject } from "./utils.js";
 import { color } from "@/utils/termcolors.js";
@@ -110,6 +113,18 @@ export async function runNode({
   abortSignal?: AbortSignal;
 }): Promise<RunNodeResult<any>> {
   const runId = nanoid();
+
+  // runNode is the entry point for a fresh agent run (resumes go through
+  // respondToInterrupts instead). If trace output is enabled, truncate the
+  // target file so this run starts with a clean slate. FileSink opens in
+  // append mode, so subsequent per-execCtx writers within this same run
+  // accumulate into the same file naturally.
+  const tracePath = resolveTraceFilePath(ctx.traceConfig, runId);
+  if (tracePath) {
+    fs.mkdirSync(path.dirname(tracePath), { recursive: true });
+    fs.writeFileSync(tracePath, "");
+  }
+
   const execCtx = await ctx.createExecutionContext(runId);
   if (initializeGlobals) {
     await initializeGlobals(execCtx);

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -1,5 +1,3 @@
-import * as fs from "fs";
-import * as path from "path";
 import { nanoid } from "nanoid";
 import { SmolConfig } from "smoltalk";
 import type { DebuggerState } from "../../debugger/debuggerState.js";
@@ -14,24 +12,12 @@ import type { InterruptResponse } from "../interrupts.js";
 import { LLMClient, SmoltalkClient } from "../llmClient.js";
 import { GlobalStore } from "../state/globalStore.js";
 import { StateStack } from "../state/stateStack.js";
-import { ContentAddressableStore } from "../trace/contentAddressableStore.js";
 import { TraceWriter } from "../trace/traceWriter.js";
 import type { TraceConfig } from "../trace/types.js";
 import type { HandlerFn } from "../types.js";
 import type { Checkpoint } from "./checkpointStore.js";
 import { CheckpointStore, RESULT_ENTRY_LABEL } from "./checkpointStore.js";
 import { PendingPromiseStore } from "./pendingPromiseStore.js";
-
-/**
- * Ensure the trace file's parent directory exists and the file is empty.
- * Called once at the start of a run (RuntimeContext constructor) and from
- * `__setTraceFile` when tests reconfigure the trace file path. FileSink
- * always appends, so this is the only place that clears stale data.
- */
-export function truncateTraceFile(filePath: string): void {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, "");
-}
 
 /**
  * Process-wide singleton CoverageCollector used when AGENCY_COVERAGE is set.
@@ -130,11 +116,6 @@ export class RuntimeContext<T> {
   abortController: AbortController;
 
   traceConfig: TraceConfig;
-  // Shared CAS for cross-segment dedup when writing to a single trace file.
-  // Created lazily on first execCtx and shared by all subsequent execCtx
-  // writers in this run, so chunks aren't re-emitted for every interrupt
-  // segment. Not used for traceDir mode (each segment is a separate file).
-  _sharedTraceStore: ContentAddressableStore | null = null;
   runId: string | null;
   verbose: boolean;
   getStaticVars?: () => Record<string, unknown>;
@@ -179,13 +160,6 @@ export class RuntimeContext<T> {
     this.runId = null;
     this.verbose = args.verbose ?? false;
     this.dirname = args.dirname;
-
-    // FileSink opens trace files in append mode (so multiple per-execCtx
-    // writers within one run don't truncate each other), so we truncate
-    // once here at run start to clear stale data from previous runs.
-    if (this.traceConfig.traceFile) {
-      truncateTraceFile(this.traceConfig.traceFile);
-    }
 
     const graphConfig = {
       debug: {
@@ -235,22 +209,9 @@ export class RuntimeContext<T> {
     execCtx._toolCallDepth = 0;
     execCtx._interruptResponses = {};
     execCtx.debuggerState = this.debuggerState;
-    // For single-file trace output, share the CAS across all execCtx writers
-    // in this run so dedup works across interrupt segments. We deliberately
-    // skip sharing when traceDir is ALSO set: the shared CAS would suppress
-    // chunks in segment-N traceDir files that were emitted in earlier
-    // segments, breaking standalone-readability of those per-segment files.
-    // The trade-off is no cross-segment dedup for traceFile in the rare
-    // both-configured case; per-segment traceDir correctness wins.
-    let sharedStore: ContentAddressableStore | undefined;
-    if (this.traceConfig.traceFile && !this.traceConfig.traceDir) {
-      this._sharedTraceStore ??= new ContentAddressableStore();
-      sharedStore = this._sharedTraceStore;
-    }
     execCtx.traceWriter = await TraceWriter.create({
       runId,
       traceConfig: this.traceConfig,
-      store: sharedStore,
     });
     execCtx.traceConfig = this.traceConfig;
     execCtx.runId = runId;

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -236,9 +236,14 @@ export class RuntimeContext<T> {
     execCtx._interruptResponses = {};
     execCtx.debuggerState = this.debuggerState;
     // For single-file trace output, share the CAS across all execCtx writers
-    // in this run so dedup works across interrupt segments.
+    // in this run so dedup works across interrupt segments. We deliberately
+    // skip sharing when traceDir is ALSO set: the shared CAS would suppress
+    // chunks in segment-N traceDir files that were emitted in earlier
+    // segments, breaking standalone-readability of those per-segment files.
+    // The trade-off is no cross-segment dedup for traceFile in the rare
+    // both-configured case; per-segment traceDir correctness wins.
     let sharedStore: ContentAddressableStore | undefined;
-    if (this.traceConfig.traceFile) {
+    if (this.traceConfig.traceFile && !this.traceConfig.traceDir) {
       this._sharedTraceStore ??= new ContentAddressableStore();
       sharedStore = this._sharedTraceStore;
     }

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as path from "path";
 import { nanoid } from "nanoid";
 import { SmolConfig } from "smoltalk";
 import type { DebuggerState } from "../../debugger/debuggerState.js";
@@ -12,12 +14,24 @@ import type { InterruptResponse } from "../interrupts.js";
 import { LLMClient, SmoltalkClient } from "../llmClient.js";
 import { GlobalStore } from "../state/globalStore.js";
 import { StateStack } from "../state/stateStack.js";
+import { ContentAddressableStore } from "../trace/contentAddressableStore.js";
 import { TraceWriter } from "../trace/traceWriter.js";
 import type { TraceConfig } from "../trace/types.js";
 import type { HandlerFn } from "../types.js";
 import type { Checkpoint } from "./checkpointStore.js";
 import { CheckpointStore, RESULT_ENTRY_LABEL } from "./checkpointStore.js";
 import { PendingPromiseStore } from "./pendingPromiseStore.js";
+
+/**
+ * Ensure the trace file's parent directory exists and the file is empty.
+ * Called once at the start of a run (RuntimeContext constructor) and from
+ * `__setTraceFile` when tests reconfigure the trace file path. FileSink
+ * always appends, so this is the only place that clears stale data.
+ */
+export function truncateTraceFile(filePath: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, "");
+}
 
 /**
  * Process-wide singleton CoverageCollector used when AGENCY_COVERAGE is set.
@@ -116,6 +130,11 @@ export class RuntimeContext<T> {
   abortController: AbortController;
 
   traceConfig: TraceConfig;
+  // Shared CAS for cross-segment dedup when writing to a single trace file.
+  // Created lazily on first execCtx and shared by all subsequent execCtx
+  // writers in this run, so chunks aren't re-emitted for every interrupt
+  // segment. Not used for traceDir mode (each segment is a separate file).
+  _sharedTraceStore: ContentAddressableStore | null = null;
   runId: string | null;
   verbose: boolean;
   getStaticVars?: () => Record<string, unknown>;
@@ -160,6 +179,13 @@ export class RuntimeContext<T> {
     this.runId = null;
     this.verbose = args.verbose ?? false;
     this.dirname = args.dirname;
+
+    // FileSink opens trace files in append mode (so multiple per-execCtx
+    // writers within one run don't truncate each other), so we truncate
+    // once here at run start to clear stale data from previous runs.
+    if (this.traceConfig.traceFile) {
+      truncateTraceFile(this.traceConfig.traceFile);
+    }
 
     const graphConfig = {
       debug: {
@@ -209,9 +235,17 @@ export class RuntimeContext<T> {
     execCtx._toolCallDepth = 0;
     execCtx._interruptResponses = {};
     execCtx.debuggerState = this.debuggerState;
+    // For single-file trace output, share the CAS across all execCtx writers
+    // in this run so dedup works across interrupt segments.
+    let sharedStore: ContentAddressableStore | undefined;
+    if (this.traceConfig.traceFile) {
+      this._sharedTraceStore ??= new ContentAddressableStore();
+      sharedStore = this._sharedTraceStore;
+    }
     execCtx.traceWriter = await TraceWriter.create({
       runId,
       traceConfig: this.traceConfig,
+      store: sharedStore,
     });
     execCtx.traceConfig = this.traceConfig;
     execCtx.runId = runId;

--- a/packages/agency-lang/lib/runtime/trace/sinks.ts
+++ b/packages/agency-lang/lib/runtime/trace/sinks.ts
@@ -10,10 +10,15 @@ export type TraceSink = {
 export class FileSink implements TraceSink {
   private stream: fs.WriteStream;
 
+  // Append mode: a single logical run can produce multiple TraceWriters
+  // (one per execCtx — i.e. one per respondToInterrupts call). Truncating
+  // would lose data from previous segments. Truncation of the trace file
+  // at the start of a run happens explicitly in RuntimeContext (and in
+  // the __setTraceFile helper).
   constructor(filePath: string) {
     this.createDirIfNotExists(path.dirname(filePath));
     this.stream = fs.createWriteStream(filePath, {
-      flags: "w",
+      flags: "a",
       encoding: "utf-8",
     });
   }

--- a/packages/agency-lang/lib/runtime/trace/sinks.ts
+++ b/packages/agency-lang/lib/runtime/trace/sinks.ts
@@ -13,8 +13,10 @@ export class FileSink implements TraceSink {
   // Append mode: a single logical run can produce multiple TraceWriters
   // (one per execCtx — i.e. one per respondToInterrupts call). Truncating
   // would lose data from previous segments. Truncation of the trace file
-  // at the start of a run happens explicitly in RuntimeContext (and in
-  // the __setTraceFile helper).
+  // at the start of a fresh run is handled by `runNode` via
+  // `resolveTraceFilePath` + `fs.writeFileSync(path, "")`. Resume paths
+  // (respondToInterrupts) never truncate, so per-execCtx writers within
+  // one run accumulate into the same file naturally.
   constructor(filePath: string) {
     this.createDirIfNotExists(path.dirname(filePath));
     this.stream = fs.createWriteStream(filePath, {

--- a/packages/agency-lang/lib/runtime/trace/traceWriter.ts
+++ b/packages/agency-lang/lib/runtime/trace/traceWriter.ts
@@ -6,10 +6,24 @@ import { CallbackSink, FileSink, type TraceSink } from "./sinks.js";
 import type { TraceConfig, TraceLine, TraceManifest } from "./types.js";
 import { CHECKPOINT_SCHEMA } from "./types.js";
 
-function generateTraceFilePath(dir: string): string {
-  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const id = Math.random().toString(16).slice(2, 6);
-  return path.join(dir, `${timestamp}_${id}.agencytrace`);
+/**
+ * Decide which file (if any) a trace writer should target for a given run.
+ *
+ * - `traceFile` set: use it verbatim. This is a fixed, process-wide path —
+ *   useful for tests and single-run inspection, but NOT safe with concurrent
+ *   runs of the same agent (they'd interleave into one file). Documented.
+ * - `traceFile` unset, `traceDir` set: derive `${traceDir}/${runId}.agencytrace`.
+ *   Each run gets its own file, naturally supporting concurrent runs without
+ *   any shared state.
+ * - Neither set: returns null (no file output; callback-only or disabled).
+ */
+export function resolveTraceFilePath(
+  traceConfig: TraceConfig,
+  runId: string,
+): string | null {
+  if (traceConfig.traceFile) return traceConfig.traceFile;
+  if (traceConfig.traceDir) return path.join(traceConfig.traceDir, `${runId}.agencytrace`);
+  return null;
 }
 
 export class TraceWriter {
@@ -20,12 +34,15 @@ export class TraceWriter {
   private program: string = "";
   private runId: string = "";
 
-  constructor(runId: string, program: string, sinks: TraceSink[], store?: ContentAddressableStore) {
-    // The CAS may be shared across multiple TraceWriters that all write to
-    // the same file (one per execCtx within a single run). Sharing keeps
-    // dedup working across segments — without it each writer would re-emit
-    // every chunk because its CAS would start empty.
-    this.store = store ?? new ContentAddressableStore();
+  constructor(runId: string, program: string, sinks: TraceSink[]) {
+    // Per-writer CAS. Cross-segment dedup is intentionally not done — it
+    // would require shared state on the parent ctx (broken for concurrent
+    // runs) or in globals (extra serialization overhead). The trade-off is
+    // that some chunks may be duplicated across segments in the file; the
+    // reader handles duplicates idempotently via loadChunks, so correctness
+    // is unaffected. Files are slightly larger but readable and concurrency
+    // -safe.
+    this.store = new ContentAddressableStore();
     this.sinks = sinks;
     this.runId = runId;
     this.program = program;
@@ -110,18 +127,13 @@ export class TraceWriter {
   static async create({
     runId,
     traceConfig,
-    store,
   }: {
     runId: string;
     traceConfig: TraceConfig;
-    store?: ContentAddressableStore;
   }): Promise<TraceWriter | null> {
     const sinks: TraceSink[] = [];
-    if (traceConfig.traceFile) {
-      sinks.push(new FileSink(traceConfig.traceFile));
-    }
-    if (traceConfig.traceDir) {
-      const filePath = generateTraceFilePath(traceConfig.traceDir);
+    const filePath = resolveTraceFilePath(traceConfig, runId);
+    if (filePath) {
       sinks.push(new FileSink(filePath));
     }
     if (traceConfig.traceCallback) {
@@ -130,7 +142,7 @@ export class TraceWriter {
     if (sinks.length === 0) {
       return null;
     }
-    const writer = new TraceWriter(runId, traceConfig.program || "unknown.agency", sinks, store);
+    const writer = new TraceWriter(runId, traceConfig.program || "unknown.agency", sinks);
     await writer.writeHeader();
     return writer;
   }

--- a/packages/agency-lang/lib/runtime/trace/traceWriter.ts
+++ b/packages/agency-lang/lib/runtime/trace/traceWriter.ts
@@ -20,8 +20,12 @@ export class TraceWriter {
   private program: string = "";
   private runId: string = "";
 
-  constructor(runId: string, program: string, sinks: TraceSink[]) {
-    this.store = new ContentAddressableStore();
+  constructor(runId: string, program: string, sinks: TraceSink[], store?: ContentAddressableStore) {
+    // The CAS may be shared across multiple TraceWriters that all write to
+    // the same file (one per execCtx within a single run). Sharing keeps
+    // dedup working across segments — without it each writer would re-emit
+    // every chunk because its CAS would start empty.
+    this.store = store ?? new ContentAddressableStore();
     this.sinks = sinks;
     this.runId = runId;
     this.program = program;
@@ -106,9 +110,11 @@ export class TraceWriter {
   static async create({
     runId,
     traceConfig,
+    store,
   }: {
     runId: string;
     traceConfig: TraceConfig;
+    store?: ContentAddressableStore;
   }): Promise<TraceWriter | null> {
     const sinks: TraceSink[] = [];
     if (traceConfig.traceFile) {
@@ -124,7 +130,7 @@ export class TraceWriter {
     if (sinks.length === 0) {
       return null;
     }
-    const writer = new TraceWriter(runId, traceConfig.program || "unknown.agency", sinks);
+    const writer = new TraceWriter(runId, traceConfig.program || "unknown.agency", sinks, store);
     await writer.writeHeader();
     return writer;
   }

--- a/packages/agency-lang/lib/runtime/trace/types.ts
+++ b/packages/agency-lang/lib/runtime/trace/types.ts
@@ -67,7 +67,22 @@ export type TraceCallback = (event: {
 
 export type TraceConfig = {
   program?: string;
+  /**
+   * Directory for trace output. When set, each run writes to
+   * `${traceDir}/${runId}.agencytrace`. Different runs (different
+   * runIds) get different files automatically — safe with concurrent
+   * runs of the same agent. Recommended for production.
+   */
   traceDir?: string;
+  /**
+   * Fixed trace file path. All runs of this module write to this same
+   * file. Useful for tests and single-run inspection. NOT safe with
+   * concurrent runs of the same agent — they will interleave into one
+   * file and runNode will truncate at each new run start. Prefer
+   * `traceDir` for production agents that may run concurrently.
+   *
+   * If both `traceFile` and `traceDir` are set, `traceFile` wins.
+   */
   traceFile?: string;
   traceCallback?: TraceCallback;
 };

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -53,15 +52,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -52,7 +53,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -31,6 +31,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -57,7 +58,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -31,7 +31,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -58,15 +57,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -28,6 +28,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -78,7 +79,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -28,7 +28,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -79,15 +78,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -28,6 +28,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -78,7 +79,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -28,7 +28,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -79,15 +78,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -28,6 +28,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -78,7 +79,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -28,7 +28,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -79,15 +78,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -28,6 +28,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -78,7 +79,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -28,7 +28,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -79,15 +78,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -28,6 +28,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -78,7 +79,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -28,7 +28,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -79,15 +78,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -28,6 +28,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -78,7 +79,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -28,7 +28,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -79,15 +78,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/debugger/thread-test.agency
+++ b/packages/agency-lang/tests/debugger/thread-test.agency
@@ -3,4 +3,9 @@ node main() {
     capital = llm("What is the capital of France?")
     population: { capital: string; pop: number } = llm("And what is its population?")
   }
+  // Trailing step so the debugger renders one more checkpoint after the
+  // second llm call completes — without it, the thread state with 4
+  // messages is never observable from a render call (debug steps fire
+  // before the callback executes).
+  done = true
 }

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -27,7 +27,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -78,15 +77,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -27,6 +27,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,7 +78,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -41,7 +41,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -92,15 +91,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -41,6 +41,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -91,7 +92,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -27,7 +27,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -78,15 +77,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -27,6 +27,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,7 +78,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -27,7 +27,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -78,15 +77,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -27,6 +27,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,7 +78,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -26,6 +26,7 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the global traceConfig
+// so that per-execCtx TraceWriters created by createExecutionContext will
+// write to this path. Truncates the file so the run starts clean (FileSink
+// itself appends, so subsequent execCtx writers don't clobber each other),
+// and resets the shared CAS so dedup is recomputed for the new file.
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+  __globalCtx._sharedTraceStore = null;
+  __truncateTraceFile(filePath);
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -26,7 +26,6 @@ import {
   __call, __callMethod,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
-  truncateTraceFile as __truncateTraceFile,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -77,15 +76,15 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-// Reconfigure the trace file path at runtime. Mutates the global traceConfig
-// so that per-execCtx TraceWriters created by createExecutionContext will
-// write to this path. Truncates the file so the run starts clean (FileSink
-// itself appends, so subsequent execCtx writers don't clobber each other),
-// and resets the shared CAS so dedup is recomputed for the new file.
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
 export const __setTraceFile = (filePath: string) => {
   __globalCtx.traceConfig.traceFile = filePath;
-  __globalCtx._sharedTraceStore = null;
-  __truncateTraceFile(filePath);
 };
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;


### PR DESCRIPTION
# Un-skip trace + thread debugger tests; fix the underlying multi-writer trace lifecycle

## What this PR does

Two previously-skipped tests in the debugger test suite now pass, and the underlying multi-writer trace lifecycle that they exposed is fixed:

- `lib/debugger/trace.test.ts > produces a trace file when running with trace enabled`
- `lib/debugger/thread.test.ts > shows thread messages after each LLM call`

(A third skipped test, `deduplicates globals across trace checkpoints`, was deleted rather than re-enabled. Rationale below.)

Getting the first two to pass required fixing a real, latent runtime bug in how trace files are written when execution spans multiple `respondToInterrupts` segments — not just a test-only patch.

## Why there are multiple writers in the first place

Each call to `respondToInterrupts` (which is what the debugger driver does on every `step`, what user-facing tools do on every `approve`/`reject`, what reload paths do, etc.) goes through `RuntimeContext.createExecutionContext`. That method builds a fresh execCtx and creates a fresh `TraceWriter`. So one logical "run" of an agency program with N pause/resume cycles produces N+1 `TraceWriter` instances, all wanting to write into the same trace file.

The previous code did not handle this:

1. **`FileSink` opened in `"w"` (truncate) mode.** Writer #2 wiped writer #1's output, etc. With single-file `traceFile`, only the last segment of a run survived. Silent data loss in production.
2. **`traceDir` mode generated a fresh timestamped filename per writer**, so one logical run was fragmented across many files (no single-file-per-run view).

## The fix

Two coordinated changes (after iterating with reviewers):

### 1. File path is keyed by runId

New `resolveTraceFilePath(traceConfig, runId)` helper:
- `traceFile` set → use it verbatim. **Process-wide, single-run-only.** Documented on the `TraceConfig` type and on `__setTraceFile`. Useful for tests and single-run inspection; not safe with concurrent runs of the same agent.
- `traceFile` unset, `traceDir` set → `${traceDir}/${runId}.agencytrace`. Concurrent runs naturally get distinct files because they have distinct runIds. **Recommended for production.**
- Neither set → no file output (callback-only or disabled).

### 2. Truncation moved to `runNode`

`runNode` is the entry point for a fresh agent run; `respondToInterrupts` is the resume path. So `runNode` truncates the resolved trace file once at run start, and `FileSink` opens in append mode for everything that follows. Per-execCtx writers within one run accumulate naturally into one file.

### 3. Per-writer ContentAddressableStore

Each `TraceWriter` has its own CAS. Cross-segment dedup is intentionally **not** done — implementing it would require either shared state on the parent `RuntimeContext` (broken for concurrent runs, as reviewers correctly flagged) or moving CAS into globals (extra serialization overhead per checkpoint). The trade-off is some chunks may be duplicated across segments in the file; `TraceReader.loadChunks` is idempotent so reading is unaffected. **Files are slightly larger but correct and concurrency-safe.**

This is why the third skipped test (`deduplicates globals across trace checkpoints`) was deleted: it asserted cross-segment dedup, which was an optimization, not a correctness property. Reader-side correctness is still covered by the main trace-readback test.

### 4. New `__setTraceFile(path)` runtime helper

Replaces the broken `__setTraceWriter` (which mutated `__globalCtx.traceWriter` only to be overwritten on the next `respondToInterrupts`). The helper just mutates `traceConfig.traceFile`; truncation happens at the next `runNode` call. Doc comment warns about concurrency.

`__setTraceWriter` was unused outside the broken trace test, so it's removed cleanly. Generated test fixtures regenerated via `make fixtures`.

### 5. Test fixes

- `isInterrupt` → `hasInterrupts` on the return value of `mod.main()`. The runtime returns `Interrupt[]`, not a single `Interrupt`, after the plural-interrupts migration; the old check was a leftover.
- `thread-test.agency`: added a trailing `done = true` step after the `thread {}` block. Debug hooks fire *before* each step's callback runs, not after, so the checkpoint reflecting "thread has 4 messages" is only visible from a render call if there's a step after the second `llm()`. Without the trailing step, the test's expectation could never be met.

## What this unlocks

- **Trace files are now correct for any run with interrupts.** Single-file `traceFile` users stop losing data; `traceDir` users get one file per run instead of fragmented per-segment files.
- **Concurrent agent runs work cleanly with `traceDir`.** Different runIds → different files → zero shared state, no race.
- **Trace tests can be written naturally.** Tests just call `mod.__setTraceFile(path)` after `compile`, run the program, and read the file. No more wrestling with `__setTraceWriter` lifecycle, shared-writer null-out races, or `pauseTraceWriter`/`closeTraceWriter` ownership puzzles.
- **Two more debugger tests are running.** Previously 21 tests were skipped; now 18.

## Things worth a larger discussion (not in this PR)

- **`traceFile` is documented as single-run-only.** Making it concurrency-safe would require either runId-suffixed filenames (defeating the "fixed path" purpose) or moving more state into globals. Not worth the complexity for a config that's primarily for tests/single-run inspection.
- **Multi-file agents share trace state only through `traceConfig` baked at compile time** (not at runtime via `__setTraceFile`). A process-wide trace registry would fix this; out of scope here.
- **One runId per agent across files** — runIds are per-execCtx, and execCtx isn't shared across file boundaries. Pre-existing limitation, not introduced by this PR.

## Verification

- `pnpm exec vitest run lib/debugger/trace.test.ts lib/debugger/thread.test.ts`: 2/2 pass (was 0/3, all skipped — third one deleted).
- Full `pnpm exec vitest run`: 3201 pass, 18 skipped, 2 pre-existing failures in `lib/typeChecker/undefinedFunctionDiagnostic.test.ts` unrelated to this PR (verified by stashing changes and re-running — same failures).
- `pnpm run lint:structure`: clean.
