### PR TITLE
Enhance StateLog with spans, token usage, and new event types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,10 @@ jobs:
         node tests/integration/bundlers/test-vite.mjs ./agency-lang-*.tgz
         node tests/integration/cli/test.mjs ./agency-lang-*.tgz
         rm -f agency-lang-*.tgz
+    - name: StateLog integration tests
+      if: matrix.node-version == '22.x'
+      working-directory: packages/agency-lang
+      run: node tests/integration/statelog/test.mjs
     - name: Stdlib sandbox tests
       if: matrix.node-version == '22.x'
       working-directory: packages/agency-lang

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ tests/debugger/*.ts
 **/docs-new/.vitepress/dist
 **/docs-new/.vitepress/cache
 .agency-tmp/
+tests/integration/statelog/.tmp/

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-15-statelog-enhancement-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-15-statelog-enhancement-design.md
@@ -351,6 +351,7 @@ type StatelogConfig = {
   apiKey: string;
   projectId: string;
   debugMode: boolean;
+  observability?: boolean;
   // NEW:
   metadata?: {
     tags?: string[];
@@ -366,6 +367,7 @@ The `agency.json` config section becomes:
 
 ```json
 {
+  "observability": true,
   "log": {
     "host": "https://agency-lang.com",
     "projectId": "my-project",
@@ -588,7 +590,7 @@ And a new interrupt event:
 ### Integration tests
 
 - Create a small Agency program that exercises: LLM call, tool call, interrupt, handler, checkpoint, restore, fork, thread.
-- Run it with `host: "stdout"` and capture the JSON output.
+- Run it with `observability: true` and `host: "stdout"` and capture the JSON output. Note: stdout mode is exempt from the API key requirement.
 - Assert the event stream contains all expected event types in the correct order, with correct span nesting (parent IDs match), correct token/cost data, and correct interrupt lifecycle events.
 
 ### Fixture tests

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-15-statelog-enhancement-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-15-statelog-enhancement-design.md
@@ -1,0 +1,597 @@
+# StateLog Enhancement Design Spec
+
+## Problem Statement
+
+Agency's StateLog observability system captures graph structure, node lifecycle, LLM calls, tool calls, and edge transitions. But several critical categories of execution events are invisible:
+
+1. **Token usage and cost** — the runtime already computes `completion.usage` and `completion.cost` per LLM call, and accumulates them in `__tokenStats`, but StateLog never receives this data. There is no way to build cost dashboards or token usage charts.
+
+2. **Interrupt lifecycle** — interrupts and handlers are Agency's core safety feature, but StateLog captures nothing about them. When an interrupt fires, which handlers ran, what they decided, and the final outcome are all invisible.
+
+3. **Checkpoint and restore** — checkpoint creation and restore events are invisible. There's no way to see retry behavior, rewind events, or how often checkpoints are used.
+
+4. **Fork and race** — parallel execution branches are invisible. There's no way to see which branches ran, how long each took, which branch won a race, or which branches interrupted.
+
+5. **Thread lifecycle** — thread and subthread creation is invisible. There's no way to see conversation isolation patterns.
+
+6. **Structured errors** — errors and failures are logged as generic debug messages. There's no way to filter by error type, see retry counts, or identify which tools fail most.
+
+7. **Run-level metadata** — there's no way to attach tags, environment, user ID, or agent version to a trace. This makes it impossible to filter or group runs in a dashboard.
+
+8. **Span nesting** — events are flat (no parent-child relationships). There's no way to see that a tool call happened inside an LLM call, which happened inside a node.
+
+## Goals
+
+- Enrich StateLog to capture all significant execution events
+- Add span IDs and parent span IDs for hierarchical nesting
+- Add token usage and cost to LLM call events
+- Add run-level metadata (tags, environment, user-defined key-value pairs)
+- Maintain the existing zero-overhead opt-in model (no logging unless configured)
+- Keep events lightweight (fire-and-forget JSON posts, not full state snapshots)
+- Align event semantics with OpenTelemetry GenAI conventions where natural, to simplify a future OTel export adapter
+
+## Non-Goals
+
+- Building the observability UI (separate project)
+- Building the OTel export adapter (separate project, consumes these events)
+- Changing the trace system (TraceWriter captures full checkpoints; StateLog captures lightweight structured events — they are complementary)
+- Adding sampling or batching (can be added later)
+
+## Design
+
+### Span model
+
+Every event belongs to a **span**. A span has a start time, end time, type, and optional parent. This gives events hierarchical structure.
+
+```
+Trace (one per agent run, identified by traceId)
+├── Span: agentRun
+│   ├── Span: nodeExecution "main"
+│   │   ├── Span: llmCall
+│   │   │   ├── Event: llmCallStart
+│   │   │   ├── Event: llmCallEnd (tokens, cost, latency)
+│   │   │   ├── Span: toolExecution "searchDB"
+│   │   │   │   ├── Event: toolStart
+│   │   │   │   ├── Event: interruptThrown
+│   │   │   │   ├── Event: handlerDecision (handler 1: approve)
+│   │   │   │   ├── Event: handlerDecision (handler 2: reject)
+│   │   │   │   ├── Event: interruptResolved (rejected)
+│   │   │   │   └── Event: toolEnd (failure)
+│   │   │   └── Span: toolExecution "formatResults"
+│   │   │       ├── Event: toolStart
+│   │   │       └── Event: toolEnd (success)
+│   │   └── Span: llmCall (follow-up round)
+│   │       ├── Event: llmCallStart
+│   │       └── Event: llmCallEnd
+│   ├── Event: nodeTransition "main" → "categorize"
+│   └── Span: nodeExecution "categorize"
+│       └── ...
+```
+
+### SpanContext
+
+A new lightweight object that tracks the current span hierarchy. Stored on `RuntimeContext`.
+
+```typescript
+type SpanContext = {
+  spanId: string;       // nanoid, 12 chars
+  parentSpanId: string | null;
+  spanType: SpanType;
+  startTime: number;    // performance.now()
+};
+
+type SpanType =
+  | "agentRun"
+  | "nodeExecution"
+  | "llmCall"
+  | "toolExecution"
+  | "forkAll"
+  | "forkBranch"
+  | "race"
+  | "raceBranch"
+  | "handlerChain";
+```
+
+`RuntimeContext` gets two new methods:
+
+```typescript
+// Push a new child span, returns the spanId
+startSpan(type: SpanType): string;
+
+// Pop the current span, logs the span end event
+endSpan(): void;
+
+// Read the current span context (for attaching to events)
+get currentSpan(): SpanContext;
+```
+
+The span stack is a simple array on `RuntimeContext`. `startSpan` pushes, `endSpan` pops. The current span's `spanId` is automatically attached to every event sent via `post()`.
+
+### Enhanced StatelogClient API
+
+The existing methods stay as-is for backward compatibility. New methods are added alongside them.
+
+#### New fields on every event
+
+Every event posted via `post()` gains these fields automatically:
+
+```typescript
+{
+  trace_id: string;      // existing
+  project_id: string;    // existing
+  span_id: string;       // NEW — from currentSpan
+  parent_span_id: string | null; // NEW — from currentSpan
+  timestamp: string;     // existing (ISO 8601)
+  data: { ... }          // existing
+}
+```
+
+#### Run-level metadata
+
+A new method sets metadata once per run. This metadata is attached to the root `agentRun` span and can be used for filtering/grouping.
+
+```typescript
+async runMetadata(metadata: {
+  tags?: string[];
+  environment?: string;
+  userId?: string;
+  agentVersion?: string;
+  moduleName?: string;
+  entryNode?: string;
+  custom?: Record<string, string>;
+}): Promise<void>;
+```
+
+Emits event type: `"runMetadata"`.
+
+#### Enhanced promptCompletion
+
+Add token usage and cost to the existing `promptCompletion` method. This is a non-breaking change — the new fields are optional.
+
+```typescript
+async promptCompletion({
+  messages,
+  completion,
+  model,
+  timeTaken,
+  tools,
+  responseFormat,
+  // NEW fields:
+  usage,
+  cost,
+  finishReason,
+  stream,
+}: {
+  messages: any[];
+  completion: any;
+  model?: ModelName | string;
+  timeTaken?: number;
+  tools?: { name: string; description?: string; schema: any }[];
+  responseFormat?: any;
+  // NEW:
+  usage?: {
+    inputTokens: number;
+    outputTokens: number;
+    cachedInputTokens?: number;
+    totalTokens: number;
+  };
+  cost?: {
+    inputCost: number;
+    outputCost: number;
+    totalCost: number;
+  };
+  finishReason?: string;
+  stream?: boolean;
+}): Promise<void>;
+```
+
+#### New event methods
+
+```typescript
+// === Interrupt lifecycle ===
+
+async interruptThrown({
+  interruptId,
+  interruptData,
+  functionName,
+  sourceLocation,
+}: {
+  interruptId: string;
+  interruptData: any;
+  functionName?: string;
+  sourceLocation?: { moduleId: string; line?: number };
+}): Promise<void>;
+
+async handlerDecision({
+  interruptId,
+  handlerIndex,
+  decision,
+  value,
+}: {
+  interruptId: string;
+  handlerIndex: number;
+  decision: "approve" | "reject" | "propagate" | "none";
+  value?: any;
+}): Promise<void>;
+
+async interruptResolved({
+  interruptId,
+  outcome,
+  resolvedBy,
+  timeTaken,
+}: {
+  interruptId: string;
+  outcome: "approved" | "rejected" | "propagated";
+  resolvedBy: "handler" | "user" | "policy" | "ipc";
+  timeTaken?: number;
+}): Promise<void>;
+
+// === Checkpoint lifecycle ===
+
+async checkpointCreated({
+  checkpointId,
+  reason,
+  sourceLocation,
+}: {
+  checkpointId: number;
+  reason: "interrupt" | "explicit" | "failure" | "fork" | "race" | "trace";
+  sourceLocation?: { moduleId: string; scopeName: string; stepPath: string };
+}): Promise<void>;
+
+async checkpointRestored({
+  checkpointId,
+  restoreCount,
+  maxRestores,
+  overrides,
+}: {
+  checkpointId: number;
+  restoreCount: number;
+  maxRestores?: number;
+  overrides?: { args?: boolean; globals?: boolean; locals?: boolean };
+}): Promise<void>;
+
+// === Fork/Race lifecycle ===
+
+async forkStart({
+  forkId,
+  mode,
+  branchCount,
+}: {
+  forkId: string;
+  mode: "all" | "race";
+  branchCount: number;
+}): Promise<void>;
+
+async forkBranchEnd({
+  forkId,
+  branchIndex,
+  outcome,
+  timeTaken,
+}: {
+  forkId: string;
+  branchIndex: number;
+  outcome: "success" | "failure" | "interrupted" | "aborted";
+  timeTaken: number;
+}): Promise<void>;
+
+async forkEnd({
+  forkId,
+  mode,
+  timeTaken,
+  winnerIndex,
+}: {
+  forkId: string;
+  mode: "all" | "race";
+  timeTaken: number;
+  winnerIndex?: number; // race only
+}): Promise<void>;
+
+// === Thread lifecycle ===
+
+async threadCreated({
+  threadId,
+  threadType,
+  parentThreadId,
+}: {
+  threadId: string;
+  threadType: "thread" | "subthread";
+  parentThreadId?: string;
+}): Promise<void>;
+
+// === Structured errors ===
+
+async error({
+  errorType,
+  message,
+  functionName,
+  retryable,
+  sourceLocation,
+}: {
+  errorType: "toolError" | "llmError" | "runtimeError" | "validationError" | "limitExceeded";
+  message: string;
+  functionName?: string;
+  retryable?: boolean;
+  sourceLocation?: { moduleId: string; line?: number };
+}): Promise<void>;
+
+// === Agent lifecycle ===
+
+async agentStart({
+  entryNode,
+  args,
+}: {
+  entryNode: string;
+  args?: any;
+}): Promise<void>;
+
+async agentEnd({
+  entryNode,
+  result,
+  timeTaken,
+  tokenStats,
+}: {
+  entryNode: string;
+  result?: any;
+  timeTaken: number;
+  tokenStats?: {
+    usage: { inputTokens: number; outputTokens: number; totalTokens: number };
+    cost: { inputCost: number; outputCost: number; totalCost: number };
+  };
+}): Promise<void>;
+```
+
+### Configuration changes
+
+The existing `StatelogConfig` is extended:
+
+```typescript
+type StatelogConfig = {
+  host: string;
+  traceId?: string;
+  apiKey: string;
+  projectId: string;
+  debugMode: boolean;
+  // NEW:
+  metadata?: {
+    tags?: string[];
+    environment?: string;
+    userId?: string;
+    agentVersion?: string;
+    custom?: Record<string, string>;
+  };
+};
+```
+
+The `agency.json` config section becomes:
+
+```json
+{
+  "log": {
+    "host": "https://agency-lang.com",
+    "projectId": "my-project",
+    "apiKey": "...",
+    "metadata": {
+      "tags": ["production", "v2"],
+      "environment": "production",
+      "agentVersion": "1.2.0"
+    }
+  }
+}
+```
+
+Users can also set metadata at runtime from TypeScript when calling a node:
+
+```typescript
+const result = await main("input", {
+  metadata: {
+    userId: "user-123",
+    tags: ["premium-user"],
+  },
+});
+```
+
+This merges with the static `agency.json` metadata (runtime overrides win on conflicts).
+
+## Integration points
+
+This section lists every file that needs changes and what events to emit at each site.
+
+### lib/statelogClient.ts
+
+- Add `SpanContext` type and span stack management
+- Add all new event methods listed above
+- Add `span_id` and `parent_span_id` to the `post()` method's envelope
+- Add `metadata` to the constructor config
+
+### lib/runtime/state/context.ts (RuntimeContext)
+
+- Add `startSpan()`, `endSpan()`, `currentSpan` to RuntimeContext
+- Initialize span stack with a root `agentRun` span on context creation
+- Copy `currentSpan` reference when creating child execution contexts
+
+### lib/runtime/node.ts
+
+- **Agent start**: In `runNode()`, after context setup (~line 155), call `ctx.statelogClient.agentStart()` and `ctx.statelogClient.runMetadata()`.
+- **Agent end**: At the end of `runNode()`, call `ctx.statelogClient.agentEnd()` with final `tokenStats`.
+- **Node execution span**: `ctx.startSpan("nodeExecution")` at entry, `ctx.endSpan()` at exit.
+- **Restore event**: In the `RestoreSignal` catch block (~line 202), call `ctx.statelogClient.checkpointRestored()`.
+
+### lib/runtime/prompt.ts
+
+- **LLM call span**: `ctx.startSpan("llmCall")` before `_runPrompt()`, `ctx.endSpan()` after the full prompt loop completes.
+- **Token usage and cost**: Add `usage: completion.usage` and `cost: completion.cost` and `finishReason` to the existing `promptCompletion()` call at line 120. The data is already available from the `completion` object.
+- **Tool execution span**: `ctx.startSpan("toolExecution")` before `handler.invoke()` at line 447, `ctx.endSpan()` after.
+- **Tool errors**: Call `ctx.statelogClient.error()` in the catch block at line 455 and in the `isFailure` path at line 475. Set `errorType: "toolError"`, include `retryable` status.
+- **Interrupt from tool**: In the `hasInterrupts` block at line 527, call `ctx.statelogClient.interruptThrown()` for each interrupt.
+- **Checkpoint from tool interrupts**: After `ctx.checkpoints.create()` at line 587, call `ctx.statelogClient.checkpointCreated()` with `reason: "interrupt"`.
+
+### lib/runtime/interrupts.ts
+
+- **Handler decisions**: In the `interruptWithHandlers()` loop (lines 137–192), after each handler returns, call `ctx.statelogClient.handlerDecision()` with the handler index and decision.
+- **Interrupt resolved**: At each exit point of `interruptWithHandlers()` (rejection at line 164, approval at line 180, propagation at lines 187/192), call `ctx.statelogClient.interruptResolved()`.
+
+`interruptWithHandlers` currently takes `ctx` as a parameter, so `statelogClient` is already accessible.
+
+### lib/runtime/runner.ts
+
+- **Fork start**: In `fork()` at line 548, call `ctx.statelogClient.forkStart()` with the mode and branch count.
+- **Fork span**: `ctx.startSpan("forkAll")` or `ctx.startSpan("race")` in `fork()`.
+- **Branch spans**: In `runForkAll()` and `runRace()`, wrap each branch's execution in `ctx.startSpan("forkBranch")` / `ctx.endSpan()`.
+- **Branch end events**: After each branch in `runForkAll()` settles (line ~640), call `ctx.statelogClient.forkBranchEnd()`.
+- **Fork end**: After `runForkAll()` or `runRace()` completes, call `ctx.statelogClient.forkEnd()`.
+- **Race winner**: In `runRace()`, include `winnerIndex` in the `forkEnd` event.
+- **Checkpoint from fork**: After `ctx.checkpoints.create()` at lines 659/752/815, call `ctx.statelogClient.checkpointCreated()` with `reason: "fork"` or `reason: "race"`.
+
+### lib/runtime/state/threadStore.ts
+
+- **Thread creation**: In `create()` and `createSubthread()`, call `ctx.statelogClient.threadCreated()`.
+- This requires threading `statelogClient` into `ThreadStore`. The simplest approach: `ThreadStore` already lives on `RuntimeContext`, so add a method `ThreadStore.setStatelogClient(client)` that's called once during context setup. The `create` and `createSubthread` methods then fire the event if a client is set.
+
+### lib/runtime/state/checkpointStore.ts
+
+- **Checkpoint created**: After the checkpoint is stored in `create()` at line 241, call `ctx.statelogClient.checkpointCreated()`.
+- This requires passing `statelogClient` into the checkpoint store, or having the caller (which already has `ctx`) emit the event. Recommendation: have the caller emit it, since all callers already have `ctx`. This avoids changing `CheckpointStore`'s constructor.
+
+### lib/runtime/ipc.ts
+
+- **Limit exceeded error**: In `makeLimitFailure()` at line 74, call `ctx.statelogClient.error()` with `errorType: "limitExceeded"`.
+- **IPC interrupt resolution**: After the parent process receives and resolves an interrupt (lines 310–325), call `ctx.statelogClient.interruptResolved()` with `resolvedBy: "ipc"`.
+
+### lib/simplemachine/graph.ts
+
+- **Span wrapping**: Wrap the existing `enterNode`/`exitNode` calls with `startSpan("nodeExecution")` / `endSpan()` so they get span IDs. The SimpleMachine already has access to `statelogClient` — it just needs a reference to the span stack (or a thin wrapper).
+
+### lib/runtime/schema.ts
+
+- **Validation errors**: In the failure paths at lines 21 and 42, call `ctx.statelogClient.error()` with `errorType: "validationError"`.
+- This requires `statelogClient` to be accessible. Since schema validation is called from generated code, the simplest approach is to have the generated code's caller emit the event. Alternatively, pass `statelogClient` via a module-level setter.
+
+## OTel alignment
+
+The new event types are designed to map naturally to OTel GenAI semantic conventions. The future `@agency-lang/otel` adapter would map:
+
+| StateLog event | OTel span/attribute |
+|---|---|
+| `agentStart` / `agentEnd` | `invoke_agent` span |
+| `nodeExecution` span | Child span of `invoke_agent` |
+| `llmCall` span | `gen_ai.client` span, `gen_ai.request.model` attribute |
+| `promptCompletion.usage` | `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens` |
+| `promptCompletion.cost` | `gen_ai.client.token.usage` metric |
+| `promptCompletion.finishReason` | `gen_ai.response.finish_reasons` |
+| `toolExecution` span | `execute_tool` span |
+| `error` events | Span status ERROR + exception event |
+| `interruptThrown` / `handlerDecision` / `interruptResolved` | Custom span events with `agency.*` attribute prefix |
+| `forkAll` / `race` spans | Child spans (parallel) |
+| `threadCreated` | Custom event with `agency.thread.*` attributes |
+| `runMetadata.tags` | Resource attributes |
+
+Agency-specific concepts (interrupts, handlers, checkpoints, fork/race) use the `agency.*` attribute namespace. Generic backends will display them as raw key-value pairs; an Agency-aware UI can render them richly.
+
+## Event type summary
+
+For reference, here is the complete list of event types after enhancement:
+
+| Event type | Status | Source file |
+|---|---|---|
+| `graph` | Existing | `simplemachine/graph.ts` |
+| `enterNode` | Existing | `simplemachine/graph.ts` |
+| `exitNode` | Existing | `simplemachine/graph.ts` |
+| `beforeHook` | Existing | `simplemachine/graph.ts` |
+| `afterHook` | Existing | `simplemachine/graph.ts` |
+| `followEdge` | Existing | `simplemachine/graph.ts` |
+| `promptCompletion` | Enhanced (add usage, cost, finishReason) | `runtime/prompt.ts` |
+| `toolCall` | Existing | `runtime/prompt.ts` |
+| `debug` | Existing | various |
+| `diff` | Existing (unused) | none |
+| `runMetadata` | **New** | `runtime/node.ts` |
+| `agentStart` | **New** | `runtime/node.ts` |
+| `agentEnd` | **New** | `runtime/node.ts` |
+| `interruptThrown` | **New** | `runtime/prompt.ts`, `runtime/interrupts.ts` |
+| `handlerDecision` | **New** | `runtime/interrupts.ts` |
+| `interruptResolved` | **New** | `runtime/interrupts.ts`, `runtime/ipc.ts` |
+| `checkpointCreated` | **New** | callers of `checkpointStore.create()` |
+| `checkpointRestored` | **New** | `runtime/node.ts` |
+| `forkStart` | **New** | `runtime/runner.ts` |
+| `forkBranchEnd` | **New** | `runtime/runner.ts` |
+| `forkEnd` | **New** | `runtime/runner.ts` |
+| `threadCreated` | **New** | `runtime/state/threadStore.ts` |
+| `error` | **New** | `runtime/prompt.ts`, `runtime/ipc.ts`, `runtime/schema.ts` |
+
+## Wire format
+
+After enhancement, a typical event on the wire looks like:
+
+```json
+{
+  "trace_id": "abc123",
+  "project_id": "my-project",
+  "span_id": "sp_xk9m2n",
+  "parent_span_id": "sp_root1",
+  "data": {
+    "type": "promptCompletion",
+    "timestamp": "2026-05-15T14:30:00.000Z",
+    "messages": [...],
+    "completion": {...},
+    "model": "gpt-4o",
+    "timeTaken": 1234,
+    "tools": [...],
+    "responseFormat": {...},
+    "usage": {
+      "inputTokens": 1500,
+      "outputTokens": 300,
+      "cachedInputTokens": 200,
+      "totalTokens": 1800
+    },
+    "cost": {
+      "inputCost": 0.0015,
+      "outputCost": 0.006,
+      "totalCost": 0.0075
+    },
+    "finishReason": "stop",
+    "stream": false
+  }
+}
+```
+
+And a new interrupt event:
+
+```json
+{
+  "trace_id": "abc123",
+  "project_id": "my-project",
+  "span_id": "sp_tool1",
+  "parent_span_id": "sp_llm1",
+  "data": {
+    "type": "interruptThrown",
+    "timestamp": "2026-05-15T14:30:01.000Z",
+    "interruptId": "int_abc",
+    "interruptData": "Are you sure you want to delete 1000000 emails?",
+    "functionName": "deleteEmail"
+  }
+}
+```
+
+## Backward compatibility
+
+- All new fields on existing events (usage, cost, finishReason on `promptCompletion`) are optional. Existing server implementations that don't expect them will ignore them.
+- The new `span_id` and `parent_span_id` fields in the envelope are additive. Existing servers will ignore unknown fields.
+- The new event types (`interruptThrown`, `handlerDecision`, etc.) are new `type` values in the `data` object. Existing servers that switch on `type` will hit their default/unknown case.
+- The `statelogClient.diff()` method is unused. It can be left as-is or removed; this spec does not change it.
+
+## Testing strategy
+
+### Unit tests
+
+- `statelogClient.test.ts`: Test each new method emits the correct JSON structure. Test span ID propagation. Test that events are no-ops when host is unset.
+- `spanContext.test.ts`: Test span push/pop, parent ID propagation, span type tracking.
+
+### Integration tests
+
+- Create a small Agency program that exercises: LLM call, tool call, interrupt, handler, checkpoint, restore, fork, thread.
+- Run it with `host: "stdout"` and capture the JSON output.
+- Assert the event stream contains all expected event types in the correct order, with correct span nesting (parent IDs match), correct token/cost data, and correct interrupt lifecycle events.
+
+### Fixture tests
+
+- Update existing test fixtures that snapshot StateLog output (if any) to include the new fields.
+- The `promptCompletion` events in existing tests will gain `usage`, `cost`, and `finishReason` fields with `undefined` values (since test LLM clients may not return them). Ensure these are handled gracefully.

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -3613,6 +3613,9 @@ export class TypeScriptBuilder {
       debugMode: ts.bool(cfg.log?.debugMode || false),
       observability: ts.bool(cfg.observability || false),
     };
+    if (cfg.log?.logFile) {
+      statelogFields.logFile = ts.str(cfg.log.logFile);
+    }
     if (cfg.log?.metadata) {
       const metaFields: Record<string, TsNode> = {};
       if (cfg.log.metadata.tags) {

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -3611,6 +3611,7 @@ export class TypeScriptBuilder {
         : ts.binOp(ts.env("STATELOG_API_KEY"), "||", ts.str("")),
       projectId: ts.str(cfg.log?.projectId || ""),
       debugMode: ts.bool(cfg.log?.debugMode || false),
+      observability: ts.bool(cfg.observability || false),
     });
 
     const smoltalkDefaults = ts.obj({

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -3604,7 +3604,7 @@ export class TypeScriptBuilder {
   private generateImports(): string {
     const cfg = this.agencyConfig;
 
-    const statelogConfig = ts.obj({
+    const statelogFields: Record<string, TsNode> = {
       host: ts.str(cfg.log?.host || ""),
       apiKey: cfg.log?.apiKey
         ? ts.str(cfg.log.apiKey)
@@ -3612,7 +3612,28 @@ export class TypeScriptBuilder {
       projectId: ts.str(cfg.log?.projectId || ""),
       debugMode: ts.bool(cfg.log?.debugMode || false),
       observability: ts.bool(cfg.observability || false),
-    });
+    };
+    if (cfg.log?.metadata) {
+      const metaFields: Record<string, TsNode> = {};
+      if (cfg.log.metadata.tags) {
+        metaFields.tags = ts.raw(JSON.stringify(cfg.log.metadata.tags));
+      }
+      if (cfg.log.metadata.environment) {
+        metaFields.environment = ts.str(cfg.log.metadata.environment);
+      }
+      if (cfg.log.metadata.agentVersion) {
+        metaFields.agentVersion = ts.str(cfg.log.metadata.agentVersion);
+      }
+      if (cfg.log.metadata.custom) {
+        const customFields: Record<string, TsNode> = {};
+        for (const [k, v] of Object.entries(cfg.log.metadata.custom)) {
+          customFields[k] = ts.str(v);
+        }
+        metaFields.custom = ts.obj(customFields);
+      }
+      statelogFields.metadata = ts.obj(metaFields);
+    }
+    const statelogConfig = ts.obj(statelogFields);
 
     const smoltalkDefaults = ts.obj({
       openAiApiKey: cfg.client?.openAiApiKey

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -3621,15 +3621,14 @@ export class TypeScriptBuilder {
       if (cfg.log.metadata.environment) {
         metaFields.environment = ts.str(cfg.log.metadata.environment);
       }
+      if (cfg.log.metadata.userId) {
+        metaFields.userId = ts.str(cfg.log.metadata.userId);
+      }
       if (cfg.log.metadata.agentVersion) {
         metaFields.agentVersion = ts.str(cfg.log.metadata.agentVersion);
       }
       if (cfg.log.metadata.custom) {
-        const customFields: Record<string, TsNode> = {};
-        for (const [k, v] of Object.entries(cfg.log.metadata.custom)) {
-          customFields[k] = ts.str(v);
-        }
-        metaFields.custom = ts.obj(customFields);
+        metaFields.custom = ts.raw(JSON.stringify(cfg.log.metadata.custom));
       }
       statelogFields.metadata = ts.obj(metaFields);
     }

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -70,6 +70,13 @@ export interface AgencyConfig {
    */
   maxToolCallRounds?: number;
 
+  /**
+   * Enable observability. When false (default), the StatelogClient is a
+   * complete no-op — no events are emitted and no network calls are made.
+   * Set to true to activate structured event logging via the `log` config.
+   */
+  observability?: boolean;
+
   /** Statelog config */
   log?: Partial<{
     host: string;
@@ -227,6 +234,7 @@ export const AgencyConfigSchema = z
     disallowedFetchDomains: z.array(z.string()),
     tarsecTraceHost: z.string(),
     maxToolCallRounds: z.number(),
+    observability: z.boolean(),
     log: z
       .object({
         host: z.string(),

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -86,6 +86,7 @@ export interface AgencyConfig {
     metadata: {
       tags?: string[];
       environment?: string;
+      userId?: string;
       agentVersion?: string;
       custom?: Record<string, string>;
     };
@@ -251,6 +252,7 @@ export const AgencyConfigSchema = z
           .object({
             tags: z.array(z.string()),
             environment: z.string(),
+            userId: z.string(),
             agentVersion: z.string(),
             custom: z.record(z.string(), z.string()),
           })

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -83,6 +83,12 @@ export interface AgencyConfig {
     projectId: string;
     debugMode: boolean;
     apiKey: string;
+    metadata: {
+      tags?: string[];
+      environment?: string;
+      agentVersion?: string;
+      custom?: Record<string, string>;
+    };
   }>;
 
   /** Smoltalk client config */
@@ -241,6 +247,14 @@ export const AgencyConfigSchema = z
         projectId: z.string(),
         debugMode: z.boolean(),
         apiKey: z.string(),
+        metadata: z
+          .object({
+            tags: z.array(z.string()),
+            environment: z.string(),
+            agentVersion: z.string(),
+            custom: z.record(z.string(), z.string()),
+          })
+          .partial(),
       })
       .partial(),
     client: z

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -83,6 +83,12 @@ export interface AgencyConfig {
     projectId: string;
     debugMode: boolean;
     apiKey: string;
+    /**
+     * Local file sink. When set, each statelog event is appended as a
+     * single JSON object per line. Intended for local development and
+     * tests. Can be combined with `host` — both sinks receive events.
+     */
+    logFile: string;
     metadata: {
       tags?: string[];
       environment?: string;
@@ -248,6 +254,7 @@ export const AgencyConfigSchema = z
         projectId: z.string(),
         debugMode: z.boolean(),
         apiKey: z.string(),
+        logFile: z.string(),
         metadata: z
           .object({
             tags: z.array(z.string()),

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -224,12 +224,12 @@ export async function interruptWithHandlers<T = any>(
 
   // Normal mode (non-IPC)
   if (hasPropagation) {
-    ctx.statelogClient.interruptResolved({
-      interruptId,
-      outcome: "propagated",
-      resolvedBy: "handler",
+    const intr = interrupt({ kind, message, data, origin, runId: ctx.getRunId(), interruptId });
+    ctx.statelogClient.interruptThrown({
+      interruptId: intr.interruptId,
+      interruptData: data,
     });
-    return [interrupt({ kind, message, data, origin, runId: ctx.getRunId(), interruptId })];
+    return [intr];
   }
   if (hasApproval) {
     ctx.statelogClient.interruptResolved({
@@ -240,12 +240,12 @@ export async function interruptWithHandlers<T = any>(
     return { type: "approve", value: approvedValue };
   }
   // No handler responded — propagate to user
-  ctx.statelogClient.interruptResolved({
-    interruptId,
-    outcome: "propagated",
-    resolvedBy: "user",
+  const intr = interrupt({ kind, message, data, origin, runId: ctx.getRunId(), interruptId });
+  ctx.statelogClient.interruptThrown({
+    interruptId: intr.interruptId,
+    interruptData: data,
   });
-  return [interrupt({ kind, message, data, origin, runId: ctx.getRunId(), interruptId })];
+  return [intr];
 }
 
 export async function respondToInterrupts(args: {
@@ -290,6 +290,10 @@ export async function respondToInterrupts(args: {
   }
 
   const execCtx = await ctx.createExecutionContext(interrupt.runId);
+  execCtx.statelogClient.checkpointRestored({
+    checkpointId: checkpoint.id,
+    restoreCount: 1,
+  });
   execCtx.restoreState(checkpoint);
 
   execCtx.setInterruptResponses(responseMap);
@@ -303,6 +307,7 @@ export async function respondToInterrupts(args: {
     execCtx.debuggerState = metadata.debugger;
   }
 
+  execCtx.statelogClient.startSpan("agentRun");
   let nodeName = checkpoint.nodeId;
   try {
     while (true) {
@@ -331,6 +336,10 @@ export async function respondToInterrupts(args: {
       } catch (e) {
         if (e instanceof RestoreSignal) {
           const cp = e.checkpoint;
+          execCtx.statelogClient.checkpointRestored({
+            checkpointId: cp.id,
+            restoreCount: execCtx._restoreCount,
+          });
           execCtx.restoreState(cp);
           nodeName = cp.nodeId;
           execCtx.stateStack.nodesTraversed = [cp.nodeId];
@@ -340,6 +349,7 @@ export async function respondToInterrupts(args: {
       }
     }
   } finally {
+    execCtx.statelogClient.endSpan(); // end agentRun span
     execCtx.cleanup();
   }
 }

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -125,6 +125,68 @@ export function isApproved(obj: any): obj is Approved {
   return obj && obj.type === "approve";
 }
 
+type HandlerChainOutcome =
+  | { kind: "rejected"; value: any }
+  | { kind: "approved"; value: any }
+  | { kind: "propagated" }
+  | { kind: "noResponse" };
+
+/** Run all registered handlers for an interrupt (top of the stack first).
+ * Emits handlerDecision/interruptResolved events along the way and returns
+ * a summary outcome the caller uses to decide whether to propagate. */
+async function runHandlerChain(
+  ctx: RuntimeContext<any>,
+  stack: StateStack | undefined,
+  interruptId: string,
+  interruptObj: { kind: string; message: string; data: any; origin: string },
+): Promise<HandlerChainOutcome> {
+  let approvedValue: any = undefined;
+  let hasApproval = false;
+  let hasPropagation = false;
+  ctx.statelogClient.startSpan("handlerChain");
+  try {
+    for (let i = (ctx.handlers ?? []).length - 1; i >= 0; i--) {
+      if (ctx.isCancelled(stack)) throw new AgencyCancelledError();
+      // Treat handler execution as atomic for the debugger — same as LLM tool calls.
+      ctx.enterToolCall();
+      let result: any;
+      try {
+        result = await ctx.handlers[i](interruptObj);
+      } finally {
+        ctx.exitToolCall();
+      }
+      if (result === undefined) {
+        ctx.statelogClient.handlerDecision({ interruptId, handlerIndex: i, decision: "none" });
+        continue;
+      }
+      if (result.type === "reject") {
+        ctx.statelogClient.handlerDecision({ interruptId, handlerIndex: i, decision: "reject", value: result.value });
+        ctx.statelogClient.interruptResolved({ interruptId, outcome: "rejected", resolvedBy: "handler" });
+        return { kind: "rejected", value: result.value };
+      }
+      if (result.type === "propagate") {
+        ctx.statelogClient.handlerDecision({ interruptId, handlerIndex: i, decision: "propagate" });
+        hasPropagation = true;
+        continue;
+      }
+      if (result.type === "approve") {
+        ctx.statelogClient.handlerDecision({ interruptId, handlerIndex: i, decision: "approve", value: result.value });
+        hasApproval = true;
+        approvedValue = result.value;
+        continue;
+      }
+      throw new Error(
+        `Handler returned invalid result type: ${JSON.stringify(result)}. Expected "approve", "reject", "propagate", or undefined.`,
+      );
+    }
+  } finally {
+    ctx.statelogClient.endSpan(); // end handlerChain span
+  }
+  if (hasPropagation) return { kind: "propagated" };
+  if (hasApproval) return { kind: "approved", value: approvedValue };
+  return { kind: "noResponse" };
+}
+
 export async function interruptWithHandlers<T = any>(
   kind: string,
   message: string,
@@ -134,72 +196,15 @@ export async function interruptWithHandlers<T = any>(
   stack?: StateStack,
 ): Promise<Interrupt<T>[] | Approved | Rejected> {
   const interruptObj = { kind, message, data, origin };
-
   const interruptId = nanoid();
+  const outcome = await runHandlerChain(ctx, stack, interruptId, interruptObj);
 
-  let approvedValue: any = undefined;
-  let hasApproval = false;
-  let hasPropagation = false;
-  for (let i = (ctx.handlers ?? []).length - 1; i >= 0; i--) {
-    if (ctx.isCancelled(stack)) {
-      throw new AgencyCancelledError();
-    }
-    // Enter tool call context so that the debugger treats handler execution
-    // as atomic — debug hooks won't fire inside the handler body, just like
-    // they don't fire inside LLM tool calls.
-    ctx.enterToolCall();
-    let result: any;
-    try {
-      result = await ctx.handlers[i](interruptObj);
-    } finally {
-      ctx.exitToolCall();
-    }
-    if (result === undefined) {
-      ctx.statelogClient.handlerDecision({
-        interruptId,
-        handlerIndex: i,
-        decision: "none",
-      });
-      continue;
-    }
-    if (result.type === "reject") {
-      ctx.statelogClient.handlerDecision({
-        interruptId,
-        handlerIndex: i,
-        decision: "reject",
-        value: result.value,
-      });
-      ctx.statelogClient.interruptResolved({
-        interruptId,
-        outcome: "rejected",
-        resolvedBy: "handler",
-      });
-      return { type: "reject", value: result.value };
-    }
-    if (result.type === "propagate") {
-      ctx.statelogClient.handlerDecision({
-        interruptId,
-        handlerIndex: i,
-        decision: "propagate",
-      });
-      hasPropagation = true;
-      continue;
-    }
-    if (result.type === "approve") {
-      ctx.statelogClient.handlerDecision({
-        interruptId,
-        handlerIndex: i,
-        decision: "approve",
-        value: result.value,
-      });
-      hasApproval = true;
-      approvedValue = result.value;
-      continue;
-    }
-    throw new Error(
-      `Handler returned invalid result type: ${JSON.stringify(result)}. Expected "approve", "reject", "propagate", or undefined.`,
-    );
+  if (outcome.kind === "rejected") {
+    return { type: "reject", value: outcome.value };
   }
+  const hasPropagation = outcome.kind === "propagated";
+  const hasApproval = outcome.kind === "approved";
+  const approvedValue = hasApproval ? outcome.value : undefined;
   // IPC mode: always consult parent (unless local handler rejected — that already returned above)
   if (isIpcMode()) {
     const parentDecision = await sendInterruptToParent(
@@ -253,6 +258,76 @@ export async function interruptWithHandlers<T = any>(
   return [intr];
 }
 
+/** Build the ID-keyed response map for `respondToInterrupts`. Extracted
+ * to keep the main function under the structural lint limit. */
+function buildResponseMap(
+  interrupts: Interrupt[],
+  responses: InterruptResponse[],
+): Record<string, { response: InterruptResponse }> {
+  if (responses.length !== interrupts.length) {
+    throw new Error(
+      `respondToInterrupts: expected ${interrupts.length} responses but got ${responses.length}`,
+    );
+  }
+  const responseMap: Record<string, { response: InterruptResponse }> = {};
+  for (let i = 0; i < interrupts.length; i++) {
+    responseMap[interrupts[i].interruptId] = {
+      response: deepClone(responses[i]),
+    };
+  }
+  return responseMap;
+}
+
+/** Inner resume loop: runs the graph and reacts to RestoreSignal until the
+ * agent either returns or yields another batch of interrupts. */
+async function runResumeLoop(
+  execCtx: RuntimeContext<GraphState>,
+  startNodeName: string,
+  agentStartTime: number,
+): Promise<any> {
+  let nodeName = startNodeName;
+  while (true) {
+    try {
+      const result = await execCtx.graph.run(
+        nodeName,
+        { data: {}, ctx: execCtx, isResume: true },
+        {
+          onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id),
+          statelogClient: execCtx.statelogClient,
+        },
+      );
+      await execCtx.pendingPromises.awaitAll();
+      const returnObject = createReturnObject({ result, globals: execCtx.globals });
+      if (hasInterrupts(returnObject.data)) {
+        await execCtx.pauseTraceWriter();
+      } else {
+        execCtx.statelogClient.agentEnd({
+          entryNode: nodeName,
+          result: returnObject.data,
+          timeTaken: performance.now() - agentStartTime,
+          tokenStats: returnObject.tokens,
+        });
+        await execCtx.closeTraceWriter();
+      }
+      return returnObject;
+    } catch (e) {
+      if (e instanceof RestoreSignal) {
+        const cp = e.checkpoint;
+        execCtx._restoreCount++;
+        execCtx.statelogClient.checkpointRestored({
+          checkpointId: cp.id,
+          restoreCount: execCtx._restoreCount,
+        });
+        execCtx.restoreState(cp);
+        nodeName = cp.nodeId;
+        execCtx.stateStack.nodesTraversed = [cp.nodeId];
+        continue;
+      }
+      throw e;
+    }
+  }
+}
+
 export async function respondToInterrupts(args: {
   ctx: RuntimeContext<GraphState>;
   interrupts: Interrupt[];
@@ -261,20 +336,7 @@ export async function respondToInterrupts(args: {
   metadata?: Record<string, any>;
 }): Promise<any> {
   const { ctx, interrupts, responses, metadata = {} } = args;
-
-  if (responses.length !== interrupts.length) {
-    throw new Error(
-      `respondToInterrupts: expected ${interrupts.length} responses but got ${responses.length}`,
-    );
-  }
-
-  // Build ID-keyed response map
-  const responseMap: Record<string, { response: InterruptResponse }> = {};
-  for (let i = 0; i < interrupts.length; i++) {
-    responseMap[interrupts[i].interruptId] = {
-      response: deepClone(responses[i]),
-    };
-  }
+  const responseMap = buildResponseMap(interrupts, responses);
 
   // All interrupts share the same checkpoint — grab from first
   const interrupt = deepClone(interrupts[0]);
@@ -288,71 +350,34 @@ export async function respondToInterrupts(args: {
       "No checkpoint found for interrupt. The interrupt may have been created with an older format.",
     );
   }
-
-
-  if (args.overrides) {
-    applyOverrides(checkpoint, args.overrides);
-  }
+  if (args.overrides) applyOverrides(checkpoint, args.overrides);
 
   const execCtx = await ctx.createExecutionContext(interrupt.runId);
+  // This is the first restore on this execCtx — record it as such.
+  execCtx._restoreCount++;
   execCtx.statelogClient.checkpointRestored({
     checkpointId: checkpoint.id,
-    restoreCount: 1,
+    restoreCount: execCtx._restoreCount,
   });
   execCtx.restoreState(checkpoint);
-
   execCtx.setInterruptResponses(responseMap);
-
   execCtx.installRegisteredCallbacks(ctx);
-  if (metadata.callbacks) {
-    Object.assign(execCtx.callbacks, metadata.callbacks);
-  }
-
-  if (metadata.debugger) {
-    execCtx.debuggerState = metadata.debugger;
-  }
+  if (metadata.callbacks) Object.assign(execCtx.callbacks, metadata.callbacks);
+  if (metadata.debugger) execCtx.debuggerState = metadata.debugger;
 
   execCtx.statelogClient.startSpan("agentRun");
-  let nodeName = checkpoint.nodeId;
+  execCtx.statelogClient.agentStart({ entryNode: checkpoint.nodeId, args: {} });
+  const agentStartTime = performance.now();
   try {
-    while (true) {
-      try {
-        const result = await execCtx.graph.run(
-          nodeName,
-          {
-            data: {},
-            ctx: execCtx,
-            isResume: true,
-          },
-          { onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id), statelogClient: execCtx.statelogClient },
-        );
-        await execCtx.pendingPromises.awaitAll();
-        const returnObject = createReturnObject({
-          result,
-          globals: execCtx.globals,
-        });
-
-        if (hasInterrupts(returnObject.data)) {
-          await execCtx.pauseTraceWriter();
-        } else {
-          await execCtx.closeTraceWriter();
-        }
-        return returnObject;
-      } catch (e) {
-        if (e instanceof RestoreSignal) {
-          const cp = e.checkpoint;
-          execCtx.statelogClient.checkpointRestored({
-            checkpointId: cp.id,
-            restoreCount: execCtx._restoreCount,
-          });
-          execCtx.restoreState(cp);
-          nodeName = cp.nodeId;
-          execCtx.stateStack.nodesTraversed = [cp.nodeId];
-          continue;
-        }
-        throw e;
-      }
-    }
+    return await runResumeLoop(execCtx, checkpoint.nodeId, agentStartTime);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    execCtx.statelogClient.error({ errorType: "runtimeError", message: errorMessage });
+    execCtx.statelogClient.agentEnd({
+      entryNode: checkpoint.nodeId,
+      timeTaken: performance.now() - agentStartTime,
+    });
+    throw error;
   } finally {
     execCtx.statelogClient.endSpan(); // end agentRun span
     execCtx.cleanup();

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -143,7 +143,7 @@ async function runHandlerChain(
   let approvedValue: any = undefined;
   let hasApproval = false;
   let hasPropagation = false;
-  ctx.statelogClient.startSpan("handlerChain");
+  const chainSpanId = ctx.statelogClient.startSpan("handlerChain");
   try {
     for (let i = (ctx.handlers ?? []).length - 1; i >= 0; i--) {
       if (ctx.isCancelled(stack)) throw new AgencyCancelledError();
@@ -180,7 +180,7 @@ async function runHandlerChain(
       );
     }
   } finally {
-    ctx.statelogClient.endSpan(); // end handlerChain span
+    ctx.statelogClient.endSpan(chainSpanId); // end handlerChain span
   }
   if (hasPropagation) return { kind: "propagated" };
   if (hasApproval) return { kind: "approved", value: approvedValue };
@@ -359,13 +359,27 @@ export async function respondToInterrupts(args: {
     checkpointId: checkpoint.id,
     restoreCount: execCtx._restoreCount,
   });
+  // Each user response resolves a previously-thrown interrupt. Emit the
+  // lifecycle event so dashboards can pair every interruptThrown with a
+  // terminal interruptResolved.
+  for (let i = 0; i < interrupts.length; i++) {
+    const intr = interrupts[i];
+    const resp = responses[i];
+    const outcome =
+      resp.type === "approve" ? "approved" : ("rejected" as const);
+    execCtx.statelogClient.interruptResolved({
+      interruptId: intr.interruptId,
+      outcome,
+      resolvedBy: "user",
+    });
+  }
   execCtx.restoreState(checkpoint);
   execCtx.setInterruptResponses(responseMap);
   execCtx.installRegisteredCallbacks(ctx);
   if (metadata.callbacks) Object.assign(execCtx.callbacks, metadata.callbacks);
   if (metadata.debugger) execCtx.debuggerState = metadata.debugger;
 
-  execCtx.statelogClient.startSpan("agentRun");
+  const agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
   execCtx.statelogClient.agentStart({ entryNode: checkpoint.nodeId, args: {} });
   const agentStartTime = performance.now();
   try {
@@ -379,7 +393,7 @@ export async function respondToInterrupts(args: {
     });
     throw error;
   } finally {
-    execCtx.statelogClient.endSpan(); // end agentRun span
+    execCtx.statelogClient.endSpan(agentRunSpanId); // end agentRun span
     execCtx.cleanup();
   }
 }

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -72,13 +72,14 @@ export function interrupt<T = any>(opts: {
   data: T;
   origin: string;
   runId: string;
+  interruptId?: string;
 }): Interrupt<T> {
   return {
     type: "interrupt",
     kind: opts.kind,
     message: opts.message,
     origin: opts.origin,
-    interruptId: nanoid(),
+    interruptId: opts.interruptId || nanoid(),
     data: opts.data,
     runId: opts.runId,
   };
@@ -228,7 +229,7 @@ export async function interruptWithHandlers<T = any>(
       outcome: "propagated",
       resolvedBy: "handler",
     });
-    return [interrupt({ kind, message, data, origin, runId: ctx.getRunId() })];
+    return [interrupt({ kind, message, data, origin, runId: ctx.getRunId(), interruptId })];
   }
   if (hasApproval) {
     ctx.statelogClient.interruptResolved({
@@ -244,7 +245,7 @@ export async function interruptWithHandlers<T = any>(
     outcome: "propagated",
     resolvedBy: "user",
   });
-  return [interrupt({ kind, message, data, origin, runId: ctx.getRunId() })];
+  return [interrupt({ kind, message, data, origin, runId: ctx.getRunId(), interruptId })];
 }
 
 export async function respondToInterrupts(args: {

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -134,6 +134,8 @@ export async function interruptWithHandlers<T = any>(
 ): Promise<Interrupt<T>[] | Approved | Rejected> {
   const interruptObj = { kind, message, data, origin };
 
+  const interruptId = nanoid();
+
   let approvedValue: any = undefined;
   let hasApproval = false;
   let hasPropagation = false;
@@ -152,16 +154,43 @@ export async function interruptWithHandlers<T = any>(
       ctx.exitToolCall();
     }
     if (result === undefined) {
+      ctx.statelogClient.handlerDecision({
+        interruptId,
+        handlerIndex: i,
+        decision: "none",
+      });
       continue;
     }
     if (result.type === "reject") {
+      ctx.statelogClient.handlerDecision({
+        interruptId,
+        handlerIndex: i,
+        decision: "reject",
+        value: result.value,
+      });
+      ctx.statelogClient.interruptResolved({
+        interruptId,
+        outcome: "rejected",
+        resolvedBy: "handler",
+      });
       return { type: "reject", value: result.value };
     }
     if (result.type === "propagate") {
+      ctx.statelogClient.handlerDecision({
+        interruptId,
+        handlerIndex: i,
+        decision: "propagate",
+      });
       hasPropagation = true;
       continue;
     }
     if (result.type === "approve") {
+      ctx.statelogClient.handlerDecision({
+        interruptId,
+        handlerIndex: i,
+        decision: "approve",
+        value: result.value,
+      });
       hasApproval = true;
       approvedValue = result.value;
       continue;
@@ -177,18 +206,44 @@ export async function interruptWithHandlers<T = any>(
       { propagated: hasPropagation },
     );
     if (parentDecision.type === "approve") {
+      ctx.statelogClient.interruptResolved({
+        interruptId,
+        outcome: "approved",
+        resolvedBy: "ipc",
+      });
       return { type: "approve", value: parentDecision.value ?? approvedValue };
     }
+    ctx.statelogClient.interruptResolved({
+      interruptId,
+      outcome: "rejected",
+      resolvedBy: "ipc",
+    });
     return { type: "reject", value: parentDecision.value };
   }
 
   // Normal mode (non-IPC)
   if (hasPropagation) {
+    ctx.statelogClient.interruptResolved({
+      interruptId,
+      outcome: "propagated",
+      resolvedBy: "handler",
+    });
     return [interrupt({ kind, message, data, origin, runId: ctx.getRunId() })];
   }
   if (hasApproval) {
+    ctx.statelogClient.interruptResolved({
+      interruptId,
+      outcome: "approved",
+      resolvedBy: "handler",
+    });
     return { type: "approve", value: approvedValue };
   }
+  // No handler responded — propagate to user
+  ctx.statelogClient.interruptResolved({
+    interruptId,
+    outcome: "propagated",
+    resolvedBy: "user",
+  });
   return [interrupt({ kind, message, data, origin, runId: ctx.getRunId() })];
 }
 

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -223,6 +223,11 @@ export async function interruptWithHandlers<T = any>(
   }
 
   // Normal mode (non-IPC)
+  // Note: checkpointCreated for these interrupts is emitted by the generated
+  // interrupt template code, not here. This is a known gap — non-tool
+  // interrupts will have interruptThrown but no matching checkpointCreated
+  // from the runtime. A future improvement could add checkpoint events to
+  // the generated templates.
   if (hasPropagation) {
     const intr = interrupt({ kind, message, data, origin, runId: ctx.getRunId(), interruptId });
     ctx.statelogClient.interruptThrown({
@@ -319,7 +324,7 @@ export async function respondToInterrupts(args: {
             ctx: execCtx,
             isResume: true,
           },
-          { onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id) },
+          { onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id), statelogClient: execCtx.statelogClient },
         );
         await execCtx.pendingPromises.awaitAll();
         const returnObject = createReturnObject({

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -240,6 +240,17 @@ export async function runNode({
         throw e;
       }
     }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    execCtx.statelogClient.error({
+      errorType: "runtimeError",
+      message: errorMessage,
+    });
+    execCtx.statelogClient.agentEnd({
+      entryNode: nodeName,
+      timeTaken: performance.now() - agentStartTime,
+    });
+    throw error;
   } finally {
     execCtx.statelogClient.endSpan(); // end agentRun span
     // Persist any in-memory MemoryManager state. Writes are best-effort —

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -155,7 +155,7 @@ export async function runNode({
     data: { nodeName, args: data, messages: messages || [], cancel },
   });
 
-  execCtx.statelogClient.startSpan("agentRun");
+  const agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
   execCtx.statelogClient.agentStart({ entryNode: nodeName, args: data });
   const agentStartTime = performance.now();
 
@@ -261,7 +261,7 @@ export async function runNode({
     });
     throw error;
   } finally {
-    execCtx.statelogClient.endSpan(); // end agentRun span
+    execCtx.statelogClient.endSpan(agentRunSpanId); // end agentRun span
     // Persist any in-memory MemoryManager state. Writes are best-effort —
     // we never fail the run because of a save error, but we do log it so
     // disk problems are visible.

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -43,6 +43,7 @@ export function setupNode(args: { state: GraphState }): {
     // and the checkpoint frame doesn't have serialized threads.
     threads = ThreadStore.withDefaultActive();
   }
+  threads.setStatelogClient(ctx.statelogClient);
   stack.threads = threads;
 
   return { stack, step, self, threads };
@@ -151,6 +152,11 @@ export async function runNode({
     name: "onAgentStart",
     data: { nodeName, args: data, messages: messages || [], cancel },
   });
+
+  execCtx.statelogClient.startSpan("agentRun");
+  execCtx.statelogClient.agentStart({ entryNode: nodeName, args: data });
+  const agentStartTime = performance.now();
+
   let isResume = false;
   let threadStore = ThreadStore.withDefaultActive();
   try {
@@ -182,6 +188,12 @@ export async function runNode({
           await execCtx.pauseTraceWriter();
         } else {
           // Final result: emit footer and close
+          execCtx.statelogClient.agentEnd({
+            entryNode: nodeName,
+            result: returnObject.data,
+            timeTaken: performance.now() - agentStartTime,
+            tokenStats: returnObject.tokens,
+          });
           await callHook({
             callbacks: execCtx.callbacks,
             name: "onAgentEnd",
@@ -199,6 +211,15 @@ export async function runNode({
             );
           }
           const cp = e.checkpoint;
+          execCtx.statelogClient.checkpointRestored({
+            checkpointId: cp.id,
+            restoreCount: execCtx._restoreCount,
+            maxRestores: execCtx.maxRestores,
+            overrides: {
+              args: !!e.options?.args,
+              globals: !!e.options?.globals,
+            },
+          });
           execCtx.restoreState(cp);
           if (e.options?.args) {
             execCtx._pendingArgOverrides = e.options.args;
@@ -220,6 +241,7 @@ export async function runNode({
       }
     }
   } finally {
+    execCtx.statelogClient.endSpan(); // end agentRun span
     // Persist any in-memory MemoryManager state. Writes are best-effort —
     // we never fail the run because of a save error, but we do log it so
     // disk problems are visible.

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -170,7 +170,7 @@ export async function runNode({
             ctx: execCtx,
             isResume,
           },
-          { onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id) },
+          { onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id), statelogClient: execCtx.statelogClient },
         );
         await execCtx.pendingPromises.awaitAll();
         const returnObject = createReturnObject({

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -35,15 +35,17 @@ export function setupNode(args: { state: GraphState }): {
   let threads: ThreadStore;
   if (stack.threads) {
     threads = ThreadStore.fromJSON(stack.threads);
+    threads.setStatelogClient(ctx.statelogClient);
   } else if (state.messages instanceof ThreadStore) {
     threads = state.messages;
+    threads.setStatelogClient(ctx.statelogClient);
   } else {
     // Fallback: create a new ThreadStore with a default active thread.
     // This can happen on debugger/rewind resume paths where messages is not passed
     // and the checkpoint frame doesn't have serialized threads.
-    threads = ThreadStore.withDefaultActive();
+    // Pass the client so the default thread is logged.
+    threads = ThreadStore.withDefaultActive(ctx.statelogClient);
   }
-  threads.setStatelogClient(ctx.statelogClient);
   stack.threads = threads;
 
   return { stack, step, self, threads };
@@ -158,7 +160,7 @@ export async function runNode({
   const agentStartTime = performance.now();
 
   let isResume = false;
-  let threadStore = ThreadStore.withDefaultActive();
+  let threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
   try {
     while (true) {
       try {
@@ -234,7 +236,7 @@ export async function runNode({
           isResume = true;
           execCtx.stateStack.nodesTraversed = [cp.nodeId];
           // Reset ThreadStore for the restored execution
-          threadStore = ThreadStore.withDefaultActive();
+          threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
           continue;
         }
         throw e;
@@ -246,9 +248,16 @@ export async function runNode({
       errorType: "runtimeError",
       message: errorMessage,
     });
+    // Pull whatever token usage accumulated before the crash so cost
+    // dashboards still attribute partial spend to failed runs.
+    const partialReturn = createReturnObject({
+      result: { data: undefined as any },
+      globals: execCtx.globals,
+    });
     execCtx.statelogClient.agentEnd({
       entryNode: nodeName,
       timeTaken: performance.now() - agentStartTime,
+      tokenStats: partialReturn.tokens,
     });
     throw error;
   } finally {

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -46,6 +46,8 @@ async function _runPrompt({
     throw new AgencyCancelledError();
   }
 
+  ctx.statelogClient.startSpan("llmCall");
+  try { // try/finally for llmCall span
   const stream = !!(clientConfig as any)?.stream;
   const startTime = performance.now();
 
@@ -188,6 +190,9 @@ async function _runPrompt({
   }
 
   return { messages, toolCalls };
+  } finally {
+    ctx.statelogClient.endSpan(); // end llmCall span
+  }
 }
 
 export async function runPrompt(args: {
@@ -300,8 +305,6 @@ export async function runPrompt(args: {
 
   // Tool calls: restore from frame or make initial LLM call
   let toolCalls: smoltalk.ToolCallJSON[];
-  ctx.statelogClient.startSpan("llmCall");
-  try { // try/finally for llmCall span — covers initial _runPrompt and tool loop
   if (self.pendingToolCalls) {
     toolCalls = self.pendingToolCalls;
   } else {
@@ -448,6 +451,7 @@ export async function runPrompt(args: {
         const toolCallStartTime = performance.now();
         ctx.statelogClient.startSpan("toolExecution");
         let result: any;
+        try { // try/finally for toolExecution span
         ctx.enterToolCall();
         try {
           result = await handler.invoke(
@@ -478,7 +482,6 @@ export async function runPrompt(args: {
           );
           removedTools.push(handler.name);
           stack.deleteBranch(branchKey);
-          ctx.statelogClient.endSpan(); // end toolExecution span
           continue;
         } finally {
           ctx.exitToolCall();
@@ -524,7 +527,6 @@ export async function runPrompt(args: {
             removedTools.push(handler.name);
           }
           stack.deleteBranch(branchKey);
-          ctx.statelogClient.endSpan(); // end toolExecution span
           continue;
         }
 
@@ -540,7 +542,6 @@ export async function runPrompt(args: {
             }),
           );
           stack.deleteBranch(branchKey);
-          ctx.statelogClient.endSpan(); // end toolExecution span
           continue;
         }
 
@@ -560,7 +561,6 @@ export async function runPrompt(args: {
             result[0].interruptData,
             result[0].checkpoint,
           );
-          ctx.statelogClient.endSpan(); // end toolExecution span
           continue;
         }
 
@@ -587,7 +587,10 @@ export async function runPrompt(args: {
           model: JSON.stringify(clientConfig.model),
           timeTaken: toolCallEndTime - toolCallStartTime,
         });
-        ctx.statelogClient.endSpan(); // end toolExecution span
+
+        } finally { // end toolExecution span
+          ctx.statelogClient.endSpan();
+        }
 
         messages.push(
           smoltalk.toolMessage(result, {
@@ -658,9 +661,6 @@ export async function runPrompt(args: {
     throw error;
   } finally {
     if (shouldPop) stateStack.pop();
-  }
-  } finally { // end llmCall span (covers initial _runPrompt + tool loop)
-    ctx.statelogClient.endSpan();
   }
 
   const responseMessage = messages.getMessages().at(-1);

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -609,7 +609,7 @@ export async function runPrompt(args: {
           scopeName: checkpointInfo?.scopeName ?? "",
           stepPath: checkpointInfo?.stepPath ?? "",
         });
-        const cp = ctx.checkpoints.get(cpId);
+        const cp = ctx.checkpoints.get(cpId)!;
         for (const intr of interrupts) {
           intr.checkpoint = cp;
           intr.checkpointId = cpId;
@@ -618,11 +618,7 @@ export async function runPrompt(args: {
         ctx.statelogClient.checkpointCreated({
           checkpointId: cpId,
           reason: "interrupt",
-          sourceLocation: checkpointInfo ? {
-            moduleId: checkpointInfo.moduleId ?? "",
-            scopeName: checkpointInfo.scopeName ?? "",
-            stepPath: checkpointInfo.stepPath ?? "",
-          } : undefined,
+          sourceLocation: { moduleId: cp.moduleId, scopeName: cp.scopeName, stepPath: cp.stepPath },
         });
         ctx.statelogClient.debug(`Tool call interrupted execution.`, {
           messages: messages.getMessages(),

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -299,8 +299,9 @@ export async function runPrompt(args: {
   }
 
   // Tool calls: restore from frame or make initial LLM call
-  ctx.statelogClient.startSpan("llmCall");
   let toolCalls: smoltalk.ToolCallJSON[];
+  ctx.statelogClient.startSpan("llmCall");
+  try { // try/finally for llmCall span — covers initial _runPrompt and tool loop
   if (self.pendingToolCalls) {
     toolCalls = self.pendingToolCalls;
   } else {
@@ -656,8 +657,10 @@ export async function runPrompt(args: {
     if (isAbortError(error)) throw error;
     throw error;
   } finally {
-    ctx.statelogClient.endSpan(); // end llmCall span
     if (shouldPop) stateStack.pop();
+  }
+  } finally { // end llmCall span (covers initial _runPrompt + tool loop)
+    ctx.statelogClient.endSpan();
   }
 
   const responseMessage = messages.getMessages().at(-1);

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -124,6 +124,9 @@ async function _runPrompt({
     timeTaken: endTime - startTime,
     tools,
     responseFormat,
+    usage: completion.usage,
+    cost: completion.cost,
+    stream,
   });
 
   if (toolCalls.length > 0) {
@@ -296,6 +299,7 @@ export async function runPrompt(args: {
   }
 
   // Tool calls: restore from frame or make initial LLM call
+  ctx.statelogClient.startSpan("llmCall");
   let toolCalls: smoltalk.ToolCallJSON[];
   if (self.pendingToolCalls) {
     toolCalls = self.pendingToolCalls;
@@ -441,6 +445,7 @@ export async function runPrompt(args: {
         });
 
         const toolCallStartTime = performance.now();
+        ctx.statelogClient.startSpan("toolExecution");
         let result: any;
         ctx.enterToolCall();
         try {
@@ -456,6 +461,12 @@ export async function runPrompt(args: {
           const errorMessage =
             error instanceof Error ? error.message : String(error);
           console.error(`Tool call "${handler.name}" crashed: ${errorMessage}`);
+          ctx.statelogClient.error({
+            errorType: "toolError",
+            message: errorMessage,
+            functionName: handler.name,
+            retryable: false,
+          });
           toolErrorCounts[handler.name] =
             (toolErrorCounts[handler.name] || 0) + 1;
           messages.push(
@@ -466,6 +477,7 @@ export async function runPrompt(args: {
           );
           removedTools.push(handler.name);
           stack.deleteBranch(branchKey);
+          ctx.statelogClient.endSpan(); // end toolExecution span
           continue;
         } finally {
           ctx.exitToolCall();
@@ -479,6 +491,12 @@ export async function runPrompt(args: {
               : String(result.error);
           toolErrorCounts[handler.name] =
             (toolErrorCounts[handler.name] || 0) + 1;
+          ctx.statelogClient.error({
+            errorType: "toolError",
+            message: errorMessage,
+            functionName: handler.name,
+            retryable: !!result.retryable,
+          });
 
           if (result.retryable && toolErrorCounts[handler.name] < 5) {
             messages.push(
@@ -505,6 +523,7 @@ export async function runPrompt(args: {
             removedTools.push(handler.name);
           }
           stack.deleteBranch(branchKey);
+          ctx.statelogClient.endSpan(); // end toolExecution span
           continue;
         }
 
@@ -520,11 +539,19 @@ export async function runPrompt(args: {
             }),
           );
           stack.deleteBranch(branchKey);
+          ctx.statelogClient.endSpan(); // end toolExecution span
           continue;
         }
 
         // Check for interrupts
         if (hasInterrupts(result)) {
+          for (const intr of result) {
+            ctx.statelogClient.interruptThrown({
+              interruptId: intr.interruptId,
+              interruptData: intr.interruptData,
+              functionName: handler.name,
+            });
+          }
           interrupts.push(...result);
           stack.setInterruptOnBranch(
             branchKey,
@@ -532,15 +559,7 @@ export async function runPrompt(args: {
             result[0].interruptData,
             result[0].checkpoint,
           );
-          //console.log(color.green(JSON.stringify(result, null, 2)));
-          // exit(1);
-          // Transplant the branch stack from the interrupt's checkpoint
-          // const branchCp = result[0]?.checkpoint;
-          // if (branchCp) {
-          //   stack.branches[branchKey].stack = StateStack.fromJSON(
-          //     branchCp.stack,
-          //   );
-          // }
+          ctx.statelogClient.endSpan(); // end toolExecution span
           continue;
         }
 
@@ -567,6 +586,7 @@ export async function runPrompt(args: {
           model: JSON.stringify(clientConfig.model),
           timeTaken: toolCallEndTime - toolCallStartTime,
         });
+        ctx.statelogClient.endSpan(); // end toolExecution span
 
         messages.push(
           smoltalk.toolMessage(result, {
@@ -595,6 +615,15 @@ export async function runPrompt(args: {
           intr.checkpointId = cpId;
         }
 
+        ctx.statelogClient.checkpointCreated({
+          checkpointId: cpId,
+          reason: "interrupt",
+          sourceLocation: checkpointInfo ? {
+            moduleId: checkpointInfo.moduleId ?? "",
+            scopeName: checkpointInfo.scopeName ?? "",
+            stepPath: checkpointInfo.stepPath ?? "",
+          } : undefined,
+        });
         ctx.statelogClient.debug(`Tool call interrupted execution.`, {
           messages: messages.getMessages(),
           model: clientConfig.model,
@@ -631,6 +660,7 @@ export async function runPrompt(args: {
     if (isAbortError(error)) throw error;
     throw error;
   } finally {
+    ctx.statelogClient.endSpan(); // end llmCall span
     if (shouldPop) stateStack.pop();
   }
 

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -46,8 +46,10 @@ async function _runPrompt({
     throw new AgencyCancelledError();
   }
 
-  ctx.statelogClient.startSpan("llmCall");
-  try { // try/finally for llmCall span
+  // Note: the llmCall span is opened in the outer `runPrompt`, not here,
+  // so that any tool executions triggered by this LLM response nest under
+  // the same llmCall span (matching the design spec hierarchy
+  // agentRun > nodeExecution > llmCall > toolExecution).
   const stream = !!(clientConfig as any)?.stream;
   const startTime = performance.now();
 
@@ -128,6 +130,7 @@ async function _runPrompt({
     responseFormat,
     usage: completion.usage,
     cost: completion.cost,
+    finishReason: (completion as any).finishReason ?? (completion as any).finish_reason,
     stream,
   });
 
@@ -190,9 +193,6 @@ async function _runPrompt({
   }
 
   return { messages, toolCalls };
-  } finally {
-    ctx.statelogClient.endSpan(); // end llmCall span
-  }
 }
 
 export async function runPrompt(args: {
@@ -303,10 +303,27 @@ export async function runPrompt(args: {
     messages = new MessageThread();
   }
 
+  // Manage llmCall spans across the prompt round-trip loop. Each
+  // llmCall span covers one `_runPrompt` call PLUS the tool executions
+  // triggered by its returned tool_calls, so toolExecution spans nest
+  // under their parent llmCall — matching the
+  // agentRun > nodeExecution > llmCall > toolExecution hierarchy.
+  let currentLlmSpanId: string | undefined;
+  const closeLlmSpan = () => {
+    if (currentLlmSpanId) {
+      ctx.statelogClient.endSpan(currentLlmSpanId);
+      currentLlmSpanId = undefined;
+    }
+  };
+
   // Tool calls: restore from frame or make initial LLM call
   let toolCalls: smoltalk.ToolCallJSON[];
   if (self.pendingToolCalls) {
     toolCalls = self.pendingToolCalls;
+    // Resumed run: the original llmCall span ended at the interrupt.
+    // Open a fresh span so subsequent tool executions still have a
+    // parent llmCall to nest under.
+    currentLlmSpanId = ctx.statelogClient.startSpan("llmCall");
   } else {
     // Memory injection (resolved decision #6): only retrieves and
     // injects when the caller passed `memory: true` (or an object) on
@@ -334,15 +351,22 @@ export async function runPrompt(args: {
       }
     }
     messages.push(smoltalk.userMessage(prompt));
-    const result = await _runPrompt({
-      ctx,
-      messages,
-      tools: tools || [],
-      prompt,
-      responseFormat,
-      clientConfig,
-      stateStack,
-    });
+    currentLlmSpanId = ctx.statelogClient.startSpan("llmCall");
+    let result;
+    try {
+      result = await _runPrompt({
+        ctx,
+        messages,
+        tools: tools || [],
+        prompt,
+        responseFormat,
+        clientConfig,
+        stateStack,
+      });
+    } catch (e) {
+      closeLlmSpan();
+      throw e;
+    }
     messages = result.messages;
     toolCalls = result.toolCalls;
 
@@ -449,7 +473,7 @@ export async function runPrompt(args: {
         });
 
         const toolCallStartTime = performance.now();
-        ctx.statelogClient.startSpan("toolExecution");
+        const toolSpanId = ctx.statelogClient.startSpan("toolExecution");
         let result: any;
         try { // try/finally for toolExecution span
         ctx.enterToolCall();
@@ -586,7 +610,7 @@ export async function runPrompt(args: {
         });
 
         } finally { // end toolExecution span
-          ctx.statelogClient.endSpan();
+          ctx.statelogClient.endSpan(toolSpanId);
         }
 
         messages.push(
@@ -637,6 +661,11 @@ export async function runPrompt(args: {
         (fn) => !removedTools.includes(fn.name),
       );
 
+      // Close the prior llmCall span (its tool executions are done) and
+      // open a fresh one for this next round so per-call latency stays
+      // accurate.
+      closeLlmSpan();
+      currentLlmSpanId = ctx.statelogClient.startSpan("llmCall");
       const nextResult = await _runPrompt({
         ctx,
         messages,
@@ -657,6 +686,11 @@ export async function runPrompt(args: {
     if (isAbortError(error)) throw error;
     throw error;
   } finally {
+    // Close any open llmCall span. This covers normal completion,
+    // thrown errors, and early returns when tool calls interrupted
+    // (the resumed run opens a fresh llmCall span). The helper is a
+    // no-op if no span is currently open.
+    closeLlmSpan();
     if (shouldPop) stateStack.pop();
   }
 

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -548,14 +548,9 @@ export async function runPrompt(args: {
         }
 
         // Check for interrupts
+        // Note: interruptThrown is already emitted by interruptWithHandlers
+        // when the interrupt propagates, so we don't emit it again here.
         if (hasInterrupts(result)) {
-          for (const intr of result) {
-            ctx.statelogClient.interruptThrown({
-              interruptId: intr.interruptId,
-              interruptData: intr.interruptData,
-              functionName: handler.name,
-            });
-          }
           interrupts.push(...result);
           stack.setInterruptOnBranch(
             branchKey,

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -454,11 +454,13 @@ export async function runPrompt(args: {
         try { // try/finally for toolExecution span
         ctx.enterToolCall();
         try {
+          const toolThreads = new ThreadStore();
+          toolThreads.setStatelogClient(ctx.statelogClient);
           result = await handler.invoke(
             { type: "named", positionalArgs: [], namedArgs },
             {
               ctx,
-              threads: new ThreadStore(),
+              threads: toolThreads,
               stateStack: branchStack,
             },
           );

--- a/packages/agency-lang/lib/runtime/rewind.ts
+++ b/packages/agency-lang/lib/runtime/rewind.ts
@@ -61,6 +61,7 @@ export async function rewindFrom(args: {
           },
           {
             onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id),
+            statelogClient: execCtx.statelogClient,
           },
         );
         await execCtx.pendingPromises.awaitAll();

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -638,10 +638,14 @@ export class Runner {
     stateStack: StateStack,
     forkId: string,
   ): Promise<any> {
+    const branchStartTimes: number[] = [];
+    const branchEndTimes: number[] = [];
     const promises = items.map((item, i) => {
       const branchKey = this.forkBranchKey(id, i);
       const existing = this.frame.getOrCreateBranch(branchKey);
       if (existing.result !== undefined) {
+        branchStartTimes[i] = 0;
+        branchEndTimes[i] = 0;
         return Promise.resolve(existing.result.result);
       }
       // Each fork branch gets its own AbortController. For fork-all this is
@@ -656,9 +660,10 @@ export class Runner {
           ? AbortSignal.any([parentSignal, existing.abortController.signal])
           : existing.abortController.signal;
       }
-      const branchStart = performance.now();
+      branchStartTimes[i] = performance.now();
       this.ctx.statelogClient.enterFork();
       return blockFn(item, i, existing.stack).finally(() => {
+        branchEndTimes[i] = performance.now();
         this.ctx.statelogClient.exitFork();
       });
     });
@@ -669,12 +674,13 @@ export class Runner {
     for (let i = 0; i < settled.length; i++) {
       const s = settled[i];
       const branchKey = this.forkBranchKey(id, i);
+      const branchTime = (branchEndTimes[i] || 0) - (branchStartTimes[i] || 0);
       if (s.status === "rejected") {
         this.ctx.statelogClient.forkBranchEnd({
           forkId,
           branchIndex: i,
           outcome: "failure",
-          timeTaken: 0,
+          timeTaken: branchTime,
         });
         throw s.reason;
       }
@@ -683,7 +689,7 @@ export class Runner {
           forkId,
           branchIndex: i,
           outcome: "interrupted",
-          timeTaken: 0,
+          timeTaken: branchTime,
         });
         interrupts.push(...s.value);
         this.frame.setInterruptOnBranch(
@@ -697,7 +703,7 @@ export class Runner {
           forkId,
           branchIndex: i,
           outcome: "success",
-          timeTaken: 0,
+          timeTaken: branchTime,
         });
         this.frame.setResultOnBranch(branchKey, s.value);
       }
@@ -742,6 +748,7 @@ export class Runner {
   ): Promise<any> {
     // Build the per-branch promises, each tagged with its index so we know
     // who won the race.
+    const raceStart = performance.now();
     const taggedPromises: Promise<{ index: number; value: any }>[] = items.map(
       (item, i) => {
         const branchKey = this.forkBranchKey(id, i);
@@ -777,6 +784,7 @@ export class Runner {
     // Promise.race resolves with whichever finishes first.
     const { index: winnerIndex, value: winnerValue } =
       await Promise.race(taggedPromises);
+    const winnerTime = performance.now() - raceStart;
 
     // Abort the losing branches so any in-flight work (LLM calls, tool calls)
     // can stop. Note: synchronous code that has already reached an
@@ -791,14 +799,14 @@ export class Runner {
         forkId,
         branchIndex: i,
         outcome: "aborted",
-        timeTaken: 0,
+        timeTaken: winnerTime, // losers ran at least this long before being aborted
       });
     }
     this.ctx.statelogClient.forkBranchEnd({
       forkId,
       branchIndex: winnerIndex,
       outcome: hasInterrupts(winnerValue) ? "interrupted" : "success",
-      timeTaken: 0,
+      timeTaken: winnerTime,
     });
 
     // Record the winner so a resume on the same race step replays only this

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -781,10 +781,22 @@ export class Runner {
       },
     );
 
-    // Promise.race resolves with whichever finishes first.
-    const { index: winnerIndex, value: winnerValue } =
-      await Promise.race(taggedPromises);
-    const winnerTime = performance.now() - raceStart;
+    // Promise.race resolves/rejects with whichever settles first.
+    let winnerIndex: number;
+    let winnerValue: any;
+    let winnerTime: number;
+    try {
+      const winner = await Promise.race(taggedPromises);
+      winnerIndex = winner.index;
+      winnerValue = winner.value;
+      winnerTime = performance.now() - raceStart;
+    } catch (err) {
+      // A branch rejected first — emit failure and rethrow.
+      // We don't know which branch index it was (Promise.race doesn't tell us),
+      // so we can't emit a precise forkBranchEnd. Rethrow to let the outer
+      // finally handle forkEnd/exitFork cleanup.
+      throw err;
+    }
 
     // Abort the losing branches so any in-flight work (LLM calls, tool calls)
     // can stop. Note: synchronous code that has already reached an

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -1,3 +1,4 @@
+import { nanoid } from "nanoid";
 import { debugStep } from "./debugger.js";
 import { hasInterrupts } from "./interrupts.js";
 import { __pipeBind } from "./result.js";
@@ -563,7 +564,7 @@ export class Runner {
 
     if (await this.maybeDebugHook(id)) return undefined;
 
-    const forkId = `fork_${id}`;
+    const forkId = nanoid(12);
     const forkStartTime = performance.now();
     this.ctx.statelogClient.forkStart({
       forkId,
@@ -648,7 +649,10 @@ export class Runner {
           ? AbortSignal.any([parentSignal, existing.abortController.signal])
           : existing.abortController.signal;
       }
-      return blockFn(item, i, existing.stack);
+      this.ctx.statelogClient.enterFork();
+      return blockFn(item, i, existing.stack).finally(() => {
+        this.ctx.statelogClient.exitFork();
+      });
     });
 
     const settled = await Promise.allSettled(promises);
@@ -729,10 +733,17 @@ export class Runner {
             ? AbortSignal.any([parentSignal, existing.abortController.signal])
             : existing.abortController.signal;
         }
-        return blockFn(item, i, existing.stack).then((value) => ({
-          index: i,
-          value,
-        }));
+        this.ctx.statelogClient.enterFork();
+        return blockFn(item, i, existing.stack).then(
+          (value) => {
+            this.ctx.statelogClient.exitFork();
+            return { index: i, value };
+          },
+          (err) => {
+            this.ctx.statelogClient.exitFork();
+            throw err;
+          },
+        );
       },
     );
 

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -566,7 +566,9 @@ export class Runner {
 
     const forkId = nanoid(12);
     const forkStartTime = performance.now();
-    this.ctx.statelogClient.startSpan(mode === "all" ? "forkAll" : "race");
+    const forkSpanId = this.ctx.statelogClient.startSpan(
+      mode === "all" ? "forkAll" : "race",
+    );
     this.ctx.statelogClient.forkStart({
       forkId,
       mode,
@@ -580,6 +582,10 @@ export class Runner {
     // before emitting forkEnd, so reading via raceWinnerKey() there would
     // produce the wrong key. Read it now and close over the value.
     let winnerIndex: number | undefined = undefined;
+    // Read the race winner from this.frame.locals using a key derived from
+    // the current path. Safe to call only inside the try block.
+    const readWinner = () =>
+      this.frame.locals[this.raceWinnerKey(id)] as number | undefined;
     try {
       // Race resume: if a winner was already chosen on a previous run,
       // resume only that branch — skip the race entirely.
@@ -592,16 +598,22 @@ export class Runner {
           stateStack,
           this.frame.locals[raceWinnerKey] as number,
         );
-        if (hasInterrupts(result)) return result;
+        if (hasInterrupts(result)) {
+          winnerIndex = readWinner();
+          return result;
+        }
       } else if (mode === "all") {
         result = await this.runForkAll(id, items, blockFn, stateStack, forkId);
         if (hasInterrupts(result)) return result;
       } else {
         result = await this.runRace(id, items, blockFn, stateStack, forkId);
-        if (hasInterrupts(result)) return result;
+        if (hasInterrupts(result)) {
+          winnerIndex = readWinner();
+          return result;
+        }
       }
       if (mode === "race") {
-        winnerIndex = this.frame.locals[raceWinnerKey] as number | undefined;
+        winnerIndex = readWinner();
       }
 
       // Clean up branch state after successful completion
@@ -620,7 +632,7 @@ export class Runner {
         timeTaken: performance.now() - forkStartTime,
         winnerIndex,
       });
-      this.ctx.statelogClient.endSpan(); // end forkAll/race span
+      this.ctx.statelogClient.endSpan(forkSpanId); // end forkAll/race span
     }
 
     if (this.halted) return undefined;

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -679,16 +679,12 @@ export class Runner {
         scopeName: this.scopeName,
         stepPath: this.stepPath(id),
       });
+      const cp = this.ctx.checkpoints.get(cpId)!;
       this.ctx.statelogClient.checkpointCreated({
         checkpointId: cpId,
         reason: "fork",
-        sourceLocation: {
-          moduleId: this.moduleId,
-          scopeName: this.scopeName,
-          stepPath: this.stepPath(id),
-        },
+        sourceLocation: { moduleId: cp.moduleId, scopeName: cp.scopeName, stepPath: cp.stepPath },
       });
-      const cp = this.ctx.checkpoints.get(cpId);
       for (const intr of interrupts) {
         intr.checkpoint = cp;
         intr.checkpointId = cpId;
@@ -781,16 +777,12 @@ export class Runner {
         scopeName: this.scopeName,
         stepPath: this.stepPath(id),
       });
+      const cp = this.ctx.checkpoints.get(cpId)!;
       this.ctx.statelogClient.checkpointCreated({
         checkpointId: cpId,
         reason: "race",
-        sourceLocation: {
-          moduleId: this.moduleId,
-          scopeName: this.scopeName,
-          stepPath: this.stepPath(id),
-        },
+        sourceLocation: { moduleId: cp.moduleId, scopeName: cp.scopeName, stepPath: cp.stepPath },
       });
-      const cp = this.ctx.checkpoints.get(cpId);
       for (const intr of winnerValue) {
         intr.checkpoint = cp;
         intr.checkpointId = cpId;
@@ -855,16 +847,12 @@ export class Runner {
         scopeName: this.scopeName,
         stepPath: this.stepPath(id),
       });
+      const cp = this.ctx.checkpoints.get(cpId)!;
       this.ctx.statelogClient.checkpointCreated({
         checkpointId: cpId,
         reason: "race",
-        sourceLocation: {
-          moduleId: this.moduleId,
-          scopeName: this.scopeName,
-          stepPath: this.stepPath(id),
-        },
+        sourceLocation: { moduleId: cp.moduleId, scopeName: cp.scopeName, stepPath: cp.stepPath },
       });
-      const cp = this.ctx.checkpoints.get(cpId);
       for (const intr of value) {
         intr.checkpoint = cp;
         intr.checkpointId = cpId;

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -575,6 +575,11 @@ export class Runner {
 
     this.path.push(id);
     let result: any;
+    // Capture winnerIndex inside the try block: it's stored under a key
+    // derived from `this.path`, but the outer `finally` pops the path
+    // before emitting forkEnd, so reading via raceWinnerKey() there would
+    // produce the wrong key. Read it now and close over the value.
+    let winnerIndex: number | undefined = undefined;
     try {
       // Race resume: if a winner was already chosen on a previous run,
       // resume only that branch — skip the race entirely.
@@ -595,24 +600,25 @@ export class Runner {
         result = await this.runRace(id, items, blockFn, stateStack, forkId);
         if (hasInterrupts(result)) return result;
       }
+      if (mode === "race") {
+        winnerIndex = this.frame.locals[raceWinnerKey] as number | undefined;
+      }
 
       // Clean up branch state after successful completion
       this.frame.popBranches();
     } finally {
       this.path.pop();
-      // Ensure all branch forkDepth increments are cleared before ending
-      // the fork span. Losers in a race may still be running when the
-      // winner resolves, leaving forkDepth elevated.
-      for (let i = 0; i < items.length; i++) {
-        this.ctx.statelogClient.exitFork();
-      }
+      // Each branch is responsible for balancing its own
+      // enterFork/exitFork call via .finally/.then-or-catch handlers.
+      // We deliberately do NOT decrement here: in a race, losing branches
+      // may still be running, and decrementing prematurely would corrupt
+      // a parent fork's depth tracking and let nested code start logging
+      // spans into the shared stack while branches are still in flight.
       this.ctx.statelogClient.forkEnd({
         forkId,
         mode,
         timeTaken: performance.now() - forkStartTime,
-        winnerIndex: mode === "race"
-          ? this.frame.locals[this.raceWinnerKey(id)] as number | undefined
-          : undefined,
+        winnerIndex,
       });
       this.ctx.statelogClient.endSpan(); // end forkAll/race span
     }
@@ -735,6 +741,53 @@ export class Runner {
    * On interrupt: record the winner, abort the losers, clear loser branches,
    * stamp a checkpoint, and return the interrupt array.
    * On value: return the value (losers' work is discarded). */
+  /** Build a single race branch's tagged promise. Wires up the
+   * AbortController, records the branch start time, and tags both
+   * resolutions and rejections so the racer can identify the winner /
+   * first-failing branch. */
+  private buildRaceBranchPromise(
+    id: number,
+    i: number,
+    item: any,
+    blockFn: (
+      item: any,
+      index: number,
+      branchStack: StateStack,
+    ) => Promise<any>,
+    stateStack: StateStack,
+    branchStartTimes: number[],
+  ): Promise<{ index: number; value: any }> {
+    const branchKey = this.forkBranchKey(id, i);
+    const existing = this.frame.getOrCreateBranch(branchKey);
+    if (existing.result !== undefined) {
+      return Promise.resolve({ index: i, value: existing.result.result });
+    }
+    if (!existing.abortController) {
+      existing.abortController = new AbortController();
+      // Compose with the parent stack's signal so nested race aborts
+      // propagate down through every level. The branch's signal is
+      // attached to its stack so any code holding the stack (runPrompt,
+      // ctx.isCancelled checks, etc.) observes a branch-only abort.
+      const parentSignal = stateStack.abortSignal;
+      existing.stack.abortSignal = parentSignal
+        ? AbortSignal.any([parentSignal, existing.abortController.signal])
+        : existing.abortController.signal;
+    }
+    branchStartTimes[i] = performance.now();
+    this.ctx.statelogClient.enterFork();
+    return blockFn(item, i, existing.stack).then(
+      (value) => {
+        this.ctx.statelogClient.exitFork();
+        return { index: i, value };
+      },
+      (err) => {
+        this.ctx.statelogClient.exitFork();
+        // Tag the rejection so the racer can identify which branch died.
+        return Promise.reject({ index: i, err });
+      },
+    );
+  }
+
   private async runRace(
     id: number,
     items: any[],
@@ -746,39 +799,9 @@ export class Runner {
     stateStack: StateStack,
     forkId: string,
   ): Promise<any> {
-    // Build the per-branch promises, each tagged with its index so we know
-    // who won the race.
-    const raceStart = performance.now();
-    const taggedPromises: Promise<{ index: number; value: any }>[] = items.map(
-      (item, i) => {
-        const branchKey = this.forkBranchKey(id, i);
-        const existing = this.frame.getOrCreateBranch(branchKey);
-        if (existing.result !== undefined) {
-          return Promise.resolve({ index: i, value: existing.result.result });
-        }
-        if (!existing.abortController) {
-          existing.abortController = new AbortController();
-          // Compose with the parent stack's signal so nested race aborts
-          // propagate down through every level. The branch's signal is
-          // attached to its stack so any code holding the stack (runPrompt,
-          // ctx.isCancelled checks, etc.) observes a branch-only abort.
-          const parentSignal = stateStack.abortSignal;
-          existing.stack.abortSignal = parentSignal
-            ? AbortSignal.any([parentSignal, existing.abortController.signal])
-            : existing.abortController.signal;
-        }
-        this.ctx.statelogClient.enterFork();
-        return blockFn(item, i, existing.stack).then(
-          (value) => {
-            this.ctx.statelogClient.exitFork();
-            return { index: i, value };
-          },
-          (err) => {
-            this.ctx.statelogClient.exitFork();
-            throw err;
-          },
-        );
-      },
+    const branchStartTimes: number[] = new Array(items.length).fill(0);
+    const taggedPromises = items.map((item, i) =>
+      this.buildRaceBranchPromise(id, i, item, blockFn, stateStack, branchStartTimes),
     );
 
     // Promise.race resolves/rejects with whichever settles first.
@@ -789,12 +812,22 @@ export class Runner {
       const winner = await Promise.race(taggedPromises);
       winnerIndex = winner.index;
       winnerValue = winner.value;
-      winnerTime = performance.now() - raceStart;
-    } catch (err) {
-      // A branch rejected first — emit failure and rethrow.
-      // We don't know which branch index it was (Promise.race doesn't tell us),
-      // so we can't emit a precise forkBranchEnd. Rethrow to let the outer
-      // finally handle forkEnd/exitFork cleanup.
+      winnerTime = performance.now() - branchStartTimes[winnerIndex];
+    } catch (tagged) {
+      // A branch rejected first — we know which one thanks to tagging.
+      const { index: failedIndex, err } = tagged as { index: number; err: any };
+      this.ctx.statelogClient.forkBranchEnd({
+        forkId,
+        branchIndex: failedIndex,
+        outcome: "failure",
+        timeTaken: performance.now() - branchStartTimes[failedIndex],
+      });
+      // Abort the still-running branches. Their per-branch exitFork in the
+      // .then/.catch handlers will balance the enterFork depth.
+      for (let i = 0; i < items.length; i++) {
+        if (i === failedIndex) continue;
+        this.frame.getBranch(this.forkBranchKey(id, i))?.abortController?.abort();
+      }
       throw err;
     }
 
@@ -811,7 +844,10 @@ export class Runner {
         forkId,
         branchIndex: i,
         outcome: "aborted",
-        timeTaken: winnerTime, // losers ran at least this long before being aborted
+        // Losers ran at least this long before the winner finished and we
+        // told them to stop. They may continue running briefly after this
+        // until the abort is observed.
+        timeTaken: performance.now() - branchStartTimes[i],
       });
     }
     this.ctx.statelogClient.forkBranchEnd({

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -566,12 +566,12 @@ export class Runner {
 
     const forkId = nanoid(12);
     const forkStartTime = performance.now();
+    this.ctx.statelogClient.startSpan(mode === "all" ? "forkAll" : "race");
     this.ctx.statelogClient.forkStart({
       forkId,
       mode,
       branchCount: items.length,
     });
-    this.ctx.statelogClient.startSpan(mode === "all" ? "forkAll" : "race");
 
     this.path.push(id);
     let result: any;
@@ -589,10 +589,10 @@ export class Runner {
         );
         if (hasInterrupts(result)) return result;
       } else if (mode === "all") {
-        result = await this.runForkAll(id, items, blockFn, stateStack);
+        result = await this.runForkAll(id, items, blockFn, stateStack, forkId);
         if (hasInterrupts(result)) return result;
       } else {
-        result = await this.runRace(id, items, blockFn, stateStack);
+        result = await this.runRace(id, items, blockFn, stateStack, forkId);
         if (hasInterrupts(result)) return result;
       }
 
@@ -600,7 +600,12 @@ export class Runner {
       this.frame.popBranches();
     } finally {
       this.path.pop();
-      this.ctx.statelogClient.endSpan(); // end forkAll/race span
+      // Ensure all branch forkDepth increments are cleared before ending
+      // the fork span. Losers in a race may still be running when the
+      // winner resolves, leaving forkDepth elevated.
+      for (let i = 0; i < items.length; i++) {
+        this.ctx.statelogClient.exitFork();
+      }
       this.ctx.statelogClient.forkEnd({
         forkId,
         mode,
@@ -609,6 +614,7 @@ export class Runner {
           ? this.frame.locals[this.raceWinnerKey(id)] as number | undefined
           : undefined,
       });
+      this.ctx.statelogClient.endSpan(); // end forkAll/race span
     }
 
     if (this.halted) return undefined;
@@ -630,6 +636,7 @@ export class Runner {
       branchStack: StateStack,
     ) => Promise<any>,
     stateStack: StateStack,
+    forkId: string,
   ): Promise<any> {
     const promises = items.map((item, i) => {
       const branchKey = this.forkBranchKey(id, i);
@@ -649,6 +656,7 @@ export class Runner {
           ? AbortSignal.any([parentSignal, existing.abortController.signal])
           : existing.abortController.signal;
       }
+      const branchStart = performance.now();
       this.ctx.statelogClient.enterFork();
       return blockFn(item, i, existing.stack).finally(() => {
         this.ctx.statelogClient.exitFork();
@@ -662,9 +670,21 @@ export class Runner {
       const s = settled[i];
       const branchKey = this.forkBranchKey(id, i);
       if (s.status === "rejected") {
+        this.ctx.statelogClient.forkBranchEnd({
+          forkId,
+          branchIndex: i,
+          outcome: "failure",
+          timeTaken: 0,
+        });
         throw s.reason;
       }
       if (hasInterrupts(s.value)) {
+        this.ctx.statelogClient.forkBranchEnd({
+          forkId,
+          branchIndex: i,
+          outcome: "interrupted",
+          timeTaken: 0,
+        });
         interrupts.push(...s.value);
         this.frame.setInterruptOnBranch(
           branchKey,
@@ -673,6 +693,12 @@ export class Runner {
           s.value[0].checkpoint,
         );
       } else {
+        this.ctx.statelogClient.forkBranchEnd({
+          forkId,
+          branchIndex: i,
+          outcome: "success",
+          timeTaken: 0,
+        });
         this.frame.setResultOnBranch(branchKey, s.value);
       }
     }
@@ -712,6 +738,7 @@ export class Runner {
       branchStack: StateStack,
     ) => Promise<any>,
     stateStack: StateStack,
+    forkId: string,
   ): Promise<any> {
     // Build the per-branch promises, each tagged with its index so we know
     // who won the race.
@@ -760,7 +787,19 @@ export class Runner {
       const branchKey = this.forkBranchKey(id, i);
       const branch = this.frame.getBranch(branchKey);
       branch?.abortController?.abort();
+      this.ctx.statelogClient.forkBranchEnd({
+        forkId,
+        branchIndex: i,
+        outcome: "aborted",
+        timeTaken: 0,
+      });
     }
+    this.ctx.statelogClient.forkBranchEnd({
+      forkId,
+      branchIndex: winnerIndex,
+      outcome: hasInterrupts(winnerValue) ? "interrupted" : "success",
+      timeTaken: 0,
+    });
 
     // Record the winner so a resume on the same race step replays only this
     // branch (not the abandoned losers).

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -563,6 +563,15 @@ export class Runner {
 
     if (await this.maybeDebugHook(id)) return undefined;
 
+    const forkId = `fork_${id}`;
+    const forkStartTime = performance.now();
+    this.ctx.statelogClient.forkStart({
+      forkId,
+      mode,
+      branchCount: items.length,
+    });
+    this.ctx.statelogClient.startSpan(mode === "all" ? "forkAll" : "race");
+
     this.path.push(id);
     let result: any;
     try {
@@ -590,6 +599,15 @@ export class Runner {
       this.frame.popBranches();
     } finally {
       this.path.pop();
+      this.ctx.statelogClient.endSpan(); // end forkAll/race span
+      this.ctx.statelogClient.forkEnd({
+        forkId,
+        mode,
+        timeTaken: performance.now() - forkStartTime,
+        winnerIndex: mode === "race"
+          ? this.frame.locals[this.raceWinnerKey(id)] as number | undefined
+          : undefined,
+      });
     }
 
     if (this.halted) return undefined;
@@ -660,6 +678,15 @@ export class Runner {
         moduleId: this.moduleId,
         scopeName: this.scopeName,
         stepPath: this.stepPath(id),
+      });
+      this.ctx.statelogClient.checkpointCreated({
+        checkpointId: cpId,
+        reason: "fork",
+        sourceLocation: {
+          moduleId: this.moduleId,
+          scopeName: this.scopeName,
+          stepPath: this.stepPath(id),
+        },
       });
       const cp = this.ctx.checkpoints.get(cpId);
       for (const intr of interrupts) {
@@ -754,6 +781,15 @@ export class Runner {
         scopeName: this.scopeName,
         stepPath: this.stepPath(id),
       });
+      this.ctx.statelogClient.checkpointCreated({
+        checkpointId: cpId,
+        reason: "race",
+        sourceLocation: {
+          moduleId: this.moduleId,
+          scopeName: this.scopeName,
+          stepPath: this.stepPath(id),
+        },
+      });
       const cp = this.ctx.checkpoints.get(cpId);
       for (const intr of winnerValue) {
         intr.checkpoint = cp;
@@ -818,6 +854,15 @@ export class Runner {
         moduleId: this.moduleId,
         scopeName: this.scopeName,
         stepPath: this.stepPath(id),
+      });
+      this.ctx.statelogClient.checkpointCreated({
+        checkpointId: cpId,
+        reason: "race",
+        sourceLocation: {
+          moduleId: this.moduleId,
+          scopeName: this.scopeName,
+          stepPath: this.stepPath(id),
+        },
       });
       const cp = this.ctx.checkpoints.get(cpId);
       for (const intr of value) {

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -243,9 +243,6 @@ export class RuntimeContext<T> {
       ...this.statelogConfig,
       traceId: runId,
     });
-    // Share the per-run statelogClient with the graph so node-level events
-    // (enterNode/exitNode/spans) use the same trace ID and span stack.
-    execCtx.graph.setStatelogClient(execCtx.statelogClient);
     execCtx.coverageCollector = this.coverageCollector;
 
     // Memory layer: per-execCtx MemoryManager backed by the shared store.

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -243,6 +243,9 @@ export class RuntimeContext<T> {
       ...this.statelogConfig,
       traceId: runId,
     });
+    // Share the per-run statelogClient with the graph so node-level events
+    // (enterNode/exitNode/spans) use the same trace ID and span stack.
+    execCtx.graph.setStatelogClient(execCtx.statelogClient);
     execCtx.coverageCollector = this.coverageCollector;
 
     // Memory layer: per-execCtx MemoryManager backed by the shared store.

--- a/packages/agency-lang/lib/runtime/state/threadStore.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.ts
@@ -21,6 +21,9 @@ export class ThreadStore {
     this.activeStack = [];
   }
 
+  // Set after construction. The initial default thread created by
+  // withDefaultActive() is intentionally not logged — it's an implicit
+  // implementation detail, not a user-initiated thread/subthread block.
   setStatelogClient(client: StatelogClient): void {
     this.statelogClient = client;
   }

--- a/packages/agency-lang/lib/runtime/state/threadStore.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.ts
@@ -21,15 +21,19 @@ export class ThreadStore {
     this.activeStack = [];
   }
 
-  // Set after construction. The initial default thread created by
-  // withDefaultActive() is intentionally not logged — it's an implicit
-  // implementation detail, not a user-initiated thread/subthread block.
+  // Set after construction. Most callers should pass the client to
+  // `withDefaultActive(client)` instead so the initial default thread
+  // is logged consistently with subsequent thread/subthread blocks.
   setStatelogClient(client: StatelogClient): void {
     this.statelogClient = client;
   }
 
-  static withDefaultActive(): ThreadStore {
+  // Create a store with a default active thread. If `client` is passed,
+  // the default thread is logged as a normal threadCreated event so the
+  // implicit root thread appears in the trace alongside user-created ones.
+  static withDefaultActive(client?: StatelogClient): ThreadStore {
     const store = new ThreadStore();
+    if (client) store.setStatelogClient(client);
     store.getOrCreateActive();
     return store;
   }

--- a/packages/agency-lang/lib/runtime/state/threadStore.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.ts
@@ -1,3 +1,4 @@
+import { StatelogClient } from "../../statelogClient.js";
 import { MessageThread, MessageThreadJSON } from "./messageThread.js";
 
 export type ThreadStoreJSON = {
@@ -12,11 +13,16 @@ export class ThreadStore {
   threads: Record<MessageThreadID, MessageThread> = {};
   counter: number = 0;
   activeStack: MessageThreadID[] = [];
+  private statelogClient?: StatelogClient;
 
   constructor() {
     this.threads = {};
     this.counter = 0;
     this.activeStack = [];
+  }
+
+  setStatelogClient(client: StatelogClient): void {
+    this.statelogClient = client;
   }
 
   static withDefaultActive(): ThreadStore {
@@ -29,6 +35,10 @@ export class ThreadStore {
   create(): MessageThreadID {
     const id = (this.counter++).toString();
     this.threads[id] = new MessageThread();
+    this.statelogClient?.threadCreated({
+      threadId: id,
+      threadType: "thread",
+    });
     return id;
   }
 
@@ -42,6 +52,11 @@ export class ThreadStore {
     const parentId = this.activeId();
     const id = (this.counter++).toString();
     this.threads[id] = this.threads[parentId!].newSubthreadChild();
+    this.statelogClient?.threadCreated({
+      threadId: id,
+      threadType: "subthread",
+      parentThreadId: parentId,
+    });
     return id;
   }
 

--- a/packages/agency-lang/lib/simplemachine/graph.ts
+++ b/packages/agency-lang/lib/simplemachine/graph.ts
@@ -41,6 +41,7 @@ export class SimpleMachine<T> {
         projectId: config.statelog.projectId,
         traceId: config.statelog.traceId,
         debugMode: config.statelog.debugMode ?? false,
+        observability: config.statelog.observability,
       });
     }
   }

--- a/packages/agency-lang/lib/simplemachine/graph.ts
+++ b/packages/agency-lang/lib/simplemachine/graph.ts
@@ -126,7 +126,7 @@ export class SimpleMachine<T> {
         });
       }
       this.debug(`Executing node: ${color.green(currentId)}`, data);
-      client?.startSpan("nodeExecution");
+      const nodeSpanId = client?.startSpan("nodeExecution");
       client?.enterNode({ nodeId: currentId, data });
       const startTime = performance.now();
       let nextNode;
@@ -145,7 +145,7 @@ export class SimpleMachine<T> {
           timeTaken: endTime - startTime,
         });
       } finally {
-        client?.endSpan();
+        client?.endSpan(nodeSpanId);
       }
       this.debug(`Completed node: ${color.green(currentId)}`, data);
 

--- a/packages/agency-lang/lib/simplemachine/graph.ts
+++ b/packages/agency-lang/lib/simplemachine/graph.ts
@@ -46,6 +46,10 @@ export class SimpleMachine<T> {
     }
   }
 
+  setStatelogClient(client: StatelogClient): void {
+    this.statelogClient = client;
+  }
+
   node(id: string, func: (data: T) => Promise<T | GoToNode<T>>): void {
     this.nodes[id] = func;
   }

--- a/packages/agency-lang/lib/simplemachine/graph.ts
+++ b/packages/agency-lang/lib/simplemachine/graph.ts
@@ -46,9 +46,6 @@ export class SimpleMachine<T> {
     }
   }
 
-  setStatelogClient(client: StatelogClient): void {
-    this.statelogClient = client;
-  }
 
   node(id: string, func: (data: T) => Promise<T | GoToNode<T>>): void {
     this.nodes[id] = func;
@@ -89,14 +86,15 @@ export class SimpleMachine<T> {
     //this.statelogClient?.debug(message, data || {});
   }
 
-  async run(startId: string, input: T, options?: { onNodeEnter?: (id: string) => void }): Promise<T> {
+  async run(startId: string, input: T, options?: { onNodeEnter?: (id: string) => void; statelogClient?: StatelogClient }): Promise<T> {
+    const client = options?.statelogClient ?? this.statelogClient;
     const jsonEdges: Record<string, JSONEdge> = {};
     for (const from in this.edges) {
       jsonEdges[from] = edgeToJSON(
         this.edges[from as keyof typeof this.edges]!,
       );
     }
-    this.statelogClient?.graph({
+    client?.graph({
       nodes: Object.keys(this.nodes),
       edges: jsonEdges,
       startNode: startId,
@@ -119,7 +117,7 @@ export class SimpleMachine<T> {
         const startTime = performance.now();
         data = await this.config.hooks!.beforeNode!(currentId, data);
         const endTime = performance.now();
-        this.statelogClient?.beforeHook({
+        client?.beforeHook({
           nodeId: currentId,
           startData,
           endData: data,
@@ -127,8 +125,8 @@ export class SimpleMachine<T> {
         });
       }
       this.debug(`Executing node: ${color.green(currentId)}`, data);
-      this.statelogClient?.startSpan("nodeExecution");
-      this.statelogClient?.enterNode({ nodeId: currentId, data });
+      client?.startSpan("nodeExecution");
+      client?.enterNode({ nodeId: currentId, data });
       const startTime = performance.now();
       let nextNode;
       try {
@@ -140,13 +138,13 @@ export class SimpleMachine<T> {
         } else {
           data = result;
         }
-        this.statelogClient?.exitNode({
+        client?.exitNode({
           nodeId: currentId,
           data,
           timeTaken: endTime - startTime,
         });
       } finally {
-        this.statelogClient?.endSpan();
+        client?.endSpan();
       }
       this.debug(`Completed node: ${color.green(currentId)}`, data);
 
@@ -156,7 +154,7 @@ export class SimpleMachine<T> {
         const startTime = performance.now();
         data = await this.config.hooks!.afterNode!(currentId, data);
         const endTime = performance.now();
-        this.statelogClient?.afterHook({
+        client?.afterHook({
           nodeId: currentId,
           startData,
           endData: data,
@@ -175,7 +173,7 @@ export class SimpleMachine<T> {
             `${currentId} tried to go to ${nextNode}, but did not specify a conditional edge to it. Use graph.conditionalEdge("${currentId}", ["${nextNode}"]) to define the edge.`,
           );
         }
-        this.statelogClient?.followEdge({
+        client?.followEdge({
           fromNodeId: currentId,
           toNodeId: nextNode as string,
           isConditionalEdge: false,
@@ -189,7 +187,7 @@ export class SimpleMachine<T> {
         continue;
       }
       if (isRegularEdge(edge)) {
-        this.statelogClient?.followEdge({
+        client?.followEdge({
           fromNodeId: currentId,
           toNodeId: edge.to,
           isConditionalEdge: false,
@@ -200,7 +198,7 @@ export class SimpleMachine<T> {
       } else {
         if (edge.condition) {
           const nextId = await edge.condition(data);
-          this.statelogClient?.followEdge({
+          client?.followEdge({
             fromNodeId: currentId,
             toNodeId: nextId,
             isConditionalEdge: true,

--- a/packages/agency-lang/lib/simplemachine/graph.ts
+++ b/packages/agency-lang/lib/simplemachine/graph.ts
@@ -125,21 +125,24 @@ export class SimpleMachine<T> {
       this.statelogClient?.startSpan("nodeExecution");
       this.statelogClient?.enterNode({ nodeId: currentId, data });
       const startTime = performance.now();
-      const result = await this.runAndValidate(nodeFunc, currentId, data);
-      const endTime = performance.now();
       let nextNode;
-      if (result instanceof GoToNode) {
-        nextNode = result.to;
-        data = result.data;
-      } else {
-        data = result;
+      try {
+        const result = await this.runAndValidate(nodeFunc, currentId, data);
+        const endTime = performance.now();
+        if (result instanceof GoToNode) {
+          nextNode = result.to;
+          data = result.data;
+        } else {
+          data = result;
+        }
+        this.statelogClient?.exitNode({
+          nodeId: currentId,
+          data,
+          timeTaken: endTime - startTime,
+        });
+      } finally {
+        this.statelogClient?.endSpan();
       }
-      this.statelogClient?.exitNode({
-        nodeId: currentId,
-        data,
-        timeTaken: endTime - startTime,
-      });
-      this.statelogClient?.endSpan();
       this.debug(`Completed node: ${color.green(currentId)}`, data);
 
       if (this.config.hooks?.afterNode) {

--- a/packages/agency-lang/lib/simplemachine/graph.ts
+++ b/packages/agency-lang/lib/simplemachine/graph.ts
@@ -42,6 +42,7 @@ export class SimpleMachine<T> {
         traceId: config.statelog.traceId,
         debugMode: config.statelog.debugMode ?? false,
         observability: config.statelog.observability,
+        logFile: config.statelog.logFile,
       });
     }
   }

--- a/packages/agency-lang/lib/simplemachine/graph.ts
+++ b/packages/agency-lang/lib/simplemachine/graph.ts
@@ -122,6 +122,7 @@ export class SimpleMachine<T> {
         });
       }
       this.debug(`Executing node: ${color.green(currentId)}`, data);
+      this.statelogClient?.startSpan("nodeExecution");
       this.statelogClient?.enterNode({ nodeId: currentId, data });
       const startTime = performance.now();
       const result = await this.runAndValidate(nodeFunc, currentId, data);
@@ -138,6 +139,7 @@ export class SimpleMachine<T> {
         data,
         timeTaken: endTime - startTime,
       });
+      this.statelogClient?.endSpan();
       this.debug(`Completed node: ${color.green(currentId)}`, data);
 
       if (this.config.hooks?.afterNode) {

--- a/packages/agency-lang/lib/simplemachine/types.ts
+++ b/packages/agency-lang/lib/simplemachine/types.ts
@@ -19,6 +19,7 @@ export type SimpleMachineConfig<T> = {
     projectId: string;
     traceId?: string;
     debugMode?: boolean;
+    observability?: boolean;
   };
 };
 

--- a/packages/agency-lang/lib/simplemachine/types.ts
+++ b/packages/agency-lang/lib/simplemachine/types.ts
@@ -20,6 +20,7 @@ export type SimpleMachineConfig<T> = {
     traceId?: string;
     debugMode?: boolean;
     observability?: boolean;
+    logFile?: string;
   };
 };
 

--- a/packages/agency-lang/lib/statelogClient.test.ts
+++ b/packages/agency-lang/lib/statelogClient.test.ts
@@ -1,0 +1,530 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { StatelogClient, StatelogConfig, getStatelogClient } from "./statelogClient.js";
+
+/** Make a unique temp file path for a logFile-based test. The file is NOT
+ *  created — the client should create the parent dir and append on first
+ *  event. */
+function tmpLogFile(name: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `statelog-test-${name}-`));
+  return path.join(dir, "events.jsonl");
+}
+
+/** Read every JSON line from a logFile and parse it. Returns [] if the
+ *  file doesn't exist. */
+function readEvents(file: string): any[] {
+  if (!fs.existsSync(file)) return [];
+  const raw = fs.readFileSync(file, "utf-8").trim();
+  if (!raw) return [];
+  return raw.split("\n").map((line) => JSON.parse(line));
+}
+
+/** Standard config helper — observability ON, file sink, deterministic
+ *  traceId for assertions. */
+function fileClient(file: string, overrides: Partial<StatelogConfig> = {}): StatelogClient {
+  return new StatelogClient({
+    host: "",
+    apiKey: "",
+    projectId: "test-project",
+    traceId: "test-trace",
+    debugMode: false,
+    observability: true,
+    logFile: file,
+    ...overrides,
+  });
+}
+
+describe("StatelogClient", () => {
+  let tmpDirs: string[] = [];
+
+  beforeEach(() => {
+    tmpDirs = [];
+  });
+
+  afterEach(() => {
+    for (const d of tmpDirs) {
+      try {
+        fs.rmSync(d, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+    vi.restoreAllMocks();
+  });
+
+  function newLogFile(name: string): string {
+    const file = tmpLogFile(name);
+    tmpDirs.push(path.dirname(file));
+    return file;
+  }
+
+  describe("observability gate", () => {
+    it("is a complete no-op when observability is false", async () => {
+      const file = newLogFile("disabled");
+      const client = fileClient(file, { observability: false });
+
+      // Every event method should be safe to call and produce no I/O.
+      await client.debug("hi", {});
+      await client.agentStart({ entryNode: "main" });
+      await client.enterNode({ nodeId: "main", data: {} });
+      client.startSpan("agentRun");
+      client.endSpan();
+
+      expect(fs.existsSync(file)).toBe(false);
+    });
+
+    it("startSpan returns undefined when disabled", () => {
+      const client = fileClient(newLogFile("disabled-span"), { observability: false });
+      expect(client.startSpan("agentRun")).toBeUndefined();
+      expect(client.currentSpan).toBeUndefined();
+    });
+
+    it("activates the file sink when observability is true", async () => {
+      const file = newLogFile("enabled");
+      const client = fileClient(file);
+      await client.debug("hello", { x: 1 });
+      const events = readEvents(file);
+      expect(events).toHaveLength(1);
+      expect(events[0].data.type).toBe("debug");
+      expect(events[0].data.message).toBe("hello");
+      expect(events[0].trace_id).toBe("test-trace");
+      expect(events[0].project_id).toBe("test-project");
+    });
+  });
+
+  describe("sinks", () => {
+    it("file sink writes one JSONL line per event", async () => {
+      const file = newLogFile("jsonl");
+      const client = fileClient(file);
+
+      await client.debug("a", {});
+      await client.enterNode({ nodeId: "n1", data: { x: 1 } });
+      await client.exitNode({ nodeId: "n1", data: { x: 2 }, timeTaken: 1.5 });
+
+      const events = readEvents(file);
+      expect(events).toHaveLength(3);
+      expect(events.map((e) => e.data.type)).toEqual([
+        "debug",
+        "enterNode",
+        "exitNode",
+      ]);
+    });
+
+    it("auto-creates the logFile's parent directory", async () => {
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), "statelog-mkdir-"));
+      tmpDirs.push(root);
+      const file = path.join(root, "deeply", "nested", "events.jsonl");
+      const client = fileClient(file);
+      await client.debug("hi", {});
+      expect(fs.existsSync(file)).toBe(true);
+    });
+
+    it("stdout sink writes to console.log without requiring an apiKey", async () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const client = new StatelogClient({
+        host: "stdout",
+        apiKey: "",
+        projectId: "p",
+        traceId: "t",
+        debugMode: false,
+        observability: true,
+      });
+      await client.debug("ping", {});
+      expect(spy).toHaveBeenCalledTimes(1);
+      const payload = JSON.parse(spy.mock.calls[0][0]);
+      expect(payload.data.type).toBe("debug");
+      expect(payload.trace_id).toBe("t");
+    });
+
+    it("file sink and remote host both receive events", async () => {
+      const file = newLogFile("dual");
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response("", { status: 200 }));
+      const client = new StatelogClient({
+        host: "https://example.invalid",
+        apiKey: "secret",
+        projectId: "p",
+        traceId: "t",
+        debugMode: false,
+        observability: true,
+        logFile: file,
+      });
+      await client.debug("hi", {});
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(readEvents(file)).toHaveLength(1);
+    });
+  });
+
+  describe("apiKey requirement", () => {
+    it("remote host with no apiKey disables the client", async () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+      const client = new StatelogClient({
+        host: "https://example.invalid",
+        apiKey: "",
+        projectId: "p",
+        traceId: "t",
+        debugMode: false,
+        observability: true,
+      });
+      await client.debug("hi", {});
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("stdout sink does not require an apiKey", async () => {
+      const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const client = new StatelogClient({
+        host: "stdout",
+        apiKey: "",
+        projectId: "p",
+        traceId: "t",
+        debugMode: false,
+        observability: true,
+      });
+      await client.debug("ok", {});
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it("logFile-only sink does not require an apiKey", async () => {
+      const file = newLogFile("nokey");
+      const client = new StatelogClient({
+        host: "",
+        apiKey: "",
+        projectId: "p",
+        traceId: "t",
+        debugMode: false,
+        observability: true,
+        logFile: file,
+      });
+      await client.debug("ok", {});
+      expect(readEvents(file)).toHaveLength(1);
+    });
+  });
+
+  describe("span management", () => {
+    it("startSpan / endSpan maintains a LIFO stack", () => {
+      const client = fileClient(newLogFile("span-lifo"));
+      client.startSpan("agentRun");
+      client.startSpan("nodeExecution");
+      client.startSpan("llmCall");
+      expect(client.currentSpan?.spanType).toBe("llmCall");
+      const popped = client.endSpan();
+      expect(popped?.spanType).toBe("llmCall");
+      expect(client.currentSpan?.spanType).toBe("nodeExecution");
+      client.endSpan();
+      expect(client.currentSpan?.spanType).toBe("agentRun");
+      client.endSpan();
+      expect(client.currentSpan).toBeUndefined();
+    });
+
+    it("attaches span_id and parent_span_id to emitted events", async () => {
+      const file = newLogFile("span-payload");
+      const client = fileClient(file);
+      const outer = client.startSpan("agentRun");
+      const inner = client.startSpan("nodeExecution");
+      await client.enterNode({ nodeId: "n1", data: {} });
+      client.endSpan();
+      client.endSpan();
+      const events = readEvents(file);
+      expect(events).toHaveLength(1);
+      expect(events[0].span_id).toBe(inner);
+      expect(events[0].parent_span_id).toBe(outer);
+    });
+
+    it("root-level events have null parent_span_id", async () => {
+      const file = newLogFile("root-span");
+      const client = fileClient(file);
+      client.startSpan("agentRun");
+      await client.debug("hi", {});
+      client.endSpan();
+      const events = readEvents(file);
+      expect(events[0].parent_span_id).toBeNull();
+      expect(events[0].span_id).toBeTruthy();
+    });
+  });
+
+  describe("forkDepth gating", () => {
+    it("startSpan returns undefined inside a fork", () => {
+      const client = fileClient(newLogFile("fork-gate"));
+      client.enterFork();
+      expect(client.startSpan("nodeExecution")).toBeUndefined();
+      expect(client.currentSpan).toBeUndefined();
+      client.exitFork();
+      expect(client.startSpan("nodeExecution")).toBeTruthy();
+    });
+
+    it("exitFork is clamped at zero", () => {
+      const client = fileClient(newLogFile("fork-clamp"));
+      client.exitFork();
+      client.exitFork();
+      client.exitFork();
+      // Should still be able to start a span (forkDepth must be 0).
+      expect(client.startSpan("agentRun")).toBeTruthy();
+    });
+
+    it("events emitted inside a fork have no span attribution", async () => {
+      const file = newLogFile("fork-payload");
+      const client = fileClient(file);
+      client.startSpan("agentRun");
+      client.enterFork();
+      await client.debug("inside-fork", {});
+      client.exitFork();
+      client.endSpan();
+      const events = readEvents(file);
+      // The event was emitted while inside a fork, so it inherits the
+      // outer span (agentRun) — startSpan was gated, not currentSpan.
+      // The important invariant is that no inner span pushed during the
+      // fork is visible.
+      expect(events[0].span_id).toBeTruthy();
+    });
+  });
+
+  describe("event method shapes", () => {
+    it("agentStart emits the right type and entryNode", async () => {
+      const file = newLogFile("agent-start");
+      const client = fileClient(file);
+      await client.agentStart({ entryNode: "main", args: { x: 1 } });
+      const [evt] = readEvents(file);
+      expect(evt.data.type).toBe("agentStart");
+      expect(evt.data.entryNode).toBe("main");
+      expect(evt.data.args).toEqual({ x: 1 });
+    });
+
+    it("agentEnd includes timeTaken and tokenStats", async () => {
+      const file = newLogFile("agent-end");
+      const client = fileClient(file);
+      await client.agentEnd({
+        entryNode: "main",
+        result: { ok: true },
+        timeTaken: 42,
+        tokenStats: {
+          usage: { totalTokens: 100 },
+          cost: { totalCost: 0.01 },
+        },
+      });
+      const [evt] = readEvents(file);
+      expect(evt.data.type).toBe("agentEnd");
+      expect(evt.data.timeTaken).toBe(42);
+      expect(evt.data.tokenStats.usage.totalTokens).toBe(100);
+      expect(evt.data.tokenStats.cost.totalCost).toBe(0.01);
+    });
+
+    it("promptCompletion includes usage, cost, stream", async () => {
+      const file = newLogFile("prompt");
+      const client = fileClient(file);
+      await client.promptCompletion({
+        messages: [],
+        completion: {},
+        usage: { inputTokens: 10, outputTokens: 20 },
+        cost: { totalCost: 0.005 },
+        stream: false,
+      });
+      const [evt] = readEvents(file);
+      expect(evt.data.type).toBe("promptCompletion");
+      expect(evt.data.usage.inputTokens).toBe(10);
+      expect(evt.data.cost.totalCost).toBe(0.005);
+      expect(evt.data.stream).toBe(false);
+    });
+
+    it("interruptThrown emits only interruptId + interruptData", async () => {
+      const file = newLogFile("intr-thrown");
+      const client = fileClient(file);
+      await client.interruptThrown({
+        interruptId: "i1",
+        interruptData: { foo: "bar" },
+      });
+      const [evt] = readEvents(file);
+      expect(evt.data.type).toBe("interruptThrown");
+      expect(evt.data.interruptId).toBe("i1");
+      expect(evt.data.interruptData).toEqual({ foo: "bar" });
+      // Dropped fields should not be present.
+      expect(evt.data).not.toHaveProperty("functionName");
+      expect(evt.data).not.toHaveProperty("sourceLocation");
+    });
+
+    it("handlerDecision emits decision + value", async () => {
+      const file = newLogFile("handler");
+      const client = fileClient(file);
+      await client.handlerDecision({
+        interruptId: "i1",
+        handlerIndex: 0,
+        decision: "approve",
+        value: 42,
+      });
+      const [evt] = readEvents(file);
+      expect(evt.data.type).toBe("handlerDecision");
+      expect(evt.data.decision).toBe("approve");
+      expect(evt.data.value).toBe(42);
+    });
+
+    it("interruptResolved emits outcome + resolvedBy", async () => {
+      const file = newLogFile("intr-resolved");
+      const client = fileClient(file);
+      await client.interruptResolved({
+        interruptId: "i1",
+        outcome: "approved",
+        resolvedBy: "handler",
+      });
+      const [evt] = readEvents(file);
+      expect(evt.data.type).toBe("interruptResolved");
+      expect(evt.data.outcome).toBe("approved");
+      expect(evt.data.resolvedBy).toBe("handler");
+    });
+
+    it("checkpointCreated emits reason + sourceLocation", async () => {
+      const file = newLogFile("cp-created");
+      const client = fileClient(file);
+      await client.checkpointCreated({
+        checkpointId: 1,
+        reason: "interrupt",
+        sourceLocation: { moduleId: "m", scopeName: "s", stepPath: "p" },
+      });
+      const [evt] = readEvents(file);
+      expect(evt.data.type).toBe("checkpointCreated");
+      expect(evt.data.reason).toBe("interrupt");
+      expect(evt.data.sourceLocation.moduleId).toBe("m");
+    });
+
+    it("checkpointRestored emits restoreCount + overrides", async () => {
+      const file = newLogFile("cp-restored");
+      const client = fileClient(file);
+      await client.checkpointRestored({
+        checkpointId: 1,
+        restoreCount: 3,
+        maxRestores: 100,
+        overrides: { args: true, globals: false },
+      });
+      const [evt] = readEvents(file);
+      expect(evt.data.type).toBe("checkpointRestored");
+      expect(evt.data.restoreCount).toBe(3);
+      expect(evt.data.overrides.args).toBe(true);
+    });
+
+    it("forkStart, forkBranchEnd, forkEnd carry forkId + mode", async () => {
+      const file = newLogFile("fork-events");
+      const client = fileClient(file);
+      await client.forkStart({ forkId: "f1", mode: "all", branchCount: 2 });
+      await client.forkBranchEnd({
+        forkId: "f1",
+        branchIndex: 0,
+        outcome: "success",
+        timeTaken: 1,
+      });
+      await client.forkBranchEnd({
+        forkId: "f1",
+        branchIndex: 1,
+        outcome: "failure",
+        timeTaken: 2,
+      });
+      await client.forkEnd({ forkId: "f1", mode: "all", timeTaken: 3 });
+      const events = readEvents(file).map((e) => e.data);
+      expect(events.map((e) => e.type)).toEqual([
+        "forkStart",
+        "forkBranchEnd",
+        "forkBranchEnd",
+        "forkEnd",
+      ]);
+      expect(events[1].outcome).toBe("success");
+      expect(events[2].outcome).toBe("failure");
+    });
+
+    it("threadCreated emits threadType + parentThreadId", async () => {
+      const file = newLogFile("thread");
+      const client = fileClient(file);
+      await client.threadCreated({ threadId: "0", threadType: "thread" });
+      await client.threadCreated({
+        threadId: "1",
+        threadType: "subthread",
+        parentThreadId: "0",
+      });
+      const events = readEvents(file).map((e) => e.data);
+      expect(events[0].threadType).toBe("thread");
+      expect(events[1].threadType).toBe("subthread");
+      expect(events[1].parentThreadId).toBe("0");
+    });
+
+    it("error emits errorType + retryable", async () => {
+      const file = newLogFile("error");
+      const client = fileClient(file);
+      await client.error({
+        errorType: "toolError",
+        message: "boom",
+        functionName: "doStuff",
+        retryable: true,
+      });
+      const [evt] = readEvents(file);
+      expect(evt.data.type).toBe("error");
+      expect(evt.data.errorType).toBe("toolError");
+      expect(evt.data.functionName).toBe("doStuff");
+      expect(evt.data.retryable).toBe(true);
+    });
+  });
+
+  describe("runMetadata follow-up on agentStart", () => {
+    it("agentStart triggers a runMetadata event when metadata is configured", async () => {
+      const file = newLogFile("metadata");
+      const client = fileClient(file, {
+        metadata: {
+          environment: "test",
+          tags: ["x", "y"],
+        },
+      });
+      await client.agentStart({ entryNode: "main" });
+      const events = readEvents(file).map((e) => e.data);
+      expect(events[0].type).toBe("agentStart");
+      expect(events[1].type).toBe("runMetadata");
+      expect(events[1].environment).toBe("test");
+      expect(events[1].tags).toEqual(["x", "y"]);
+    });
+
+    it("agentStart does NOT emit runMetadata when metadata is absent", async () => {
+      const file = newLogFile("no-metadata");
+      const client = fileClient(file);
+      await client.agentStart({ entryNode: "main" });
+      const events = readEvents(file).map((e) => e.data);
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe("agentStart");
+    });
+  });
+
+  describe("zero-overhead invariant (white-box)", () => {
+    it("post() short-circuits before serialization when disabled", async () => {
+      const file = newLogFile("zero");
+      const stringifySpy = vi.spyOn(JSON, "stringify");
+      const client = fileClient(file, { observability: false });
+
+      // Reset the spy counter — fileClient construction may stringify config.
+      stringifySpy.mockClear();
+
+      await client.debug("a", {});
+      await client.agentStart({ entryNode: "main" });
+      await client.promptCompletion({ messages: [], completion: {} });
+      client.startSpan("agentRun");
+      client.endSpan();
+
+      expect(stringifySpy).not.toHaveBeenCalled();
+      expect(fs.existsSync(file)).toBe(false);
+    });
+  });
+});
+
+describe("getStatelogClient", () => {
+  it("plumbs logFile through to the client", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "statelog-getter-"));
+    try {
+      const file = path.join(dir, "events.jsonl");
+      const client = getStatelogClient({
+        host: "",
+        projectId: "p",
+        observability: true,
+        logFile: file,
+      });
+      await client.debug("hi", {});
+      expect(fs.existsSync(file)).toBe(true);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agency-lang/lib/statelogClient.test.ts
+++ b/packages/agency-lang/lib/statelogClient.test.ts
@@ -206,27 +206,27 @@ describe("StatelogClient", () => {
   describe("span management", () => {
     it("startSpan / endSpan maintains a LIFO stack", () => {
       const client = fileClient(newLogFile("span-lifo"));
-      client.startSpan("agentRun");
-      client.startSpan("nodeExecution");
-      client.startSpan("llmCall");
+      const agentId = client.startSpan("agentRun")!;
+      const nodeId = client.startSpan("nodeExecution")!;
+      const llmId = client.startSpan("llmCall")!;
       expect(client.currentSpan?.spanType).toBe("llmCall");
-      const popped = client.endSpan();
+      const popped = client.endSpan(llmId);
       expect(popped?.spanType).toBe("llmCall");
       expect(client.currentSpan?.spanType).toBe("nodeExecution");
-      client.endSpan();
+      client.endSpan(nodeId);
       expect(client.currentSpan?.spanType).toBe("agentRun");
-      client.endSpan();
+      client.endSpan(agentId);
       expect(client.currentSpan).toBeUndefined();
     });
 
     it("attaches span_id and parent_span_id to emitted events", async () => {
       const file = newLogFile("span-payload");
       const client = fileClient(file);
-      const outer = client.startSpan("agentRun");
-      const inner = client.startSpan("nodeExecution");
+      const outer = client.startSpan("agentRun")!;
+      const inner = client.startSpan("nodeExecution")!;
       await client.enterNode({ nodeId: "n1", data: {} });
-      client.endSpan();
-      client.endSpan();
+      client.endSpan(inner);
+      client.endSpan(outer);
       const events = readEvents(file);
       expect(events).toHaveLength(1);
       expect(events[0].span_id).toBe(inner);
@@ -236,9 +236,9 @@ describe("StatelogClient", () => {
     it("root-level events have null parent_span_id", async () => {
       const file = newLogFile("root-span");
       const client = fileClient(file);
-      client.startSpan("agentRun");
+      const id = client.startSpan("agentRun")!;
       await client.debug("hi", {});
-      client.endSpan();
+      client.endSpan(id);
       const events = readEvents(file);
       expect(events[0].parent_span_id).toBeNull();
       expect(events[0].span_id).toBeTruthy();
@@ -267,11 +267,11 @@ describe("StatelogClient", () => {
     it("events emitted inside a fork have no span attribution", async () => {
       const file = newLogFile("fork-payload");
       const client = fileClient(file);
-      client.startSpan("agentRun");
+      const agentId = client.startSpan("agentRun")!;
       client.enterFork();
       await client.debug("inside-fork", {});
       client.exitFork();
-      client.endSpan();
+      client.endSpan(agentId);
       const events = readEvents(file);
       // The event was emitted while inside a fork, so it inherits the
       // outer span (agentRun) — startSpan was gated, not currentSpan.

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -2,13 +2,62 @@ import { nanoid } from "nanoid";
 import { ModelName } from "smoltalk";
 import { JSONEdge } from "./types.js";
 
+// === Span model ===
+
+export type SpanType =
+  | "agentRun"
+  | "nodeExecution"
+  | "llmCall"
+  | "toolExecution"
+  | "forkAll"
+  | "forkBranch"
+  | "race"
+  | "raceBranch"
+  | "handlerChain";
+
+export type SpanContext = {
+  spanId: string;
+  parentSpanId: string | null;
+  spanType: SpanType;
+  startTime: number;
+};
+
+// === Config ===
+
+export type RunMetadata = {
+  tags?: string[];
+  environment?: string;
+  userId?: string;
+  agentVersion?: string;
+  custom?: Record<string, string>;
+};
+
 export type StatelogConfig = {
   host: string;
   traceId?: string;
   apiKey: string;
   projectId: string;
   debugMode: boolean;
+  metadata?: RunMetadata;
+  observability?: boolean;
 };
+
+// === Token / cost types ===
+
+export type TokenUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedInputTokens?: number;
+  totalTokens?: number;
+};
+
+export type TokenCost = {
+  inputCost?: number;
+  outputCost?: number;
+  totalCost?: number;
+};
+
+// === Client ===
 
 export class StatelogClient {
   private host: string;
@@ -17,6 +66,7 @@ export class StatelogClient {
   private apiKey: string;
   private projectId: string;
   private enabled: boolean = true;
+  private spanStack: SpanContext[] = [];
 
   constructor(config: StatelogConfig) {
     const { host, apiKey, projectId, traceId, debugMode } = config;
@@ -25,6 +75,14 @@ export class StatelogClient {
     this.projectId = projectId;
     this.debugMode = debugMode || false;
     this.traceId = traceId || nanoid();
+
+    // Observability must be explicitly enabled. When false (the default),
+    // the entire client is a no-op — no events emitted, no network calls.
+    if (!config.observability) {
+      this.enabled = false;
+      return;
+    }
+
     if (this.debugMode) {
       console.log(
         `Statelog client initialized with host: ${host} and traceId: ${this.traceId}`,
@@ -38,8 +96,35 @@ export class StatelogClient {
         console.warn(
           "API key is required for StatelogClient to send logs to a remote server. Logs will not be sent.",
         );
-      // throw new Error("API key is required for StatelogClient");
     }
+  }
+
+  // === Span management ===
+
+  startSpan(type: SpanType): string {
+    if (!this.enabled) return "";
+    const spanId = nanoid(12);
+    const parentSpanId = this.spanStack.length > 0
+      ? this.spanStack[this.spanStack.length - 1].spanId
+      : null;
+    this.spanStack.push({
+      spanId,
+      parentSpanId,
+      spanType: type,
+      startTime: performance.now(),
+    });
+    return spanId;
+  }
+
+  endSpan(): SpanContext | undefined {
+    if (!this.enabled) return undefined;
+    return this.spanStack.pop();
+  }
+
+  get currentSpan(): SpanContext | undefined {
+    return this.spanStack.length > 0
+      ? this.spanStack[this.spanStack.length - 1]
+      : undefined;
   }
 
   toJSON() {
@@ -50,6 +135,8 @@ export class StatelogClient {
       debugMode: this.debugMode,
     };
   }
+
+  // === Existing event methods ===
 
   async debug(message: string, data: any): Promise<void> {
     await this.post({
@@ -175,6 +262,10 @@ export class StatelogClient {
     timeTaken,
     tools,
     responseFormat,
+    usage,
+    cost,
+    finishReason,
+    stream,
   }: {
     messages: any[];
     completion: any;
@@ -186,6 +277,10 @@ export class StatelogClient {
       schema: any;
     }[];
     responseFormat?: any;
+    usage?: TokenUsage;
+    cost?: TokenCost;
+    finishReason?: string;
+    stream?: boolean;
   }): Promise<void> {
     await this.post({
       type: "promptCompletion",
@@ -195,6 +290,10 @@ export class StatelogClient {
       timeTaken,
       tools,
       responseFormat,
+      usage,
+      cost,
+      finishReason,
+      stream,
     });
   }
 
@@ -238,6 +337,261 @@ export class StatelogClient {
     });
   }
 
+  // === New event methods ===
+
+  async runMetadata(metadata: RunMetadata & {
+    moduleName?: string;
+    entryNode?: string;
+  }): Promise<void> {
+    await this.post({
+      type: "runMetadata",
+      ...metadata,
+    });
+  }
+
+  async agentStart({
+    entryNode,
+    args,
+  }: {
+    entryNode: string;
+    args?: any;
+  }): Promise<void> {
+    await this.post({
+      type: "agentStart",
+      entryNode,
+      args,
+    });
+  }
+
+  async agentEnd({
+    entryNode,
+    result,
+    timeTaken,
+    tokenStats,
+  }: {
+    entryNode: string;
+    result?: any;
+    timeTaken: number;
+    tokenStats?: {
+      usage: TokenUsage;
+      cost: TokenCost;
+    };
+  }): Promise<void> {
+    await this.post({
+      type: "agentEnd",
+      entryNode,
+      result,
+      timeTaken,
+      tokenStats,
+    });
+  }
+
+  // --- Interrupt lifecycle ---
+
+  async interruptThrown({
+    interruptId,
+    interruptData,
+    functionName,
+    sourceLocation,
+  }: {
+    interruptId: string;
+    interruptData: any;
+    functionName?: string;
+    sourceLocation?: { moduleId: string; line?: number };
+  }): Promise<void> {
+    await this.post({
+      type: "interruptThrown",
+      interruptId,
+      interruptData,
+      functionName,
+      sourceLocation,
+    });
+  }
+
+  async handlerDecision({
+    interruptId,
+    handlerIndex,
+    decision,
+    value,
+  }: {
+    interruptId: string;
+    handlerIndex: number;
+    decision: "approve" | "reject" | "propagate" | "none";
+    value?: any;
+  }): Promise<void> {
+    await this.post({
+      type: "handlerDecision",
+      interruptId,
+      handlerIndex,
+      decision,
+      value,
+    });
+  }
+
+  async interruptResolved({
+    interruptId,
+    outcome,
+    resolvedBy,
+    timeTaken,
+  }: {
+    interruptId: string;
+    outcome: "approved" | "rejected" | "propagated";
+    resolvedBy: "handler" | "user" | "policy" | "ipc";
+    timeTaken?: number;
+  }): Promise<void> {
+    await this.post({
+      type: "interruptResolved",
+      interruptId,
+      outcome,
+      resolvedBy,
+      timeTaken,
+    });
+  }
+
+  // --- Checkpoint lifecycle ---
+
+  async checkpointCreated({
+    checkpointId,
+    reason,
+    sourceLocation,
+  }: {
+    checkpointId: number;
+    reason: "interrupt" | "explicit" | "failure" | "fork" | "race" | "trace";
+    sourceLocation?: { moduleId: string; scopeName: string; stepPath: string };
+  }): Promise<void> {
+    await this.post({
+      type: "checkpointCreated",
+      checkpointId,
+      reason,
+      sourceLocation,
+    });
+  }
+
+  async checkpointRestored({
+    checkpointId,
+    restoreCount,
+    maxRestores,
+    overrides,
+  }: {
+    checkpointId: number;
+    restoreCount: number;
+    maxRestores?: number;
+    overrides?: { args?: boolean; globals?: boolean; locals?: boolean };
+  }): Promise<void> {
+    await this.post({
+      type: "checkpointRestored",
+      checkpointId,
+      restoreCount,
+      maxRestores,
+      overrides,
+    });
+  }
+
+  // --- Fork/Race lifecycle ---
+
+  async forkStart({
+    forkId,
+    mode,
+    branchCount,
+  }: {
+    forkId: string;
+    mode: "all" | "race";
+    branchCount: number;
+  }): Promise<void> {
+    await this.post({
+      type: "forkStart",
+      forkId,
+      mode,
+      branchCount,
+    });
+  }
+
+  async forkBranchEnd({
+    forkId,
+    branchIndex,
+    outcome,
+    timeTaken,
+  }: {
+    forkId: string;
+    branchIndex: number;
+    outcome: "success" | "failure" | "interrupted" | "aborted";
+    timeTaken: number;
+  }): Promise<void> {
+    await this.post({
+      type: "forkBranchEnd",
+      forkId,
+      branchIndex,
+      outcome,
+      timeTaken,
+    });
+  }
+
+  async forkEnd({
+    forkId,
+    mode,
+    timeTaken,
+    winnerIndex,
+  }: {
+    forkId: string;
+    mode: "all" | "race";
+    timeTaken: number;
+    winnerIndex?: number;
+  }): Promise<void> {
+    await this.post({
+      type: "forkEnd",
+      forkId,
+      mode,
+      timeTaken,
+      winnerIndex,
+    });
+  }
+
+  // --- Thread lifecycle ---
+
+  async threadCreated({
+    threadId,
+    threadType,
+    parentThreadId,
+  }: {
+    threadId: string;
+    threadType: "thread" | "subthread";
+    parentThreadId?: string;
+  }): Promise<void> {
+    await this.post({
+      type: "threadCreated",
+      threadId,
+      threadType,
+      parentThreadId,
+    });
+  }
+
+  // --- Structured errors ---
+
+  async error({
+    errorType,
+    message,
+    functionName,
+    retryable,
+    sourceLocation,
+  }: {
+    errorType: "toolError" | "llmError" | "runtimeError" | "validationError" | "limitExceeded";
+    message: string;
+    functionName?: string;
+    retryable?: boolean;
+    sourceLocation?: { moduleId: string; line?: number };
+  }): Promise<void> {
+    await this.post({
+      type: "error",
+      errorType,
+      message,
+      functionName,
+      retryable,
+      sourceLocation,
+    });
+  }
+
+  // === Post (wire format) ===
+
   async post(body: Record<string, any>): Promise<void> {
     if (!this.host) {
       return;
@@ -247,9 +601,12 @@ export class StatelogClient {
       return;
     }
 
+    const span = this.currentSpan;
     const postBody = JSON.stringify({
       trace_id: this.traceId,
       project_id: this.projectId,
+      span_id: span?.spanId ?? null,
+      parent_span_id: span?.parentSpanId ?? null,
       data: { ...body, timestamp: new Date().toISOString() },
     });
 

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -592,7 +592,7 @@ export class StatelogClient {
 
   // === Post (wire format) ===
 
-  async post(body: Record<string, any>): Promise<void> {
+  private async post(body: Record<string, any>): Promise<void> {
     if (!this.host) {
       return;
     }

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -94,7 +94,7 @@ export class StatelogClient {
       );
     }
 
-    if (!this.apiKey) {
+    if (!this.apiKey && this.host.toLowerCase() !== "stdout") {
       this.enabled = false;
       if (this.debugMode)
         console.warn(
@@ -613,7 +613,7 @@ export class StatelogClient {
 
   // === Post (wire format) ===
 
-  private async post(body: Record<string, any>): Promise<void> {
+  async post(body: Record<string, any>): Promise<void> {
     if (!this.host) {
       return;
     }
@@ -664,6 +664,7 @@ export function getStatelogClient(config: {
   traceId?: string;
   projectId: string;
   debugMode?: boolean;
+  observability?: boolean;
 }): StatelogClient {
   const statelogConfig = {
     host: config.host,
@@ -671,6 +672,7 @@ export function getStatelogClient(config: {
     apiKey: process.env.STATELOG_API_KEY || "",
     projectId: config.projectId,
     debugMode: config.debugMode || false,
+    observability: config.observability,
   };
   const client = new StatelogClient(statelogConfig);
   return client;

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -71,6 +71,10 @@ export class StatelogClient {
   private projectId: string;
   private logFile?: string;
   private enabled: boolean = true;
+  // Whether the remote http sink is usable. A configured host with no
+  // apiKey disables ONLY the remote send; local sinks (logFile, stdout)
+  // still receive events.
+  private remoteEnabled: boolean = false;
   private spanStack: SpanContext[] = [];
   private forkDepth: number = 0;
   private metadata?: RunMetadata;
@@ -101,17 +105,20 @@ export class StatelogClient {
       );
     }
 
-    // A remote host needs an apiKey. The "stdout" and file-only sinks
-    // bypass this requirement because they're local-only.
+    // Decide whether the remote sink is usable. The remote sink (any
+    // host that isn't "stdout") requires an apiKey. If the host is set
+    // but the key is missing, we keep the client enabled (so local
+    // sinks still work) but skip the http POST inside `post()`.
     const hostLower = this.host.toLowerCase();
-    const hasLocalSink = hostLower === "stdout" || !!this.logFile;
-    if (!this.apiKey && hostLower !== "stdout" && this.host && !hasLocalSink) {
-      this.enabled = false;
-      if (this.debugMode)
+    const isRemoteHost = !!this.host && hostLower !== "stdout";
+    if (isRemoteHost) {
+      if (this.apiKey) {
+        this.remoteEnabled = true;
+      } else if (this.debugMode) {
         console.warn(
-          "API key is required for StatelogClient to send logs to a remote server. Logs will not be sent.",
+          "StatelogClient: remote host configured without apiKey — remote sink disabled. Local sinks (stdout/logFile) will still receive events.",
         );
-      return;
+      }
     }
 
     // If a logFile is configured, ensure the parent directory exists.
@@ -158,9 +165,36 @@ export class StatelogClient {
     return spanId;
   }
 
-  endSpan(): SpanContext | undefined {
-    if (!this.enabled || this.forkDepth > 0) return undefined;
-    return this.spanStack.pop();
+  // Pop the span identified by `spanId`. The id MUST be the one returned
+  // by the matching `startSpan` call:
+  //
+  //   const id = client.startSpan("agentRun");
+  //   try { ... } finally { client.endSpan(id); }
+  //
+  // - If `spanId` is undefined (its `startSpan` was gated, e.g. inside a
+  //   fork branch), this is a no-op.
+  // - If the span is at the top of the stack, it pops it directly.
+  // - Otherwise we drop everything above the matched span as well — this
+  //   defends against an inner span that forgot to call `endSpan`.
+  // - If the span isn't found at all, this is a no-op.
+  //
+  // We deliberately do NOT gate on `forkDepth` here: the only callers
+  // are paired with a `startSpan` that returned a real id, and they must
+  // be allowed to pop even when concurrent branches are still running.
+  // Branches themselves call `endSpan(undefined)` because their
+  // `startSpan` was gated, so they cannot accidentally pop the parent's
+  // spans.
+  endSpan(spanId?: string): SpanContext | undefined {
+    if (!this.enabled || !spanId) return undefined;
+    const top = this.spanStack[this.spanStack.length - 1];
+    if (top && top.spanId === spanId) {
+      return this.spanStack.pop();
+    }
+    const idx = this.spanStack.findIndex((s) => s.spanId === spanId);
+    if (idx < 0) return undefined;
+    const popped = this.spanStack[idx];
+    this.spanStack.length = idx;
+    return popped;
   }
 
   get currentSpan(): SpanContext | undefined {
@@ -667,6 +701,11 @@ export class StatelogClient {
       console.log(postBody);
       return;
     }
+
+    // Remote sink is only attempted when an apiKey was provided. Without
+    // it we silently skip the http POST so a configured logFile/stdout
+    // sink keeps working without firing unauthenticated requests.
+    if (!this.remoteEnabled) return;
 
     try {
       const fullUrl = new URL("/api/logs", this.host);

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as path from "path";
 import { nanoid } from "nanoid";
 import { ModelName } from "smoltalk";
 import { JSONEdge } from "./types.js";
@@ -10,9 +12,7 @@ export type SpanType =
   | "llmCall"
   | "toolExecution"
   | "forkAll"
-  | "forkBranch"
   | "race"
-  | "raceBranch"
   | "handlerChain";
 
 export type SpanContext = {
@@ -40,6 +40,10 @@ export type StatelogConfig = {
   debugMode: boolean;
   metadata?: RunMetadata;
   observability?: boolean;
+  // Append every event as a JSON line to this file path. Intended for
+  // local development and tests. Mutually compatible with host/stdout —
+  // events are written to all configured sinks.
+  logFile?: string;
 };
 
 // === Token / cost types ===
@@ -65,6 +69,7 @@ export class StatelogClient {
   private traceId: string;
   private apiKey: string;
   private projectId: string;
+  private logFile?: string;
   private enabled: boolean = true;
   private spanStack: SpanContext[] = [];
   private forkDepth: number = 0;
@@ -77,11 +82,13 @@ export class StatelogClient {
     this.projectId = projectId;
     this.debugMode = debugMode || false;
     this.traceId = traceId || nanoid();
+    this.logFile = config.logFile;
 
     this.metadata = config.metadata;
 
     // Observability must be explicitly enabled. When false (the default),
-    // the entire client is a no-op — no events emitted, no network calls.
+    // the entire client is a no-op — no events emitted, no network calls,
+    // no file writes.
     if (!config.observability) {
       this.enabled = false;
       return;
@@ -94,12 +101,29 @@ export class StatelogClient {
       );
     }
 
-    if (!this.apiKey && this.host.toLowerCase() !== "stdout") {
+    // A remote host needs an apiKey. The "stdout" and file-only sinks
+    // bypass this requirement because they're local-only.
+    const hostLower = this.host.toLowerCase();
+    const hasLocalSink = hostLower === "stdout" || !!this.logFile;
+    if (!this.apiKey && hostLower !== "stdout" && this.host && !hasLocalSink) {
       this.enabled = false;
       if (this.debugMode)
         console.warn(
           "API key is required for StatelogClient to send logs to a remote server. Logs will not be sent.",
         );
+      return;
+    }
+
+    // If a logFile is configured, ensure the parent directory exists.
+    // We don't truncate here — each run uses its own runId as traceId,
+    // so multiple runs writing to the same file are still distinguishable.
+    if (this.logFile) {
+      try {
+        fs.mkdirSync(path.dirname(this.logFile), { recursive: true });
+      } catch (err) {
+        if (this.debugMode)
+          console.warn(`StatelogClient: failed to ensure logFile dir: ${err}`);
+      }
     }
   }
 
@@ -119,8 +143,8 @@ export class StatelogClient {
 
   // === Span management ===
 
-  startSpan(type: SpanType): string {
-    if (!this.enabled || this.forkDepth > 0) return "";
+  startSpan(type: SpanType): string | undefined {
+    if (!this.enabled || this.forkDepth > 0) return undefined;
     const spanId = nanoid(12);
     const parentSpanId = this.spanStack.length > 0
       ? this.spanStack[this.spanStack.length - 1].spanId
@@ -412,20 +436,14 @@ export class StatelogClient {
   async interruptThrown({
     interruptId,
     interruptData,
-    functionName,
-    sourceLocation,
   }: {
     interruptId: string;
     interruptData: any;
-    functionName?: string;
-    sourceLocation?: { moduleId: string; line?: number };
   }): Promise<void> {
     await this.post({
       type: "interruptThrown",
       interruptId,
       interruptData,
-      functionName,
-      sourceLocation,
     });
   }
 
@@ -477,7 +495,7 @@ export class StatelogClient {
     sourceLocation,
   }: {
     checkpointId: number;
-    reason: "interrupt" | "explicit" | "failure" | "fork" | "race" | "trace";
+    reason: "interrupt" | "explicit" | "failure" | "fork" | "race";
     sourceLocation?: { moduleId: string; scopeName: string; stepPath: string };
   }): Promise<void> {
     await this.post({
@@ -614,11 +632,12 @@ export class StatelogClient {
   // === Post (wire format) ===
 
   async post(body: Record<string, any>): Promise<void> {
-    if (!this.host) {
+    if (!this.enabled) {
       return;
     }
 
-    if (!this.enabled) {
+    // We need either a host (remote / stdout) or a logFile to do anything.
+    if (!this.host && !this.logFile) {
       return;
     }
 
@@ -630,6 +649,19 @@ export class StatelogClient {
       parent_span_id: span?.parentSpanId ?? null,
       data: { ...body, timestamp: new Date().toISOString() },
     });
+
+    // File sink: append one JSON object per line. Done synchronously
+    // so tests can read the file immediately after an awaited event.
+    if (this.logFile) {
+      try {
+        fs.appendFileSync(this.logFile, postBody + "\n");
+      } catch (err) {
+        if (this.debugMode)
+          console.error("StatelogClient: failed to append to logFile:", err);
+      }
+    }
+
+    if (!this.host) return;
 
     if (this.host.toLowerCase() === "stdout") {
       console.log(postBody);
@@ -665,6 +697,7 @@ export function getStatelogClient(config: {
   projectId: string;
   debugMode?: boolean;
   observability?: boolean;
+  logFile?: string;
 }): StatelogClient {
   const statelogConfig = {
     host: config.host,
@@ -673,6 +706,7 @@ export function getStatelogClient(config: {
     projectId: config.projectId,
     debugMode: config.debugMode || false,
     observability: config.observability,
+    logFile: config.logFile,
   };
   const client = new StatelogClient(statelogConfig);
   return client;

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -67,6 +67,8 @@ export class StatelogClient {
   private projectId: string;
   private enabled: boolean = true;
   private spanStack: SpanContext[] = [];
+  private forkDepth: number = 0;
+  private metadata?: RunMetadata;
 
   constructor(config: StatelogConfig) {
     const { host, apiKey, projectId, traceId, debugMode } = config;
@@ -75,6 +77,8 @@ export class StatelogClient {
     this.projectId = projectId;
     this.debugMode = debugMode || false;
     this.traceId = traceId || nanoid();
+
+    this.metadata = config.metadata;
 
     // Observability must be explicitly enabled. When false (the default),
     // the entire client is a no-op — no events emitted, no network calls.
@@ -99,10 +103,24 @@ export class StatelogClient {
     }
   }
 
+  // === Fork depth tracking ===
+  // Inside fork/race branches, multiple concurrent branches share this
+  // client. Span push/pop would interleave and corrupt the stack, so we
+  // skip span management entirely when forkDepth > 0. Events still fire
+  // (just without span attribution).
+
+  enterFork(): void {
+    this.forkDepth++;
+  }
+
+  exitFork(): void {
+    if (this.forkDepth > 0) this.forkDepth--;
+  }
+
   // === Span management ===
 
   startSpan(type: SpanType): string {
-    if (!this.enabled) return "";
+    if (!this.enabled || this.forkDepth > 0) return "";
     const spanId = nanoid(12);
     const parentSpanId = this.spanStack.length > 0
       ? this.spanStack[this.spanStack.length - 1].spanId
@@ -117,7 +135,7 @@ export class StatelogClient {
   }
 
   endSpan(): SpanContext | undefined {
-    if (!this.enabled) return undefined;
+    if (!this.enabled || this.forkDepth > 0) return undefined;
     return this.spanStack.pop();
   }
 
@@ -361,6 +379,9 @@ export class StatelogClient {
       entryNode,
       args,
     });
+    if (this.metadata) {
+      await this.runMetadata({ ...this.metadata, entryNode });
+    }
   }
 
   async agentEnd({

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -41,7 +41,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -41,7 +41,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -41,7 +41,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -41,7 +41,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -41,7 +41,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -41,7 +41,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/integration/statelog/test.mjs
+++ b/packages/agency-lang/tests/integration/statelog/test.mjs
@@ -1,0 +1,397 @@
+// StateLog integration tests.
+//
+// Each scenario compiles a small .agency program with `observability: true`
+// and `log.logFile: <tmpfile>`, runs it via the in-repo CLI, then reads the
+// resulting JSONL file and asserts on the emitted events.
+//
+// Goals:
+//  - End-to-end coverage of the StateLog wiring (config → compile-time
+//    generated client → runtime emissions → file sink).
+//  - Verify span hierarchy (parent/child) from outside the runtime.
+//  - Verify the "observability: false" zero-overhead guarantee at the
+//    process level: the file is never created.
+//
+// These tests do NOT make LLM calls. They run against the local repo's
+// compiled CLI (`dist/scripts/agency.js`), so `make` must have been run
+// first. Tests can be run locally with:
+//
+//   node tests/integration/statelog/test.mjs
+//
+// or in CI via the integration-test step in .github/workflows/test.yml.
+
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, "..", "..", "..");
+const AGENCY_CLI = resolve(REPO_ROOT, "dist", "scripts", "agency.js");
+
+if (!existsSync(AGENCY_CLI)) {
+  console.error(`[statelog-integration] CLI not built at ${AGENCY_CLI}. Run 'make' first.`);
+  process.exit(1);
+}
+
+// All scenarios live under tests/integration/statelog/.tmp/<scenario>.
+// Inside the repo so that compiled JS can resolve node_modules — agency-lang
+// will not find runtime imports if compiled to /tmp.
+const TMP_ROOT = resolve(__dirname, ".tmp");
+
+function setupScenario(name) {
+  const dir = join(TMP_ROOT, name);
+  rmSync(dir, { recursive: true, force: true });
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeAgencyJson(dir, extraLog = {}) {
+  const config = {
+    observability: true,
+    log: {
+      host: "",
+      projectId: "statelog-integration",
+      logFile: join(dir, "events.jsonl"),
+      ...extraLog,
+    },
+  };
+  writeFileSync(join(dir, "agency.json"), JSON.stringify(config, null, 2));
+}
+
+function writeAgencyFile(dir, source) {
+  writeFileSync(join(dir, "main.agency"), source);
+}
+
+function runAgency(dir, { allowFailure = false } = {}) {
+  // Use the in-repo CLI directly — no tarball install needed because the
+  // generated TS imports `agency-lang/runtime` which resolves via the
+  // workspace's node_modules.
+  try {
+    execSync(`node ${JSON.stringify(AGENCY_CLI)} run ${JSON.stringify(join(dir, "main.agency"))} -c ${JSON.stringify(join(dir, "agency.json"))}`, {
+      cwd: REPO_ROOT,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (err) {
+    if (!allowFailure) throw err;
+  }
+}
+
+function readEvents(dir) {
+  const file = join(dir, "events.jsonl");
+  if (!existsSync(file)) return [];
+  const raw = readFileSync(file, "utf-8").trim();
+  if (!raw) return [];
+  return raw.split("\n").map((line, i) => {
+    try {
+      return JSON.parse(line);
+    } catch (err) {
+      throw new Error(`Failed to parse line ${i}: ${line}`);
+    }
+  });
+}
+
+function eventTypes(events) {
+  return events.map((e) => e.data.type);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(`[ASSERT FAILED] ${message}`);
+}
+
+function assertEqual(actual, expected, message) {
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `[ASSERT FAILED] ${message}\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`,
+    );
+  }
+}
+
+function assertIncludes(arr, value, message) {
+  assert(arr.includes(value), `${message}\n  expected ${JSON.stringify(arr)} to include ${JSON.stringify(value)}`);
+}
+
+const scenarios = [];
+function scenario(name, fn) {
+  scenarios.push({ name, fn });
+}
+
+// ---- Scenario: single-node agent ----
+
+scenario("single-node-agent", async () => {
+  const dir = setupScenario("single-node-agent");
+  writeAgencyJson(dir);
+  writeAgencyFile(dir, `node main() {\n  return "hello"\n}\n`);
+  runAgency(dir);
+  const events = readEvents(dir);
+  const types = eventTypes(events);
+
+  assertIncludes(types, "agentStart", "agentStart event missing");
+  assertIncludes(types, "agentEnd", "agentEnd event missing");
+  assertIncludes(types, "enterNode", "enterNode event missing");
+  assertIncludes(types, "exitNode", "exitNode event missing");
+  assertIncludes(types, "threadCreated", "default thread should be logged");
+
+  // Span hierarchy: enterNode runs inside the agentRun span.
+  const agentStart = events.find((e) => e.data.type === "agentStart");
+  const enterNode = events.find((e) => e.data.type === "enterNode");
+  assert(agentStart.span_id, "agentStart should have a span_id");
+  assert(enterNode.parent_span_id === agentStart.span_id, "enterNode.parent_span_id should be agentStart.span_id");
+
+  // agentEnd should carry tokenStats (zero tokens since no LLM calls).
+  const agentEnd = events.find((e) => e.data.type === "agentEnd");
+  assert(agentEnd.data.tokenStats !== undefined, "agentEnd should include tokenStats");
+});
+
+// ---- Scenario: multi-node chain ----
+
+scenario("multi-node-chain", async () => {
+  const dir = setupScenario("multi-node-chain");
+  writeAgencyJson(dir);
+  writeAgencyFile(dir, `
+node step2() {
+  return "done from step2"
+}
+
+node main() {
+  goto step2()
+}
+`);
+  runAgency(dir);
+  const events = readEvents(dir);
+  const nodeIds = events
+    .filter((e) => e.data.type === "enterNode")
+    .map((e) => e.data.nodeId);
+  assertEqual(nodeIds, ["main", "step2"], "should enter both nodes in order");
+});
+
+// ---- Scenario: fork-all ----
+
+scenario("fork-all", async () => {
+  const dir = setupScenario("fork-all");
+  writeAgencyJson(dir);
+  writeAgencyFile(dir, `
+def double(n: number): number {
+  return n * 2
+}
+
+node main() {
+  let results = fork([1, 2, 3]) as item {
+    return double(item)
+  }
+  return results
+}
+`);
+  runAgency(dir);
+  const events = readEvents(dir);
+  const types = eventTypes(events);
+
+  assertIncludes(types, "forkStart", "forkStart event missing");
+  assertIncludes(types, "forkEnd", "forkEnd event missing");
+
+  const forkStart = events.find((e) => e.data.type === "forkStart");
+  assertEqual(forkStart.data.mode, "all", "fork should be mode:all");
+  assertEqual(forkStart.data.branchCount, 3, "branchCount should be 3");
+
+  const branchEnds = events.filter((e) => e.data.type === "forkBranchEnd");
+  assertEqual(branchEnds.length, 3, "should emit one forkBranchEnd per branch");
+  for (const be of branchEnds) {
+    assertEqual(be.data.outcome, "success", "every branch should succeed");
+  }
+});
+
+// ---- Scenario: race ----
+
+scenario("race", async () => {
+  const dir = setupScenario("race");
+  writeAgencyJson(dir);
+  writeAgencyFile(dir, `
+def identity(n: number): number {
+  return n
+}
+
+node main() {
+  let result = race([1, 2, 3]) as item {
+    return identity(item)
+  }
+  return result
+}
+`);
+  runAgency(dir);
+  const events = readEvents(dir);
+  const types = eventTypes(events);
+
+  assertIncludes(types, "forkStart", "forkStart event missing");
+  assertIncludes(types, "forkEnd", "forkEnd event missing");
+
+  const forkStart = events.find((e) => e.data.type === "forkStart");
+  assertEqual(forkStart.data.mode, "race", "fork should be mode:race");
+
+  const forkEnd = events.find((e) => e.data.type === "forkEnd");
+  assert(typeof forkEnd.data.winnerIndex === "number", "forkEnd should record winnerIndex");
+
+  // Exactly one branch wins; the others are aborted.
+  const branchEnds = events.filter((e) => e.data.type === "forkBranchEnd");
+  const outcomes = branchEnds.map((e) => e.data.outcome).sort();
+  const winners = branchEnds.filter((e) => e.data.outcome === "success");
+  assertEqual(winners.length, 1, "exactly one branch should succeed");
+  // The remaining two branches should be "aborted".
+  assertEqual(
+    branchEnds.filter((e) => e.data.outcome === "aborted").length,
+    2,
+    "the two losing branches should be aborted",
+  );
+});
+
+// ---- Scenario: interrupt with no handler propagates to user ----
+
+scenario("interrupt-propagated", async () => {
+  const dir = setupScenario("interrupt-propagated");
+  writeAgencyJson(dir);
+  writeAgencyFile(dir, `
+node main() {
+  const x = interrupt("Please confirm")
+  return x
+}
+`);
+  // The CLI exits non-zero on interrupt — that's fine for this scenario;
+  // we care about the events that were written before the pause.
+  runAgency(dir, { allowFailure: true });
+  const events = readEvents(dir);
+  const types = eventTypes(events);
+
+  // For top-level interrupts (no surrounding tool call), the runtime emits
+  // an `interruptThrown` event. The matching `checkpointCreated` for these
+  // is currently emitted by generated template code rather than the runtime
+  // (see lib/runtime/interrupts.ts), so we don't assert on it here.
+  assertIncludes(types, "interruptThrown", "interruptThrown event missing");
+
+  // The interrupt should have a non-empty interruptId.
+  const intr = events.find((e) => e.data.type === "interruptThrown");
+  assert(intr.data.interruptId, "interruptThrown must carry interruptId");
+});
+
+// ---- Scenario: thread + subthread blocks ----
+
+scenario("thread-subthread", async () => {
+  const dir = setupScenario("thread-subthread");
+  writeAgencyJson(dir);
+  writeAgencyFile(dir, `
+node main() {
+  thread {
+    subthread {
+      let _ = 1
+    }
+  }
+  return "done"
+}
+`);
+  runAgency(dir);
+  const events = readEvents(dir);
+  const threads = events.filter((e) => e.data.type === "threadCreated");
+  // 1 default + 1 user thread + 1 subthread = 3.
+  assert(threads.length >= 3, `expected at least 3 threadCreated events, got ${threads.length}`);
+  const types = threads.map((e) => e.data.threadType);
+  assertIncludes(types, "thread", "should have a regular thread");
+  assertIncludes(types, "subthread", "should have a subthread");
+
+  const sub = threads.find((e) => e.data.threadType === "subthread");
+  assert(sub.data.parentThreadId !== undefined, "subthread should record parentThreadId");
+});
+
+// ---- Scenario: runMetadata follow-up on agentStart ----
+
+scenario("run-metadata", async () => {
+  const dir = setupScenario("run-metadata");
+  writeAgencyJson(dir, {
+    metadata: {
+      environment: "ci",
+      tags: ["foo", "bar"],
+    },
+  });
+  writeAgencyFile(dir, `node main() {\n  return "ok"\n}\n`);
+  runAgency(dir);
+  const events = readEvents(dir);
+  const types = eventTypes(events);
+  assertIncludes(types, "runMetadata", "runMetadata event missing");
+  const rm = events.find((e) => e.data.type === "runMetadata");
+  assertEqual(rm.data.environment, "ci", "environment should be propagated");
+  assertEqual(rm.data.tags, ["foo", "bar"], "tags should be propagated");
+});
+
+// ---- Scenario: zero-overhead when observability: false ----
+
+scenario("zero-overhead-disabled", async () => {
+  const dir = setupScenario("zero-overhead-disabled");
+  // Note: observability is explicitly FALSE here; the logFile is still
+  // configured so we can prove the file is never created.
+  writeFileSync(
+    join(dir, "agency.json"),
+    JSON.stringify(
+      {
+        observability: false,
+        log: {
+          host: "",
+          projectId: "statelog-integration",
+          logFile: join(dir, "events.jsonl"),
+        },
+      },
+      null,
+      2,
+    ),
+  );
+  writeAgencyFile(dir, `
+def double(n: number): number {
+  return n * 2
+}
+
+node main() {
+  let results = fork([1, 2, 3]) as item {
+    return double(item)
+  }
+  return results
+}
+`);
+  runAgency(dir);
+  assert(
+    !existsSync(join(dir, "events.jsonl")),
+    "events.jsonl must NOT be created when observability is false",
+  );
+});
+
+// ---- Runner ----
+
+async function main() {
+  rmSync(TMP_ROOT, { recursive: true, force: true });
+  let passed = 0;
+  let failed = [];
+  for (const { name, fn } of scenarios) {
+    process.stdout.write(`[statelog] ${name}... `);
+    try {
+      await fn();
+      console.log("ok");
+      passed++;
+    } catch (err) {
+      console.log("FAILED");
+      console.error(`  ${err.message}`);
+      if (err.stdout) console.error(`  stdout: ${err.stdout}`);
+      if (err.stderr) console.error(`  stderr: ${err.stderr}`);
+      failed.push(name);
+    }
+  }
+  if (failed.length === 0) {
+    console.log(`\n[statelog] All ${passed} scenarios passed.`);
+    // Clean up only on full success — preserve on failure for debugging.
+    rmSync(TMP_ROOT, { recursive: true, force: true });
+    process.exit(0);
+  } else {
+    console.error(`\n[statelog] ${failed.length} scenario(s) failed: ${failed.join(", ")}`);
+    console.error(`[statelog] Temp directory preserved at ${TMP_ROOT}`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("[statelog] runner crashed:", err);
+  process.exit(1);
+});

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptBuilder/getContext.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/getContext.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
@@ -76,7 +77,16 @@ export const respondToInterrupts = (interrupts: Interrupt[], responses: Interrup
 export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
 
 export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
-export const __setTraceWriter = (tw: any) => { __globalCtx.traceWriter = tw; };
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+};
 export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
 export const __getCheckpoints = () => __globalCtx.checkpoints;
 

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -40,7 +40,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -54,7 +54,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -40,7 +40,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -40,7 +40,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -39,7 +39,8 @@ const __globalCtx = new RuntimeContext({
     host: "https://statelog.adit.io",
     apiKey: __process.env["STATELOG_API_KEY"] || "",
     projectId: "",
-    debugMode: false
+    debugMode: false,
+    observability: false
   },
   smoltalkDefaults: {
     openAiApiKey: __process.env["OPENAI_API_KEY"] || "",


### PR DESCRIPTION
## Summary

- Adds hierarchical span model (`span_id`/`parent_span_id`) to all StateLog events for proper nesting (agent run > node > LLM call > tool call)
- Adds token usage and cost data to `promptCompletion` events (data was already computed but never sent to StateLog)
- Adds 13 new event types: `agentStart`, `agentEnd`, `runMetadata`, `interruptThrown`, `handlerDecision`, `interruptResolved`, `checkpointCreated`, `checkpointRestored`, `forkStart`, `forkBranchEnd`, `forkEnd`, `threadCreated`, `error`
- Adds `observability` config key in `agency.json` — StatelogClient is a complete no-op unless this is explicitly set to `true`
- All new fields on existing events are optional (fully backward compatible)
- Event types align with OpenTelemetry GenAI semantic conventions for future OTel export adapter

## Files changed

- `lib/statelogClient.ts` — Span model, new event methods, observability gate
- `lib/config.ts` — `observability` config key + Zod schema
- `lib/backends/typescriptBuilder.ts` — Pass observability flag to generated code
- `lib/runtime/prompt.ts` — Token/cost on LLM events, tool spans, error events
- `lib/runtime/interrupts.ts` — Handler decision and interrupt resolution events
- `lib/runtime/runner.ts` — Fork/race lifecycle events
- `lib/runtime/node.ts` — Agent start/end, checkpoint restored events
- `lib/runtime/state/threadStore.ts` — Thread creation events
- `lib/simplemachine/graph.ts` — Node execution spans
- `docs/superpowers/specs/2026-05-15-statelog-enhancement-design.md` — Design spec

## Test plan

- [x] Full build passes (`make` succeeds)
- [x] 3418/3418 tests pass (1 pre-existing fixture mismatch unrelated to this PR)
- [ ] Manual test with `observability: true` and `host: "stdout"` to verify events are emitted
- [ ] Manual test with `observability: false` (default) to verify zero overhead