### PR TITLE
Per-branch span stacks via AsyncLocalStorage

### DIFF
--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -620,12 +620,11 @@ export class Runner {
       this.frame.popBranches();
     } finally {
       this.path.pop();
-      // Each branch is responsible for balancing its own
-      // enterFork/exitFork call via .finally/.then-or-catch handlers.
-      // We deliberately do NOT decrement here: in a race, losing branches
-      // may still be running, and decrementing prematurely would corrupt
-      // a parent fork's depth tracking and let nested code start logging
-      // spans into the shared stack while branches are still in flight.
+      // Each branch ran inside its own AsyncLocalStorage span context, so
+      // its pushes/pops are isolated from the parent. We can safely emit
+      // forkEnd and pop the fork span here even while loser race branches
+      // are still draining in the background — their stacks live in
+      // independent ALS contexts and cannot touch the parent's stack.
       this.ctx.statelogClient.forkEnd({
         forkId,
         mode,
@@ -658,6 +657,10 @@ export class Runner {
   ): Promise<any> {
     const branchStartTimes: number[] = [];
     const branchEndTimes: number[] = [];
+    // Snapshot the current span stack ONCE, before branches are scheduled.
+    // Each branch runs inside its own ALS context seeded from this snapshot,
+    // so spans pushed in one branch never leak to siblings or the parent.
+    const parentStack = this.ctx.statelogClient.snapshotStack();
     const promises = items.map((item, i) => {
       const branchKey = this.forkBranchKey(id, i);
       const existing = this.frame.getOrCreateBranch(branchKey);
@@ -679,11 +682,11 @@ export class Runner {
           : existing.abortController.signal;
       }
       branchStartTimes[i] = performance.now();
-      this.ctx.statelogClient.enterFork();
-      return blockFn(item, i, existing.stack).finally(() => {
-        branchEndTimes[i] = performance.now();
-        this.ctx.statelogClient.exitFork();
-      });
+      return this.ctx.statelogClient
+        .runInBranchContext(parentStack, () => blockFn(item, i, existing.stack))
+        .finally(() => {
+          branchEndTimes[i] = performance.now();
+        });
     });
 
     const settled = await Promise.allSettled(promises);
@@ -768,6 +771,7 @@ export class Runner {
     ) => Promise<any>,
     stateStack: StateStack,
     branchStartTimes: number[],
+    parentSpanStack: import("../statelogClient.js").SpanContext[],
   ): Promise<{ index: number; value: any }> {
     const branchKey = this.forkBranchKey(id, i);
     const existing = this.frame.getOrCreateBranch(branchKey);
@@ -786,68 +790,30 @@ export class Runner {
         : existing.abortController.signal;
     }
     branchStartTimes[i] = performance.now();
-    this.ctx.statelogClient.enterFork();
-    return blockFn(item, i, existing.stack).then(
-      (value) => {
-        this.ctx.statelogClient.exitFork();
-        return { index: i, value };
-      },
-      (err) => {
-        this.ctx.statelogClient.exitFork();
+    return this.ctx.statelogClient
+      .runInBranchContext(parentSpanStack, () => blockFn(item, i, existing.stack))
+      .then(
+        (value) => ({ index: i, value }),
         // Tag the rejection so the racer can identify which branch died.
-        return Promise.reject({ index: i, err });
-      },
-    );
+        (err) => Promise.reject({ index: i, err }),
+      );
   }
 
-  private async runRace(
+  /** After a race winner is chosen, abort the loser branches and emit
+   * a `forkBranchEnd` event for every branch (winner + losers). The
+   * abort is best-effort: synchronous code that has already reached an
+   * `interrupt()` call before we get here will still resolve its orphan
+   * promise — runRace's caller discards those resolutions. */
+  private abortLoserBranchesAndEmitEnds(
     id: number,
-    items: any[],
-    blockFn: (
-      item: any,
-      index: number,
-      branchStack: StateStack,
-    ) => Promise<any>,
-    stateStack: StateStack,
+    itemCount: number,
+    winnerIndex: number,
+    winnerValue: any,
+    winnerTime: number,
+    branchStartTimes: number[],
     forkId: string,
-  ): Promise<any> {
-    const branchStartTimes: number[] = new Array(items.length).fill(0);
-    const taggedPromises = items.map((item, i) =>
-      this.buildRaceBranchPromise(id, i, item, blockFn, stateStack, branchStartTimes),
-    );
-
-    // Promise.race resolves/rejects with whichever settles first.
-    let winnerIndex: number;
-    let winnerValue: any;
-    let winnerTime: number;
-    try {
-      const winner = await Promise.race(taggedPromises);
-      winnerIndex = winner.index;
-      winnerValue = winner.value;
-      winnerTime = performance.now() - branchStartTimes[winnerIndex];
-    } catch (tagged) {
-      // A branch rejected first — we know which one thanks to tagging.
-      const { index: failedIndex, err } = tagged as { index: number; err: any };
-      this.ctx.statelogClient.forkBranchEnd({
-        forkId,
-        branchIndex: failedIndex,
-        outcome: "failure",
-        timeTaken: performance.now() - branchStartTimes[failedIndex],
-      });
-      // Abort the still-running branches. Their per-branch exitFork in the
-      // .then/.catch handlers will balance the enterFork depth.
-      for (let i = 0; i < items.length; i++) {
-        if (i === failedIndex) continue;
-        this.frame.getBranch(this.forkBranchKey(id, i))?.abortController?.abort();
-      }
-      throw err;
-    }
-
-    // Abort the losing branches so any in-flight work (LLM calls, tool calls)
-    // can stop. Note: synchronous code that has already reached an
-    // interrupt() call before we get here will still resolve its orphan
-    // promise — we discard those resolutions below.
-    for (let i = 0; i < items.length; i++) {
+  ): void {
+    for (let i = 0; i < itemCount; i++) {
       if (i === winnerIndex) continue;
       const branchKey = this.forkBranchKey(id, i);
       const branch = this.frame.getBranch(branchKey);
@@ -868,6 +834,74 @@ export class Runner {
       outcome: hasInterrupts(winnerValue) ? "interrupted" : "success",
       timeTaken: winnerTime,
     });
+  }
+
+  private async runRace(
+    id: number,
+    items: any[],
+    blockFn: (
+      item: any,
+      index: number,
+      branchStack: StateStack,
+    ) => Promise<any>,
+    stateStack: StateStack,
+    forkId: string,
+  ): Promise<any> {
+    const branchStartTimes: number[] = new Array(items.length).fill(0);
+    // Snapshot the current span stack ONCE — each race branch will run
+    // inside its own ALS context seeded from this snapshot, so concurrent
+    // branches cannot interleave span pushes/pops on the parent stack.
+    const parentSpanStack = this.ctx.statelogClient.snapshotStack();
+    const taggedPromises = items.map((item, i) =>
+      this.buildRaceBranchPromise(
+        id,
+        i,
+        item,
+        blockFn,
+        stateStack,
+        branchStartTimes,
+        parentSpanStack,
+      ),
+    );
+
+    // Promise.race resolves/rejects with whichever settles first.
+    let winnerIndex: number;
+    let winnerValue: any;
+    let winnerTime: number;
+    try {
+      const winner = await Promise.race(taggedPromises);
+      winnerIndex = winner.index;
+      winnerValue = winner.value;
+      winnerTime = performance.now() - branchStartTimes[winnerIndex];
+    } catch (tagged) {
+      // A branch rejected first — we know which one thanks to tagging.
+      const { index: failedIndex, err } = tagged as { index: number; err: any };
+      this.ctx.statelogClient.forkBranchEnd({
+        forkId,
+        branchIndex: failedIndex,
+        outcome: "failure",
+        timeTaken: performance.now() - branchStartTimes[failedIndex],
+      });
+      // Abort the still-running branches. Each branch already runs in
+      // its own ALS-scoped span context, so no parent span bookkeeping
+      // needs balancing here — losers' span stacks simply go away with
+      // their async contexts.
+      for (let i = 0; i < items.length; i++) {
+        if (i === failedIndex) continue;
+        this.frame.getBranch(this.forkBranchKey(id, i))?.abortController?.abort();
+      }
+      throw err;
+    }
+
+    this.abortLoserBranchesAndEmitEnds(
+      id,
+      items.length,
+      winnerIndex,
+      winnerValue,
+      winnerTime,
+      branchStartTimes,
+      forkId,
+    );
 
     // Record the winner so a resume on the same race step replays only this
     // branch (not the abandoned losers).
@@ -951,7 +985,14 @@ export class Runner {
       existing.abortController = new AbortController();
       existing.stack.abortSignal = existing.abortController.signal;
     }
-    const value = await blockFn(items[winnerIndex], winnerIndex, existing.stack);
+    // Run the resumed winner inside its own branch-local span context
+    // so its spans nest under the (resumed) race span rather than
+    // mutating the outer stack directly.
+    const parentSpanStack = this.ctx.statelogClient.snapshotStack();
+    const value = await this.ctx.statelogClient.runInBranchContext(
+      parentSpanStack,
+      () => blockFn(items[winnerIndex], winnerIndex, existing.stack),
+    );
 
     if (hasInterrupts(value)) {
       this.frame.setInterruptOnBranch(

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -1,4 +1,5 @@
 import { nanoid } from "nanoid";
+import type { SpanContext } from "../statelogClient.js";
 import { debugStep } from "./debugger.js";
 import { hasInterrupts } from "./interrupts.js";
 import { __pipeBind } from "./result.js";
@@ -771,7 +772,7 @@ export class Runner {
     ) => Promise<any>,
     stateStack: StateStack,
     branchStartTimes: number[],
-    parentSpanStack: import("../statelogClient.js").SpanContext[],
+    parentSpanStack: SpanContext[],
   ): Promise<{ index: number; value: any }> {
     const branchKey = this.forkBranchKey(id, i);
     const existing = this.frame.getOrCreateBranch(branchKey);

--- a/packages/agency-lang/lib/statelogClient.test.ts
+++ b/packages/agency-lang/lib/statelogClient.test.ts
@@ -81,6 +81,29 @@ describe("StatelogClient", () => {
       expect(client.currentSpan).toBeUndefined();
     });
 
+    it("snapshotStack and runInBranchContext short-circuit when disabled", async () => {
+      // The runner calls `snapshotStack()` and wraps every branch in
+      // `runInBranchContext()` unconditionally. When the client is a
+      // no-op, neither call should allocate a fresh stack copy or set
+      // up an AsyncLocalStorage context. We verify behavior — same
+      // empty array reference, no ALS plumbing — to keep the no-op
+      // mode genuinely free of per-fork overhead.
+      const client = fileClient(newLogFile("disabled-fork"), { observability: false });
+      const snap1 = client.snapshotStack();
+      const snap2 = client.snapshotStack();
+      expect(snap1).toHaveLength(0);
+      // Same shared empty stack returned every call — no per-fork allocation.
+      expect(snap1).toBe(snap2);
+
+      // runInBranchContext just calls fn() directly when disabled, so
+      // we observe no ALS context inside it.
+      const inside = await client.runInBranchContext(snap1, async () => {
+        // currentSpan stays undefined (no rootStack pushes, no ALS store).
+        return client.currentSpan;
+      });
+      expect(inside).toBeUndefined();
+    });
+
     it("activates the file sink when observability is true", async () => {
       const file = newLogFile("enabled");
       const client = fileClient(file);

--- a/packages/agency-lang/lib/statelogClient.test.ts
+++ b/packages/agency-lang/lib/statelogClient.test.ts
@@ -245,39 +245,114 @@ describe("StatelogClient", () => {
     });
   });
 
-  describe("forkDepth gating", () => {
-    it("startSpan returns undefined inside a fork", () => {
-      const client = fileClient(newLogFile("fork-gate"));
-      client.enterFork();
-      expect(client.startSpan("nodeExecution")).toBeUndefined();
-      expect(client.currentSpan).toBeUndefined();
-      client.exitFork();
-      expect(client.startSpan("nodeExecution")).toBeTruthy();
+  describe("branch span isolation (AsyncLocalStorage)", () => {
+    it("snapshotStack copies the active stack and decouples it from later pushes", () => {
+      const client = fileClient(newLogFile("snapshot"));
+      const a = client.startSpan("agentRun")!;
+      const snap = client.snapshotStack();
+      const b = client.startSpan("nodeExecution")!;
+      // Snapshot was taken before `b` was pushed, so it must NOT contain b.
+      expect(snap.map((s) => s.spanId)).toEqual([a]);
+      // And mutating the live stack must not retroactively alter the snapshot.
+      expect(snap.length).toBe(1);
+      client.endSpan(b);
+      client.endSpan(a);
     });
 
-    it("exitFork is clamped at zero", () => {
-      const client = fileClient(newLogFile("fork-clamp"));
-      client.exitFork();
-      client.exitFork();
-      client.exitFork();
-      // Should still be able to start a span (forkDepth must be 0).
-      expect(client.startSpan("agentRun")).toBeTruthy();
+    it("spans pushed inside runInBranchContext are invisible outside it", async () => {
+      const client = fileClient(newLogFile("branch-iso"));
+      const outer = client.startSpan("agentRun")!;
+      const parent = client.snapshotStack();
+      let innerIdInsideBranch: string | undefined;
+      let currentInsideBranch: string | undefined;
+      await client.runInBranchContext(parent, async () => {
+        innerIdInsideBranch = client.startSpan("nodeExecution");
+        currentInsideBranch = client.currentSpan?.spanId;
+        // Inside the branch, currentSpan is the branch-local push.
+        expect(currentInsideBranch).toBe(innerIdInsideBranch);
+      });
+      // Back outside the branch, the outer stack must be unaffected.
+      expect(client.currentSpan?.spanId).toBe(outer);
+      client.endSpan(outer);
     });
 
-    it("events emitted inside a fork have no span attribution", async () => {
-      const file = newLogFile("fork-payload");
+    it("concurrent branches each see their own stack — no interleaving", async () => {
+      const client = fileClient(newLogFile("branch-concurrent"));
+      const outer = client.startSpan("agentRun")!;
+      const parent = client.snapshotStack();
+
+      // Two branches run concurrently. Each pushes a different span and
+      // yields control multiple times via `await`. If the two branches
+      // shared a stack, they would observe each other's pushes.
+      const branch0 = client.runInBranchContext(parent, async () => {
+        const id = client.startSpan("nodeExecution")!;
+        await new Promise((r) => setImmediate(r));
+        const top0 = client.currentSpan?.spanId;
+        await new Promise((r) => setImmediate(r));
+        const top1 = client.currentSpan?.spanId;
+        client.endSpan(id);
+        return { id, top0, top1, parentSpan: id && client.currentSpan?.spanId };
+      });
+      const branch1 = client.runInBranchContext(parent, async () => {
+        const id = client.startSpan("llmCall")!;
+        await new Promise((r) => setImmediate(r));
+        const top0 = client.currentSpan?.spanId;
+        await new Promise((r) => setImmediate(r));
+        const top1 = client.currentSpan?.spanId;
+        client.endSpan(id);
+        return { id, top0, top1 };
+      });
+
+      const [b0, b1] = await Promise.all([branch0, branch1]);
+      // Each branch's "currentSpan" across awaits is its own push, never
+      // the sibling's push.
+      expect(b0.top0).toBe(b0.id);
+      expect(b0.top1).toBe(b0.id);
+      expect(b1.top0).toBe(b1.id);
+      expect(b1.top1).toBe(b1.id);
+      expect(b0.id).not.toBe(b1.id);
+
+      // The outer stack still has only the agentRun span.
+      expect(client.currentSpan?.spanId).toBe(outer);
+      client.endSpan(outer);
+    });
+
+    it("events emitted inside a branch attribute to the branch's span", async () => {
+      const file = newLogFile("branch-attribution");
       const client = fileClient(file);
-      const agentId = client.startSpan("agentRun")!;
-      client.enterFork();
-      await client.debug("inside-fork", {});
-      client.exitFork();
-      client.endSpan(agentId);
+      const outer = client.startSpan("agentRun")!;
+      const parent = client.snapshotStack();
+      await client.runInBranchContext(parent, async () => {
+        const inner = client.startSpan("nodeExecution")!;
+        await client.debug("inside-branch", {});
+        client.endSpan(inner);
+      });
+      client.endSpan(outer);
       const events = readEvents(file);
-      // The event was emitted while inside a fork, so it inherits the
-      // outer span (agentRun) — startSpan was gated, not currentSpan.
-      // The important invariant is that no inner span pushed during the
-      // fork is visible.
+      expect(events).toHaveLength(1);
+      // The debug event must be attributed to the branch's nodeExecution
+      // span (not to the outer agentRun span).
+      expect(events[0].parent_span_id).toBe(outer);
+      // And its span_id must be the branch-local span — which means the
+      // branch saw a fresh push.
       expect(events[0].span_id).toBeTruthy();
+      expect(events[0].span_id).not.toBe(outer);
+    });
+
+    it("a branch ending a span it never opened is a no-op on the parent stack", async () => {
+      const client = fileClient(newLogFile("branch-no-parent-pop"));
+      const outer = client.startSpan("agentRun")!;
+      const parent = client.snapshotStack();
+      await client.runInBranchContext(parent, async () => {
+        // Try to pop the parent's outer span from inside the branch. The
+        // branch's snapshot includes `outer`, but ending it pops only the
+        // branch's *local* copy — it must not pop the real outer stack.
+        client.endSpan(outer);
+      });
+      // The parent's outer span is still active.
+      expect(client.currentSpan?.spanId).toBe(outer);
+      client.endSpan(outer);
+      expect(client.currentSpan).toBeUndefined();
     });
   });
 

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -64,6 +64,12 @@ export type TokenCost = {
 
 // === Client ===
 
+// Shared empty stack returned by `snapshotStack()` when the client is
+// disabled. Reusing one frozen array avoids per-fork allocations in the
+// default no-op mode. The runner only ever reads from this snapshot
+// (passes it back into `runInBranchContext`), never mutates it.
+const EMPTY_STACK: ReadonlyArray<SpanContext> = Object.freeze([]) as ReadonlyArray<SpanContext>;
+
 export class StatelogClient {
   private host: string;
   private debugMode: boolean;
@@ -158,7 +164,12 @@ export class StatelogClient {
   // Returns a shallow snapshot of the active span stack — used by the
   // runner to seed each branch's stack with the parent's spans so
   // events inside the branch nest under the fork/race span.
+  //
+  // Short-circuits to a shared empty array when observability is off
+  // so the runner can call this unconditionally without paying for an
+  // allocation on every fork/race in the no-op default mode.
   snapshotStack(): SpanContext[] {
+    if (!this.enabled) return EMPTY_STACK as SpanContext[];
     return [...this.currentStack()];
   }
 
@@ -170,10 +181,16 @@ export class StatelogClient {
   // Spans pushed inside `fn` are popped against this private stack only,
   // never the parent. Defensively copies `parentStack` so the caller's
   // array is never mutated.
+  //
+  // When observability is disabled the ALS plumbing is skipped entirely
+  // — we just invoke `fn()` directly. The runner can therefore always
+  // wrap branches in this call without paying ALS overhead in no-op
+  // mode.
   runInBranchContext<T>(
     parentStack: SpanContext[],
     fn: () => Promise<T>,
   ): Promise<T> {
+    if (!this.enabled) return fn();
     return this.spanStorage.run([...parentStack], fn);
   }
 

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
+import { AsyncLocalStorage } from "node:async_hooks";
 import { nanoid } from "nanoid";
 import { ModelName } from "smoltalk";
 import { JSONEdge } from "./types.js";
@@ -75,8 +76,15 @@ export class StatelogClient {
   // apiKey disables ONLY the remote send; local sinks (logFile, stdout)
   // still receive events.
   private remoteEnabled: boolean = false;
-  private spanStack: SpanContext[] = [];
-  private forkDepth: number = 0;
+  // The "root" span stack — used by the outer agent run thread. Code
+  // running inside `runInBranchContext` sees a branch-local stack
+  // delivered via AsyncLocalStorage instead.
+  private rootStack: SpanContext[] = [];
+  // Per-branch span stacks live in this AsyncLocalStorage. Each concurrent
+  // fork/race branch gets its own stack so its `startSpan`/`endSpan`
+  // calls never bleed into the parent or siblings — even though they all
+  // share this single StatelogClient instance.
+  private spanStorage = new AsyncLocalStorage<SpanContext[]>();
   private metadata?: RunMetadata;
 
   constructor(config: StatelogConfig) {
@@ -134,29 +142,47 @@ export class StatelogClient {
     }
   }
 
-  // === Fork depth tracking ===
-  // Inside fork/race branches, multiple concurrent branches share this
-  // client. Span push/pop would interleave and corrupt the stack, so we
-  // skip span management entirely when forkDepth > 0. Events still fire
-  // (just without span attribution).
-
-  enterFork(): void {
-    this.forkDepth++;
-  }
-
-  exitFork(): void {
-    if (this.forkDepth > 0) this.forkDepth--;
-  }
-
   // === Span management ===
+  //
+  // Spans are tracked per-async-context. Outside fork/race branches the
+  // active stack is `rootStack`. Inside `runInBranchContext` it is the
+  // per-branch stack delivered by `spanStorage`. This means concurrent
+  // branches each get a private stack — their `startSpan`/`endSpan`
+  // calls cannot interleave or pop each other's spans, and events
+  // emitted inside a branch are attributed to that branch's current
+  // span (which inherits the parent fork span at branch entry).
+  private currentStack(): SpanContext[] {
+    return this.spanStorage.getStore() ?? this.rootStack;
+  }
+
+  // Returns a shallow snapshot of the active span stack — used by the
+  // runner to seed each branch's stack with the parent's spans so
+  // events inside the branch nest under the fork/race span.
+  snapshotStack(): SpanContext[] {
+    return [...this.currentStack()];
+  }
+
+  // Run `fn` with a fresh, branch-local span stack seeded from
+  // `parentStack`. Each call to this method creates an independent ALS
+  // context; sibling calls (e.g. concurrent fork branches) see
+  // independent stacks even though they share this StatelogClient.
+  //
+  // Spans pushed inside `fn` are popped against this private stack only,
+  // never the parent. Defensively copies `parentStack` so the caller's
+  // array is never mutated.
+  runInBranchContext<T>(
+    parentStack: SpanContext[],
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    return this.spanStorage.run([...parentStack], fn);
+  }
 
   startSpan(type: SpanType): string | undefined {
-    if (!this.enabled || this.forkDepth > 0) return undefined;
+    if (!this.enabled) return undefined;
+    const stack = this.currentStack();
     const spanId = nanoid(12);
-    const parentSpanId = this.spanStack.length > 0
-      ? this.spanStack[this.spanStack.length - 1].spanId
-      : null;
-    this.spanStack.push({
+    const parentSpanId = stack.length > 0 ? stack[stack.length - 1].spanId : null;
+    stack.push({
       spanId,
       parentSpanId,
       spanType: type,
@@ -165,42 +191,36 @@ export class StatelogClient {
     return spanId;
   }
 
-  // Pop the span identified by `spanId`. The id MUST be the one returned
-  // by the matching `startSpan` call:
+  // Pop the span identified by `spanId` from the active stack. The id
+  // MUST be the one returned by the matching `startSpan` call:
   //
   //   const id = client.startSpan("agentRun");
   //   try { ... } finally { client.endSpan(id); }
   //
-  // - If `spanId` is undefined (its `startSpan` was gated, e.g. inside a
-  //   fork branch), this is a no-op.
-  // - If the span is at the top of the stack, it pops it directly.
-  // - Otherwise we drop everything above the matched span as well — this
+  // - If `spanId` is undefined, this is a no-op.
+  // - If the span is at the top of the active stack, it pops it directly.
+  // - Otherwise we drop everything above the matched span — this
   //   defends against an inner span that forgot to call `endSpan`.
-  // - If the span isn't found at all, this is a no-op.
-  //
-  // We deliberately do NOT gate on `forkDepth` here: the only callers
-  // are paired with a `startSpan` that returned a real id, and they must
-  // be allowed to pop even when concurrent branches are still running.
-  // Branches themselves call `endSpan(undefined)` because their
-  // `startSpan` was gated, so they cannot accidentally pop the parent's
-  // spans.
+  // - If the span isn't found in the active stack, this is a no-op.
+  //   That can legitimately happen when a branch tries to end a span
+  //   that lives on the parent's stack, or vice versa.
   endSpan(spanId?: string): SpanContext | undefined {
     if (!this.enabled || !spanId) return undefined;
-    const top = this.spanStack[this.spanStack.length - 1];
+    const stack = this.currentStack();
+    const top = stack[stack.length - 1];
     if (top && top.spanId === spanId) {
-      return this.spanStack.pop();
+      return stack.pop();
     }
-    const idx = this.spanStack.findIndex((s) => s.spanId === spanId);
+    const idx = stack.findIndex((s) => s.spanId === spanId);
     if (idx < 0) return undefined;
-    const popped = this.spanStack[idx];
-    this.spanStack.length = idx;
+    const popped = stack[idx];
+    stack.length = idx;
     return popped;
   }
 
   get currentSpan(): SpanContext | undefined {
-    return this.spanStack.length > 0
-      ? this.spanStack[this.spanStack.length - 1]
-      : undefined;
+    const stack = this.currentStack();
+    return stack.length > 0 ? stack[stack.length - 1] : undefined;
   }
 
   toJSON() {


### PR DESCRIPTION
## Summary

Replaces the fork-depth gate in `StatelogClient` with per-async-context span stacks via Node's `AsyncLocalStorage`, so spans (and the events they own) are correctly attributed inside concurrent fork/race branches.

## Background

`StatelogClient` is shared across an entire agent run. Fork/race branches run concurrently in JavaScript (`Promise.all` / `Promise.race`), so a single mutable `spanStack: SpanContext[]` cannot serve all branches at once — parallel `startSpan` / `endSpan` calls from different branches would pop each other's spans.

The previous workaround was to disable span tracking whenever `forkDepth > 0`. Functionally safe, but events emitted from inside a branch all inherited the outer span. The StateLog viewer therefore could not show "branch 0 did X while branch 1 did Y" — both branches looked identical from the trace's perspective.

## Solution

A per-async-context span stack via `AsyncLocalStorage`:

- `StatelogClient` now keeps:
  - `rootStack: SpanContext[]` — used outside branches.
  - `spanStorage: AsyncLocalStorage<SpanContext[]>` — used inside branches.
- `currentStack()` returns the ALS store if present, otherwise the root stack. All span-related methods (`startSpan`, `endSpan`, `currentSpan`, and the event-emission `parent_span_id` lookup) go through it.
- New `runInBranchContext(parentStack, fn)` runs `fn` inside `spanStorage.run([...parentStack], fn)`. Each call creates an independent ALS context with a defensive copy of the parent stack, so sibling branches can never see or mutate each other's pushes.
- New `snapshotStack()` returns a shallow copy of the current stack — used by the runner to seed each branch.
- Removed `enterFork()` / `exitFork()` / `forkDepth`.

In the runner:

- `runForkAll`, `runRace`, and `resumeRaceWinner` snapshot the current span stack once before scheduling branches and wrap every branch's `blockFn` in `runInBranchContext(snapshot, ...)`.
- Race winner-abort + branch-end emission is extracted into `abortLoserBranchesAndEmitEnds` (helper) to keep `runRace` under the 100-line structural limit.

## Interrupt / resume

Spans are intentionally ephemeral (not serialized in checkpoints). When a branch interrupts, its ALS context simply ends with the unwinding promise — nothing to persist. On resume the runtime re-enters the fork; each branch (re-running or returning a cached result) gets a fresh ALS context. This matches the existing behavior of opening a fresh `agentRun` span on resume.

## Tests

- Deleted the old `forkDepth gating` tests (gate no longer exists).
- Added a `branch span isolation (AsyncLocalStorage)` suite covering:
  - `snapshotStack` returns a decoupled copy.
  - Pushes inside `runInBranchContext` are invisible outside.
  - Concurrent branches see independent stacks across `await` boundaries.
  - Events emitted inside a branch carry the branch's local span as `parent_span_id`.
  - A branch ending a span it never opened is a no-op on the parent stack.

All 3452 unit tests pass. All 8 statelog integration scenarios pass.

## Dependency

This change builds on the StateLog infrastructure introduced in #147. It should land after #147 (or be rebased onto main once #147 merges).
