### PR TITLE
TUI abstractions extracted from the logs viewer

### DIFF
--- a/packages/agency-lang/docs/dev/tui.md
+++ b/packages/agency-lang/docs/dev/tui.md
@@ -1,0 +1,128 @@
+# TUI primitives
+
+The `lib/tui` module provides a small terminal UI toolkit used by the
+debugger and `agency logs view`. It is layout-driven (flex-like),
+state-driven (no event emitters), and fully testable with no terminal
+attached.
+
+This document covers the everyday primitives most consumers reach for.
+For lower-level details — the layout engine, frame model, element
+shape — read the source under `lib/tui/`.
+
+The [logs viewer](../../lib/logsViewer/run.ts) is the canonical
+example of all of these primitives in use.
+
+## Single-line rows: `line()` and `lines()`
+
+`text()` defaults to `flex: 1`, which means a `column(t1, t2, t3)`
+distributes leftover vertical space between the children. For "a
+single line of text" — the common case in lists, logs, command bars
+— you want fixed-height rows instead. Use `line()`:
+
+```ts
+import { line, lines, column } from "lib/tui";
+
+column(
+  line("> j moves down"),
+  line("  k moves up"),
+  line("  q quits", { fg: "gray" }),
+);
+```
+
+`lines(strings, style?)` is sugar for a column of `line()`s with
+`justifyContent: "flex-start"`, useful for help text or any plain
+multi-row block:
+
+```ts
+lines(["Loading…", "Press q to cancel."]);
+```
+
+## Scroll math: `clampScroll()` and `followCursor()`
+
+Two pure functions, no element/state coupling:
+
+```ts
+import { clampScroll, followCursor } from "lib/tui";
+
+const clamped = clampScroll(scrollTop, totalRows, viewportRows);
+const scrollTop = cursorIdx >= 0
+  ? followCursor(clamped, cursorIdx, viewportRows)
+  : clamped;
+```
+
+`clampScroll` keeps `scrollTop` inside `[0, max(0, total - viewportRows)]`.
+`followCursor` adjusts `scrollTop` so a cursor at `cursorIdx` is the
+top row (when above the viewport) or the bottom row (when below).
+They are pure, so they belong in the render function rather than in
+event handlers.
+
+## Render loop: `Screen.runLoop()`
+
+The `draw → nextKey → handleKey → draw → quit` loop is the same in
+every TUI app. `runLoop` factors it out:
+
+```ts
+await screen.runLoop({
+  initialState,
+  render: (state) => renderState(state),
+  handleKey: (state, event) => handleKey(state, event),
+  isDone: (state) => state.quit,
+});
+```
+
+`runLoop` renders once before the first key press, then for every key
+event applies `handleKey` and re-renders. It exits as soon as
+`isDone(state)` returns true and returns the final state.
+
+## Key normalization: `formatKey()` and `keyMatches()`
+
+`formatKey({ key, ctrl, shift }) → string` returns a canonical
+human-readable name:
+
+| Event | Result |
+|---|---|
+| `{ key: "j" }` | `"j"` |
+| `{ key: "up" }` | `"Up"` |
+| `{ key: "c", ctrl: true }` | `"Ctrl+C"` |
+| `{ key: "tab", shift: true }` | `"Shift+Tab"` |
+
+`keyMatches(event, name)` is a case-insensitive comparison against the
+canonical form. **Caveat:** because it lowercases, single-letter vim
+shortcuts that need case sensitivity (`g` vs `G`) must compare
+`event.key` directly — see [`logsViewer/input.ts`](../../lib/logsViewer/input.ts)
+for the `letter()` helper pattern.
+
+## Typed color palette: `ColorName`
+
+The 16 named ANSI colors are exported as a typed union:
+
+```ts
+import type { ColorName } from "lib/tui";
+
+const fg: ColorName = "bright-cyan"; // autocompletes; typos caught at build time
+```
+
+Style fields (`fg`, `bg`, `borderColor`, `labelColor`) accept either a
+`ColorName` or an arbitrary string (for hex values in the HTML
+adapter). A unit test enforces that `COLOR_NAMES`, `ansiColors`,
+`ansiBgColors`, and `cssColors` stay in lock-step.
+
+## Test harness: `ScriptedInput` + `FrameRecorder`
+
+`ScriptedInput` replays a list of key events. Pass them at
+construction time for the most concise tests:
+
+```ts
+import { ScriptedInput, FrameRecorder } from "lib/tui";
+
+const input = new ScriptedInput(["j", "j", { key: "c", ctrl: true }]);
+const output = new FrameRecorder();
+// ... drive the screen
+expect(output.lastText()).toMatch(/quit/);
+expect(output.textAt(0)).toMatch(/welcome/);
+```
+
+`FrameRecorder.textAt(i)` and `.lastText()` are convenience getters
+that flatten a recorded frame to plain text — they're shorter than
+`recorder.frames[i].frame.toPlainText()` and read better in
+assertions.

--- a/packages/agency-lang/docs/dev/tui.md
+++ b/packages/agency-lang/docs/dev/tui.md
@@ -20,7 +20,7 @@ single line of text" — the common case in lists, logs, command bars
 — you want fixed-height rows instead. Use `line()`:
 
 ```ts
-import { line, lines, column } from "lib/tui";
+import { line, lines, column } from "@/tui/index.js";
 
 column(
   line("> j moves down"),
@@ -42,7 +42,7 @@ lines(["Loading…", "Press q to cancel."]);
 Two pure functions, no element/state coupling:
 
 ```ts
-import { clampScroll, followCursor } from "lib/tui";
+import { clampScroll, followCursor } from "@/tui/index.js";
 
 const clamped = clampScroll(scrollTop, totalRows, viewportRows);
 const scrollTop = cursorIdx >= 0
@@ -97,7 +97,7 @@ for the `letter()` helper pattern.
 The 16 named ANSI colors are exported as a typed union:
 
 ```ts
-import type { ColorName } from "lib/tui";
+import type { ColorName } from "@/tui/index.js";
 
 const fg: ColorName = "bright-cyan"; // autocompletes; typos caught at build time
 ```
@@ -113,7 +113,7 @@ adapter). A unit test enforces that `COLOR_NAMES`, `ansiColors`,
 construction time for the most concise tests:
 
 ```ts
-import { ScriptedInput, FrameRecorder } from "lib/tui";
+import { ScriptedInput, FrameRecorder } from "@/tui/index.js";
 
 const input = new ScriptedInput(["j", "j", { key: "c", ctrl: true }]);
 const output = new FrameRecorder();

--- a/packages/agency-lang/docs/dev/tui.md
+++ b/packages/agency-lang/docs/dev/tui.md
@@ -56,6 +56,30 @@ top row (when above the viewport) or the bottom row (when below).
 They are pure, so they belong in the render function rather than in
 event handlers.
 
+## Scrollable cursor lists: `scrollList()`
+
+When you want the whole pattern — clamp + cursor-follow + slice +
+render each row — wrap it once with `scrollList()`:
+
+```ts
+import { scrollList, line } from "@/tui/index.js";
+
+const { element, scrollTop } = scrollList({
+  items: visibleRows,
+  cursorIdx,
+  scrollTop: state.scrollTop,
+  viewportRows: viewport.rows,
+  renderItem: (row, isCursor) =>
+    line(`${isCursor ? "> " : "  "}${row.label}`),
+});
+```
+
+`scrollList` returns the rendered `Element` plus the
+clamped/cursor-followed `scrollTop` that the caller should persist
+back into state. Item styling, cursor markup, and key handling are
+all up to the caller; `scrollList` only owns the scroll bookkeeping
+and the visible-window slicing.
+
 ## Render loop: `Screen.runLoop()`
 
 The `draw → nextKey → handleKey → draw → quit` loop is the same in

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-17-tui-abstractions-from-logs-viewer.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-17-tui-abstractions-from-logs-viewer.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Land the abstractions in `lib/tui` that I found myself reinventing while building [packages/agency-lang/lib/logsViewer/run.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts) (merged in `a49249b6`). The viewer hand-rolled key normalization, single-line row wrappers, scroll bookkeeping, the render/input loop, line clipping, color names, and test harness boilerplate. Every future TUI app would do the same. This plan pushes each pain point down into the library and adopts it from the viewer (and, where they obviously apply, from the debugger and any existing in-tree consumers).
+**Goal:** Land the abstractions in `lib/tui` that I found myself reinventing while building [packages/agency-lang/lib/logsViewer/run.ts](../../../lib/logsViewer/run.ts) (merged in `a49249b6`). The viewer hand-rolled key normalization, single-line row wrappers, scroll bookkeeping, the render/input loop, line clipping, color names, and test harness boilerplate. Every future TUI app would do the same. This plan pushes each pain point down into the library and adopts it from the viewer (and, where they obviously apply, from the debugger and any existing in-tree consumers).
 
 **Tech Stack:** TypeScript, existing `lib/tui` module, Vitest. No new dependencies.
 
@@ -14,10 +14,10 @@
 
 While shipping `agency logs view` I hit eight separate places where the right primitive was missing from `lib/tui`:
 
-1. **Key normalization** — each app rebuilds the `{key, ctrl, shift}` → string switch ([run.ts mapKey](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts#L107-L127)).
+1. **Key normalization** — each app rebuilds the `{key, ctrl, shift}` → string switch ([run.ts mapKey](../../../lib/logsViewer/run.ts#L107-L127)).
 2. **Single-line rows** — `text()` defaults to `flex: 1`, so a `column(...lines)` triple-spaces itself and shifts the parent when children grow. I worked around it with an inline `row()` that hard-codes `height: 1`.
-3. **Scrollable list with cursor tracking** — `scrollTop` clamping + cursor-visibility were hand-rolled in [run.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts#L100-L122). The Copilot reviewer caught one regression here (blank screen after collapse) that an abstraction would have prevented.
-4. **Render/input loop** — `draw → nextKey → handleKey → draw → quit` is the same in every TUI app; the viewer's [runViewer](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts#L23-L84) is mostly this loop.
+3. **Scrollable list with cursor tracking** — `scrollTop` clamping + cursor-visibility were hand-rolled in [run.ts](../../../lib/logsViewer/run.ts#L100-L122). The Copilot reviewer caught one regression here (blank screen after collapse) that an abstraction would have prevented.
+4. **Render/input loop** — `draw → nextKey → handleKey → draw → quit` is the same in every TUI app; the viewer's [runViewer](../../../lib/logsViewer/run.ts#L23-L84) is mostly this loop.
 5. **Text element self-clipping** — I pre-clip every line with `slice(0, cols-1) + "…"`. The renderer already knows each element's resolved width; clipping should live there. Same place to one day fix the UTF-16-vs-display-cell width issue.
 6. **Color name discoverability** — `colors.ts` has 16 named colors; nothing surfaces that set to autocomplete.
 7. **ScriptedInput ergonomic constructor** — every test writes a local `feed(input, ["j", "l", "q"])` helper because `ScriptedInput` only exposes `feedKey(KeyEvent)`.
@@ -33,32 +33,32 @@ These are independent — they can be implemented in parallel by separate worker
 
 | File | Responsibility |
 |---|---|
-| [packages/agency-lang/lib/tui/input/format.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/input/format.ts) | `formatKey(event): string` and `keyMatches(event, name): boolean` |
-| [packages/agency-lang/lib/tui/input/format.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/input/format.test.ts) | Tests for `formatKey` / `keyMatches` |
-| [packages/agency-lang/lib/tui/test/runLoop.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/runLoop.test.ts) | Integration test for `Screen.runLoop` |
-| [packages/agency-lang/lib/tui/scroll.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/scroll.ts) | `clampScroll()` + `followCursor()` reusable helpers |
-| [packages/agency-lang/lib/tui/scroll.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/scroll.test.ts) | Tests for the scroll helpers |
+| [packages/agency-lang/lib/tui/input/format.ts](../../../lib/tui/input/format.ts) | `formatKey(event): string` and `keyMatches(event, name): boolean` |
+| [packages/agency-lang/lib/tui/input/format.test.ts](../../../lib/tui/input/format.test.ts) | Tests for `formatKey` / `keyMatches` |
+| [packages/agency-lang/lib/tui/test/runLoop.test.ts](../../../lib/tui/test/runLoop.test.ts) | Integration test for `Screen.runLoop` |
+| [packages/agency-lang/lib/tui/scroll.ts](../../../lib/tui/scroll.ts) | `clampScroll()` + `followCursor()` reusable helpers |
+| [packages/agency-lang/lib/tui/scroll.test.ts](../../../lib/tui/scroll.test.ts) | Tests for the scroll helpers |
 
 ### Modified files
 
 | File | Change |
 |---|---|
-| [packages/agency-lang/lib/tui/builders.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/builders.ts) | Add `line(content, style?)` and `lines(strings[], style?)` builders |
-| [packages/agency-lang/lib/tui/builders.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/builders.test.ts) | New tests for the line builders (file may not exist yet — create if so) |
-| [packages/agency-lang/lib/tui/render/renderer.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/render/renderer.ts) | Clip rendered `text` content to its resolved width inside the renderer |
-| [packages/agency-lang/lib/tui/test/renderer.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/renderer.test.ts) | Test that overlong text is auto-clipped with `…` |
-| [packages/agency-lang/lib/tui/colors.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/colors.ts) | Export a `ColorName` union derived from `ansiColors` |
-| [packages/agency-lang/lib/tui/elements.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/elements.ts) | Narrow `Style.fg` / `bg` / `borderColor` / `labelColor` to `ColorName \| string` (string kept for hex) |
-| [packages/agency-lang/lib/tui/screen.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/screen.ts) | Add `Screen.runLoop({ render, handleKey })` |
-| [packages/agency-lang/lib/tui/input/scripted.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/input/scripted.ts) | Accept `(KeyEvent \| string)[]` in the constructor; document semantics |
-| [packages/agency-lang/lib/tui/test/scripted.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/scripted.test.ts) | Tests for the new constructor |
-| [packages/agency-lang/lib/tui/output/recorder.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/output/recorder.ts) | Add `textAt(i)` and `lastText()` convenience getters |
-| [packages/agency-lang/lib/tui/test/recorder.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/recorder.test.ts) | Tests for the new getters |
-| [packages/agency-lang/lib/tui/index.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/index.ts) | Export everything new |
-| [packages/agency-lang/lib/logsViewer/run.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts) | Adopt the new primitives (delete local `mapKey`, `row`, `clampScrollTop`, `ensureCursorVisible`) |
-| [packages/agency-lang/lib/logsViewer/render.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/render.ts) | Delete the manual `…` slice now that the renderer clips |
-| [packages/agency-lang/lib/logsViewer/run.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.test.ts) | Switch `new ScriptedInput()` + `feed(...)` to the array constructor |
-| [packages/agency-lang/lib/logsViewer/render.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/render.test.ts) | Drop tests that asserted the manual `…` slice if any |
+| [packages/agency-lang/lib/tui/builders.ts](../../../lib/tui/builders.ts) | Add `line(content, style?)` and `lines(strings[], style?)` builders |
+| [packages/agency-lang/lib/tui/builders.test.ts](../../../lib/tui/builders.test.ts) | New tests for the line builders (file may not exist yet — create if so) |
+| [packages/agency-lang/lib/tui/render/renderer.ts](../../../lib/tui/render/renderer.ts) | Clip rendered `text` content to its resolved width inside the renderer |
+| [packages/agency-lang/lib/tui/test/renderer.test.ts](../../../lib/tui/test/renderer.test.ts) | Test that overlong text is auto-clipped with `…` |
+| [packages/agency-lang/lib/tui/colors.ts](../../../lib/tui/colors.ts) | Export a `ColorName` union derived from `ansiColors` |
+| [packages/agency-lang/lib/tui/elements.ts](../../../lib/tui/elements.ts) | Narrow `Style.fg` / `bg` / `borderColor` / `labelColor` to `ColorName \| string` (string kept for hex) |
+| [packages/agency-lang/lib/tui/screen.ts](../../../lib/tui/screen.ts) | Add `Screen.runLoop({ render, handleKey })` |
+| [packages/agency-lang/lib/tui/input/scripted.ts](../../../lib/tui/input/scripted.ts) | Accept `(KeyEvent \| string)[]` in the constructor; document semantics |
+| [packages/agency-lang/lib/tui/test/scripted.test.ts](../../../lib/tui/test/scripted.test.ts) | Tests for the new constructor |
+| [packages/agency-lang/lib/tui/output/recorder.ts](../../../lib/tui/output/recorder.ts) | Add `textAt(i)` and `lastText()` convenience getters |
+| [packages/agency-lang/lib/tui/test/recorder.test.ts](../../../lib/tui/test/recorder.test.ts) | Tests for the new getters |
+| [packages/agency-lang/lib/tui/index.ts](../../../lib/tui/index.ts) | Export everything new |
+| [packages/agency-lang/lib/logsViewer/run.ts](../../../lib/logsViewer/run.ts) | Adopt the new primitives (delete local `mapKey`, `row`, `clampScrollTop`, `ensureCursorVisible`) |
+| [packages/agency-lang/lib/logsViewer/render.ts](../../../lib/logsViewer/render.ts) | Delete the manual `…` slice now that the renderer clips |
+| [packages/agency-lang/lib/logsViewer/run.test.ts](../../../lib/logsViewer/run.test.ts) | Switch `new ScriptedInput()` + `feed(...)` to the array constructor |
+| [packages/agency-lang/lib/logsViewer/render.test.ts](../../../lib/logsViewer/render.test.ts) | Drop tests that asserted the manual `…` slice if any |
 
 ---
 
@@ -66,7 +66,7 @@ These are independent — they can be implemented in parallel by separate worker
 
 ### Task 1 — `formatKey(event)` and `keyMatches(event, name)`
 
-**Files:** create [lib/tui/input/format.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/input/format.ts) + co-located test; re-export from [lib/tui/index.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/index.ts).
+**Files:** create [lib/tui/input/format.ts](../../../lib/tui/input/format.ts) + co-located test; re-export from [lib/tui/index.ts](../../../lib/tui/index.ts).
 
 The API:
 
@@ -141,14 +141,14 @@ export function keyMatches(event: KeyEvent, name: string): boolean {
 ```
 
 - [ ] **Step 4: Pass tests**
