### PR TITLE
Follow-ups for the undefined-function diagnostic

### DIFF
--- a/packages/agency-lang/docs/superpowers/plans/2026-05-15-undefined-function-followups.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-15-undefined-function-followups.md
@@ -1,0 +1,187 @@
+# Follow-ups for the undefined-function diagnostic
+
+> **Context:** This document is the hand-off after [PR #143](https://github.com/egonSchiele/agency-lang/pull/143) — the initial undefined-function diagnostic, JS globals registry, and `typechecker` config consolidation. The diagnostic ships at default `"silent"`. These follow-ups complete the picture.
+>
+> **Dependencies matter.** Several items below have ordering constraints; do them in roughly the order presented unless noted.
+
+## Quick orientation
+
+Read these first:
+
+- [`docs/dev/typechecker.md`](../dev/typechecker.md) — bidirectional type checking + the new "Diagnostics" section.
+- [`docs/dev/undefined-function-diagnostic.md`](../dev/undefined-function-diagnostic.md) — the diagnostic's architecture.
+- [`lib/typeChecker/resolveCall.ts`](../../lib/typeChecker/resolveCall.ts) — pure registries (`JS_GLOBALS`, `RESERVED_FUNCTION_NAMES`) and the `resolveCall` / `lookupJsMember` helpers. The big block comment on `CallResolution` and the resolution-order comment above `resolveCall` explain the registries and how they interact.
+- [`lib/typeChecker/builtins.ts`](../../lib/typeChecker/builtins.ts) — `BUILTIN_FUNCTION_TYPES` (a mix of language primitives + hardcoded stdlib signatures; see the `NOTE` in the file).
+
+---
+
+## Task 1 — Block `let`/`const` of reserved or built-in names
+
+**Why:** Today `RESERVED_FUNCTION_NAMES` only blocks `def`/`node` redeclarations. A user can write `static const schema = 42` and it's accepted. The variable is then unusable as a function (`schema(Foo)` always parses as a `SchemaExpression` regardless of scope), so allowing it is a footgun — verified in the PR conversation.
+
+**Scope question (resolve before implementing):** the user requested blocking "reserved OR built-in" names. Two interpretations:
+
+- **(A) Reserved only.** Blocks `let schema`, `let interrupt`, `let debugger`, plus the names also in `BUILTIN_FUNCTION_TYPES` (the language primitives like `success`, `failure`, `approve`, etc.). Breaks no current code.
+- **(B) Reserved + everything in `BUILTIN_FUNCTION_TYPES`.** Also blocks `let print`, `let fetch`, etc. **Breaks stdlib shadowing** — currently users can `def print() { ... }` and `let print = ...`. A backwards-incompatible change to userland code.
+
+Recommend (A) for this task; (B) becomes natural after Task 3 (stdlib moves out of `BUILTIN_FUNCTION_TYPES`).
+
+**Where:**
+
+- Extend the loop at [`lib/typeChecker/index.ts:155-160`](../../lib/typeChecker/index.ts#L155-L160) to also walk top-level `assignment` nodes in `ctx.programNodes` and check `RESERVED_FUNCTION_NAMES.has(node.variableName)`.
+- Decide whether to also walk per-scope assignments (inside `def`/`node` bodies). Probably yes for consistency; pull from `scopes` in `buildScopes`.
+- Use `Object.prototype.hasOwnProperty.call` everywhere — see PR #143 fix for why `in` is unsafe.
+
+**Tests:**
+
+- `static const schema = 42` is now an error.
+- `static const schemaForX = 42` is fine (substring match must NOT fire).
+- `let interrupt = 5` inside a node body is an error.
+- `def schema()` still errors (existing behavior unchanged).
+
+---
+
+## Task 2 — Move stdlib signatures out of `BUILTIN_FUNCTION_TYPES`
+
+**Why:** This is existing tech debt flagged by the `NOTE` comment at [`builtins.ts:62-71`](../../lib/typeChecker/builtins.ts#L62-L71). Stdlib functions like `print`, `fetch`, `read`, `range`, `keys`, `values`, `entries`, `mostCommon`, `notify`, `sleep`, `round`, `printJSON`, `input`, `readImage`, `write`, `fetchJSON`, `emit` are defined as real Agency code in [`stdlib/index.agency`](../../stdlib/index.agency) but have hardcoded signatures in `BUILTIN_FUNCTION_TYPES` for typechecker convenience. Their signatures should come from the `SymbolTable` via `importedFunctions` instead.
+
+**Why before Tasks 3–5:** Cleaning this up first means downstream tasks (signature lookups, hover, blocking declarations) only have to think about *true* built-ins.
+
+**Where:**
+
+- `SymbolTable` already resolves stdlib imports — see [`lib/symbolTable.ts`](../../lib/symbolTable.ts). The challenge is exposing typed parameter info (with parameter types) on `ImportedFunctionSignature` in the shape the typechecker's `checkSingleFunctionCall` already consumes (mirror what's done for non-stdlib imports today).
+- Once stdlib signatures resolve through `importedFunctions`, the corresponding entries in `BUILTIN_FUNCTION_TYPES` can be deleted.
+- `BUILTIN_FUNCTION_TYPES` after this change keeps only true language primitives: `success`, `failure`, `isSuccess`, `isFailure`, `restore`, `llm`, `approve`, `reject`, `propagate`, `checkpoint`, `getCheckpoint`. (Keep `llm` here — it's a primitive, not stdlib.)
+
+**Tests:**
+
+- Existing typechecker tests for stdlib calls (`print(123, "hi")`, `read("/tmp/x")`, etc.) still pass.
+- Shadowing: `def print(x: number): void { ... }` is accepted and the user definition takes precedence over the stdlib one.
+
+---
+
+## Task 3 — Populate `sig` on `JS_GLOBALS` entries
+
+**Why:** Today every `JS_GLOBALS` entry is a bare `callable()` with no signature. This means `JSON.parse(1, 2, 3, 4)` doesn't get an arity error and `Math.floor("hi")` doesn't get a type error. The registry shape already supports `sig?: BuiltinSignature` for exactly this reason — see [`resolveCall.ts:JsRegistryEntry`](../../lib/typeChecker/resolveCall.ts).
+
+**Where:**
+
+- `lib/typeChecker/resolveCall.ts` — populate `sig` on entries we want enforced. Start with high-traffic ones: `JSON.parse`, `JSON.stringify`, `Math.floor`, `Math.ceil`, `Math.round`, `Math.abs`, `Math.max`, `Math.min`, `Math.random`, `Math.sqrt`, `parseInt`, `parseFloat`, `Number.isInteger`, `Array.isArray`, `Object.keys`, `Object.values`, `Object.entries`, `Date.now`.
+- The diagnostic and typechecker need a code path that consults `lookupJsMember(...)`, sees the resulting entry is `kind: "callable"` with a populated `sig`, and runs the existing `checkArity` / `checkArgsAgainstParams` logic against it. Today only `BUILTIN_FUNCTION_TYPES` flows through this path — extend it to JS globals as a parallel branch in `checker.ts:checkSingleFunctionCall` (mirror the `BUILTIN_FUNCTION_TYPES` branch).
+- Pure addition: entries without a `sig` keep the Phase 1 existence-only behavior.
+
+**Tests:**
+
+- `JSON.parse("{}")` — no arity error.
+- `JSON.parse()` — arity error (expects 1 arg).
+- `Math.floor("not a number")` — type error.
+- `console.log(1, 2, 3)` — no error (variadic / no `sig`).
+
+---
+
+## Task 4 — LSP: signature help / hover for built-ins and JS globals
+
+**Why:** Once Tasks 2 and 3 are done, the typechecker has typed signatures for true built-ins, stdlib functions (via imports), and the most common JS globals. The LSP currently doesn't surface any of this on hover.
+
+**Where:**
+
+- LSP hover lives at [`lib/lsp/hover.ts`](../../lib/lsp/hover.ts). Today it hovers types for variables; needs new logic when the cursor is on a `functionCall.functionName` or a `valueAccess` member.
+- Reuse `resolveCall` + `lookupJsMember` to identify what the cursor is pointing at.
+- Format using existing `formatTypeHint` from [`lib/utils/formatType.ts`](../../lib/utils/formatType.ts).
+- Consider also adding to [`lib/lsp/completion.ts`](../../lib/lsp/completion.ts) — when a user types `JSON.`, suggest the members from `JS_GLOBALS.JSON.members`.
+
+**Tests:**
+
+- LSP tests live in `lib/lsp/*.test.ts`. Add hover tests for `print`, `JSON.parse`, `Math.floor`, `success`, `approve`.
+
+---
+
+## Task 5 — Flip `typechecker.undefinedFunctions` default from `"silent"` to `"warn"`
+
+**Why:** The diagnostic shipped silent so the initial PR wouldn't break any internal tests. Once the registries are accurate (Tasks 2 + 3), it's safe to default to warn.
+
+**Where:**
+
+- [`lib/typeChecker/undefinedFunctionDiagnostic.ts`](../../lib/typeChecker/undefinedFunctionDiagnostic.ts) — change `?? "silent"` to `?? "warn"`.
+- Run `pnpm test:run` and `pnpm run agency test tests/agency` to surface any false positives. Likely candidates: tests that intentionally call missing functions, tests that use JS globals not yet in `JS_GLOBALS`.
+- For each false positive: either add the missing entry to `JS_GLOBALS`, or add a `# typecheck-ignore` comment, or fix the test program.
+
+**Tests:**
+
+- `lib/typeChecker/undefinedFunctionDiagnostic.test.ts` — update the `"silent" (default)` test to expect `"warn"` behavior.
+- Make sure no agency test files regress.
+
+---
+
+## Task 6 — Synth a structured `Schema<T>` type for `schemaExpression`
+
+**Why:** Today `synthType(schemaExpression)` returns `"any"` (see the comment at [`synthesizer.ts:117`](../../lib/typeChecker/synthesizer.ts#L117-L132)). This means `.parse()` / `.safeParse()` calls on a schema lose all type info. A structured `Schema<T>` would let the typechecker validate that `schema(MyType).parse(x)` returns `MyType` (or a Result wrapping `MyType`).
+
+**Where:**
+
+- Add `Schema` to the type system — likely a new variant `{ type: "schemaType", inner: VariableType }` in [`lib/types/typeSystem.ts`](../../lib/types/typeSystem.ts) or wherever `VariableType` is defined.
+- Update `synthType` for `schemaExpression` to return `{ type: "schemaType", inner: expr.typeArg }`.
+- Update `synthValueAccess` to recognize `.parse(...)` and `.safeParse(...)` on a `schemaType` and return the appropriate type.
+- Pretty-print in `formatTypeHint`.
+
+**Tests:**
+
+- `let s = schema(MyType); let x = s.parse(input)` — `x` should synth as `MyType`.
+- `let r = s.safeParse(input)` — `r` should synth as `Result<MyType, any>` (Zod's actual return shape is `{ success: true, data: T } | { success: false, error: ... }`; matching that exactly may need more work).
+
+---
+
+## Task 7 — Symmetric undefined-variable diagnostic
+
+**Why:** This PR catches `undefinedFunc()` but not `let x = undefinedVar`. They're the same kind of bug — a name reference that doesn't resolve to anything — and the same `resolveCall` / `lookupJsMember` infrastructure can power it.
+
+**Where:**
+
+- New module: `lib/typeChecker/undefinedVariableDiagnostic.ts`. Same shape as `undefinedFunctionDiagnostic.ts`: one public function `checkUndefinedVariables(scopes, ctx)`, walks AST with `walkNodes`, fires on `variableName` nodes whose `value` doesn't resolve.
+- Need a parallel pure helper `resolveVariable(name, input)` in `resolveCall.ts` (or a new `resolveVariable.ts`) — same registries as `resolveCall` but the rules differ slightly (e.g., a function reference is OK as a variable name).
+- Add `typechecker.undefinedVariables: "silent" | "warn" | "error"` to [`lib/config.ts`](../../lib/config.ts), default `"silent"` for the initial landing.
+- Wire one call into `TypeChecker.check()`, alongside `checkUndefinedFunctions`.
+
+**Tests:**
+
+- `let x = doesNotExist` — emits diagnostic.
+- `let x = myDef` (function reference) — does NOT emit.
+- `for item in someArray` where `someArray` is undefined — emits.
+- Respects the same `silent` / `warn` / `error` modes.
+
+---
+
+## Task 8 — Higher-order callback safety
+
+**Why:** Today `map(items, doesNotExist)` slips through. The undefined name appears as a `variableName` argument, not a `functionCall`, so neither this PR's diagnostic nor a plain undefined-variable check (Task 7) is quite right — we want to know the name should resolve to something *callable*.
+
+**Where:**
+
+- Probably belongs in or right after Task 7. Walk arguments of `functionCall` and `methodCall`; for any `variableName` argument whose synthesized type is `functionRefType`, run `resolveCall` against the name. (See `interruptAnalysis.ts`'s `functionRefsInArgs` for how function-ref names are extracted.)
+- Plug into the same `typechecker.undefinedFunctions` config knob — it's the same conceptual bug.
+
+**Tests:**
+
+- `map(items, doesNotExist)` — emits diagnostic.
+- `map(items, myDef)` — no diagnostic.
+- `map(items, \(x) -> x + 1)` — no diagnostic (lambda, not a name).
+
+---
+
+## Optional cleanup
+
+- **Delete the dead `"reserved"` branch in `resolveCall`.** With the parser as-is, the three names listed there (`schema`, `interrupt`, `debugger`) never reach `resolveCall` as a `functionCall`. Branch is kept as belt-and-suspenders. Cheap to delete; up to taste. If deleted, also remove `kind: "reserved"` from `CallResolution` and update the doc comment.
+- **Class methods get their own `ScopeInfo`.** Today methods on a `classDefinition` share the global scope, which is why this PR's diagnostic walks top-level (skipping nested `function`/`graphNode`) to cover them. Giving methods proper scopes would make the diagnostic walk more uniform and would benefit other passes (interrupt analysis, return-type inference).
+
+---
+
+## Suggested order of execution
+
+1. **Task 1** (block reserved-name `let`/`const`) — small, isolated, high-value.
+2. **Task 2** (stdlib via imports) — unblocks Tasks 3, 4, 5.
+3. **Task 3** (`sig` on `JS_GLOBALS`).
+4. **Task 4** (LSP hover) — depends on Tasks 2 + 3 for accurate signatures.
+5. **Task 5** (flip default) — depends on accurate registries.
+6. **Task 7** (undefined-variable diagnostic) — independent of Tasks 2–5; can be done in parallel.
+7. **Task 8** (higher-order callback safety) — after Task 7.
+8. **Task 6** (`Schema<T>` type) — independent; do whenever convenient.

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -11,6 +11,7 @@ import type {
   ImportNodeStatement,
   ImportStatement,
 } from "./types/importStatement.js";
+import { getImportedNames } from "./types/importStatement.js";
 import type { SymbolTable, InterruptKind } from "./symbolTable.js";
 import { walkNodes } from "./utils/node.js";
 import { resultTypeForValidation } from "./typeChecker/validation.js";
@@ -88,6 +89,14 @@ export type CompilationUnit = {
   importStatements: ImportStatement[];
   safeFunctions: Record<string, boolean>;
   importedFunctions: Record<string, ImportedFunctionSignature>;
+  /**
+   * Local names brought in by non-Agency `import { … } from "some.js"`
+   * statements. We don't have signatures for these (they're JS), so they
+   * live in their own bag and the typechecker treats them as untyped
+   * known-callable bindings — enough to keep undefined-function /
+   * variable diagnostics quiet without pretending we know their types.
+   */
+  jsImportedNames: Record<string, true>;
   classDefinitions: Record<string, ClassDefinition>;
   /** Original source text. Used by the typechecker to locate
    * `// @tc-nocheck` / `// @tc-ignore` directives. Optional because
@@ -129,6 +138,7 @@ export function buildCompilationUnit(
     importedNodes: [],
     importStatements: [],
     importedFunctions: {},
+    jsImportedNames: {},
     classDefinitions: {},
     safeFunctions: {},
     sourceText,
@@ -162,6 +172,18 @@ export function buildCompilationUnit(
           for (const safeName of nameType.safeNames) {
             const localSafe = nameType.aliases[safeName] ?? safeName;
             unit.safeFunctions[localSafe] = true;
+          }
+        }
+        // JS imports (`import { foo } from "./helpers.js"`) don't have
+        // typed signatures the way Agency imports do — symbolTable.resolveImport
+        // skips them — but the names ARE bound at runtime, so the typechecker
+        // shouldn't flag them as undefined. Track them here so resolveCall /
+        // resolveVariable can recognize them.
+        if (!node.isAgencyImport) {
+          for (const nameType of node.importedNames) {
+            for (const local of getImportedNames(nameType)) {
+              unit.jsImportedNames[local] = true;
+            }
           }
         }
         break;

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -103,11 +103,18 @@ export interface AgencyConfig {
     strictTypes?: boolean;
     /**
      * What to do when a function call cannot be resolved:
+     * - "silent": ignore
+     * - "warn": emit a warning (default)
+     * - "error": emit an error
+     */
+    undefinedFunctions?: "silent" | "warn" | "error";
+    /**
+     * What to do when a variable reference cannot be resolved:
      * - "silent": ignore (default for the initial landing)
      * - "warn": emit a warning
      * - "error": emit an error
      */
-    undefinedFunctions?: "silent" | "warn" | "error";
+    undefinedVariables?: "silent" | "warn" | "error";
   };
 
   /** Enable debugger mode — auto-inserts breakpoints before every step */
@@ -223,6 +230,7 @@ export const AgencyConfigSchema = z
         strict: z.boolean(),
         strictTypes: z.boolean(),
         undefinedFunctions: z.enum(["silent", "warn", "error"]),
+        undefinedVariables: z.enum(["silent", "warn", "error"]),
       })
       .partial(),
     debugger: z.boolean(),

--- a/packages/agency-lang/lib/lsp/builtinHover.ts
+++ b/packages/agency-lang/lib/lsp/builtinHover.ts
@@ -1,0 +1,94 @@
+import type { BuiltinSignature } from "../typeChecker/types.js";
+import { BUILTIN_FUNCTION_TYPES } from "../typeChecker/builtins.js";
+import { JS_GLOBALS, lookupJsMember } from "../typeChecker/resolveCall.js";
+import { formatTypeHint } from "../utils/formatType.js";
+
+/**
+ * Format a BuiltinSignature as a callable type string. Shape:
+ *   (T1, T2, ...) => R
+ * Variadic params (`restParam`) render as `...T[]`.
+ */
+function formatSig(sig: BuiltinSignature): string {
+  const parts = sig.params.map((p) =>
+    p === "any" ? "any" : formatTypeHint(p),
+  );
+  if (sig.restParam !== undefined) {
+    const rest =
+      sig.restParam === "any" ? "any" : formatTypeHint(sig.restParam);
+    parts.push(`...${rest}[]`);
+  }
+  const ret = sig.returnType === "any" ? "any" : formatTypeHint(sig.returnType);
+  return `(${parts.join(", ")}) => ${ret}`;
+}
+
+/**
+ * Hover info for a name that may be a language primitive or JS global.
+ * Returns a markdown-formatted string ready for `Hover.contents.value`,
+ * or `null` if the name isn't recognized.
+ *
+ * Currently covers:
+ *   - True language primitives in BUILTIN_FUNCTION_TYPES (success,
+ *     failure, llm, …).
+ *   - Flat callable JS globals with a populated `sig` (parseInt, …).
+ *   - JS namespace bases (JSON, Math, …) — describes the namespace.
+ *
+ * Stdlib functions (print, fetch, …) come through importedFunctions,
+ * which the existing semantic-symbol path already handles.
+ */
+export function lookupBuiltinHover(name: string): string | null {
+  if (Object.prototype.hasOwnProperty.call(BUILTIN_FUNCTION_TYPES, name)) {
+    const sig = BUILTIN_FUNCTION_TYPES[name];
+    return [
+      "```agency",
+      `${name}: ${formatSig(sig)}`,
+      "```",
+      "",
+      "_Agency language primitive._",
+    ].join("\n");
+  }
+  if (Object.prototype.hasOwnProperty.call(JS_GLOBALS, name)) {
+    const entry = JS_GLOBALS[name];
+    if (entry.kind === "callable") {
+      const sigText = entry.sig ? formatSig(entry.sig) : "(any) => any";
+      return [
+        "```ts",
+        `${name}: ${sigText}`,
+        "```",
+        "",
+        "_JavaScript global._",
+      ].join("\n");
+    }
+    // namespace
+    const memberNames = Object.keys(entry.members).sort();
+    return [
+      "```ts",
+      `namespace ${name}`,
+      "```",
+      "",
+      "_JavaScript namespace._",
+      "",
+      `Members: ${memberNames.join(", ")}`,
+    ].join("\n");
+  }
+  return null;
+}
+
+/**
+ * Hover info for a `<JsNamespace>.<member>` pair (e.g. `JSON.parse`).
+ * Returns null if the chain doesn't resolve to a known JS global.
+ */
+export function lookupJsMemberHover(
+  baseName: string,
+  memberName: string,
+): string | null {
+  const entry = lookupJsMember([baseName, memberName]);
+  if (!entry || entry.kind !== "callable") return null;
+  const sigText = entry.sig ? formatSig(entry.sig) : "(any) => any";
+  return [
+    "```ts",
+    `${baseName}.${memberName}: ${sigText}`,
+    "```",
+    "",
+    "_JavaScript global._",
+  ].join("\n");
+}

--- a/packages/agency-lang/lib/lsp/diagnostics.test.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { TextDocument } from "vscode-languageserver-textdocument";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import { runDiagnostics } from "./diagnostics.js";
 import { SymbolTable } from "../symbolTable.js";
 
@@ -38,5 +41,44 @@ describe("runDiagnostics", () => {
     const doc = makeDoc("def greet() { let msg: string = `hello` }");
     const result = runDiagnostics(doc, "/test.agency", {}, emptySymbolTable);
     expect(result.program).not.toBeNull();
+  });
+});
+
+describe("runDiagnostics — stdlib auto-import parity with CLI", () => {
+  // The CLI parser template prepends a fixed `import { print, … } from "std::index"`
+  // line regardless of whatever the user wrote (see
+  // lib/templates/backends/agency/template.mustache). The LSP must mirror
+  // that — even when the user already imports a *subset* of names from
+  // std::index, the auto-imports must still be visible so call sites like
+  // `print(x)` don't get a false "undefined" warning.
+  it("recognizes auto-imports even when user imports a subset from std::index", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agency-lsp-stdlib-"));
+    try {
+      const mainFile = path.join(tmpDir, "main.agency");
+      const source = [
+        'import { range } from "std::index"',
+        "node main() {",
+        "  let xs = range(0, 3)",
+        '  print("hi")',
+        "}",
+        "",
+      ].join("\n");
+      fs.writeFileSync(mainFile, source);
+
+      const doc = makeDoc(source, `file://${mainFile}`);
+      const symbolTable = SymbolTable.build(mainFile, {});
+      const { diagnostics } = runDiagnostics(
+        doc,
+        mainFile,
+        { typechecker: { undefinedFunctions: "warn" } },
+        symbolTable,
+      );
+      const printNotDefined = diagnostics.filter(
+        (d) => d.message.includes("print") && d.message.includes("not defined"),
+      );
+      expect(printNotDefined).toHaveLength(0);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/agency-lang/lib/lsp/diagnostics.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.ts
@@ -14,6 +14,58 @@ import { AgencyProgram } from "../types.js";
 import { CompilationUnit } from "../compilationUnit.js";
 import { buildSemanticIndex, type SemanticIndex } from "./semantics.js";
 import type { ScopeInfo } from "../typeChecker/types.js";
+import { ImportStatement } from "../types/importStatement.js";
+import { resolveAgencyImportPath } from "../importPaths.js";
+
+// Names auto-imported from std::index by the parser template. Kept in sync
+// with lib/templates/backends/agency/template.mustache.
+const STDLIB_AUTO_IMPORTS: string[] = [
+  "print", "printJSON", "parseJSON", "input", "sleep", "round", "fetch",
+  "fetchJSON", "read", "write", "readImage", "notify", "range",
+  "mostCommon", "keys", "values", "entries", "emit",
+];
+
+/**
+ * Inject a synthetic `import { ... } from "std::index"` if the program
+ * doesn't already have one AND the SymbolTable has std::index loaded.
+ * Returns the original program unchanged otherwise.
+ *
+ * Skipping when the SymbolTable doesn't have std::index avoids generating
+ * downstream "Symbol 'print' is not defined in std::index" errors when
+ * tests pass an empty SymbolTable.
+ */
+function ensureStdlibImport(
+  program: AgencyProgram,
+  symbolTable: SymbolTable,
+  fsPath: string,
+): AgencyProgram {
+  for (const node of program.nodes) {
+    if (node.type === "importStatement" && node.modulePath === "std::index") {
+      return program;
+    }
+  }
+  let stdlibPath: string;
+  try {
+    stdlibPath = resolveAgencyImportPath("std::index", fsPath);
+  } catch {
+    return program;
+  }
+  if (!symbolTable.has(stdlibPath)) return program;
+  const synthetic: ImportStatement = {
+    type: "importStatement",
+    importedNames: [
+      {
+        type: "namedImport",
+        importedNames: STDLIB_AUTO_IMPORTS,
+        safeNames: [],
+        aliases: {},
+      },
+    ],
+    modulePath: "std::index",
+    isAgencyImport: true,
+  };
+  return { ...program, nodes: [synthetic, ...program.nodes] };
+}
 
 type DiagnosticsResult = {
   diagnostics: Diagnostic[];
@@ -57,6 +109,14 @@ export function runDiagnostics(
   }
 
   let program = parseResult.result;
+
+  // The CLI parses source through a template that auto-injects an
+  // `import { ... } from "std::index"` statement. The LSP path uses
+  // `applyTemplate: false` so editor positions match the user's source —
+  // but that means stdlib calls (`print`, `read`, …) would resolve as
+  // undefined here. Synthesize the same import so they resolve through
+  // `importedFunctions` like in the CLI flow.
+  program = ensureStdlibImport(program, symbolTable, fsPath);
 
   try {
     program = resolveReExports(program, symbolTable, fsPath);

--- a/packages/agency-lang/lib/lsp/diagnostics.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.ts
@@ -26,24 +26,23 @@ const STDLIB_AUTO_IMPORTS: string[] = [
 ];
 
 /**
- * Inject a synthetic `import { ... } from "std::index"` if the program
- * doesn't already have one AND the SymbolTable has std::index loaded.
- * Returns the original program unchanged otherwise.
+ * Inject a synthetic `import { ... } from "std::index"` so the LSP sees the
+ * same auto-imports the CLI parser template prepends — see
+ * lib/templates/backends/agency/template.mustache. The synthetic is added
+ * unconditionally (alongside any user `import … from "std::index"`) so a
+ * user who imports a *subset* like `import { range } from "std::index"`
+ * still gets `print`, `read`, etc. from the auto-imports — matching CLI
+ * behavior where the template prepends a separate fixed import line.
  *
- * Skipping when the SymbolTable doesn't have std::index avoids generating
- * downstream "Symbol 'print' is not defined in std::index" errors when
- * tests pass an empty SymbolTable.
+ * Skipped when the SymbolTable doesn't have std::index loaded — that's
+ * the test-with-empty-SymbolTable case and synthesizing here would just
+ * produce downstream "Symbol 'print' is not defined" noise.
  */
 function ensureStdlibImport(
   program: AgencyProgram,
   symbolTable: SymbolTable,
   fsPath: string,
 ): AgencyProgram {
-  for (const node of program.nodes) {
-    if (node.type === "importStatement" && node.modulePath === "std::index") {
-      return program;
-    }
-  }
   let stdlibPath: string;
   try {
     stdlibPath = resolveAgencyImportPath("std::index", fsPath);

--- a/packages/agency-lang/lib/lsp/hover.test.ts
+++ b/packages/agency-lang/lib/lsp/hover.test.ts
@@ -181,6 +181,89 @@ greet("world")`;
     }
   });
 
+  it("returns hover info for a language primitive (success)", () => {
+    const source = 'node main() {\n  let r = success(1)\n}';
+    const doc = makeDoc(source);
+    const { semanticIndex } = runDiagnostics(
+      doc,
+      "/test.agency",
+      {},
+      new SymbolTable(),
+    );
+    // Hover over "success"
+    const result = handleHover(
+      { textDocument: { uri: doc.uri }, position: { line: 1, character: 12 } },
+      doc,
+      semanticIndex,
+    );
+    expect(result).not.toBeNull();
+    const value = (result!.contents as any).value;
+    expect(value).toContain("success");
+    expect(value).toContain("Agency language primitive");
+  });
+
+  it("returns hover info for a flat JS global (parseInt)", () => {
+    const source = 'node main() {\n  let n = parseInt("42")\n}';
+    const doc = makeDoc(source);
+    const { semanticIndex } = runDiagnostics(
+      doc,
+      "/test.agency",
+      {},
+      new SymbolTable(),
+    );
+    const result = handleHover(
+      { textDocument: { uri: doc.uri }, position: { line: 1, character: 12 } },
+      doc,
+      semanticIndex,
+    );
+    expect(result).not.toBeNull();
+    const value = (result!.contents as any).value;
+    expect(value).toContain("parseInt");
+    expect(value).toContain("JavaScript global");
+  });
+
+  it("returns hover info for a JS namespace member (JSON.parse)", () => {
+    const source = 'node main() {\n  let x = JSON.parse("{}")\n}';
+    const doc = makeDoc(source);
+    const { semanticIndex } = runDiagnostics(
+      doc,
+      "/test.agency",
+      {},
+      new SymbolTable(),
+    );
+    // Hover over "parse" in JSON.parse
+    const result = handleHover(
+      { textDocument: { uri: doc.uri }, position: { line: 1, character: 17 } },
+      doc,
+      semanticIndex,
+    );
+    expect(result).not.toBeNull();
+    const value = (result!.contents as any).value;
+    expect(value).toContain("JSON.parse");
+    expect(value).toContain("JavaScript global");
+  });
+
+  it("returns hover info for a JS namespace base (JSON)", () => {
+    const source = 'node main() {\n  let x = JSON.parse("{}")\n}';
+    const doc = makeDoc(source);
+    const { semanticIndex } = runDiagnostics(
+      doc,
+      "/test.agency",
+      {},
+      new SymbolTable(),
+    );
+    // Hover over "JSON"
+    const result = handleHover(
+      { textDocument: { uri: doc.uri }, position: { line: 1, character: 11 } },
+      doc,
+      semanticIndex,
+    );
+    expect(result).not.toBeNull();
+    const value = (result!.contents as any).value;
+    expect(value).toContain("namespace JSON");
+    expect(value).toContain("JavaScript namespace");
+  });
+
   it("returns null when not on an identifier", () => {
     const doc = makeDoc("let x: number = 5");
     const { semanticIndex } = runDiagnostics(

--- a/packages/agency-lang/lib/lsp/hover.ts
+++ b/packages/agency-lang/lib/lsp/hover.ts
@@ -4,8 +4,40 @@ import { formatSemanticHover, lookupSemanticSymbol, type SemanticIndex } from ".
 import { resolveTypeAtPosition } from "./typeResolution.js";
 import { formatTypeHint } from "../utils/formatType.js";
 import { getWordAtPosition } from "../cli/definition.js";
+import { lookupBuiltinHover, lookupJsMemberHover } from "./builtinHover.js";
 import type { AgencyProgram } from "../types.js";
 import type { ScopeInfo } from "../typeChecker/types.js";
+
+/**
+ * If the cursor's word is preceded by `<Identifier>.`, return that base
+ * identifier — used to detect JS namespace member access like `JSON.parse`
+ * so we can hover the member instead of the bare function name.
+ */
+function getDottedBase(
+  source: string,
+  line: number,
+  column: number,
+): string | null {
+  const lines = source.split("\n");
+  if (line < 0 || line >= lines.length) return null;
+  const lineText = lines[line];
+
+  // Walk left from column to the start of the current word.
+  let start = column;
+  while (start > 0 && /[a-zA-Z0-9_]/.test(lineText[start - 1])) {
+    start--;
+  }
+  if (start === 0 || lineText[start - 1] !== ".") return null;
+
+  // Walk left across the base identifier.
+  let baseEnd = start - 1;
+  let baseStart = baseEnd;
+  while (baseStart > 0 && /[a-zA-Z0-9_]/.test(lineText[baseStart - 1])) {
+    baseStart--;
+  }
+  if (baseStart === baseEnd) return null;
+  return lineText.slice(baseStart, baseEnd);
+}
 
 export function handleHover(
   params: HoverParams,
@@ -47,6 +79,28 @@ export function handleHover(
           value: `\`\`\`agency\nlet ${word}: ${typeStr}\n\`\`\``,
         },
       };
+    }
+  }
+
+  // Last: language primitives (success, failure, …) and JS globals.
+  // Stdlib functions (print, fetch, …) come through importedFunctions and
+  // are already covered by the semantic-symbol path above.
+  const word = getWordAtPosition(
+    source,
+    params.position.line,
+    params.position.character,
+  );
+  if (word) {
+    const base = getDottedBase(
+      source,
+      params.position.line,
+      params.position.character,
+    );
+    const hover = base
+      ? lookupJsMemberHover(base, word)
+      : lookupBuiltinHover(word);
+    if (hover) {
+      return { contents: { kind: "markdown", value: hover } };
     }
   }
 

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -14,6 +14,14 @@ function withImports(
   return info;
 }
 
+// These tests build ASTs by hand and never run the parser, so the
+// auto-injected std::index import is missing. Without it, stdlib calls
+// (`print(...)`, `sleep(...)`, `fetchJSON(...)`, …) would warn as
+// "undefined function" — that's a false positive for these tests, which are
+// exercising other parts of the typechecker. Pass this config to silence
+// that diagnostic.
+const SILENT_UNDEF = { typechecker: { undefinedFunctions: "silent" as const } };
+
 describe("TypeChecker", () => {
   describe("function call argument type matching", () => {
     it("should pass with correct argument types", () => {
@@ -585,7 +593,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = typeCheck(program, SILENT_UNDEF);
       expect(errors).toHaveLength(0);
     });
 
@@ -601,7 +609,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = typeCheck(program, SILENT_UNDEF);
       expect(errors).toHaveLength(0);
     });
 
@@ -1404,7 +1412,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = typeCheck(program, SILENT_UNDEF);
       expect(errors).toHaveLength(1);
       expect(errors[0].message).toContain("Property 'nonexistent' does not exist on type");
     });
@@ -1448,7 +1456,7 @@ describe("TypeChecker", () => {
         ],
       };
 
-      const { errors } = typeCheck(program);
+      const { errors } = typeCheck(program, SILENT_UNDEF);
       expect(errors).toHaveLength(1);
       expect(errors[0].message).toContain("Property 'asdasd' does not exist on type");
     });
@@ -1483,7 +1491,7 @@ describe("TypeChecker", () => {
       };
 
       // data is any (fetchJSON returns any), so property access is fine
-      const { errors } = typeCheck(program);
+      const { errors } = typeCheck(program, SILENT_UNDEF);
       expect(errors).toHaveLength(0);
     });
   });
@@ -2219,7 +2227,7 @@ describe("TypeChecker", () => {
       };
 
       // fetchJSON returns any, so it should pass any parameter check
-      const { errors } = typeCheck(program);
+      const { errors } = typeCheck(program, SILENT_UNDEF);
       expect(errors).toHaveLength(0);
     });
   });
