### PR TITLE
Logs Viewer v2: search, JSON pane, follow, help, clipboard

### DIFF
--- a/packages/agency-lang/docs/site/guide/observability.md
+++ b/packages/agency-lang/docs/site/guide/observability.md
@@ -41,17 +41,58 @@ Read from stdin:
 cat run.jsonl | agency logs view -
 ```
 
+Tail a file that is still being written to (e.g. a long-running
+agent):
+
+```bash
+agency logs view --follow path/to/run.jsonl
+```
+
 ### Keybindings
 
 | Key | Action |
 |---|---|
 | `j`, `Down`, `Ctrl+N` | Move cursor down |
 | `k`, `Up`, `Ctrl+P` | Move cursor up |
-| `l`, `Right`, `Enter` | Expand the focused node (or jump into its children) |
+| `l`, `Right` | Expand the focused node (or jump into its children) |
+| `Enter` | Expand; on a leaf, open the JSON payload pane and focus it |
 | `h`, `Left` | Collapse the focused node (or jump to its parent) |
 | `g` | Jump to the top |
 | `G` | Jump to the bottom |
+| `Tab`, `Shift+Tab` | Jump cursor to the next / previous trace |
+| `e` / `E` | Expand all / collapse all |
+| `p` | Toggle the JSON payload pane |
+| `/`, then text + Enter | Search rows for a substring |
+| `n` / `N` | Jump to next / previous match |
+| `Esc` | Clear active search |
+| `y` | Copy the focused node's JSON to the clipboard |
+| `f` | Toggle follow mode at runtime |
+| `?` | Show / hide the keybinding help |
 | `q`, `Ctrl+C` | Quit |
 
 A single-trace file opens with the trace expanded; multi-trace files
 open with everything collapsed.
+
+### JSON payload pane
+
+Press `Enter` on a leaf to open a bottom split-pane that renders the
+event's full payload as a collapsible JSON tree (objects/arrays show
+as `▶ { 3 keys }` collapsed and expand on `l` or `Enter`). Long
+strings (with newlines or > 80 chars) collapse to a preview. The pane
+follows the focused leaf in the tree; `Esc` releases focus back to
+the tree; `p` toggles the pane.
+
+### Search
+
+Press `/`, type a substring, then `Enter`. Matches are highlighted
+in-place (yellow background), the cursor jumps to the first match,
+and ancestors of matches are auto-expanded so they are visible.
+Cycle with `n` / `N`; clear with `Esc`. The status bar shows
+`match i/n — "query"`.
+
+### Magnitude coloring
+
+Durations over `viewer.slowMs` (default 5s) and costs over
+`viewer.expensiveUsd` (default $0.01) render in bright-red; durations
+under `viewer.fastMs` (default 100ms) render gray. Configure in
+`agency.json` under the `viewer` key.

--- a/packages/agency-lang/docs/site/guide/observability.md
+++ b/packages/agency-lang/docs/site/guide/observability.md
@@ -80,6 +80,23 @@ below it as gray, indented lines. Press `h` (or `Left`) to collapse
 it back. Leaves with payloads show a `▶` / `▼` glyph instead of `●`
 so the affordance is visible.
 
+### Conversation view for `promptCompletion`
+
+Expanding a `promptCompletion` leaf shows a compact conversation
+summary — one line per message — instead of the raw JSON. For
+example:
+
+```text
+[user] "Greet Alice using the greet tool"
+[assistant] tool call: greet({"name":"Alice"})
+[tool: greet] "Hello, Alice!"
+[assistant] "Hello, Alice!"
+▶ raw data
+```
+
+Expand the `▶ raw data` row to reveal the full JSON envelope when
+you need it.
+
 ### Search
 
 Press `/`, type a substring, then `Enter`. Matches are highlighted

--- a/packages/agency-lang/docs/site/guide/observability.md
+++ b/packages/agency-lang/docs/site/guide/observability.md
@@ -58,6 +58,8 @@ agency logs view --follow path/to/run.jsonl
 | `h`, `Left` | Collapse the focused node (or jump to its parent) |
 | `g` | Jump to the top |
 | `G` | Jump to the bottom |
+| `Ctrl+F`, `PageDown` / `Ctrl+B`, `PageUp` | Page down / up |
+| `Ctrl+D` / `Ctrl+U` | Half-page down / up |
 | `Tab`, `Shift+Tab` | Jump cursor to the next / previous trace |
 | `e` / `E` | Expand all / collapse all |
 | `/`, then text + Enter | Search rows for a substring |

--- a/packages/agency-lang/docs/site/guide/observability.md
+++ b/packages/agency-lang/docs/site/guide/observability.md
@@ -54,14 +54,12 @@ agency logs view --follow path/to/run.jsonl
 |---|---|
 | `j`, `Down`, `Ctrl+N` | Move cursor down |
 | `k`, `Up`, `Ctrl+P` | Move cursor up |
-| `l`, `Right` | Expand the focused node (or jump into its children) |
-| `Enter` | Expand; on a leaf, open the JSON payload pane and focus it |
+| `l`, `Right`, `Enter` | Expand the focused node — on a span/trace, reveal children; on a leaf, inline the JSON payload |
 | `h`, `Left` | Collapse the focused node (or jump to its parent) |
 | `g` | Jump to the top |
 | `G` | Jump to the bottom |
 | `Tab`, `Shift+Tab` | Jump cursor to the next / previous trace |
 | `e` / `E` | Expand all / collapse all |
-| `p` | Toggle the JSON payload pane |
 | `/`, then text + Enter | Search rows for a substring |
 | `n` / `N` | Jump to next / previous match |
 | `Esc` | Clear active search |
@@ -73,14 +71,12 @@ agency logs view --follow path/to/run.jsonl
 A single-trace file opens with the trace expanded; multi-trace files
 open with everything collapsed.
 
-### JSON payload pane
+### Inline JSON payload
 
-Press `Enter` on a leaf to open a bottom split-pane that renders the
-event's full payload as a collapsible JSON tree (objects/arrays show
-as `▶ { 3 keys }` collapsed and expand on `l` or `Enter`). Long
-strings (with newlines or > 80 chars) collapse to a preview. The pane
-follows the focused leaf in the tree; `Esc` releases focus back to
-the tree; `p` toggles the pane.
+Press `Enter` (or `l`) on a leaf to inline its full JSON payload
+below it as gray, indented lines. Press `h` (or `Left`) to collapse
+it back. Leaves with payloads show a `▶` / `▼` glyph instead of `●`
+so the affordance is visible.
 
 ### Search
 

--- a/packages/agency-lang/lib/cli/logsView.ts
+++ b/packages/agency-lang/lib/cli/logsView.ts
@@ -4,11 +4,17 @@ import { runViewer } from "@/logsViewer/run.js";
 import { TerminalInput } from "@/tui/input/terminal.js";
 import { TerminalOutput } from "@/tui/output/terminal.js";
 
-export async function logsView(file: string): Promise<void> {
+export async function logsView(
+  file: string,
+  cliOpts: { follow?: boolean } = {},
+): Promise<void> {
   if (file === "-") {
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
     const jsonl = Buffer.concat(chunks).toString("utf8");
+    if (cliOpts.follow) {
+      console.error("--follow ignored when reading from stdin");
+    }
     await runWith(jsonl, { stdinIsPipe: true });
     return;
   }
@@ -17,12 +23,15 @@ export async function logsView(file: string): Promise<void> {
     process.exit(1);
   }
   const jsonl = fs.readFileSync(file, "utf8");
-  await runWith(jsonl, { stdinIsPipe: false });
+  await runWith(jsonl, {
+    stdinIsPipe: false,
+    followPath: cliOpts.follow ? file : undefined,
+  });
 }
 
 async function runWith(
   jsonl: string,
-  opts: { stdinIsPipe: boolean },
+  opts: { stdinIsPipe: boolean; followPath?: string },
 ): Promise<void> {
   // When stdin was used to feed the JSONL data we cannot also use it
   // for interactive keystrokes — it's been drained and isn't a TTY.
@@ -36,7 +45,7 @@ async function runWith(
     cols: process.stdout.columns ?? 80,
   };
   try {
-    await runViewer({ jsonl, input, output, viewport });
+    await runViewer({ jsonl, input, output, viewport, followPath: opts.followPath });
   } finally {
     input.destroy();
     if (output.destroy) output.destroy();

--- a/packages/agency-lang/lib/cli/logsView.ts
+++ b/packages/agency-lang/lib/cli/logsView.ts
@@ -23,15 +23,19 @@ export async function logsView(
     process.exit(1);
   }
   const jsonl = fs.readFileSync(file, "utf8");
+  // Always pass `file` as `followPath` so the user can toggle follow
+  // mode at runtime with `f`. `initialFollow` only controls whether
+  // the watcher is started immediately at boot.
   await runWith(jsonl, {
     stdinIsPipe: false,
-    followPath: cliOpts.follow ? file : undefined,
+    followPath: file,
+    initialFollow: cliOpts.follow ?? false,
   });
 }
 
 async function runWith(
   jsonl: string,
-  opts: { stdinIsPipe: boolean; followPath?: string },
+  opts: { stdinIsPipe: boolean; followPath?: string; initialFollow?: boolean },
 ): Promise<void> {
   // When stdin was used to feed the JSONL data we cannot also use it
   // for interactive keystrokes — it's been drained and isn't a TTY.
@@ -45,7 +49,14 @@ async function runWith(
     cols: process.stdout.columns ?? 80,
   };
   try {
-    await runViewer({ jsonl, input, output, viewport, followPath: opts.followPath });
+    await runViewer({
+      jsonl,
+      input,
+      output,
+      viewport,
+      followPath: opts.followPath,
+      initialFollow: opts.initialFollow ?? false,
+    });
   } finally {
     input.destroy();
     if (output.destroy) output.destroy();

--- a/packages/agency-lang/lib/config.ts
+++ b/packages/agency-lang/lib/config.ts
@@ -206,6 +206,18 @@ export interface AgencyConfig {
     };
   };
 
+  /**
+   * Visual thresholds used by `agency logs view`. Durations at or
+   * above `slowMs` (default 5000) render bright-red; durations below
+   * `fastMs` (default 100) render gray. Costs at or above
+   * `expensiveUsd` (default 0.01) render bright-red.
+   */
+  viewer?: {
+    slowMs?: number;
+    fastMs?: number;
+    expensiveUsd?: number;
+  };
+
   coverage?: {
     /** Output directory for collected coverage data (default: ".coverage") */
     outDir?: string;
@@ -299,6 +311,13 @@ export const AgencyConfigSchema = z
     distDir: z.string(),
     test: z.object({ parallel: z.number() }).partial(),
     doc: z.object({ outDir: z.string(), baseUrl: z.string() }).partial(),
+    viewer: z
+      .object({
+        slowMs: z.number(),
+        fastMs: z.number(),
+        expensiveUsd: z.number(),
+      })
+      .partial(),
     coverage: z
       .object({
         outDir: z.string(),

--- a/packages/agency-lang/lib/logsViewer/clipboard.test.ts
+++ b/packages/agency-lang/lib/logsViewer/clipboard.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { detectClipboard, resetClipboardCache } from "./clipboard.js";
+import type { SpawnSyncReturns } from "node:child_process";
+
+type SpawnArgs = { cmd: string; args: string[]; input?: string };
+
+function makeSpawn(present: string[]) {
+  const calls: SpawnArgs[] = [];
+  const fakeSpawn = (cmd: string, args?: string[], opts?: any): SpawnSyncReturns<string> => {
+    calls.push({ cmd, args: args ?? [], input: opts?.input as string | undefined });
+    if (!present.includes(cmd)) {
+      return {
+        pid: 0,
+        output: [null, "", ""],
+        stdout: "",
+        stderr: "",
+        status: null,
+        signal: null,
+        error: Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+      };
+    }
+    return {
+      pid: 1,
+      output: [null, "", ""],
+      stdout: "",
+      stderr: "",
+      status: 0,
+      signal: null,
+    };
+  };
+  return { fakeSpawn: fakeSpawn as any, calls };
+}
+
+describe("detectClipboard", () => {
+  beforeEach(() => resetClipboardCache());
+
+  it("returns null when no clipboard backend is available", () => {
+    const { fakeSpawn } = makeSpawn([]);
+    expect(detectClipboard(fakeSpawn)).toBeNull();
+  });
+
+  it("picks pbcopy when present", () => {
+    const { fakeSpawn, calls } = makeSpawn(["pbcopy"]);
+    const clip = detectClipboard(fakeSpawn);
+    expect(clip).not.toBeNull();
+    clip!.write("hello");
+    const writeCall = calls.find((c) => c.input === "hello");
+    expect(writeCall?.cmd).toBe("pbcopy");
+  });
+
+  it("picks xclip with the right args when only xclip is available", () => {
+    const { fakeSpawn, calls } = makeSpawn(["xclip"]);
+    const clip = detectClipboard(fakeSpawn);
+    expect(clip).not.toBeNull();
+    clip!.write("x");
+    const writeCall = calls.find((c) => c.input === "x");
+    expect(writeCall?.cmd).toBe("xclip");
+    expect(writeCall?.args).toEqual(["-selection", "clipboard"]);
+  });
+
+  it("caches the chosen backend across calls", () => {
+    const { fakeSpawn, calls } = makeSpawn(["pbcopy"]);
+    detectClipboard(fakeSpawn);
+    const probeCalls = calls.length;
+    detectClipboard(fakeSpawn);
+    // Second call should not re-probe.
+    expect(calls.length).toBe(probeCalls);
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/clipboard.ts
+++ b/packages/agency-lang/lib/logsViewer/clipboard.ts
@@ -1,0 +1,78 @@
+import { spawnSync, type SpawnSyncOptions } from "node:child_process";
+
+export type Clipboard = {
+  // Send `text` to the system clipboard. Throws on failure so the
+  // caller can show "clipboard unavailable" in the status bar.
+  write(text: string): void;
+};
+
+// One backend per platform we know how to drive. The first one that
+// looks runnable (i.e. `--version` exits 0) is selected at probe time.
+const BACKENDS: { cmd: string; args: string[] }[] = [
+  { cmd: "pbcopy", args: [] },
+  { cmd: "wl-copy", args: [] },
+  { cmd: "xclip", args: ["-selection", "clipboard"] },
+  { cmd: "clip.exe", args: [] },
+];
+
+// Resolved at first call; cached for the process lifetime so we don't
+// spawn a probe on every paste.
+let cached: Clipboard | null | undefined;
+
+export function detectClipboard(
+  spawn: typeof spawnSync = spawnSync,
+): Clipboard | null {
+  if (cached !== undefined) return cached;
+  for (const backend of BACKENDS) {
+    if (isRunnable(backend.cmd, spawn)) {
+      cached = makeBackend(backend.cmd, backend.args, spawn);
+      return cached;
+    }
+  }
+  cached = null;
+  return cached;
+}
+
+// Test-only: reset the cached probe result. Lets each test pick a
+// fresh backend via dependency injection.
+export function resetClipboardCache(): void {
+  cached = undefined;
+}
+
+function isRunnable(cmd: string, spawn: typeof spawnSync): boolean {
+  // `--version` is the most-supported "does this exist" probe across
+  // pbcopy / xclip / wl-copy / clip.exe. We don't care about the exit
+  // code — only whether the binary exists on PATH (which we infer
+  // from `spawnSync.error` being unset).
+  try {
+    const r = spawn(cmd, ["--version"], {
+      stdio: "ignore",
+      timeout: 1_000,
+    } satisfies SpawnSyncOptions);
+    return !r.error;
+  } catch {
+    return false;
+  }
+}
+
+function makeBackend(
+  cmd: string,
+  args: string[],
+  spawn: typeof spawnSync,
+): Clipboard {
+  return {
+    write(text: string): void {
+      const r = spawn(cmd, args, {
+        input: text,
+        stdio: ["pipe", "ignore", "pipe"],
+        timeout: 3_000,
+      } satisfies SpawnSyncOptions);
+      if (r.error) throw r.error;
+      if (r.status !== 0 && r.status !== null) {
+        throw new Error(
+          `${cmd} exited with status ${r.status}: ${r.stderr?.toString() ?? ""}`,
+        );
+      }
+    },
+  };
+}

--- a/packages/agency-lang/lib/logsViewer/conversation.test.ts
+++ b/packages/agency-lang/lib/logsViewer/conversation.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { formatConversation } from "./conversation.js";
+
+describe("formatConversation", () => {
+  it("formats a simple user/assistant exchange", () => {
+    const lines = formatConversation([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ]);
+    expect(lines).toEqual([`[user] "hi"`, `[assistant] "hello"`]);
+  });
+
+  it("formats an assistant tool call (camelCase shape)", () => {
+    const lines = formatConversation([
+      { role: "user", content: "Greet Alice using the greet tool" },
+      {
+        role: "assistant",
+        content: null,
+        toolCalls: [{ id: "x", name: "greet", arguments: { name: "Alice" } }],
+      },
+      { role: "tool", name: "greet", content: "Hello, Alice!", tool_call_id: "x" },
+      { role: "assistant", content: "Hello, Alice!" },
+    ]);
+    expect(lines).toEqual([
+      `[user] "Greet Alice using the greet tool"`,
+      `[assistant] tool call: greet({"name":"Alice"})`,
+      `[tool: greet] "Hello, Alice!"`,
+      `[assistant] "Hello, Alice!"`,
+    ]);
+  });
+
+  it("handles snake_case tool_calls and JSON-encoded arguments", () => {
+    const lines = formatConversation([
+      {
+        role: "assistant",
+        tool_calls: [
+          {
+            id: "y",
+            function: { name: "add", arguments: '{"a":1,"b":2}' },
+          },
+        ],
+      },
+    ]);
+    expect(lines).toEqual([`[assistant] tool call: add({"a":1,"b":2})`]);
+  });
+
+  it("renders an array content payload as joined text", () => {
+    const lines = formatConversation([
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "first" },
+          { type: "text", text: "second" },
+        ],
+      },
+    ]);
+    expect(lines).toEqual([`[user] "first second"`]);
+  });
+
+  it("emits a placeholder row for empty turns", () => {
+    const lines = formatConversation([{ role: "assistant", content: null }]);
+    expect(lines).toEqual([`[assistant]`]);
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/conversation.ts
+++ b/packages/agency-lang/lib/logsViewer/conversation.ts
@@ -1,0 +1,108 @@
+// Pretty-print the `messages` array on a promptCompletion event into
+// one short line per message. Used by the logs viewer to show a
+// readable conversation summary in place of the raw JSON dump.
+//
+// We intentionally keep this dependency-free and tolerant of partial
+// payloads — older statelog files may use slightly different shapes
+// for tool calls, content, etc.
+
+export type ConvoMessage = {
+  role?: string;
+  content?: unknown;
+  name?: string;
+  toolCalls?: ToolCall[];
+  tool_calls?: ToolCall[];
+  tool_call_id?: string;
+  toolCallId?: string;
+};
+
+type ToolCall = {
+  id?: string;
+  name?: string;
+  arguments?: unknown;
+  function?: { name?: string; arguments?: unknown };
+};
+
+// Returns one display string per message. A single message can become
+// multiple lines (tool calls + text content) — they're returned as a
+// flat list, in order, so the viewer can render one row per entry.
+export function formatConversation(messages: ConvoMessage[]): string[] {
+  const out: string[] = [];
+  for (const msg of messages) {
+    out.push(...formatMessage(msg));
+  }
+  return out;
+}
+
+function formatMessage(msg: ConvoMessage): string[] {
+  const role = msg.role ?? "unknown";
+  const prefix = formatRole(role, msg);
+  const lines: string[] = [];
+  const text = stringifyContent(msg.content);
+  if (text !== undefined && text.length > 0) {
+    lines.push(`${prefix} ${text}`);
+  }
+  const toolCalls = msg.toolCalls ?? msg.tool_calls ?? [];
+  for (const tc of toolCalls) {
+    lines.push(`${prefix} tool call: ${formatToolCall(tc)}`);
+  }
+  // Empty assistant turn with no text and no tool calls — still emit
+  // a row so it's visible in the conversation.
+  if (lines.length === 0) {
+    lines.push(`${prefix}`);
+  }
+  return lines;
+}
+
+function formatRole(role: string, msg: ConvoMessage): string {
+  if (role === "tool") {
+    const name = msg.name ?? "tool";
+    return `[tool: ${name}]`;
+  }
+  return `[${role}]`;
+}
+
+// Content can be a string, null, or (for some providers) a structured
+// array of content parts. Normalize to a single short string.
+function stringifyContent(content: unknown): string | undefined {
+  if (content === null || content === undefined) return undefined;
+  if (typeof content === "string") return JSON.stringify(content);
+  if (Array.isArray(content)) {
+    const parts = content
+      .map((p) => contentPartText(p))
+      .filter((s): s is string => s !== undefined);
+    if (parts.length === 0) return undefined;
+    return JSON.stringify(parts.join(" "));
+  }
+  return JSON.stringify(content);
+}
+
+function contentPartText(part: unknown): string | undefined {
+  if (typeof part === "string") return part;
+  if (part && typeof part === "object") {
+    const p = part as { text?: unknown; type?: unknown };
+    if (typeof p.text === "string") return p.text;
+  }
+  return undefined;
+}
+
+function formatToolCall(tc: ToolCall): string {
+  const name = tc.name ?? tc.function?.name ?? "?";
+  const args = tc.arguments ?? tc.function?.arguments;
+  const argText = formatArguments(args);
+  return `${name}(${argText})`;
+}
+
+function formatArguments(args: unknown): string {
+  if (args === undefined || args === null) return "";
+  if (typeof args === "string") {
+    // Some providers ship arguments as a JSON-encoded string. Try to
+    // re-parse for a tidier display; fall back to the raw string.
+    try {
+      return JSON.stringify(JSON.parse(args));
+    } catch {
+      return args;
+    }
+  }
+  return JSON.stringify(args);
+}

--- a/packages/agency-lang/lib/logsViewer/follow.test.ts
+++ b/packages/agency-lang/lib/logsViewer/follow.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { follow } from "./follow.js";
+
+function makeTempFile(initial = ""): string {
+  const p = path.join(os.tmpdir(), `follow-test-${Date.now()}-${Math.random().toString(36).slice(2)}.log`);
+  fs.writeFileSync(p, initial);
+  return p;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe("follow", () => {
+  it("emits the appended chunk when the file grows", async () => {
+    const p = makeTempFile("line1\n");
+    const chunks: string[] = [];
+    const watcher = follow({
+      path: p,
+      onAppend: (s) => chunks.push(s),
+      intervalMs: 50,
+    });
+    try {
+      fs.appendFileSync(p, "line2\nline3\n");
+      // Allow the polled watcher to notice.
+      for (let i = 0; i < 20 && chunks.length === 0; i++) await sleep(60);
+      expect(chunks.join("")).toBe("line2\nline3\n");
+    } finally {
+      watcher.stop();
+      fs.unlinkSync(p);
+    }
+  });
+
+  it("does not emit the initial file contents on startup", async () => {
+    const p = makeTempFile("preexisting\n");
+    const chunks: string[] = [];
+    const watcher = follow({
+      path: p,
+      onAppend: (s) => chunks.push(s),
+      intervalMs: 50,
+    });
+    try {
+      await sleep(200);
+      expect(chunks).toEqual([]);
+    } finally {
+      watcher.stop();
+      fs.unlinkSync(p);
+    }
+  });
+
+  it("stop() stops emitting further events", async () => {
+    const p = makeTempFile("");
+    const chunks: string[] = [];
+    const watcher = follow({
+      path: p,
+      onAppend: (s) => chunks.push(s),
+      intervalMs: 50,
+    });
+    watcher.stop();
+    try {
+      fs.appendFileSync(p, "after-stop\n");
+      await sleep(200);
+      expect(chunks).toEqual([]);
+    } finally {
+      fs.unlinkSync(p);
+    }
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/follow.ts
+++ b/packages/agency-lang/lib/logsViewer/follow.ts
@@ -1,0 +1,62 @@
+import * as fs from "node:fs";
+
+export type FollowOpts = {
+  path: string;
+  // Called whenever the file grew, with the newly-appended chunk only.
+  // The chunk is the raw bytes from the prior offset to current size.
+  onAppend: (chunk: string) => void;
+  // Poll interval. Defaults to 250ms; tests inject 50ms.
+  intervalMs?: number;
+};
+
+export type Follower = {
+  stop(): void;
+};
+
+// Watch `path` for size growth and push the appended bytes into
+// `onAppend`. We use `fs.watchFile` rather than `fs.watch` because
+// watchFile works uniformly across platforms and gives us prev/curr
+// stat objects, which is exactly what we need to compute the delta
+// range. The first callback (when the file already exists) doesn't
+// emit anything — only growth from the starting offset onward.
+export function follow(opts: FollowOpts): Follower {
+  const interval = opts.intervalMs ?? 250;
+  let offset = safeSize(opts.path);
+  let stopped = false;
+
+  const listener = (curr: fs.Stats, prev: fs.Stats): void => {
+    if (stopped) return;
+    if (curr.size <= offset) {
+      // File shrank (rotation/truncation): rewind to start and
+      // emit everything from there next tick.
+      if (curr.size < prev.size) offset = 0;
+      return;
+    }
+    const fd = fs.openSync(opts.path, "r");
+    try {
+      const length = curr.size - offset;
+      const buf = Buffer.alloc(length);
+      fs.readSync(fd, buf, 0, length, offset);
+      offset = curr.size;
+      opts.onAppend(buf.toString("utf-8"));
+    } finally {
+      fs.closeSync(fd);
+    }
+  };
+
+  fs.watchFile(opts.path, { interval }, listener);
+  return {
+    stop(): void {
+      stopped = true;
+      fs.unwatchFile(opts.path, listener);
+    },
+  };
+}
+
+function safeSize(path: string): number {
+  try {
+    return fs.statSync(path).size;
+  } catch {
+    return 0;
+  }
+}

--- a/packages/agency-lang/lib/logsViewer/help.ts
+++ b/packages/agency-lang/lib/logsViewer/help.ts
@@ -1,0 +1,65 @@
+// Help-screen content. Lives in its own module so it's easy to update
+// when new bindings land and so the help text is testable.
+
+export type BindingGroup = {
+  heading: string;
+  bindings: { keys: string; action: string }[];
+};
+
+export const HELP_GROUPS: BindingGroup[] = [
+  {
+    heading: "Navigate",
+    bindings: [
+      { keys: "j / Down / Ctrl+N", action: "next row" },
+      { keys: "k / Up / Ctrl+P", action: "previous row" },
+      { keys: "g", action: "first row" },
+      { keys: "G", action: "last row" },
+      { keys: "Tab / Shift+Tab", action: "next / previous trace" },
+    ],
+  },
+  {
+    heading: "Expand",
+    bindings: [
+      { keys: "l / Right / Enter", action: "expand or open payload pane" },
+      { keys: "h / Left", action: "collapse or go to parent" },
+      { keys: "e / E", action: "expand-all / collapse-all" },
+      { keys: "p", action: "toggle payload pane" },
+    ],
+  },
+  {
+    heading: "Search",
+    bindings: [
+      { keys: "/", action: "search prompt" },
+      { keys: "n", action: "next match" },
+      { keys: "N", action: "previous match" },
+      { keys: "Esc", action: "clear search / release focus" },
+    ],
+  },
+  {
+    heading: "Inspect",
+    bindings: [
+      { keys: "y", action: "copy JSON of focused node to clipboard" },
+    ],
+  },
+  {
+    heading: "Modes",
+    bindings: [
+      { keys: "f", action: "toggle follow mode" },
+      { keys: "?", action: "toggle this help" },
+      { keys: "q / Ctrl+C", action: "quit" },
+    ],
+  },
+];
+
+export function helpLines(): string[] {
+  const lines: string[] = [];
+  for (const group of HELP_GROUPS) {
+    lines.push(`${group.heading}:`);
+    for (const b of group.bindings) {
+      lines.push(`  ${b.keys.padEnd(22)} ${b.action}`);
+    }
+    lines.push("");
+  }
+  lines.push("Press any key to close.");
+  return lines;
+}

--- a/packages/agency-lang/lib/logsViewer/help.ts
+++ b/packages/agency-lang/lib/logsViewer/help.ts
@@ -20,10 +20,9 @@ export const HELP_GROUPS: BindingGroup[] = [
   {
     heading: "Expand",
     bindings: [
-      { keys: "l / Right / Enter", action: "expand or open payload pane" },
+      { keys: "l / Right / Enter", action: "expand — leaves inline their JSON payload" },
       { keys: "h / Left", action: "collapse or go to parent" },
       { keys: "e / E", action: "expand-all / collapse-all" },
-      { keys: "p", action: "toggle payload pane" },
     ],
   },
   {

--- a/packages/agency-lang/lib/logsViewer/help.ts
+++ b/packages/agency-lang/lib/logsViewer/help.ts
@@ -14,6 +14,8 @@ export const HELP_GROUPS: BindingGroup[] = [
       { keys: "k / Up / Ctrl+P", action: "previous row" },
       { keys: "g", action: "first row" },
       { keys: "G", action: "last row" },
+      { keys: "Ctrl+F / Ctrl+B / PageDown / PageUp", action: "page down / up" },
+      { keys: "Ctrl+D / Ctrl+U", action: "half page down / up" },
       { keys: "Tab / Shift+Tab", action: "next / previous trace" },
     ],
   },

--- a/packages/agency-lang/lib/logsViewer/input.test.ts
+++ b/packages/agency-lang/lib/logsViewer/input.test.ts
@@ -114,4 +114,72 @@ describe("handleKey", () => {
     const next = handleKey(initial("trace-t"), k("down"));
     expect(next.cursorId).toBe("a");
   });
+
+  it("e expands every span and trace in the forest", () => {
+    // child 'a' has a grandchild so expanding everything reveals it.
+    const state = initial("trace-t");
+    const a = state.roots[0].children[0];
+    a.children = [
+      {
+        id: "a-child",
+        traceId: "t",
+        parentId: "a",
+        children: [],
+        nodeKind: "event",
+        label: "debug",
+        summary: "debug",
+      },
+    ];
+    const next = handleKey(state, k("e"));
+    expect(next.expanded.has("trace-t")).toBe(true);
+    expect(next.expanded.has("a")).toBe(true);
+    expect(next.expanded.has("b")).toBe(true);
+  });
+
+  it("E collapses everything, auto-expanding the lone trace", () => {
+    const state = initial("a");
+    state.expanded = new Set(["trace-t", "a", "b"]);
+    const next = handleKey(state, k("E"));
+    expect(next.expanded.has("a")).toBe(false);
+    expect(next.expanded.has("b")).toBe(false);
+    expect(next.expanded.has("trace-t")).toBe(true); // lone trace stays expanded
+  });
+
+  it("Tab cycles to the next trace root", () => {
+    const state: ViewerState = {
+      roots: [
+        { ...child("t1"), id: "t1", nodeKind: "trace", traceId: "t1", parentId: null, summary: "t1" },
+        { ...child("t2"), id: "t2", nodeKind: "trace", traceId: "t2", parentId: null, summary: "t2" },
+        { ...child("t3"), id: "t3", nodeKind: "trace", traceId: "t3", parentId: null, summary: "t3" },
+      ],
+      expanded: new Set(),
+      cursorId: "t1",
+      scrollTop: 0,
+      quit: false,
+    };
+    const next = handleKey(state, k("tab"));
+    expect(next.cursorId).toBe("t2");
+    const wrapped = handleKey({ ...state, cursorId: "t3" }, k("tab"));
+    expect(wrapped.cursorId).toBe("t1");
+  });
+
+  it("Shift+Tab cycles to the previous trace root", () => {
+    const state: ViewerState = {
+      roots: [
+        { ...child("t1"), id: "t1", nodeKind: "trace", traceId: "t1", parentId: null, summary: "t1" },
+        { ...child("t2"), id: "t2", nodeKind: "trace", traceId: "t2", parentId: null, summary: "t2" },
+      ],
+      expanded: new Set(),
+      cursorId: "t1",
+      scrollTop: 0,
+      quit: false,
+    };
+    const next = handleKey(state, k("tab", { shift: true }));
+    expect(next.cursorId).toBe("t2"); // wraps backwards
+  });
+
+  it("Tab is a no-op when there is only one trace", () => {
+    const state = initial();
+    expect(handleKey(state, k("tab"))).toBe(state);
+  });
 });

--- a/packages/agency-lang/lib/logsViewer/input.ts
+++ b/packages/agency-lang/lib/logsViewer/input.ts
@@ -1,4 +1,4 @@
-import { ViewerState } from "./types.js";
+import { ViewerState, TreeNode } from "./types.js";
 import { flattenVisibleRows, VisibleRow } from "./render.js";
 import type { KeyEvent } from "../tui/input/types.js";
 import { formatKey } from "../tui/input/format.js";
@@ -30,12 +30,73 @@ export function handleKey(state: ViewerState, event: KeyEvent): ViewerState {
     case "h":
     case "Left":
       return collapseOrParent(state, rows, idx);
+    case "e":
+      return expandAll(state);
+    case "E":
+      return collapseAll(state);
+    case "Tab":
+      return cycleTrace(state, +1);
+    case "Shift+Tab":
+      return cycleTrace(state, -1);
     case "q":
     case "Ctrl+C":
       return { ...state, quit: true };
     default:
       return state;
   }
+}
+
+// Expand every span and trace in the forest. Leaves stay leaves.
+function expandAll(state: ViewerState): ViewerState {
+  const next = new Set(state.expanded);
+  const walk = (node: TreeNode): void => {
+    if (node.nodeKind !== "event") next.add(node.id);
+    for (const c of node.children) walk(c);
+  };
+  for (const r of state.roots) walk(r);
+  return { ...state, expanded: next };
+}
+
+// Collapse everything. Per the v1 default-expand-only-trace rule,
+// auto-expand the lone trace when there is exactly one — keeps the
+// "press E to see the top-level view" behavior intuitive.
+function collapseAll(state: ViewerState): ViewerState {
+  const onlyTrace = state.roots.length === 1 ? state.roots[0].id : undefined;
+  const expanded = new Set<string>();
+  if (onlyTrace !== undefined) expanded.add(onlyTrace);
+  // Keep the cursor on something visible; if its node is now hidden,
+  // move it to the trace root containing it (or the first trace).
+  const cursorTraceRoot = traceRootOf(state.roots, state.cursorId);
+  const cursorId = expanded.has(state.cursorId)
+    ? state.cursorId
+    : cursorTraceRoot ?? state.roots[0]?.id ?? state.cursorId;
+  return { ...state, expanded, cursorId, scrollTop: 0 };
+}
+
+// Move the cursor to the previous/next trace root, wrapping at the
+// edges. No-op when there's only one trace.
+function cycleTrace(state: ViewerState, direction: 1 | -1): ViewerState {
+  const traceIds = state.roots.map((r) => r.id);
+  if (traceIds.length <= 1) return state;
+  const cur = traceRootOf(state.roots, state.cursorId);
+  const startIdx = cur ? traceIds.indexOf(cur) : -1;
+  const nextIdx = (startIdx + direction + traceIds.length) % traceIds.length;
+  return { ...state, cursorId: traceIds[nextIdx] };
+}
+
+function traceRootOf(roots: TreeNode[], id: string): string | undefined {
+  for (const r of roots) {
+    if (containsId(r, id)) return r.id;
+  }
+  return undefined;
+}
+
+function containsId(node: TreeNode, id: string): boolean {
+  if (node.id === id) return true;
+  for (const c of node.children) {
+    if (containsId(c, id)) return true;
+  }
+  return false;
 }
 
 function moveCursor(

--- a/packages/agency-lang/lib/logsViewer/input.ts
+++ b/packages/agency-lang/lib/logsViewer/input.ts
@@ -3,6 +3,59 @@ import { flattenVisibleRows, VisibleRow } from "./render.js";
 import type { KeyEvent } from "../tui/input/types.js";
 import { formatKey } from "../tui/input/format.js";
 
+// Signals from the input layer back to the run loop. `requestSearch`
+// asks the loop to open the line-prompt for `/`. `requestCopy` asks
+// it to shell out to the clipboard. Pure reducers can't do either on
+// their own.
+export type ViewerCommand =
+  | { kind: "search" }
+  | { kind: "copy" }
+  | { kind: "toggleFollow" };
+
+export type HandleKeyResult = {
+  state: ViewerState;
+  command?: ViewerCommand;
+};
+
+export function handleKeyEx(
+  state: ViewerState,
+  event: KeyEvent,
+): HandleKeyResult {
+  // Help overlay swallows the next keystroke — any key closes it.
+  if (state.helpOpen) {
+    return { state: { ...state, helpOpen: false } };
+  }
+  // Any keystroke clears a transient status message.
+  const cleared = state.messageBar ? { ...state, messageBar: undefined } : state;
+  const fmt = formatKey(event);
+  // Enter on a leaf opens the JSON pane and grabs focus, instead of
+  // the no-op the default reducer would do (leaves can't expand).
+  if (fmt === "Enter" || fmt === "l" || fmt === "Right") {
+    const cursor = findCursorNode(cleared);
+    if (cursor && cursor.nodeKind === "event") {
+      return {
+        state: { ...cleared, jsonPaneOpen: true, pane: "json" },
+      };
+    }
+  }
+  const next = handleKey(cleared, event);
+  // Promote special keys into commands the run loop has to action.
+  if (fmt === "/") return { state: next, command: { kind: "search" } };
+  if (fmt === "y") return { state: next, command: { kind: "copy" } };
+  if (fmt === "f") return { state: next, command: { kind: "toggleFollow" } };
+  return { state: next };
+}
+
+function findCursorNode(state: ViewerState): TreeNode | undefined {
+  const stack: TreeNode[] = [...state.roots];
+  while (stack.length > 0) {
+    const n = stack.pop()!;
+    if (n.id === state.cursorId) return n;
+    for (const c of n.children) stack.push(c);
+  }
+  return undefined;
+}
+
 export function handleKey(state: ViewerState, event: KeyEvent): ViewerState {
   const rows = flattenVisibleRows(state);
   if (rows.length === 0) return state;
@@ -38,12 +91,36 @@ export function handleKey(state: ViewerState, event: KeyEvent): ViewerState {
       return cycleTrace(state, +1);
     case "Shift+Tab":
       return cycleTrace(state, -1);
+    case "n":
+      return jumpMatch(state, +1);
+    case "N":
+      return jumpMatch(state, -1);
+    case "p":
+      return { ...state, jsonPaneOpen: !state.jsonPaneOpen };
+    case "Escape":
+      return clearSearch(state);
+    case "?":
+      return { ...state, helpOpen: true };
     case "q":
     case "Ctrl+C":
       return { ...state, quit: true };
     default:
       return state;
   }
+}
+
+// Jump cursor to next/previous match. Wraps. No-op if no active query.
+function jumpMatch(state: ViewerState, direction: 1 | -1): ViewerState {
+  const matches = state.matches ?? [];
+  if (matches.length === 0) return state;
+  const cur = state.matchIdx ?? -1;
+  const next = (cur + direction + matches.length) % matches.length;
+  return { ...state, matchIdx: next, cursorId: matches[next] };
+}
+
+function clearSearch(state: ViewerState): ViewerState {
+  if (!state.query && !state.matches?.length) return state;
+  return { ...state, query: undefined, matches: undefined, matchIdx: undefined };
 }
 
 // Expand every span and trace in the forest. Leaves stay leaves.

--- a/packages/agency-lang/lib/logsViewer/input.ts
+++ b/packages/agency-lang/lib/logsViewer/input.ts
@@ -170,11 +170,16 @@ function expand(
 ): ViewerState {
   if (idx < 0) return state;
   const node = rows[idx].node;
-  // jsonLine rows aren't expandable and have no children to descend
-  // into; leave them alone.
-  if (node.nodeKind === "jsonLine") return state;
+  // Synthetic text rows aren't expandable and have no children to
+  // descend into; leave them alone.
+  if (node.nodeKind === "jsonLine" || node.nodeKind === "convoLine") {
+    return state;
+  }
   const isLeafWithPayload = node.nodeKind === "event" && !!node.event;
-  if (node.children.length === 0 && !isLeafWithPayload) return state;
+  const isRawToggle = node.nodeKind === "rawDataToggle";
+  if (node.children.length === 0 && !isLeafWithPayload && !isRawToggle) {
+    return state;
+  }
   // If the node is already expanded, descend into its first child
   // (only for true tree nodes — leaves' "children" are synthetic
   // jsonLine rows that aren't worth landing the cursor on first).

--- a/packages/agency-lang/lib/logsViewer/input.ts
+++ b/packages/agency-lang/lib/logsViewer/input.ts
@@ -28,32 +28,12 @@ export function handleKeyEx(
   // Any keystroke clears a transient status message.
   const cleared = state.messageBar ? { ...state, messageBar: undefined } : state;
   const fmt = formatKey(event);
-  // Enter on a leaf opens the JSON pane and grabs focus, instead of
-  // the no-op the default reducer would do (leaves can't expand).
-  if (fmt === "Enter" || fmt === "l" || fmt === "Right") {
-    const cursor = findCursorNode(cleared);
-    if (cursor && cursor.nodeKind === "event") {
-      return {
-        state: { ...cleared, jsonPaneOpen: true, pane: "json" },
-      };
-    }
-  }
   const next = handleKey(cleared, event);
   // Promote special keys into commands the run loop has to action.
   if (fmt === "/") return { state: next, command: { kind: "search" } };
   if (fmt === "y") return { state: next, command: { kind: "copy" } };
   if (fmt === "f") return { state: next, command: { kind: "toggleFollow" } };
   return { state: next };
-}
-
-function findCursorNode(state: ViewerState): TreeNode | undefined {
-  const stack: TreeNode[] = [...state.roots];
-  while (stack.length > 0) {
-    const n = stack.pop()!;
-    if (n.id === state.cursorId) return n;
-    for (const c of n.children) stack.push(c);
-  }
-  return undefined;
 }
 
 export function handleKey(state: ViewerState, event: KeyEvent): ViewerState {
@@ -95,8 +75,6 @@ export function handleKey(state: ViewerState, event: KeyEvent): ViewerState {
       return jumpMatch(state, +1);
     case "N":
       return jumpMatch(state, -1);
-    case "p":
-      return { ...state, jsonPaneOpen: !state.jsonPaneOpen };
     case "Escape":
       return clearSearch(state);
     case "?":
@@ -192,10 +170,19 @@ function expand(
 ): ViewerState {
   if (idx < 0) return state;
   const node = rows[idx].node;
-  if (node.children.length === 0) return state;
-  // If the node is already expanded, descend into its first child.
+  // jsonLine rows aren't expandable and have no children to descend
+  // into; leave them alone.
+  if (node.nodeKind === "jsonLine") return state;
+  const isLeafWithPayload = node.nodeKind === "event" && !!node.event;
+  if (node.children.length === 0 && !isLeafWithPayload) return state;
+  // If the node is already expanded, descend into its first child
+  // (only for true tree nodes — leaves' "children" are synthetic
+  // jsonLine rows that aren't worth landing the cursor on first).
   if (state.expanded.has(node.id)) {
-    return { ...state, cursorId: node.children[0].id };
+    if (node.children.length > 0) {
+      return { ...state, cursorId: node.children[0].id };
+    }
+    return state;
   }
   const next = new Set(state.expanded);
   next.add(node.id);

--- a/packages/agency-lang/lib/logsViewer/jsonView/build.test.ts
+++ b/packages/agency-lang/lib/logsViewer/jsonView/build.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { buildJsonTree, isLongString } from "./build.js";
+
+describe("buildJsonTree", () => {
+  it("classifies primitives by value type", () => {
+    expect(buildJsonTree("hi")).toEqual({
+      kind: "primitive",
+      path: "$",
+      valueType: "string",
+      raw: '"hi"',
+    });
+    expect(buildJsonTree(42)).toEqual({
+      kind: "primitive",
+      path: "$",
+      valueType: "number",
+      raw: "42",
+    });
+    expect(buildJsonTree(true)).toEqual({
+      kind: "primitive",
+      path: "$",
+      valueType: "boolean",
+      raw: "true",
+    });
+    expect(buildJsonTree(null)).toEqual({
+      kind: "primitive",
+      path: "$",
+      valueType: "null",
+      raw: "null",
+    });
+  });
+
+  it("preserves insertion order in objects", () => {
+    const node = buildJsonTree({ z: 1, a: 2, m: 3 });
+    expect(node.kind).toBe("object");
+    if (node.kind !== "object") return;
+    expect(node.entries.map((e) => e.key)).toEqual(["z", "a", "m"]);
+  });
+
+  it("recurses into arrays with index-based paths", () => {
+    const node = buildJsonTree([10, 20, 30]);
+    expect(node.kind).toBe("array");
+    if (node.kind !== "array") return;
+    expect(node.items).toHaveLength(3);
+    expect(node.items[0].path).toBe("$[0]");
+    expect(node.items[2].path).toBe("$[2]");
+  });
+
+  it("recurses into nested objects with dotted paths", () => {
+    const node = buildJsonTree({ usage: { inputTokens: 100 } });
+    if (node.kind !== "object") throw new Error("not an object");
+    const usage = node.entries[0].child;
+    if (usage.kind !== "object") throw new Error("not an object");
+    expect(usage.path).toBe("$.usage");
+    expect(usage.entries[0].child.path).toBe("$.usage.inputTokens");
+  });
+
+  it("classifies strings with newlines as longString", () => {
+    const node = buildJsonTree("hello\nworld");
+    expect(node.kind).toBe("longString");
+  });
+
+  it("classifies strings longer than 80 chars as longString", () => {
+    const node = buildJsonTree("a".repeat(100));
+    expect(node.kind).toBe("longString");
+  });
+
+  it("classifies short single-line strings as primitive", () => {
+    const node = buildJsonTree("short");
+    expect(node.kind).toBe("primitive");
+  });
+
+  it("handles deeply-nested structures", () => {
+    const node = buildJsonTree({ a: { b: { c: { d: 1 } } } });
+    if (node.kind !== "object") throw new Error("not an object");
+    expect(node.entries[0].child.path).toBe("$.a");
+  });
+
+  it("formats numbers like JSON would (no exponential)", () => {
+    expect(buildJsonTree(0.000234).raw).toBe("0.000234");
+  });
+
+  it("treats NaN/Infinity as null per JSON convention", () => {
+    expect(buildJsonTree(NaN).raw).toBe("null");
+    expect(buildJsonTree(Infinity).raw).toBe("null");
+  });
+});
+
+describe("isLongString", () => {
+  it("returns true for strings with newlines", () => {
+    expect(isLongString("a\nb")).toBe(true);
+  });
+  it("returns true for strings over 80 chars", () => {
+    expect(isLongString("a".repeat(81))).toBe(true);
+  });
+  it("returns false for short single-line strings", () => {
+    expect(isLongString("hello world")).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/jsonView/build.test.ts
+++ b/packages/agency-lang/lib/logsViewer/jsonView/build.test.ts
@@ -76,12 +76,18 @@ describe("buildJsonTree", () => {
   });
 
   it("formats numbers like JSON would (no exponential)", () => {
-    expect(buildJsonTree(0.000234).raw).toBe("0.000234");
+    const node = buildJsonTree(0.000234);
+    if (node.kind !== "primitive") throw new Error("not primitive");
+    expect(node.raw).toBe("0.000234");
   });
 
   it("treats NaN/Infinity as null per JSON convention", () => {
-    expect(buildJsonTree(NaN).raw).toBe("null");
-    expect(buildJsonTree(Infinity).raw).toBe("null");
+    const nan = buildJsonTree(NaN);
+    if (nan.kind !== "primitive") throw new Error("not primitive");
+    expect(nan.raw).toBe("null");
+    const inf = buildJsonTree(Infinity);
+    if (inf.kind !== "primitive") throw new Error("not primitive");
+    expect(inf.raw).toBe("null");
   });
 });
 

--- a/packages/agency-lang/lib/logsViewer/jsonView/build.test.ts
+++ b/packages/agency-lang/lib/logsViewer/jsonView/build.test.ts
@@ -75,6 +75,17 @@ describe("buildJsonTree", () => {
     expect(node.entries[0].child.path).toBe("$.a");
   });
 
+  it("treats undefined values as null instead of crashing", () => {
+    // Real payloads sometimes carry `undefined` for missing fields;
+    // we must not blow up on `Object.entries(undefined)` deeper in.
+    const node = buildJsonTree({ a: undefined, b: { c: undefined } });
+    if (node.kind !== "object") throw new Error("expected object");
+    const a = node.entries[0].child;
+    if (a.kind !== "primitive") throw new Error("expected primitive");
+    expect(a.valueType).toBe("null");
+    expect(a.raw).toBe("null");
+  });
+
   it("formats numbers like JSON would (no exponential)", () => {
     const node = buildJsonTree(0.000234);
     if (node.kind !== "primitive") throw new Error("not primitive");

--- a/packages/agency-lang/lib/logsViewer/jsonView/build.ts
+++ b/packages/agency-lang/lib/logsViewer/jsonView/build.ts
@@ -1,0 +1,70 @@
+import { JsonNode, LONG_STRING_THRESHOLD } from "./types.js";
+
+// Walk the JSON value once and produce a tree of JsonNodes. Each node
+// gets a deterministic path string derived from how we reached it
+// (`$.usage.inputTokens`, `$[0]`, ...). The path is used by the
+// renderer as the key into the "open" set, so it must stay stable
+// across rebuilds.
+export function buildJsonTree(value: unknown, path = "$"): JsonNode {
+  if (value === null) {
+    return { kind: "primitive", path, valueType: "null", raw: "null" };
+  }
+  if (typeof value === "string") {
+    if (isLongString(value)) {
+      return { kind: "longString", path, raw: value };
+    }
+    return {
+      kind: "primitive",
+      path,
+      valueType: "string",
+      raw: JSON.stringify(value),
+    };
+  }
+  if (typeof value === "number") {
+    return {
+      kind: "primitive",
+      path,
+      valueType: "number",
+      raw: formatNumber(value),
+    };
+  }
+  if (typeof value === "boolean") {
+    return {
+      kind: "primitive",
+      path,
+      valueType: "boolean",
+      raw: value ? "true" : "false",
+    };
+  }
+  if (Array.isArray(value)) {
+    return {
+      kind: "array",
+      path,
+      items: value.map((item, i) => buildJsonTree(item, `${path}[${i}]`)),
+    };
+  }
+  // Object — preserve insertion order via Object.entries.
+  return {
+    kind: "object",
+    path,
+    entries: Object.entries(value as Record<string, unknown>).map(
+      ([key, child]) => ({
+        key,
+        child: buildJsonTree(child, `${path}.${key}`),
+      }),
+    ),
+  };
+}
+
+export function isLongString(s: string): boolean {
+  if (s.includes("\n")) return true;
+  return s.length > LONG_STRING_THRESHOLD;
+}
+
+// Print numbers as JSON would. Avoid Number.toString()'s exponential
+// notation for very small/large floats — match what `JSON.stringify`
+// produces for parity with the on-wire format.
+function formatNumber(n: number): string {
+  if (Number.isNaN(n) || !Number.isFinite(n)) return "null";
+  return JSON.stringify(n);
+}

--- a/packages/agency-lang/lib/logsViewer/jsonView/build.ts
+++ b/packages/agency-lang/lib/logsViewer/jsonView/build.ts
@@ -6,7 +6,10 @@ import { JsonNode, LONG_STRING_THRESHOLD } from "./types.js";
 // renderer as the key into the "open" set, so it must stay stable
 // across rebuilds.
 export function buildJsonTree(value: unknown, path = "$"): JsonNode {
-  if (value === null) {
+  // `undefined` is not valid JSON but turns up routinely in real
+  // payloads (optional fields, dropped keys, etc.). Treat it as null
+  // so the renderer doesn't crash on `Object.entries(undefined)`.
+  if (value === null || value === undefined) {
     return { kind: "primitive", path, valueType: "null", raw: "null" };
   }
   if (typeof value === "string") {

--- a/packages/agency-lang/lib/logsViewer/jsonView/input.test.ts
+++ b/packages/agency-lang/lib/logsViewer/jsonView/input.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { buildJsonTree } from "./build.js";
+import { defaultOpenSet } from "./render.js";
+import { handlePaneKey, JsonPaneState, flattenJsonRows } from "./input.js";
+import type { KeyEvent } from "../../tui/input/types.js";
+
+const k = (key: string, mods: Partial<KeyEvent> = {}): KeyEvent => ({
+  key,
+  ...mods,
+});
+
+function makeState(value: unknown, cursorPath = "$"): JsonPaneState {
+  const root = buildJsonTree(value);
+  return {
+    root,
+    open: defaultOpenSet(root),
+    cursorPath,
+    scrollTop: 0,
+    releaseFocus: false,
+  };
+}
+
+describe("handlePaneKey", () => {
+  it("j moves cursor down to the next visible row", () => {
+    const state = makeState({ a: 1, b: 2 });
+    const next = handlePaneKey(state, k("j"));
+    expect(next.cursorPath).toBe("$.a");
+  });
+
+  it("k moves cursor up", () => {
+    const state = makeState({ a: 1, b: 2 }, "$.b");
+    const next = handlePaneKey(state, k("k"));
+    expect(next.cursorPath).toBe("$.a");
+  });
+
+  it("l on a closed container opens it", () => {
+    const state = makeState({ a: { x: Array.from({ length: 20 }, (_, i) => i) } }, "$.a.x");
+    expect(state.open.has("$.a.x")).toBe(false);
+    const next = handlePaneKey(state, k("l"));
+    expect(next.open.has("$.a.x")).toBe(true);
+  });
+
+  it("l on an already-open container descends to first child", () => {
+    const state = makeState({ a: { x: 1, y: 2 } }, "$.a");
+    expect(state.open.has("$.a")).toBe(true);
+    const next = handlePaneKey(state, k("l"));
+    expect(next.cursorPath).toBe("$.a.x");
+  });
+
+  it("h on an open container closes it", () => {
+    const state = makeState({ a: { x: 1 } }, "$.a");
+    expect(state.open.has("$.a")).toBe(true);
+    const next = handlePaneKey(state, k("h"));
+    expect(next.open.has("$.a")).toBe(false);
+  });
+
+  it("h on a closed container moves cursor to parent", () => {
+    const state = makeState({ a: { x: 1, y: 2 } }, "$.a");
+    // First close it.
+    const closed: JsonPaneState = { ...state, open: new Set(["$"]) };
+    const next = handlePaneKey(closed, k("h"));
+    expect(next.cursorPath).toBe("$");
+  });
+
+  it("g jumps to the first row", () => {
+    const state = makeState({ a: 1, b: 2 }, "$.b");
+    const next = handlePaneKey(state, k("g"));
+    expect(next.cursorPath).toBe("$");
+  });
+
+  it("G jumps to the last visible row", () => {
+    const state = makeState({ a: 1, b: 2 });
+    const next = handlePaneKey(state, k("G"));
+    const rows = flattenJsonRows(state);
+    expect(next.cursorPath).toBe(rows[rows.length - 1]);
+  });
+
+  it("Escape sets releaseFocus so the run loop hands focus back", () => {
+    const state = makeState({ a: 1 });
+    const next = handlePaneKey(state, k("escape"));
+    expect(next.releaseFocus).toBe(true);
+  });
+
+  it("ignores unrelated keys", () => {
+    const state = makeState({ a: 1 });
+    const next = handlePaneKey(state, k("z"));
+    expect(next).toBe(state);
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/jsonView/input.ts
+++ b/packages/agency-lang/lib/logsViewer/jsonView/input.ts
@@ -1,0 +1,133 @@
+import type { KeyEvent } from "../../tui/input/types.js";
+import { formatKey } from "../../tui/input/format.js";
+import { JsonNode } from "./types.js";
+import { renderJson } from "./render.js";
+
+// The pane's own state: which paths are open, where the cursor is,
+// and how far we've scrolled. Owned by the outer ViewerState; this
+// module only knows how to mutate it.
+export type JsonPaneState = {
+  root: JsonNode;
+  open: Set<string>;
+  cursorPath: string;
+  scrollTop: number;
+  // Set to true when Esc was pressed so the run loop knows to hand
+  // focus back to the outer tree.
+  releaseFocus: boolean;
+};
+
+// Compute the cursor-eligible paths in display order. We pin focus
+// onto whatever the renderer emits a `> `-eligible line for: every
+// node owns one such line. We re-derive this from the tree + open
+// state instead of caching to keep the state shape narrow.
+export function flattenJsonRows(state: JsonPaneState): string[] {
+  return renderJson(state.root, { open: state.open, cursorPath: state.cursorPath })
+    .map((l) => l.ownerPath)
+    // Each container produces an open AND a close line with the
+    // same ownerPath; the cursor is allowed only on the first
+    // appearance (the open line).
+    .filter((p, i, arr) => arr.indexOf(p) === i);
+}
+
+export function handlePaneKey(
+  state: JsonPaneState,
+  event: KeyEvent,
+): JsonPaneState {
+  const rows = flattenJsonRows(state);
+  if (rows.length === 0) return state;
+  const idx = Math.max(0, rows.indexOf(state.cursorPath));
+  switch (formatKey(event)) {
+    case "j":
+    case "Down":
+      return moveCursor(state, rows, Math.min(idx + 1, rows.length - 1));
+    case "k":
+    case "Up":
+      return moveCursor(state, rows, Math.max(idx - 1, 0));
+    case "g":
+      return { ...state, cursorPath: rows[0], scrollTop: 0 };
+    case "G":
+      return moveCursor(state, rows, rows.length - 1);
+    case "l":
+    case "Right":
+    case "Enter":
+      return expand(state);
+    case "h":
+    case "Left":
+      return collapseOrParent(state);
+    case "Escape":
+      return { ...state, releaseFocus: true };
+    default:
+      return state;
+  }
+}
+
+function moveCursor(
+  state: JsonPaneState,
+  rows: string[],
+  newIdx: number,
+): JsonPaneState {
+  if (newIdx < 0 || newIdx >= rows.length) return state;
+  return { ...state, cursorPath: rows[newIdx] };
+}
+
+function expand(state: JsonPaneState): JsonPaneState {
+  const node = findByPath(state.root, state.cursorPath);
+  if (!node || !canExpand(node)) return state;
+  if (state.open.has(node.path)) {
+    // Already open: descend into the first child.
+    const first = firstChildPath(node);
+    return first ? { ...state, cursorPath: first } : state;
+  }
+  const open = new Set(state.open);
+  open.add(node.path);
+  return { ...state, open };
+}
+
+function collapseOrParent(state: JsonPaneState): JsonPaneState {
+  const node = findByPath(state.root, state.cursorPath);
+  if (!node) return state;
+  if (state.open.has(node.path)) {
+    const open = new Set(state.open);
+    open.delete(node.path);
+    return { ...state, open };
+  }
+  const parent = parentPath(node.path);
+  return parent ? { ...state, cursorPath: parent } : state;
+}
+
+function canExpand(node: JsonNode): boolean {
+  return node.kind === "object" || node.kind === "array" || node.kind === "longString";
+}
+
+function firstChildPath(node: JsonNode): string | undefined {
+  if (node.kind === "object" && node.entries.length > 0) {
+    return node.entries[0].child.path;
+  }
+  if (node.kind === "array" && node.items.length > 0) {
+    return node.items[0].path;
+  }
+  return undefined;
+}
+
+function parentPath(path: string): string | undefined {
+  if (path === "$") return undefined;
+  // Strip the last "[...]" or ".key" segment.
+  const m = path.match(/^(.*)(\.[^.\[]+|\[\d+\])$/);
+  return m ? m[1] : undefined;
+}
+
+export function findByPath(root: JsonNode, path: string): JsonNode | undefined {
+  if (root.path === path) return root;
+  if (root.kind === "object") {
+    for (const { child } of root.entries) {
+      const hit = findByPath(child, path);
+      if (hit) return hit;
+    }
+  } else if (root.kind === "array") {
+    for (const item of root.items) {
+      const hit = findByPath(item, path);
+      if (hit) return hit;
+    }
+  }
+  return undefined;
+}

--- a/packages/agency-lang/lib/logsViewer/jsonView/render.test.ts
+++ b/packages/agency-lang/lib/logsViewer/jsonView/render.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { buildJsonTree } from "./build.js";
+import {
+  renderJson,
+  lineToText,
+  defaultOpenSet,
+} from "./render.js";
+
+describe("renderJson", () => {
+  it("renders a collapsed object as one line with key count", () => {
+    const tree = buildJsonTree({ a: 1, b: 2 });
+    const lines = renderJson(tree, { open: new Set() });
+    expect(lines).toHaveLength(1);
+    expect(lineToText(lines[0])).toMatch(/\{\s*2 keys\s*\}/);
+    expect(lineToText(lines[0])).toMatch(/▶/);
+  });
+
+  it("renders an expanded object as one line per key plus braces", () => {
+    const tree = buildJsonTree({ a: 1 });
+    const lines = renderJson(tree, { open: new Set(["$"]) });
+    expect(lines.map(lineToText)).toEqual([
+      expect.stringMatching(/▼ \{/),
+      expect.stringMatching(/"a":\s+1$/),
+      expect.stringMatching(/\}$/),
+    ]);
+  });
+
+  it("renders an expanded array as one item per line plus brackets", () => {
+    const tree = buildJsonTree([10, 20]);
+    const lines = renderJson(tree, { open: new Set(["$"]) });
+    expect(lines.map(lineToText)).toEqual([
+      expect.stringMatching(/▼ \[/),
+      expect.stringMatching(/^\s+>?\s*10,$/m),
+      expect.stringMatching(/^\s+>?\s*20$/m),
+      expect.stringMatching(/\]$/),
+    ]);
+  });
+
+  it("assigns the documented foreground color per primitive type", () => {
+    const tree = buildJsonTree({ s: "x", n: 1, b: true, z: null });
+    const lines = renderJson(tree, { open: new Set(["$"]) });
+    const segByText = (txt: string) =>
+      lines.flatMap((l) => l.segments).find((s) => s.text === txt);
+    expect(segByText('"x"')?.fg).toBe("bright-green");
+    expect(segByText("1")?.fg).toBe("bright-cyan");
+    expect(segByText("true")?.fg).toBe("bright-magenta");
+    expect(segByText("null")?.fg).toBe("gray");
+  });
+
+  it("colors object keys as bright-white", () => {
+    const tree = buildJsonTree({ k: 1 });
+    const lines = renderJson(tree, { open: new Set(["$"]) });
+    const keySeg = lines
+      .flatMap((l) => l.segments)
+      .find((s) => s.text.includes('"k"'));
+    expect(keySeg?.fg).toBe("bright-white");
+  });
+
+  it("renders a longString collapsed with a preview and length", () => {
+    const tree = buildJsonTree("a".repeat(200));
+    const lines = renderJson(tree, { open: new Set() });
+    expect(lines).toHaveLength(1);
+    expect(lineToText(lines[0])).toMatch(/▶/);
+    expect(lineToText(lines[0])).toMatch(/\(200 chars\)/);
+  });
+
+  it("renders a longString expanded across multiple lines", () => {
+    const tree = buildJsonTree("hello\nworld");
+    const lines = renderJson(tree, { open: new Set(["$"]) });
+    expect(lines.length).toBeGreaterThanOrEqual(3);
+    expect(lineToText(lines[0])).toMatch(/▼/);
+  });
+
+  it("places a > marker on the cursor row", () => {
+    const tree = buildJsonTree({ a: { b: 1 } });
+    const lines = renderJson(tree, {
+      open: new Set(["$", "$.a"]),
+      cursorPath: "$.a",
+    });
+    const cursorLine = lines.find((l) => lineToText(l).startsWith("> "));
+    expect(cursorLine).toBeDefined();
+    expect(lineToText(cursorLine!)).toMatch(/"a":/);
+  });
+});
+
+describe("defaultOpenSet", () => {
+  it("expands top-level object and one level of nested objects", () => {
+    const tree = buildJsonTree({ outer: { inner: { leaf: 1 } } });
+    const open = defaultOpenSet(tree);
+    expect(open.has("$")).toBe(true);
+    expect(open.has("$.outer")).toBe(true);
+    // The third level (`$.outer.inner`) qualifies as "small" so it's
+    // also open per the small-container rule.
+    expect(open.has("$.outer.inner")).toBe(true);
+  });
+
+  it("expands small containers (≤ 3 items) by default", () => {
+    const tree = buildJsonTree({ a: { x: 1, y: 2, z: 3 } });
+    const open = defaultOpenSet(tree);
+    expect(open.has("$.a")).toBe(true);
+  });
+
+  it("leaves large nested containers collapsed", () => {
+    const big = Object.fromEntries(
+      Array.from({ length: 10 }, (_, i) => [`k${i}`, i]),
+    );
+    const tree = buildJsonTree({ a: { b: big } });
+    const open = defaultOpenSet(tree);
+    expect(open.has("$.a.b")).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/jsonView/render.ts
+++ b/packages/agency-lang/lib/logsViewer/jsonView/render.ts
@@ -1,0 +1,320 @@
+import { JsonNode, LONG_STRING_THRESHOLD } from "./types.js";
+import type { Color } from "../../tui/elements.js";
+
+// A single rendered line in the JSON pane. Segments carry per-text
+// style so the consumer can build TUI text elements with multiple
+// colors (and so unit tests can assert colors per substring).
+export type JsonLine = {
+  // Path of the node that "owns" this line (the line where the
+  // glyph and key sit). Used for cursor/expand state — clicking
+  // on a continuation line still expands the owning node.
+  ownerPath: string;
+  segments: JsonSegment[];
+};
+
+export type JsonSegment = {
+  text: string;
+  fg?: Color;
+  bg?: Color;
+};
+
+// Color palette per the design.
+const KEY_FG: Color = "bright-white";
+const STRING_FG: Color = "bright-green";
+const NUMBER_FG: Color = "bright-cyan";
+const BOOLEAN_FG: Color = "bright-magenta";
+const NULL_FG: Color = "gray";
+const GLYPH_FG: Color = "gray";
+const PREVIEW_FG: Color = "gray";
+
+const INDENT = "  ";
+
+export type JsonRenderOpts = {
+  // Set of paths whose container is expanded (object/array/longString).
+  open: ReadonlySet<string>;
+  // Path of the currently-focused line (gets a "> " marker).
+  cursorPath?: string;
+};
+
+export function renderJson(node: JsonNode, opts: JsonRenderOpts): JsonLine[] {
+  return renderNode(node, 0, opts, undefined, true);
+}
+
+// Render a JsonNode at the given depth. `keyLabel` is the JSON
+// object-key (already JSON-quoted with the colon, e.g. `"usage": `)
+// when this node is being rendered as an object value. `isLast`
+// controls trailing-comma suppression.
+function renderNode(
+  node: JsonNode,
+  depth: number,
+  opts: JsonRenderOpts,
+  keyLabel: string | undefined,
+  isLast: boolean,
+): JsonLine[] {
+  const indent = INDENT.repeat(depth);
+  const trailing = isLast ? "" : ",";
+
+  switch (node.kind) {
+    case "primitive":
+      return [
+        primitiveLine(node, indent, keyLabel, trailing, opts),
+      ];
+    case "longString":
+      return renderLongString(node, indent, depth, keyLabel, trailing, opts);
+    case "object":
+      return renderObject(node, indent, depth, keyLabel, trailing, opts);
+    case "array":
+      return renderArray(node, indent, depth, keyLabel, trailing, opts);
+  }
+}
+
+function primitiveLine(
+  node: Extract<JsonNode, { kind: "primitive" }>,
+  indent: string,
+  keyLabel: string | undefined,
+  trailing: string,
+  opts: JsonRenderOpts,
+): JsonLine {
+  const segments: JsonSegment[] = [
+    cursor(node.path, opts.cursorPath),
+    { text: indent },
+  ];
+  if (keyLabel !== undefined) {
+    segments.push({ text: keyLabel, fg: KEY_FG });
+  }
+  segments.push({ text: node.raw, fg: primitiveColor(node.valueType) });
+  if (trailing) segments.push({ text: trailing });
+  return { ownerPath: node.path, segments };
+}
+
+function primitiveColor(
+  vt: "string" | "number" | "boolean" | "null",
+): Color {
+  switch (vt) {
+    case "string":
+      return STRING_FG;
+    case "number":
+      return NUMBER_FG;
+    case "boolean":
+      return BOOLEAN_FG;
+    case "null":
+      return NULL_FG;
+  }
+}
+
+function renderLongString(
+  node: Extract<JsonNode, { kind: "longString" }>,
+  indent: string,
+  depth: number,
+  keyLabel: string | undefined,
+  trailing: string,
+  opts: JsonRenderOpts,
+): JsonLine[] {
+  const isOpen = opts.open.has(node.path);
+  const glyph = isOpen ? "▼" : "▶";
+  if (!isOpen) {
+    const preview = node.raw.split("\n")[0].slice(0, LONG_STRING_THRESHOLD - 20);
+    const segments: JsonSegment[] = [
+      cursor(node.path, opts.cursorPath),
+      { text: indent },
+      { text: `${glyph} `, fg: GLYPH_FG },
+    ];
+    if (keyLabel !== undefined) {
+      segments.push({ text: keyLabel, fg: KEY_FG });
+    }
+    segments.push(
+      { text: `"${preview}…"`, fg: STRING_FG },
+      { text: ` (${node.raw.length} chars)`, fg: PREVIEW_FG },
+    );
+    if (trailing) segments.push({ text: trailing });
+    return [{ ownerPath: node.path, segments }];
+  }
+  // Open: the first line shows the glyph and key (if any) plus an
+  // opening quote; subsequent lines indent the body; the final line
+  // closes the quote.
+  const childIndent = INDENT.repeat(depth + 1);
+  const lines: JsonLine[] = [];
+  const headerSegs: JsonSegment[] = [
+    cursor(node.path, opts.cursorPath),
+    { text: indent },
+    { text: `${glyph} `, fg: GLYPH_FG },
+  ];
+  if (keyLabel !== undefined) headerSegs.push({ text: keyLabel, fg: KEY_FG });
+  headerSegs.push({ text: '"', fg: STRING_FG });
+  lines.push({ ownerPath: node.path, segments: headerSegs });
+  for (const ln of node.raw.split("\n")) {
+    lines.push({
+      ownerPath: node.path,
+      segments: [
+        { text: "  " },
+        { text: childIndent },
+        { text: ln, fg: STRING_FG },
+      ],
+    });
+  }
+  const closeSegs: JsonSegment[] = [
+    { text: "  " },
+    { text: indent },
+    { text: '"', fg: STRING_FG },
+  ];
+  if (trailing) closeSegs.push({ text: trailing });
+  lines.push({ ownerPath: node.path, segments: closeSegs });
+  return lines;
+}
+
+function renderObject(
+  node: Extract<JsonNode, { kind: "object" }>,
+  indent: string,
+  depth: number,
+  keyLabel: string | undefined,
+  trailing: string,
+  opts: JsonRenderOpts,
+): JsonLine[] {
+  const isOpen = opts.open.has(node.path);
+  if (!isOpen) {
+    return [
+      collapsedContainer(node.path, indent, keyLabel, "{", `${node.entries.length} keys`, "}", trailing, opts),
+    ];
+  }
+  const lines: JsonLine[] = [];
+  lines.push(openLine(node.path, indent, keyLabel, "{", opts));
+  node.entries.forEach((entry, i) => {
+    const childKey = `${JSON.stringify(entry.key)}: `;
+    const childLines = renderNode(
+      entry.child,
+      depth + 1,
+      opts,
+      childKey,
+      i === node.entries.length - 1,
+    );
+    lines.push(...childLines);
+  });
+  lines.push(closeLine(node.path, indent, "}", trailing));
+  return lines;
+}
+
+function renderArray(
+  node: Extract<JsonNode, { kind: "array" }>,
+  indent: string,
+  depth: number,
+  keyLabel: string | undefined,
+  trailing: string,
+  opts: JsonRenderOpts,
+): JsonLine[] {
+  const isOpen = opts.open.has(node.path);
+  if (!isOpen) {
+    return [
+      collapsedContainer(node.path, indent, keyLabel, "[", `${node.items.length} items`, "]", trailing, opts),
+    ];
+  }
+  const lines: JsonLine[] = [];
+  lines.push(openLine(node.path, indent, keyLabel, "[", opts));
+  node.items.forEach((item, i) => {
+    const childLines = renderNode(
+      item,
+      depth + 1,
+      opts,
+      undefined,
+      i === node.items.length - 1,
+    );
+    lines.push(...childLines);
+  });
+  lines.push(closeLine(node.path, indent, "]", trailing));
+  return lines;
+}
+
+function collapsedContainer(
+  path: string,
+  indent: string,
+  keyLabel: string | undefined,
+  openChar: string,
+  countLabel: string,
+  closeChar: string,
+  trailing: string,
+  opts: JsonRenderOpts,
+): JsonLine {
+  const segments: JsonSegment[] = [
+    cursor(path, opts.cursorPath),
+    { text: indent },
+    { text: "▶ ", fg: GLYPH_FG },
+  ];
+  if (keyLabel !== undefined) segments.push({ text: keyLabel, fg: KEY_FG });
+  segments.push({ text: `${openChar} ${countLabel} ${closeChar}` });
+  if (trailing) segments.push({ text: trailing });
+  return { ownerPath: path, segments };
+}
+
+function openLine(
+  path: string,
+  indent: string,
+  keyLabel: string | undefined,
+  openChar: string,
+  opts: JsonRenderOpts,
+): JsonLine {
+  const segments: JsonSegment[] = [
+    cursor(path, opts.cursorPath),
+    { text: indent },
+    { text: "▼ ", fg: GLYPH_FG },
+  ];
+  if (keyLabel !== undefined) segments.push({ text: keyLabel, fg: KEY_FG });
+  segments.push({ text: openChar });
+  return { ownerPath: path, segments };
+}
+
+function closeLine(
+  path: string,
+  indent: string,
+  closeChar: string,
+  trailing: string,
+): JsonLine {
+  const segments: JsonSegment[] = [
+    { text: "  " },
+    { text: indent },
+    { text: closeChar },
+  ];
+  if (trailing) segments.push({ text: trailing });
+  return { ownerPath: path, segments };
+}
+
+function cursor(path: string, cursorPath?: string): JsonSegment {
+  return { text: cursorPath === path ? "> " : "  " };
+}
+
+// Convert a line's segments to plain text — useful for tests and the
+// outer composition layer when it just needs the text content.
+export function lineToText(line: JsonLine): string {
+  return line.segments.map((s) => s.text).join("");
+}
+
+// Compute the default-open set per the design: top-level container
+// open; one level of nested containers open; small containers (≤ 3
+// items) open. Returns paths only.
+export function defaultOpenSet(root: JsonNode): Set<string> {
+  const out = new Set<string>();
+  if (isContainer(root)) out.add(root.path);
+  // One level deep.
+  for (const child of containerChildren(root)) {
+    if (isContainer(child)) out.add(child.path);
+    // Plus small grandchildren.
+    for (const grand of containerChildren(child)) {
+      if (isContainer(grand) && isSmall(grand)) out.add(grand.path);
+    }
+  }
+  return out;
+}
+
+function isContainer(node: JsonNode): boolean {
+  return node.kind === "object" || node.kind === "array";
+}
+
+function isSmall(node: JsonNode): boolean {
+  if (node.kind === "object") return node.entries.length <= 3;
+  if (node.kind === "array") return node.items.length <= 3;
+  return false;
+}
+
+function containerChildren(node: JsonNode): JsonNode[] {
+  if (node.kind === "object") return node.entries.map((e) => e.child);
+  if (node.kind === "array") return node.items;
+  return [];
+}

--- a/packages/agency-lang/lib/logsViewer/jsonView/types.ts
+++ b/packages/agency-lang/lib/logsViewer/jsonView/types.ts
@@ -1,0 +1,34 @@
+// Tree shape for the bottom JSON-payload pane. One JsonNode per JSON
+// value in the payload; objects/arrays are containers, primitives and
+// `longString` are leaves. Insertion-order matters and is preserved
+// across builds — the on-wire field order is meaningful here.
+export type JsonNode =
+  | {
+      kind: "primitive";
+      path: string;
+      valueType: "string" | "number" | "boolean" | "null";
+      // The exact text we want to render (e.g. `"foo"`, `42`, `null`).
+      raw: string;
+    }
+  | {
+      kind: "object";
+      path: string;
+      entries: { key: string; child: JsonNode }[];
+    }
+  | {
+      kind: "array";
+      path: string;
+      items: JsonNode[];
+    }
+  | {
+      // Strings that contain a newline OR exceed 80 characters. The
+      // renderer collapses these by default and gives the user `l` to
+      // see the full content.
+      kind: "longString";
+      path: string;
+      raw: string;
+    };
+
+// Default-open heuristic. The renderer respects an external "open"
+// set; this constant lives in build.ts and is referenced in tests.
+export const LONG_STRING_THRESHOLD = 80;

--- a/packages/agency-lang/lib/logsViewer/render.test.ts
+++ b/packages/agency-lang/lib/logsViewer/render.test.ts
@@ -133,6 +133,61 @@ describe("renderViewerLines", () => {
   });
 });
 
+describe("promptCompletion expansion", () => {
+  // A promptCompletion leaf should expand into one row per message
+  // followed by a single "raw data" toggle row. Expanding the toggle
+  // should then reveal the JSON dump.
+  function pcLeaf(): TreeNode {
+    return {
+      id: "evt-0",
+      traceId: "t",
+      parentId: "trace-t",
+      children: [],
+      nodeKind: "event",
+      label: "promptCompletion",
+      summary: "promptCompletion",
+      event: {
+        format_version: 1,
+        trace_id: "t",
+        project_id: "p",
+        span_id: null,
+        parent_span_id: null,
+        data: {
+          type: "promptCompletion",
+          timestamp: "2026-01-01T00:00:00Z",
+          messages: [
+            { role: "user", content: "hi" },
+            { role: "assistant", content: "hello" },
+          ],
+        },
+      },
+    };
+  }
+
+  it("expands into conversation lines + raw data toggle", () => {
+    const t = trace([pcLeaf()]);
+    const rows = flattenVisibleRows(baseState([t], ["trace-t", "evt-0"]));
+    // trace, leaf, [user], [assistant], raw-data toggle
+    expect(rows).toHaveLength(5);
+    expect(rows[2].node.nodeKind).toBe("convoLine");
+    expect(rows[2].node.summary).toBe(`[user] "hi"`);
+    expect(rows[3].node.nodeKind).toBe("convoLine");
+    expect(rows[4].node.nodeKind).toBe("rawDataToggle");
+    expect(rows[4].node.id).toBe("evt-0:raw");
+  });
+
+  it("expands the raw-data toggle into JSON lines", () => {
+    const t = trace([pcLeaf()]);
+    const rows = flattenVisibleRows(
+      baseState([t], ["trace-t", "evt-0", "evt-0:raw"]),
+    );
+    // Should now include JSON lines after the toggle.
+    const jsonRows = rows.filter((r) => r.node.nodeKind === "jsonLine");
+    expect(jsonRows.length).toBeGreaterThan(0);
+    expect(jsonRows[0].node.summary.trim()).toBe("{");
+  });
+});
+
 describe("colorFor", () => {
   it("returns a span-type color for known span labels", () => {
     expect(colorFor(span("a", "agentRun"))).toBe("bright-cyan");

--- a/packages/agency-lang/lib/logsViewer/render.ts
+++ b/packages/agency-lang/lib/logsViewer/render.ts
@@ -1,4 +1,6 @@
 import { TreeNode, ViewerState } from "./types.js";
+import { summarizeSpanStyled, summarizeTraceStyled } from "./summary.js";
+import { DEFAULT_THRESHOLDS, ViewerThresholds } from "./thresholds.js";
 
 export type Viewport = { rows: number; cols: number };
 export type VisibleRow = { node: TreeNode; depth: number };
@@ -34,13 +36,76 @@ export function renderRowText(
   row: VisibleRow,
   isCursor: boolean,
   isExpanded: boolean,
+  opts: { query?: string; thresholds?: ViewerThresholds } = {},
 ): string {
   const indent = "  ".repeat(row.depth);
   const glyph = chooseGlyph(row.node, isExpanded);
   const marker = isCursor ? "> " : "  ";
+  // Spans and traces get the magnitude-colored summary so durations
+  // and costs render in red/gray per the configured thresholds; raw
+  // event leaves use the plain pre-computed summary (no metrics).
+  const t = opts.thresholds ?? DEFAULT_THRESHOLDS;
+  const styledSummary =
+    row.node.nodeKind === "span"
+      ? summarizeSpanStyled(row.node, t)
+      : row.node.nodeKind === "trace"
+        ? summarizeTraceStyled(row.node, t)
+        : row.node.summary;
+  const withHighlight = opts.query
+    ? highlightInline(styledSummary, opts.query)
+    : styledSummary;
   // Over-long lines are clipped centrally by the TUI renderer; no
   // need to slice here.
-  return `${marker}${indent}${glyph} ${row.node.summary}`;
+  return `${marker}${indent}${glyph} ${withHighlight}`;
+}
+
+// Wrap every case-insensitive occurrence of `query` in the source
+// string with `{yellow-bg}...{/yellow-bg}` style tags, taking care
+// not to break existing tags that the styled summary may already
+// have inserted (e.g. `{bright-red-fg}5.2s{/bright-red-fg}`). We
+// only highlight substrings that fall fully outside a tag body.
+export function highlightInline(text: string, query: string): string {
+  if (!query) return text;
+  const needle = query.toLowerCase();
+  // Walk through the source one segment at a time, splitting at any
+  // `{...}` tag boundary. Highlight inside text segments only.
+  const parts = splitOnTags(text);
+  const out: string[] = [];
+  for (const part of parts) {
+    if (part.kind === "tag") {
+      out.push(part.text);
+      continue;
+    }
+    let i = 0;
+    const lower = part.text.toLowerCase();
+    while (i < part.text.length) {
+      const hit = lower.indexOf(needle, i);
+      if (hit < 0) {
+        out.push(part.text.slice(i));
+        break;
+      }
+      if (hit > i) out.push(part.text.slice(i, hit));
+      out.push(`{yellow-bg}${part.text.slice(hit, hit + query.length)}{/yellow-bg}`);
+      i = hit + query.length;
+    }
+  }
+  return out.join("");
+}
+
+type Part = { kind: "text" | "tag"; text: string };
+
+function splitOnTags(text: string): Part[] {
+  const re = /\{[^}]+\}/g;
+  const out: Part[] = [];
+  let last = 0;
+  for (const m of text.matchAll(re)) {
+    const start = m.index ?? 0;
+    if (start > last) out.push({ kind: "text", text: text.slice(last, start) });
+    out.push({ kind: "tag", text: m[0] });
+    last = start + m[0].length;
+  }
+  if (last < text.length) out.push({ kind: "text", text: text.slice(last) });
+  return out;
 }
 
 function chooseGlyph(node: TreeNode, isExpanded: boolean): string {

--- a/packages/agency-lang/lib/logsViewer/render.ts
+++ b/packages/agency-lang/lib/logsViewer/render.ts
@@ -38,12 +38,24 @@ export function flattenVisibleRows(state: ViewerState): VisibleRow[] {
 // promptCompletion events get a readable conversation view plus a
 // "raw data" toggle for the JSON; other events fall back to raw JSON
 // lines directly.
-function eventExpansionChildren(leaf: TreeNode): TreeNode[] {
+//
+// Exported so search.ts can walk these the same way the renderer does
+// — otherwise `/foo` would match a highlighted row but `n`/`N` would
+// claim there are no matches (the rows aren't in the persistent
+// forest).
+export function eventExpansionChildren(leaf: TreeNode): TreeNode[] {
   if (!leaf.event) return [];
   if (leaf.event.data.type === "promptCompletion") {
     return promptCompletionChildren(leaf);
   }
   return jsonLineChildren(leaf, leaf.event);
+}
+
+// Synthetic children of a "raw data" toggle row. Exported for the
+// same reason as eventExpansionChildren above.
+export function rawDataChildren(toggle: TreeNode): TreeNode[] {
+  if (!toggle.event) return [];
+  return jsonLineChildren(toggle, toggle.event);
 }
 
 function promptCompletionChildren(leaf: TreeNode): TreeNode[] {

--- a/packages/agency-lang/lib/logsViewer/render.ts
+++ b/packages/agency-lang/lib/logsViewer/render.ts
@@ -10,11 +10,37 @@ export function flattenVisibleRows(state: ViewerState): VisibleRow[] {
   const walk = (node: TreeNode, depth: number): void => {
     out.push({ node, depth });
     if (state.expanded.has(node.id)) {
-      for (const c of node.children) walk(c, depth + 1);
+      // Leaf event nodes can be "expanded" to inline their JSON
+      // payload as synthetic jsonLine rows. Real children only ever
+      // exist for non-leaf nodes.
+      if (node.nodeKind === "event" && node.event) {
+        for (const child of jsonLineChildren(node)) walk(child, depth + 1);
+      } else {
+        for (const c of node.children) walk(c, depth + 1);
+      }
     }
   };
   for (const r of state.roots) walk(r, 0);
   return out;
+}
+
+// Pretty-print the leaf event payload and turn it into one synthetic
+// TreeNode per line, so the visible-rows pipeline can fold them into
+// the same scroll/cursor model used for real tree rows. Heavy work is
+// kept here so callers don't have to know the format.
+function jsonLineChildren(leaf: TreeNode): TreeNode[] {
+  if (!leaf.event) return [];
+  const text = JSON.stringify(leaf.event, null, 2);
+  const lines = text.split("\n");
+  return lines.map((line, i) => ({
+    id: `${leaf.id}:json:${i}`,
+    traceId: leaf.traceId,
+    parentId: leaf.id,
+    children: [],
+    nodeKind: "jsonLine" as const,
+    label: "",
+    summary: line,
+  }));
 }
 
 export function renderViewerLines(
@@ -39,8 +65,16 @@ export function renderRowText(
   opts: { query?: string; thresholds?: ViewerThresholds } = {},
 ): string {
   const indent = "  ".repeat(row.depth);
-  const glyph = chooseGlyph(row.node, isExpanded);
   const marker = isCursor ? "> " : "  ";
+  if (row.node.nodeKind === "jsonLine") {
+    // No glyph; the raw JSON line is the summary text. Highlight
+    // matches per the active search.
+    const text = opts.query
+      ? highlightInline(row.node.summary, opts.query)
+      : row.node.summary;
+    return `${marker}${indent}${text}`;
+  }
+  const glyph = chooseGlyph(row.node, isExpanded);
   // Spans and traces get the magnitude-colored summary so durations
   // and costs render in red/gray per the configured thresholds; raw
   // event leaves use the plain pre-computed summary (no metrics).
@@ -109,7 +143,13 @@ function splitOnTags(text: string): Part[] {
 }
 
 function chooseGlyph(node: TreeNode, isExpanded: boolean): string {
-  if (node.nodeKind === "event" || node.children.length === 0) return "●";
+  if (node.nodeKind === "jsonLine") return "";
+  if (node.nodeKind === "event") {
+    // Event leaves with a payload are expandable (inline JSON).
+    if (node.event) return isExpanded ? "▼" : "▶";
+    return "●";
+  }
+  if (node.children.length === 0) return "●";
   return isExpanded ? "▼" : "▶";
 }
 
@@ -118,6 +158,7 @@ function chooseGlyph(node: TreeNode, isExpanded: boolean): string {
 // terminal fg" — used for trace headers (which we'd rather see in
 // the default color so the bold/inverse cursor style stays readable).
 export function colorFor(node: TreeNode): string | undefined {
+  if (node.nodeKind === "jsonLine") return "gray";
   if (node.nodeKind === "trace") return undefined;
   if (node.nodeKind === "span") {
     switch (node.label) {

--- a/packages/agency-lang/lib/logsViewer/render.ts
+++ b/packages/agency-lang/lib/logsViewer/render.ts
@@ -1,6 +1,7 @@
 import { TreeNode, ViewerState } from "./types.js";
 import { summarizeSpanStyled, summarizeTraceStyled } from "./summary.js";
 import { DEFAULT_THRESHOLDS, ViewerThresholds } from "./thresholds.js";
+import { formatConversation } from "./conversation.js";
 
 export type Viewport = { rows: number; cols: number };
 export type VisibleRow = { node: TreeNode; depth: number };
@@ -9,33 +10,82 @@ export function flattenVisibleRows(state: ViewerState): VisibleRow[] {
   const out: VisibleRow[] = [];
   const walk = (node: TreeNode, depth: number): void => {
     out.push({ node, depth });
-    if (state.expanded.has(node.id)) {
-      // Leaf event nodes can be "expanded" to inline their JSON
-      // payload as synthetic jsonLine rows. Real children only ever
-      // exist for non-leaf nodes.
-      if (node.nodeKind === "event" && node.event) {
-        for (const child of jsonLineChildren(node)) walk(child, depth + 1);
-      } else {
-        for (const c of node.children) walk(c, depth + 1);
-      }
+    if (!state.expanded.has(node.id)) return;
+    // Leaf event nodes can be "expanded" to inline a synthetic
+    // payload view (conversation lines for promptCompletion, raw
+    // JSON otherwise). Real children only ever exist for non-leaf
+    // tree nodes.
+    if (node.nodeKind === "event" && node.event) {
+      for (const child of eventExpansionChildren(node)) walk(child, depth + 1);
+      return;
     }
+    // A "raw data" toggle row, when expanded, reveals the JSON
+    // payload of the parent event leaf. We carry the original event
+    // on the toggle node so we can recompute lines here.
+    if (node.nodeKind === "rawDataToggle" && node.event) {
+      for (const child of jsonLineChildren(node, node.event)) {
+        walk(child, depth + 1);
+      }
+      return;
+    }
+    for (const c of node.children) walk(c, depth + 1);
   };
   for (const r of state.roots) walk(r, 0);
   return out;
 }
 
-// Pretty-print the leaf event payload and turn it into one synthetic
-// TreeNode per line, so the visible-rows pipeline can fold them into
-// the same scroll/cursor model used for real tree rows. Heavy work is
-// kept here so callers don't have to know the format.
-function jsonLineChildren(leaf: TreeNode): TreeNode[] {
+// Return the synthetic children shown when a leaf event is expanded.
+// promptCompletion events get a readable conversation view plus a
+// "raw data" toggle for the JSON; other events fall back to raw JSON
+// lines directly.
+function eventExpansionChildren(leaf: TreeNode): TreeNode[] {
   if (!leaf.event) return [];
-  const text = JSON.stringify(leaf.event, null, 2);
-  const lines = text.split("\n");
-  return lines.map((line, i) => ({
-    id: `${leaf.id}:json:${i}`,
+  if (leaf.event.data.type === "promptCompletion") {
+    return promptCompletionChildren(leaf);
+  }
+  return jsonLineChildren(leaf, leaf.event);
+}
+
+function promptCompletionChildren(leaf: TreeNode): TreeNode[] {
+  const messages = Array.isArray(leaf.event!.data.messages)
+    ? leaf.event!.data.messages
+    : [];
+  const convoLines = formatConversation(messages);
+  const convoNodes: TreeNode[] = convoLines.map((line, i) => ({
+    id: `${leaf.id}:convo:${i}`,
     traceId: leaf.traceId,
     parentId: leaf.id,
+    children: [],
+    nodeKind: "convoLine" as const,
+    label: "",
+    summary: line,
+  }));
+  const toggle: TreeNode = {
+    id: `${leaf.id}:raw`,
+    traceId: leaf.traceId,
+    parentId: leaf.id,
+    children: [],
+    nodeKind: "rawDataToggle" as const,
+    label: "raw data",
+    summary: "raw data",
+    event: leaf.event,
+  };
+  return [...convoNodes, toggle];
+}
+
+// Pretty-print the leaf event payload and turn it into one synthetic
+// TreeNode per line, so the visible-rows pipeline can fold them into
+// the same scroll/cursor model used for real tree rows.
+function jsonLineChildren(
+  parent: TreeNode,
+  envelope: NonNullable<TreeNode["event"]>,
+): TreeNode[] {
+  const text = JSON.stringify(envelope, null, 2);
+  const lines = text.split("\n");
+  return lines.map((line, i) => ({
+    id: `${parent.id}:json:${i}`,
+    traceId: parent.traceId,
+    parentId: parent.id,
     children: [],
     nodeKind: "jsonLine" as const,
     label: "",
@@ -66,8 +116,8 @@ export function renderRowText(
 ): string {
   const indent = "  ".repeat(row.depth);
   const marker = isCursor ? "> " : "  ";
-  if (row.node.nodeKind === "jsonLine") {
-    // No glyph; the raw JSON line is the summary text. Highlight
+  if (row.node.nodeKind === "jsonLine" || row.node.nodeKind === "convoLine") {
+    // No glyph; the raw text line *is* the summary. Highlight
     // matches per the active search.
     const text = opts.query
       ? highlightInline(row.node.summary, opts.query)
@@ -143,7 +193,8 @@ function splitOnTags(text: string): Part[] {
 }
 
 function chooseGlyph(node: TreeNode, isExpanded: boolean): string {
-  if (node.nodeKind === "jsonLine") return "";
+  if (node.nodeKind === "jsonLine" || node.nodeKind === "convoLine") return "";
+  if (node.nodeKind === "rawDataToggle") return isExpanded ? "▼" : "▶";
   if (node.nodeKind === "event") {
     // Event leaves with a payload are expandable (inline JSON).
     if (node.event) return isExpanded ? "▼" : "▶";
@@ -159,6 +210,8 @@ function chooseGlyph(node: TreeNode, isExpanded: boolean): string {
 // the default color so the bold/inverse cursor style stays readable).
 export function colorFor(node: TreeNode): string | undefined {
   if (node.nodeKind === "jsonLine") return "gray";
+  if (node.nodeKind === "rawDataToggle") return "gray";
+  if (node.nodeKind === "convoLine") return undefined;
   if (node.nodeKind === "trace") return undefined;
   if (node.nodeKind === "span") {
     switch (node.label) {

--- a/packages/agency-lang/lib/logsViewer/run.test.ts
+++ b/packages/agency-lang/lib/logsViewer/run.test.ts
@@ -90,6 +90,58 @@ describe("runViewer", () => {
     expect(last).toMatch(/\[abc\]/);
   });
 
+  it("Enter on a leaf opens the JSON pane with the payload", async () => {
+    const out = new FrameRecorder();
+    await runViewer({
+      jsonl: sample,
+      // Navigate: l (expand trace) l (expand agentRun span) j (move
+      // to first child leaf, agentStart) Enter (open pane) q (quit).
+      input: new ScriptedInput(["l", "l", "j", "Enter", "q"]),
+      output: out,
+      viewport: { rows: 20, cols: 80 },
+    });
+    const last = out.lastText();
+    // The pane should show the agentStart event payload (the
+    // EventEnvelope shape includes trace_id and "data" at the top
+    // level). Header `▼ {` indicates the pane is open and expanded.
+    expect(last).toMatch(/"data":/);
+    expect(last).toMatch(/agentStart/);
+  });
+
+  it("/ then a query jumps the cursor to the first match", async () => {
+    const out = new FrameRecorder();
+    const scripted = new ScriptedInput(["l", "j", "/"]);
+    // Pre-load the search prompt response and the final 'q'.
+    scripted.feedLine("agentEnd");
+    scripted.feedKey({ key: "q" });
+    await runViewer({
+      jsonl: sample,
+      input: scripted,
+      output: out,
+      viewport: { rows: 10, cols: 80 },
+    });
+    const last = out.lastText();
+    // Status bar should show the match indicator.
+    expect(last).toMatch(/match 1\/1/);
+    // And mention the query string.
+    expect(last).toMatch(/agentEnd/);
+  });
+
+  it("? opens the help overlay; any key closes it", async () => {
+    const out = new FrameRecorder();
+    await runViewer({
+      jsonl: sample,
+      input: new ScriptedInput(["?", "j", "q"]),
+      output: out,
+      viewport: { rows: 20, cols: 80 },
+    });
+    // At least one frame should show the help heading.
+    const anyHelp = out.frames.some((_, i) => out.textAt(i).includes("Keybindings"));
+    expect(anyHelp).toBe(true);
+    // And the final frame (after `j`) should not.
+    expect(out.lastText()).not.toMatch(/Keybindings/);
+  });
+
   it("shows parse errors as a footer line", async () => {
     const out = new FrameRecorder();
     const bad = sample + "this is not json\n";

--- a/packages/agency-lang/lib/logsViewer/run.test.ts
+++ b/packages/agency-lang/lib/logsViewer/run.test.ts
@@ -90,22 +90,31 @@ describe("runViewer", () => {
     expect(last).toMatch(/\[abc\]/);
   });
 
-  it("Enter on a leaf opens the JSON pane with the payload", async () => {
+  it("Enter on a leaf inlines its JSON payload below the leaf", async () => {
     const out = new FrameRecorder();
     await runViewer({
       jsonl: sample,
       // Navigate: l (expand trace) l (expand agentRun span) j (move
-      // to first child leaf, agentStart) Enter (open pane) q (quit).
+      // to first child leaf, agentStart) Enter (inline its JSON) q.
       input: new ScriptedInput(["l", "l", "j", "Enter", "q"]),
       output: out,
       viewport: { rows: 20, cols: 80 },
     });
     const last = out.lastText();
-    // The pane should show the agentStart event payload (the
-    // EventEnvelope shape includes trace_id and "data" at the top
-    // level). Header `▼ {` indicates the pane is open and expanded.
+    // The inlined JSON includes the full EventEnvelope shape: keys
+    // like `"data":` and the event type literal `agentStart`.
     expect(last).toMatch(/"data":/);
     expect(last).toMatch(/agentStart/);
+    // h collapses the inline JSON back. Smoke check: re-run with an
+    // extra `h` and ensure `"data":` is gone from the final frame.
+    const out2 = new FrameRecorder();
+    await runViewer({
+      jsonl: sample,
+      input: new ScriptedInput(["l", "l", "j", "Enter", "h", "q"]),
+      output: out2,
+      viewport: { rows: 20, cols: 80 },
+    });
+    expect(out2.lastText()).not.toMatch(/"data":/);
   });
 
   it("/ then a query jumps the cursor to the first match", async () => {

--- a/packages/agency-lang/lib/logsViewer/run.test.ts
+++ b/packages/agency-lang/lib/logsViewer/run.test.ts
@@ -130,9 +130,11 @@ describe("runViewer", () => {
       viewport: { rows: 10, cols: 80 },
     });
     const last = out.lastText();
-    // Status bar should show the match indicator.
-    expect(last).toMatch(/match 1\/1/);
-    // And mention the query string.
+    // Status bar should show the match indicator. The query also
+    // matches occurrences inside the leaf's expanded JSON payload,
+    // so total matches is >1 — we only assert the cursor landed on
+    // the first one and the query text is shown.
+    expect(last).toMatch(/match 1\/\d+/);
     expect(last).toMatch(/agentEnd/);
   });
 

--- a/packages/agency-lang/lib/logsViewer/run.ts
+++ b/packages/agency-lang/lib/logsViewer/run.ts
@@ -13,14 +13,26 @@ import {
   renderRowText,
   VisibleRow,
 } from "./render.js";
-import { handleKey } from "./input.js";
-import { ViewerState } from "./types.js";
+import { handleKeyEx } from "./input.js";
+import { handlePaneKey, flattenJsonRows } from "./jsonView/input.js";
+import { buildJsonTree } from "./jsonView/build.js";
+import { defaultOpenSet, renderJson } from "./jsonView/render.js";
+import { ViewerState, TreeNode, JsonPaneStateRef } from "./types.js";
+import { findMatches, expandAncestorsOf } from "./search.js";
+import { detectClipboard } from "./clipboard.js";
+import { follow, Follower } from "./follow.js";
+import { helpLines } from "./help.js";
+import { DEFAULT_THRESHOLDS, ViewerThresholds } from "./thresholds.js";
 
 export type RunViewerOpts = {
   jsonl: string;
   input: InputSource;
   output: OutputTarget;
   viewport: { rows: number; cols: number };
+  // Optional path to enable --follow mode (re-read as the file grows).
+  // Undefined disables follow even if the user presses `f`.
+  followPath?: string;
+  thresholds?: ViewerThresholds;
 };
 
 export async function runViewer(opts: RunViewerOpts): Promise<void> {
@@ -40,21 +52,244 @@ export async function runViewer(opts: RunViewerOpts): Promise<void> {
     return;
   }
 
-  const initialState: ViewerState = {
-    roots,
-    // Default-expand the only trace if there is exactly one.
-    expanded: new Set(roots.length === 1 ? [roots[0].id] : []),
-    cursorId: roots[0].id,
-    scrollTop: 0,
-    quit: false,
+  const thresholds = opts.thresholds ?? DEFAULT_THRESHOLDS;
+  let state: ViewerState = applyScroll(
+    {
+      roots,
+      // Default-expand the only trace if there is exactly one.
+      expanded: new Set(roots.length === 1 ? [roots[0].id] : []),
+      cursorId: roots[0].id,
+      scrollTop: 0,
+      quit: false,
+      pane: "tree",
+    },
+    opts.viewport,
+  );
+
+  // Follow mode book-keeping. The watcher is started/stopped lazily
+  // when the user toggles `f`. We re-parse the *whole* JSONL on each
+  // append — simpler than incremental and the file is usually tiny.
+  let followerState: { f: Follower; jsonl: string } | undefined;
+  const startFollow = (): void => {
+    if (!opts.followPath || followerState) return;
+    let accum = opts.jsonl;
+    followerState = {
+      jsonl: accum,
+      f: follow({
+        path: opts.followPath,
+        onAppend: (chunk) => {
+          accum += chunk;
+          if (followerState) followerState.jsonl = accum;
+          state = onFollowAppend(state, accum, opts.viewport);
+          screen.render(renderState(state, parsed.errors, opts.viewport, thresholds));
+        },
+      }),
+    };
+  };
+  const stopFollow = (): void => {
+    if (!followerState) return;
+    followerState.f.stop();
+    followerState = undefined;
   };
 
-  await screen.runLoop({
-    initialState: applyScroll(initialState, opts.viewport),
-    render: (s) => renderState(s, parsed.errors, opts.viewport),
-    handleKey: (s, event) => applyScroll(handleKey(s, event), opts.viewport),
-    isDone: (s) => s.quit,
-  });
+  screen.render(renderState(state, parsed.errors, opts.viewport, thresholds));
+  try {
+    while (!state.quit) {
+      const event = await screen.nextKey();
+      // Global quit, regardless of which pane has focus.
+      if (
+        event.key === "q" ||
+        (event.ctrl && (event.key === "c" || event.key === "C"))
+      ) {
+        state = { ...state, quit: true };
+        break;
+      }
+      // JSON pane has focus: route keys there.
+      if (state.pane === "json" && state.jsonPane) {
+        const builtFor = state.jsonPane.builtFor;
+        const nextJson = handlePaneKey(state.jsonPane, event);
+        if (nextJson.releaseFocus) {
+          state = {
+            ...state,
+            pane: "tree",
+            jsonPane: { ...nextJson, releaseFocus: false, builtFor },
+          };
+        } else {
+          state = { ...state, jsonPane: { ...nextJson, builtFor } };
+        }
+      } else {
+        const { state: next, command } = handleKeyEx(state, event);
+        state = applyScroll(next, opts.viewport);
+        if (command?.kind === "search") {
+          const query = await screen.nextLine("Search: ");
+          state = applySearch(state, query, opts.viewport);
+        } else if (command?.kind === "copy") {
+          state = runCopy(state);
+        } else if (command?.kind === "toggleFollow") {
+          state = runToggleFollow(state, opts.followPath, startFollow, stopFollow);
+        }
+      }
+      // Maintain the JSON pane: rebuild content when the focused
+      // tree leaf changes, drop it when the pane is closed.
+      state = syncJsonPane(state);
+      state = applyScroll(state, opts.viewport);
+      screen.render(renderState(state, parsed.errors, opts.viewport, thresholds));
+    }
+  } finally {
+    stopFollow();
+  }
+}
+
+// Build / rebuild / clear the inner JSON pane based on the current
+// focused tree node. Cheap to call on every key — the JSON tree is
+// only re-built when the focused-node id actually changed.
+function syncJsonPane(state: ViewerState): ViewerState {
+  if (!state.jsonPaneOpen) {
+    return state.jsonPane ? { ...state, jsonPane: undefined } : state;
+  }
+  if (state.jsonPane?.builtFor === state.cursorId) return state;
+  const node = findNode(state.roots, state.cursorId);
+  if (!node) return state;
+  const payload = jsonPayloadFor(node);
+  const root = buildJsonTree(payload);
+  const open = defaultOpenSet(root);
+  const pane: JsonPaneStateRef = {
+    root,
+    open,
+    cursorPath: root.path,
+    scrollTop: 0,
+    releaseFocus: false,
+    builtFor: state.cursorId,
+  };
+  return { ...state, jsonPane: pane };
+}
+
+// JSON payload for a tree node. Leaves serialize their EventEnvelope;
+// spans and traces synthesize a small summary object because spans
+// don't have one canonical payload (multiple events share a span).
+function jsonPayloadFor(node: TreeNode): unknown {
+  if (node.nodeKind === "event" && node.event) return node.event;
+  if (node.nodeKind === "span") {
+    return {
+      spanType: node.label,
+      spanId: node.id,
+      parentId: node.parentId,
+      metrics: {
+        duration: node.duration,
+        tokens: node.tokens,
+        cost: node.cost,
+      },
+      eventCount: countEvents(node),
+    };
+  }
+  // trace
+  return {
+    traceId: node.traceId,
+    metrics: {
+      duration: node.duration,
+      tokens: node.tokens,
+      cost: node.cost,
+    },
+    eventCount: countEvents(node),
+  };
+}
+
+function countEvents(node: TreeNode): number {
+  let n = node.nodeKind === "event" ? 1 : 0;
+  for (const c of node.children) n += countEvents(c);
+  return n;
+}
+
+function findNode(roots: TreeNode[], id: string): TreeNode | undefined {
+  const stack: TreeNode[] = [...roots];
+  while (stack.length > 0) {
+    const n = stack.pop()!;
+    if (n.id === id) return n;
+    for (const c of n.children) stack.push(c);
+  }
+  return undefined;
+}
+
+function applySearch(
+  state: ViewerState,
+  query: string,
+  viewport: { rows: number; cols: number },
+): ViewerState {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) {
+    return { ...state, query: undefined, matches: undefined, matchIdx: undefined };
+  }
+  const matches = findMatches(state.roots, trimmed);
+  if (matches.length === 0) {
+    return {
+      ...state,
+      query: trimmed,
+      matches: [],
+      matchIdx: undefined,
+      messageBar: `no matches for "${trimmed}"`,
+    };
+  }
+  const withAncestors = expandAncestorsOf(state, matches);
+  const jumped: ViewerState = {
+    ...withAncestors,
+    query: trimmed,
+    matches,
+    matchIdx: 0,
+    cursorId: matches[0],
+  };
+  return applyScroll(jumped, viewport);
+}
+
+function runToggleFollow(
+  state: ViewerState,
+  followPath: string | undefined,
+  start: () => void,
+  stop: () => void,
+): ViewerState {
+  if (!followPath) {
+    return { ...state, messageBar: "follow disabled (stdin or no file)" };
+  }
+  if (state.followOn) {
+    stop();
+    return { ...state, followOn: false, messageBar: "follow off" };
+  }
+  start();
+  return { ...state, followOn: true, messageBar: "follow on" };
+}
+
+function runCopy(state: ViewerState): ViewerState {
+  const node = findNode(state.roots, state.cursorId);
+  if (!node) return state;
+  const cb = detectClipboard();
+  if (!cb) return { ...state, messageBar: "clipboard unavailable" };
+  const payload = jsonPayloadFor(node);
+  const text = JSON.stringify(payload, null, 2);
+  try {
+    cb.write(text);
+    return { ...state, messageBar: `copied ${text.length} bytes` };
+  } catch (e) {
+    return { ...state, messageBar: `copy failed: ${(e as Error).message}` };
+  }
+}
+
+// Re-parse the whole accumulated JSONL after a follow append. We
+// preserve the cursor id across reloads; if it has been removed,
+// fall back to the first trace root.
+function onFollowAppend(
+  prev: ViewerState,
+  jsonl: string,
+  viewport: { rows: number; cols: number },
+): ViewerState {
+  const parsed = parseStatelogJsonl(jsonl);
+  const roots = buildForest(parsed.events);
+  if (roots.length === 0) return prev;
+  const stillThere = findNode(roots, prev.cursorId);
+  const next: ViewerState = {
+    ...prev,
+    roots,
+    cursorId: stillThere ? prev.cursorId : roots[0].id,
+  };
+  return applyScroll(next, viewport);
 }
 
 // Clamp and cursor-follow scrollTop based on the current visible
@@ -66,45 +301,139 @@ function applyScroll(
 ): ViewerState {
   const rows = flattenVisibleRows(state);
   const cursorIdx = rows.findIndex((r) => r.node.id === state.cursorId);
-  const clamped = clampScroll(state.scrollTop, rows.length, viewport.rows);
+  const visible = treePaneRows(viewport, state);
+  const clamped = clampScroll(state.scrollTop, rows.length, visible);
   const scrollTop = cursorIdx >= 0
-    ? followCursor(clamped, cursorIdx, viewport.rows)
+    ? followCursor(clamped, cursorIdx, visible)
     : clamped;
   return scrollTop === state.scrollTop ? state : { ...state, scrollTop };
+}
+
+// Rows available to the tree pane after subtracting (a) the JSON
+// pane allotment when open, (b) the bottom status line when present.
+function treePaneRows(
+  viewport: { rows: number; cols: number },
+  state: ViewerState,
+): number {
+  const reserved = hasStatusBar(state) ? 1 : 0;
+  const usable = Math.max(1, viewport.rows - reserved);
+  if (!state.jsonPaneOpen) return usable;
+  // Tree gets ~60%, pane ~40%, min 1 row each.
+  return Math.max(1, Math.floor(usable * 0.6));
+}
+
+function jsonPaneRows(
+  viewport: { rows: number; cols: number },
+  state: ViewerState,
+): number {
+  const reserved = hasStatusBar(state) ? 1 : 0;
+  const usable = Math.max(1, viewport.rows - reserved);
+  return Math.max(1, usable - treePaneRows(viewport, state));
+}
+
+function hasStatusBar(state: ViewerState): boolean {
+  return !!(state.messageBar || (state.matches && state.matches.length > 0) || state.followOn || state.query);
 }
 
 function renderState(
   state: ViewerState,
   parseErrors: ReadonlyArray<{ line: number }>,
   viewport: { rows: number; cols: number },
+  thresholds: ViewerThresholds,
 ): Element {
-  const rows = flattenVisibleRows(state);
-  const cursorIdx = rows.findIndex((r) => r.node.id === state.cursorId);
-  const reserved = parseErrors.length > 0 ? 2 : 0; // blank line + error line
-  const listViewportRows = Math.max(1, viewport.rows - reserved);
+  if (state.helpOpen) return renderHelpOverlay();
 
-  const { element: list } = scrollList<VisibleRow>({
-    items: rows,
+  const treeRows = flattenVisibleRows(state);
+  const cursorIdx = treeRows.findIndex((r) => r.node.id === state.cursorId);
+  const treeHeight = treePaneRows(viewport, state);
+
+  const { element: tree } = scrollList<VisibleRow>({
+    items: treeRows,
     cursorIdx,
     scrollTop: state.scrollTop,
-    viewportRows: listViewportRows,
+    viewportRows: treeHeight,
     renderItem: (vrow, isCursor) => {
-      const fg = colorFor(vrow.node);
+      const fg = state.pane === "json" ? "gray" : colorFor(vrow.node);
       return line(
-        renderRowText(vrow, isCursor, state.expanded.has(vrow.node.id)),
+        renderRowText(vrow, isCursor, state.expanded.has(vrow.node.id), {
+          query: state.query,
+          thresholds,
+        }),
         fg ? { fg } : undefined,
       );
     },
   });
 
-  if (parseErrors.length === 0) return list;
-  return column(
-    { justifyContent: "flex-start" },
-    list,
-    line(""),
-    line(
+  const parts: Element[] = [tree];
+
+  if (state.jsonPaneOpen && state.jsonPane) {
+    parts.push(renderJsonPane(state, jsonPaneRows(viewport, state)));
+  }
+
+  if (hasStatusBar(state)) {
+    parts.push(renderStatusBar(state));
+  }
+
+  if (parseErrors.length > 0) {
+    parts.push(line(
       `${parseErrors.length} parse error(s) — first: line ${parseErrors[0].line}`,
       { fg: "bright-red" },
-    ),
+    ));
+  }
+
+  return column({ justifyContent: "flex-start" }, ...parts);
+}
+
+function renderJsonPane(state: ViewerState, height: number): Element {
+  const pane = state.jsonPane!;
+  const allLines = renderJson(pane.root, {
+    open: pane.open,
+    cursorPath: pane.cursorPath,
+  });
+  // The JSON pane needs its own scroll. Compute cursor index for
+  // followCursor; we treat the owner-path of the line as the cursor.
+  const rowPaths = flattenJsonRows(pane);
+  const cursorIdx = rowPaths.indexOf(pane.cursorPath);
+  const clamped = clampScroll(pane.scrollTop, allLines.length, height);
+  const scrollTop =
+    cursorIdx >= 0 ? followCursor(clamped, cursorIdx, height) : clamped;
+  const slice = allLines.slice(scrollTop, scrollTop + height);
+  const baseFg = state.pane === "json" ? undefined : "gray";
+  return column(
+    { justifyContent: "flex-start", height },
+    ...slice.map((l) => line(segmentsToStyled(l.segments), baseFg ? { fg: baseFg } : undefined)),
   );
+}
+
+// Convert per-segment `{text, fg?, bg?}` into a single inline-tagged
+// string the TUI's parseStyledText understands. We don't bother
+// closing intermediate tags — each segment is fully wrapped.
+function segmentsToStyled(
+  segments: ReadonlyArray<{ text: string; fg?: string; bg?: string }>,
+): string {
+  return segments
+    .map((s) => {
+      let out = s.text;
+      if (s.bg) out = `{${s.bg}-bg}${out}{/${s.bg}-bg}`;
+      if (s.fg) out = `{${s.fg}-fg}${out}{/${s.fg}-fg}`;
+      return out;
+    })
+    .join("");
+}
+
+function renderStatusBar(state: ViewerState): Element {
+  const parts: string[] = [];
+  if (state.query && state.matches !== undefined) {
+    const total = state.matches.length;
+    const idx = (state.matchIdx ?? 0) + 1;
+    parts.push(total > 0 ? `match ${idx}/${total} — "${state.query}"` : `no matches — "${state.query}"`);
+  }
+  if (state.followOn) parts.push("[FOLLOW]");
+  if (state.messageBar) parts.push(state.messageBar);
+  return line(parts.join("  "), { fg: "gray" });
+}
+
+function renderHelpOverlay(): Element {
+  const out = ["Keybindings", "─────────────", ...helpLines()];
+  return lines(out);
 }

--- a/packages/agency-lang/lib/logsViewer/run.ts
+++ b/packages/agency-lang/lib/logsViewer/run.ts
@@ -14,10 +14,7 @@ import {
   VisibleRow,
 } from "./render.js";
 import { handleKeyEx } from "./input.js";
-import { handlePaneKey, flattenJsonRows } from "./jsonView/input.js";
-import { buildJsonTree } from "./jsonView/build.js";
-import { defaultOpenSet, renderJson } from "./jsonView/render.js";
-import { ViewerState, TreeNode, JsonPaneStateRef } from "./types.js";
+import { ViewerState, TreeNode } from "./types.js";
 import { findMatches, expandAncestorsOf } from "./search.js";
 import { detectClipboard } from "./clipboard.js";
 import { follow, Follower } from "./follow.js";
@@ -61,7 +58,6 @@ export async function runViewer(opts: RunViewerOpts): Promise<void> {
       cursorId: roots[0].id,
       scrollTop: 0,
       quit: false,
-      pane: "tree",
     },
     opts.viewport,
   );
@@ -96,7 +92,7 @@ export async function runViewer(opts: RunViewerOpts): Promise<void> {
   try {
     while (!state.quit) {
       const event = await screen.nextKey();
-      // Global quit, regardless of which pane has focus.
+      // Global quit, regardless of any overlay.
       if (
         event.key === "q" ||
         (event.ctrl && (event.key === "c" || event.key === "C"))
@@ -104,100 +100,22 @@ export async function runViewer(opts: RunViewerOpts): Promise<void> {
         state = { ...state, quit: true };
         break;
       }
-      // JSON pane has focus: route keys there.
-      if (state.pane === "json" && state.jsonPane) {
-        const builtFor = state.jsonPane.builtFor;
-        const nextJson = handlePaneKey(state.jsonPane, event);
-        if (nextJson.releaseFocus) {
-          state = {
-            ...state,
-            pane: "tree",
-            jsonPane: { ...nextJson, releaseFocus: false, builtFor },
-          };
-        } else {
-          state = { ...state, jsonPane: { ...nextJson, builtFor } };
-        }
-      } else {
-        const { state: next, command } = handleKeyEx(state, event);
-        state = applyScroll(next, opts.viewport);
-        if (command?.kind === "search") {
-          const query = await screen.nextLine("Search: ");
-          state = applySearch(state, query, opts.viewport);
-        } else if (command?.kind === "copy") {
-          state = runCopy(state);
-        } else if (command?.kind === "toggleFollow") {
-          state = runToggleFollow(state, opts.followPath, startFollow, stopFollow);
-        }
+      const { state: next, command } = handleKeyEx(state, event);
+      state = applyScroll(next, opts.viewport);
+      if (command?.kind === "search") {
+        const query = await screen.nextLine("Search: ");
+        state = applySearch(state, query, opts.viewport);
+      } else if (command?.kind === "copy") {
+        state = runCopy(state);
+      } else if (command?.kind === "toggleFollow") {
+        state = runToggleFollow(state, opts.followPath, startFollow, stopFollow);
       }
-      // Maintain the JSON pane: rebuild content when the focused
-      // tree leaf changes, drop it when the pane is closed.
-      state = syncJsonPane(state);
       state = applyScroll(state, opts.viewport);
       screen.render(renderState(state, parsed.errors, opts.viewport, thresholds));
     }
   } finally {
     stopFollow();
   }
-}
-
-// Build / rebuild / clear the inner JSON pane based on the current
-// focused tree node. Cheap to call on every key — the JSON tree is
-// only re-built when the focused-node id actually changed.
-function syncJsonPane(state: ViewerState): ViewerState {
-  if (!state.jsonPaneOpen) {
-    return state.jsonPane ? { ...state, jsonPane: undefined } : state;
-  }
-  if (state.jsonPane?.builtFor === state.cursorId) return state;
-  const node = findNode(state.roots, state.cursorId);
-  if (!node) return state;
-  const payload = jsonPayloadFor(node);
-  const root = buildJsonTree(payload);
-  const open = defaultOpenSet(root);
-  const pane: JsonPaneStateRef = {
-    root,
-    open,
-    cursorPath: root.path,
-    scrollTop: 0,
-    releaseFocus: false,
-    builtFor: state.cursorId,
-  };
-  return { ...state, jsonPane: pane };
-}
-
-// JSON payload for a tree node. Leaves serialize their EventEnvelope;
-// spans and traces synthesize a small summary object because spans
-// don't have one canonical payload (multiple events share a span).
-function jsonPayloadFor(node: TreeNode): unknown {
-  if (node.nodeKind === "event" && node.event) return node.event;
-  if (node.nodeKind === "span") {
-    return {
-      spanType: node.label,
-      spanId: node.id,
-      parentId: node.parentId,
-      metrics: {
-        duration: node.duration,
-        tokens: node.tokens,
-        cost: node.cost,
-      },
-      eventCount: countEvents(node),
-    };
-  }
-  // trace
-  return {
-    traceId: node.traceId,
-    metrics: {
-      duration: node.duration,
-      tokens: node.tokens,
-      cost: node.cost,
-    },
-    eventCount: countEvents(node),
-  };
-}
-
-function countEvents(node: TreeNode): number {
-  let n = node.nodeKind === "event" ? 1 : 0;
-  for (const c of node.children) n += countEvents(c);
-  return n;
 }
 
 function findNode(roots: TreeNode[], id: string): TreeNode | undefined {
@@ -262,7 +180,11 @@ function runCopy(state: ViewerState): ViewerState {
   if (!node) return state;
   const cb = detectClipboard();
   if (!cb) return { ...state, messageBar: "clipboard unavailable" };
-  const payload = jsonPayloadFor(node);
+  const payload = node.event ?? {
+    label: node.label,
+    traceId: node.traceId,
+    metrics: { duration: node.duration, tokens: node.tokens, cost: node.cost },
+  };
   const text = JSON.stringify(payload, null, 2);
   try {
     cb.write(text);
@@ -309,30 +231,23 @@ function applyScroll(
   return scrollTop === state.scrollTop ? state : { ...state, scrollTop };
 }
 
-// Rows available to the tree pane after subtracting (a) the JSON
-// pane allotment when open, (b) the bottom status line when present.
+// Rows available to the tree after subtracting the bottom status
+// line (when present).
 function treePaneRows(
   viewport: { rows: number; cols: number },
   state: ViewerState,
 ): number {
   const reserved = hasStatusBar(state) ? 1 : 0;
-  const usable = Math.max(1, viewport.rows - reserved);
-  if (!state.jsonPaneOpen) return usable;
-  // Tree gets ~60%, pane ~40%, min 1 row each.
-  return Math.max(1, Math.floor(usable * 0.6));
-}
-
-function jsonPaneRows(
-  viewport: { rows: number; cols: number },
-  state: ViewerState,
-): number {
-  const reserved = hasStatusBar(state) ? 1 : 0;
-  const usable = Math.max(1, viewport.rows - reserved);
-  return Math.max(1, usable - treePaneRows(viewport, state));
+  return Math.max(1, viewport.rows - reserved);
 }
 
 function hasStatusBar(state: ViewerState): boolean {
-  return !!(state.messageBar || (state.matches && state.matches.length > 0) || state.followOn || state.query);
+  return !!(
+    state.messageBar ||
+    (state.matches && state.matches.length > 0) ||
+    state.followOn ||
+    state.query
+  );
 }
 
 function renderState(
@@ -353,7 +268,7 @@ function renderState(
     scrollTop: state.scrollTop,
     viewportRows: treeHeight,
     renderItem: (vrow, isCursor) => {
-      const fg = state.pane === "json" ? "gray" : colorFor(vrow.node);
+      const fg = colorFor(vrow.node);
       return line(
         renderRowText(vrow, isCursor, state.expanded.has(vrow.node.id), {
           query: state.query,
@@ -365,10 +280,6 @@ function renderState(
   });
 
   const parts: Element[] = [tree];
-
-  if (state.jsonPaneOpen && state.jsonPane) {
-    parts.push(renderJsonPane(state, jsonPaneRows(viewport, state)));
-  }
 
   if (hasStatusBar(state)) {
     parts.push(renderStatusBar(state));
@@ -382,43 +293,6 @@ function renderState(
   }
 
   return column({ justifyContent: "flex-start" }, ...parts);
-}
-
-function renderJsonPane(state: ViewerState, height: number): Element {
-  const pane = state.jsonPane!;
-  const allLines = renderJson(pane.root, {
-    open: pane.open,
-    cursorPath: pane.cursorPath,
-  });
-  // The JSON pane needs its own scroll. Compute cursor index for
-  // followCursor; we treat the owner-path of the line as the cursor.
-  const rowPaths = flattenJsonRows(pane);
-  const cursorIdx = rowPaths.indexOf(pane.cursorPath);
-  const clamped = clampScroll(pane.scrollTop, allLines.length, height);
-  const scrollTop =
-    cursorIdx >= 0 ? followCursor(clamped, cursorIdx, height) : clamped;
-  const slice = allLines.slice(scrollTop, scrollTop + height);
-  const baseFg = state.pane === "json" ? undefined : "gray";
-  return column(
-    { justifyContent: "flex-start", height },
-    ...slice.map((l) => line(segmentsToStyled(l.segments), baseFg ? { fg: baseFg } : undefined)),
-  );
-}
-
-// Convert per-segment `{text, fg?, bg?}` into a single inline-tagged
-// string the TUI's parseStyledText understands. We don't bother
-// closing intermediate tags — each segment is fully wrapped.
-function segmentsToStyled(
-  segments: ReadonlyArray<{ text: string; fg?: string; bg?: string }>,
-): string {
-  return segments
-    .map((s) => {
-      let out = s.text;
-      if (s.bg) out = `{${s.bg}-bg}${out}{/${s.bg}-bg}`;
-      if (s.fg) out = `{${s.fg}-fg}${out}{/${s.fg}-fg}`;
-      return out;
-    })
-    .join("");
 }
 
 function renderStatusBar(state: ViewerState): Element {

--- a/packages/agency-lang/lib/logsViewer/run.ts
+++ b/packages/agency-lang/lib/logsViewer/run.ts
@@ -14,6 +14,8 @@ import {
   VisibleRow,
 } from "./render.js";
 import { handleKeyEx } from "./input.js";
+import { formatKey } from "../tui/input/format.js";
+import type { KeyEvent } from "../tui/input/types.js";
 import { ViewerState, TreeNode } from "./types.js";
 import { findMatches, expandAncestorsOf } from "./search.js";
 import { detectClipboard } from "./clipboard.js";
@@ -99,6 +101,16 @@ export async function runViewer(opts: RunViewerOpts): Promise<void> {
       ) {
         state = { ...state, quit: true };
         break;
+      }
+      // Vim-style page scroll — handled here because page size is
+      // viewport-dependent and the pure reducer doesn't know the
+      // viewport. We move the cursor by N rows; applyScroll then
+      // pages the viewport along with it.
+      const paged = paginate(state, event, opts.viewport);
+      if (paged) {
+        state = applyScroll(paged, opts.viewport);
+        screen.render(renderState(state, parsed.errors, opts.viewport, thresholds));
+        continue;
       }
       const { state: next, command } = handleKeyEx(state, event);
       state = applyScroll(next, opts.viewport);
@@ -212,6 +224,30 @@ function onFollowAppend(
     cursorId: stillThere ? prev.cursorId : roots[0].id,
   };
   return applyScroll(next, viewport);
+}
+
+// Vim-style page scroll. Returns the updated state if `event` is a
+// page-scroll key; otherwise undefined so the caller falls through
+// to the normal reducer.
+function paginate(
+  state: ViewerState,
+  event: KeyEvent,
+  viewport: { rows: number; cols: number },
+): ViewerState | undefined {
+  const fmt = formatKey(event);
+  const pageRows = Math.max(1, treePaneRows(viewport, state) - 1);
+  const halfPage = Math.max(1, Math.floor(pageRows / 2));
+  let delta = 0;
+  if (fmt === "Ctrl+F" || fmt === "PageDown") delta = +pageRows;
+  else if (fmt === "Ctrl+B" || fmt === "PageUp") delta = -pageRows;
+  else if (fmt === "Ctrl+D") delta = +halfPage;
+  else if (fmt === "Ctrl+U") delta = -halfPage;
+  else return undefined;
+  const rows = flattenVisibleRows(state);
+  if (rows.length === 0) return state;
+  const curIdx = Math.max(0, rows.findIndex((r) => r.node.id === state.cursorId));
+  const nextIdx = Math.min(rows.length - 1, Math.max(0, curIdx + delta));
+  return { ...state, cursorId: rows[nextIdx].node.id };
 }
 
 // Clamp and cursor-follow scrollTop based on the current visible

--- a/packages/agency-lang/lib/logsViewer/run.ts
+++ b/packages/agency-lang/lib/logsViewer/run.ts
@@ -29,8 +29,13 @@ export type RunViewerOpts = {
   output: OutputTarget;
   viewport: { rows: number; cols: number };
   // Optional path to enable --follow mode (re-read as the file grows).
-  // Undefined disables follow even if the user presses `f`.
+  // Undefined disables follow even if the user presses `f` (e.g. when
+  // reading from stdin).
   followPath?: string;
+  // If true, start the file watcher immediately at boot — equivalent
+  // to launching the viewer and then pressing `f`. Ignored when
+  // followPath is undefined.
+  initialFollow?: boolean;
   thresholds?: ViewerThresholds;
 };
 
@@ -89,6 +94,14 @@ export async function runViewer(opts: RunViewerOpts): Promise<void> {
     followerState.f.stop();
     followerState = undefined;
   };
+
+  // Auto-start follow if --follow was passed. We do this after
+  // building state so the [FOLLOW] indicator appears in the first
+  // render below.
+  if (opts.initialFollow && opts.followPath) {
+    startFollow();
+    state = { ...state, followOn: true };
+  }
 
   screen.render(renderState(state, parsed.errors, opts.viewport, thresholds));
   try {
@@ -177,7 +190,9 @@ function runToggleFollow(
   stop: () => void,
 ): ViewerState {
   if (!followPath) {
-    return { ...state, messageBar: "follow disabled (stdin or no file)" };
+    // We only end up here when the viewer was launched without a
+    // file path (stdin pipe). There is no on-disk file to tail.
+    return { ...state, messageBar: "follow unavailable when reading from stdin" };
   }
   if (state.followOn) {
     stop();

--- a/packages/agency-lang/lib/logsViewer/search.test.ts
+++ b/packages/agency-lang/lib/logsViewer/search.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import { findMatches, expandAncestorsOf, highlightMatches } from "./search.js";
+import { TreeNode, ViewerState } from "./types.js";
+
+function span(id: string, summary: string, children: TreeNode[] = [], parentId: string | null = null): TreeNode {
+  return {
+    id,
+    traceId: "t",
+    parentId,
+    children,
+    nodeKind: "span",
+    label: id,
+    summary,
+  };
+}
+
+function trace(id: string, children: TreeNode[] = []): TreeNode {
+  return {
+    id,
+    traceId: id,
+    parentId: null,
+    children,
+    nodeKind: "trace",
+    label: id,
+    summary: `trace ${id}`,
+  };
+}
+
+describe("findMatches", () => {
+  it("returns ids of nodes whose summary contains the query case-insensitively", () => {
+    const t = trace("T", [
+      span("a", "agentRun (1s)", [
+        span("b", "llmCall (2s)"),
+        span("c", "toolCall search"),
+      ]),
+    ]);
+    expect(findMatches([t], "llm")).toEqual(["b"]);
+    expect(findMatches([t], "LLM")).toEqual(["b"]);
+  });
+
+  it("returns ids in depth-first pre-order", () => {
+    const t = trace("T", [
+      span("a", "X", [span("b", "X"), span("c", "X")]),
+      span("d", "X"),
+    ]);
+    expect(findMatches([t], "X")).toEqual(["a", "b", "c", "d"]);
+  });
+
+  it("returns an empty list for an empty query", () => {
+    const t = trace("T", [span("a", "anything")]);
+    expect(findMatches([t], "")).toEqual([]);
+  });
+
+  it("returns an empty list when nothing matches", () => {
+    const t = trace("T", [span("a", "alpha")]);
+    expect(findMatches([t], "zzz")).toEqual([]);
+  });
+});
+
+describe("expandAncestorsOf", () => {
+  it("adds every ancestor of every match to expanded", () => {
+    const c = span("c", "match");
+    const b = span("b", "...", [c], "a");
+    c.parentId = "b";
+    const a = span("a", "...", [b], "T");
+    b.parentId = "a";
+    const t = trace("T", [a]);
+    a.parentId = "T";
+    const state: ViewerState = {
+      roots: [t],
+      expanded: new Set(),
+      cursorId: "T",
+      scrollTop: 0,
+      quit: false,
+    };
+    const next = expandAncestorsOf(state, ["c"]);
+    expect([...next.expanded].sort()).toEqual(["T", "a", "b"]);
+  });
+
+  it("returns the original state when there are no matches", () => {
+    const state: ViewerState = {
+      roots: [],
+      expanded: new Set(),
+      cursorId: "",
+      scrollTop: 0,
+      quit: false,
+    };
+    expect(expandAncestorsOf(state, [])).toBe(state);
+  });
+});
+
+describe("highlightMatches", () => {
+  it("returns one segment when the query is empty", () => {
+    expect(highlightMatches("foo bar", "")).toEqual([{ text: "foo bar" }]);
+  });
+
+  it("marks the matching substring with bg yellow", () => {
+    expect(highlightMatches("hello world", "wor")).toEqual([
+      { text: "hello " },
+      { text: "wor", bg: "yellow" },
+      { text: "ld" },
+    ]);
+  });
+
+  it("matches case-insensitively but preserves source case", () => {
+    expect(highlightMatches("Hello", "ell")).toEqual([
+      { text: "H" },
+      { text: "ell", bg: "yellow" },
+      { text: "o" },
+    ]);
+    expect(highlightMatches("Hello", "ELL")).toEqual([
+      { text: "H" },
+      { text: "ell", bg: "yellow" },
+      { text: "o" },
+    ]);
+  });
+
+  it("highlights multiple non-overlapping matches", () => {
+    expect(highlightMatches("aaaa", "a")).toEqual([
+      { text: "a", bg: "yellow" },
+      { text: "a", bg: "yellow" },
+      { text: "a", bg: "yellow" },
+      { text: "a", bg: "yellow" },
+    ]);
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/search.test.ts
+++ b/packages/agency-lang/lib/logsViewer/search.test.ts
@@ -89,6 +89,77 @@ describe("expandAncestorsOf", () => {
   });
 });
 
+describe("findMatches — synthetic rows", () => {
+  // A promptCompletion leaf whose conversation rows include the word
+  // "Alice". `findMatches` must reach the synthetic convoLine and
+  // `expandAncestorsOf` must auto-expand the leaf so `n`/`N` lands
+  // on it.
+  function pcLeaf(): TreeNode {
+    return {
+      id: "evt-0",
+      traceId: "T",
+      parentId: "T",
+      children: [],
+      nodeKind: "event",
+      label: "promptCompletion",
+      summary: "promptCompletion",
+      event: {
+        format_version: 1,
+        trace_id: "T",
+        project_id: "p",
+        span_id: null,
+        parent_span_id: null,
+        data: {
+          type: "promptCompletion",
+          timestamp: "2026-01-01T00:00:00Z",
+          messages: [{ role: "user", content: "Hello Alice" }],
+        },
+      },
+    };
+  }
+
+  it("matches text inside synthetic conversation rows", () => {
+    const leaf = pcLeaf();
+    const t = trace("T", [leaf]);
+    leaf.parentId = "T";
+    // "Alice" appears in the conversation row and again inside the
+    // raw-data JSON payload, so we expect both synthetic ids.
+    expect(findMatches([t], "Alice")).toContain("evt-0:convo:0");
+  });
+
+  it("expands the parent leaf when a convo row matches", () => {
+    const leaf = pcLeaf();
+    const t = trace("T", [leaf]);
+    leaf.parentId = "T";
+    const state: ViewerState = {
+      roots: [t],
+      expanded: new Set(),
+      cursorId: "T",
+      scrollTop: 0,
+      quit: false,
+    };
+    const next = expandAncestorsOf(state, ["evt-0:convo:0"]);
+    expect(next.expanded.has("evt-0")).toBe(true);
+    expect(next.expanded.has("T")).toBe(true);
+  });
+
+  it("expands both leaf and raw-data toggle for raw-JSON matches", () => {
+    const leaf = pcLeaf();
+    const t = trace("T", [leaf]);
+    leaf.parentId = "T";
+    const state: ViewerState = {
+      roots: [t],
+      expanded: new Set(),
+      cursorId: "T",
+      scrollTop: 0,
+      quit: false,
+    };
+    const next = expandAncestorsOf(state, ["evt-0:raw:json:5"]);
+    expect(next.expanded.has("evt-0")).toBe(true);
+    expect(next.expanded.has("evt-0:raw")).toBe(true);
+  });
+});
+
 describe("highlightMatches", () => {
   it("returns one segment when the query is empty", () => {
     expect(highlightMatches("foo bar", "")).toEqual([{ text: "foo bar" }]);

--- a/packages/agency-lang/lib/logsViewer/search.ts
+++ b/packages/agency-lang/lib/logsViewer/search.ts
@@ -1,0 +1,75 @@
+import { TreeNode, ViewerState } from "./types.js";
+
+// Walk every node in the forest (regardless of current expansion
+// state) and return the ids of nodes whose `summary` contains the
+// query case-insensitively. The returned order matches a depth-first
+// pre-order walk, which is also the visible order once ancestors are
+// expanded.
+export function findMatches(roots: TreeNode[], query: string): string[] {
+  if (query.length === 0) return [];
+  const needle = query.toLowerCase();
+  const out: string[] = [];
+  const walk = (node: TreeNode): void => {
+    if (node.summary.toLowerCase().includes(needle)) {
+      out.push(node.id);
+    }
+    for (const child of node.children) walk(child);
+  };
+  for (const r of roots) walk(r);
+  return out;
+}
+
+// Given a list of match node ids, return a new ViewerState whose
+// `expanded` set includes every ancestor of every match. The match
+// nodes themselves are NOT expanded (we only need their ancestors
+// visible so the cursor can land on the match).
+export function expandAncestorsOf(
+  state: ViewerState,
+  matchIds: string[],
+): ViewerState {
+  if (matchIds.length === 0) return state;
+  const byId = indexById(state.roots);
+  const next = new Set(state.expanded);
+  for (const id of matchIds) {
+    let cur = byId[id];
+    while (cur && cur.parentId) {
+      next.add(cur.parentId);
+      cur = byId[cur.parentId];
+    }
+  }
+  return next.size === state.expanded.size ? state : { ...state, expanded: next };
+}
+
+function indexById(roots: TreeNode[]): Record<string, TreeNode> {
+  const out: Record<string, TreeNode> = {};
+  const walk = (n: TreeNode): void => {
+    out[n.id] = n;
+    for (const c of n.children) walk(c);
+  };
+  for (const r of roots) walk(r);
+  return out;
+}
+
+// Highlight a substring in a row's rendered text. Returns segment
+// list where the matching substring(s) carry `bg: "yellow"`. The
+// caller turns segments into TUI text. Case-insensitive match.
+export type Segment = { text: string; bg?: "yellow" };
+
+export function highlightMatches(text: string, query: string): Segment[] {
+  if (query.length === 0) return [{ text }];
+  const needle = query.toLowerCase();
+  const lower = text.toLowerCase();
+  const out: Segment[] = [];
+  let i = 0;
+  while (i < text.length) {
+    const hit = lower.indexOf(needle, i);
+    if (hit < 0) {
+      out.push({ text: text.slice(i) });
+      break;
+    }
+    if (hit > i) out.push({ text: text.slice(i, hit) });
+    out.push({ text: text.slice(hit, hit + query.length), bg: "yellow" });
+    i = hit + query.length;
+  }
+  return out;
+}

--- a/packages/agency-lang/lib/logsViewer/search.ts
+++ b/packages/agency-lang/lib/logsViewer/search.ts
@@ -1,10 +1,17 @@
 import { TreeNode, ViewerState } from "./types.js";
+import { eventExpansionChildren, rawDataChildren } from "./render.js";
 
 // Walk every node in the forest (regardless of current expansion
-// state) and return the ids of nodes whose `summary` contains the
-// query case-insensitively. The returned order matches a depth-first
-// pre-order walk, which is also the visible order once ancestors are
-// expanded.
+// state) AND every synthetic expansion row (conversation lines, JSON
+// payload lines, raw-data toggle) and return the ids of nodes whose
+// `summary` contains the query case-insensitively. The returned order
+// matches a depth-first pre-order walk, which is also the visible
+// order once ancestors are expanded.
+//
+// We have to walk the synthetic rows here too — otherwise `/foo`
+// would visibly highlight a match in a conversation/JSON row but
+// `n`/`N` would jump to "no matches" because those rows aren't in
+// state.roots.
 export function findMatches(roots: TreeNode[], query: string): string[] {
   if (query.length === 0) return [];
   const needle = query.toLowerCase();
@@ -12,6 +19,20 @@ export function findMatches(roots: TreeNode[], query: string): string[] {
   const walk = (node: TreeNode): void => {
     if (node.summary.toLowerCase().includes(needle)) {
       out.push(node.id);
+    }
+    if (node.nodeKind === "event" && node.event) {
+      for (const synth of eventExpansionChildren(node)) {
+        if (synth.summary.toLowerCase().includes(needle)) {
+          out.push(synth.id);
+        }
+        if (synth.nodeKind === "rawDataToggle") {
+          for (const json of rawDataChildren(synth)) {
+            if (json.summary.toLowerCase().includes(needle)) {
+              out.push(json.id);
+            }
+          }
+        }
+      }
     }
     for (const child of node.children) walk(child);
   };
@@ -23,6 +44,12 @@ export function findMatches(roots: TreeNode[], query: string): string[] {
 // `expanded` set includes every ancestor of every match. The match
 // nodes themselves are NOT expanded (we only need their ancestors
 // visible so the cursor can land on the match).
+//
+// Synthetic ids (e.g. "evt-3:convo:1", "evt-3:raw", "evt-3:raw:json:7")
+// are not in the persistent forest, so we first walk back along the
+// synthetic-id chain to the underlying leaf event id, expanding each
+// synthetic ancestor along the way, then walk the real-forest
+// ancestors as before.
 export function expandAncestorsOf(
   state: ViewerState,
   matchIds: string[],
@@ -31,13 +58,35 @@ export function expandAncestorsOf(
   const byId = indexById(state.roots);
   const next = new Set(state.expanded);
   for (const id of matchIds) {
-    let cur = byId[id];
+    const realLeafId = expandSyntheticAncestors(id, next);
+    let cur = byId[realLeafId];
     while (cur && cur.parentId) {
       next.add(cur.parentId);
       cur = byId[cur.parentId];
     }
   }
   return next.size === state.expanded.size ? state : { ...state, expanded: next };
+}
+
+// Walk a synthetic id back to its real-forest leaf id, expanding each
+// synthetic parent so the match is visible. Synthetic id forms:
+//   <leaf>:convo:<n>          — conversation line under a leaf event
+//   <leaf>:json:<n>           — raw JSON line under a non-pc leaf
+//   <leaf>:raw                — "raw data" toggle under a leaf
+//   <leaf>:raw:json:<n>       — JSON line under an opened raw toggle
+// Leaves themselves are returned unchanged.
+function expandSyntheticAncestors(id: string, expanded: Set<string>): string {
+  const colon = id.indexOf(":");
+  if (colon < 0) return id;
+  const leafId = id.slice(0, colon);
+  const rest = id.slice(colon + 1);
+  // Always expand the leaf so its synthetic children become visible.
+  expanded.add(leafId);
+  // If the match lives under the "raw data" toggle, also expand it.
+  if (rest.startsWith("raw:") || rest === "raw") {
+    expanded.add(`${leafId}:raw`);
+  }
+  return leafId;
 }
 
 function indexById(roots: TreeNode[]): Record<string, TreeNode> {

--- a/packages/agency-lang/lib/logsViewer/summary.test.ts
+++ b/packages/agency-lang/lib/logsViewer/summary.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { summarize, summarizeSpan, summarizeTrace } from "./summary.js";
+import {
+  summarize,
+  summarizeSpan,
+  summarizeTrace,
+  summarizeSpanStyled,
+} from "./summary.js";
 import { TreeNode } from "./types.js";
 
 describe("summarize (leaf events)", () => {
@@ -122,5 +127,48 @@ describe("summarizeTrace", () => {
       summary: "",
     };
     expect(summarizeTrace(node)).toBe("trace  [abc123]");
+  });
+});
+
+describe("summarizeSpanStyled", () => {
+  const makeNode = (duration?: number, cost?: number): TreeNode => ({
+    id: "s",
+    traceId: "",
+    parentId: null,
+    children: [],
+    nodeKind: "span",
+    label: "llmCall",
+    summary: "",
+    duration,
+    cost,
+  });
+
+  it("wraps slow durations in bright-red tags", () => {
+    const s = summarizeSpanStyled(makeNode(10_000));
+    expect(s).toMatch(/\{bright-red-fg\}10\.0s\{\/bright-red-fg\}/);
+  });
+
+  it("wraps fast durations in gray tags", () => {
+    const s = summarizeSpanStyled(makeNode(50));
+    expect(s).toMatch(/\{gray-fg\}50ms\{\/gray-fg\}/);
+  });
+
+  it("leaves normal-range durations untagged", () => {
+    const s = summarizeSpanStyled(makeNode(500));
+    expect(s).toContain("500ms");
+    expect(s).not.toMatch(/\{[a-z-]+-fg\}500ms/);
+  });
+
+  it("wraps expensive costs in bright-red tags", () => {
+    const s = summarizeSpanStyled(makeNode(undefined, 0.05));
+    expect(s).toMatch(/\{bright-red-fg\}\$0\.050\{\/bright-red-fg\}/);
+  });
+
+  it("does not color token counts", () => {
+    const n = makeNode();
+    n.tokens = 1500;
+    const s = summarizeSpanStyled(n);
+    expect(s).toContain("1500 tok");
+    expect(s).not.toMatch(/\{[a-z-]+-fg\}1500 tok/);
   });
 });

--- a/packages/agency-lang/lib/logsViewer/summary.ts
+++ b/packages/agency-lang/lib/logsViewer/summary.ts
@@ -1,4 +1,11 @@
 import { EventEnvelope, TreeNode } from "./types.js";
+import {
+  DEFAULT_THRESHOLDS,
+  ViewerThresholds,
+  durationMagnitude,
+  costMagnitude,
+  Magnitude,
+} from "./thresholds.js";
 
 export function summarize(evt: EventEnvelope): string {
   const d = evt.data;
@@ -102,4 +109,68 @@ function stripQuotes(s?: string): string {
 
 function truncate(s: string, n: number): string {
   return s.length <= n ? s : s.slice(0, n - 1) + "…";
+}
+
+// ---------------------------------------------------------------------------
+// Styled-summary variants: produce the same text as the plain functions
+// above but wrap durations/costs in `{...-fg}...{/...-fg}` tags so the
+// TUI renderer can color them by magnitude. Token counts stay
+// uncolored (they're noisy and not actionable). The plain functions
+// are still used at tree-build time so `node.summary` stays grep-able
+// for search; the renderer asks for the styled version when drawing.
+
+export function summarizeSpanStyled(
+  node: TreeNode,
+  thresholds: ViewerThresholds = DEFAULT_THRESHOLDS,
+): string {
+  const metrics = formatMetricsStyled(node, thresholds);
+  return metrics ? `${node.label} (${metrics})` : node.label;
+}
+
+export function summarizeTraceStyled(
+  node: TreeNode,
+  thresholds: ViewerThresholds = DEFAULT_THRESHOLDS,
+): string {
+  const shortTraceId = node.traceId.slice(0, 6);
+  const metrics = formatMetricsStyled(node, thresholds);
+  const head = node.firstTs !== undefined ? fmtTime(node.firstTs) : "trace";
+  const middle = metrics ? `  (${metrics})` : "";
+  return `${head}${middle}  [${shortTraceId}]`;
+}
+
+function formatMetricsStyled(node: TreeNode, t: ViewerThresholds): string {
+  const parts: string[] = [];
+  if (node.duration !== undefined) {
+    parts.push(wrapTag(fmtDuration(node.duration), durationColor(node.duration, t)));
+  }
+  if (node.tokens !== undefined) parts.push(`${node.tokens} tok`);
+  if (node.cost !== undefined) {
+    parts.push(wrapTag(fmtCost(node.cost), costColor(node.cost, t)));
+  }
+  return parts.join(", ");
+}
+
+function durationColor(ms: number, t: ViewerThresholds): string | undefined {
+  return colorForMagnitude(durationMagnitude(ms, t));
+}
+
+function costColor(usd: number, t: ViewerThresholds): string | undefined {
+  return colorForMagnitude(costMagnitude(usd, t));
+}
+
+function colorForMagnitude(m: Magnitude): string | undefined {
+  switch (m) {
+    case "slow":
+    case "expensive":
+      return "bright-red";
+    case "fast":
+      return "gray";
+    default:
+      return undefined;
+  }
+}
+
+function wrapTag(text: string, color: string | undefined): string {
+  if (!color) return text;
+  return `{${color}-fg}${text}{/${color}-fg}`;
 }

--- a/packages/agency-lang/lib/logsViewer/thresholds.test.ts
+++ b/packages/agency-lang/lib/logsViewer/thresholds.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import {
+  DEFAULT_THRESHOLDS,
+  durationMagnitude,
+  costMagnitude,
+} from "./thresholds.js";
+
+describe("durationMagnitude", () => {
+  it("returns 'slow' at or above the slow threshold", () => {
+    expect(durationMagnitude(DEFAULT_THRESHOLDS.slowMs)).toBe("slow");
+    expect(durationMagnitude(DEFAULT_THRESHOLDS.slowMs + 1)).toBe("slow");
+  });
+  it("returns 'fast' below the fast threshold", () => {
+    expect(durationMagnitude(0)).toBe("fast");
+    expect(durationMagnitude(DEFAULT_THRESHOLDS.fastMs - 1)).toBe("fast");
+  });
+  it("returns 'normal' in the middle band", () => {
+    expect(durationMagnitude(DEFAULT_THRESHOLDS.fastMs)).toBe("normal");
+    expect(durationMagnitude(DEFAULT_THRESHOLDS.slowMs - 1)).toBe("normal");
+  });
+});
+
+describe("costMagnitude", () => {
+  it("returns 'expensive' at or above the expensive threshold", () => {
+    expect(costMagnitude(DEFAULT_THRESHOLDS.expensiveUsd)).toBe("expensive");
+    expect(costMagnitude(DEFAULT_THRESHOLDS.expensiveUsd + 0.001)).toBe("expensive");
+  });
+  it("returns 'cheap' below the expensive threshold", () => {
+    expect(costMagnitude(0)).toBe("cheap");
+    expect(costMagnitude(0.0001)).toBe("cheap");
+  });
+});

--- a/packages/agency-lang/lib/logsViewer/thresholds.ts
+++ b/packages/agency-lang/lib/logsViewer/thresholds.ts
@@ -1,0 +1,36 @@
+// Color-coding thresholds for the logs viewer. Durations above
+// `SLOW_MS` and costs above `EXPENSIVE_USD` render bright-red so
+// long/expensive operations jump out. Durations under `FAST_MS`
+// render gray so the noise fades. Tunable via `agency.json` —
+// see `lib/config.ts`.
+
+export type ViewerThresholds = {
+  slowMs: number;
+  fastMs: number;
+  expensiveUsd: number;
+};
+
+export const DEFAULT_THRESHOLDS: ViewerThresholds = {
+  slowMs: 5000,
+  fastMs: 100,
+  expensiveUsd: 0.01,
+};
+
+export type Magnitude = "fast" | "normal" | "slow" | "cheap" | "expensive";
+
+export function durationMagnitude(
+  ms: number,
+  t: ViewerThresholds = DEFAULT_THRESHOLDS,
+): Magnitude {
+  if (ms >= t.slowMs) return "slow";
+  if (ms < t.fastMs) return "fast";
+  return "normal";
+}
+
+export function costMagnitude(
+  usd: number,
+  t: ViewerThresholds = DEFAULT_THRESHOLDS,
+): Magnitude {
+  if (usd >= t.expensiveUsd) return "expensive";
+  return "cheap";
+}

--- a/packages/agency-lang/lib/logsViewer/tree.test.ts
+++ b/packages/agency-lang/lib/logsViewer/tree.test.ts
@@ -13,6 +13,18 @@ const evt = (over: Partial<EventEnvelope>): EventEnvelope => ({
 });
 
 describe("buildForest", () => {
+  it("hides graph schema events from the tree", () => {
+    const forest = buildForest([
+      evt({ data: { type: "agentStart", timestamp: "" } }),
+      evt({ data: { type: "graph", timestamp: "", nodes: ["main"], edges: {}, startNode: "main" } }),
+      evt({ data: { type: "enterNode", timestamp: "", nodeId: "main" } }),
+    ]);
+    const labels = forest[0].children.map((c) => c.label);
+    expect(labels).not.toContain("graph");
+    expect(labels).toContain("agentStart");
+    expect(labels).toContain("enterNode");
+  });
+
   it("returns one root per trace_id", () => {
     const forest = buildForest([
       evt({ trace_id: "a" }),

--- a/packages/agency-lang/lib/logsViewer/tree.ts
+++ b/packages/agency-lang/lib/logsViewer/tree.ts
@@ -1,6 +1,12 @@
 import { EventEnvelope, TreeNode } from "./types.js";
 import { summarize, summarizeSpan, summarizeTrace } from "./summary.js";
 
+// Event types the viewer skips entirely. `graph` is a one-shot
+// schema dump (nodes + edges + start node) emitted at the top of
+// each agent run; useful in the JSONL for tooling but not in the
+// interactive tree.
+const HIDDEN_EVENT_TYPES = new Set<string>(["graph"]);
+
 export function buildForest(events: EventEnvelope[]): TreeNode[] {
   // traceId → trace root
   const traces: Record<string, TreeNode> = {};
@@ -43,9 +49,12 @@ export function buildForest(events: EventEnvelope[]): TreeNode[] {
   }
 
   // Pass 2: attach each event as a leaf under its span (or under the
-  // trace root if it has no span_id), preserving arrival order.
+  // trace root if it has no span_id), preserving arrival order. Some
+  // event types are noise (e.g. the `graph` schema dump) and are
+  // hidden from the viewer entirely.
   let leafCounter = 0;
   for (const evt of events) {
+    if (HIDDEN_EVENT_TYPES.has(evt.data.type)) continue;
     const traceRoot = traces[evt.trace_id];
     const parent = evt.span_id ? spans[evt.span_id] : traceRoot;
     const leaf: TreeNode = {

--- a/packages/agency-lang/lib/logsViewer/types.ts
+++ b/packages/agency-lang/lib/logsViewer/types.ts
@@ -54,4 +54,33 @@ export type ViewerState = {
   scrollTop: number;
   // Set by the input layer; consumed by the run loop.
   quit: boolean;
+  // ---- v2 additions ----
+  // Active substring query for `/`, `n`, `N`. Empty when search is off.
+  query?: string;
+  // Node ids that currently match `query`, in flatten order.
+  matches?: string[];
+  // Index into `matches` for the current "n/N" position.
+  matchIdx?: number;
+  // Bottom JSON payload pane: visible? Owned by run.ts.
+  jsonPaneOpen?: boolean;
+  // Which pane has keyboard focus.
+  pane?: "tree" | "json";
+  // Inner JSON-pane state — built lazily for the currently-focused
+  // tree node when the pane is open. Run loop owns rebuilds.
+  jsonPane?: JsonPaneStateRef;
+  // Help-screen overlay shown?
+  helpOpen?: boolean;
+  // Follow mode (`--follow` / `f`) — viewer re-reads the file when it grows.
+  followOn?: boolean;
+  // One-line status message (`copied 312 bytes`, etc.); auto-clears
+  // on the next keystroke. Owned by the input layer.
+  messageBar?: string;
+};
+
+// Re-export so consumers don't need a second import.
+import type { JsonPaneState } from "./jsonView/input.js";
+export type JsonPaneStateRef = JsonPaneState & {
+  // Tree-node id this pane content was built from. Lets the run loop
+  // detect when the focused tree node changed and rebuild.
+  builtFor: string;
 };

--- a/packages/agency-lang/lib/logsViewer/types.ts
+++ b/packages/agency-lang/lib/logsViewer/types.ts
@@ -24,10 +24,13 @@ export type TreeNode = {
   traceId: string;
   parentId: string | null;
   children: TreeNode[];
-  // "jsonLine" is a synthetic, on-the-fly row generated when a leaf
-  // event is expanded — it carries one rendered line of the leaf's
-  // JSON payload. Not part of the persistent forest.
-  nodeKind: "trace" | "span" | "event" | "jsonLine";
+  // Synthetic, on-the-fly rows generated when a leaf event is
+  // expanded — none are part of the persistent forest:
+  //   - "jsonLine"      : one rendered line of the leaf's JSON payload
+  //   - "convoLine"     : one rendered conversation message (promptCompletion only)
+  //   - "rawDataToggle" : expandable "raw data" header that, when opened,
+  //                       reveals the underlying JSON payload as jsonLine rows
+  nodeKind: "trace" | "span" | "event" | "jsonLine" | "convoLine" | "rawDataToggle";
   // For "trace": the trace_id; for "span": the span type (agentRun,
   // llmCall, ...); for "event": the data.type.
   label: string;

--- a/packages/agency-lang/lib/logsViewer/types.ts
+++ b/packages/agency-lang/lib/logsViewer/types.ts
@@ -24,7 +24,10 @@ export type TreeNode = {
   traceId: string;
   parentId: string | null;
   children: TreeNode[];
-  nodeKind: "trace" | "span" | "event";
+  // "jsonLine" is a synthetic, on-the-fly row generated when a leaf
+  // event is expanded — it carries one rendered line of the leaf's
+  // JSON payload. Not part of the persistent forest.
+  nodeKind: "trace" | "span" | "event" | "jsonLine";
   // For "trace": the trace_id; for "span": the span type (agentRun,
   // llmCall, ...); for "event": the data.type.
   label: string;
@@ -61,13 +64,6 @@ export type ViewerState = {
   matches?: string[];
   // Index into `matches` for the current "n/N" position.
   matchIdx?: number;
-  // Bottom JSON payload pane: visible? Owned by run.ts.
-  jsonPaneOpen?: boolean;
-  // Which pane has keyboard focus.
-  pane?: "tree" | "json";
-  // Inner JSON-pane state — built lazily for the currently-focused
-  // tree node when the pane is open. Run loop owns rebuilds.
-  jsonPane?: JsonPaneStateRef;
   // Help-screen overlay shown?
   helpOpen?: boolean;
   // Follow mode (`--follow` / `f`) — viewer re-reads the file when it grows.
@@ -75,12 +71,4 @@ export type ViewerState = {
   // One-line status message (`copied 312 bytes`, etc.); auto-clears
   // on the next keystroke. Owned by the input layer.
   messageBar?: string;
-};
-
-// Re-export so consumers don't need a second import.
-import type { JsonPaneState } from "./jsonView/input.js";
-export type JsonPaneStateRef = JsonPaneState & {
-  // Tree-node id this pane content was built from. Lets the run loop
-  // detect when the focused tree node changed and rebuild.
-  builtFor: string;
 };

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -88,7 +88,6 @@ async function _runPrompt({
     _completion = ctx.llmClient.text(promptConfig);
   }
 
-  const endTime = performance.now();
   let completion: PromptResult;
   let toolCalls: ToolCallJSON[] = [];
 
@@ -118,6 +117,12 @@ async function _runPrompt({
     completion = response.value;
     toolCalls = completion.toolCalls || [];
   }
+
+  // Capture endTime AFTER the response has been fully received. The
+  // request Promise is created above but only awaited inside the
+  // stream/non-stream branches; sampling earlier would only measure
+  // request setup, not the actual round-trip time.
+  const endTime = performance.now();
 
   const modelName = completion.model || clientConfig.model || "unknown model";
 

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -192,8 +192,9 @@ export function createProgram(deps: CliDependencies = {}): Command {
     .command("view")
     .description("Open an interactive TUI viewer for a statelog JSONL file")
     .argument("<file>", "Path to a .statelog.jsonl file, or '-' for stdin")
-    .action(async (file: string) => {
-      await logsView(file);
+    .option("--follow", "Tail the file — re-read and re-render as new events are appended")
+    .action(async (file: string, options: { follow?: boolean }) => {
+      await logsView(file, { follow: options.follow });
     });
 
   program


### PR DESCRIPTION
## Logs Viewer v2

Implements the v2 plan ([2026-05-17-statelog-tui-viewer-v2.md](docs/superpowers/plans/2026-05-17-statelog-tui-viewer-v2.md)) for `agency logs view`.

### Headline features

- **Search** — `/`, `n`, `N`, `Esc`. Substring matches are highlighted in-place (yellow background), the cursor jumps to the first match, and ancestors of matches are auto-expanded.
- **JSON payload pane** — `Enter` on a leaf opens a bottom split-pane that renders the event payload as a collapsible JSON tree. `Tab` / `Esc` swap focus; `p` toggles visibility.
- **Follow mode** — `--follow` CLI flag and runtime `f` toggle.
- **Magnitude coloring** — slow (>5s) durations and expensive (>$0.01) costs render in bright-red; fast (<100ms) durations render gray. Thresholds configurable via `agency.json` under `viewer.{slowMs,fastMs,expensiveUsd}`.
- **Copy to clipboard** — `y` shells out to `pbcopy` / `xclip` / `wl-copy` / `clip.exe`. Shows result in a transient status message.
- **Help overlay** — `?` opens a centered overlay listing every keybinding; any key closes it.
- **Expand-all / collapse-all** — `e` / `E`.
- **Cycle traces** — `Tab` / `Shift+Tab` jumps cursor between trace roots.

### Keybinding summary

| Key | Action |
|---|---|
| `j` `k` `h` `l` `g` `G` | Vim-style navigation |
| `Enter` | Expand; on a leaf, open JSON pane + focus it |
| `Tab` / `Shift+Tab` | Cycle traces |
| `e` / `E` | Expand-all / collapse-all |
| `p` | Toggle JSON payload pane |
| `/` then text + Enter | Search |
| `n` / `N` | Next / previous match |
| `Esc` | Clear search / release pane focus |
| `y` | Copy focused node JSON to clipboard |
| `f` | Toggle follow mode |
| `?` | Help overlay |
| `q` / `Ctrl+C` | Quit |

### Architecture

- All pure-data helpers (`jsonView/*`, `search.ts`, `thresholds.ts`, `clipboard.ts`, `follow.ts`, `help.ts`) landed in earlier commits in this branch.
- The final commit on this branch wires everything into `run.ts`'s loop: tree pane + JSON pane composition, key routing by pane focus, search-prompt invocation via `screen.nextLine`, clipboard write side-effects, follow watcher attach/detach, and the help overlay render.
- Pure reducers stay in `input.ts`; effects live in `run.ts` and are surfaced via a `ViewerCommand` ADT (`search` / `copy` / `toggleFollow`).

### Validation

- `pnpm vitest run lib/logsViewer/ lib/tui/` → **234 passed**
- `node tests/integration/statelog/test.mjs` → **8/8 scenarios pass**
- `pnpm run lint:structure` → clean except for the pre-existing `lib/lsp/hover.ts` error
- `make` builds cleanly
- `agency logs view --help` shows the new `--follow` flag

### Files touched

- New: `lib/logsViewer/help.ts`
- New (earlier commits in branch): `lib/logsViewer/jsonView/*`, `search.ts`, `thresholds.ts`, `clipboard.ts`, `follow.ts`
- Modified: `lib/logsViewer/run.ts` (composition, custom loop), `input.ts` (commands, Enter-on-leaf), `types.ts` (v2 state fields), `render.ts` (search highlight, magnitude coloring), `run.test.ts` (3 new integration tests)
- Modified: `lib/cli/logsView.ts` (`--follow` plumbing), `scripts/agency.ts` (`--follow` flag), `docs/site/guide/observability.md` (v2 docs)