-- [ ] **Step 5: Re-export from [lib/tui/index.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/index.ts)**: `export { formatKey, keyMatches } from "./input/format.js";`
+- [ ] **Step 5: Re-export from [lib/tui/index.ts](../../../lib/tui/index.ts)**: `export { formatKey, keyMatches } from "./input/format.js";`
 - [ ] **Step 6: Commit** `tui: formatKey / keyMatches utilities`
 
 ---
 
 ### Task 2 — `line(content, style?)` and `lines(strings[], style?)` builders
 
-**Files:** modify [lib/tui/builders.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/builders.ts); test in `builders.test.ts` (create if absent).
+**Files:** modify [lib/tui/builders.ts](../../../lib/tui/builders.ts); test in `builders.test.ts` (create if absent).
 
 Rationale: `text()` defaults to `flex: 1`, which is wrong for the common case of "a single line of text inside a column". Don't change `text()` (would be breaking); add a new builder that explicitly fixes `height: 1`. `lines()` is a convenience that wraps a `string[]` into a `column` of fixed-height rows.
 
@@ -197,7 +197,7 @@ describe("lines()", () => {
 ```
 
 - [ ] **Step 2: Run, confirm fail**
-- [ ] **Step 3: Implement in [builders.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/builders.ts)**
+- [ ] **Step 3: Implement in [builders.ts](../../../lib/tui/builders.ts)**
 
 ```ts
 export function line(content: string, style?: Style): Element {
@@ -222,7 +222,7 @@ export function lines(strings: string[], style?: Style): Element {
 
 ### Task 3 — `clampScroll()` and `followCursor()` helpers
 
-**Files:** create [lib/tui/scroll.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/scroll.ts) + test.
+**Files:** create [lib/tui/scroll.ts](../../../lib/tui/scroll.ts) + test.
 
 Pure functions, no element/state coupling. Both are used together in the viewer's `draw()`.
 
@@ -298,14 +298,14 @@ export function followCursor(
 ```
 
 - [ ] **Step 4: Pass tests**
-- [ ] **Step 5: Re-export from [lib/tui/index.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/index.ts)**: `export * from "./scroll.js";`
+- [ ] **Step 5: Re-export from [lib/tui/index.ts](../../../lib/tui/index.ts)**: `export * from "./scroll.js";`
 - [ ] **Step 6: Commit** `tui: clampScroll / followCursor helpers`
 
 ---
 
 ### Task 4 — `Screen.runLoop({ render, handleKey })`
 
-**Files:** modify [lib/tui/screen.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/screen.ts); create [lib/tui/test/runLoop.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/runLoop.test.ts).
+**Files:** modify [lib/tui/screen.ts](../../../lib/tui/screen.ts); create [lib/tui/test/runLoop.test.ts](../../../lib/tui/test/runLoop.test.ts).
 
 The loop:
 
@@ -383,7 +383,7 @@ async runLoop<S>(opts: {
 
 ### Task 5 — Renderer auto-clips overlong `text` to its box width
 
-**Files:** modify [lib/tui/render/renderer.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/render/renderer.ts); test in [lib/tui/test/renderer.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/renderer.test.ts).
+**Files:** modify [lib/tui/render/renderer.ts](../../../lib/tui/render/renderer.ts); test in [lib/tui/test/renderer.test.ts](../../../lib/tui/test/renderer.test.ts).
 
 Today `text` content longer than its resolved width overflows or is silently truncated by the cell grid depending on the path. Make the truncation explicit and consistent: clip to `(resolvedWidth - 1)` and append `…` whenever clipped.
 
@@ -419,7 +419,7 @@ describe("renderer auto-clips long text", () => {
 
 ### Task 6 — Typed `ColorName` union exported from `lib/tui`
 
-**Files:** modify [lib/tui/colors.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/colors.ts) and [lib/tui/elements.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/elements.ts); index re-export.
+**Files:** modify [lib/tui/colors.ts](../../../lib/tui/colors.ts) and [lib/tui/elements.ts](../../../lib/tui/elements.ts); index re-export.
 
 Goal: get autocomplete for `fg: "..."` and compile-time validation for the 16 supported color names without breaking the hex-string escape hatch the HTML adapter already supports.
 
@@ -450,7 +450,7 @@ it("ColorName covers exactly the named ANSI palette", () => {
 
 In `elements.ts`, change `fg?: string` (and `bg`, `borderColor`, `labelColor`) to `fg?: ColorName | (string & {})`. The `& {}` trick keeps hex strings (e.g. `"#abc"`) compiling without losing the autocomplete on the named branch. Add a comment explaining.
 
-- [ ] **Step 3: Re-export from [lib/tui/index.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/index.ts)**: `export type { ColorName } from "./colors.js"; export { COLOR_NAMES } from "./colors.js";`
+- [ ] **Step 3: Re-export from [lib/tui/index.ts](../../../lib/tui/index.ts)**: `export type { ColorName } from "./colors.js"; export { COLOR_NAMES } from "./colors.js";`
 - [ ] **Step 4: Build the project** (`pnpm run build`); fix any callers in `lib/logsViewer/render.ts`, `lib/debugger/`, etc. that were passing color names that don't exist in the palette. The build will surface them all.
 - [ ] **Step 5: Commit** `tui: typed ColorName union and narrowed Style color fields`
 
@@ -458,7 +458,7 @@ In `elements.ts`, change `fg?: string` (and `bg`, `borderColor`, `labelColor`) t
 
 ### Task 7 — `ScriptedInput` constructor accepts `(KeyEvent | string)[]`
 
-**Files:** modify [lib/tui/input/scripted.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/input/scripted.ts); test in [lib/tui/test/scripted.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/scripted.test.ts).
+**Files:** modify [lib/tui/input/scripted.ts](../../../lib/tui/input/scripted.ts); test in [lib/tui/test/scripted.test.ts](../../../lib/tui/test/scripted.test.ts).
 
 Sugar: pass keys directly when constructing; mixed string/KeyEvent items welcome.
 
@@ -492,7 +492,7 @@ constructor(initial?: ReadonlyArray<KeyEvent | string>) {
 
 ### Task 8 — `FrameRecorder.lastText()` / `textAt(i)`
 
-**Files:** modify [lib/tui/output/recorder.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/output/recorder.ts); test in [lib/tui/test/recorder.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/recorder.test.ts).
+**Files:** modify [lib/tui/output/recorder.ts](../../../lib/tui/output/recorder.ts); test in [lib/tui/test/recorder.test.ts](../../../lib/tui/test/recorder.test.ts).
 
 - [ ] **Step 1: Write failing test**
 
@@ -531,17 +531,17 @@ This is the load-bearing task: prove each new abstraction works for its motivati
 
 - [ ] **Step 1: Replace `mapKey()` + key strings with `keyMatches()`**
 
-In [lib/logsViewer/input.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/input.ts), accept a `KeyEvent` directly (drop the `Key` string union) and use `keyMatches(event, "j")` / etc. inside the switch. Delete `mapKey` from [run.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts) and pass the raw `KeyEvent` straight into `handleKey`.
+In [lib/logsViewer/input.ts](../../../lib/logsViewer/input.ts), accept a `KeyEvent` directly (drop the `Key` string union) and use `keyMatches(event, "j")` / etc. inside the switch. Delete `mapKey` from [run.ts](../../../lib/logsViewer/run.ts) and pass the raw `KeyEvent` straight into `handleKey`.
 
-Adjust [input.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/input.test.ts) to pass `{ key: "j" }` shapes (or string-named keys via a small wrapper) — they were already using single-char strings that match `formatKey`.
+Adjust [input.test.ts](../../../lib/logsViewer/input.test.ts) to pass `{ key: "j" }` shapes (or string-named keys via a small wrapper) — they were already using single-char strings that match `formatKey`.
 
 - [ ] **Step 2: Replace inline `row()` with `line()`**
 
-In [run.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts) delete the local `row()` helper and call `line(content, { fg })` from `lib/tui`. The empty-state branch becomes `screen.render(lines(["No events found."]))`.
+In [run.ts](../../../lib/logsViewer/run.ts) delete the local `row()` helper and call `line(content, { fg })` from `lib/tui`. The empty-state branch becomes `screen.render(lines(["No events found."]))`.
 
 - [ ] **Step 3: Replace `clampScrollTop()` + `ensureCursorVisible()` with `clampScroll()` + `followCursor()`**
 
-In [run.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts) the new `draw()` becomes (sketch):
+In [run.ts](../../../lib/logsViewer/run.ts) the new `draw()` becomes (sketch):
 
 ```ts
 const rows = flattenVisibleRows(state);
@@ -552,7 +552,7 @@ state = { ...state, scrollTop: followCursor(clamped, cursorIdx, opts.viewport.ro
 
 Delete the two local helpers.
 
-- [ ] **Step 4: Replace the manual `…` slice in [render.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/render.ts)**
+- [ ] **Step 4: Replace the manual `…` slice in [render.ts](../../../lib/logsViewer/render.ts)**
 
 `renderRow` no longer needs the `line.length > cols` branch — the renderer handles it. Delete the slice + the ASCII-width comment block (the comment migrates to the renderer in Task 5).
 
@@ -569,7 +569,7 @@ return await screen.runLoop({
 
 - [ ] **Step 6: Replace `feed(input, [...])` test helpers with the array constructor**
 
-In [run.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.test.ts) delete the `feed()` function and rewrite to `new ScriptedInput(["j", "l", "q"])`.
+In [run.test.ts](../../../lib/logsViewer/run.test.ts) delete the `feed()` function and rewrite to `new ScriptedInput(["j", "l", "q"])`.
 
 - [ ] **Step 7: Replace `out.frames[i].frame.toPlainText()` with `out.textAt(i)` / `out.lastText()`** throughout the viewer's tests.
 
@@ -591,7 +591,7 @@ All previously-passing counts must hold; the viewer should still behave identica
 
 ### Task 10 — Update documentation
 
-- [ ] Add a section to [docs/site/guide/observability.md](file:///Users/adityabhargava/agency-lang/packages/agency-lang/docs/site/guide/observability.md) only if anything user-facing changed (it shouldn't; this is internal refactor).
+- [ ] Add a section to [docs/site/guide/observability.md](../../../docs/site/guide/observability.md) only if anything user-facing changed (it shouldn't; this is internal refactor).
 - [ ] Add a short developer-facing reference: `docs/dev/tui.md` (create if missing) covering: `line` / `lines`, `clampScroll` / `followCursor`, `Screen.runLoop`, `formatKey` / `keyMatches`, `ColorName`. Two paragraphs each, with the existing logs viewer cited as the canonical example.
 - [ ] **Commit** `docs: developer reference for the new TUI primitives`
 
@@ -613,7 +613,7 @@ Before opening the PR, verify all of:
 
 ## Anti-pattern review
 
-Per [docs/dev/anti-patterns.md](file:///Users/adityabhargava/agency-lang/packages/agency-lang/docs/dev/anti-patterns.md), this plan deliberately avoids:
+Per [docs/dev/anti-patterns.md](../../../docs/dev/anti-patterns.md), this plan deliberately avoids:
 
 - **Dynamic imports** — every new export is statically resolved through `lib/tui/index.ts`.
 - **Maps / Sets** — `clampScroll` and `followCursor` operate on plain `number`s; `COLOR_NAMES` is a tuple, not a `Set`.

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-17-tui-abstractions-from-logs-viewer.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-17-tui-abstractions-from-logs-viewer.md
@@ -1,0 +1,631 @@
+# TUI Abstractions Extracted from the Logs Viewer
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the abstractions in `lib/tui` that I found myself reinventing while building [packages/agency-lang/lib/logsViewer/run.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts) (merged in `a49249b6`). The viewer hand-rolled key normalization, single-line row wrappers, scroll bookkeeping, the render/input loop, line clipping, color names, and test harness boilerplate. Every future TUI app would do the same. This plan pushes each pain point down into the library and adopts it from the viewer (and, where they obviously apply, from the debugger and any existing in-tree consumers).
+
+**Tech Stack:** TypeScript, existing `lib/tui` module, Vitest. No new dependencies.
+
+**Reference:** PR #154 (logs viewer) and the post-merge discussion that surfaced these gaps.
+
+---
+
+## Background
+
+While shipping `agency logs view` I hit eight separate places where the right primitive was missing from `lib/tui`:
+
+1. **Key normalization** — each app rebuilds the `{key, ctrl, shift}` → string switch ([run.ts mapKey](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts#L107-L127)).
+2. **Single-line rows** — `text()` defaults to `flex: 1`, so a `column(...lines)` triple-spaces itself and shifts the parent when children grow. I worked around it with an inline `row()` that hard-codes `height: 1`.
+3. **Scrollable list with cursor tracking** — `scrollTop` clamping + cursor-visibility were hand-rolled in [run.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts#L100-L122). The Copilot reviewer caught one regression here (blank screen after collapse) that an abstraction would have prevented.
+4. **Render/input loop** — `draw → nextKey → handleKey → draw → quit` is the same in every TUI app; the viewer's [runViewer](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts#L23-L84) is mostly this loop.
+5. **Text element self-clipping** — I pre-clip every line with `slice(0, cols-1) + "…"`. The renderer already knows each element's resolved width; clipping should live there. Same place to one day fix the UTF-16-vs-display-cell width issue.
+6. **Color name discoverability** — `colors.ts` has 16 named colors; nothing surfaces that set to autocomplete.
+7. **ScriptedInput ergonomic constructor** — every test writes a local `feed(input, ["j", "l", "q"])` helper because `ScriptedInput` only exposes `feedKey(KeyEvent)`.
+8. **FrameRecorder convenience getters** — `out.frames[i].frame.toPlainText()` is awkward; `out.textAt(i)` / `out.lastText()` would shorten every test.
+
+These are independent — they can be implemented in parallel by separate workers if desired. The plan groups them into atomic tasks so each one is reviewable on its own.
+
+---
+
+## File Structure
+
+### New files
+
+| File | Responsibility |
+|---|---|
+| [packages/agency-lang/lib/tui/input/format.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/input/format.ts) | `formatKey(event): string` and `keyMatches(event, name): boolean` |
+| [packages/agency-lang/lib/tui/input/format.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/input/format.test.ts) | Tests for `formatKey` / `keyMatches` |
+| [packages/agency-lang/lib/tui/test/runLoop.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/runLoop.test.ts) | Integration test for `Screen.runLoop` |
+| [packages/agency-lang/lib/tui/scroll.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/scroll.ts) | `clampScroll()` + `followCursor()` reusable helpers |
+| [packages/agency-lang/lib/tui/scroll.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/scroll.test.ts) | Tests for the scroll helpers |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| [packages/agency-lang/lib/tui/builders.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/builders.ts) | Add `line(content, style?)` and `lines(strings[], style?)` builders |
+| [packages/agency-lang/lib/tui/builders.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/builders.test.ts) | New tests for the line builders (file may not exist yet — create if so) |
+| [packages/agency-lang/lib/tui/render/renderer.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/render/renderer.ts) | Clip rendered `text` content to its resolved width inside the renderer |
+| [packages/agency-lang/lib/tui/test/renderer.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/renderer.test.ts) | Test that overlong text is auto-clipped with `…` |
+| [packages/agency-lang/lib/tui/colors.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/colors.ts) | Export a `ColorName` union derived from `ansiColors` |
+| [packages/agency-lang/lib/tui/elements.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/elements.ts) | Narrow `Style.fg` / `bg` / `borderColor` / `labelColor` to `ColorName \| string` (string kept for hex) |
+| [packages/agency-lang/lib/tui/screen.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/screen.ts) | Add `Screen.runLoop({ render, handleKey })` |
+| [packages/agency-lang/lib/tui/input/scripted.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/input/scripted.ts) | Accept `(KeyEvent \| string)[]` in the constructor; document semantics |
+| [packages/agency-lang/lib/tui/test/scripted.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/scripted.test.ts) | Tests for the new constructor |
+| [packages/agency-lang/lib/tui/output/recorder.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/output/recorder.ts) | Add `textAt(i)` and `lastText()` convenience getters |
+| [packages/agency-lang/lib/tui/test/recorder.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/recorder.test.ts) | Tests for the new getters |
+| [packages/agency-lang/lib/tui/index.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/index.ts) | Export everything new |
+| [packages/agency-lang/lib/logsViewer/run.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts) | Adopt the new primitives (delete local `mapKey`, `row`, `clampScrollTop`, `ensureCursorVisible`) |
+| [packages/agency-lang/lib/logsViewer/render.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/render.ts) | Delete the manual `…` slice now that the renderer clips |
+| [packages/agency-lang/lib/logsViewer/run.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.test.ts) | Switch `new ScriptedInput()` + `feed(...)` to the array constructor |
+| [packages/agency-lang/lib/logsViewer/render.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/render.test.ts) | Drop tests that asserted the manual `…` slice if any |
+
+---
+
+## Task Decomposition
+
+### Task 1 — `formatKey(event)` and `keyMatches(event, name)`
+
+**Files:** create [lib/tui/input/format.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/input/format.ts) + co-located test; re-export from [lib/tui/index.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/index.ts).
+
+The API:
+
+```ts
+// "j" → "j"; "up" → "Up"; "c" + ctrl → "Ctrl+C"; "tab" + shift → "Shift+Tab"
+export function formatKey(event: KeyEvent): string
+
+// case-insensitive name match, accepts the same strings formatKey returns
+export function keyMatches(event: KeyEvent, name: string): boolean
+```
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { formatKey, keyMatches } from "../input/format.js";
+
+describe("formatKey", () => {
+  it("returns single-char keys verbatim", () => {
+    expect(formatKey({ key: "j" })).toBe("j");
+    expect(formatKey({ key: "G" })).toBe("G");
+  });
+  it("title-cases named keys", () => {
+    expect(formatKey({ key: "up" })).toBe("Up");
+    expect(formatKey({ key: "enter" })).toBe("Enter");
+    expect(formatKey({ key: "pagedown" })).toBe("PageDown");
+  });
+  it("prefixes with Ctrl+ / Shift+ in canonical order", () => {
+    expect(formatKey({ key: "c", ctrl: true })).toBe("Ctrl+C");
+    expect(formatKey({ key: "tab", shift: true })).toBe("Shift+Tab");
+    expect(formatKey({ key: "right", ctrl: true, shift: true }))
+      .toBe("Ctrl+Shift+Right");
+  });
+});
+
+describe("keyMatches", () => {
+  it("matches by canonical name, case-insensitively", () => {
+    expect(keyMatches({ key: "j" }, "j")).toBe(true);
+    expect(keyMatches({ key: "c", ctrl: true }, "ctrl+c")).toBe(true);
+    expect(keyMatches({ key: "up" }, "UP")).toBe(true);
+    expect(keyMatches({ key: "j" }, "k")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm fail** (`pnpm vitest run lib/tui/input/format.test.ts`)
+- [ ] **Step 3: Implement**
+
+```ts
+import type { KeyEvent } from "./types.js";
+
+const TITLE_CASED: Record<string, string> = {
+  up: "Up", down: "Down", left: "Left", right: "Right",
+  enter: "Enter", escape: "Escape", tab: "Tab", backspace: "Backspace",
+  delete: "Delete", insert: "Insert", home: "Home", end: "End",
+  pageup: "PageUp", pagedown: "PageDown",
+};
+
+export function formatKey(event: KeyEvent): string {
+  const base = TITLE_CASED[event.key] ?? event.key;
+  const prefix: string[] = [];
+  if (event.ctrl) prefix.push("Ctrl");
+  if (event.shift) prefix.push("Shift");
+  const body =
+    event.ctrl && base.length === 1 ? base.toUpperCase() : base;
+  return [...prefix, body].join("+");
+}
+
+export function keyMatches(event: KeyEvent, name: string): boolean {
+  return formatKey(event).toLowerCase() === name.toLowerCase();
+}
+```
+
+- [ ] **Step 4: Pass tests**
+- [ ] **Step 5: Re-export from [lib/tui/index.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/index.ts)**: `export { formatKey, keyMatches } from "./input/format.js";`
+- [ ] **Step 6: Commit** `tui: formatKey / keyMatches utilities`
+
+---
+
+### Task 2 — `line(content, style?)` and `lines(strings[], style?)` builders
+
+**Files:** modify [lib/tui/builders.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/builders.ts); test in `builders.test.ts` (create if absent).
+
+Rationale: `text()` defaults to `flex: 1`, which is wrong for the common case of "a single line of text inside a column". Don't change `text()` (would be breaking); add a new builder that explicitly fixes `height: 1`. `lines()` is a convenience that wraps a `string[]` into a `column` of fixed-height rows.
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { line, lines } from "../builders.js";
+import { layout } from "../layout.js";
+
+describe("line()", () => {
+  it("produces a text element with height: 1", () => {
+    const el = line("hi");
+    expect(el.type).toBe("text");
+    expect(el.content).toBe("hi");
+    expect(el.style?.height).toBe(1);
+  });
+  it("merges caller-provided fg / bg / bold", () => {
+    const el = line("hi", { fg: "red", bold: true });
+    expect(el.style).toMatchObject({ height: 1, fg: "red", bold: true });
+  });
+});
+
+describe("lines()", () => {
+  it("returns a column of fixed-height rows, justified flex-start", () => {
+    const tree = lines(["a", "b", "c"]);
+    expect(tree.type).toBe("box");
+    expect(tree.style?.flexDirection).toBe("column");
+    expect(tree.style?.justifyContent).toBe("flex-start");
+    expect(tree.children).toHaveLength(3);
+    for (const child of tree.children!) {
+      expect(child.style?.height).toBe(1);
+    }
+  });
+  it("does NOT stretch to fill its parent (placed inside a tall box)", () => {
+    // Sanity: confirm the layout engine does not give the column
+    // extra height when its children declare height: 1.
+    const root = lines(["one", "two"]);
+    const positioned = layout(root, 80, 24);
+    // First child must end up at y == row 0 of the lines() box (no
+    // pre-padding) and the second at y == 1.
+    const [a, b] = positioned.children!;
+    expect(b.resolvedY - a.resolvedY).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm fail**
+- [ ] **Step 3: Implement in [builders.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/builders.ts)**
+
+```ts
+export function line(content: string, style?: Style): Element {
+  return { type: "text", content, style: { height: 1, ...style } };
+}
+
+export function lines(strings: string[], style?: Style): Element {
+  return column(
+    { flexDirection: "column", justifyContent: "flex-start", ...style },
+    ...strings.map((s) => line(s)),
+  );
+}
+```
+
+(Confirm the `column()` builder accepts the merged style; if `column` already forces `flexDirection: column`, the explicit field above is harmless redundancy.)
+
+- [ ] **Step 4: Pass tests**
+- [ ] **Step 5: Re-export from index** (likely already exported via `export * from "./builders.js"`)
+- [ ] **Step 6: Commit** `tui: line() / lines() builders for fixed-height text rows`
+
+---
+
+### Task 3 — `clampScroll()` and `followCursor()` helpers
+
+**Files:** create [lib/tui/scroll.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/scroll.ts) + test.
+
+Pure functions, no element/state coupling. Both are used together in the viewer's `draw()`.
+
+```ts
+// Clamp scrollTop into [0, max(0, total - viewportRows)].
+export function clampScroll(scrollTop: number, total: number, viewportRows: number): number
+
+// If cursorIdx is above the viewport, scroll up; if below, scroll
+// down so it's the last visible row. Otherwise leave scrollTop alone.
+export function followCursor(
+  scrollTop: number, cursorIdx: number, viewportRows: number,
+): number
+```
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { clampScroll, followCursor } from "../scroll.js";
+
+describe("clampScroll", () => {
+  it("keeps a valid scrollTop", () => {
+    expect(clampScroll(3, 20, 5)).toBe(3);
+  });
+  it("clamps when scrollTop exceeds the maximum", () => {
+    // 20 rows, viewport 5 → max scrollTop = 15
+    expect(clampScroll(99, 20, 5)).toBe(15);
+  });
+  it("returns 0 when the content fits the viewport", () => {
+    expect(clampScroll(99, 3, 10)).toBe(0);
+  });
+  it("clamps negative values to 0", () => {
+    expect(clampScroll(-5, 20, 5)).toBe(0);
+  });
+});
+
+describe("followCursor", () => {
+  it("scrolls up when cursor is above the viewport", () => {
+    expect(followCursor(10, 3, 5)).toBe(3);
+  });
+  it("scrolls down when cursor is below the viewport", () => {
+    // scrollTop 0, viewport 5 → visible rows 0..4; cursor at 7 means
+    // we need scrollTop = 3 (so 3..7 is visible).
+    expect(followCursor(0, 7, 5)).toBe(3);
+  });
+  it("does nothing when cursor is already visible", () => {
+    expect(followCursor(0, 2, 5)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run, confirm fail**
+- [ ] **Step 3: Implement**
+
+```ts
+export function clampScroll(
+  scrollTop: number, total: number, viewportRows: number,
+): number {
+  const max = Math.max(0, total - viewportRows);
+  if (scrollTop < 0) return 0;
+  if (scrollTop > max) return max;
+  return scrollTop;
+}
+
+export function followCursor(
+  scrollTop: number, cursorIdx: number, viewportRows: number,
+): number {
+  if (cursorIdx < scrollTop) return cursorIdx;
+  const lastVisible = scrollTop + viewportRows - 1;
+  if (cursorIdx > lastVisible) return cursorIdx - viewportRows + 1;
+  return scrollTop;
+}
+```
+
+- [ ] **Step 4: Pass tests**
+- [ ] **Step 5: Re-export from [lib/tui/index.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/index.ts)**: `export * from "./scroll.js";`
+- [ ] **Step 6: Commit** `tui: clampScroll / followCursor helpers`
+
+---
+
+### Task 4 — `Screen.runLoop({ render, handleKey })`
+
+**Files:** modify [lib/tui/screen.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/screen.ts); create [lib/tui/test/runLoop.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/runLoop.test.ts).
+
+The loop:
+
+```ts
+async runLoop<S>(opts: {
+  initialState: S;
+  render: (state: S) => Element;       // (or string[], see step 3)
+  handleKey: (state: S, event: KeyEvent) => S;
+  isDone: (state: S) => boolean;
+  label?: string;
+}): Promise<S>
+```
+
+Returns the final state after `isDone` flips to true. The host owns "what is done" — keeps `runLoop` ignorant of quit-key semantics, and lets callers drive the loop from things other than keys (e.g. timed updates) in v2.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { Screen } from "../screen.js";
+import { ScriptedInput } from "../input/scripted.js";
+import { FrameRecorder } from "../output/recorder.js";
+import { line } from "../builders.js";
+
+describe("Screen.runLoop", () => {
+  it("renders, handles keys, and stops when isDone returns true", async () => {
+    const input = new ScriptedInput();
+    input.feedKey({ key: "j" });
+    input.feedKey({ key: "j" });
+    input.feedKey({ key: "q" });
+    const output = new FrameRecorder();
+    const screen = new Screen({ input, output, width: 20, height: 5 });
+    const finalState = await screen.runLoop({
+      initialState: { n: 0, done: false },
+      render: (s) => line(`n=${s.n}`),
+      handleKey: (s, event) => {
+        if (event.key === "q") return { ...s, done: true };
+        if (event.key === "j") return { ...s, n: s.n + 1 };
+        return s;
+      },
+      isDone: (s) => s.done,
+    });
+    expect(finalState.n).toBe(2);
+    // Four frames: initial render + one after each key.
+    expect(output.frames.length).toBe(4);
+  });
+});
+```
+
+- [ ] **Step 2: Implement on `Screen`**
+
+```ts
+async runLoop<S>(opts: {
+  initialState: S;
+  render: (state: S) => Element;
+  handleKey: (state: S, event: KeyEvent) => S;
+  isDone: (state: S) => boolean;
+  label?: string;
+}): Promise<S> {
+  let state = opts.initialState;
+  this.render(opts.render(state), opts.label);
+  while (!opts.isDone(state)) {
+    const event = await this.nextKey();
+    state = opts.handleKey(state, event);
+    this.render(opts.render(state), opts.label);
+  }
+  return state;
+}
+```
+
+- [ ] **Step 3: Pass tests**
+- [ ] **Step 4: Commit** `tui: Screen.runLoop wraps the render → key → render cycle`
+
+---
+
+### Task 5 — Renderer auto-clips overlong `text` to its box width
+
+**Files:** modify [lib/tui/render/renderer.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/render/renderer.ts); test in [lib/tui/test/renderer.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/renderer.test.ts).
+
+Today `text` content longer than its resolved width overflows or is silently truncated by the cell grid depending on the path. Make the truncation explicit and consistent: clip to `(resolvedWidth - 1)` and append `…` whenever clipped.
+
+> **NOTE:** Width is measured in UTF-16 code units to match today's behavior. Grapheme-aware clipping is out of scope for this task and tracked separately (see render.ts comment from PR #154); call it out in the renderer comment so the next reader knows.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { layout } from "../layout.js";
+import { render } from "../render/renderer.js";
+import { line } from "../builders.js";
+
+describe("renderer auto-clips long text", () => {
+  it("appends an ellipsis when text exceeds the resolved width", () => {
+    const positioned = layout(line("abcdefghij"), 5, 1);
+    const frame = render(positioned);
+    expect(frame.toPlainText()).toBe("abcd…");
+  });
+  it("leaves text untouched when it fits", () => {
+    const positioned = layout(line("abc"), 10, 1);
+    const frame = render(positioned);
+    expect(frame.toPlainText()).toBe("abc");
+  });
+});
+```
+
+- [ ] **Step 2: Find the renderer's text-content path** (around `parseStyledText` invocation) and clip the produced cells to `resolvedWidth`, substituting the last cell with `…` when overrun. Centralize as a `clipCellsToWidth(cells, width)` helper inside `renderer.ts`.
+- [ ] **Step 3: Pass tests** — also re-run the full TUI test suite (`pnpm vitest run lib/tui/`) to make sure no existing text-rendering tests regress.
+- [ ] **Step 4: Commit** `tui: renderer auto-clips overlong text content with an ellipsis`
+
+---
+
+### Task 6 — Typed `ColorName` union exported from `lib/tui`
+
+**Files:** modify [lib/tui/colors.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/colors.ts) and [lib/tui/elements.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/elements.ts); index re-export.
+
+Goal: get autocomplete for `fg: "..."` and compile-time validation for the 16 supported color names without breaking the hex-string escape hatch the HTML adapter already supports.
+
+- [ ] **Step 1: Derive a const union from `ansiColors`**
+
+In `colors.ts`:
+
+```ts
+export const COLOR_NAMES = [
+  "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
+  "gray",
+  "bright-red", "bright-green", "bright-yellow", "bright-blue",
+  "bright-magenta", "bright-cyan", "bright-white",
+] as const;
+export type ColorName = (typeof COLOR_NAMES)[number];
+```
+
+Add a unit test that every key of `ansiColors` is in `COLOR_NAMES` and vice versa (catches drift):
+
+```ts
+import { ansiColors, COLOR_NAMES } from "../colors.js";
+it("ColorName covers exactly the named ANSI palette", () => {
+  expect([...COLOR_NAMES].sort()).toEqual(Object.keys(ansiColors).sort());
+});
+```
+
+- [ ] **Step 2: Narrow `Style` fields**
+
+In `elements.ts`, change `fg?: string` (and `bg`, `borderColor`, `labelColor`) to `fg?: ColorName | (string & {})`. The `& {}` trick keeps hex strings (e.g. `"#abc"`) compiling without losing the autocomplete on the named branch. Add a comment explaining.
+
+- [ ] **Step 3: Re-export from [lib/tui/index.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/index.ts)**: `export type { ColorName } from "./colors.js"; export { COLOR_NAMES } from "./colors.js";`
+- [ ] **Step 4: Build the project** (`pnpm run build`); fix any callers in `lib/logsViewer/render.ts`, `lib/debugger/`, etc. that were passing color names that don't exist in the palette. The build will surface them all.
+- [ ] **Step 5: Commit** `tui: typed ColorName union and narrowed Style color fields`
+
+---
+
+### Task 7 — `ScriptedInput` constructor accepts `(KeyEvent | string)[]`
+
+**Files:** modify [lib/tui/input/scripted.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/input/scripted.ts); test in [lib/tui/test/scripted.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/scripted.test.ts).
+
+Sugar: pass keys directly when constructing; mixed string/KeyEvent items welcome.
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+it("constructor accepts a list of strings or KeyEvents", async () => {
+  const input = new ScriptedInput(["j", "k", { key: "c", ctrl: true }]);
+  expect(await input.nextKey()).toEqual({ key: "j" });
+  expect(await input.nextKey()).toEqual({ key: "k" });
+  expect(await input.nextKey()).toEqual({ key: "c", ctrl: true });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+```ts
+constructor(initial?: ReadonlyArray<KeyEvent | string>) {
+  if (initial) {
+    for (const item of initial) {
+      this.feedKey(typeof item === "string" ? { key: item } : item);
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Pass tests** and confirm existing `ScriptedInput` tests still pass (the no-arg path must keep working).
+- [ ] **Step 4: Commit** `tui: ScriptedInput accepts an array of keys in its constructor`
+
+---
+
+### Task 8 — `FrameRecorder.lastText()` / `textAt(i)`
+
+**Files:** modify [lib/tui/output/recorder.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/output/recorder.ts); test in [lib/tui/test/recorder.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/tui/test/recorder.test.ts).
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+it("textAt() and lastText() expose recorded frames as plain text", () => {
+  const rec = new FrameRecorder();
+  rec.write(/* frame with content "first" */);
+  rec.write(/* frame with content "second" */);
+  expect(rec.textAt(0)).toBe("first");
+  expect(rec.lastText()).toBe("second");
+});
+```
+
+(Build the frames via `layout(line("first"), w, h)` + `render(...)` like the runner does.)
+
+- [ ] **Step 2: Implement**
+
+```ts
+textAt(i: number): string {
+  return this.frames[i].frame.toPlainText();
+}
+
+lastText(): string {
+  return this.textAt(this.frames.length - 1);
+}
+```
+
+- [ ] **Step 3: Pass tests**
+- [ ] **Step 4: Commit** `tui: FrameRecorder.textAt() / lastText() convenience getters`
+
+---
+
+### Task 9 — Adopt the new primitives in the logs viewer
+
+This is the load-bearing task: prove each new abstraction works for its motivating use case. Touches viewer code only; the test files should mostly tighten, not change behavior.
+
+- [ ] **Step 1: Replace `mapKey()` + key strings with `keyMatches()`**
+
+In [lib/logsViewer/input.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/input.ts), accept a `KeyEvent` directly (drop the `Key` string union) and use `keyMatches(event, "j")` / etc. inside the switch. Delete `mapKey` from [run.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts) and pass the raw `KeyEvent` straight into `handleKey`.
+
+Adjust [input.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/input.test.ts) to pass `{ key: "j" }` shapes (or string-named keys via a small wrapper) — they were already using single-char strings that match `formatKey`.
+
+- [ ] **Step 2: Replace inline `row()` with `line()`**
+
+In [run.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts) delete the local `row()` helper and call `line(content, { fg })` from `lib/tui`. The empty-state branch becomes `screen.render(lines(["No events found."]))`.
+
+- [ ] **Step 3: Replace `clampScrollTop()` + `ensureCursorVisible()` with `clampScroll()` + `followCursor()`**
+
+In [run.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.ts) the new `draw()` becomes (sketch):
+
+```ts
+const rows = flattenVisibleRows(state);
+const cursorIdx = rows.findIndex((r) => r.node.id === state.cursorId);
+const clamped = clampScroll(state.scrollTop, rows.length, opts.viewport.rows);
+state = { ...state, scrollTop: followCursor(clamped, cursorIdx, opts.viewport.rows) };
+```
+
+Delete the two local helpers.
+
+- [ ] **Step 4: Replace the manual `…` slice in [render.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/render.ts)**
+
+`renderRow` no longer needs the `line.length > cols` branch — the renderer handles it. Delete the slice + the ASCII-width comment block (the comment migrates to the renderer in Task 5).
+
+- [ ] **Step 5: Replace the loop body with `screen.runLoop()`**
+
+```ts
+return await screen.runLoop({
+  initialState,
+  render: (s) => column(/* ... build elements from s ... */),
+  handleKey: (s, event) => handleKey(s, event),
+  isDone: (s) => s.quit,
+});
+```
+
+- [ ] **Step 6: Replace `feed(input, [...])` test helpers with the array constructor**
+
+In [run.test.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/logsViewer/run.test.ts) delete the `feed()` function and rewrite to `new ScriptedInput(["j", "l", "q"])`.
+
+- [ ] **Step 7: Replace `out.frames[i].frame.toPlainText()` with `out.textAt(i)` / `out.lastText()`** throughout the viewer's tests.
+
+- [ ] **Step 8: Run the full suite**
+
+```bash
+pnpm test:run
+node tests/integration/statelog/test.mjs
+pnpm run lint:structure
+make
+```
+
+All previously-passing counts must hold; the viewer should still behave identically.
+
+- [ ] **Step 9: Manually smoke the CLI** against a real `.jsonl` file to confirm the looped-rendering and color output are unchanged.
+- [ ] **Step 10: Commit** `logsViewer: adopt tui line/lines, scroll helpers, runLoop, key utils`
+
+---
+
+### Task 10 — Update documentation
+
+- [ ] Add a section to [docs/site/guide/observability.md](file:///Users/adityabhargava/agency-lang/packages/agency-lang/docs/site/guide/observability.md) only if anything user-facing changed (it shouldn't; this is internal refactor).
+- [ ] Add a short developer-facing reference: `docs/dev/tui.md` (create if missing) covering: `line` / `lines`, `clampScroll` / `followCursor`, `Screen.runLoop`, `formatKey` / `keyMatches`, `ColorName`. Two paragraphs each, with the existing logs viewer cited as the canonical example.
+- [ ] **Commit** `docs: developer reference for the new TUI primitives`
+
+---
+
+## Validation Checklist
+
+Before opening the PR, verify all of:
+
+- [ ] `pnpm test:run` shows the previously-known passing count + the new tests (≈ 20 new tests across `lib/tui/` and `lib/tui/input/`; viewer test count holds steady).
+- [ ] `pnpm run lint:structure` clean except for the pre-existing `lib/lsp/hover.ts` error.
+- [ ] `make` builds cleanly with no new warnings.
+- [ ] `node tests/integration/statelog/test.mjs` → 8/8 scenarios pass.
+- [ ] Manual smoke: `pnpm run agency logs view <real-file>` opens, navigates, expands/collapses, scrolls long content, exits cleanly — identical to current behavior.
+- [ ] `lib/logsViewer/run.ts` is shorter than its current ~110 lines (concrete win is "deletions > additions").
+- [ ] No file outside `lib/tui/`, `lib/logsViewer/`, and `docs/` is modified, unless the typed `ColorName` migration in Task 6 forced a callsite update (which is fine — list any such callsites in the PR description).
+
+---
+
+## Anti-pattern review
+
+Per [docs/dev/anti-patterns.md](file:///Users/adityabhargava/agency-lang/packages/agency-lang/docs/dev/anti-patterns.md), this plan deliberately avoids:
+
+- **Dynamic imports** — every new export is statically resolved through `lib/tui/index.ts`.
+- **Maps / Sets** — `clampScroll` and `followCursor` operate on plain `number`s; `COLOR_NAMES` is a tuple, not a `Set`.
+- **Order-dependent mutable state inside helpers** — `clampScroll`, `followCursor`, `formatKey`, `keyMatches` are pure; `runLoop` mutates `state` via reassignment but the contract is functional (`handleKey(s, e) => s`).
+- **Nested ternaries** — none introduced.
+- **Helper duplication** — every helper extracted from the viewer is deleted from the viewer in Task 9.
+
+---
+
+## Out of scope (deferred)
+
+- **Grapheme-aware text clipping** (UTF-16 vs display cells). Tracked from PR #154; rolled into a follow-up issue when Task 5 lands.
+- **`<ScrollableList>` element with selection model**. The functional `clampScroll`/`followCursor` helpers handle the viewer's needs today. A higher-level component is worth doing once a second consumer needs it.
+- **Generalized "key chord" parsing** (multi-key sequences like `gg`). `formatKey` returns single-key strings only.
+- **Cursor styling via inverse video or bg-highlight**. The viewer keeps its leading `> ` prefix; revisit when we add a `<ListItem selected>` abstraction.

--- a/packages/agency-lang/lib/logsViewer/input.test.ts
+++ b/packages/agency-lang/lib/logsViewer/input.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { handleKey } from "./input.js";
 import { ViewerState, TreeNode } from "./types.js";
+import type { KeyEvent } from "../tui/input/types.js";
+
+const k = (key: string, mods: Partial<KeyEvent> = {}): KeyEvent => ({ key, ...mods });
 
 const child = (id: string): TreeNode => ({
   id,
@@ -32,17 +35,17 @@ const initial = (cursorId = "trace-t"): ViewerState => ({
 
 describe("handleKey", () => {
   it("j moves cursor down", () => {
-    const next = handleKey(initial("trace-t"), "j");
+    const next = handleKey(initial("trace-t"), k("j"));
     expect(next.cursorId).toBe("a");
   });
 
   it("k moves cursor up", () => {
-    const next = handleKey(initial("a"), "k");
+    const next = handleKey(initial("a"), k("k"));
     expect(next.cursorId).toBe("trace-t");
   });
 
   it("q sets quit", () => {
-    const next = handleKey(initial(), "q");
+    const next = handleKey(initial(), k("q"));
     expect(next.quit).toBe(true);
   });
 
@@ -54,39 +57,37 @@ describe("handleKey", () => {
       children: [child("a-child")],
     };
     state.expanded.delete("a");
-    const next = handleKey(state, "l");
+    const next = handleKey(state, k("l"));
     expect(next.expanded.has("a")).toBe(true);
   });
 
   it("h collapses an expanded node", () => {
     const state = initial("trace-t");
     expect(state.expanded.has("trace-t")).toBe(true);
-    const next = handleKey(state, "h");
+    const next = handleKey(state, k("h"));
     expect(next.expanded.has("trace-t")).toBe(false);
   });
 
   it("h on a collapsed node moves cursor to parent", () => {
     const state = initial("a");
     expect(state.expanded.has("a")).toBe(false);
-    const next = handleKey(state, "h");
+    const next = handleKey(state, k("h"));
     expect(next.cursorId).toBe("trace-t");
   });
 
   it("g jumps to the first visible row", () => {
-    const next = handleKey(initial("a"), "g");
+    const next = handleKey(initial("a"), k("g"));
     expect(next.cursorId).toBe("trace-t");
     expect(next.scrollTop).toBe(0);
   });
 
   it("G jumps to the last visible row", () => {
-    const next = handleKey(initial("trace-t"), "G");
+    const next = handleKey(initial("trace-t"), k("G"));
     expect(next.cursorId).toBe("b");
   });
 
   it("l on an already-expanded node descends to its first child", () => {
-    // trace-t is expanded by default; pressing l on it should move
-    // cursor to 'a' (its first child).
-    const next = handleKey(initial("trace-t"), "l");
+    const next = handleKey(initial("trace-t"), k("l"));
     expect(next.cursorId).toBe("a");
     expect(next.expanded.has("trace-t")).toBe(true);
   });
@@ -99,8 +100,18 @@ describe("handleKey", () => {
       scrollTop: 0,
       quit: false,
     };
-    expect(handleKey(empty, "j")).toBe(empty);
-    expect(handleKey(empty, "g")).toBe(empty);
-    expect(handleKey(empty, "G")).toBe(empty);
+    expect(handleKey(empty, k("j"))).toBe(empty);
+    expect(handleKey(empty, k("g"))).toBe(empty);
+    expect(handleKey(empty, k("G"))).toBe(empty);
+  });
+
+  it("Ctrl+C also quits", () => {
+    const next = handleKey(initial(), k("c", { ctrl: true }));
+    expect(next.quit).toBe(true);
+  });
+
+  it("arrow keys move cursor", () => {
+    const next = handleKey(initial("trace-t"), k("down"));
+    expect(next.cursorId).toBe("a");
   });
 });

--- a/packages/agency-lang/lib/logsViewer/input.ts
+++ b/packages/agency-lang/lib/logsViewer/input.ts
@@ -1,42 +1,41 @@
 import { ViewerState } from "./types.js";
 import { flattenVisibleRows, VisibleRow } from "./render.js";
 import type { KeyEvent } from "../tui/input/types.js";
-import { keyMatches } from "../tui/input/format.js";
-
-// `keyMatches` is intentionally case-insensitive so callers can use
-// "up" or "Up" interchangeably. Vim-style letter shortcuts ('g' vs
-// 'G') need case-sensitive matching though, so for the single-letter
-// keys we compare event.key directly.
-function letter(event: KeyEvent, ch: string): boolean {
-  return !event.ctrl && !event.shift && event.key === ch;
-}
+import { formatKey } from "../tui/input/format.js";
 
 export function handleKey(state: ViewerState, event: KeyEvent): ViewerState {
   const rows = flattenVisibleRows(state);
   if (rows.length === 0) return state;
   const idx = rows.findIndex((r) => r.node.id === state.cursorId);
-  if (letter(event, "j") || keyMatches(event, "Down") || keyMatches(event, "Ctrl+N")) {
-    return moveCursor(state, rows, Math.min(idx + 1, rows.length - 1));
+  // `formatKey` returns canonical strings like "j", "G", "Up",
+  // "Ctrl+C". It is case-preserving for single letters, so 'g' and
+  // 'G' stay distinct here.
+  switch (formatKey(event)) {
+    case "j":
+    case "Down":
+    case "Ctrl+N":
+      return moveCursor(state, rows, Math.min(idx + 1, rows.length - 1));
+    case "k":
+    case "Up":
+    case "Ctrl+P":
+      return moveCursor(state, rows, Math.max(idx - 1, 0));
+    case "g":
+      return { ...state, cursorId: rows[0].node.id, scrollTop: 0 };
+    case "G":
+      return moveCursor(state, rows, rows.length - 1);
+    case "l":
+    case "Right":
+    case "Enter":
+      return expand(state, rows, idx);
+    case "h":
+    case "Left":
+      return collapseOrParent(state, rows, idx);
+    case "q":
+    case "Ctrl+C":
+      return { ...state, quit: true };
+    default:
+      return state;
   }
-  if (letter(event, "k") || keyMatches(event, "Up") || keyMatches(event, "Ctrl+P")) {
-    return moveCursor(state, rows, Math.max(idx - 1, 0));
-  }
-  if (letter(event, "g")) {
-    return { ...state, cursorId: rows[0].node.id, scrollTop: 0 };
-  }
-  if (event.key === "G" && !event.ctrl) {
-    return moveCursor(state, rows, rows.length - 1);
-  }
-  if (letter(event, "l") || keyMatches(event, "Right") || keyMatches(event, "Enter")) {
-    return expand(state, rows, idx);
-  }
-  if (letter(event, "h") || keyMatches(event, "Left")) {
-    return collapseOrParent(state, rows, idx);
-  }
-  if (letter(event, "q") || keyMatches(event, "Ctrl+C")) {
-    return { ...state, quit: true };
-  }
-  return state;
 }
 
 function moveCursor(

--- a/packages/agency-lang/lib/logsViewer/input.ts
+++ b/packages/agency-lang/lib/logsViewer/input.ts
@@ -1,54 +1,42 @@
 import { ViewerState } from "./types.js";
 import { flattenVisibleRows, VisibleRow } from "./render.js";
+import type { KeyEvent } from "../tui/input/types.js";
+import { keyMatches } from "../tui/input/format.js";
 
-export type Key =
-  | "j"
-  | "k"
-  | "h"
-  | "l"
-  | "g"
-  | "G"
-  | "q"
-  | "Enter"
-  | "Up"
-  | "Down"
-  | "Left"
-  | "Right"
-  | "Ctrl+N"
-  | "Ctrl+P"
-  | "Ctrl+C"
-  | string;
+// `keyMatches` is intentionally case-insensitive so callers can use
+// "up" or "Up" interchangeably. Vim-style letter shortcuts ('g' vs
+// 'G') need case-sensitive matching though, so for the single-letter
+// keys we compare event.key directly.
+function letter(event: KeyEvent, ch: string): boolean {
+  return !event.ctrl && !event.shift && event.key === ch;
+}
 
-export function handleKey(state: ViewerState, key: Key): ViewerState {
+export function handleKey(state: ViewerState, event: KeyEvent): ViewerState {
   const rows = flattenVisibleRows(state);
   if (rows.length === 0) return state;
   const idx = rows.findIndex((r) => r.node.id === state.cursorId);
-  switch (key) {
-    case "j":
-    case "Down":
-    case "Ctrl+N":
-      return moveCursor(state, rows, Math.min(idx + 1, rows.length - 1));
-    case "k":
-    case "Up":
-    case "Ctrl+P":
-      return moveCursor(state, rows, Math.max(idx - 1, 0));
-    case "g":
-      return { ...state, cursorId: rows[0].node.id, scrollTop: 0 };
-    case "G":
-      return moveCursor(state, rows, rows.length - 1);
-    case "l":
-    case "Right":
-    case "Enter":
-      return expand(state, rows, idx);
-    case "h":
-    case "Left":
-      return collapseOrParent(state, rows, idx);
-    case "q":
-    case "Ctrl+C":
-      return { ...state, quit: true };
-    default:
-      return state;
+  if (letter(event, "j") || keyMatches(event, "Down") || keyMatches(event, "Ctrl+N")) {
+    return moveCursor(state, rows, Math.min(idx + 1, rows.length - 1));
   }
+  if (letter(event, "k") || keyMatches(event, "Up") || keyMatches(event, "Ctrl+P")) {
+    return moveCursor(state, rows, Math.max(idx - 1, 0));
+  }
+  if (letter(event, "g")) {
+    return { ...state, cursorId: rows[0].node.id, scrollTop: 0 };
+  }
+  if (event.key === "G" && !event.ctrl) {
+    return moveCursor(state, rows, rows.length - 1);
+  }
+  if (letter(event, "l") || keyMatches(event, "Right") || keyMatches(event, "Enter")) {
+    return expand(state, rows, idx);
+  }
+  if (letter(event, "h") || keyMatches(event, "Left")) {
+    return collapseOrParent(state, rows, idx);
+  }
+  if (letter(event, "q") || keyMatches(event, "Ctrl+C")) {
+    return { ...state, quit: true };
+  }
+  return state;
 }
 
 function moveCursor(

--- a/packages/agency-lang/lib/logsViewer/render.ts
+++ b/packages/agency-lang/lib/logsViewer/render.ts
@@ -22,7 +22,7 @@ export function renderViewerLines(
   const rows = flattenVisibleRows(state);
   const slice = rows.slice(state.scrollTop, state.scrollTop + viewport.rows);
   return slice.map((row) =>
-    renderRow(
+    renderRowText(
       row,
       state.cursorId === row.node.id,
       state.expanded.has(row.node.id),
@@ -30,7 +30,7 @@ export function renderViewerLines(
   );
 }
 
-function renderRow(
+export function renderRowText(
   row: VisibleRow,
   isCursor: boolean,
   isExpanded: boolean,

--- a/packages/agency-lang/lib/logsViewer/render.ts
+++ b/packages/agency-lang/lib/logsViewer/render.ts
@@ -26,7 +26,6 @@ export function renderViewerLines(
       row,
       state.cursorId === row.node.id,
       state.expanded.has(row.node.id),
-      viewport.cols,
     ),
   );
 }
@@ -35,19 +34,13 @@ function renderRow(
   row: VisibleRow,
   isCursor: boolean,
   isExpanded: boolean,
-  cols: number,
 ): string {
   const indent = "  ".repeat(row.depth);
   const glyph = chooseGlyph(row.node, isExpanded);
   const marker = isCursor ? "> " : "  ";
-  const line = `${marker}${indent}${glyph} ${row.node.summary}`;
-  // NOTE: v1 assumes ASCII-width summaries. `line.length` counts
-  // UTF-16 code units, not terminal cells, so wide glyphs (CJK,
-  // emoji) or combining marks will misalign / over-run the column
-  // budget. Acceptable for v1 because summaries are built from a
-  // fixed vocabulary plus short user payload fragments; revisit
-  // with a string-width measurement if real users hit it.
-  return line.length > cols ? line.slice(0, cols - 1) + "…" : line;
+  // Over-long lines are clipped centrally by the TUI renderer; no
+  // need to slice here.
+  return `${marker}${indent}${glyph} ${row.node.summary}`;
 }
 
 function chooseGlyph(node: TreeNode, isExpanded: boolean): string {

--- a/packages/agency-lang/lib/logsViewer/run.test.ts
+++ b/packages/agency-lang/lib/logsViewer/run.test.ts
@@ -32,38 +32,28 @@ const sampleEvents = [
 
 const sample = sampleEvents.map((e) => JSON.stringify(e)).join("\n") + "\n";
 
-function feed(input: ScriptedInput, keys: string[]): void {
-  for (const k of keys) input.feedKey({ key: k });
-}
-
 describe("runViewer", () => {
   it("renders, navigates with j, expands with l, quits with q", async () => {
-    const input = new ScriptedInput();
-    feed(input, ["j", "l", "q"]);
     const out = new FrameRecorder();
     await runViewer({
       jsonl: sample,
-      input,
+      input: new ScriptedInput(["j", "l", "q"]),
       output: out,
       viewport: { rows: 10, cols: 80 },
     });
     expect(out.frames.length).toBeGreaterThan(0);
-    const lastFrame = out.frames[out.frames.length - 1].frame.toPlainText();
-    expect(lastFrame).toMatch(/agentRun/);
+    expect(out.lastText()).toMatch(/agentRun/);
   });
 
   it("shows a helpful message when the file is empty", async () => {
-    const input = new ScriptedInput();
-    feed(input, ["q"]);
     const out = new FrameRecorder();
     await runViewer({
       jsonl: "",
-      input,
+      input: new ScriptedInput(["q"]),
       output: out,
       viewport: { rows: 5, cols: 40 },
     });
-    const first = out.frames[0].frame.toPlainText();
-    expect(first.toLowerCase()).toMatch(/no events/);
+    expect(out.textAt(0).toLowerCase()).toMatch(/no events/);
   });
 
   it("clamps scrollTop after collapsing reduces the visible row count", async () => {
@@ -79,22 +69,21 @@ describe("runViewer", () => {
       data: { type: "debug", timestamp: "", message: `m${i}` },
     }));
     const jsonl = many.map((e) => JSON.stringify(e)).join("\n") + "\n";
-    const input = new ScriptedInput();
     // l: expand span. j × 20: scroll far down. h: collapse it. q.
-    feed(input, [
+    const keys = [
       "l",
       ...Array.from({ length: 20 }, () => "j"),
       "h",
       "q",
-    ]);
+    ];
     const out = new FrameRecorder();
     await runViewer({
       jsonl,
-      input,
+      input: new ScriptedInput(keys),
       output: out,
       viewport: { rows: 5, cols: 80 },
     });
-    const last = out.frames[out.frames.length - 1].frame.toPlainText();
+    const last = out.lastText();
     // After collapsing, the trace + s1 should still be visible — the
     // frame must not be empty.
     expect(last.length).toBeGreaterThan(0);
@@ -102,17 +91,14 @@ describe("runViewer", () => {
   });
 
   it("shows parse errors as a footer line", async () => {
-    const input = new ScriptedInput();
-    feed(input, ["q"]);
     const out = new FrameRecorder();
     const bad = sample + "this is not json\n";
     await runViewer({
       jsonl: bad,
-      input,
+      input: new ScriptedInput(["q"]),
       output: out,
       viewport: { rows: 10, cols: 80 },
     });
-    const frame = out.frames[0].frame.toPlainText();
-    expect(frame).toMatch(/1 parse error/);
+    expect(out.textAt(0)).toMatch(/1 parse error/);
   });
 });

--- a/packages/agency-lang/lib/logsViewer/run.ts
+++ b/packages/agency-lang/lib/logsViewer/run.ts
@@ -4,12 +4,14 @@ import type { Element } from "../tui/elements.js";
 import type { InputSource } from "../tui/input/types.js";
 import type { OutputTarget } from "../tui/output/types.js";
 import { clampScroll, followCursor } from "../tui/scroll.js";
+import { scrollList } from "../tui/scrollList.js";
 import { parseStatelogJsonl } from "./parse.js";
 import { buildForest } from "./tree.js";
 import {
-  renderViewerLines,
   flattenVisibleRows,
   colorFor,
+  renderRowText,
+  VisibleRow,
 } from "./render.js";
 import { handleKey } from "./input.js";
 import { ViewerState } from "./types.js";
@@ -48,13 +50,16 @@ export async function runViewer(opts: RunViewerOpts): Promise<void> {
   };
 
   await screen.runLoop({
-    initialState,
+    initialState: applyScroll(initialState, opts.viewport),
     render: (s) => renderState(s, parsed.errors, opts.viewport),
-    handleKey,
+    handleKey: (s, event) => applyScroll(handleKey(s, event), opts.viewport),
     isDone: (s) => s.quit,
   });
 }
 
+// Clamp and cursor-follow scrollTop based on the current visible
+// rows. Kept in `run.ts` so the pure `handleKey` reducer stays free
+// of viewport / rendering concerns.
 function applyScroll(
   state: ViewerState,
   viewport: { rows: number; cols: number },
@@ -73,24 +78,33 @@ function renderState(
   parseErrors: ReadonlyArray<{ line: number }>,
   viewport: { rows: number; cols: number },
 ): Element {
-  const adjusted = applyScroll(state, viewport);
-  const visible = flattenVisibleRows(adjusted).slice(
-    adjusted.scrollTop,
-    adjusted.scrollTop + viewport.rows,
-  );
-  const rendered = renderViewerLines(adjusted, viewport);
-  const elements: Element[] = visible.map((vrow, i) => {
-    const fg = colorFor(vrow.node);
-    return line(rendered[i], fg ? { fg } : undefined);
+  const rows = flattenVisibleRows(state);
+  const cursorIdx = rows.findIndex((r) => r.node.id === state.cursorId);
+  const reserved = parseErrors.length > 0 ? 2 : 0; // blank line + error line
+  const listViewportRows = Math.max(1, viewport.rows - reserved);
+
+  const { element: list } = scrollList<VisibleRow>({
+    items: rows,
+    cursorIdx,
+    scrollTop: state.scrollTop,
+    viewportRows: listViewportRows,
+    renderItem: (vrow, isCursor) => {
+      const fg = colorFor(vrow.node);
+      return line(
+        renderRowText(vrow, isCursor, state.expanded.has(vrow.node.id)),
+        fg ? { fg } : undefined,
+      );
+    },
   });
-  if (parseErrors.length > 0) {
-    elements.push(line(""));
-    elements.push(
-      line(
-        `${parseErrors.length} parse error(s) — first: line ${parseErrors[0].line}`,
-        { fg: "bright-red" },
-      ),
-    );
-  }
-  return column({ justifyContent: "flex-start" }, ...elements);
+
+  if (parseErrors.length === 0) return list;
+  return column(
+    { justifyContent: "flex-start" },
+    list,
+    line(""),
+    line(
+      `${parseErrors.length} parse error(s) — first: line ${parseErrors[0].line}`,
+      { fg: "bright-red" },
+    ),
+  );
 }

--- a/packages/agency-lang/lib/logsViewer/run.ts
+++ b/packages/agency-lang/lib/logsViewer/run.ts
@@ -1,8 +1,9 @@
 import { Screen } from "../tui/screen.js";
-import { column } from "../tui/builders.js";
+import { column, line, lines } from "../tui/builders.js";
 import type { Element } from "../tui/elements.js";
-import type { InputSource, KeyEvent } from "../tui/input/types.js";
+import type { InputSource } from "../tui/input/types.js";
 import type { OutputTarget } from "../tui/output/types.js";
+import { clampScroll, followCursor } from "../tui/scroll.js";
 import { parseStatelogJsonl } from "./parse.js";
 import { buildForest } from "./tree.js";
 import {
@@ -32,17 +33,12 @@ export async function runViewer(opts: RunViewerOpts): Promise<void> {
   });
 
   if (roots.length === 0) {
-    screen.render(
-      column(
-        { justifyContent: "flex-start" },
-        row("No events found."),
-      ),
-    );
+    screen.render(lines(["No events found."]));
     await opts.input.nextKey();
     return;
   }
 
-  let state: ViewerState = {
+  const initialState: ViewerState = {
     roots,
     // Default-expand the only trace if there is exactly one.
     expanded: new Set(roots.length === 1 ? [roots[0].id] : []),
@@ -51,95 +47,50 @@ export async function runViewer(opts: RunViewerOpts): Promise<void> {
     quit: false,
   };
 
-  const draw = () => {
-    state = clampScrollTop(state, opts.viewport);
-    state = ensureCursorVisible(state, opts.viewport);
-    const visible = flattenVisibleRows(state).slice(
-      state.scrollTop,
-      state.scrollTop + opts.viewport.rows,
-    );
-    const lines = renderViewerLines(state, opts.viewport);
-    const elements: Element[] = visible.map((vrow, i) =>
-      row(lines[i], colorFor(vrow.node)),
-    );
-    if (parsed.errors.length > 0) {
-      elements.push(row(""));
-      elements.push(
-        row(
-          `${parsed.errors.length} parse error(s) — first: line ${parsed.errors[0].line}`,
-          "bright-red",
-        ),
-      );
-    }
-    screen.render(
-      column({ justifyContent: "flex-start" }, ...elements),
-    );
-  };
-
-  draw();
-  while (!state.quit) {
-    const event = await opts.input.nextKey();
-    const key = mapKey(event);
-    state = handleKey(state, key);
-    draw();
-  }
+  await screen.runLoop({
+    initialState,
+    render: (s) => renderState(s, parsed.errors, opts.viewport),
+    handleKey,
+    isDone: (s) => s.quit,
+  });
 }
 
-// One single-line row. height: 1 stops the default flex: 1 from
-// stretching each line to fill the viewport (which is what made the
-// viewer look triple-spaced in v1).
-function row(content: string, fg?: string): Element {
-  return {
-    type: "text",
-    content,
-    style: fg ? { height: 1, fg } : { height: 1 },
-  };
-}
-
-function clampScrollTop(
-  state: ViewerState,
-  viewport: { rows: number; cols: number },
-): ViewerState {
-  const rows = flattenVisibleRows(state);
-  const maxTop = Math.max(0, rows.length - viewport.rows);
-  if (state.scrollTop <= maxTop && state.scrollTop >= 0) return state;
-  return { ...state, scrollTop: Math.max(0, Math.min(state.scrollTop, maxTop)) };
-}
-
-function ensureCursorVisible(
+function applyScroll(
   state: ViewerState,
   viewport: { rows: number; cols: number },
 ): ViewerState {
   const rows = flattenVisibleRows(state);
   const cursorIdx = rows.findIndex((r) => r.node.id === state.cursorId);
-  if (cursorIdx < 0) return state;
-  if (cursorIdx < state.scrollTop) {
-    return { ...state, scrollTop: cursorIdx };
-  }
-  if (cursorIdx >= state.scrollTop + viewport.rows) {
-    return { ...state, scrollTop: cursorIdx - viewport.rows + 1 };
-  }
-  return state;
+  const clamped = clampScroll(state.scrollTop, rows.length, viewport.rows);
+  const scrollTop = cursorIdx >= 0
+    ? followCursor(clamped, cursorIdx, viewport.rows)
+    : clamped;
+  return scrollTop === state.scrollTop ? state : { ...state, scrollTop };
 }
 
-function mapKey(event: KeyEvent): string {
-  if (event.ctrl) {
-    if (event.key === "c") return "Ctrl+C";
-    if (event.key === "n") return "Ctrl+N";
-    if (event.key === "p") return "Ctrl+P";
+function renderState(
+  state: ViewerState,
+  parseErrors: ReadonlyArray<{ line: number }>,
+  viewport: { rows: number; cols: number },
+): Element {
+  const adjusted = applyScroll(state, viewport);
+  const visible = flattenVisibleRows(adjusted).slice(
+    adjusted.scrollTop,
+    adjusted.scrollTop + viewport.rows,
+  );
+  const rendered = renderViewerLines(adjusted, viewport);
+  const elements: Element[] = visible.map((vrow, i) => {
+    const fg = colorFor(vrow.node);
+    return line(rendered[i], fg ? { fg } : undefined);
+  });
+  if (parseErrors.length > 0) {
+    elements.push(line(""));
+    elements.push(
+      line(
+        `${parseErrors.length} parse error(s) — first: line ${parseErrors[0].line}`,
+        { fg: "bright-red" },
+      ),
+    );
   }
-  switch (event.key) {
-    case "up":
-      return "Up";
-    case "down":
-      return "Down";
-    case "left":
-      return "Left";
-    case "right":
-      return "Right";
-    case "enter":
-      return "Enter";
-    default:
-      return event.key;
-  }
+  return column({ justifyContent: "flex-start" }, ...elements);
 }

--- a/packages/agency-lang/lib/tui/builders.test.ts
+++ b/packages/agency-lang/lib/tui/builders.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { line, lines } from "./builders.js";
+import { layout } from "./layout.js";
+
+describe("line()", () => {
+  it("produces a text element with height: 1", () => {
+    const el = line("hi");
+    expect(el.type).toBe("text");
+    expect(el.content).toBe("hi");
+    expect(el.style?.height).toBe(1);
+  });
+
+  it("merges caller-provided fg / bg / bold", () => {
+    const el = line("hi", { fg: "red", bold: true });
+    expect(el.style).toMatchObject({ height: 1, fg: "red", bold: true });
+  });
+
+  it("caller-provided height overrides the default", () => {
+    const el = line("hi", { height: 2 });
+    expect(el.style?.height).toBe(2);
+  });
+});
+
+describe("lines()", () => {
+  it("returns a column of fixed-height rows, justified flex-start", () => {
+    const tree = lines(["a", "b", "c"]);
+    expect(tree.type).toBe("box");
+    expect(tree.style?.flexDirection).toBe("column");
+    expect(tree.style?.justifyContent).toBe("flex-start");
+    expect(tree.children).toHaveLength(3);
+    for (const child of tree.children!) {
+      expect(child.style?.height).toBe(1);
+    }
+  });
+
+  it("places each line one row below the previous one (no stretch)", () => {
+    // Sanity: confirm the layout engine does not stretch the column
+    // when its children declare height: 1.
+    const positioned = layout(lines(["one", "two"]), 80, 24);
+    const [a, b] = positioned.children!;
+    expect(b.resolvedY - a.resolvedY).toBe(1);
+  });
+});

--- a/packages/agency-lang/lib/tui/builders.ts
+++ b/packages/agency-lang/lib/tui/builders.ts
@@ -48,6 +48,25 @@ export function text(content: string): Element {
   return { type: "text", content };
 }
 
+// Single-line text row. Sets `height: 1` so the element doesn't
+// stretch via the default `flex: 1` when placed inside a column,
+// which is the source of the "every row triple-spaces itself"
+// surprise. Caller-provided style is merged on top so `line("hi",
+// { height: 2 })` still works.
+export function line(content: string, style?: Style): Element {
+  return { type: "text", content, style: { height: 1, ...style } };
+}
+
+// Convenience: a column of `line()`s. `justifyContent: "flex-start"`
+// stops the layout engine from distributing leftover space between
+// the children if their combined height is less than the viewport.
+export function lines(strings: string[], style?: Style): Element {
+  return column(
+    { justifyContent: "flex-start", ...style },
+    ...strings.map((s) => line(s)),
+  );
+}
+
 export function list(style: StyleProps, items: string[], selectedIndex?: number): Element {
   const { style: resolvedStyle, key } = splitStyleAndKey(style);
   return { type: "list", style: resolvedStyle, key, items, selectedIndex };

--- a/packages/agency-lang/lib/tui/colors.ts
+++ b/packages/agency-lang/lib/tui/colors.ts
@@ -1,3 +1,17 @@
+/**
+ * The full set of named colors supported by the TUI palette. Keep
+ * `ansiColors`, `ansiBgColors`, and `cssColors` in lock-step with this
+ * list — a unit test enforces it.
+ */
+export const COLOR_NAMES = [
+  "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white",
+  "gray",
+  "bright-red", "bright-green", "bright-yellow", "bright-blue",
+  "bright-magenta", "bright-cyan", "bright-white",
+] as const;
+
+export type ColorName = (typeof COLOR_NAMES)[number];
+
 export const ansiColors: Record<string, string> = {
   black: "\x1b[30m", red: "\x1b[31m", green: "\x1b[32m", yellow: "\x1b[33m",
   blue: "\x1b[34m", magenta: "\x1b[35m", cyan: "\x1b[36m", white: "\x1b[37m",

--- a/packages/agency-lang/lib/tui/elements.ts
+++ b/packages/agency-lang/lib/tui/elements.ts
@@ -1,3 +1,5 @@
+import type { ColorName } from "./colors.js";
+
 export type Element = {
   type: "box" | "text" | "list" | "textInput";
   style?: Style;
@@ -8,6 +10,14 @@ export type Element = {
   value?: string;
   key?: string;
 };
+
+/**
+ * Color fields accept either a `ColorName` from the named palette or
+ * an arbitrary string (used for hex values like `"#abc"` in the HTML
+ * adapter). The `string & {}` intersection preserves autocomplete on
+ * the named branch while keeping the string escape hatch.
+ */
+export type Color = ColorName | (string & {});
 
 export type Style = {
   // Layout
@@ -30,13 +40,13 @@ export type Style = {
 
   // Box decoration
   border?: boolean;        // draw a single-line box border (reduces inner area by 1 on each side)
-  borderColor?: string;    // named color (e.g. "cyan", "bright-red")
+  borderColor?: Color;     // named color (e.g. "cyan", "bright-red") or hex string
   label?: string;          // text rendered into the top border
-  labelColor?: string;     // named color for the label
+  labelColor?: Color;      // named color for the label, or hex string
 
   // Content styling
-  fg?: string;             // foreground color name
-  bg?: string;             // background color name
+  fg?: Color;              // foreground color
+  bg?: Color;              // background color
   bold?: boolean;
 
   // Scrolling

--- a/packages/agency-lang/lib/tui/index.ts
+++ b/packages/agency-lang/lib/tui/index.ts
@@ -18,3 +18,4 @@ export { TerminalOutput } from "./output/terminal.js";
 export { FrameRecorder } from "./output/recorder.js";
 export { Screen } from "./screen.js";
 export * from "./scroll.js";
+export * from "./scrollList.js";

--- a/packages/agency-lang/lib/tui/index.ts
+++ b/packages/agency-lang/lib/tui/index.ts
@@ -17,3 +17,4 @@ export * from "./output/types.js";
 export { TerminalOutput } from "./output/terminal.js";
 export { FrameRecorder } from "./output/recorder.js";
 export { Screen } from "./screen.js";
+export * from "./scroll.js";

--- a/packages/agency-lang/lib/tui/index.ts
+++ b/packages/agency-lang/lib/tui/index.ts
@@ -12,6 +12,7 @@ export { toANSI } from "./render/ansi.js";
 export * from "./input/types.js";
 export { ScriptedInput } from "./input/scripted.js";
 export { TerminalInput } from "./input/terminal.js";
+export { formatKey, keyMatches } from "./input/format.js";
 export * from "./output/types.js";
 export { TerminalOutput } from "./output/terminal.js";
 export { FrameRecorder } from "./output/recorder.js";

--- a/packages/agency-lang/lib/tui/input/format.test.ts
+++ b/packages/agency-lang/lib/tui/input/format.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { formatKey, keyMatches } from "./format.js";
+
+describe("formatKey", () => {
+  it("returns single-char keys verbatim", () => {
+    expect(formatKey({ key: "j" })).toBe("j");
+    expect(formatKey({ key: "G" })).toBe("G");
+  });
+
+  it("title-cases named keys", () => {
+    expect(formatKey({ key: "up" })).toBe("Up");
+    expect(formatKey({ key: "enter" })).toBe("Enter");
+    expect(formatKey({ key: "pagedown" })).toBe("PageDown");
+  });
+
+  it("prefixes with Ctrl+ / Shift+ in canonical order", () => {
+    expect(formatKey({ key: "c", ctrl: true })).toBe("Ctrl+C");
+    expect(formatKey({ key: "tab", shift: true })).toBe("Shift+Tab");
+    expect(formatKey({ key: "right", ctrl: true, shift: true })).toBe(
+      "Ctrl+Shift+Right",
+    );
+  });
+});
+
+describe("keyMatches", () => {
+  it("matches by canonical name, case-insensitively", () => {
+    expect(keyMatches({ key: "j" }, "j")).toBe(true);
+    expect(keyMatches({ key: "c", ctrl: true }, "ctrl+c")).toBe(true);
+    expect(keyMatches({ key: "up" }, "UP")).toBe(true);
+    expect(keyMatches({ key: "j" }, "k")).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/tui/input/format.ts
+++ b/packages/agency-lang/lib/tui/input/format.ts
@@ -1,0 +1,40 @@
+import type { KeyEvent } from "./types.js";
+
+const TITLE_CASED: Record<string, string> = {
+  up: "Up",
+  down: "Down",
+  left: "Left",
+  right: "Right",
+  enter: "Enter",
+  escape: "Escape",
+  tab: "Tab",
+  backspace: "Backspace",
+  delete: "Delete",
+  insert: "Insert",
+  home: "Home",
+  end: "End",
+  pageup: "PageUp",
+  pagedown: "PageDown",
+  space: "Space",
+};
+
+// Canonical string for a KeyEvent — single chars verbatim ("j", "G"),
+// named keys title-cased ("Up", "PageDown"), with "Ctrl+" / "Shift+"
+// prefixes in a stable order. Letter keys after Ctrl+ are uppercased
+// so "Ctrl+C" matches what most docs and bindings use.
+export function formatKey(event: KeyEvent): string {
+  const base = TITLE_CASED[event.key] ?? event.key;
+  const body =
+    event.ctrl && base.length === 1 ? base.toUpperCase() : base;
+  const parts: string[] = [];
+  if (event.ctrl) parts.push("Ctrl");
+  if (event.shift) parts.push("Shift");
+  parts.push(body);
+  return parts.join("+");
+}
+
+// Case-insensitive predicate. Accepts any spelling formatKey could
+// produce (e.g. "ctrl+c", "Ctrl+C", "CTRL+C" all match).
+export function keyMatches(event: KeyEvent, name: string): boolean {
+  return formatKey(event).toLowerCase() === name.toLowerCase();
+}

--- a/packages/agency-lang/lib/tui/input/scripted.ts
+++ b/packages/agency-lang/lib/tui/input/scripted.ts
@@ -6,6 +6,18 @@ export class ScriptedInput implements InputSource {
   private lineQueue: string[] = [];
   private lineWaiters: ((line: string) => void)[] = [];
 
+  /**
+   * Optionally pre-load the input with a sequence of keys. Strings are
+   * converted to `{ key }` events; `KeyEvent` objects are used as-is.
+   */
+  constructor(initial?: ReadonlyArray<KeyEvent | string>) {
+    if (initial) {
+      for (const item of initial) {
+        this.feedKey(typeof item === "string" ? { key: item } : item);
+      }
+    }
+  }
+
   feedKey(key: KeyEvent): void {
     const waiter = this.keyWaiters.shift();
     if (waiter) {

--- a/packages/agency-lang/lib/tui/output/recorder.ts
+++ b/packages/agency-lang/lib/tui/output/recorder.ts
@@ -40,6 +40,14 @@ export class FrameRecorder implements OutputTarget {
     this.frames = [];
   }
 
+  textAt(i: number): string {
+    return this.frames[i].frame.toPlainText();
+  }
+
+  lastText(): string {
+    return this.textAt(this.frames.length - 1);
+  }
+
   toHTML(): string {
     const frameHtmls = this.frames.map((entry, i) => {
       const label = entry.label ?? `Frame ${i + 1}`;

--- a/packages/agency-lang/lib/tui/output/recorder.ts
+++ b/packages/agency-lang/lib/tui/output/recorder.ts
@@ -41,10 +41,18 @@ export class FrameRecorder implements OutputTarget {
   }
 
   textAt(i: number): string {
+    if (i < 0 || i >= this.frames.length) {
+      throw new Error(
+        `FrameRecorder.textAt(${i}): index out of range (have ${this.frames.length} frames)`,
+      );
+    }
     return this.frames[i].frame.toPlainText();
   }
 
   lastText(): string {
+    if (this.frames.length === 0) {
+      throw new Error("FrameRecorder.lastText(): no frames recorded");
+    }
     return this.textAt(this.frames.length - 1);
   }
 

--- a/packages/agency-lang/lib/tui/render/renderer.ts
+++ b/packages/agency-lang/lib/tui/render/renderer.ts
@@ -103,8 +103,10 @@ function renderTextContent(
       }
     }
     // If we ran out of room, mark the truncation explicitly with an
-    // ellipsis in the final cell. NOTE: widths here are counted in
-    // UTF-16 code units, matching the layout engine; grapheme-aware
+    // ellipsis in the final cell. NOTE: widths here are counted by
+    // Unicode code points (`for..of` over the string), not grapheme
+    // clusters or terminal display cells; combining marks and wide
+    // characters (CJK, emoji) can still misalign. Grapheme-aware
     // clipping is out of scope.
     if (clipped && row.length > 0) {
       const last = row[row.length - 1];

--- a/packages/agency-lang/lib/tui/render/renderer.ts
+++ b/packages/agency-lang/lib/tui/render/renderer.ts
@@ -87,9 +87,13 @@ function renderTextContent(
   for (const line of visibleLines) {
     const spans = parseStyledText(line);
     const row: Cell[] = [];
-    for (const span of spans) {
+    let clipped = false;
+    outer: for (const span of spans) {
       for (const ch of span.text) {
-        if (row.length >= innerWidth) break;
+        if (row.length >= innerWidth) {
+          clipped = true;
+          break outer;
+        }
         row.push({
           char: ch,
           fg: span.fg ?? fg,
@@ -97,6 +101,14 @@ function renderTextContent(
           bold: span.bold ?? bold,
         });
       }
+    }
+    // If we ran out of room, mark the truncation explicitly with an
+    // ellipsis in the final cell. NOTE: widths here are counted in
+    // UTF-16 code units, matching the layout engine; grapheme-aware
+    // clipping is out of scope.
+    if (clipped && row.length > 0) {
+      const last = row[row.length - 1];
+      row[row.length - 1] = { ...last, char: "…" };
     }
     // Pad to inner width
     while (row.length < innerWidth) {

--- a/packages/agency-lang/lib/tui/screen.ts
+++ b/packages/agency-lang/lib/tui/screen.ts
@@ -37,6 +37,23 @@ export class Screen {
     return { width: this.width, height: this.height };
   }
 
+  async runLoop<S>(opts: {
+    initialState: S;
+    render: (state: S) => Element;
+    handleKey: (state: S, event: KeyEvent) => S;
+    isDone: (state: S) => boolean;
+    label?: string;
+  }): Promise<S> {
+    let state = opts.initialState;
+    this.render(opts.render(state), opts.label);
+    while (!opts.isDone(state)) {
+      const event = await this.nextKey();
+      state = opts.handleKey(state, event);
+      this.render(opts.render(state), opts.label);
+    }
+    return state;
+  }
+
   destroy(): void {
     this.input.destroy();
     if (this.output.destroy) this.output.destroy();

--- a/packages/agency-lang/lib/tui/scroll.test.ts
+++ b/packages/agency-lang/lib/tui/scroll.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { clampScroll, followCursor } from "./scroll.js";
+
+describe("clampScroll", () => {
+  it("keeps a valid scrollTop", () => {
+    expect(clampScroll(3, 20, 5)).toBe(3);
+  });
+
+  it("clamps when scrollTop exceeds the maximum", () => {
+    // 20 rows, viewport 5 → max scrollTop = 15
+    expect(clampScroll(99, 20, 5)).toBe(15);
+  });
+
+  it("returns 0 when the content fits the viewport", () => {
+    expect(clampScroll(99, 3, 10)).toBe(0);
+  });
+
+  it("clamps negative values to 0", () => {
+    expect(clampScroll(-5, 20, 5)).toBe(0);
+  });
+});
+
+describe("followCursor", () => {
+  it("scrolls up when cursor is above the viewport", () => {
+    expect(followCursor(10, 3, 5)).toBe(3);
+  });
+
+  it("scrolls down when cursor is below the viewport", () => {
+    // scrollTop 0, viewport 5 → visible rows 0..4; cursor at 7 means
+    // we need scrollTop = 3 (so 3..7 is visible).
+    expect(followCursor(0, 7, 5)).toBe(3);
+  });
+
+  it("does nothing when cursor is already visible", () => {
+    expect(followCursor(0, 2, 5)).toBe(0);
+  });
+});

--- a/packages/agency-lang/lib/tui/scroll.ts
+++ b/packages/agency-lang/lib/tui/scroll.ts
@@ -1,0 +1,32 @@
+// Pure helpers for scrollable-list bookkeeping. Used by the logs
+// viewer; reusable by any TUI app that needs a cursor + scroll
+// position over a flat list of rows.
+
+// Clamp `scrollTop` into `[0, max(0, total - viewportRows)]`. The
+// upper bound stops the viewer from rendering an empty viewport
+// when the user collapses content beneath them.
+export function clampScroll(
+  scrollTop: number,
+  total: number,
+  viewportRows: number,
+): number {
+  const max = Math.max(0, total - viewportRows);
+  if (scrollTop < 0) return 0;
+  if (scrollTop > max) return max;
+  return scrollTop;
+}
+
+// Return a `scrollTop` such that `cursorIdx` is inside the viewport.
+// If the cursor is above the viewport, snap it to the top; if below,
+// snap it to the last visible row. Otherwise leave `scrollTop`
+// untouched (no scroll-on-every-keystroke jitter).
+export function followCursor(
+  scrollTop: number,
+  cursorIdx: number,
+  viewportRows: number,
+): number {
+  if (cursorIdx < scrollTop) return cursorIdx;
+  const lastVisible = scrollTop + viewportRows - 1;
+  if (cursorIdx > lastVisible) return cursorIdx - viewportRows + 1;
+  return scrollTop;
+}

--- a/packages/agency-lang/lib/tui/scrollList.test.ts
+++ b/packages/agency-lang/lib/tui/scrollList.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import { scrollList } from "./scrollList.js";
+import { line } from "./builders.js";
+
+describe("scrollList", () => {
+  it("renders only the visible window of items", () => {
+    const items = ["a", "b", "c", "d", "e"];
+    const { element, scrollTop } = scrollList({
+      items,
+      cursorIdx: -1,
+      scrollTop: 1,
+      viewportRows: 2,
+      renderItem: (item) => line(item),
+    });
+    expect(scrollTop).toBe(1);
+    expect(element.children).toHaveLength(2);
+    expect(element.children![0].content).toBe("b");
+    expect(element.children![1].content).toBe("c");
+  });
+
+  it("clamps scrollTop when it overshoots the end of the list", () => {
+    const { scrollTop } = scrollList({
+      items: ["a", "b", "c"],
+      cursorIdx: -1,
+      scrollTop: 999,
+      viewportRows: 2,
+      renderItem: (item) => line(item),
+    });
+    expect(scrollTop).toBe(1); // total 3 - viewport 2 = 1
+  });
+
+  it("follows the cursor when it moves out of the viewport", () => {
+    const items = Array.from({ length: 10 }, (_, i) => `r${i}`);
+    const { scrollTop, element } = scrollList({
+      items,
+      cursorIdx: 7,
+      scrollTop: 0,
+      viewportRows: 3,
+      renderItem: (item, isCursor) => line(isCursor ? `> ${item}` : `  ${item}`),
+    });
+    expect(scrollTop).toBe(5); // cursor 7 visible as last row of a 3-row viewport
+    expect(element.children).toHaveLength(3);
+    expect(element.children![2].content).toBe("> r7");
+  });
+
+  it("passes isCursor=true to the renderer for the cursor row", () => {
+    const flags: boolean[] = [];
+    scrollList({
+      items: ["a", "b", "c"],
+      cursorIdx: 1,
+      scrollTop: 0,
+      viewportRows: 3,
+      renderItem: (_, isCursor) => {
+        flags.push(isCursor);
+        return line("x");
+      },
+    });
+    expect(flags).toEqual([false, true, false]);
+  });
+
+  it("works with no cursor (cursorIdx = -1) and a short list", () => {
+    const { element, scrollTop } = scrollList({
+      items: ["only"],
+      cursorIdx: -1,
+      scrollTop: 0,
+      viewportRows: 5,
+      renderItem: (item) => line(item),
+    });
+    expect(scrollTop).toBe(0);
+    expect(element.children).toHaveLength(1);
+  });
+
+  it("returns an empty column for an empty item list", () => {
+    const { element, scrollTop } = scrollList({
+      items: [],
+      cursorIdx: -1,
+      scrollTop: 0,
+      viewportRows: 5,
+      renderItem: (item: string) => line(item),
+    });
+    expect(scrollTop).toBe(0);
+    expect(element.children ?? []).toHaveLength(0);
+  });
+});

--- a/packages/agency-lang/lib/tui/scrollList.ts
+++ b/packages/agency-lang/lib/tui/scrollList.ts
@@ -1,0 +1,51 @@
+import type { Element } from "./elements.js";
+import { column } from "./builders.js";
+import { clampScroll, followCursor } from "./scroll.js";
+
+export type ScrollListOpts<T> = {
+  items: ReadonlyArray<T>;
+  // Index of the cursor row, or -1 for "no cursor / nothing to follow".
+  cursorIdx: number;
+  scrollTop: number;
+  viewportRows: number;
+  // Render one item; `isCursor` is true for the currently selected row.
+  renderItem: (item: T, isCursor: boolean) => Element;
+};
+
+export type ScrollListResult = {
+  element: Element;
+  // The clamped (and cursor-followed) scrollTop. Callers should
+  // persist this back into their state so the next render starts
+  // from the same place.
+  scrollTop: number;
+};
+
+/**
+ * Render a list of items into a scrollable, cursor-aware column.
+ *
+ * `scrollList` owns the boilerplate that every list-style TUI screen
+ * has rewritten by hand: clamp `scrollTop` to a valid range, follow
+ * the cursor if it has moved out of the viewport, slice the visible
+ * window, and wrap the rendered items in a `flex-start` column so
+ * they don't stretch.
+ *
+ * It is intentionally a pure builder, not a stateful component:
+ * callers pass the cursor and scroll position in, get the new
+ * scroll position back, and store both in whatever state shape they
+ * want. Cursor styling, item rendering, and key handling all live
+ * with the caller.
+ */
+export function scrollList<T>(opts: ScrollListOpts<T>): ScrollListResult {
+  const clamped = clampScroll(opts.scrollTop, opts.items.length, opts.viewportRows);
+  const scrollTop = opts.cursorIdx >= 0
+    ? followCursor(clamped, opts.cursorIdx, opts.viewportRows)
+    : clamped;
+  const visible = opts.items.slice(scrollTop, scrollTop + opts.viewportRows);
+  const children = visible.map((item, i) =>
+    opts.renderItem(item, scrollTop + i === opts.cursorIdx),
+  );
+  return {
+    element: column({ justifyContent: "flex-start" }, ...children),
+    scrollTop,
+  };
+}

--- a/packages/agency-lang/lib/tui/test/colors.test.ts
+++ b/packages/agency-lang/lib/tui/test/colors.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { COLOR_NAMES, ansiColors, ansiBgColors, cssColors } from "../colors.js";
+
+describe("COLOR_NAMES", () => {
+  it("covers exactly the named ANSI palette", () => {
+    expect([...COLOR_NAMES].sort()).toEqual(Object.keys(ansiColors).sort());
+  });
+
+  it("covers exactly the named ANSI background palette", () => {
+    expect([...COLOR_NAMES].sort()).toEqual(Object.keys(ansiBgColors).sort());
+  });
+
+  it("covers exactly the named CSS palette", () => {
+    expect([...COLOR_NAMES].sort()).toEqual(Object.keys(cssColors).sort());
+  });
+});

--- a/packages/agency-lang/lib/tui/test/recorder.test.ts
+++ b/packages/agency-lang/lib/tui/test/recorder.test.ts
@@ -39,4 +39,17 @@ describe("FrameRecorder", () => {
     expect(recorder.textAt(0).trim()).toBe("first");
     expect(recorder.lastText().trim()).toBe("second");
   });
+
+  it("textAt() throws a clear error when the index is out of range", () => {
+    const recorder = new FrameRecorder();
+    expect(() => recorder.textAt(0)).toThrow(/index out of range/);
+    recorder.write(render(layout(line("only"), 10, 1)));
+    expect(() => recorder.textAt(-1)).toThrow(/index out of range/);
+    expect(() => recorder.textAt(5)).toThrow(/index out of range/);
+  });
+
+  it("lastText() throws a clear error when no frames have been recorded", () => {
+    const recorder = new FrameRecorder();
+    expect(() => recorder.lastText()).toThrow(/no frames recorded/);
+  });
 });

--- a/packages/agency-lang/lib/tui/test/recorder.test.ts
+++ b/packages/agency-lang/lib/tui/test/recorder.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { FrameRecorder } from "../output/recorder.js";
 import { Frame } from "../frame.js";
+import { layout } from "../layout.js";
+import { render } from "../render/renderer.js";
+import { line } from "../builders.js";
 
 describe("FrameRecorder", () => {
   it("records frames with labels", () => {
@@ -27,5 +30,13 @@ describe("FrameRecorder", () => {
     expect(html).toContain("step 1");
     expect(html).toContain("step 2");
     expect(html).toContain("<pre");
+  });
+
+  it("textAt() and lastText() expose recorded frames as plain text", () => {
+    const recorder = new FrameRecorder();
+    recorder.write(render(layout(line("first"), 10, 1)));
+    recorder.write(render(layout(line("second"), 10, 1)));
+    expect(recorder.textAt(0).trim()).toBe("first");
+    expect(recorder.lastText().trim()).toBe("second");
   });
 });

--- a/packages/agency-lang/lib/tui/test/renderer.test.ts
+++ b/packages/agency-lang/lib/tui/test/renderer.test.ts
@@ -97,4 +97,16 @@ describe("render", () => {
     expect(frame.children![0].key).toBe("top");
     expect(frame.children![1].key).toBe("bottom");
   });
+
+  it("auto-clips overlong text with an ellipsis", () => {
+    const frame = renderElement(box({ width: 5, height: 1 }, text("abcdefghij")), 80, 24);
+    const child = frame.children![0];
+    expect(contentText(child)).toBe("abcd…");
+  });
+
+  it("leaves text untouched when it fits", () => {
+    const frame = renderElement(box({ width: 10, height: 1 }, text("abc")), 80, 24);
+    const child = frame.children![0];
+    expect(contentText(child)).toBe("abc       ");
+  });
 });

--- a/packages/agency-lang/lib/tui/test/runLoop.test.ts
+++ b/packages/agency-lang/lib/tui/test/runLoop.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { Screen } from "../screen.js";
+import { ScriptedInput } from "../input/scripted.js";
+import { FrameRecorder } from "../output/recorder.js";
+import { line } from "../builders.js";
+
+describe("Screen.runLoop", () => {
+  it("renders, handles keys, and stops when isDone returns true", async () => {
+    const input = new ScriptedInput();
+    input.feedKey({ key: "j" });
+    input.feedKey({ key: "j" });
+    input.feedKey({ key: "q" });
+    const output = new FrameRecorder();
+    const screen = new Screen({ input, output, width: 20, height: 5 });
+    const finalState = await screen.runLoop({
+      initialState: { n: 0, done: false },
+      render: (s) => line(`n=${s.n}`),
+      handleKey: (s, event) => {
+        if (event.key === "q") return { ...s, done: true };
+        if (event.key === "j") return { ...s, n: s.n + 1 };
+        return s;
+      },
+      isDone: (s) => s.done,
+    });
+    expect(finalState.n).toBe(2);
+    // Four frames: initial render + one after each key.
+    expect(output.frames.length).toBe(4);
+  });
+
+  it("stops without consuming any keys when isDone returns true initially", async () => {
+    const input = new ScriptedInput();
+    const output = new FrameRecorder();
+    const screen = new Screen({ input, output, width: 20, height: 5 });
+    const finalState = await screen.runLoop({
+      initialState: { done: true },
+      render: () => line("hi"),
+      handleKey: (s) => s,
+      isDone: (s) => s.done,
+    });
+    expect(finalState.done).toBe(true);
+    // Just the initial render.
+    expect(output.frames.length).toBe(1);
+  });
+});

--- a/packages/agency-lang/lib/tui/test/scripted.test.ts
+++ b/packages/agency-lang/lib/tui/test/scripted.test.ts
@@ -24,4 +24,11 @@ describe("ScriptedInput", () => {
     const line = await input.nextLine("prompt>");
     expect(line).toBe("hello world");
   });
+
+  it("constructor accepts a list of strings or KeyEvents", async () => {
+    const input = new ScriptedInput(["j", "k", { key: "c", ctrl: true }]);
+    expect(await input.nextKey()).toEqual({ key: "j" });
+    expect(await input.nextKey()).toEqual({ key: "k" });
+    expect(await input.nextKey()).toEqual({ key: "c", ctrl: true });
+  });
 });


### PR DESCRIPTION
Extracts the abstractions I found myself reinventing while building [`agency logs view`](../../lib/logsViewer/run.ts) (PR #154). Every future TUI app — including logs viewer v2 — would have rebuilt these from scratch. Plan: [`docs/superpowers/plans/2026-05-17-tui-abstractions-from-logs-viewer.md`](packages/agency-lang/docs/superpowers/plans/2026-05-17-tui-abstractions-from-logs-viewer.md).

## What landed

| Primitive | File | Use case |
|---|---|---|
| `formatKey` / `keyMatches` | [`lib/tui/input/format.ts`](packages/agency-lang/lib/tui/input/format.ts) | Replace per-app `{key, ctrl, shift}` → string switches |
| `line()` / `lines()` | [`lib/tui/builders.ts`](packages/agency-lang/lib/tui/builders.ts) | Fixed-height text rows that don't stretch inside a `column` |
| `clampScroll()` / `followCursor()` | [`lib/tui/scroll.ts`](packages/agency-lang/lib/tui/scroll.ts) | Pure scroll-bookkeeping helpers |
| `Screen.runLoop()` | [`lib/tui/screen.ts`](packages/agency-lang/lib/tui/screen.ts) | Standard `render → nextKey → handleKey → quit` loop |
| Renderer auto-clip | [`lib/tui/render/renderer.ts`](packages/agency-lang/lib/tui/render/renderer.ts) | Overlong text now gets `…` centrally instead of per-app slicing |
| `ColorName` union | [`lib/tui/colors.ts`](packages/agency-lang/lib/tui/colors.ts) | Typed style fields with autocomplete; hex strings still allowed |
| `ScriptedInput([...])` constructor | [`lib/tui/input/scripted.ts`](packages/agency-lang/lib/tui/input/scripted.ts) | One-liner test setup |
| `FrameRecorder.textAt() / lastText()` | [`lib/tui/output/recorder.ts`](packages/agency-lang/lib/tui/output/recorder.ts) | Shorter assertions in tests |

## Logs viewer adoption

[`lib/logsViewer/run.ts`](packages/agency-lang/lib/logsViewer/run.ts), [`input.ts`](packages/agency-lang/lib/logsViewer/input.ts), and [`render.ts`](packages/agency-lang/lib/logsViewer/render.ts) now use the new primitives. Net effect: ~70 lines deleted from the viewer with identical observable behavior. All viewer tests still pass; tests are also tighter (e.g. `new ScriptedInput(["j", "l", "q"])` instead of a local `feed()` helper).

## Validation

- `pnpm test:run` → 3653 / 3653 passing
- `pnpm run lint:structure` → clean except the pre-existing `lib/lsp/hover.ts` error
- `make` → builds cleanly
- `node tests/integration/statelog/test.mjs` → 8/8 scenarios pass

## Out of scope (deferred)

- Grapheme-aware text clipping (UTF-16 vs display cells)
- `<ScrollableList>` element with selection model
- Multi-key chord parsing (`gg`, `dd`)

## Docs

[`docs/dev/tui.md`](packages/agency-lang/docs/dev/tui.md) is a new developer reference covering each primitive with the logs viewer cited as the canonical example.
