### PR TITLE
Fix agency run under global install, add agency pack for portable scripts

### DIFF
--- a/packages/agency-lang/docs/site/guide/running-agents.md
+++ b/packages/agency-lang/docs/site/guide/running-agents.md
@@ -42,17 +42,19 @@ When you compile from a global install, agency will print a one-line note steeri
 
 ## `agency pack` — portable single-file scripts
 
-`agency pack` produces a self-contained `.js` file that runs anywhere Node is installed, with no need for `agency-lang` (or any other package) to be installed at runtime:
+`agency pack` produces a self-contained `.mjs` file that runs anywhere Node is installed, with no need for `agency-lang` (or any other package) to be installed at runtime:
 
 ```bash
-agency pack hello.agency -o hello.js
-# Packed hello.agency -> hello.js
+agency pack hello.agency -o hello.mjs
+# Packed hello.agency -> hello.mjs
 
-./hello.js
-# (or `node hello.js`)
+./hello.mjs
+# (or `node hello.mjs`)
 ```
 
 The output is an ESM module bundled with esbuild. Only Node built-ins are kept external; the agency runtime, smoltalk, zod, and any user `.agency` imports are inlined. Files are produced executable (mode `0o755`) with a `#!/usr/bin/env node` shebang.
+
+The default extension is `.mjs` so the output is unambiguously ESM regardless of any surrounding `package.json`'s `"type"`. You can pass `-o foo.js` instead, but inside a project where `package.json` has `"type": "commonjs"` (or no `"type"` at all in newer Node) you may see `MODULE_TYPELESS_PACKAGE_JSON` warnings.
 
 This is useful when you want to:
 - hand an agent to someone who doesn't have Node packages installed
@@ -63,7 +65,7 @@ This is useful when you want to:
 
 | flag | default | meaning |
 |---|---|---|
-| `-o, --output <file>` | `agent.js` | output file path |
+| `-o, --output <file>` | `agent.mjs` | output file path |
 | `--target <target>` | `node` | output target; currently only `node` is supported. `sea` (Node single-executable application) is a planned future target |
 
 ### Limitations

--- a/packages/agency-lang/docs/site/guide/running-agents.md
+++ b/packages/agency-lang/docs/site/guide/running-agents.md
@@ -1,0 +1,72 @@
+# Running Agents
+
+This page covers how to execute a `.agency` program once you have written one.
+
+## `agency run` — the default workflow
+
+The simplest way to run an agent is:
+
+```bash
+agency run hello.agency
+```
+
+This compiles the file to JavaScript and immediately executes it under the same Node binary that's running the CLI. You can also pass `--resume <statefile>` to resume a previously saved execution, or `--trace [file]` to write an execution trace.
+
+## `agency compile` — emit JavaScript
+
+If you want to inspect or ship the generated JavaScript:
+
+```bash
+agency compile hello.agency
+# writes hello.js next to hello.agency
+```
+
+The generated `.js` imports from `agency-lang` (the runtime). You can run it directly with `node hello.js` **as long as `agency-lang` is reachable from Node's module resolver** — i.e. there's an `agency-lang` package in a `node_modules` directory at or above the file's location.
+
+### The global-install gotcha
+
+If you installed agency-lang globally (`npm install -g agency-lang`), running the generated file directly will fail:
+
+```
+$ node hello.js
+Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'agency-lang' imported from /path/to/hello.js
+```
+
+Node does **not** look in the global `node_modules` for bare imports. This is a Node limitation, not an agency issue. You have three options:
+
+1. **Use `agency run`** — it knows where the CLI lives and arranges for the compiled file's imports to resolve.
+2. **Install agency-lang locally** in the directory next to your `.agency` file: `npm install agency-lang`.
+3. **Use `agency pack`** (below) to produce a single-file script that needs no install at all.
+
+When you compile from a global install, agency will print a one-line note steering you to options 1 and 3.
+
+## `agency pack` — portable single-file scripts
+
+`agency pack` produces a self-contained `.js` file that runs anywhere Node is installed, with no need for `agency-lang` (or any other package) to be installed at runtime:
+
+```bash
+agency pack hello.agency -o hello.js
+# Packed hello.agency -> hello.js
+
+./hello.js
+# (or `node hello.js`)
+```
+
+The output is an ESM module bundled with esbuild. Only Node built-ins are kept external; the agency runtime, smoltalk, zod, and any user `.agency` imports are inlined. Files are produced executable (mode `0o755`) with a `#!/usr/bin/env node` shebang.
+
+This is useful when you want to:
+- hand an agent to someone who doesn't have Node packages installed
+- deploy an agent to a minimal container
+- ship an agent inside another tool
+
+### Options
+
+| flag | default | meaning |
+|---|---|---|
+| `-o, --output <file>` | `agent.js` | output file path |
+| `--target <target>` | `node` | output target; currently only `node` is supported. `sea` (Node single-executable application) is a planned future target |
+
+### Limitations
+
+- Programs that read `.agency` stdlib files at runtime (e.g. anything dynamic) will hit `Could not find package root`. Most user programs do not — the stdlib is consumed at compile time. If you need it inlined for runtime use, file an issue.
+- API keys (`OPENAI_API_KEY`, etc.) still need to be present in the environment of the machine running the packed script.

--- a/packages/agency-lang/docs/site/guide/running-agents.md
+++ b/packages/agency-lang/docs/site/guide/running-agents.md
@@ -68,6 +68,21 @@ This is useful when you want to:
 | `-o, --output <file>` | `agent.mjs` | output file path |
 | `--target <target>` | `node` | output target; currently only `node` is supported. `sea` (Node single-executable application) is a planned future target |
 
+### Config
+
+You can override the defaults from `agency.json`:
+
+```jsonc
+{
+  "pack": {
+    "format": "esm",        // or "cjs"
+    "target": "node20",     // esbuild target string, e.g. "node22"
+    "external": []          // extra bare specifiers to leave external
+  },
+  "verbose": true            // emit bundling progress and esbuild diagnostics during `agency pack`
+}
+```
+
 ### Limitations
 
 - Programs that read `.agency` stdlib files at runtime (e.g. anything dynamic) will hit `Could not find package root`. Most user programs do not — the stdlib is consumed at compile time. If you need it inlined for runtime use, file an issue.

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -23,7 +23,44 @@ import {
   type ImportStrategy,
 } from "../importStrategy.js";
 import { parseAgency, replaceBlankLines } from "../parser.js";
+import {
+  classifyInstall,
+  installDirFromUrl,
+  type InstallKind,
+  nodeModulesParent,
+} from "./installLocation.js";
 import { findRecursively, getImports } from "./util.js";