@@ -3088,7 +3096,7 @@ describe("TypeChecker", () => {
           { type: "functionCall", functionName: "print", arguments: [] },
         ],
       };
-      expect(typeCheck(program).errors).toHaveLength(0);
+      expect(typeCheck(program, SILENT_UNDEF).errors).toHaveLength(0);
     });
   });
 

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -605,13 +605,16 @@ describe("TypeChecker", () => {
       expect(errors).toHaveLength(0);
     });
 
-    it("should error sleep with a string argument", () => {
+    it("should error builtin call with wrong arg type", () => {
+      // `getCheckpoint` is a real language primitive that takes a number.
+      // Stdlib functions (sleep, write, …) used to be hardcoded here too
+      // but now resolve through the SymbolTable from stdlib/index.agency.
       const program: AgencyProgram = {
         type: "agencyProgram",
         nodes: [
           {
             type: "functionCall",
-            functionName: "sleep",
+            functionName: "getCheckpoint",
             arguments: [
               { type: "string", segments: [{ type: "text", value: "hello" }] },
             ],
@@ -622,18 +625,19 @@ describe("TypeChecker", () => {
       const { errors } = typeCheck(program);
       expect(errors).toHaveLength(1);
       expect(errors[0].message).toContain("not assignable to parameter type");
-      expect(errors[0].message).toContain("sleep");
+      expect(errors[0].message).toContain("getCheckpoint");
     });
 
-    it("should error write with wrong arity", () => {
+    it("should error builtin call with wrong arity", () => {
+      // `restore` takes 2 args. Calling with 1 should error.
       const program: AgencyProgram = {
         type: "agencyProgram",
         nodes: [
           {
             type: "functionCall",
-            functionName: "write",
+            functionName: "restore",
             arguments: [
-              { type: "string", segments: [{ type: "text", value: "file.txt" }] },
+              { type: "number", value: "1" },
             ],
           },
         ],
@@ -645,7 +649,7 @@ describe("TypeChecker", () => {
       expect(errors[0].message).toContain("but got 1");
     });
 
-    it("should infer builtin return type (round returns number)", () => {
+    it("should infer builtin return type (checkpoint returns number)", () => {
       const program: AgencyProgram = {
         type: "agencyProgram",
         nodes: [
@@ -667,11 +671,8 @@ describe("TypeChecker", () => {
             arguments: [
               {
                 type: "functionCall",
-                functionName: "round",
-                arguments: [
-                  { type: "number", value: "3.14" },
-                  { type: "number", value: "2" },
-                ],
+                functionName: "checkpoint",
+                arguments: [],
               },
             ],
           },
@@ -2144,7 +2145,10 @@ describe("TypeChecker", () => {
   });
 
   describe("builtin return type inference", () => {
-    it("should infer string from input() return type", () => {
+    it("should infer string from a builtin's declared return type (llm)", () => {
+      // `llm` is a true language primitive whose signature lives in
+      // BUILTIN_FUNCTION_TYPES. Stdlib (input, read) used to be hardcoded
+      // here too but now resolves through the SymbolTable.
       const program: AgencyProgram = {
         type: "agencyProgram",
         nodes: [
@@ -2166,47 +2170,9 @@ describe("TypeChecker", () => {
             arguments: [
               {
                 type: "functionCall",
-                functionName: "input",
+                functionName: "llm",
                 arguments: [
                   { type: "string", segments: [{ type: "text", value: "Enter name: " }] },
-                ],
-              },
-            ],
-          },
-        ],
-      };
-
-      const { errors } = typeCheck(program);
-      expect(errors).toHaveLength(1);
-      expect(errors[0].actualType).toBe("string");
-      expect(errors[0].expectedType).toBe("number");
-    });
-
-    it("should infer string from read() return type", () => {
-      const program: AgencyProgram = {
-        type: "agencyProgram",
-        nodes: [
-          {
-            type: "function",
-            functionName: "expectNum",
-            parameters: [
-              {
-                type: "functionParameter",
-                name: "n",
-                typeHint: { type: "primitiveType", value: "number" },
-              },
-            ],
-            body: [],
-          },
-          {
-            type: "functionCall",
-            functionName: "expectNum",
-            arguments: [
-              {
-                type: "functionCall",
-                functionName: "read",
-                arguments: [
-                  { type: "string", segments: [{ type: "text", value: "file.txt" }] },
                 ],
               },
             ],
@@ -5496,13 +5462,13 @@ describe("TypeChecker", () => {
     });
 
     it("named args on a builtin call error with a clear message", () => {
-      // print(x="hi")  ← builtins don't accept named args
+      // success(x="hi")  ← language primitives don't accept named args
       const program: AgencyProgram = {
         type: "agencyProgram",
         nodes: [
           {
             type: "functionCall",
-            functionName: "print",
+            functionName: "success",
             arguments: [
               { type: "namedArgument", name: "x", value: { type: "string", segments: [{ type: "text", value: "hi" }] } },
             ],
@@ -6481,13 +6447,13 @@ describe("TypeChecker", () => {
     });
 
     it("a builtin call is rejected when given a block argument", () => {
-      // print(1) as x { return 2 }  ← `print` is a builtin, not a block-taker.
+      // success(1) as x { return 2 }  ← `success` is a primitive, not a block-taker.
       const program: AgencyProgram = {
         type: "agencyProgram",
         nodes: [
           {
             type: "functionCall",
-            functionName: "print",
+            functionName: "success",
             arguments: [{ type: "number", value: "1" }],
             block: {
               type: "blockArgument",
@@ -6498,7 +6464,7 @@ describe("TypeChecker", () => {
         ],
       };
       const errors = typeCheck(program).errors;
-      expect(errors.some((e) => /'print' does not accept a block/.test(e.message))).toBe(true);
+      expect(errors.some((e) => /'success' does not accept a block/.test(e.message))).toBe(true);
     });
 
     it("accepts a block argument when the last param is untyped", () => {

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -46,6 +46,11 @@ export function widenType(vt: VariableType | "any"): VariableType | "any" {
         successType: widenType(vt.successType) as VariableType,
         failureType: widenType(vt.failureType) as VariableType,
       };
+    case "schemaType":
+      return {
+        type: "schemaType",
+        inner: widenType(vt.inner) as VariableType,
+      };
     default:
       return vt;
   }
@@ -233,6 +238,16 @@ export function isAssignable(
       isAssignable(resolvedSource.successType, resolvedTarget.successType, typeAliases) &&
       isAssignable(resolvedSource.failureType, resolvedTarget.failureType, typeAliases)
     );
+  }
+
+  // Schema<T>: covariant in the validated type. There's no parser surface
+  // for `Schema<T>` annotations yet — this rule lets a synthed schema flow
+  // through `let` bindings whose RHS is `schema(T)` without false positives.
+  if (
+    resolvedSource.type === "schemaType" &&
+    resolvedTarget.type === "schemaType"
+  ) {
+    return isAssignable(resolvedSource.inner, resolvedTarget.inner, typeAliases);
   }
 
   if (

--- a/packages/agency-lang/lib/typeChecker/blockBody.test.ts
+++ b/packages/agency-lang/lib/typeChecker/blockBody.test.ts
@@ -7,7 +7,13 @@ function check(source: string): string[] {
   const parsed = parseAgency(source);
   if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
   const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
-  return typeCheck(parsed.result, {}, info).errors.map((e) => e.message);
+  // Silence the undefined-function diagnostic — no SymbolTable means
+  // stdlib calls (print, …) would warn as unresolved.
+  return typeCheck(
+    parsed.result,
+    { typechecker: { undefinedFunctions: "silent" } },
+    info,
+  ).errors.map((e) => e.message);
 }
 
 describe("block body type-checking", () => {

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -9,7 +9,6 @@ import {
   VOID_T as voidT,
 } from "./primitives.js";
 
-const stringArray = { type: "arrayType", elementType: string } as const;
 const anyArray = { type: "arrayType", elementType: ANY_T } as const;
 
 const optional = (t: VariableType): VariableType => ({
@@ -60,37 +59,22 @@ const llmOptions: VariableType = {
 };
 
 /**
- * Signatures for builtin / auto-imported functions that the typechecker
- * needs to know about.
+ * Signatures for true Agency language primitives — names without a `def`
+ * source. The runtime implements them directly, the typechecker treats
+ * them as if they had these signatures.
  *
- * NOTE: many entries here (print, fetch, read, etc.) are also defined as
- * real functions in stdlib/index.agency. Ideally the typechecker would
- * resolve them through the SymbolTable instead of hardcoding signatures.
- * Until that lands, hardcoding here keeps arg-count and return-type
- * checking working for callers.
+ * Stdlib functions (`print`, `read`, `fetch`, `range`, etc.) used to live
+ * here too. They are now resolved through `importedFunctions` via the
+ * auto-injected `import { ... } from "std::index"` statement, using the
+ * real signatures from `stdlib/index.agency`. This means a user `def
+ * print()` correctly shadows the stdlib version with no special-casing.
+ *
+ * `llm` stays here — the runtime implements it as a primitive, not a
+ * stdlib wrapper, and its argument is structurally typed.
  */
 export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
-  // --- IO / debugging ---
-  print: { params: [], restParam: "any", returnType: voidT },
-  printJSON: { params: [], restParam: "any", returnType: voidT },
-  input: { params: [string], returnType: string },
-  read: { params: [string], returnType: string },
-  readImage: { params: [string], returnType: string },
-  write: { params: [string, string], returnType: voidT },
-  fetch: { params: [string], returnType: string },
-  fetchJSON: { params: [string], returnType: "any" },
-  notify: { params: [string, string], returnType: boolean },
-  sleep: { params: [number], returnType: voidT },
-  round: { params: [number, number], returnType: number },
+  // --- LLM primitive ---
   llm: { params: ["any", llmOptions], minParams: 1, returnType: string },
-  emit: { params: [], restParam: "any", returnType: voidT },
-
-  // --- Object / array helpers (auto-imported from stdlib/index.agency) ---
-  range: { params: [number, number], minParams: 1, returnType: { type: "arrayType", elementType: number } },
-  keys: { params: ["any"], returnType: stringArray },
-  values: { params: ["any"], returnType: anyArray },
-  entries: { params: ["any"], returnType: anyArray },
-  mostCommon: { params: [anyArray], returnType: "any" },
 
   // --- Result type (lib/runtime/result.ts) ---
   success: { params: ["any"], returnType: "any" },

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -10,7 +10,8 @@ import type { Scope as WalkScope } from "../types.js";
 import { formatTypeHint } from "../utils/formatType.js";
 import type { ValueAccess } from "../types/access.js";
 import { BUILTIN_FUNCTION_TYPES } from "./builtins.js";
-import { JS_GLOBALS, lookupJsMember } from "./resolveCall.js";
+import { JS_GLOBALS, isJsGlobalBase, lookupJsMember } from "./resolveCall.js";
+import { collectProgramShadowing } from "./shadowing.js";
 import { isAssignable } from "./assignability.js";
 import { synthType } from "./synthesizer.js";
 import { ScopeInfo } from "./types.js";
@@ -282,13 +283,21 @@ function checkJsNamespaceMemberCall(
   expr: ValueAccess,
   scope: Scope,
   ctx: TypeCheckerContext,
+  shadowing: { importedNodeNames: readonly string[]; classNames: object },
 ): void {
   if (expr.base.type !== "variableName") return;
   const baseName = expr.base.value;
-  if (scope.has(baseName)) return;
-  if (Object.prototype.hasOwnProperty.call(ctx.functionDefs, baseName)) return;
-  if (Object.prototype.hasOwnProperty.call(ctx.importedFunctions, baseName)) return;
-  if (!Object.prototype.hasOwnProperty.call(JS_GLOBALS, baseName)) return;
+  if (
+    !isJsGlobalBase(baseName, {
+      scope,
+      functionDefs: ctx.functionDefs,
+      nodeDefs: ctx.nodeDefs,
+      importedFunctions: ctx.importedFunctions,
+      importedNodeNames: shadowing.importedNodeNames,
+      classNames: shadowing.classNames,
+    })
+  )
+    return;
   if (expr.chain.length !== 1) return;
   const access = expr.chain[0];
   if (access.kind !== "methodCall") return;
@@ -592,10 +601,11 @@ function checkExpressionsInScope(
   info: ScopeInfo,
   ctx: TypeCheckerContext,
 ): void {
+  const shadowing = collectProgramShadowing(ctx.programNodes);
   for (const { node, ancestors, scopes } of walkNodes(info.body)) {
     if (!isInScope(scopes, info)) continue;
     if (node.type === "valueAccess") {
-      checkJsNamespaceMemberCall(node, info.scope, ctx);
+      checkJsNamespaceMemberCall(node, info.scope, ctx, shadowing);
       synthType(node, info.scope, ctx);
     } else if (node.type === "returnStatement" && node.value) {
       // A return inside a block body belongs to the block, not the enclosing

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -8,11 +8,13 @@ import { walkNodes, isInsideBlock, type WalkAncestor } from "../utils/node.js";
 import { scopeKey as getScopeKey } from "../compilationUnit.js";
 import type { Scope as WalkScope } from "../types.js";
 import { formatTypeHint } from "../utils/formatType.js";
+import type { ValueAccess } from "../types/access.js";
 import { BUILTIN_FUNCTION_TYPES } from "./builtins.js";
+import { JS_GLOBALS, lookupJsMember } from "./resolveCall.js";
 import { isAssignable } from "./assignability.js";
 import { synthType } from "./synthesizer.js";
 import { ScopeInfo } from "./types.js";
-import type { TypeCheckerContext } from "./types.js";
+import type { BuiltinSignature, TypeCheckerContext } from "./types.js";
 import {
   checkType,
   isAnyType,
@@ -198,42 +200,106 @@ function checkSingleFunctionCall(
   }
 
   if (Object.prototype.hasOwnProperty.call(BUILTIN_FUNCTION_TYPES, call.functionName)) {
-    // Builtins don't have parameter names — named args have nowhere to bind.
-    // The backend throws at codegen time (typescriptBuilder.ts); surface it
-    // here with a proper diagnostic instead.
-    if (call.arguments.some((a) => a.type === "namedArgument")) {
-      ctx.errors.push({
-        message: `Named arguments can only be used with Agency-defined functions, not '${call.functionName}'.`,
-        loc: call.loc,
-      });
-      return;
-    }
-    if (call.block) {
-      // None of the entries in BUILTIN_FUNCTION_TYPES take a block. (fork /
-      // race do, but they're special-cased in the backend and never reach
-      // this branch — they fall through with no params lookup at all.)
-      ctx.errors.push({
-        message: `'${call.functionName}' does not accept a block argument.`,
-        loc: call.block.loc ?? call.loc,
-      });
-      return;
-    }
-    const sig = BUILTIN_FUNCTION_TYPES[call.functionName];
-    const minArgs = sig.minParams ?? sig.params.length;
-    const hasRest = sig.restParam !== undefined;
-    const maxArgs = hasRest ? Infinity : sig.params.length;
-    if (!checkArity(call, minArgs, maxArgs, hasSplatArg, ctx)) return;
-    const slots: ParamSlot[] = sig.params.map((type) => ({
-      type,
-      validated: false,
-    }));
-    if (hasRest) {
-      while (slots.length < call.arguments.length) {
-        slots.push({ type: sig.restParam!, validated: false });
-      }
-    }
-    checkArgsAgainstParams(call, slots, scope, ctx);
+    checkCallAgainstBuiltinSig(
+      call,
+      BUILTIN_FUNCTION_TYPES[call.functionName],
+      scope,
+      ctx,
+      hasSplatArg,
+    );
+    return;
   }
+
+  // Flat callable JS globals (parseInt, parseFloat, isNaN, …) with a
+  // populated `sig`. Namespace member calls like `JSON.parse(...)` are
+  // valueAccess nodes and are checked in checkExpressionsInScope. JS
+  // globals without a `sig` keep the existence-only behavior — no arity
+  // or type validation, mirroring the diagnostic's Phase 1 behavior.
+  if (Object.prototype.hasOwnProperty.call(JS_GLOBALS, call.functionName)) {
+    const entry = JS_GLOBALS[call.functionName];
+    if (entry.kind === "callable" && entry.sig) {
+      checkCallAgainstBuiltinSig(call, entry.sig, scope, ctx, hasSplatArg);
+    }
+  }
+}
+
+/**
+ * Common arity + per-arg type validation for a call against a
+ * `BuiltinSignature`. Used for both `BUILTIN_FUNCTION_TYPES` entries (true
+ * Agency primitives) and `JS_GLOBALS` entries that have a populated `sig`.
+ *
+ * Builtins have no parameter names, so named args and block args are
+ * rejected here — the backend can't bind either.
+ */
+function checkCallAgainstBuiltinSig(
+  call: FunctionCall,
+  sig: BuiltinSignature,
+  scope: Scope,
+  ctx: TypeCheckerContext,
+  hasSplatArg: boolean,
+): void {
+  if (call.arguments.some((a) => a.type === "namedArgument")) {
+    ctx.errors.push({
+      message: `Named arguments can only be used with Agency-defined functions, not '${call.functionName}'.`,
+      loc: call.loc,
+    });
+    return;
+  }
+  if (call.block) {
+    ctx.errors.push({
+      message: `'${call.functionName}' does not accept a block argument.`,
+      loc: call.block.loc ?? call.loc,
+    });
+    return;
+  }
+  const minArgs = sig.minParams ?? sig.params.length;
+  const hasRest = sig.restParam !== undefined;
+  const maxArgs = hasRest ? Infinity : sig.params.length;
+  if (!checkArity(call, minArgs, maxArgs, hasSplatArg, ctx)) return;
+  const slots: ParamSlot[] = sig.params.map((type) => ({
+    type,
+    validated: false,
+  }));
+  if (hasRest) {
+    while (slots.length < call.arguments.length) {
+      slots.push({ type: sig.restParam!, validated: false });
+    }
+  }
+  checkArgsAgainstParams(call, slots, scope, ctx);
+}
+
+/**
+ * Validate a `<JsNamespace>.<member>(args)` call against `JS_GLOBALS`'s
+ * sig (when populated). Only the simple shape — base = bare variableName
+ * matching a JS namespace, single methodCall in the chain — is checked;
+ * deeper or computed chains are left to the runtime.
+ *
+ * Skips cases where the base is shadowed by a local binding (so `let JSON
+ * = ...` cleanly opts out). Entries without `sig` (e.g. `console.log`)
+ * are skipped — they're variadic / loosely typed by design.
+ */
+function checkJsNamespaceMemberCall(
+  expr: ValueAccess,
+  scope: Scope,
+  ctx: TypeCheckerContext,
+): void {
+  if (expr.base.type !== "variableName") return;
+  const baseName = expr.base.value;
+  if (scope.has(baseName)) return;
+  if (Object.prototype.hasOwnProperty.call(ctx.functionDefs, baseName)) return;
+  if (Object.prototype.hasOwnProperty.call(ctx.importedFunctions, baseName)) return;
+  if (!Object.prototype.hasOwnProperty.call(JS_GLOBALS, baseName)) return;
+  if (expr.chain.length !== 1) return;
+  const access = expr.chain[0];
+  if (access.kind !== "methodCall") return;
+  const member = access.functionCall;
+  const entry = lookupJsMember([baseName, member.functionName]);
+  if (!entry || entry.kind !== "callable" || !entry.sig) return;
+  const hasSplatArg = member.arguments.some((a) => a.type === "splat");
+  // Reuse the BUILTIN-style check. It uses `member.functionName` in error
+  // messages, so the user sees `'parse' …` for `JSON.parse(...)`. Acceptable
+  // — disambiguation is in the source location, not the function name.
+  checkCallAgainstBuiltinSig(member, entry.sig, scope, ctx, hasSplatArg);
 }
 
 /**
@@ -529,6 +595,7 @@ function checkExpressionsInScope(
   for (const { node, ancestors, scopes } of walkNodes(info.body)) {
     if (!isInScope(scopes, info)) continue;
     if (node.type === "valueAccess") {
+      checkJsNamespaceMemberCall(node, info.scope, ctx);
       synthType(node, info.scope, ctx);
     } else if (node.type === "returnStatement" && node.value) {
       // A return inside a block body belongs to the block, not the enclosing

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -294,6 +294,7 @@ function checkJsNamespaceMemberCall(
       nodeDefs: ctx.nodeDefs,
       importedFunctions: ctx.importedFunctions,
       importedNodeNames: shadowing.importedNodeNames,
+      jsImportedNames: ctx.jsImportedNames,
       classNames: shadowing.classNames,
     })
   )

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -53,6 +53,7 @@ export class TypeChecker {
   private functionDefs: Record<string, FunctionDefinition> = {};
   private nodeDefs: Record<string, GraphNodeDefinition> = {};
   private importedFunctions: Record<string, ImportedFunctionSignature> = {};
+  private jsImportedNames: Record<string, true> = {};
   private interruptKindsByFunction: Record<string, InterruptKind[]> = {};
   private errors: TypeCheckError[] = [];
   private inferredReturnTypes: Record<string, VariableType | "any"> = {};
@@ -73,6 +74,7 @@ export class TypeChecker {
       resolved.graphNodes.map((n) => [n.nodeName, n]),
     );
     this.importedFunctions = { ...resolved.importedFunctions };
+    this.jsImportedNames = { ...resolved.jsImportedNames };
     this.interruptKindsByFunction = resolved.interruptKindsByFunction ?? {};
     this.sourceText = resolved.sourceText;
   }
@@ -99,6 +101,7 @@ export class TypeChecker {
       functionDefs: this.functionDefs,
       nodeDefs: this.nodeDefs,
       importedFunctions: this.importedFunctions,
+      jsImportedNames: this.jsImportedNames,
       interruptKindsByFunction: this.interruptKindsByFunction,
       errors: this.errors,
       inferredReturnTypes: this.inferredReturnTypes,

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -36,6 +36,7 @@ import {
   checkUnhandledInterruptWarnings,
 } from "./interruptAnalysis.js";
 import { checkUndefinedFunctions } from "./undefinedFunctionDiagnostic.js";
+import { checkUndefinedVariables } from "./undefinedVariableDiagnostic.js";
 import { RESERVED_FUNCTION_NAMES } from "./resolveCall.js";
 import { walkNodes } from "../utils/node.js";
 
@@ -229,6 +230,9 @@ export class TypeChecker {
 
     // 7. Check for undefined function calls (config-controlled severity).
     checkUndefinedFunctions(scopes, ctx);
+
+    // 8. Check for undefined variable references (config-controlled severity).
+    checkUndefinedVariables(scopes, ctx);
 
     return {
       errors: this.applySuppressions(this.deduplicateErrors()),

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -37,6 +37,7 @@ import {
 } from "./interruptAnalysis.js";
 import { checkUndefinedFunctions } from "./undefinedFunctionDiagnostic.js";
 import { RESERVED_FUNCTION_NAMES } from "./resolveCall.js";
+import { walkNodes } from "../utils/node.js";
 
 export type { TypeCheckError, TypeCheckResult } from "./types.js";
 
@@ -165,6 +166,24 @@ export class TypeChecker {
             message: `'${name}' is a reserved built-in type; cannot be redefined.`,
           });
         }
+      }
+    }
+
+    // 1d. Reserved names cannot be `let`/`const` / `static const` declared
+    // either. The variable would be unusable as a function (e.g. `schema(X)`
+    // always parses as a SchemaExpression regardless of scope), and shadowing
+    // primitives like `success`/`failure` silently changes semantics.
+    // Walk every assignment in the program — top-level and inside function /
+    // graphNode bodies — and check the variable name. Only fires on actual
+    // declarations (where `declKind` is set), not reassignments.
+    for (const { node } of walkNodes(this.program.nodes)) {
+      if (node.type !== "assignment") continue;
+      if (!node.declKind) continue;
+      if (RESERVED_FUNCTION_NAMES.has(node.variableName)) {
+        this.errors.push({
+          message: `'${node.variableName}' is a reserved built-in; cannot be redefined.`,
+          loc: node.loc,
+        });
       }
     }
 

--- a/packages/agency-lang/lib/typeChecker/jsGlobalsSig.test.ts
+++ b/packages/agency-lang/lib/typeChecker/jsGlobalsSig.test.ts
@@ -109,4 +109,20 @@ describe("JS_GLOBALS — namespace member sigs", () => {
     );
     expect(errors.filter(arityErr)).toHaveLength(0);
   });
+
+  it("does not validate when shadowed by a local node", () => {
+    // `node JSON()` shadows the JS global; JSON.parse() should not be
+    // checked against JS_GLOBALS arity.
+    const errors = errorsFrom(
+      `node JSON() { return { parse: 1 } }\nnode main() { let x = JSON.parse() }\n`,
+    );
+    expect(errors.filter(arityErr)).toHaveLength(0);
+  });
+
+  it("does not validate when shadowed by a class definition", () => {
+    const errors = errorsFrom(
+      `class JSON {\n  parse: number\n}\nnode main() {\n let j = new JSON(1)\n let x = j.parse\n print(x)\n}\n`,
+    );
+    expect(errors.filter(arityErr)).toHaveLength(0);
+  });
 });

--- a/packages/agency-lang/lib/typeChecker/jsGlobalsSig.test.ts
+++ b/packages/agency-lang/lib/typeChecker/jsGlobalsSig.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, unlinkSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
+import type { AgencyConfig } from "../config.js";
+
+function errorsFrom(source: string, config: AgencyConfig = {}): TypeCheckError[] {
+  const file = path.join(
+    os.tmpdir(),
+    `tc-jsglobals-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`,
+  );
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath, config);
+    const parseResult = parseAgency(source, config);
+    if (!parseResult.success) throw new Error("Parse failed");
+    const program = parseResult.result;
+    const info = buildCompilationUnit(program, symbolTable, absPath, source);
+    return typeCheck(program, config, info).errors;
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+const arityErr = (e: TypeCheckError) => /Expected .* argument/.test(e.message);
+const typeErr = (e: TypeCheckError) => /not assignable to parameter type/.test(e.message);
+
+describe("JS_GLOBALS — flat callable sigs", () => {
+  it("accepts parseInt with one string arg", () => {
+    const errors = errorsFrom(`node main() { let n = parseInt("42") }`);
+    expect(errors.filter(arityErr)).toHaveLength(0);
+    expect(errors.filter(typeErr)).toHaveLength(0);
+  });
+
+  it("accepts parseInt with optional radix", () => {
+    const errors = errorsFrom(`node main() { let n = parseInt("ff", 16) }`);
+    expect(errors.filter(arityErr)).toHaveLength(0);
+    expect(errors.filter(typeErr)).toHaveLength(0);
+  });
+
+  it("rejects parseInt with a boolean", () => {
+    const errors = errorsFrom(`node main() { let n = parseInt(true) }`);
+    expect(errors.filter(typeErr).length).toBeGreaterThan(0);
+  });
+
+  it("rejects parseInt with three args", () => {
+    const errors = errorsFrom(`node main() { let n = parseInt("1", 2, 3) }`);
+    expect(errors.filter(arityErr).length).toBeGreaterThan(0);
+  });
+
+  it("infers parseInt's return type as number", () => {
+    const errors = errorsFrom(
+      `def expectNum(n: number): number { return n }\nnode main() { expectNum(parseInt("1")) }\n`,
+    );
+    expect(errors.filter(typeErr)).toHaveLength(0);
+  });
+});
+
+describe("JS_GLOBALS — namespace member sigs", () => {
+  it("accepts JSON.parse with one string arg", () => {
+    const errors = errorsFrom(`node main() { let x = JSON.parse("{}") }`);
+    expect(errors.filter(arityErr)).toHaveLength(0);
+    expect(errors.filter(typeErr)).toHaveLength(0);
+  });
+
+  it("rejects JSON.parse with no args", () => {
+    const errors = errorsFrom(`node main() { let x = JSON.parse() }`);
+    expect(errors.filter(arityErr).length).toBeGreaterThan(0);
+  });
+
+  it("rejects JSON.parse with two args", () => {
+    const errors = errorsFrom(`node main() { let x = JSON.parse("{}", "{}") }`);
+    expect(errors.filter(arityErr).length).toBeGreaterThan(0);
+  });
+
+  it("rejects Math.floor with a non-number", () => {
+    const errors = errorsFrom(`node main() { let n = Math.floor("hi") }`);
+    expect(errors.filter(typeErr).length).toBeGreaterThan(0);
+  });
+
+  it("accepts Math.floor with a number", () => {
+    const errors = errorsFrom(`node main() { let n = Math.floor(3.7) }`);
+    expect(errors.filter(arityErr)).toHaveLength(0);
+    expect(errors.filter(typeErr)).toHaveLength(0);
+  });
+
+  it("accepts variadic Math.max with any number of args", () => {
+    const errors = errorsFrom(`node main() { let n = Math.max(1, 2, 3, 4, 5) }`);
+    expect(errors.filter(arityErr)).toHaveLength(0);
+    expect(errors.filter(typeErr)).toHaveLength(0);
+  });
+
+  it("does not error on console.log with multiple args (no sig)", () => {
+    const errors = errorsFrom(`node main() { console.log(1, 2, 3) }`);
+    expect(errors.filter(arityErr)).toHaveLength(0);
+    expect(errors.filter(typeErr)).toHaveLength(0);
+  });
+
+  it("does not validate when the namespace base is shadowed", () => {
+    // `let JSON = ...` opts out of JS_GLOBALS validation entirely.
+    const errors = errorsFrom(
+      `node main() { let JSON = { parse: 1 }\n let x = JSON.parse }`,
+    );
+    expect(errors.filter(arityErr)).toHaveLength(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/reservedNameDeclaration.test.ts
+++ b/packages/agency-lang/lib/typeChecker/reservedNameDeclaration.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, unlinkSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
+import type { AgencyConfig } from "../config.js";
+
+function errorsFrom(source: string, config: AgencyConfig = {}): TypeCheckError[] {
+  const file = path.join(
+    os.tmpdir(),
+    `tc-reserved-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`,
+  );
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath, config);
+    const parseResult = parseAgency(source, config);
+    if (!parseResult.success) throw new Error("Parse failed");
+    const program = parseResult.result;
+    const info = buildCompilationUnit(program, symbolTable, absPath, source);
+    return typeCheck(program, config, info).errors;
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+describe("reserved-name declaration check", () => {
+  it("blocks `static const schema = 42`", () => {
+    const errors = errorsFrom(`static const schema = 42\nnode main() { print(schema) }\n`);
+    const reserved = errors.filter(
+      (e) => e.message.includes("schema") && e.message.includes("reserved"),
+    );
+    expect(reserved).toHaveLength(1);
+  });
+
+  it("does not fire on substring matches like `static const schemaForX = 42`", () => {
+    const errors = errorsFrom(
+      `static const schemaForX = 42\nnode main() { print(schemaForX) }\n`,
+    );
+    const reserved = errors.filter(
+      (e) => e.message.includes("schemaForX") && e.message.includes("reserved"),
+    );
+    expect(reserved).toHaveLength(0);
+  });
+
+  it("blocks `let interrupt = 5` inside a node body", () => {
+    const errors = errorsFrom(`node main() { let interrupt = 5\n print(interrupt) }\n`);
+    const reserved = errors.filter(
+      (e) => e.message.includes("interrupt") && e.message.includes("reserved"),
+    );
+    expect(reserved).toHaveLength(1);
+  });
+
+  it("blocks `const success = 1` inside a function body", () => {
+    const errors = errorsFrom(
+      `def helper(): number { const success = 1\n return success }\n`,
+    );
+    const reserved = errors.filter(
+      (e) => e.message.includes("success") && e.message.includes("reserved"),
+    );
+    expect(reserved).toHaveLength(1);
+  });
+
+  it("`def schema()` still errors (existing behavior unchanged)", () => {
+    const errors = errorsFrom(`def schema(): number { return 1 }\n`);
+    const reserved = errors.filter(
+      (e) => e.message.includes("schema") && e.message.includes("reserved"),
+    );
+    expect(reserved.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not fire on `let s = schema(MyType)` (use, not declaration)", () => {
+    const errors = errorsFrom(
+      `type MyType = number\nnode main() { let s = schema(MyType)\n print(s) }\n`,
+    );
+    const reserved = errors.filter(
+      (e) => e.message.includes("schema") && e.message.includes("reserved"),
+    );
+    expect(reserved).toHaveLength(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/resolveCall.test.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveCall.test.ts
@@ -28,7 +28,10 @@ describe("resolveCall", () => {
   });
 
   it("resolves a builtin function", () => {
-    const result = resolveCall("print", emptyInput);
+    // `success` is a true language primitive — kept in BUILTIN_FUNCTION_TYPES.
+    // Stdlib functions (print, fetch, …) used to resolve here too but now
+    // resolve as `imported` via the auto-injected std::index import.
+    const result = resolveCall("success", emptyInput);
     expect(result.kind).toBe("builtin");
   });
 

--- a/packages/agency-lang/lib/typeChecker/resolveCall.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveCall.ts
@@ -2,6 +2,15 @@ import type { FunctionDefinition, GraphNodeDefinition } from "../types.js";
 import type { ImportedFunctionSignature } from "../compilationUnit.js";
 import type { BuiltinSignature } from "./types.js";
 import { BUILTIN_FUNCTION_TYPES } from "./builtins.js";
+import {
+  ANY_T,
+  BOOLEAN_T,
+  NUMBER_T,
+  STRING_T,
+} from "./primitives.js";
+
+const stringArray = { type: "arrayType", elementType: STRING_T } as const;
+const anyArray = { type: "arrayType", elementType: ANY_T } as const;
 
 /**
  * Names of Agency's *built-in* functions — language primitives with no
@@ -82,87 +91,114 @@ const namespace = (
   members,
 });
 
+// Common single-number-arg, returns-number signature (Math.floor / ceil / round / abs / sqrt / sign / trunc / cbrt etc.).
+const numToNum: BuiltinSignature = { params: [NUMBER_T], returnType: NUMBER_T };
+
 export const JS_GLOBALS: Record<string, JsRegistryEntry> = {
   // --- Flat callable globals ---
-  parseInt: callable(),
-  parseFloat: callable(),
-  isNaN: callable(),
-  isFinite: callable(),
-  encodeURIComponent: callable(),
-  decodeURIComponent: callable(),
-  encodeURI: callable(),
-  decodeURI: callable(),
+  // `parseInt` accepts an optional radix; we accept a 1-or-2-arg call against
+  // (string|number, number) which covers the realistic cases without false
+  // positives on numeric inputs (`parseInt(0.5)`, `parseInt(1, 2)`).
+  parseInt: callable({
+    params: [{ type: "unionType", types: [STRING_T, NUMBER_T] }, NUMBER_T],
+    minParams: 1,
+    returnType: NUMBER_T,
+  }),
+  parseFloat: callable({
+    params: [{ type: "unionType", types: [STRING_T, NUMBER_T] }],
+    returnType: NUMBER_T,
+  }),
+  isNaN: callable({ params: ["any"], returnType: BOOLEAN_T }),
+  isFinite: callable({ params: ["any"], returnType: BOOLEAN_T }),
+  encodeURIComponent: callable({ params: [STRING_T], returnType: STRING_T }),
+  decodeURIComponent: callable({ params: [STRING_T], returnType: STRING_T }),
+  encodeURI: callable({ params: [STRING_T], returnType: STRING_T }),
+  decodeURI: callable({ params: [STRING_T], returnType: STRING_T }),
   setTimeout: callable(),
   setInterval: callable(),
   clearTimeout: callable(),
   clearInterval: callable(),
   queueMicrotask: callable(),
-  structuredClone: callable(),
+  structuredClone: callable({ params: ["any"], returnType: "any" }),
   BigInt: callable(),
   Symbol: callable(),
 
   // --- Namespaces ---
   JSON: namespace({
-    parse: callable(),
-    stringify: callable(),
+    parse: callable({ params: [STRING_T], returnType: "any" }),
+    // JSON.stringify(value, replacer?, space?). Replacer can be many things —
+    // type as `any` to avoid false positives.
+    stringify: callable({
+      params: ["any", "any", { type: "unionType", types: [STRING_T, NUMBER_T] }],
+      minParams: 1,
+      returnType: STRING_T,
+    }),
   }),
   Math: namespace({
-    floor: callable(),
-    ceil: callable(),
-    round: callable(),
-    abs: callable(),
-    max: callable(),
-    min: callable(),
-    pow: callable(),
-    sqrt: callable(),
-    random: callable(),
-    log: callable(),
-    log2: callable(),
-    log10: callable(),
-    exp: callable(),
-    sin: callable(),
-    cos: callable(),
-    tan: callable(),
-    asin: callable(),
-    acos: callable(),
-    atan: callable(),
-    atan2: callable(),
-    sign: callable(),
-    trunc: callable(),
-    cbrt: callable(),
-    hypot: callable(),
+    floor: callable(numToNum),
+    ceil: callable(numToNum),
+    round: callable(numToNum),
+    abs: callable(numToNum),
+    sqrt: callable(numToNum),
+    sign: callable(numToNum),
+    trunc: callable(numToNum),
+    cbrt: callable(numToNum),
+    log: callable(numToNum),
+    log2: callable(numToNum),
+    log10: callable(numToNum),
+    exp: callable(numToNum),
+    sin: callable(numToNum),
+    cos: callable(numToNum),
+    tan: callable(numToNum),
+    asin: callable(numToNum),
+    acos: callable(numToNum),
+    atan: callable(numToNum),
+    // Variadic — keep arity loose so `Math.max(1, 2, 3)` doesn't false-positive.
+    max: callable({ params: [], restParam: NUMBER_T, returnType: NUMBER_T }),
+    min: callable({ params: [], restParam: NUMBER_T, returnType: NUMBER_T }),
+    pow: callable({ params: [NUMBER_T, NUMBER_T], returnType: NUMBER_T }),
+    atan2: callable({ params: [NUMBER_T, NUMBER_T], returnType: NUMBER_T }),
+    hypot: callable({ params: [], restParam: NUMBER_T, returnType: NUMBER_T }),
+    random: callable({ params: [], returnType: NUMBER_T }),
   }),
   Object: namespace({
-    keys: callable(),
-    values: callable(),
-    entries: callable(),
+    keys: callable({ params: ["any"], returnType: stringArray }),
+    values: callable({ params: ["any"], returnType: anyArray }),
+    entries: callable({ params: ["any"], returnType: anyArray }),
+    fromEntries: callable({ params: [anyArray], returnType: "any" }),
     assign: callable(),
-    freeze: callable(),
-    fromEntries: callable(),
-    getOwnPropertyNames: callable(),
-    getPrototypeOf: callable(),
+    freeze: callable({ params: ["any"], returnType: "any" }),
+    getOwnPropertyNames: callable({ params: ["any"], returnType: stringArray }),
+    getPrototypeOf: callable({ params: ["any"], returnType: "any" }),
     setPrototypeOf: callable(),
   }),
   Array: namespace({
-    isArray: callable(),
+    isArray: callable({ params: ["any"], returnType: BOOLEAN_T }),
     from: callable(),
     of: callable(),
   }),
   String: namespace({
-    fromCharCode: callable(),
+    fromCharCode: callable({ params: [], restParam: NUMBER_T, returnType: STRING_T }),
     raw: callable(),
   }),
   Number: namespace({
-    isInteger: callable(),
-    isFinite: callable(),
-    isNaN: callable(),
-    isSafeInteger: callable(),
-    parseFloat: callable(),
-    parseInt: callable(),
+    isInteger: callable({ params: ["any"], returnType: BOOLEAN_T }),
+    isFinite: callable({ params: ["any"], returnType: BOOLEAN_T }),
+    isNaN: callable({ params: ["any"], returnType: BOOLEAN_T }),
+    isSafeInteger: callable({ params: ["any"], returnType: BOOLEAN_T }),
+    parseFloat: callable({
+      params: [{ type: "unionType", types: [STRING_T, NUMBER_T] }],
+      returnType: NUMBER_T,
+    }),
+    parseInt: callable({
+      params: [{ type: "unionType", types: [STRING_T, NUMBER_T] }, NUMBER_T],
+      minParams: 1,
+      returnType: NUMBER_T,
+    }),
   }),
   Date: namespace({
-    now: callable(),
-    parse: callable(),
+    now: callable({ params: [], returnType: NUMBER_T }),
+    parse: callable({ params: [STRING_T], returnType: NUMBER_T }),
     UTC: callable(),
   }),
   Promise: namespace({
@@ -173,6 +209,8 @@ export const JS_GLOBALS: Record<string, JsRegistryEntry> = {
     race: callable(),
     any: callable(),
   }),
+  // console.* — variadic, intentionally untyped so `console.log(1, 2, 3)` etc.
+  // never false-positives.
   console: namespace({
     log: callable(),
     error: callable(),

--- a/packages/agency-lang/lib/typeChecker/resolveCall.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveCall.ts
@@ -256,13 +256,12 @@ type ResolveCallInput = {
  *                   (`import { foo } from "./other.agency"` or
  *                   `import node { foo } from "./other.agency"`).
  *   builtin       — has a typed signature in `BUILTIN_FUNCTION_TYPES`.
- *                   Includes both true language primitives (`success`,
- *                   `failure`, `llm`, `approve`, `reject`, `propagate`,
- *                   `checkpoint`, `getCheckpoint`, `restore`,
- *                   `isSuccess`, `isFailure`) AND stdlib functions whose
- *                   signatures are hardcoded for typechecker convenience
- *                   (`print`, `fetch`, `read`, etc. — see the NOTE in
- *                   `builtins.ts` flagging this as tech debt).
+ *                   True language primitives only: `success`, `failure`,
+ *                   `llm`, `approve`, `reject`, `propagate`, `checkpoint`,
+ *                   `getCheckpoint`, `restore`, `isSuccess`, `isFailure`.
+ *                   Stdlib functions (`print`, `fetch`, `read`, etc.)
+ *                   resolve as `imported` instead, via the auto-injected
+ *                   `import { ... } from "std::index"` statement.
  *   reserved      — listed in `RESERVED_FUNCTION_NAMES` but NOT in
  *                   `BUILTIN_FUNCTION_TYPES`. In practice these are the
  *                   three names parsed into their own AST node type
@@ -299,9 +298,11 @@ const has = (obj: object, name: string): boolean =>
  * Resolution order matters:
  *
  *   1. Local `def`/`node`             — user code wins.
- *   2. Imported from another file     — cross-file `def`/`node`.
- *   3. `BUILTIN_FUNCTION_TYPES`       — language primitives + hardcoded
- *                                       stdlib signatures.
+ *   2. Imported from another file     — cross-file `def`/`node`. Stdlib
+ *                                       functions (print, fetch, read,
+ *                                       …) resolve here via the
+ *                                       auto-injected std::index import.
+ *   3. `BUILTIN_FUNCTION_TYPES`       — Agency language primitives.
  *   4. `RESERVED_FUNCTION_NAMES`      — defensive fallback for the three
  *                                       names parsed into their own AST
  *                                       node type (schema / interrupt /
@@ -310,10 +311,6 @@ const has = (obj: object, name: string): boolean =>
  *   5. Local scope binding            — lambdas, `partial`, `for` vars.
  *   6. Flat JS global callable        — parseInt, setTimeout, etc.
  *   7. Otherwise: unresolved.
- *
- * Imports take precedence over builtins so a real stdlib `def print()`
- * shadows the hardcoded BUILTIN_FUNCTION_TYPES signature when the
- * SymbolTable wires it through. See the NOTE in `builtins.ts`.
  */
 export function resolveCall(
   name: string,

--- a/packages/agency-lang/lib/typeChecker/resolveCall.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveCall.ts
@@ -280,6 +280,8 @@ type ResolveCallInput = {
   importedFunctions: Record<string, ImportedFunctionSignature>;
   /** Names imported via `import node { ... } from "..."`. */
   importedNodeNames: readonly string[];
+  /** Names imported via `import { foo } from "./helpers.js"` (non-Agency). */
+  jsImportedNames?: object;
   scopeHas: (name: string) => boolean;
 };
 
@@ -318,6 +320,7 @@ type ResolveCallInput = {
 export type CallResolution =
   | { kind: "def" }
   | { kind: "imported" }
+  | { kind: "jsImported" }
   | { kind: "builtin" }
   | { kind: "reserved" }
   | { kind: "scopeBinding" }
@@ -362,6 +365,7 @@ export type ShadowingInput = {
   nodeDefs: object;
   importedFunctions: object;
   importedNodeNames: readonly string[];
+  jsImportedNames?: object;
   classNames: object;
 };
 
@@ -378,6 +382,7 @@ export function isJsGlobalBase(name: string, input: ShadowingInput): boolean {
   if (has(input.nodeDefs, name)) return false;
   if (has(input.importedFunctions, name)) return false;
   if (input.importedNodeNames.includes(name)) return false;
+  if (input.jsImportedNames && has(input.jsImportedNames, name)) return false;
   if (has(input.classNames, name)) return false;
   return true;
 }
@@ -390,6 +395,8 @@ export function resolveCall(
     return { kind: "def" };
   if (has(input.importedFunctions, name)) return { kind: "imported" };
   if (input.importedNodeNames.includes(name)) return { kind: "imported" };
+  if (input.jsImportedNames && has(input.jsImportedNames, name))
+    return { kind: "jsImported" };
   if (has(BUILTIN_FUNCTION_TYPES, name)) return { kind: "builtin" };
   if (RESERVED_FUNCTION_NAMES.has(name)) return { kind: "reserved" };
   if (input.scopeHas(name)) return { kind: "scopeBinding" };

--- a/packages/agency-lang/lib/typeChecker/resolveCall.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveCall.ts
@@ -350,6 +350,38 @@ const has = (obj: object, name: string): boolean =>
  *   6. Flat JS global callable        — parseInt, setTimeout, etc.
  *   7. Otherwise: unresolved.
  */
+/**
+ * Inputs for {@link isJsGlobalBase}. The shape mirrors {@link ResolveCallInput}
+ * but adds class and import-node bookkeeping so user definitions of
+ * `JSON` / `Math` / etc. (via `node`, `import node`, or `class`) cleanly
+ * opt out of JS_GLOBALS validation.
+ */
+export type ShadowingInput = {
+  scope: { has(name: string): boolean };
+  functionDefs: object;
+  nodeDefs: object;
+  importedFunctions: object;
+  importedNodeNames: readonly string[];
+  classNames: object;
+};
+
+/**
+ * `true` only when `name` resolves to a JS global *and* nothing user-defined
+ * shadows it. Use this to gate JS-namespace member validation (e.g.
+ * `JSON.parse(...)`) and avoid checking against `JS_GLOBALS` when the user
+ * has their own `node JSON()` / `class JSON` / `let JSON = …`.
+ */
+export function isJsGlobalBase(name: string, input: ShadowingInput): boolean {
+  if (!has(JS_GLOBALS, name)) return false;
+  if (input.scope.has(name)) return false;
+  if (has(input.functionDefs, name)) return false;
+  if (has(input.nodeDefs, name)) return false;
+  if (has(input.importedFunctions, name)) return false;
+  if (input.importedNodeNames.includes(name)) return false;
+  if (has(input.classNames, name)) return false;
+  return true;
+}
+
 export function resolveCall(
   name: string,
   input: ResolveCallInput,

--- a/packages/agency-lang/lib/typeChecker/resolveVariable.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveVariable.ts
@@ -17,6 +17,8 @@ type ResolveVariableInput = {
   nodeDefs: Record<string, GraphNodeDefinition>;
   importedFunctions: Record<string, ImportedFunctionSignature>;
   importedNodeNames: readonly string[];
+  /** Names imported via `import { foo } from "./helpers.js"` (non-Agency). */
+  jsImportedNames?: Record<string, true>;
   classNames: Record<string, true>;
   scopeHas: (name: string) => boolean;
 };
@@ -45,6 +47,7 @@ export type VariableResolution =
   | { kind: "scopeBinding" }
   | { kind: "def" }
   | { kind: "imported" }
+  | { kind: "jsImported" }
   | { kind: "class" }
   | { kind: "builtin" }
   | { kind: "reserved" }
@@ -79,6 +82,8 @@ export function resolveVariable(
   }
   if (has(input.importedFunctions, name)) return { kind: "imported" };
   if (input.importedNodeNames.includes(name)) return { kind: "imported" };
+  if (input.jsImportedNames && has(input.jsImportedNames, name))
+    return { kind: "jsImported" };
   if (has(input.classNames, name)) return { kind: "class" };
   if (has(BUILTIN_FUNCTION_TYPES, name)) return { kind: "builtin" };
   if (RESERVED_FUNCTION_NAMES.has(name)) return { kind: "reserved" };

--- a/packages/agency-lang/lib/typeChecker/resolveVariable.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveVariable.ts
@@ -1,0 +1,87 @@
+import type { FunctionDefinition, GraphNodeDefinition } from "../types.js";
+import type { ImportedFunctionSignature } from "../compilationUnit.js";
+import { BUILTIN_FUNCTION_TYPES } from "./builtins.js";
+import { JS_GLOBALS, RESERVED_FUNCTION_NAMES } from "./resolveCall.js";
+
+/**
+ * Inputs for variable name resolution. Mirrors `ResolveCallInput` in
+ * `resolveCall.ts` but adds class names and uses `scopeHas` to cover
+ * let/const/params/for-vars/lambda-params/handler-params.
+ *
+ * `classNames` only holds presence info — value type is `true`. We don't
+ * import the full `ClassDefinition` here because the resolver doesn't
+ * need anything beyond name existence.
+ */
+type ResolveVariableInput = {
+  functionDefs: Record<string, FunctionDefinition>;
+  nodeDefs: Record<string, GraphNodeDefinition>;
+  importedFunctions: Record<string, ImportedFunctionSignature>;
+  importedNodeNames: readonly string[];
+  classNames: Record<string, true>;
+  scopeHas: (name: string) => boolean;
+};
+
+/**
+ * Tagged union describing where a variable name resolved to. The
+ * diagnostic only cares whether `kind === "unresolved"`; the other kinds
+ * are informational.
+ *
+ *   scopeBinding  — bound in the local scope (let/const, parameter,
+ *                   for-loop variable, lambda/block parameter, handler
+ *                   param, etc.).
+ *   def           — references a locally-defined `def`/`node` as a
+ *                   first-class function reference (e.g. `map(xs, foo)`).
+ *   imported      — references an imported function or node.
+ *   class         — references a class defined in this file.
+ *   builtin       — references a builtin (success, failure, llm, …) as
+ *                   a function reference.
+ *   reserved      — listed in `RESERVED_FUNCTION_NAMES`. Same defensive
+ *                   fallback as in resolveCall.
+ *   jsGlobal      — references a JS global (parseInt, JSON, Math, …)
+ *                   either as a flat callable or a namespace base.
+ *   unresolved    — none of the above. The diagnostic emits.
+ */
+export type VariableResolution =
+  | { kind: "scopeBinding" }
+  | { kind: "def" }
+  | { kind: "imported" }
+  | { kind: "class" }
+  | { kind: "builtin" }
+  | { kind: "reserved" }
+  | { kind: "jsGlobal" }
+  | { kind: "unresolved" };
+
+const has = (obj: object, name: string): boolean =>
+  Object.prototype.hasOwnProperty.call(obj, name);
+
+/**
+ * Resolution order for variable references — mirrors `resolveCall` but
+ * starts from local scope, since variable references are usually local.
+ *
+ *   1. Local scope binding              — let/const, params, for-vars, …
+ *   2. Local `def`/`node`               — function reference.
+ *   3. Imported function/node           — cross-file function reference.
+ *   4. Class definition                 — `new MyClass()` and `MyClass`
+ *                                         as a value (instanceof, etc.).
+ *   5. `BUILTIN_FUNCTION_TYPES`         — Agency primitive as function ref.
+ *   6. `RESERVED_FUNCTION_NAMES`        — defensive fallback.
+ *   7. JS global (callable or namespace) — covers both bare `parseInt` and
+ *                                          namespace bases like `JSON`.
+ *   8. Otherwise: unresolved.
+ */
+export function resolveVariable(
+  name: string,
+  input: ResolveVariableInput,
+): VariableResolution {
+  if (input.scopeHas(name)) return { kind: "scopeBinding" };
+  if (has(input.functionDefs, name) || has(input.nodeDefs, name)) {
+    return { kind: "def" };
+  }
+  if (has(input.importedFunctions, name)) return { kind: "imported" };
+  if (input.importedNodeNames.includes(name)) return { kind: "imported" };
+  if (has(input.classNames, name)) return { kind: "class" };
+  if (has(BUILTIN_FUNCTION_TYPES, name)) return { kind: "builtin" };
+  if (RESERVED_FUNCTION_NAMES.has(name)) return { kind: "reserved" };
+  if (has(JS_GLOBALS, name)) return { kind: "jsGlobal" };
+  return { kind: "unresolved" };
+}

--- a/packages/agency-lang/lib/typeChecker/schemaType.test.ts
+++ b/packages/agency-lang/lib/typeChecker/schemaType.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, unlinkSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
+import type { AgencyConfig } from "../config.js";
+
+function errorsFrom(source: string, config: AgencyConfig = {}): TypeCheckError[] {
+  const file = path.join(
+    os.tmpdir(),
+    `tc-schema-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`,
+  );
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath, config);
+    const parseResult = parseAgency(source, config);
+    if (!parseResult.success) throw new Error("Parse failed: " + parseResult.message);
+    const program = parseResult.result;
+    const info = buildCompilationUnit(program, symbolTable, absPath, source);
+    return typeCheck(program, config, info).errors;
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+describe("Schema<T> type synthesis", () => {
+  it("`schema(MyType).parse(x)` synths to Result<MyType, any>", () => {
+    // Assigning a Result to a non-Result number should fail.
+    const errors = errorsFrom(
+      [
+        "type MyType = number",
+        "node main() {",
+        "  let s = schema(MyType)",
+        "  let r: number = s.parse(42)",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    const mismatch = errors.filter(
+      (e) => e.message.includes("Result") && e.message.includes("number"),
+    );
+    expect(mismatch.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("`schema(MyType).parse(x)` is assignable to a Result<MyType, any> binding", () => {
+    const errors = errorsFrom(
+      [
+        "type MyType = number",
+        "node main() {",
+        "  let s = schema(MyType)",
+        "  let r: Result<number, any> = s.parse(42)",
+        "  print(r)",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    expect(errors.filter((e) => e.severity !== "warning")).toEqual([]);
+  });
+
+  it("`.parseJSON` on a schema also synths to Result<T, any>", () => {
+    const errors = errorsFrom(
+      [
+        "type MyType = number",
+        "node main() {",
+        "  let s = schema(MyType)",
+        '  let r: Result<number, any> = s.parseJSON("42")',
+        "  print(r)",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    expect(errors.filter((e) => e.severity !== "warning")).toEqual([]);
+  });
+
+  it("an unknown method on a schema falls back to any (no false positives)", () => {
+    const errors = errorsFrom(
+      [
+        "type MyType = number",
+        "node main() {",
+        "  let s = schema(MyType)",
+        "  let r = s.somethingWeird(1)",
+        "  print(r)",
+        "}",
+        "",
+      ].join("\n"),
+    );
+    // Should not raise a type-mismatch error from synth (the method is
+    // unknown, so currentType becomes "any" and downstream is silent).
+    const mismatch = errors.filter(
+      (e) => e.message.includes("not assignable"),
+    );
+    expect(mismatch).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/scope.ts
+++ b/packages/agency-lang/lib/typeChecker/scope.ts
@@ -33,7 +33,10 @@ export class Scope {
   }
 
   isConst(name: string): boolean {
-    if (name in this.vars) return this.consts[name] === true;
+    // Own-property check — `name in this.vars` walks the prototype chain.
+    if (Object.prototype.hasOwnProperty.call(this.vars, name)) {
+      return this.consts[name] === true;
+    }
     return this.parent?.isConst(name) ?? false;
   }
 

--- a/packages/agency-lang/lib/typeChecker/shadowing.ts
+++ b/packages/agency-lang/lib/typeChecker/shadowing.ts
@@ -1,0 +1,23 @@
+import type { AgencyNode } from "../types.js";
+
+/**
+ * Walk top-level program nodes once and collect the bookkeeping needed
+ * for {@link isJsGlobalBase} (and similar shadowing checks). Cheap to
+ * compute, but should be hoisted above the per-node walk so callers
+ * don't pay it on every check.
+ */
+export function collectProgramShadowing(programNodes: readonly AgencyNode[]): {
+  importedNodeNames: string[];
+  classNames: Record<string, true>;
+} {
+  const importedNodeNames: string[] = [];
+  const classNames: Record<string, true> = {};
+  for (const node of programNodes) {
+    if (node.type === "importNodeStatement") {
+      importedNodeNames.push(...node.importedNodes);
+    } else if (node.type === "classDefinition") {
+      classNames[node.className] = true;
+    }
+  }
+  return { importedNodeNames, classNames };
+}

--- a/packages/agency-lang/lib/typeChecker/suppression.test.ts
+++ b/packages/agency-lang/lib/typeChecker/suppression.test.ts
@@ -97,7 +97,9 @@ describe("typeCheck honors suppressions end-to-end", () => {
     if (!parseResult.success) throw new Error(`Parse failed: ${parseResult.message}`);
     const program = parseResult.result;
     const info = buildCompilationUnit(program, undefined, undefined, source);
-    return typeCheck(program, {}, info);
+    // Silence the undefined-function diagnostic — these tests don't supply a
+    // SymbolTable, so stdlib calls (print, …) would warn as unresolved.
+    return typeCheck(program, { typechecker: { undefinedFunctions: "silent" } }, info);
   }
 
   it("@tc-ignore suppresses the next-line error", () => {

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -117,20 +117,18 @@ export function synthType(
       return synthTryExpression(expr, scope, ctx);
     case "schemaExpression":
       // `schema(Type)` is a language built-in that bridges *type space* and
-      // *value space*: the parser captures `Type` as a VariableType (not as a
-      // value expression — see schemaExpressionParser in parsers.ts), and at
-      // runtime the SchemaExpression node compiles to a zod schema constructed
-      // from that type.
+      // *value space*: the parser captures `Type` as a VariableType (not as
+      // a value expression — see schemaExpressionParser in parsers.ts), and
+      // at runtime the SchemaExpression node compiles to a zod schema
+      // constructed from that type.
       //
-      // We currently synthesize its result as "any" because there's no
-      // structured `Schema<T>` type in Agency's type system yet. Adding one
-      // would let downstream code see e.g. `Schema<MyType>` and validate
-      // .parse() / .safeParse() return types — that's future work, deliberately
-      // out of scope here.
+      // We synth it as `Schema<T>` so chained `.parse(...)` /
+      // `.parseJSON(...)` calls can track the validated type through to a
+      // `Result<T, any>` (see synthValueAccess for the method handling).
       //
       // `schema` is listed in RESERVED_FUNCTION_NAMES so users can't define
       // their own `def schema()` (which would create parse ambiguity).
-      return "any";
+      return { type: "schemaType", inner: expr.typeArg };
     default:
       return "any";
   }
@@ -551,6 +549,20 @@ export function synthValueAccess(
         break;
       }
       case "methodCall": {
+        // `schema(T).parse(x)` and `.parseJSON(s)` both return Result<T, any>
+        // at runtime (see lib/runtime/schema.ts). Track the inner type
+        // through the chain so callers can use `.value` / `catch` / pipes.
+        if (resolved.type === "schemaType") {
+          const methodName = element.functionCall.functionName;
+          if (methodName === "parse" || methodName === "parseJSON") {
+            currentType = {
+              type: "resultType",
+              successType: resolved.inner,
+              failureType: ANY_T,
+            };
+            break;
+          }
+        }
         return "any";
       }
     }

--- a/packages/agency-lang/lib/typeChecker/typeWalker.ts
+++ b/packages/agency-lang/lib/typeChecker/typeWalker.ts
@@ -24,6 +24,8 @@ export function visitTypes(
       return (
         visitTypes(t.successType, visit) || visitTypes(t.failureType, visit)
       );
+    case "schemaType":
+      return visitTypes(t.inner, visit);
     case "blockType":
       for (const p of t.params)
         if (visitTypes(p.typeAnnotation, visit)) return true;

--- a/packages/agency-lang/lib/typeChecker/types.ts
+++ b/packages/agency-lang/lib/typeChecker/types.ts
@@ -50,6 +50,8 @@ export type TypeCheckerContext = {
   functionDefs: Record<string, FunctionDefinition>;
   nodeDefs: Record<string, GraphNodeDefinition>;
   importedFunctions: Record<string, ImportedFunctionSignature>;
+  /** Names brought in by non-Agency JS imports — see CompilationUnit. */
+  jsImportedNames: Record<string, true>;
   interruptKindsByFunction: Record<string, InterruptKind[]>;
   errors: TypeCheckError[];
   inferredReturnTypes: Record<string, VariableType | "any">;

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.test.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.test.ts
@@ -302,6 +302,41 @@ describe("undefined function diagnostic — JS namespaces", () => {
   });
 });
 
+describe("undefined function diagnostic — JS imports", () => {
+  // `import { foo } from "./helpers.js"` doesn't go through the symbol
+  // table (those are JS, not Agency), but the names ARE bound at runtime.
+  // Make sure the diagnostic doesn't false-positive on them.
+  it("does not warn on calls to JS-imported functions", () => {
+    const source = [
+      'import { _now, _add } from "./helpers.js"',
+      "node main() {",
+      "  let t = _now()",
+      "  return _add(t, 1)",
+      "}",
+      "",
+    ].join("\n");
+    const errors = errorsFrom(source, WARN);
+    expect(errors.filter((e) => e.message.includes("'_now'"))).toHaveLength(0);
+    expect(errors.filter((e) => e.message.includes("'_add'"))).toHaveLength(0);
+  });
+
+  it("respects aliases on JS imports", () => {
+    const source = [
+      'import { foo as bar } from "./helpers.js"',
+      "node main() {",
+      "  return bar(1)",
+      "}",
+      "",
+    ].join("\n");
+    const errors = errorsFrom(source, WARN);
+    expect(errors.filter((e) => e.message.includes("'bar'"))).toHaveLength(0);
+    // The original name is NOT bound; only the alias.
+    expect(
+      errors.filter((e) => e.message.includes("'foo'") && e.message.includes("not defined")),
+    ).toHaveLength(0);
+  });
+});
+
 describe("undefined function diagnostic — imported nodes", () => {
   it("does not warn on calls to nodes imported via `import node { ... }`", () => {
     // Set up a sibling .agency file the symbol table can resolve.

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.test.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.test.ts
@@ -148,12 +148,26 @@ describe("undefined function diagnostic", () => {
     expect(errors.filter((e) => e.message.includes("doesNotExist"))).toHaveLength(1);
   });
 
-  it("respects undefinedFunctions: silent (default)", () => {
+  it("warns by default (no config override)", () => {
     const errors = errorsFrom(`
       node main() {
         totallyMadeUpFn("{}")
       }
     `);
+    const undef = errors.filter((e) => e.message.includes("totallyMadeUpFn"));
+    expect(undef).toHaveLength(1);
+    expect(undef[0].severity).toBe("warning");
+  });
+
+  it("respects undefinedFunctions: silent override", () => {
+    const errors = errorsFrom(
+      `
+      node main() {
+        totallyMadeUpFn("{}")
+      }
+    `,
+      { typechecker: { undefinedFunctions: "silent" } },
+    );
     expect(errors.filter((e) => e.message.includes("totallyMadeUpFn"))).toHaveLength(0);
   });
 

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.test.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.test.ts
@@ -35,12 +35,12 @@ describe("undefined function diagnostic", () => {
     const errors = errorsFrom(
       `
       node main() {
-        let x = parseJSON("{}")
+        let x = totallyMadeUpFn("{}")
       }
     `,
       WARN,
     );
-    const undef = errors.filter((e) => e.message.includes("parseJSON"));
+    const undef = errors.filter((e) => e.message.includes("totallyMadeUpFn"));
     expect(undef).toHaveLength(1);
     expect(undef[0].severity).toBe("warning");
   });
@@ -151,22 +151,22 @@ describe("undefined function diagnostic", () => {
   it("respects undefinedFunctions: silent (default)", () => {
     const errors = errorsFrom(`
       node main() {
-        parseJSON("{}")
+        totallyMadeUpFn("{}")
       }
     `);
-    expect(errors.filter((e) => e.message.includes("parseJSON"))).toHaveLength(0);
+    expect(errors.filter((e) => e.message.includes("totallyMadeUpFn"))).toHaveLength(0);
   });
 
   it("respects undefinedFunctions: error", () => {
     const errors = errorsFrom(
       `
       node main() {
-        parseJSON("{}")
+        totallyMadeUpFn("{}")
       }
     `,
       { typechecker: { undefinedFunctions: "error" } },
     );
-    const undef = errors.filter((e) => e.message.includes("parseJSON"));
+    const undef = errors.filter((e) => e.message.includes("totallyMadeUpFn"));
     expect(undef).toHaveLength(1);
     expect(undef[0].severity).toBe("error");
   });

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
@@ -26,7 +26,11 @@ export function checkUndefinedFunctions(
   scopes: ScopeInfo[],
   ctx: TypeCheckerContext,
 ): void {
-  const mode = ctx.config.typechecker?.undefinedFunctions ?? "silent";
+  // Default is "warn" — the registries (BUILTIN_FUNCTION_TYPES,
+  // importedFunctions via SymbolTable, JS_GLOBALS) are now accurate enough
+  // that false positives are rare. Users can opt back into silence with
+  // `{ typechecker: { undefinedFunctions: "silent" } }` in agency.json.
+  const mode = ctx.config.typechecker?.undefinedFunctions ?? "warn";
   if (mode === "silent") return;
 
   // Collect names from `import node { ... } from "..."` statements at the

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
@@ -6,8 +6,9 @@ import { walkNodes } from "../utils/node.js";
 import {
   resolveCall,
   lookupJsMember,
-  JS_GLOBALS,
+  isJsGlobalBase,
 } from "./resolveCall.js";
+import { collectProgramShadowing } from "./shadowing.js";
 
 /**
  * Emit a diagnostic for every call site that doesn't resolve to a known
@@ -33,14 +34,7 @@ export function checkUndefinedFunctions(
   const mode = ctx.config.typechecker?.undefinedFunctions ?? "warn";
   if (mode === "silent") return;
 
-  // Collect names from `import node { ... } from "..."` statements at the
-  // program level — `nodeDefs` only includes locally-defined nodes.
-  const importedNodeNames: string[] = [];
-  for (const node of ctx.programNodes) {
-    if (node.type === "importNodeStatement") {
-      importedNodeNames.push(...node.importedNodes);
-    }
-  }
+  const shadowing = collectProgramShadowing(ctx.programNodes);
 
   for (const info of scopes) {
     if (!info.name) continue;
@@ -61,9 +55,9 @@ export function checkUndefinedFunctions(
           // also incorrectly treat `obj.foo()` as a bare call to `foo`.
           const parent = ancestors[ancestors.length - 1];
           if (parent && (parent as AgencyNode).type === "valueAccess") continue;
-          checkBareCall(node, info.scope, ctx, mode, importedNodeNames);
+          checkBareCall(node, info.scope, ctx, mode, shadowing.importedNodeNames);
         } else if (node.type === "valueAccess") {
-          checkAccessChain(node, info.scope, ctx, mode);
+          checkAccessChain(node, info.scope, ctx, mode, shadowing);
         }
       }
     });
@@ -107,16 +101,24 @@ function checkAccessChain(
   scope: Scope,
   ctx: TypeCheckerContext,
   mode: "warn" | "error",
+  shadowing: { importedNodeNames: readonly string[]; classNames: object },
 ): void {
   // Only handle <variableName>.<member>... chains where the base is a JS
   // namespace global. Everything else (objects in scope, computed lookups,
   // optional chains) is the typechecker's job — not this diagnostic's.
   if (expr.base.type !== "variableName") return;
   const baseName = expr.base.value;
-  if (scope.has(baseName)) return;
-  if (Object.prototype.hasOwnProperty.call(ctx.functionDefs, baseName)) return;
-  if (Object.prototype.hasOwnProperty.call(ctx.importedFunctions, baseName)) return;
-  if (!Object.prototype.hasOwnProperty.call(JS_GLOBALS, baseName)) return;
+  if (
+    !isJsGlobalBase(baseName, {
+      scope,
+      functionDefs: ctx.functionDefs,
+      nodeDefs: ctx.nodeDefs,
+      importedFunctions: ctx.importedFunctions,
+      importedNodeNames: shadowing.importedNodeNames,
+      classNames: shadowing.classNames,
+    })
+  )
+    return;
 
   // Only diagnose call sites — `Math.PI` (property lookup) is a value, not a
   // function. The chain must end in a callable element.

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
@@ -86,6 +86,7 @@ function checkBareCall(
     nodeDefs: ctx.nodeDefs,
     importedFunctions: ctx.importedFunctions,
     importedNodeNames,
+    jsImportedNames: ctx.jsImportedNames,
     scopeHas: (name) => scope.has(name),
   });
   if (resolution.kind !== "unresolved") return;
@@ -115,6 +116,7 @@ function checkAccessChain(
       nodeDefs: ctx.nodeDefs,
       importedFunctions: ctx.importedFunctions,
       importedNodeNames: shadowing.importedNodeNames,
+      jsImportedNames: ctx.jsImportedNames,
       classNames: shadowing.classNames,
     })
   )

--- a/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.test.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, unlinkSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
+import type { AgencyConfig } from "../config.js";
+
+function errorsFrom(source: string, config: AgencyConfig = {}): TypeCheckError[] {
+  const file = path.join(
+    os.tmpdir(),
+    `tc-undef-var-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`,
+  );
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath, config);
+    const parseResult = parseAgency(source, config);
+    if (!parseResult.success) throw new Error("Parse failed");
+    const program = parseResult.result;
+    const info = buildCompilationUnit(program, symbolTable, absPath, source);
+    return typeCheck(program, config, info).errors;
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+const WARN: AgencyConfig = { typechecker: { undefinedVariables: "warn" } };
+
+describe("undefined variable diagnostic", () => {
+  it("warns on `let x = doesNotExist`", () => {
+    const errors = errorsFrom(
+      `node main() {\n let x = doesNotExist\n print(x)\n }\n`,
+      WARN,
+    );
+    const undef = errors.filter(
+      (e) => e.message.includes("doesNotExist") && e.message.includes("not defined"),
+    );
+    expect(undef).toHaveLength(1);
+    expect(undef[0].severity).toBe("warning");
+  });
+
+  it("does not warn on a function reference (`map(items, myDef)`)", () => {
+    const errors = errorsFrom(
+      `def myDef(x: number): number { return x }\nnode main() {\n let xs = [1, 2, 3]\n let ys = xs.map(myDef)\n print(ys)\n }\n`,
+      WARN,
+    );
+    expect(
+      errors.filter((e) => e.message.includes("myDef") && e.message.includes("not defined")),
+    ).toHaveLength(0);
+  });
+
+  it("does not warn on a builtin reference (`success`)", () => {
+    const errors = errorsFrom(
+      `node main() {\n let f = success\n print(f)\n }\n`,
+      WARN,
+    );
+    expect(
+      errors.filter((e) => e.message.includes("'success'") && e.message.includes("not defined")),
+    ).toHaveLength(0);
+  });
+
+  it("does not warn on a JS namespace base (`JSON`)", () => {
+    const errors = errorsFrom(
+      `node main() {\n let x = JSON.parse("{}")\n print(x)\n }\n`,
+      WARN,
+    );
+    expect(
+      errors.filter((e) => e.message.includes("'JSON'") && e.message.includes("not defined")),
+    ).toHaveLength(0);
+  });
+
+  it("warns when iterating an undefined array", () => {
+    const errors = errorsFrom(
+      `node main() {\n for (item in someArray) {\n print(item)\n }\n }\n`,
+      WARN,
+    );
+    expect(
+      errors.filter((e) => e.message.includes("'someArray'") && e.message.includes("not defined")),
+    ).toHaveLength(1);
+  });
+
+  it("does not warn on a for-loop's own itemVar/indexVar", () => {
+    const errors = errorsFrom(
+      `node main() {\n let xs = [1, 2, 3]\n for (item in xs) {\n print(item)\n }\n }\n`,
+      WARN,
+    );
+    expect(
+      errors.filter((e) => e.message.includes("item") && e.message.includes("not defined")),
+    ).toHaveLength(0);
+  });
+
+  it("respects undefinedVariables: silent (default)", () => {
+    const errors = errorsFrom(
+      `node main() {\n let x = doesNotExist\n print(x)\n }\n`,
+    );
+    expect(
+      errors.filter((e) => e.message.includes("doesNotExist") && e.message.includes("not defined")),
+    ).toHaveLength(0);
+  });
+
+  it("respects undefinedVariables: error", () => {
+    const errors = errorsFrom(
+      `node main() {\n let x = doesNotExist\n print(x)\n }\n`,
+      { typechecker: { undefinedVariables: "error" } },
+    );
+    const undef = errors.filter(
+      (e) => e.message.includes("doesNotExist") && e.message.includes("not defined"),
+    );
+    expect(undef).toHaveLength(1);
+    expect(undef[0].severity).toBe("error");
+  });
+
+  it("does not warn on a class definition reference (`new MyClass()`)", () => {
+    const errors = errorsFrom(
+      `class MyClass {\n  x: number\n}\nnode main() {\n  let m = new MyClass(1)\n  print(m)\n}\n`,
+      WARN,
+    );
+    expect(
+      errors.filter((e) => e.message.includes("MyClass") && e.message.includes("not defined")),
+    ).toHaveLength(0);
+  });
+
+  it("does not warn on lambda/block parameters", () => {
+    const errors = errorsFrom(
+      `node main() {\n let xs = [1, 2, 3]\n let ys = xs.map(\\(x) -> x + 1)\n print(ys)\n }\n`,
+      WARN,
+    );
+    expect(
+      errors.filter((e) => e.message.includes("'x'") && e.message.includes("not defined")),
+    ).toHaveLength(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.test.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.test.ts
@@ -124,6 +124,30 @@ describe("undefined variable diagnostic", () => {
     ).toHaveLength(0);
   });
 
+  it("warns on a callback argument that doesn't resolve (`xs.map(doesNotExist)`)", () => {
+    const errors = errorsFrom(
+      `node main() {\n let xs = [1, 2, 3]\n let ys = xs.map(doesNotExist)\n print(ys)\n }\n`,
+      WARN,
+    );
+    expect(
+      errors.filter(
+        (e) => e.message.includes("doesNotExist") && e.message.includes("not defined"),
+      ),
+    ).toHaveLength(1);
+  });
+
+  it("warns on a callback argument to a bare call (`map(xs, doesNotExist)`)", () => {
+    const errors = errorsFrom(
+      `node main() {\n let xs = [1, 2, 3]\n let ys = map(xs, doesNotExist)\n print(ys)\n }\n`,
+      WARN,
+    );
+    expect(
+      errors.filter(
+        (e) => e.message.includes("doesNotExist") && e.message.includes("not defined"),
+      ),
+    ).toHaveLength(1);
+  });
+
   it("does not warn on lambda/block parameters", () => {
     const errors = errorsFrom(
       `node main() {\n let xs = [1, 2, 3]\n let ys = xs.map(\\(x) -> x + 1)\n print(ys)\n }\n`,

--- a/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.ts
@@ -4,6 +4,7 @@ import type { AgencyNode, VariableNameLiteral } from "../types.js";
 import type { WalkAncestor } from "../utils/node.js";
 import { walkNodes } from "../utils/node.js";
 import { resolveVariable } from "./resolveVariable.js";
+import { collectProgramShadowing } from "./shadowing.js";
 
 /**
  * Emit a diagnostic for every variable reference that doesn't resolve
@@ -39,15 +40,9 @@ export function checkUndefinedVariables(
   const mode = ctx.config.typechecker?.undefinedVariables ?? "silent";
   if (mode === "silent") return;
 
-  const importedNodeNames: string[] = [];
-  const classDefs: Record<string, true> = {};
-  for (const node of ctx.programNodes) {
-    if (node.type === "importNodeStatement") {
-      importedNodeNames.push(...node.importedNodes);
-    } else if (node.type === "classDefinition") {
-      classDefs[node.className] = true;
-    }
-  }
+  const { importedNodeNames, classNames: classDefs } = collectProgramShadowing(
+    ctx.programNodes,
+  );
 
   for (const info of scopes) {
     if (!info.name) continue;

--- a/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.ts
@@ -135,6 +135,7 @@ function checkVariableRef(
     nodeDefs: ctx.nodeDefs,
     importedFunctions: ctx.importedFunctions,
     importedNodeNames,
+    jsImportedNames: ctx.jsImportedNames,
     classNames,
     scopeHas: (name) => scope.has(name),
   });

--- a/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedVariableDiagnostic.ts
@@ -1,0 +1,152 @@
+import type { ScopeInfo, TypeCheckerContext } from "./types.js";
+import type { Scope } from "./scope.js";
+import type { AgencyNode, VariableNameLiteral } from "../types.js";
+import type { WalkAncestor } from "../utils/node.js";
+import { walkNodes } from "../utils/node.js";
+import { resolveVariable } from "./resolveVariable.js";
+
+/**
+ * Emit a diagnostic for every variable reference that doesn't resolve
+ * — `let x = undefinedVar`, `print(missingThing)`, `for (item in
+ * notArray)`, etc.
+ *
+ * Severity is controlled by `config.typechecker.undefinedVariables`:
+ *   - "silent" (default): no diagnostics emitted
+ *   - "warn":  pushed as warnings
+ *   - "error": pushed as errors
+ *
+ * Resolution is delegated to `resolveVariable` (pure function in
+ * resolveVariable.ts) — this module just walks the AST and translates
+ * "didn't resolve" into a diagnostic.
+ *
+ * Skipped contexts (handled by other passes / not actually variable
+ * lookups):
+ *   - `valueAccess.chain[i].kind === "property"` — property names like
+ *     `obj.x` are not variable references; the typechecker checks them
+ *     against the base's structural type elsewhere.
+ *   - The base of a `valueAccess` is checked here (it's the variable),
+ *     but only when it's a `variableName`.
+ *   - `functionCall.functionName` is checked by `checkUndefinedFunctions`,
+ *     not here.
+ *   - The `name` of a `namedArgument` is a parameter name, not a variable.
+ *   - Object literal keys (`{ key: value }`) are field names, not
+ *     variable refs.
+ */
+export function checkUndefinedVariables(
+  scopes: ScopeInfo[],
+  ctx: TypeCheckerContext,
+): void {
+  const mode = ctx.config.typechecker?.undefinedVariables ?? "silent";
+  if (mode === "silent") return;
+
+  const importedNodeNames: string[] = [];
+  const classDefs: Record<string, true> = {};
+  for (const node of ctx.programNodes) {
+    if (node.type === "importNodeStatement") {
+      importedNodeNames.push(...node.importedNodes);
+    } else if (node.type === "classDefinition") {
+      classDefs[node.className] = true;
+    }
+  }
+
+  for (const info of scopes) {
+    if (!info.name) continue;
+    const isTopLevel = info.name === "top-level";
+    ctx.withScope(info.scopeKey, () => {
+      for (const { node, ancestors } of walkNodes(info.body)) {
+        // Mirror checkUndefinedFunctions: avoid double-reporting
+        // function/graphNode bodies during the top-level pass.
+        if (isTopLevel && hasFunctionOrNodeAncestor(ancestors)) continue;
+        if (node.type !== "variableName") continue;
+        if (isReferencePosition(node, ancestors)) {
+          checkVariableRef(node, ancestors, info.scope, ctx, mode, importedNodeNames, classDefs);
+        }
+      }
+    });
+  }
+}
+
+function hasFunctionOrNodeAncestor(ancestors: readonly unknown[]): boolean {
+  for (const a of ancestors) {
+    const t = (a as AgencyNode | undefined)?.type;
+    if (t === "function" || t === "graphNode") return true;
+  }
+  return false;
+}
+
+/**
+ * A bare `variableName` node can show up in many positions where it's
+ * NOT a real variable reference (e.g. import statements, type alias
+ * names, parameter names). Only fire the diagnostic when the position
+ * actually represents a value being read.
+ *
+ * Rather than enumerate every "skip" position, we accept positions where
+ * walkNodes recurses into a value — those are the ones where a missing
+ * binding would actually be a runtime error.
+ */
+function isReferencePosition(
+  node: VariableNameLiteral,
+  ancestors: readonly WalkAncestor[],
+): boolean {
+  const parent = ancestors[ancestors.length - 1];
+  if (!parent) return false;
+  const p = parent as AgencyNode;
+
+  // The base of a valueAccess (`obj.x`, `obj[i]`, `obj.foo()`). The base
+  // IS a value reference and must resolve. Property/method names are NOT
+  // variable refs and are filtered by walkNodes already (it doesn't yield
+  // them as standalone variableNames).
+  if (p.type === "valueAccess") return p.base === node;
+
+  // LHS of assignment (`x = 5`, no decl) is a write, not a read; the
+  // const-reassignment pass handles unknown writes.
+  if (p.type === "assignment") {
+    // walkNodes only yields `node.value` (and accessChain elements), not
+    // `variableName`. So if we reach here, it's nested deeper. Treat as
+    // a real reference.
+    return true;
+  }
+  return true;
+}
+
+function checkVariableRef(
+  ref: VariableNameLiteral,
+  ancestors: readonly WalkAncestor[],
+  scope: Scope,
+  ctx: TypeCheckerContext,
+  mode: "warn" | "error",
+  importedNodeNames: readonly string[],
+  classNames: Record<string, true>,
+): void {
+  // Don't check the LHS of `for (item in items)` — itemVar/indexVar are
+  // declarations, not references. (walkNodes shouldn't yield them, but
+  // belt-and-suspenders.)
+  for (const a of ancestors) {
+    if ((a as AgencyNode).type === "forLoop") {
+      const fl = a as AgencyNode & { type: "forLoop" };
+      if (ref.value === fl.itemVar || ref.value === fl.indexVar) return;
+    }
+    // Block params on method calls (`xs.map(\(x) -> x + 1)`) and any
+    // other call-with-block aren't currently tracked in the typechecker's
+    // Scope, so look them up directly from any enclosing blockArgument.
+    if ((a as { type: string }).type === "blockArgument") {
+      const block = a as { type: "blockArgument"; params: { name: string }[] };
+      if (block.params.some((p) => p.name === ref.value)) return;
+    }
+  }
+
+  const resolution = resolveVariable(ref.value, {
+    functionDefs: ctx.functionDefs,
+    nodeDefs: ctx.nodeDefs,
+    importedFunctions: ctx.importedFunctions,
+    importedNodeNames,
+    classNames,
+    scopeHas: (name) => scope.has(name),
+  });
+  if (resolution.kind !== "unresolved") return;
+  ctx.errors.push({
+    message: `Variable '${ref.value}' is not defined.`,
+    severity: mode === "warn" ? "warning" : "error",
+    loc: ref.loc,
+  });
+}

--- a/packages/agency-lang/lib/types/typeHints.ts
+++ b/packages/agency-lang/lib/types/typeHints.ts
@@ -13,12 +13,25 @@ export type VariableType =
   | TypeAliasVariable
   | BlockType
   | ResultType
+  | SchemaType
   | FunctionRefType;
 
 export type ResultType = {
   type: "resultType";
   successType: VariableType;
   failureType: VariableType;
+};
+
+/**
+ * `Schema<T>` — synthesized type of a `schema(T)` expression. The runtime
+ * `Schema` class wraps a zod schema and exposes `.parse(...)` /
+ * `.parseJSON(...)`, both returning `Result<T, any>`. Carrying `inner`
+ * lets the typechecker track the validated type through the call chain
+ * (e.g. `schema(MyType).parse(x)` → `Result<MyType, any>`).
+ */
+export type SchemaType = {
+  type: "schemaType";
+  inner: VariableType;
 };
 
 export type BlockType = {

--- a/packages/agency-lang/lib/utils/formatType.ts
+++ b/packages/agency-lang/lib/utils/formatType.ts
@@ -44,6 +44,8 @@ export function formatTypeHint(
       if (s === "any" && f === "any") return "Result";
       return `Result<${s}, ${f}>`;
     }
+    case "schemaType":
+      return `Schema<${recurse(vt.inner)}>`;
     case "functionRefType": {
       const params = vt.params
         .map((p) => `${p.name}${p.typeHint ? `: ${recurse(p.typeHint)}` : ""}`)


### PR DESCRIPTION
Implements the follow-up plan from #143
([2026-05-15-undefined-function-followups.md](docs/superpowers/plans/2026-05-15-undefined-function-followups.md)).
All eight tasks are now done.

## Tasks

### Task 1 — Block `let`/`const` of reserved names
`static const schema = 42`, `let interrupt = 5`, etc. now error.
Substring matches like `schemaForX` are unaffected. Includes a
prototype-leak fix in `lib/typeChecker/scope.ts`.

### Task 2 — Move stdlib signatures out of `BUILTIN_FUNCTION_TYPES`
`print`, `fetch`, `read`, `write`, `range`, `keys`, `values`,
`entries`, `mostCommon`, `notify`, `sleep`, `round`, `printJSON`,
`input`, `readImage`, `fetchJSON`, `emit` now resolve via
`importedFunctions` from `std::index`.
`BUILTIN_FUNCTION_TYPES` keeps only true language primitives.

### Task 3 — Populate `sig` on `JS_GLOBALS`
Typed signatures for the high-traffic JS globals (`JSON.parse`,
`JSON.stringify`, `Math.floor`/`ceil`/`round`/`abs`/`max`/`min`/
`random`/`sqrt`, `parseInt`, `parseFloat`, `Number.isInteger`,
`Array.isArray`, `Object.keys`/`values`/`entries`, `Date.now`).
`checker.ts` now runs `checkArity`/`checkArgsAgainstParams` for
JS member calls when a `sig` is present.

### Task 4 — LSP signature info for built-ins and JS globals
`handleHover` now falls through to `lookupBuiltinHover` /
`lookupJsMemberHover` for primitives and JS globals. Detects
`<JsNamespace>.<member>` cursor positions like `JSON.parse`.

### Task 5 — Default `typechecker.undefinedFunctions` to `"warn"`
The registries are accurate enough to flip the default from
`"silent"` to `"warn"` without false positives.

### Task 6 — Synth `Schema<T>` for `schemaExpression`
New `SchemaType` variant; `synthValueAccess` recognizes
`.parse(...)` / `.parseJSON(...)` and synthesizes
`Result<T, any>` matching the runtime in `lib/runtime/schema.ts`.

### Task 7 — Symmetric undefined-variable diagnostic
New `lib/typeChecker/undefinedVariableDiagnostic.ts` and
`resolveVariable.ts`. Same shape as `checkUndefinedFunctions`,
controlled by a new `typechecker.undefinedVariables` config
key (default `"silent"`).

### Task 8 — Higher-order callback safety
Task 7 already covers the case (`xs.map(doesNotExist)` and
`map(xs, doesNotExist)`); added regression tests pinning the
behavior — no extra production code needed.

### LSP fix
The LSP path skips the parser template that injects the stdlib
import, so stdlib functions were reported as undefined. Added
`ensureStdlibImport` in `lib/lsp/diagnostics.ts` to synthesize
the missing import.

## Test results

All 3236 tests pass (23 skipped).