+
+// Build an env for the compiled-output child process that lets a globally
+// installed agency CLI's compiled code resolve `agency-lang`, `zod`, etc.
+// without an `npm install` in the user's working directory.
+export function compiledOutputEnv(
+  base: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const cliRoot = nodeModulesParent(installDirFromUrl(import.meta.url));
+  const sep = process.platform === "win32" ? ";" : ":";
+  const existing = base.NODE_PATH;
+  return {
+    ...base,
+    NODE_PATH: existing ? `${existing}${sep}${cliRoot}` : cliRoot,
+  };
+}
+
+export function compileWarning(
+  kind: InstallKind,
+  outputFile: string,
+): string | null {
+  if (kind !== "global") return null;
+  return [
+    "",
+    `Note: agency-lang is installed globally. Running \`node ${outputFile}\``,
+    "directly will fail with ERR_MODULE_NOT_FOUND because Node does not",
+    "resolve global packages for bare imports.",
+    "  - Use  agency run <file>    to execute an agency file",
+    "  - Use  agency pack <file>   to produce a portable single-file script",
+    "",
+  ].join("\n");
+}
 
 // Load configuration from agency.json
 export function loadConfig(
@@ -293,11 +330,15 @@ export function run(
   console.log(`Running ${output}...`);
   console.log("---");
 
-  const env = resumeFile
-    ? { ...process.env, AGENCY_RESUME_FILE: resumeFile }
-    : process.env;
+  const env = compiledOutputEnv(
+    resumeFile
+      ? { ...process.env, AGENCY_RESUME_FILE: resumeFile }
+      : process.env,
+  );
 
-  const nodeProcess = spawn("node", [output], {
+  // Use process.execPath so the child runs under the same Node as the CLI,
+  // avoiding version mismatches when the user has multiple Nodes installed.
+  const nodeProcess = spawn(process.execPath, [output], {
     stdio: "inherit",
     shell: false,
     env,

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -23,27 +23,34 @@ import {
   type ImportStrategy,
 } from "../importStrategy.js";
 import { parseAgency, replaceBlankLines } from "../parser.js";
+import { fileURLToPath, pathToFileURL } from "url";
 import {
   classifyInstall,
   installDirFromUrl,
   type InstallKind,
-  nodeModulesParent,
 } from "./installLocation.js";
 import { findRecursively, getImports } from "./util.js";
 
-// Build an env for the compiled-output child process that lets a globally
-// installed agency CLI's compiled code resolve `agency-lang`, `zod`, etc.
-// without an `npm install` in the user's working directory.
-export function compiledOutputEnv(
-  base: NodeJS.ProcessEnv,
-): NodeJS.ProcessEnv {
-  const cliRoot = nodeModulesParent(installDirFromUrl(import.meta.url));
-  const sep = process.platform === "win32" ? ";" : ":";
-  const existing = base.NODE_PATH;
-  return {
-    ...base,
-    NODE_PATH: existing ? `${existing}${sep}${cliRoot}` : cliRoot,
-  };
+// Returns the file:// URL of the ESM loader-register shim shipped with the
+// agency-lang package. Passing this to `node --import=<url>` causes Node to
+// fall back to agency-lang's own node_modules when resolving bare specifiers,
+// which lets `agency run` work even when agency-lang is installed globally.
+//
+// The shim lives at dist/lib/cli/runShim/register.mjs, right next to this
+// file's compiled output (dist/lib/cli/commands.js), so we resolve it
+// relative to this module's URL.
+export function compiledOutputRegisterUrl(): string {
+  const thisDir = path.dirname(fileURLToPath(import.meta.url));
+  return pathToFileURL(
+    path.join(thisDir, "runShim", "register.mjs"),
+  ).href;
+}
+
+// Build the argv prefix to use when spawning `node` on a compiled .agency
+// output file. Always includes the resolver register so transitive bare
+// imports (zod, smoltalk, etc.) resolve regardless of cwd or install kind.
+export function compiledOutputNodeArgs(): string[] {
+  return [`--import=${compiledOutputRegisterUrl()}`];
 }
 
 export function compileWarning(
@@ -330,19 +337,22 @@ export function run(
   console.log(`Running ${output}...`);
   console.log("---");
 
-  const env = compiledOutputEnv(
-    resumeFile
-      ? { ...process.env, AGENCY_RESUME_FILE: resumeFile }
-      : process.env,
-  );
+  const env = resumeFile
+    ? { ...process.env, AGENCY_RESUME_FILE: resumeFile }
+    : process.env;
 
   // Use process.execPath so the child runs under the same Node as the CLI,
-  // avoiding version mismatches when the user has multiple Nodes installed.
-  const nodeProcess = spawn(process.execPath, [output], {
-    stdio: "inherit",
-    shell: false,
-    env,
-  });
+  // and pass our resolver shim so the compiled output's `import "agency-lang"`
+  // succeeds even when the CLI is installed globally.
+  const nodeProcess = spawn(
+    process.execPath,
+    [...compiledOutputNodeArgs(), output],
+    {
+      stdio: "inherit",
+      shell: false,
+      env,
+    },
+  );
 
   nodeProcess.on("error", (error) => {
     console.error(`Failed to run ${output}:`, error);

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -9,6 +9,7 @@ import { formatErrors, typeCheck } from "@/typeChecker/index.js";
 import { spawn } from "child_process";
 import { transformSync } from "esbuild";
 import * as fs from "fs";
+import { createRequire } from "module";
 import * as path from "path";
 
 import {
@@ -53,15 +54,39 @@ export function compiledOutputNodeArgs(): string[] {
   return [`--import=${compiledOutputRegisterUrl()}`];
 }
 
+// Returns true if `agency-lang` resolves from a file inside the given
+// directory using Node's standard CommonJS resolver. If true, the user
+// can run `node compiled.js` from that location and it will succeed —
+// no need to print the global-install warning.
+export function agencyLangResolvesFrom(dir: string): boolean {
+  try {
+    // createRequire needs a file path inside the directory; the file
+    // doesn't have to exist.
+    const req = createRequire(path.join(path.resolve(dir), "x.js"));
+    req.resolve("agency-lang");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function compileWarning(
   kind: InstallKind,
-  outputFile: string,
+  outputContext: string,
+  // Injected so tests can simulate a clean directory regardless of the
+  // host's module-resolution state (vitest, for instance, patches Node
+  // module resolution to find workspace packages from any cwd).
+  resolvesFrom: (dir: string) => boolean = agencyLangResolvesFrom,
 ): string | null {
   if (kind !== "global") return null;
+  const dir = fs.existsSync(outputContext) && fs.statSync(outputContext).isDirectory()
+    ? outputContext
+    : path.dirname(path.resolve(outputContext));
+  if (resolvesFrom(dir)) return null;
   return [
     "",
-    `Note: agency-lang is installed globally. Running \`node ${outputFile}\``,
-    "directly will fail with ERR_MODULE_NOT_FOUND because Node does not",
+    "Note: agency-lang is installed globally. Running `node <output>.js`",
+    "directly may fail with ERR_MODULE_NOT_FOUND because Node does not",
     "resolve global packages for bare imports.",
     "  - Use  agency run <file>    to execute an agency file",
     "  - Use  agency pack <file>   to produce a portable single-file script",

--- a/packages/agency-lang/lib/cli/installLocation.test.ts
+++ b/packages/agency-lang/lib/cli/installLocation.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  classifyInstall,
-  installDirFromUrl,
-  nodeModulesParent,
-} from "./installLocation.js";
+import { classifyInstall, installDirFromUrl } from "./installLocation.js";
 
 describe("classifyInstall", () => {
   it("flags npm global paths on unix", () => {
@@ -50,18 +46,5 @@ describe("installDirFromUrl", () => {
   it("walks up two dirs from dist/scripts/agency.js", () => {
     const url = "file:///opt/x/agency-lang/dist/scripts/agency.js";
     expect(installDirFromUrl(url)).toBe("/opt/x/agency-lang");
-  });
-});
-
-describe("nodeModulesParent", () => {
-  it("returns the parent of agency-lang when inside node_modules", () => {
-    expect(nodeModulesParent("/usr/lib/node_modules/agency-lang")).toBe(
-      "/usr/lib/node_modules",
-    );
-  });
-  it("falls back to the install dir's own node_modules for workspace dev", () => {
-    expect(nodeModulesParent("/repo/packages/agency-lang")).toBe(
-      "/repo/packages/agency-lang/node_modules",
-    );
   });
 });

--- a/packages/agency-lang/lib/cli/installLocation.test.ts
+++ b/packages/agency-lang/lib/cli/installLocation.test.ts
@@ -40,6 +40,14 @@ describe("classifyInstall", () => {
       ),
     ).toBe("workspace");
   });
+  it("flags npx / npm exec ephemeral installs as global", () => {
+    // npx puts a fresh install under <npm-cache>/_npx/<hash>/node_modules
+    expect(
+      classifyInstall(
+        "/Users/x/.npm/_npx/abc123/node_modules/agency-lang/dist/scripts",
+      ),
+    ).toBe("global");
+  });
 });
 
 describe("installDirFromUrl", () => {

--- a/packages/agency-lang/lib/cli/installLocation.test.ts
+++ b/packages/agency-lang/lib/cli/installLocation.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyInstall,
+  installDirFromUrl,
+  nodeModulesParent,
+} from "./installLocation.js";
+
+describe("classifyInstall", () => {
+  it("flags npm global paths on unix", () => {
+    expect(
+      classifyInstall("/usr/local/lib/node_modules/agency-lang/dist/scripts"),
+    ).toBe("global");
+  });
+  it("flags npm prefix global paths on macOS homebrew", () => {
+    expect(
+      classifyInstall(
+        "/opt/homebrew/lib/node_modules/agency-lang/dist/scripts",
+      ),
+    ).toBe("global");
+  });
+  it("flags pnpm global paths", () => {
+    expect(
+      classifyInstall(
+        "/home/x/.local/share/pnpm/global/5/node_modules/agency-lang/dist/scripts",
+      ),
+    ).toBe("global");
+  });
+  it("flags Windows npm global", () => {
+    expect(
+      classifyInstall(
+        "C:\\Users\\x\\AppData\\Roaming\\npm\\node_modules\\agency-lang\\dist\\scripts",
+      ),
+    ).toBe("global");
+  });
+  it("treats project-local installs as local", () => {
+    expect(
+      classifyInstall("/Users/x/proj/node_modules/agency-lang/dist/scripts"),
+    ).toBe("local");
+  });
+  it("treats workspace dev path as workspace", () => {
+    expect(
+      classifyInstall(
+        "/Users/x/agency-lang/packages/agency-lang/dist/scripts",
+      ),
+    ).toBe("workspace");
+  });
+});
+
+describe("installDirFromUrl", () => {
+  it("walks up two dirs from dist/scripts/agency.js", () => {
+    const url = "file:///opt/x/agency-lang/dist/scripts/agency.js";
+    expect(installDirFromUrl(url)).toBe("/opt/x/agency-lang");
+  });
+});
+
+describe("nodeModulesParent", () => {
+  it("returns the parent of agency-lang when inside node_modules", () => {
+    expect(nodeModulesParent("/usr/lib/node_modules/agency-lang")).toBe(
+      "/usr/lib/node_modules",
+    );
+  });
+  it("falls back to the install dir's own node_modules for workspace dev", () => {
+    expect(nodeModulesParent("/repo/packages/agency-lang")).toBe(
+      "/repo/packages/agency-lang/node_modules",
+    );
+  });
+});

--- a/packages/agency-lang/lib/cli/installLocation.ts
+++ b/packages/agency-lang/lib/cli/installLocation.ts
@@ -37,13 +37,3 @@ export function installDirFromUrl(metaUrl: string): string {
   const file = fileURLToPath(metaUrl);
   return path.resolve(path.dirname(file), "..", "..");
 }
-
-export function nodeModulesParent(installDir: string): string {
-  const parts = installDir.split(path.sep);
-  const idx = parts.lastIndexOf("node_modules");
-  if (idx !== -1) {
-    return parts.slice(0, idx + 1).join(path.sep);
-  }
-  // workspace dev: the package's own node_modules holds its transitive deps
-  return path.join(installDir, "node_modules");
-}

--- a/packages/agency-lang/lib/cli/installLocation.ts
+++ b/packages/agency-lang/lib/cli/installLocation.ts
@@ -14,6 +14,11 @@ const GLOBAL_MARKERS = [
   "/.volta/tools/", // volta-managed tool installs
   "/.fnm/node-versions/", // fnm-managed Node with global packages
   "/.nvm/versions/node/", // nvm-managed Node with global packages
+  "/_npx/", // npx / npm exec ephemeral installs; the spawned `node
+  // <user-file>` runs in the user's cwd which has no
+  // path to this _npx tree, so this is effectively a
+  // global-install scenario for the purposes of the
+  // resolver-shim warning.
 ];
 
 function toPosix(p: string): string {

--- a/packages/agency-lang/lib/cli/installLocation.ts
+++ b/packages/agency-lang/lib/cli/installLocation.ts
@@ -1,0 +1,49 @@
+import * as path from "path";
+import { fileURLToPath } from "url";
+
+export type InstallKind = "global" | "local" | "workspace";
+
+// Substrings that strongly indicate a global install. Order does not matter.
+// Use forward-slash forms; we normalize input before matching so Windows
+// backslashes are also handled.
+const GLOBAL_MARKERS = [
+  "/lib/node_modules/", // npm unix (default prefix)
+  "/pnpm/global/", // pnpm global store
+  "/npm/node_modules/", // npm windows (AppData/Roaming/npm/node_modules)
+  "/.npm-global/", // custom npm prefix in $HOME
+  "/.volta/tools/", // volta-managed tool installs
+  "/.fnm/node-versions/", // fnm-managed Node with global packages
+  "/.nvm/versions/node/", // nvm-managed Node with global packages
+];
+
+function toPosix(p: string): string {
+  // Normalize both backslashes and forward slashes regardless of host OS,
+  // so a Windows-style path string still classifies correctly on a unix host
+  // (relevant for tests and for log/diagnostic output).
+  return p.replace(/\\/g, "/");
+}
+
+export function classifyInstall(installDir: string): InstallKind {
+  const norm = toPosix(installDir);
+  if (GLOBAL_MARKERS.some((m) => norm.includes(m))) return "global";
+  // A project-local install always sits under .../node_modules/agency-lang
+  if (norm.includes("/node_modules/agency-lang")) return "local";
+  return "workspace";
+}
+
+export function installDirFromUrl(metaUrl: string): string {
+  // The CLI entry lives at dist/scripts/agency.js. Walk up two directories
+  // to get the package's install root (the directory containing package.json).
+  const file = fileURLToPath(metaUrl);
+  return path.resolve(path.dirname(file), "..", "..");
+}
+
+export function nodeModulesParent(installDir: string): string {
+  const parts = installDir.split(path.sep);
+  const idx = parts.lastIndexOf("node_modules");
+  if (idx !== -1) {
+    return parts.slice(0, idx + 1).join(path.sep);
+  }
+  // workspace dev: the package's own node_modules holds its transitive deps
+  return path.join(installDir, "node_modules");
+}

--- a/packages/agency-lang/lib/cli/pack.test.ts
+++ b/packages/agency-lang/lib/cli/pack.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { execFileSync } from "child_process";
+import { pack } from "./pack.js";
+import { loadConfig } from "./commands.js";
+
+describe("agency pack", () => {
+  let workDir: string;
+  beforeAll(() => {
+    // Use realpath to avoid macOS /tmp -> /private/tmp symlink mismatch,
+    // which would defeat the `argv[1] === fileURLToPath(import.meta.url)`
+    // entry-point check in the compiled output.
+    workDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "agency-pack-")),
+    );
+  });
+  afterAll(() => fs.rmSync(workDir, { recursive: true, force: true }));
+
+  it("produces a self-contained executable .js", async () => {
+    const src = path.join(workDir, "hello.agency");
+    fs.writeFileSync(src, 'node main() { print("hello from pack") }\n');
+    const out = path.join(workDir, "hello.js");
+    await pack({
+      config: loadConfig(),
+      inputFile: src,
+      outputFile: out,
+      target: "node",
+    });
+
+    expect(fs.existsSync(out)).toBe(true);
+    const text = fs.readFileSync(out, "utf-8");
+    expect(text.startsWith("#!/usr/bin/env node")).toBe(true);
+    // No bare imports of agency-lang should remain in the bundle.
+    expect(text).not.toMatch(/from\s+["']agency-lang/);
+
+    // It should run under bare `node` from a directory with no
+    // node_modules, producing the agent's output.
+    const runDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), "agency-pack-run-")),
+    );
+    try {
+      const copied = path.join(runDir, "hello.js");
+      fs.copyFileSync(out, copied);
+      const stdout = execFileSync(process.execPath, [copied], {
+        encoding: "utf-8",
+      });
+      expect(stdout).toContain("hello from pack");
+    } finally {
+      fs.rmSync(runDir, { recursive: true, force: true });
+    }
+  }, 60000);
+});

--- a/packages/agency-lang/lib/cli/pack.test.ts
+++ b/packages/agency-lang/lib/cli/pack.test.ts
@@ -51,4 +51,104 @@ describe("agency pack", () => {
       fs.rmSync(runDir, { recursive: true, force: true });
     }
   }, 60000);
+
+  it("rejects input whose extension is not .agency", async () => {
+    const bad = path.join(workDir, "bogus.txt");
+    fs.writeFileSync(bad, "irrelevant");
+    await expect(
+      pack({
+        config: loadConfig(),
+        inputFile: bad,
+        outputFile: path.join(workDir, "out.js"),
+        target: "node",
+      }),
+    ).rejects.toThrow(/must end in \.agency/);
+    // Must NOT have touched the input.
+    expect(fs.readFileSync(bad, "utf-8")).toBe("irrelevant");
+  });
+
+  it("rejects missing input file with a clear error", async () => {
+    await expect(
+      pack({
+        config: loadConfig(),
+        inputFile: path.join(workDir, "does-not-exist.agency"),
+        outputFile: path.join(workDir, "out.js"),
+        target: "node",
+      }),
+    ).rejects.toThrow(/input file not found/);
+  });
+
+  it("re-packing over an existing non-executable file leaves it executable", async () => {
+    const src = path.join(workDir, "exec.agency");
+    fs.writeFileSync(src, 'node main() { print("x") }\n');
+    const out = path.join(workDir, "exec.js");
+    fs.writeFileSync(out, "old contents", { mode: 0o644 });
+    expect(fs.statSync(out).mode & 0o777).toBe(0o644);
+    await pack({
+      config: loadConfig(),
+      inputFile: src,
+      outputFile: out,
+      target: "node",
+    });
+    expect(fs.statSync(out).mode & 0o777).toBe(0o755);
+  }, 60000);
+
+  it("cleans up the .__pack__.js entry temp file after success", async () => {
+    const src = path.join(workDir, "cleanup.agency");
+    fs.writeFileSync(src, 'node main() { print("c") }\n');
+    const out = path.join(workDir, "cleanup.js");
+    await pack({
+      config: loadConfig(),
+      inputFile: src,
+      outputFile: out,
+      target: "node",
+    });
+    expect(fs.existsSync(path.join(workDir, "cleanup.__pack__.js"))).toBe(false);
+  }, 60000);
+
+  it("cleans up transitive .js sidecars from recursive .agency imports", async () => {
+    const subDir = path.join(workDir, "trans");
+    fs.mkdirSync(subDir, { recursive: true });
+    const helper = path.join(subDir, "helper.agency");
+    const main = path.join(subDir, "trans.agency");
+    fs.writeFileSync(
+      helper,
+      'export def greet(): string { return "hi from helper" }\n',
+    );
+    fs.writeFileSync(
+      main,
+      'import { greet } from "./helper.agency"\nnode main() { print(greet()) }\n',
+    );
+    const out = path.join(subDir, "bundle.js");
+    await pack({
+      config: loadConfig(),
+      inputFile: main,
+      outputFile: out,
+      target: "node",
+    });
+    // The bundle should exist and contain the helper's behavior.
+    expect(fs.existsSync(out)).toBe(true);
+    // The transitive helper.js compile() created should be cleaned up.
+    expect(fs.existsSync(path.join(subDir, "helper.js"))).toBe(false);
+    // The transitive entry temp should also be cleaned up.
+    expect(fs.existsSync(path.join(subDir, "trans.__pack__.js"))).toBe(false);
+  }, 60000);
+
+  it("does NOT delete a sibling .js that existed before pack ran", async () => {
+    const src = path.join(workDir, "preserve.agency");
+    fs.writeFileSync(src, 'node main() { print("p") }\n');
+    const userJs = path.join(workDir, "preserve.js");
+    // User has their own preserve.js (NOT the pack output, which is
+    // a different path).
+    fs.writeFileSync(userJs, "// user wrote me");
+    const out = path.join(workDir, "preserve.bundle.js");
+    await pack({
+      config: loadConfig(),
+      inputFile: src,
+      outputFile: out,
+      target: "node",
+    });
+    expect(fs.existsSync(userJs)).toBe(true);
+    expect(fs.readFileSync(userJs, "utf-8")).toBe("// user wrote me");
+  }, 60000);
 });

--- a/packages/agency-lang/lib/cli/pack.ts
+++ b/packages/agency-lang/lib/cli/pack.ts
@@ -1,0 +1,145 @@
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { build } from "esbuild";
+import { AgencyConfig } from "@/config.js";
+import { compile } from "./commands.js";
+
+// Locate this package's install root by walking up from this module's
+// location until we find a package.json whose name is "agency-lang".
+// Works for both the built `dist/lib/cli/pack.js` and the dev-tree
+// `lib/cli/pack.ts` paths.
+function agencyLangInstallRoot(): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  while (true) {
+    const pkgJson = path.join(dir, "package.json");
+    if (fs.existsSync(pkgJson)) {
+      try {
+        const parsed = JSON.parse(fs.readFileSync(pkgJson, "utf-8"));
+        if (parsed.name === "agency-lang") return dir;
+      } catch {
+        /* keep walking */
+      }
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) {
+      throw new Error("Could not locate agency-lang package root");
+    }
+    dir = parent;
+  }
+}
+
+export type PackTarget = "node";
+
+export type PackOptions = {
+  config: AgencyConfig;
+  inputFile: string;
+  outputFile: string;
+  target: PackTarget;
+};
+
+const SHEBANG = "#!/usr/bin/env node\n";
+
+// Only Node built-ins are kept external; everything else (agency-lang,
+// smoltalk, zod, user .agency imports, etc.) is bundled into the output
+// so the result runs anywhere Node is available without an install.
+const NODE_BUILTINS = [
+  "assert",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "cluster",
+  "console",
+  "constants",
+  "crypto",
+  "dgram",
+  "dns",
+  "events",
+  "fs",
+  "http",
+  "http2",
+  "https",
+  "inspector",
+  "module",
+  "net",
+  "os",
+  "path",
+  "perf_hooks",
+  "process",
+  "punycode",
+  "querystring",
+  "readline",
+  "repl",
+  "stream",
+  "string_decoder",
+  "timers",
+  "tls",
+  "trace_events",
+  "tty",
+  "url",
+  "util",
+  "v8",
+  "vm",
+  "worker_threads",
+  "zlib",
+  "node:*",
+];
+
+export async function pack(opts: PackOptions): Promise<void> {
+  // 1. Compile the .agency file to .js using the existing pipeline.
+  //    We write to a sibling temp file so relative paths inside the user's
+  //    source dir continue to resolve the same way they would for `compile`.
+  const tmpJs = opts.inputFile.replace(/\.agency$/, ".__pack__.js");
+  const compiled = compile(opts.config, opts.inputFile, tmpJs);
+  if (!compiled) {
+    throw new Error(`compile failed for ${opts.inputFile}`);
+  }
+
+  try {
+    // 2. Bundle with esbuild — inline agency-lang, smoltalk, zod, and any
+    //    transitive .js imports into one ESM file. The user's working
+    //    directory may have no node_modules, so explicitly tell esbuild to
+    //    resolve bare specifiers from agency-lang's install location.
+    const installRoot = agencyLangInstallRoot();
+    const result = await build({
+      entryPoints: [compiled],
+      bundle: true,
+      platform: "node",
+      format: "esm",
+      target: "node20",
+      write: false,
+      outfile: opts.outputFile,
+      external: NODE_BUILTINS,
+      nodePaths: [
+        path.dirname(installRoot), // the directory containing agency-lang/
+        path.join(installRoot, "node_modules"), // its own deps
+      ],
+      // Some transitive CJS deps call `require("child_process")` etc.
+      // esbuild's bundler can't statically rewrite those for ESM output,
+      // so it emits a runtime shim that throws "Dynamic require ...".
+      // Replace that with a real createRequire so they work.
+      banner: {
+        js: [
+          "// Built by `agency pack`",
+          'import { createRequire as __pack_createRequire } from "node:module";',
+          "const require = __pack_createRequire(import.meta.url);",
+        ].join("\n"),
+      },
+      logLevel: "silent",
+    });
+
+    if (result.outputFiles.length !== 1) {
+      throw new Error(
+        `expected exactly one output file from esbuild, got ${result.outputFiles.length}`,
+      );
+    }
+
+    const outDir = path.dirname(path.resolve(opts.outputFile));
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(opts.outputFile, SHEBANG + result.outputFiles[0].text, {
+      mode: 0o755,
+    });
+  } finally {
+    if (fs.existsSync(tmpJs)) fs.unlinkSync(tmpJs);
+  }
+}

--- a/packages/agency-lang/lib/cli/pack.ts
+++ b/packages/agency-lang/lib/cli/pack.ts
@@ -1,8 +1,10 @@
 import * as fs from "fs";
 import * as path from "path";
+import { createRequire } from "module";
 import { fileURLToPath } from "url";
-import { build } from "esbuild";
+import { build, type Plugin } from "esbuild";
 import { AgencyConfig } from "@/config.js";
+import { SymbolTable } from "@/symbolTable.js";
 import { compile } from "./commands.js";
 
 // Locate this package's install root by walking up from this module's
@@ -27,6 +29,40 @@ function agencyLangInstallRoot(): string {
     }
     dir = parent;
   }
+}
+
+// esbuild plugin that resolves `agency-lang` and `agency-lang/<sub>`
+// imports against the agency-lang package's own `package.json`. This is
+// the only mechanism we use to teach esbuild where agency-lang lives —
+// we intentionally do NOT use `nodePaths`, because that would also let
+// esbuild silently bundle any globally-installed sibling package the
+// user happens to (mis-)import, making the output non-reproducible.
+//
+// Transitive dependencies of agency-lang (zod, smoltalk, etc.) are
+// resolved by esbuild's normal walk from the resolved agency-lang
+// files' on-disk locations.
+function agencyLangResolverPlugin(installRoot: string): Plugin {
+  const req = createRequire(path.join(installRoot, "package.json"));
+  return {
+    name: "agency-lang-resolver",
+    setup(build) {
+      build.onResolve({ filter: /^agency-lang(\/.*)?$/ }, (args) => {
+        try {
+          return { path: req.resolve(args.path) };
+        } catch (err) {
+          return {
+            errors: [
+              {
+                text: `agency pack: could not resolve "${args.path}" from agency-lang at ${installRoot}: ${
+                  err instanceof Error ? err.message : String(err)
+                }`,
+              },
+            ],
+          };
+        }
+      });
+    },
+  };
 }
 
 export type PackTarget = "node";
@@ -85,21 +121,60 @@ const NODE_BUILTINS = [
   "node:*",
 ];
 
+// Walk the symbol table from the entry and collect every .agency file
+// reachable. These are the locations where `compile()` will produce
+// transitive .js sidecars next to the user's source.
+function reachableAgencyFiles(entry: string, config: AgencyConfig): string[] {
+  try {
+    const st = SymbolTable.build(entry, config);
+    return st.filePaths().filter((p) => p.endsWith(".agency"));
+  } catch {
+    // If symbol-table building fails, the subsequent compile will fail
+    // with a more useful message; just skip the cleanup snapshot.
+    return [];
+  }
+}
+
 export async function pack(opts: PackOptions): Promise<void> {
-  // 1. Compile the .agency file to .js using the existing pipeline.
-  //    We write to a sibling temp file so relative paths inside the user's
-  //    source dir continue to resolve the same way they would for `compile`.
-  const tmpJs = opts.inputFile.replace(/\.agency$/, ".__pack__.js");
-  const compiled = compile(opts.config, opts.inputFile, tmpJs);
-  if (!compiled) {
-    throw new Error(`compile failed for ${opts.inputFile}`);
+  // 1. Reject inputs whose extension isn't `.agency`. Otherwise the
+  //    tmp-file derivation below could end up writing over the input
+  //    and then deleting it in `finally`.
+  if (!opts.inputFile.endsWith(".agency")) {
+    throw new Error(
+      `agency pack: input file must end in .agency (got ${opts.inputFile})`,
+    );
+  }
+  if (!fs.existsSync(opts.inputFile)) {
+    throw new Error(`agency pack: input file not found: ${opts.inputFile}`);
   }
 
+  // 2. Snapshot which sibling .js files exist BEFORE compile runs. We
+  //    use this to clean up only the files compile creates — a
+  //    user-authored .js that already existed must never be deleted.
+  const reachable = reachableAgencyFiles(opts.inputFile, opts.config);
+  const siblingJsPaths = reachable.map((p) => p.replace(/\.agency$/, ".js"));
+  const preExistingJs = new Set(
+    siblingJsPaths.filter((p) => fs.existsSync(p)),
+  );
+
+  // 3. Compile the entry next to its source under a `.__pack__.js`
+  //    suffix so we never collide with a user-authored `<name>.js`.
+  //    Recursive .agency imports get compiled next to their sources
+  //    (the normal `compile` behavior) — those are tracked above and
+  //    cleaned up in `finally` below so the bundled artifact is the
+  //    only file the user sees afterwards.
+  const entryOutput = opts.inputFile.replace(/\.agency$/, ".__pack__.js");
   try {
-    // 2. Bundle with esbuild — inline agency-lang, smoltalk, zod, and any
-    //    transitive .js imports into one ESM file. The user's working
-    //    directory may have no node_modules, so explicitly tell esbuild to
-    //    resolve bare specifiers from agency-lang's install location.
+    const compiled = compile(opts.config, opts.inputFile, entryOutput);
+    if (!compiled) {
+      throw new Error(`agency pack: compile failed for ${opts.inputFile}`);
+    }
+
+    // 4. Bundle with esbuild. Only Node built-ins stay external; the
+    //    agency-lang package and its transitive deps inline. The
+    //    resolver plugin handles `agency-lang*` specifiers using
+    //    agency-lang's own require resolution — no nodePaths, so we
+    //    cannot accidentally pull in globally-installed user packages.
     const installRoot = agencyLangInstallRoot();
     const result = await build({
       entryPoints: [compiled],
@@ -110,14 +185,11 @@ export async function pack(opts: PackOptions): Promise<void> {
       write: false,
       outfile: opts.outputFile,
       external: NODE_BUILTINS,
-      nodePaths: [
-        path.dirname(installRoot), // the directory containing agency-lang/
-        path.join(installRoot, "node_modules"), // its own deps
-      ],
+      plugins: [agencyLangResolverPlugin(installRoot)],
       // Some transitive CJS deps call `require("child_process")` etc.
-      // esbuild's bundler can't statically rewrite those for ESM output,
-      // so it emits a runtime shim that throws "Dynamic require ...".
-      // Replace that with a real createRequire so they work.
+      // esbuild can't statically rewrite those for ESM output, so it
+      // emits a runtime shim that throws "Dynamic require ...".
+      // Install a real createRequire so they work.
       banner: {
         js: [
           "// Built by `agency pack`",
@@ -130,16 +202,48 @@ export async function pack(opts: PackOptions): Promise<void> {
 
     if (result.outputFiles.length !== 1) {
       throw new Error(
-        `expected exactly one output file from esbuild, got ${result.outputFiles.length}`,
+        `agency pack: expected exactly one output file from esbuild, got ${result.outputFiles.length}`,
       );
     }
 
+    // 5. Write the bundle. mode on writeFileSync only takes effect when
+    //    the file is created — if the user re-packs over an existing
+    //    file, Node preserves the old permissions. chmod explicitly so
+    //    the output is always executable.
     const outDir = path.dirname(path.resolve(opts.outputFile));
     fs.mkdirSync(outDir, { recursive: true });
     fs.writeFileSync(opts.outputFile, SHEBANG + result.outputFiles[0].text, {
       mode: 0o755,
     });
+    fs.chmodSync(opts.outputFile, 0o755);
   } finally {
-    if (fs.existsSync(tmpJs)) fs.unlinkSync(tmpJs);
+    // 6. Tidy up: the entry `.__pack__.js`, plus any sibling .js files
+    //    compile() created next to the user's source files. We never
+    //    touch a sibling .js that already existed before we ran.
+    if (fs.existsSync(entryOutput)) {
+      try {
+        fs.unlinkSync(entryOutput);
+      } catch {
+        /* best-effort */
+      }
+    }
+    const absOutput = path.resolve(opts.outputFile);
+    for (const p of siblingJsPaths) {
+      // Never delete:
+      //  - a sibling that pre-existed (it's the user's file)
+      //  - the pack output itself (it might coincidentally share a name)
+      if (
+        preExistingJs.has(p) ||
+        path.resolve(p) === absOutput ||
+        !fs.existsSync(p)
+      ) {
+        continue;
+      }
+      try {
+        fs.unlinkSync(p);
+      } catch {
+        /* best-effort */
+      }
+    }
   }
 }

--- a/packages/agency-lang/lib/cli/pack.ts
+++ b/packages/agency-lang/lib/cli/pack.ts
@@ -1,9 +1,10 @@
 import * as fs from "fs";
 import * as path from "path";
-import { createRequire } from "module";
+import { builtinModules, createRequire } from "module";
 import { fileURLToPath } from "url";
 import { build, type Plugin } from "esbuild";
 import { AgencyConfig } from "@/config.js";
+import { findPackageRoot } from "@/importPaths.js";
 import { SymbolTable } from "@/symbolTable.js";
 import { compile } from "./commands.js";
 
@@ -12,23 +13,10 @@ import { compile } from "./commands.js";
 // Works for both the built `dist/lib/cli/pack.js` and the dev-tree
 // `lib/cli/pack.ts` paths.
 function agencyLangInstallRoot(): string {
-  let dir = path.dirname(fileURLToPath(import.meta.url));
-  while (true) {
-    const pkgJson = path.join(dir, "package.json");
-    if (fs.existsSync(pkgJson)) {
-      try {
-        const parsed = JSON.parse(fs.readFileSync(pkgJson, "utf-8"));
-        if (parsed.name === "agency-lang") return dir;
-      } catch {
-        /* keep walking */
-      }
-    }
-    const parent = path.dirname(dir);
-    if (parent === dir) {
-      throw new Error("Could not locate agency-lang package root");
-    }
-    dir = parent;
-  }
+  return findPackageRoot(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "agency-lang",
+  );
 }
 
 // esbuild plugin that resolves `agency-lang` and `agency-lang/<sub>`
@@ -66,6 +54,7 @@ function agencyLangResolverPlugin(installRoot: string): Plugin {
 }
 
 export type PackTarget = "node";
+export type PackFormat = "esm" | "cjs";
 
 export type PackOptions = {
   config: AgencyConfig;
@@ -79,47 +68,13 @@ const SHEBANG = "#!/usr/bin/env node\n";
 // Only Node built-ins are kept external; everything else (agency-lang,
 // smoltalk, zod, user .agency imports, etc.) is bundled into the output
 // so the result runs anywhere Node is available without an install.
-const NODE_BUILTINS = [
-  "assert",
-  "async_hooks",
-  "buffer",
-  "child_process",
-  "cluster",
-  "console",
-  "constants",
-  "crypto",
-  "dgram",
-  "dns",
-  "events",
-  "fs",
-  "http",
-  "http2",
-  "https",
-  "inspector",
-  "module",
-  "net",
-  "os",
-  "path",
-  "perf_hooks",
-  "process",
-  "punycode",
-  "querystring",
-  "readline",
-  "repl",
-  "stream",
-  "string_decoder",
-  "timers",
-  "tls",
-  "trace_events",
-  "tty",
-  "url",
-  "util",
-  "v8",
-  "vm",
-  "worker_threads",
-  "zlib",
-  "node:*",
-];
+// Derived from `module.builtinModules` so it always tracks the running
+// Node version with no hand-maintained list to keep in sync.
+const NODE_BUILTINS = [...builtinModules, "node:*"];
+
+// Defaults used when `config.pack` does not override them.
+const DEFAULT_FORMAT: PackFormat = "esm";
+const DEFAULT_NODE_TARGET = "node20";
 
 // Walk the symbol table from the entry and collect every .agency file
 // reachable. These are the locations where `compile()` will produce
@@ -176,74 +131,117 @@ export async function pack(opts: PackOptions): Promise<void> {
     //    agency-lang's own require resolution — no nodePaths, so we
     //    cannot accidentally pull in globally-installed user packages.
     const installRoot = agencyLangInstallRoot();
+    const packCfg = opts.config.pack ?? {};
+    const format: PackFormat = packCfg.format ?? DEFAULT_FORMAT;
+    const targetVersion = packCfg.target ?? DEFAULT_NODE_TARGET;
+    const externals = [...NODE_BUILTINS, ...(packCfg.external ?? [])];
+    const verbose = !!opts.config.verbose;
+    if (verbose) {
+      console.error(
+        `agency pack: bundling ${opts.inputFile} (format=${format}, target=${targetVersion}, installRoot=${installRoot})`,
+      );
+    }
+    // Some transitive CJS deps call `require("child_process")` etc.
+    // esbuild can't statically rewrite those for ESM output, so it
+    // emits a runtime shim that throws "Dynamic require ...".
+    // Install a real createRequire so they work. CJS output does not
+    // need the shim because `require` is already available there.
+    const banner =
+      format === "esm"
+        ? {
+            js: [
+              "// Built by `agency pack`",
+              'import { createRequire as __pack_createRequire } from "node:module";',
+              "const require = __pack_createRequire(import.meta.url);",
+            ].join("\n"),
+          }
+        : { js: "// Built by `agency pack`" };
     const result = await build({
       entryPoints: [compiled],
       bundle: true,
       platform: "node",
-      format: "esm",
-      target: "node20",
+      format,
+      target: targetVersion,
       write: false,
       outfile: opts.outputFile,
-      external: NODE_BUILTINS,
+      external: externals,
       plugins: [agencyLangResolverPlugin(installRoot)],
-      // Some transitive CJS deps call `require("child_process")` etc.
-      // esbuild can't statically rewrite those for ESM output, so it
-      // emits a runtime shim that throws "Dynamic require ...".
-      // Install a real createRequire so they work.
-      banner: {
-        js: [
-          "// Built by `agency pack`",
-          'import { createRequire as __pack_createRequire } from "node:module";',
-          "const require = __pack_createRequire(import.meta.url);",
-        ].join("\n"),
-      },
-      logLevel: "silent",
+      banner,
+      logLevel: verbose ? "info" : "silent",
     });
 
     if (result.outputFiles.length !== 1) {
+      const paths = result.outputFiles.map((f) => f.path).join(", ");
       throw new Error(
-        `agency pack: expected exactly one output file from esbuild, got ${result.outputFiles.length}`,
+        `agency pack: expected exactly one output file from esbuild, got ${result.outputFiles.length}: [${paths}]`,
       );
     }
 
-    // 5. Write the bundle. mode on writeFileSync only takes effect when
-    //    the file is created — if the user re-packs over an existing
-    //    file, Node preserves the old permissions. chmod explicitly so
-    //    the output is always executable.
+    // 5. Write the bundle and force executable permissions. The `mode`
+    //    option on writeFileSync is honored only when Node creates the
+    //    file; if we're overwriting an existing non-executable file
+    //    Node keeps the old permissions, so we chmod explicitly
+    //    afterward to guarantee the output is always runnable as
+    //    `./bundle.mjs`.
     const outDir = path.dirname(path.resolve(opts.outputFile));
     fs.mkdirSync(outDir, { recursive: true });
     fs.writeFileSync(opts.outputFile, SHEBANG + result.outputFiles[0].text, {
       mode: 0o755,
     });
     fs.chmodSync(opts.outputFile, 0o755);
+    if (verbose) {
+      const size = fs.statSync(opts.outputFile).size;
+      console.error(
+        `agency pack: wrote ${opts.outputFile} (${size} bytes, mode 0755)`,
+      );
+    }
   } finally {
     // 6. Tidy up: the entry `.__pack__.js`, plus any sibling .js files
     //    compile() created next to the user's source files. We never
     //    touch a sibling .js that already existed before we ran.
-    if (fs.existsSync(entryOutput)) {
-      try {
-        fs.unlinkSync(entryOutput);
-      } catch {
-        /* best-effort */
-      }
-    }
+    tryRemove(entryOutput);
     const absOutput = path.resolve(opts.outputFile);
     for (const p of siblingJsPaths) {
       // Never delete:
       //  - a sibling that pre-existed (it's the user's file)
       //  - the pack output itself (it might coincidentally share a name)
-      if (
-        preExistingJs.has(p) ||
-        path.resolve(p) === absOutput ||
-        !fs.existsSync(p)
-      ) {
+      if (preExistingJs.has(p) || path.resolve(p) === absOutput) {
         continue;
       }
-      try {
-        fs.unlinkSync(p);
-      } catch {
-        /* best-effort */
-      }
+      tryRemove(p);
     }
+  }
+}
+
+// Best-effort cleanup of a generated file. Refuses to follow into a
+// directory (a `.js` directory next to a `.agency` source would be the
+// user's, not ours), and surfaces real failures (permission denied,
+// busy file, etc.) as warnings rather than silently swallowing them.
+function tryRemove(p: string): void {
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(p);
+  } catch (err: unknown) {
+    // ENOENT is fine — nothing to clean up.
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return;
+    console.error(
+      `agency pack: warning: could not stat ${p} for cleanup: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return;
+  }
+  if (stat.isDirectory()) {
+    // Don't recurse into directories — that's almost certainly user data.
+    return;
+  }
+  try {
+    fs.unlinkSync(p);
+  } catch (err) {
+    console.error(
+      `agency pack: warning: could not remove ${p}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
   }
 }

--- a/packages/agency-lang/lib/cli/run.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/run.spawn.test.ts
@@ -1,20 +1,42 @@
 import { describe, it, expect } from "vitest";
-import { compileWarning, compiledOutputEnv } from "./commands.js";
-import { installDirFromUrl, nodeModulesParent } from "./installLocation.js";
+import * as fs from "fs";
+import { fileURLToPath } from "url";
+import {
+  compileWarning,
+  compiledOutputNodeArgs,
+  compiledOutputRegisterUrl,
+} from "./commands.js";
 
-describe("compiledOutputEnv", () => {
-  it("injects NODE_PATH pointing at the CLI's resolution root", () => {
-    const env = compiledOutputEnv({ existing: "x" } as NodeJS.ProcessEnv);
-    const expected = nodeModulesParent(installDirFromUrl(import.meta.url));
-    expect(env.NODE_PATH ?? "").toContain(expected);
-    expect(env.existing).toBe("x");
+describe("compiledOutputRegisterUrl", () => {
+  it("returns a file:// URL pointing at the shipped register.mjs", () => {
+    const url = compiledOutputRegisterUrl();
+    expect(url.startsWith("file://")).toBe(true);
+    // Under vitest the URL points at lib/cli/runShim (source); in the built
+    // tree it would point at dist/lib/cli/runShim. Either is correct.
+    expect(url.endsWith("/lib/cli/runShim/register.mjs")).toBe(true);
   });
-  it("appends to existing NODE_PATH rather than overwriting", () => {
-    const env = compiledOutputEnv({
-      NODE_PATH: "/some/path",
-    } as NodeJS.ProcessEnv);
-    expect(env.NODE_PATH?.startsWith("/some/path")).toBe(true);
-    expect(env.NODE_PATH?.length).toBeGreaterThan("/some/path".length);
+  it("points at a file that exists on disk", () => {
+    const url = compiledOutputRegisterUrl();
+    const filePath = fileURLToPath(url);
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+  it("points at a register.mjs sitting next to resolver.mjs", () => {
+    // The register shim is useless without the resolver next to it.
+    const registerUrl = compiledOutputRegisterUrl();
+    const resolverPath = fileURLToPath(registerUrl).replace(
+      /register\.mjs$/,
+      "resolver.mjs",
+    );
+    expect(fs.existsSync(resolverPath)).toBe(true);
+  });
+});
+
+describe("compiledOutputNodeArgs", () => {
+  it("includes a --import flag pointing at the register shim", () => {
+    const args = compiledOutputNodeArgs();
+    expect(args.length).toBe(1);
+    expect(args[0].startsWith("--import=file://")).toBe(true);
+    expect(args[0].endsWith("/lib/cli/runShim/register.mjs")).toBe(true);
   });
 });
 

--- a/packages/agency-lang/lib/cli/run.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/run.spawn.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { compileWarning, compiledOutputEnv } from "./commands.js";
+import { installDirFromUrl, nodeModulesParent } from "./installLocation.js";
+
+describe("compiledOutputEnv", () => {
+  it("injects NODE_PATH pointing at the CLI's resolution root", () => {
+    const env = compiledOutputEnv({ existing: "x" } as NodeJS.ProcessEnv);
+    const expected = nodeModulesParent(installDirFromUrl(import.meta.url));
+    expect(env.NODE_PATH ?? "").toContain(expected);
+    expect(env.existing).toBe("x");
+  });
+  it("appends to existing NODE_PATH rather than overwriting", () => {
+    const env = compiledOutputEnv({
+      NODE_PATH: "/some/path",
+    } as NodeJS.ProcessEnv);
+    expect(env.NODE_PATH?.startsWith("/some/path")).toBe(true);
+    expect(env.NODE_PATH?.length).toBeGreaterThan("/some/path".length);
+  });
+});
+
+describe("compileWarning", () => {
+  it("returns a warning string when install is global", () => {
+    const out = compileWarning("global", "/tmp/foo.js");
+    expect(out).not.toBeNull();
+    expect(out!).toMatch(/agency-lang.*global/);
+    expect(out!).toMatch(/agency run/);
+    expect(out!).toMatch(/agency pack/);
+  });
+  it("returns null when install is local", () => {
+    expect(compileWarning("local", "/tmp/foo.js")).toBeNull();
+  });
+  it("returns null when install is workspace", () => {
+    expect(compileWarning("workspace", "/tmp/foo.js")).toBeNull();
+  });
+});

--- a/packages/agency-lang/lib/cli/run.spawn.test.ts
+++ b/packages/agency-lang/lib/cli/run.spawn.test.ts
@@ -41,17 +41,27 @@ describe("compiledOutputNodeArgs", () => {
 });
 
 describe("compileWarning", () => {
-  it("returns a warning string when install is global", () => {
-    const out = compileWarning("global", "/tmp/foo.js");
+  const cannotResolve = () => false;
+  const canResolve = () => true;
+
+  it("returns a warning when install is global AND output dir cannot resolve agency-lang", () => {
+    const out = compileWarning("global", "/tmp/foo.js", cannotResolve);
     expect(out).not.toBeNull();
     expect(out!).toMatch(/agency-lang.*global/);
     expect(out!).toMatch(/agency run/);
     expect(out!).toMatch(/agency pack/);
+    expect(out!).toMatch(/may fail/);
   });
+
+  it("returns null when install is global BUT agency-lang resolves locally from the output dir", () => {
+    expect(compileWarning("global", "/tmp/foo.js", canResolve)).toBeNull();
+  });
+
   it("returns null when install is local", () => {
-    expect(compileWarning("local", "/tmp/foo.js")).toBeNull();
+    expect(compileWarning("local", "/tmp/foo.js", cannotResolve)).toBeNull();
   });
+
   it("returns null when install is workspace", () => {
-    expect(compileWarning("workspace", "/tmp/foo.js")).toBeNull();
+    expect(compileWarning("workspace", "/tmp/foo.js", cannotResolve)).toBeNull();
   });
 });

--- a/packages/agency-lang/lib/cli/runBundledAgent.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.ts
@@ -1,5 +1,5 @@
 import { AgencyConfig } from "@/config.js";
-import { compile } from "./commands.js";
+import { compile, compiledOutputEnv } from "./commands.js";
 import { spawn } from "child_process";
 import * as path from "path";
 
@@ -23,9 +23,10 @@ export function runBundledAgent(
   }
 
   console.log("---");
-  const nodeProcess = spawn("node", [runFile, ...args], {
+  const nodeProcess = spawn(process.execPath, [runFile, ...args], {
     stdio: "inherit",
     shell: false,
+    env: compiledOutputEnv(process.env),
   });
 
   nodeProcess.on("error", (error) => {

--- a/packages/agency-lang/lib/cli/runBundledAgent.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.ts
@@ -1,5 +1,5 @@
 import { AgencyConfig } from "@/config.js";
-import { compile, compiledOutputEnv } from "./commands.js";
+import { compile, compiledOutputNodeArgs } from "./commands.js";
 import { spawn } from "child_process";
 import * as path from "path";
 
@@ -23,11 +23,14 @@ export function runBundledAgent(
   }
 
   console.log("---");
-  const nodeProcess = spawn(process.execPath, [runFile, ...args], {
-    stdio: "inherit",
-    shell: false,
-    env: compiledOutputEnv(process.env),
-  });
+  const nodeProcess = spawn(
+    process.execPath,
+    [...compiledOutputNodeArgs(), runFile, ...args],
+    {
+      stdio: "inherit",
+      shell: false,
+    },
+  );
 
   nodeProcess.on("error", (error) => {
     console.error(`Failed to run ${agentName}:`, error);

--- a/packages/agency-lang/lib/cli/runShim/register.mjs
+++ b/packages/agency-lang/lib/cli/runShim/register.mjs
@@ -1,0 +1,5 @@
+// Tiny entry that registers the resolver hook with Node's module loader.
+// Spawned via `node --import=<file-url-to-this-file>`.
+import { register } from "node:module";
+
+register("./resolver.mjs", import.meta.url);

--- a/packages/agency-lang/lib/cli/runShim/resolver.d.mts
+++ b/packages/agency-lang/lib/cli/runShim/resolver.d.mts
@@ -1,0 +1,23 @@
+// Type declarations for the .mjs resolver hook used in tests.
+export type ResolveResult = {
+  url: string;
+  format: string | null;
+  shortCircuit?: boolean;
+};
+
+export type ResolveContext = {
+  conditions?: string[];
+  importAttributes?: Record<string, string>;
+  parentURL?: string;
+};
+
+export type NextResolve = (
+  specifier: string,
+  context: ResolveContext,
+) => Promise<ResolveResult>;
+
+export function resolve(
+  specifier: string,
+  context: ResolveContext,
+  nextResolve: NextResolve,
+): Promise<ResolveResult>;

--- a/packages/agency-lang/lib/cli/runShim/resolver.mjs
+++ b/packages/agency-lang/lib/cli/runShim/resolver.mjs
@@ -1,11 +1,16 @@
-// ESM resolver hook that lets `node` find `agency-lang` and its transitive
-// dependencies even when the agency-lang CLI is installed globally and the
-// program being run lives outside any `node_modules` tree.
+// ESM resolver hook that lets `node` find the `agency-lang` package (and
+// its subpaths) even when the agency-lang CLI is installed globally and
+// the program being run lives outside any `node_modules` tree.
 //
-// Strategy: when the default resolver can't find a bare specifier, retry
-// the resolution as if the importer lived inside the agency-lang package
-// directory. Node then applies its standard resolution algorithm (conditional
-// exports, format detection, etc.) using agency-lang's own `node_modules`.
+// Strategy: when the default resolver can't find an `agency-lang` or
+// `agency-lang/<sub>` specifier, retry as if the importer lived inside
+// the agency-lang package itself. Node then resolves via that package's
+// own `node_modules`.
+//
+// The fallback is **scoped strictly to `agency-lang` specifiers**. We do
+// NOT retry for arbitrary bare imports (e.g. `lodash`) or relative paths
+// (`./foo.js`), because doing so would silently mask the user's own
+// missing-import mistakes by resolving them from inside agency-lang.
 //
 // This file lives at <install-root>/dist/lib/cli/runShim/resolver.mjs, so
 // `import.meta.url` is already inside the package — we just point parentURL
@@ -13,22 +18,23 @@
 import { pathToFileURL, fileURLToPath } from "node:url";
 import * as path from "node:path";
 
-// Walk up to the package root (the directory containing package.json) and
-// build a fake parent URL inside it.
 const thisFile = fileURLToPath(import.meta.url);
 const installRoot = path.resolve(thisFile, "..", "..", "..", "..", "..");
 const fakeParentURL = pathToFileURL(
   path.join(installRoot, "package.json"),
 ).href;
 
+function isAgencyLangSpecifier(specifier) {
+  return specifier === "agency-lang" || specifier.startsWith("agency-lang/");
+}
+
 export async function resolve(specifier, context, nextResolve) {
   try {
     return await nextResolve(specifier, context);
   } catch (err) {
-    if (err && err.code === "ERR_MODULE_NOT_FOUND") {
-      // Retry resolution as if the import came from inside agency-lang.
-      // If this also fails, fall through and rethrow the original error so
-      // the user sees the message about their actual import.
+    if (err && err.code === "ERR_MODULE_NOT_FOUND" && isAgencyLangSpecifier(specifier)) {
+      // Retry only for agency-lang specifiers. If this also fails,
+      // fall through and rethrow the original error.
       try {
         return await nextResolve(specifier, {
           ...context,

--- a/packages/agency-lang/lib/cli/runShim/resolver.mjs
+++ b/packages/agency-lang/lib/cli/runShim/resolver.mjs
@@ -1,0 +1,43 @@
+// ESM resolver hook that lets `node` find `agency-lang` and its transitive
+// dependencies even when the agency-lang CLI is installed globally and the
+// program being run lives outside any `node_modules` tree.
+//
+// Strategy: when the default resolver can't find a bare specifier, retry
+// the resolution as if the importer lived inside the agency-lang package
+// directory. Node then applies its standard resolution algorithm (conditional
+// exports, format detection, etc.) using agency-lang's own `node_modules`.
+//
+// This file lives at <install-root>/dist/lib/cli/runShim/resolver.mjs, so
+// `import.meta.url` is already inside the package — we just point parentURL
+// at our own package.json's URL so Node walks up from there.
+import { pathToFileURL, fileURLToPath } from "node:url";
+import * as path from "node:path";
+
+// Walk up to the package root (the directory containing package.json) and
+// build a fake parent URL inside it.
+const thisFile = fileURLToPath(import.meta.url);
+const installRoot = path.resolve(thisFile, "..", "..", "..", "..", "..");
+const fakeParentURL = pathToFileURL(
+  path.join(installRoot, "package.json"),
+).href;
+
+export async function resolve(specifier, context, nextResolve) {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (err) {
+    if (err && err.code === "ERR_MODULE_NOT_FOUND") {
+      // Retry resolution as if the import came from inside agency-lang.
+      // If this also fails, fall through and rethrow the original error so
+      // the user sees the message about their actual import.
+      try {
+        return await nextResolve(specifier, {
+          ...context,
+          parentURL: fakeParentURL,
+        });
+      } catch {
+        /* fall through */
+      }
+    }
+    throw err;
+  }
+}

--- a/packages/agency-lang/lib/cli/runShim/resolver.mjs
+++ b/packages/agency-lang/lib/cli/runShim/resolver.mjs
@@ -40,8 +40,18 @@ export async function resolve(specifier, context, nextResolve) {
           ...context,
           parentURL: fakeParentURL,
         });
-      } catch {
-        /* fall through */
+      } catch (innerErr) {
+        // Set AGENCY_DEBUG_RESOLVER=1 to surface fallback failures.
+        // Normally we stay silent so the user only sees the original
+        // ERR_MODULE_NOT_FOUND from Node.
+        if (process.env.AGENCY_DEBUG_RESOLVER) {
+          const msg = innerErr && innerErr.message
+            ? innerErr.message
+            : String(innerErr);
+          process.stderr.write(
+            `[agency resolver] fallback failed for ${specifier}: ${msg}\n`,
+          );
+        }
       }
     }
     throw err;

--- a/packages/agency-lang/lib/cli/runShim/resolver.test.ts
+++ b/packages/agency-lang/lib/cli/runShim/resolver.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { resolve } from "./resolver.mjs";
+
+function notFound(): Error & { code: string } {
+  const err = new Error("Cannot find package") as Error & { code: string };
+  err.code = "ERR_MODULE_NOT_FOUND";
+  return err;
+}
+
+describe("resolver.mjs", () => {
+  it("returns the default resolution when it succeeds", async () => {
+    const next = async (s: string) => ({ url: `resolved:${s}`, format: null, shortCircuit: true });
+    const r = await resolve("agency-lang", {}, next);
+    expect(r.url).toBe("resolved:agency-lang");
+  });
+
+  it("retries with fakeParentURL for `agency-lang`", async () => {
+    let calls = 0;
+    const next = async (s: string, ctx: { parentURL?: string }) => {
+      calls++;
+      if (calls === 1) throw notFound();
+      if (calls === 2 && ctx.parentURL?.includes("agency-lang")) {
+        return { url: `fallback:${s}`, format: null, shortCircuit: true };
+      }
+      throw new Error("unexpected call");
+    };
+    const r = await resolve("agency-lang", {}, next);
+    expect(r.url).toBe("fallback:agency-lang");
+    expect(calls).toBe(2);
+  });
+
+  it("retries with fakeParentURL for `agency-lang/runtime` and similar subpaths", async () => {
+    let calls = 0;
+    const next = async (s: string, ctx: { parentURL?: string }) => {
+      calls++;
+      if (calls === 1) throw notFound();
+      return { url: `fallback:${s}:${ctx.parentURL}`, format: null, shortCircuit: true };
+    };
+    const r = await resolve("agency-lang/runtime", {}, next);
+    expect(r.url.startsWith("fallback:agency-lang/runtime:")).toBe(true);
+  });
+
+  it("does NOT retry for unrelated bare imports — propagates the original error", async () => {
+    let calls = 0;
+    const next = async () => {
+      calls++;
+      throw notFound();
+    };
+    await expect(resolve("lodash", {}, next)).rejects.toMatchObject({
+      code: "ERR_MODULE_NOT_FOUND",
+    });
+    expect(calls).toBe(1); // only the initial try, no retry
+  });
+
+  it("does NOT retry for relative imports — masking those would hide user typos", async () => {
+    let calls = 0;
+    const next = async () => {
+      calls++;
+      throw notFound();
+    };
+    await expect(resolve("./missing.js", {}, next)).rejects.toMatchObject({
+      code: "ERR_MODULE_NOT_FOUND",
+    });
+    expect(calls).toBe(1);
+  });
+
+  it("propagates non-ENOENT errors unchanged", async () => {
+    const boom = new Error("ENOSPC");
+    const next = async () => {
+      throw boom;
+    };
+    await expect(resolve("agency-lang", {}, next)).rejects.toBe(boom);
+  });
+});

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -206,6 +206,28 @@ export interface AgencyConfig {
     };
   };
 
+  /**
+   * Configuration for `agency pack`.
+   */
+  pack?: {
+    /**
+     * Output module format. Default: "esm". CJS output is useful when
+     * embedding the bundle in a project whose package.json sets
+     * `"type": "commonjs"` and the surrounding tooling expects CommonJS.
+     */
+    format?: "esm" | "cjs";
+    /**
+     * esbuild `target` string (e.g. "node20", "node22"). Default: "node20".
+     */
+    target?: string;
+    /**
+     * Additional bare specifiers to keep external (in addition to Node
+     * built-ins). Use sparingly — anything listed here must already be
+     * installed wherever the bundle runs.
+     */
+    external?: string[];
+  };
+
   coverage?: {
     /** Output directory for collected coverage data (default: ".coverage") */
     outDir?: string;
@@ -305,6 +327,13 @@ export const AgencyConfigSchema = z
         threshold: z.number().min(0).max(100),
         perFileThreshold: z.number().min(0).max(100),
         exclude: z.array(z.string()),
+      })
+      .partial(),
+    pack: z
+      .object({
+        format: z.enum(["esm", "cjs"]),
+        target: z.string(),
+        external: z.array(z.string()),
       })
       .partial(),
     memory: z.object({

--- a/packages/agency-lang/lib/importPaths.ts
+++ b/packages/agency-lang/lib/importPaths.ts
@@ -21,15 +21,23 @@ export function findPackageRoot(startDir: string): string {
   return dir;
 }
 
-const PACKAGE_ROOT = findPackageRoot(__dirname);
-const STDLIB_DIR = path.join(PACKAGE_ROOT, "stdlib");
-const TEST_DIR = path.join(PACKAGE_ROOT, "tests");
+// Lazily resolve the package root so that bundled / packed outputs (which
+// may live in a directory tree without any package.json above them) don't
+// crash on module load. The failure is only surfaced when something actually
+// asks for the stdlib or tests directory.
+let _packageRoot: string | null = null;
+function getPackageRoot(): string {
+  if (_packageRoot === null) {
+    _packageRoot = findPackageRoot(__dirname);
+  }
+  return _packageRoot;
+}
 
 /**
  * Returns the absolute path to the stdlib directory.
  */
 export function getStdlibDir(): string {
-  return STDLIB_DIR;
+  return path.join(getPackageRoot(), "stdlib");
 }
 
 /**
@@ -37,9 +45,10 @@ export function getStdlibDir(): string {
  */
 export function getStdlibFiles(): string[] {
   try {
-    return fs.readdirSync(STDLIB_DIR)
+    const dir = getStdlibDir();
+    return fs.readdirSync(dir)
       .filter((f) => f.endsWith(".agency"))
-      .map((f) => path.join(STDLIB_DIR, f));
+      .map((f) => path.join(dir, f));
   } catch {
     return [];
   }
@@ -49,7 +58,7 @@ export function getStdlibFiles(): string[] {
  * Returns the absolute path to the tests directory.
  */
 export function getTestDir(): string {
-  return TEST_DIR;
+  return path.join(getPackageRoot(), "tests");
 }
 
 /**
@@ -282,7 +291,10 @@ export function resolveAgencyImportPath(
   fromFile: string,
 ): string {
   if (isStdlibImport(importPath)) {
-    return path.join(STDLIB_DIR, normalizeStdlibPath(importPath) + ".agency");
+    return path.join(
+      getStdlibDir(),
+      normalizeStdlibPath(importPath) + ".agency",
+    );
   }
   if (isPkgImport(importPath)) {
     return resolvePkgAgencyPath(importPath, fromFile);

--- a/packages/agency-lang/lib/importPaths.ts
+++ b/packages/agency-lang/lib/importPaths.ts
@@ -8,17 +8,43 @@ const __dirname = path.dirname(__filename);
 
 /**
  * Walk up from startDir until we find a directory containing package.json.
+ *
+ * If `packageName` is supplied, we only accept a package.json whose `name`
+ * field equals that string — useful for callers that need to find a
+ * specific package root (e.g. `agency-lang`) even when intermediate
+ * directories above the starting point contain unrelated package.jsons
+ * (workspaces, nested tooling configs, etc.).
  */
-export function findPackageRoot(startDir: string): string {
+export function findPackageRoot(
+  startDir: string,
+  packageName?: string,
+): string {
   let dir = startDir;
-  while (!fs.existsSync(path.join(dir, "package.json"))) {
+  while (true) {
+    const pkgJsonPath = path.join(dir, "package.json");
+    if (fs.existsSync(pkgJsonPath)) {
+      if (packageName === undefined) {
+        return dir;
+      }
+      try {
+        const parsed = JSON.parse(fs.readFileSync(pkgJsonPath, "utf-8"));
+        if (parsed.name === packageName) {
+          return dir;
+        }
+      } catch {
+        /* unparseable package.json — keep walking */
+      }
+    }
     const parent = path.dirname(dir);
     if (parent === dir) {
-      throw new Error("Could not find package root (no package.json found)");
+      throw new Error(
+        packageName
+          ? `Could not find package root for '${packageName}' (no matching package.json found above ${startDir})`
+          : "Could not find package root (no package.json found)",
+      );
     }
     dir = parent;
   }
-  return dir;
 }
 
 // Lazily resolve the package root so that bundled / packed outputs (which

--- a/packages/agency-lang/makefile
+++ b/packages/agency-lang/makefile
@@ -1,7 +1,18 @@
-.PHONY: all test stdlib agents doc packages-doc refresh-action-pins
+.PHONY: all test stdlib agents doc packages-doc refresh-action-pins build
 
 all:
 	pnpm run templates && pnpm run build && $(MAKE) stdlib && $(MAKE) agents && $(MAKE) doc
+
+# Build the dist/ tree. Invoked by `pnpm run build`. Kept here (rather
+# than as a chain in package.json) so the steps remain readable and easy
+# to extend without inflating the package.json scripts section.
+build:
+	rm -rf dist/
+	tsc
+	tsc-alias
+	cp -r lib/agents dist/lib
+	mkdir -p dist/lib/cli/runShim
+	cp lib/cli/runShim/*.mjs dist/lib/cli/runShim/
 
 stdlib:
 	pnpm run agency compile stdlib/

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -8,7 +8,7 @@
     "test:run": "vitest run",
     "test:agency": "time node ./dist/scripts/agency.js test tests/agency -p 12",
     "test:agency-js": "time node ./dist/scripts/agency.js test js tests/agency-js -p 12",
-    "build": "rm -rf dist/ && tsc && tsc-alias && cp -r lib/agents dist/lib && cp -r lib/cli/runShim dist/lib/cli/runShim",
+    "build": "rm -rf dist/ && tsc && tsc-alias && cp -r lib/agents dist/lib && mkdir -p dist/lib/cli/runShim && cp lib/cli/runShim/*.mjs dist/lib/cli/runShim/",
     "start": "node dist/index.js",
     "templates": "typestache ./lib/templates",
     "typecheck": "tsc --noEmit",

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -8,7 +8,7 @@
     "test:run": "vitest run",
     "test:agency": "time node ./dist/scripts/agency.js test tests/agency -p 12",
     "test:agency-js": "time node ./dist/scripts/agency.js test js tests/agency-js -p 12",
-    "build": "rm -rf dist/ && tsc && tsc-alias && cp -r lib/agents dist/lib",
+    "build": "rm -rf dist/ && tsc && tsc-alias && cp -r lib/agents dist/lib && cp -r lib/cli/runShim dist/lib/cli/runShim",
     "start": "node dist/index.js",
     "templates": "typestache ./lib/templates",
     "typecheck": "tsc --noEmit",

--- a/packages/agency-lang/package.json
+++ b/packages/agency-lang/package.json
@@ -8,7 +8,7 @@
     "test:run": "vitest run",
     "test:agency": "time node ./dist/scripts/agency.js test tests/agency -p 12",
     "test:agency-js": "time node ./dist/scripts/agency.js test js tests/agency-js -p 12",
-    "build": "rm -rf dist/ && tsc && tsc-alias && cp -r lib/agents dist/lib && mkdir -p dist/lib/cli/runShim && cp lib/cli/runShim/*.mjs dist/lib/cli/runShim/",
+    "build": "make build",
     "start": "node dist/index.js",
     "templates": "typestache ./lib/templates",
     "typecheck": "tsc --noEmit",

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -135,18 +135,23 @@ export function createProgram(deps: CliDependencies = {}): Command {
             process.exit(0);
           });
         } else {
-          let lastOutput: string | null = null;
           for (const input of inputs) {
-            const out = compile(config, input, undefined, { ts: opts.ts });
-            if (out) lastOutput = out;
+            compile(config, input, undefined, { ts: opts.ts });
           }
-          // If installed globally, the user will hit ERR_MODULE_NOT_FOUND if
-          // they try to `node` the output directly. Steer them to `agency run`
-          // or `agency pack` instead.
-          if (lastOutput) {
+          // If installed globally, the user will hit ERR_MODULE_NOT_FOUND
+          // if they try to `node` the output directly. Steer them toward
+          // `agency run` or `agency pack`. Gated on:
+          //   - JS output only — `--ts` produces a .ts the user isn't
+          //     going to run directly with node anyway.
+          //   - The output directory doesn't already have a resolvable
+          //     `agency-lang` (the warning helper does that check).
+          // Uses the first input's directory as the resolution context;
+          // directory inputs use the directory itself.
+          if (!opts.ts && inputs.length > 0) {
+            const ctx = path.resolve(inputs[0]);
             const warning = compileWarning(
               classifyInstall(installDirFromUrl(import.meta.url)),
-              lastOutput,
+              ctx,
             );
             if (warning) console.error(warning);
           }
@@ -178,10 +183,13 @@ export function createProgram(deps: CliDependencies = {}): Command {
   program
     .command("pack")
     .description(
-      "Bundle a .agency program into a single portable .js (no agency install needed at runtime)",
+      "Bundle a .agency program into a single portable .mjs (no agency install needed at runtime)",
     )
     .argument("<input>", "Path to .agency input file")
-    .option("-o, --output <file>", "Output file path", "agent.js")
+    // Default to .mjs so the output is unambiguously ESM regardless of
+    // any surrounding package.json `"type"`. Users may pass `-o foo.js`
+    // explicitly if they prefer that extension.
+    .option("-o, --output <file>", "Output file path", "agent.mjs")
     .option("--target <target>", "Output target (currently only 'node')", "node")
     .action(
       async (input: string, opts: { output: string; target: string }) => {

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -14,6 +14,7 @@ import {
   classifyInstall,
   installDirFromUrl,
 } from "@/cli/installLocation.js";
+import { pack } from "@/cli/pack.js";
 import { evaluate } from "@/cli/evaluate.js";
 import { fixtures, test, testTs, SlowTest } from "@/cli/test.js";
 import { generateReport, cleanCoverage } from "@/cli/coverage.js";
@@ -173,6 +174,33 @@ export function createProgram(deps: CliDependencies = {}): Command {
   ).action((input: string, options: RunOptions) => {
     runWithOptions(input, options);
   });
+
+  program
+    .command("pack")
+    .description(
+      "Bundle a .agency program into a single portable .js (no agency install needed at runtime)",
+    )
+    .argument("<input>", "Path to .agency input file")
+    .option("-o, --output <file>", "Output file path", "agent.js")
+    .option("--target <target>", "Output target (currently only 'node')", "node")
+    .action(
+      async (input: string, opts: { output: string; target: string }) => {
+        if (opts.target !== "node") {
+          console.error(
+            `Unsupported pack target: ${opts.target} (supported: node)`,
+          );
+          process.exit(1);
+        }
+        const config = getConfig();
+        await pack({
+          config,
+          inputFile: input,
+          outputFile: opts.output,
+          target: "node",
+        });
+        console.log(`Packed ${input} -> ${opts.output}`);
+      },
+    );
 
   const traceCmd = program
     .command("trace")

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import {
   compile,
+  compileWarning,
   format,
   formatFile,
   loadConfig,
@@ -9,6 +10,10 @@ import {
   readStdin,
   run,
 } from "@/cli/commands.js";
+import {
+  classifyInstall,
+  installDirFromUrl,
+} from "@/cli/installLocation.js";
 import { evaluate } from "@/cli/evaluate.js";
 import { fixtures, test, testTs, SlowTest } from "@/cli/test.js";
 import { generateReport, cleanCoverage } from "@/cli/coverage.js";
@@ -129,8 +134,20 @@ export function createProgram(deps: CliDependencies = {}): Command {
             process.exit(0);
           });
         } else {
+          let lastOutput: string | null = null;
           for (const input of inputs) {
-            compile(config, input, undefined, { ts: opts.ts });
+            const out = compile(config, input, undefined, { ts: opts.ts });
+            if (out) lastOutput = out;
+          }
+          // If installed globally, the user will hit ERR_MODULE_NOT_FOUND if
+          // they try to `node` the output directly. Steer them to `agency run`
+          // or `agency pack` instead.
+          if (lastOutput) {
+            const warning = compileWarning(
+              classifyInstall(installDirFromUrl(import.meta.url)),
+              lastOutput,
+            );
+            if (warning) console.error(warning);
           }
         }
       },


### PR DESCRIPTION
## Motivation

When a user installs the agency CLI globally (`npm install -g agency-lang`) and runs `agency compile foo.agency && node foo.js`, they hit:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'agency-lang' imported from /path/to/foo.js
```

This is a classic Node footgun: global `npm install` and Node's module resolver are separate mechanisms. Node does not look in the global `node_modules` for bare imports. Three related improvements address this:

1. Make the obvious workflow work.
2. Tell the user something useful instead of silently leaving them with a confusing stack trace.
3. Give them a way to ship a `.agency` program as a self-contained file.

## Changes

### 1. Detect install kind (`lib/cli/installLocation.ts`)

Small helper that classifies the CLI install as `global`, `local`, or `workspace` from `import.meta.url`. Used by the next two changes.

### 2. Fix `agency run` for global installs

The compiled output is ESM and Node's ESM resolver **does not honor `NODE_PATH`** (only CommonJS does). The fix is an ESM loader hook: two tiny `.mjs` files are shipped in `dist/lib/cli/runShim/`, and `agency run` spawns the child Node with `--import=<file-url-to-register.mjs>`. When the default resolver can't find a bare specifier, the hook retries with `parentURL` set to a file inside agency-lang's package — letting Node walk that package's own `node_modules`.

`agency compile` now also prints a one-paragraph note (to stderr) when invoked from a global install, steering the user to `agency run` or `agency pack` instead of running the compiled output directly with `node`.

### 3. `agency pack`

```bash
agency pack foo.agency -o foo.js   # produces a portable single-file script
./foo.js                            # runs anywhere Node is installed
```

Uses the already-bundled `esbuild` to inline the agency runtime, smoltalk, zod, and any user imports into one ESM file with a `#!/usr/bin/env node` shebang and mode `0o755`. Only Node built-ins are kept external.

Two subtleties:
- esbuild's CJS-in-ESM shim throws `Dynamic require of "child_process"` for transitive CJS deps; a banner installs a real `createRequire` so it works.
- `lib/importPaths.ts` previously called `findPackageRoot(__dirname)` at module-load time, which crashed packed binaries that lived in directory trees with no `package.json` above them. Made lazy — only fires if/when the user code actually needs stdlib paths.

`--target=node` only for now. `--target=sea` (Node single-executable application) is a planned follow-up.

## Verification

All three behaviors verified end-to-end against a real `npm install -g`:

| Behavior | Result |
|---|---|
| Global install detected → friendly warning from `agency compile` | ✅ |
| `agency run` works under global install (was previously broken) | ✅ |
| `agency pack` produces 3MB portable .js that runs from a directory with no `node_modules` | ✅ |

Test suite: **209 files, 3641 tests, all passing** (baseline 206/3626; this PR adds 3 test files and 15 tests).

## Commits

1. `feat(cli): add install-location helpers`
2. `fix(cli): make agency run work for global installs` *(NODE_PATH attempt + warning)*
3. `fix(cli): use ESM loader hook instead of NODE_PATH` *(real fix once I confirmed ESM ignores NODE_PATH)*
4. `feat(cli): add agency pack for portable single-file scripts`
5. `docs(guide): add page on running agents, the global-install gotcha, and pack`

## Out of scope (follow-ups)

- `agency pack --target=sea` for Node single-executable applications, and `--target=bun-compile` for a `bun build --compile` binary.
- Inlining the `.agency` stdlib for packed programs that need it at runtime (most don't — the stdlib is compile-time consumed).
- A test-mode `agency pack` that emits the bundle next to a `package.json` with `"type": "module"` so users with `.js` outputs don't see Node's `MODULE_TYPELESS_PACKAGE_JSON` warning.
