### PR TITLE
Memory observability: statelog spans, embedCompletion event, level-gated logging

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -227,6 +227,11 @@ export class TypeScriptBuilder {
   private configDefaults(): Partial<AgencyConfig> {
     return {
       maxToolCallRounds: 10,
+      // Top-level threshold for runtime subsystem loggers (memory,
+      // etc.). Distinct from `client.logLevel` which is the
+      // smoltalk-internal one. "info" matches the existing
+      // no-debug-by-default behavior — users opt in via agency.json.
+      logLevel: "info",
       log: {
         host: "https://statelog.adit.io",
       },
@@ -3681,6 +3686,13 @@ export class TypeScriptBuilder {
     };
     if (this.agencyConfig.verbose) {
       runtimeCtxArgs.verbose = ts.raw("true");
+    }
+    // Always render the top-level logLevel; `configDefaults()` guarantees
+    // a value, so this never emits a runtime default-fallback path. The
+    // RuntimeContext uses this to construct ad-hoc loggers in subsystems
+    // (e.g. memory) on demand.
+    if (this.agencyConfig.logLevel) {
+      runtimeCtxArgs.logLevel = ts.str(this.agencyConfig.logLevel);
     }
     if (this.agencyConfig.checkpoints?.maxRestores !== undefined) {
       runtimeCtxArgs.maxRestores = ts.raw(

--- a/packages/agency-lang/lib/runtime/memory/manager.test.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MemoryManager } from "./manager.js";
 import { FileMemoryStore } from "./store.js";
+import { StatelogClient } from "../../statelogClient.js";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -304,5 +305,203 @@ describe("MemoryManager", () => {
     expect(current).toHaveLength(0);
     // Original observation still present, just expired
     expect(mom.observations[0].validTo).toBeTruthy();
+  });
+
+  /**
+   * These tests drive the manager with a real `StatelogClient`
+   * pointed at a temp file sink and assert the resulting event
+   * stream. The shape of the stream is the contract the trace
+   * viewer relies on, so regressions here would silently break
+   * the tarsec viewer.
+   *
+   * We build the events file with `observability: true` and a
+   * stable `traceId` so the run-id continuity check at the end is
+   * deterministic.
+   */
+  describe("statelog observability", () => {
+    function makeStatelogClient(file: string): StatelogClient {
+      return new StatelogClient({
+        host: "",
+        apiKey: "",
+        projectId: "test",
+        traceId: "test-trace-id",
+        debugMode: false,
+        observability: true,
+        logFile: file,
+      });
+    }
+
+    function readEvents(file: string): any[] {
+      if (!fs.existsSync(file)) return [];
+      const raw = fs.readFileSync(file, "utf-8").trim();
+      if (!raw) return [];
+      return raw.split("\n").map((line) => JSON.parse(line));
+    }
+
+    /**
+     * Tap startSpan to record the sequence of span types opened during
+     * the test. startSpan/endSpan don't emit events themselves —
+     * they just maintain a stack that nested events attach to via
+     * `span_id` / `parent_span_id`. To assert that the umbrella spans
+     * exist we spy on the call directly.
+     */
+    function spyOnSpans(statelogClient: StatelogClient): string[] {
+      const opened: string[] = [];
+      const realStart = statelogClient.startSpan.bind(statelogClient);
+      vi.spyOn(statelogClient, "startSpan").mockImplementation((type) => {
+        opened.push(type);
+        return realStart(type);
+      });
+      return opened;
+    }
+
+    it("remember opens a memoryRemember span and emits prompt/embed events", async () => {
+      const eventsFile = path.join(tmpDir, "events.jsonl");
+      const statelogClient = makeStatelogClient(eventsFile);
+      const openedSpans = spyOnSpans(statelogClient);
+      const client = mockLlmClient();
+      client.text.mockResolvedValue(
+        wrapTextResult(JSON.stringify({
+          entities: [{ name: "Mom", type: "person", observations: ["likes pottery"] }],
+          relations: [],
+          expirations: [],
+        }))
+      );
+      const manager = new MemoryManager({
+        store: new FileMemoryStore(tmpDir),
+        config: { dir: tmpDir },
+        llmClient: client,
+        statelogClient,
+      });
+
+      await manager.remember("Mom likes pottery");
+
+      // The umbrella + inner spans were all opened in the right
+      // shape — memoryRemember wraps an llmCall (extraction) and an
+      // embedding span (per new observation).
+      expect(openedSpans).toContain("memoryRemember");
+      expect(openedSpans).toContain("llmCall");
+      expect(openedSpans).toContain("embedding");
+
+      const events = readEvents(eventsFile);
+      const types = events.map((e) => e.data.type);
+      expect(types).toContain("promptCompletion");
+      expect(types).toContain("embedCompletion");
+    });
+
+    it("recall opens memoryRecall and parents inner spans correctly", async () => {
+      const eventsFile = path.join(tmpDir, "events.jsonl");
+      const statelogClient = makeStatelogClient(eventsFile);
+      const client = mockLlmClient();
+      // Seed an entity via remember.
+      client.text.mockResolvedValueOnce(
+        wrapTextResult(JSON.stringify({
+          entities: [{ name: "Mom", type: "person", observations: ["likes pottery"] }],
+          relations: [],
+          expirations: [],
+        }))
+      );
+      const manager = new MemoryManager({
+        store: new FileMemoryStore(tmpDir),
+        config: { dir: tmpDir },
+        llmClient: client,
+        statelogClient,
+      });
+      await manager.remember("Mom likes pottery");
+
+      // Tier-3 LLM returns the seeded entity id.
+      const mom = manager.getGraph().findEntityByName("Mom")!;
+      client.text.mockResolvedValueOnce(wrapTextResult(JSON.stringify([mom.id])));
+
+      // Spy on spans + reset the events file so we only see recall.
+      const openedSpans = spyOnSpans(statelogClient);
+      fs.writeFileSync(eventsFile, "");
+      await manager.recall("mom");
+
+      expect(openedSpans).toContain("memoryRecall");
+      // Tier 2 fires an embedding span; tier 3 fires an llmCall.
+      expect(openedSpans).toContain("embedding");
+      expect(openedSpans).toContain("llmCall");
+
+      // Every event emitted inside recall has a parent_span_id —
+      // they all live under the memoryRecall umbrella (or under one
+      // of its child spans, which themselves chain back to recall).
+      // The root-level case is when parent_span_id is null.
+      const events = readEvents(eventsFile);
+      const childishEvents = events.filter(
+        (e) =>
+          e.data.type === "promptCompletion" ||
+          e.data.type === "embedCompletion",
+      );
+      expect(childishEvents.length).toBeGreaterThan(0);
+      for (const evt of childishEvents) {
+        expect(evt.parent_span_id).not.toBeNull();
+      }
+    });
+
+    it("forget opens a memoryForget span", async () => {
+      const eventsFile = path.join(tmpDir, "events.jsonl");
+      const statelogClient = makeStatelogClient(eventsFile);
+      const client = mockLlmClient();
+      client.text.mockResolvedValueOnce(
+        wrapTextResult(JSON.stringify({
+          entities: [{ name: "Mom", type: "person", observations: ["likes pottery"] }],
+          relations: [],
+          expirations: [],
+        }))
+      );
+      const manager = new MemoryManager({
+        store: new FileMemoryStore(tmpDir),
+        config: { dir: tmpDir },
+        llmClient: client,
+        statelogClient,
+      });
+      await manager.remember("Mom likes pottery");
+      client.text.mockResolvedValueOnce(
+        wrapTextResult(JSON.stringify({
+          observations: [{ entityName: "Mom", observationContent: "pottery" }],
+          relations: [],
+        }))
+      );
+      const openedSpans = spyOnSpans(statelogClient);
+      fs.writeFileSync(eventsFile, "");
+      await manager.forget("forget mom pottery");
+      expect(openedSpans).toContain("memoryForget");
+    });
+
+    /**
+     * Locks the run-id continuity invariant in §5 of the plan:
+     * every memory-emitted event must carry the same `trace_id` as
+     * the StatelogClient instance, which (in production) is set to
+     * the run id by `RuntimeContext.createExecutionContext`. If
+     * something accidentally bypasses the shared client and emits
+     * via a new one, the trace splits and the viewer can't stitch.
+     */
+    it("all memory events inherit the StatelogClient's trace_id", async () => {
+      const eventsFile = path.join(tmpDir, "events.jsonl");
+      const statelogClient = makeStatelogClient(eventsFile);
+      const client = mockLlmClient();
+      client.text.mockResolvedValue(
+        wrapTextResult(JSON.stringify({
+          entities: [{ name: "Mom", type: "person", observations: ["likes pottery"] }],
+          relations: [],
+          expirations: [],
+        }))
+      );
+      const manager = new MemoryManager({
+        store: new FileMemoryStore(tmpDir),
+        config: { dir: tmpDir },
+        llmClient: client,
+        statelogClient,
+      });
+      await manager.remember("Mom likes pottery");
+      const events = readEvents(eventsFile);
+      expect(events.length).toBeGreaterThan(0);
+      for (const evt of events) {
+        // Every line shares the configured trace_id — no shadow
+        // StatelogClient created somewhere in the manager.
+        expect(evt.trace_id).toBe("test-trace-id");
+      }
+    });
   });
 });

--- a/packages/agency-lang/lib/runtime/memory/manager.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.ts
@@ -26,9 +26,21 @@ import {
   findCompactionSplitPoint,
 } from "./compaction.js";
 import { MEMORY_COMPACTION_DEFAULT_THRESHOLD } from "../../constants.js";
+import { createLogger, type Logger, type LogLevel } from "../../logger.js";
+import type { StatelogClient } from "../../statelogClient.js";
 import forgetTemplate from "../../templates/prompts/memory/forget.js";
 import retrievalTemplate from "../../templates/prompts/memory/retrieval.js";
 import type { LLMClient } from "../llmClient.js";
+
+// Cap on the `inputPreview` slice we put on every embedCompletion
+// event. Short enough that a transcript fragment in stderr or in a
+// statelog payload doesn't accidentally leak a wall of user text;
+// long enough to be diagnostically useful.
+const EMBED_PREVIEW_CHARS = 200;
+
+// Cap on the recall-query preview emitted at debug. Same intent —
+// long enough to recognize, short enough not to dominate a log line.
+const QUERY_PREVIEW_CHARS = 80;
 
 /**
  * A pluggable reference to the active memoryId.
@@ -72,6 +84,17 @@ export type MemoryManagerOptions = {
   smoltalkDefaults?: Partial<SmolConfig>;
   source?: string;
   memoryIdRef?: MemoryIdRef;
+  /** Statelog client used to emit `llmCall`/`embedding` spans and
+   *  `promptCompletion`/`embedCompletion` events for memory's
+   *  internal LLM/embed calls. Optional so tests can construct
+   *  managers without one; production wires the per-execCtx
+   *  client through `context.ts`. When absent, every statelog hook
+   *  is a no-op. */
+  statelogClient?: StatelogClient;
+  /** Threshold for the manager's internal logger. The manager
+   *  creates one logger per instance via `createLogger(logLevel)`;
+   *  every line is `[memory]`-prefixed so users can grep/filter. */
+  logLevel?: LogLevel;
 };
 
 const DEFAULT_RECALL_K = 10;
@@ -117,6 +140,13 @@ export class MemoryManager {
   private smoltalkDefaults: Partial<SmolConfig>;
   private source: string;
   private memoryIdRef: MemoryIdRef;
+  /** Optional — every call site uses `?.` so the absence of a
+   *  statelog client (e.g. in unit tests) is a clean no-op. */
+  private statelogClient?: StatelogClient;
+  /** Built once in the constructor from `options.logLevel`. Each line
+   *  emitted by the manager is prefixed `[memory]` so users can
+   *  filter on the prefix from stderr. */
+  private logger: Logger;
 
   // Per-memoryId cache; switching id selects a different entry rather
   // than discarding state (resolved decision #2). We use a null-prototype
@@ -138,6 +168,11 @@ export class MemoryManager {
     this.smoltalkDefaults = options.smoltalkDefaults ?? {};
     this.source = options.source ?? "unknown";
     this.memoryIdRef = options.memoryIdRef ?? createInMemoryRef();
+    this.statelogClient = options.statelogClient;
+    // Default "info" so tests that don't pass a level don't get a
+    // wall of debug output. Production reads `AgencyConfig.logLevel`
+    // through `RuntimeContext.logLevel`.
+    this.logger = createLogger(options.logLevel ?? "info");
   }
 
   /**
@@ -146,43 +181,144 @@ export class MemoryManager {
    * to smoltalk) so a custom client registered via `setLLMClient`
    * — including the `DeterministicClient` used in tests — controls
    * memory's text calls too.
+   *
+   * Wrapped in an `llmCall` span + `promptCompletion` event so the
+   * call shows up in the trace viewer alongside agency-driven LLM
+   * calls. Errors emit a statelog `error` event before being
+   * re-thrown so a failed memory call is visible even though the
+   * post-turn hook in `prompt.ts` swallows it to keep the agent
+   * running.
    */
   private async _text(
     prompt: string,
-    options?: { model?: string; responseFormat?: z.ZodType },
+    options?: { model?: string; responseFormat?: z.ZodType; phase?: string },
   ): Promise<string> {
-    const result = await this.llmClient.text({
-      ...this.smoltalkDefaults,
-      messages: [smoltalk.userMessage(prompt)],
-      model: options?.model ?? this.smoltalkDefaults.model,
-      ...(options?.responseFormat
-        ? { responseFormat: options.responseFormat }
-        : {}),
-    } as any);
-    if (!result.success) {
-      throw new Error(`memory llm text call failed: ${result.error}`);
+    const model = options?.model ?? this.smoltalkDefaults.model;
+    const phase = options?.phase ?? "memory.text";
+    const spanId = this.statelogClient?.startSpan("llmCall");
+    const startTime = performance.now();
+    try {
+      const result = await this.llmClient.text({
+        ...this.smoltalkDefaults,
+        messages: [smoltalk.userMessage(prompt)],
+        model,
+        ...(options?.responseFormat
+          ? { responseFormat: options.responseFormat }
+          : {}),
+      } as any);
+      const timeTaken = performance.now() - startTime;
+      if (!result.success) {
+        this.logger.warn(
+          `[memory] llm text call failed (phase=${phase}): ${result.error}`,
+        );
+        // Best-effort statelog notification — never let an observability
+        // failure mask the real LLM error.
+        try {
+          // Use the generic `llmError` errorType; the phase prefix
+          // ("memory.text", "remember.extract", etc.) carries the
+          // memory-specific signal so a viewer can filter without
+          // needing a dedicated enum value.
+          await this.statelogClient?.error({
+            errorType: "llmError",
+            message: String(result.error),
+            functionName: phase,
+            retryable: false,
+          });
+        } catch (err) {
+          this.logger.debug(
+            `[memory] statelog error event failed: ${(err as Error).message}`,
+          );
+        }
+        throw new Error(`memory llm text call failed: ${result.error}`);
+      }
+      try {
+        await this.statelogClient?.promptCompletion({
+          messages: [smoltalk.userMessage(prompt)],
+          completion: result.value,
+          model,
+          timeTaken,
+          tools: [],
+          usage: result.value.usage,
+          cost: result.value.cost,
+          stream: false,
+        });
+      } catch (err) {
+        this.logger.debug(
+          `[memory] statelog promptCompletion failed: ${(err as Error).message}`,
+        );
+      }
+      return result.value.output ?? "";
+    } finally {
+      this.statelogClient?.endSpan(spanId);
     }
-    return result.value.output ?? "";
   }
 
   /** Same routing as _text(), but for embeddings. Returns a single
    *  vector (the LLMClient.embed protocol accepts string|string[]; we
-   *  always pass one string here so the response is one vector). */
+   *  always pass one string here so the response is one vector).
+   *
+   *  Wrapped in an `embedding` span + `embedCompletion` event. The
+   *  span type is distinct from `llmCall` so the viewer can render
+   *  cost/latency for embeddings separately. */
   private async _embed(
     text: string,
-    options?: { model?: string },
+    options?: { model?: string; phase?: string },
   ): Promise<number[]> {
-    const result = await this.llmClient.embed(text, {
-      model: options?.model,
-      openAiApiKey: (this.smoltalkDefaults as any).openAiApiKey,
-      googleApiKey: (this.smoltalkDefaults as any).googleApiKey,
-    });
-    if (!result.success) {
-      throw new Error(`memory embed call failed: ${result.error}`);
+    const phase = options?.phase ?? "memory.embed";
+    const spanId = this.statelogClient?.startSpan("embedding");
+    const startTime = performance.now();
+    try {
+      const result = await this.llmClient.embed(text, {
+        model: options?.model,
+        openAiApiKey: (this.smoltalkDefaults as any).openAiApiKey,
+        googleApiKey: (this.smoltalkDefaults as any).googleApiKey,
+      });
+      const timeTaken = performance.now() - startTime;
+      if (!result.success) {
+        this.logger.warn(
+          `[memory] embed call failed (phase=${phase}): ${result.error}`,
+        );
+        try {
+          // Same rationale as `_text` above: reuse `llmError` and let
+          // the phase string convey the embed-specific context.
+          await this.statelogClient?.error({
+            errorType: "llmError",
+            message: String(result.error),
+            functionName: phase,
+            retryable: false,
+          });
+        } catch (err) {
+          this.logger.debug(
+            `[memory] statelog error event failed: ${(err as Error).message}`,
+          );
+        }
+        throw new Error(`memory embed call failed: ${result.error}`);
+      }
+      const vector = result.value.embeddings[0];
+      if (!vector) {
+        this.logger.warn(
+          `[memory] embed returned no vectors (phase=${phase}, model=${result.value.model ?? "?"})`,
+        );
+        throw new Error("memory embed returned no vectors");
+      }
+      try {
+        await this.statelogClient?.embedCompletion({
+          inputPreview: text.slice(0, EMBED_PREVIEW_CHARS),
+          inputCount: 1,
+          model: result.value.model ?? options?.model,
+          dimensions: vector.length,
+          timeTaken,
+          phase,
+        });
+      } catch (err) {
+        this.logger.debug(
+          `[memory] statelog embedCompletion failed: ${(err as Error).message}`,
+        );
+      }
+      return vector;
+    } finally {
+      this.statelogClient?.endSpan(spanId);
     }
-    const vector = result.value.embeddings[0];
-    if (!vector) throw new Error("memory embed returned no vectors");
-    return vector;
   }
 
   getMemoryId(): string {
@@ -257,7 +393,7 @@ export class MemoryManager {
         // memoryId with no on-disk index isn't a discard, it's a
         // first-time load.
         const onDiskVersion = embeddingIndex.formatVersion ?? 1;
-        console.warn(
+        this.logger.warn(
           `[memory] discarding embeddings for memoryId="${id}" (on-disk format v${onDiskVersion}, model="${embeddingIndex.model}"; current format v${EMBEDDING_FORMAT_VERSION}${configuredModel ? `, configured model="${configuredModel}"` : ""}); will rebuild on next write`,
         );
       }
@@ -270,6 +406,14 @@ export class MemoryManager {
     const summary = await this.store.loadSummary(id);
     const entry = new MemoryCacheEntry(id, graph, embeddings, summary);
     this.cache[id] = entry;
+    // One-line summary of what was loaded so users can sanity-check
+    // graph sizes and embedding coverage on first use of a memoryId.
+    const obsCount = graph
+      .getEntities()
+      .reduce((n, e) => n + e.observations.length, 0);
+    this.logger.debug(
+      `[memory] loaded memoryId="${id}" entities=${graph.getEntities().length} observations=${obsCount} embeddings=${embeddings.toIndex().entries.length}`,
+    );
     return entry;
   }
 
@@ -303,25 +447,70 @@ export class MemoryManager {
    * Apply a typed extraction result to the active graph. Used by the
    * agency-side `remember` after it gets a structured result from
    * `llm(...)`.
+   *
+   * Wrapped in a `memoryRemember` umbrella span so the agency-side
+   * call shape (`buildExtractionPromptFor` → `llm` → `applyExtractionFromLLM`)
+   * still nests its embedding work under one parent in the viewer.
    */
   async applyExtractionFromLLM(result: ExtractionResult): Promise<void> {
-    const entry = await this.getEntry();
-    const outcome = entry.applyExtraction(result, this.source);
-    await this.generateEmbeddings(entry, outcome.newObservations);
-    await entry.persist(this.store);
+    const spanId = this.statelogClient?.startSpan("memoryRemember");
+    try {
+      const entry = await this.getEntry();
+      const outcome = entry.applyExtraction(result, this.source);
+      await this.generateEmbeddings(entry, outcome.newObservations);
+      await entry.persist(this.store);
+      this.logger.debug(
+        `[memory] applyExtraction added observations=${outcome.newObservations.length} expired=${outcome.expiredObservationIds.length}`,
+      );
+    } catch (err) {
+      this.logger.debug(
+        `[memory] applyExtractionFromLLM caught: ${(err as Error).message}`,
+      );
+      throw err;
+    } finally {
+      this.statelogClient?.endSpan(spanId);
+    }
   }
 
   /**
    * Convenience wrapper used by tests that want the whole extraction
    * round-trip in one call. The agency runtime path goes through
    * `buildExtractionPromptFor` + `applyExtractionFromLLM` instead.
+   *
+   * Opens its own `memoryRemember` span — the nested
+   * `applyExtractionFromLLM` opens a child of the same type, which
+   * is acceptable: the viewer will see two adjacent rows for the
+   * same logical operation. We could short-circuit the inner call,
+   * but the duplication is harmless and avoids coupling the two
+   * methods through a flag.
    */
   async remember(content: string): Promise<void> {
-    const prompt = await this.buildExtractionPromptFor(content);
-    const response = await this._text(prompt, { model: this.model() });
-    const result = parseExtractionResult(response);
-    if (!result) return;
-    await this.applyExtractionFromLLM(result);
+    const spanId = this.statelogClient?.startSpan("memoryRemember");
+    this.logger.debug(
+      `[memory] remember content="${truncatePreview(content, QUERY_PREVIEW_CHARS)}"`,
+    );
+    try {
+      const prompt = await this.buildExtractionPromptFor(content);
+      const response = await this._text(prompt, {
+        model: this.model(),
+        phase: "remember.extract",
+      });
+      const result = parseExtractionResult(response);
+      if (!result) {
+        this.logger.debug(
+          `[memory] remember: extraction parse returned null (no-op)`,
+        );
+        return;
+      }
+      await this.applyExtractionFromLLM(result);
+    } catch (err) {
+      this.logger.debug(
+        `[memory] remember caught: ${(err as Error).message}`,
+      );
+      throw err;
+    } finally {
+      this.statelogClient?.endSpan(spanId);
+    }
   }
 
   // Run the cheap tiers (structured lookup + embedding similarity) and
@@ -338,74 +527,128 @@ export class MemoryManager {
     for (const e of tier1) {
       if (!orderedIds.includes(e.id)) orderedIds.push(e.id);
     }
+    this.logger.debug(`[memory] tier1 matched ${tier1.length} entities`);
 
     const tier2EntityIds = await this.embeddingRecallEntityIds(entry, query);
     for (const id of tier2EntityIds) {
       if (!orderedIds.includes(id)) orderedIds.push(id);
     }
+    this.logger.debug(
+      `[memory] tier2 matched ${tier2EntityIds.length} entities (k=${DEFAULT_RECALL_K}, threshold=${DEFAULT_EMBEDDING_THRESHOLD})`,
+    );
 
     return orderedIds;
   }
 
   async recall(query: string, options?: { model?: string }): Promise<string> {
-    const entry = await this.getEntry();
-    const graph = entry.getGraph();
-    if (graph.getEntities().length === 0) return "";
-
-    // Stage A: cheap tiers gather candidate ids.
-    let candidateIds = await this.tier1And2(entry, query);
-
-    // Stage B (fallback): if cheap tiers found nothing AND the graph
-    // is small enough to fit in the prompt without blowing tokens,
-    // hand the entire graph to Tier 3 as candidates. Above the limit
-    // we accept "no recall" — Tiers 1+2 should have surfaced something
-    // for a graph that big, and the LLM doesn't help if every entity
-    // is a candidate at scale.
-    if (candidateIds.length === 0) {
-      const all = graph.getEntities();
-      if (all.length > FALLBACK_GRAPH_SIZE_LIMIT) return "";
-      candidateIds = all.map((e) => e.id);
-    }
-
-    // Stage C: LLM relevance filter over the candidate set. The LLM
-    // can only return ids from the set we offered (hallucinations are
-    // dropped). Best-effort: a provider error falls back to the
-    // cheap-tier order so we still return something usable.
-    const model = options?.model ?? this.model();
-    let relevantIds: string[];
+    const spanId = this.statelogClient?.startSpan("memoryRecall");
+    this.logger.debug(
+      `[memory] recall query="${truncatePreview(query, QUERY_PREVIEW_CHARS)}"`,
+    );
     try {
-      relevantIds = await this.llmFilterCandidates(
-        entry,
-        query,
-        candidateIds,
-        model,
-      );
-      // An empty filter result on a fallback (whole-graph) call most
-      // likely means the LLM correctly judged nothing relevant —
-      // honour that. On a non-fallback call (cheap tiers had hits),
-      // also honour it: the tiers gave us *candidates*, the LLM is
-      // the precision filter. Returning the cheap-tier order anyway
-      // would defeat the filter's purpose.
-    } catch (err) {
-      console.warn(
-        `[memory] tier 3 (LLM filter) failed for query=${JSON.stringify(query)}: ${(err as Error).message}`,
-      );
-      // Fail open: keep whatever the cheap tiers found rather than
-      // returning nothing on a transient provider error.
-      relevantIds = candidateIds;
-    }
+      const entry = await this.getEntry();
+      const graph = entry.getGraph();
+      if (graph.getEntities().length === 0) {
+        this.logger.debug(`[memory] recall: empty graph, returning ""`);
+        return "";
+      }
 
-    return this.formatTopK(graph, relevantIds);
+      // Stage A: cheap tiers gather candidate ids.
+      let candidateIds = await this.tier1And2(entry, query);
+
+      // Stage B (fallback): if cheap tiers found nothing AND the graph
+      // is small enough to fit in the prompt without blowing tokens,
+      // hand the entire graph to Tier 3 as candidates. Above the limit
+      // we accept "no recall" — Tiers 1+2 should have surfaced something
+      // for a graph that big, and the LLM doesn't help if every entity
+      // is a candidate at scale.
+      let usedFallback = false;
+      if (candidateIds.length === 0) {
+        const all = graph.getEntities();
+        if (all.length > FALLBACK_GRAPH_SIZE_LIMIT) {
+          this.logger.debug(
+            `[memory] recall: tiers 1+2 empty, graph size=${all.length} > ${FALLBACK_GRAPH_SIZE_LIMIT}; returning ""`,
+          );
+          return "";
+        }
+        candidateIds = all.map((e) => e.id);
+        usedFallback = true;
+        this.logger.debug(
+          `[memory] recall: tiers 1+2 empty, falling back to whole graph (${all.length} entities)`,
+        );
+      }
+
+      // Stage C: LLM relevance filter over the candidate set. The LLM
+      // can only return ids from the set we offered (hallucinations are
+      // dropped). Best-effort: a provider error falls back to the
+      // cheap-tier order so we still return something usable.
+      const model = options?.model ?? this.model();
+      let relevantIds: string[];
+      try {
+        relevantIds = await this.llmFilterCandidates(
+          entry,
+          query,
+          candidateIds,
+          model,
+        );
+        this.logger.debug(
+          `[memory] tier3 matched ${relevantIds.length} / candidates=${candidateIds.length}${usedFallback ? " (fallback)" : ""}`,
+        );
+        // An empty filter result on a fallback (whole-graph) call most
+        // likely means the LLM correctly judged nothing relevant —
+        // honour that. On a non-fallback call (cheap tiers had hits),
+        // also honour it: the tiers gave us *candidates*, the LLM is
+        // the precision filter. Returning the cheap-tier order anyway
+        // would defeat the filter's purpose.
+      } catch (err) {
+        this.logger.warn(
+          `[memory] tier 3 (LLM filter) failed for query="${truncatePreview(query, QUERY_PREVIEW_CHARS)}": ${(err as Error).message}`,
+        );
+        // Fail open: keep whatever the cheap tiers found rather than
+        // returning nothing on a transient provider error.
+        relevantIds = candidateIds;
+      }
+
+      const result = this.formatTopK(graph, relevantIds);
+      this.logger.debug(
+        `[memory] recall returned ${Math.min(relevantIds.length, DEFAULT_RECALL_K)} entities (${result.length} chars)`,
+      );
+      return result;
+    } catch (err) {
+      this.logger.debug(
+        `[memory] recall caught: ${(err as Error).message}`,
+      );
+      throw err;
+    } finally {
+      this.statelogClient?.endSpan(spanId);
+    }
   }
 
   async recallForInjection(query: string): Promise<string> {
-    const entry = await this.getEntry();
-    const graph = entry.getGraph();
+    const spanId = this.statelogClient?.startSpan("memoryRecall");
+    this.logger.debug(
+      `[memory] recallForInjection query="${truncatePreview(query, QUERY_PREVIEW_CHARS)}"`,
+    );
+    try {
+      const entry = await this.getEntry();
+      const graph = entry.getGraph();
 
-    // Tiers 1+2 only for low latency (resolved decision #4).
-    const orderedIds = await this.tier1And2(entry, query);
+      // Tiers 1+2 only for low latency (resolved decision #4).
+      const orderedIds = await this.tier1And2(entry, query);
 
-    return this.formatTopK(graph, orderedIds);
+      const result = this.formatTopK(graph, orderedIds);
+      this.logger.debug(
+        `[memory] recallForInjection injecting ${Math.min(orderedIds.length, DEFAULT_RECALL_K)} facts (${result.length} chars)`,
+      );
+      return result;
+    } catch (err) {
+      this.logger.debug(
+        `[memory] recallForInjection caught: ${(err as Error).message}`,
+      );
+      throw err;
+    } finally {
+      this.statelogClient?.endSpan(spanId);
+    }
   }
 
   /**
@@ -439,46 +682,69 @@ export class MemoryManager {
   /**
    * Apply a typed forget result to the active graph. Substring match,
    * case-insensitive (resolved decision #7).
+   *
+   * Wrapped in a `memoryForget` umbrella span so the agency-side call
+   * shape (`buildForgetPromptFor` → `llm` → `applyForgetFromLLM`)
+   * groups its writes under one parent in the viewer.
    */
   async applyForgetFromLLM(parsed: ForgetResult): Promise<void> {
-    const entry = await this.getEntry();
-    const graph = entry.getGraph();
+    const spanId = this.statelogClient?.startSpan("memoryForget");
+    try {
+      const entry = await this.getEntry();
+      const graph = entry.getGraph();
+      let expiredObservations = 0;
+      let expiredRelations = 0;
 
-    for (const exp of parsed.observations) {
-      const entity = graph.findEntityByName(exp.entityName);
-      if (!entity) continue;
-      const obs = entity.observations.find(
-        (o) =>
-          o.validTo === null &&
-          o.content
-            .toLowerCase()
-            .includes(exp.observationContent.toLowerCase()),
-      );
-      if (obs) {
-        // Goes through the entry so the embedding entry for this
-        // observation is dropped in lockstep with the graph mutation.
-        entry.expireObservation(obs.id);
-      }
-    }
-
-    for (const exp of parsed.relations) {
-      const fromEntity = graph.findEntityByName(exp.fromName);
-      const toEntity = graph.findEntityByName(exp.toName);
-      if (!fromEntity || !toEntity) continue;
-      const lowerType = exp.type.toLowerCase();
-      const rel = graph
-        .getRelations()
-        .find(
-          (r) =>
-            r.validTo === null &&
-            r.from === fromEntity.id &&
-            r.to === toEntity.id &&
-            r.type.toLowerCase().includes(lowerType),
+      for (const exp of parsed.observations) {
+        const entity = graph.findEntityByName(exp.entityName);
+        if (!entity) continue;
+        const obs = entity.observations.find(
+          (o) =>
+            o.validTo === null &&
+            o.content
+              .toLowerCase()
+              .includes(exp.observationContent.toLowerCase()),
         );
-      if (rel) entry.expireRelation(rel.id);
-    }
+        if (obs) {
+          // Goes through the entry so the embedding entry for this
+          // observation is dropped in lockstep with the graph mutation.
+          entry.expireObservation(obs.id);
+          expiredObservations++;
+        }
+      }
 
-    await entry.persist(this.store);
+      for (const exp of parsed.relations) {
+        const fromEntity = graph.findEntityByName(exp.fromName);
+        const toEntity = graph.findEntityByName(exp.toName);
+        if (!fromEntity || !toEntity) continue;
+        const lowerType = exp.type.toLowerCase();
+        const rel = graph
+          .getRelations()
+          .find(
+            (r) =>
+              r.validTo === null &&
+              r.from === fromEntity.id &&
+              r.to === toEntity.id &&
+              r.type.toLowerCase().includes(lowerType),
+          );
+        if (rel) {
+          entry.expireRelation(rel.id);
+          expiredRelations++;
+        }
+      }
+
+      await entry.persist(this.store);
+      this.logger.debug(
+        `[memory] forget expired observations=${expiredObservations} relations=${expiredRelations}`,
+      );
+    } catch (err) {
+      this.logger.debug(
+        `[memory] applyForgetFromLLM caught: ${(err as Error).message}`,
+      );
+      throw err;
+    } finally {
+      this.statelogClient?.endSpan(spanId);
+    }
   }
 
   /**
@@ -487,20 +753,49 @@ export class MemoryManager {
    * `buildForgetPromptFor` + `applyForgetFromLLM` instead.
    */
   async forget(query: string): Promise<void> {
-    const prompt = await this.buildForgetPromptFor(query);
-    const response = await this._text(prompt, { model: this.model() });
-    const parsed = parseForgetResult(response);
-    if (!parsed) return;
-    await this.applyForgetFromLLM(parsed);
+    const spanId = this.statelogClient?.startSpan("memoryForget");
+    this.logger.debug(
+      `[memory] forget query="${truncatePreview(query, QUERY_PREVIEW_CHARS)}"`,
+    );
+    try {
+      const prompt = await this.buildForgetPromptFor(query);
+      const response = await this._text(prompt, {
+        model: this.model(),
+        phase: "forget.plan",
+      });
+      const parsed = parseForgetResult(response, this.logger);
+      if (!parsed) {
+        this.logger.debug(`[memory] forget: parse returned null (no-op)`);
+        return;
+      }
+      await this.applyForgetFromLLM(parsed);
+    } catch (err) {
+      this.logger.debug(
+        `[memory] forget caught: ${(err as Error).message}`,
+      );
+      throw err;
+    } finally {
+      this.statelogClient?.endSpan(spanId);
+    }
   }
 
   async onTurn(messages: smoltalk.Message[]): Promise<void> {
-    const entry = await this.getEntry();
-    entry.turnsSinceExtraction++;
-    const interval = this.config.autoExtract?.interval ?? 5;
-    if (entry.turnsSinceExtraction >= interval) {
-      await this.autoExtract(entry, messages);
-      entry.turnsSinceExtraction = 0;
+    try {
+      const entry = await this.getEntry();
+      entry.turnsSinceExtraction++;
+      const interval = this.config.autoExtract?.interval ?? 5;
+      if (entry.turnsSinceExtraction >= interval) {
+        this.logger.debug(
+          `[memory] onTurn: turn ${entry.turnsSinceExtraction}/${interval} — running autoExtract`,
+        );
+        await this.autoExtract(entry, messages);
+        entry.turnsSinceExtraction = 0;
+      }
+    } catch (err) {
+      this.logger.debug(
+        `[memory] onTurn caught: ${(err as Error).message}`,
+      );
+      throw err;
     }
   }
 
@@ -508,90 +803,108 @@ export class MemoryManager {
   async compactIfNeeded(
     messages: smoltalk.Message[]
   ): Promise<CompactionPlan | null> {
-    const entry = await this.getEntry();
-    const compactionConfig = {
-      trigger: this.config.compaction?.trigger ?? ("token" as const),
-      threshold:
-        this.config.compaction?.threshold ?? MEMORY_COMPACTION_DEFAULT_THRESHOLD,
-    };
-    if (!shouldCompact(messages, compactionConfig)) return null;
+    const spanId = this.statelogClient?.startSpan("memoryCompaction");
+    try {
+      const entry = await this.getEntry();
+      const compactionConfig = {
+        trigger: this.config.compaction?.trigger ?? ("token" as const),
+        threshold:
+          this.config.compaction?.threshold ?? MEMORY_COMPACTION_DEFAULT_THRESHOLD,
+      };
+      if (!shouldCompact(messages, compactionConfig)) return null;
+      this.logger.debug(
+        `[memory] compaction triggered (trigger=${compactionConfig.trigger}, threshold=${compactionConfig.threshold}, messages=${messages.length})`,
+      );
 
-    // Preserve system messages at the head verbatim — but exclude any
-    // previously-injected summary message. We replace it rather than
-    // stack a new one beside it, so the head doesn't grow on every
-    // compaction.
-    let systemPrefixEnd = 0;
-    while (
-      systemPrefixEnd < messages.length &&
-      messages[systemPrefixEnd].role === "system"
-    ) {
-      systemPrefixEnd++;
-    }
-    const systemPrefixIndices: number[] = [];
-    for (let i = 0; i < systemPrefixEnd; i++) {
-      if (!messages[i].content.startsWith(SUMMARY_MESSAGE_PREFIX)) {
-        systemPrefixIndices.push(i);
+      // Preserve system messages at the head verbatim — but exclude any
+      // previously-injected summary message. We replace it rather than
+      // stack a new one beside it, so the head doesn't grow on every
+      // compaction.
+      let systemPrefixEnd = 0;
+      while (
+        systemPrefixEnd < messages.length &&
+        messages[systemPrefixEnd].role === "system"
+      ) {
+        systemPrefixEnd++;
       }
-    }
-    const conversation = messages.slice(systemPrefixEnd);
+      const systemPrefixIndices: number[] = [];
+      for (let i = 0; i < systemPrefixEnd; i++) {
+        if (!messages[i].content.startsWith(SUMMARY_MESSAGE_PREFIX)) {
+          systemPrefixIndices.push(i);
+        }
+      }
+      const conversation = messages.slice(systemPrefixEnd);
 
-    // Find a clean split point that does not break a tool_call/tool sequence.
-    const splitInConv = findCompactionSplitPoint(conversation);
-    if (splitInConv === -1) {
-      // No clean split — log enough to debug what the conversation
-      // shape was so users can tell why their thread isn't being
-      // compacted (e.g. mostly assistant + tool messages with no
-      // user turns past the midpoint).
-      console.warn(
-        `[memory] compaction skipped: no clean split point found. messages=${JSON.stringify(messages)}`,
-      );
-      return null;
-    }
+      // Find a clean split point that does not break a tool_call/tool sequence.
+      const splitInConv = findCompactionSplitPoint(conversation);
+      if (splitInConv === -1) {
+        // No clean split — warn with the message count so users can tell
+        // why their thread isn't being compacted (e.g. mostly assistant
+        // + tool messages with no user turns past the midpoint).
+        this.logger.warn(
+          `[memory] compaction skipped: no clean split point found in ${messages.length} messages (conversation=${conversation.length})`,
+        );
+        return null;
+      }
 
-    const toCompact = conversation.slice(0, splitInConv);
-    const tailStart = systemPrefixEnd + splitInConv;
-    const tailIndices: number[] = [];
-    for (let i = tailStart; i < messages.length; i++) {
-      tailIndices.push(i);
-    }
+      const toCompact = conversation.slice(0, splitInConv);
+      const tailStart = systemPrefixEnd + splitInConv;
+      const tailIndices: number[] = [];
+      for (let i = tailStart; i < messages.length; i++) {
+        tailIndices.push(i);
+      }
 
-    // Extract facts from the prefix before compacting. Note: tool
-    // messages stay in `toCompact` here so the summarizer below sees
-    // tool outputs (the summary then captures any facts from them);
-    // the role mapping inside buildCompactionPrompt prefixes tool
-    // messages naturally so the LLM can read them.
-    await this.autoExtract(entry, toCompact);
+      // Extract facts from the prefix before compacting. Note: tool
+      // messages stay in `toCompact` here so the summarizer below sees
+      // tool outputs (the summary then captures any facts from them);
+      // the role mapping inside buildCompactionPrompt prefixes tool
+      // messages naturally so the LLM can read them.
+      await this.autoExtract(entry, toCompact);
 
-    const compactionPrompt = buildCompactionPrompt(toCompact);
-    let newSummary = await this._text(compactionPrompt, {
-      model: this.model(),
-    });
-
-    const prevSummary = entry.getSummary();
-    if (prevSummary) {
-      const mergePrompt = buildMergeSummaryPrompt(
-        prevSummary.summary,
-        newSummary,
-      );
-      newSummary = await this._text(mergePrompt, {
+      const compactionPrompt = buildCompactionPrompt(toCompact);
+      let newSummary = await this._text(compactionPrompt, {
         model: this.model(),
+        phase: "compaction.summary",
       });
+
+      const prevSummary = entry.getSummary();
+      const merged = prevSummary !== null;
+      if (prevSummary) {
+        const mergePrompt = buildMergeSummaryPrompt(
+          prevSummary.summary,
+          newSummary,
+        );
+        newSummary = await this._text(mergePrompt, {
+          model: this.model(),
+          phase: "compaction.merge",
+        });
+      }
+
+      entry.setSummary({
+        summary: newSummary,
+        lastCompactedAt: new Date().toISOString(),
+        messagesSummarized:
+          (prevSummary?.messagesSummarized ?? 0) + toCompact.length,
+      });
+
+      await entry.persist(this.store);
+      this.logger.debug(
+        `[memory] compaction done: toCompact=${toCompact.length} tail=${tailIndices.length} merged=${merged} summaryChars=${newSummary.length}`,
+      );
+
+      return {
+        systemPrefixIndices,
+        tailIndices,
+        summaryMessageContent: `${SUMMARY_MESSAGE_PREFIX}${newSummary}`,
+      };
+    } catch (err) {
+      this.logger.debug(
+        `[memory] compactIfNeeded caught: ${(err as Error).message}`,
+      );
+      throw err;
+    } finally {
+      this.statelogClient?.endSpan(spanId);
     }
-
-    entry.setSummary({
-      summary: newSummary,
-      lastCompactedAt: new Date().toISOString(),
-      messagesSummarized:
-        (prevSummary?.messagesSummarized ?? 0) + toCompact.length,
-    });
-
-    await entry.persist(this.store);
-
-    return {
-      systemPrefixIndices,
-      tailIndices,
-      summaryMessageContent: `${SUMMARY_MESSAGE_PREFIX}${newSummary}`,
-    };
   }
 
   /** Persist all cached memoryIds to disk. */
@@ -608,18 +921,30 @@ export class MemoryManager {
     messages: smoltalk.Message[]
   ): Promise<void> {
     const prompt = buildExtractionPrompt(messages, entry.getGraph());
-    const response = await this._text(prompt, { model: this.model() });
+    const response = await this._text(prompt, {
+      model: this.model(),
+      phase: "autoExtract",
+    });
     const result = parseExtractionResult(response);
-    if (!result) return;
+    if (!result) {
+      this.logger.debug(
+        `[memory] autoExtract: parse returned null (no-op)`,
+      );
+      return;
+    }
     const outcome = entry.applyExtraction(result, this.source);
     await this.generateEmbeddings(entry, outcome.newObservations);
     await entry.persist(this.store);
+    this.logger.debug(
+      `[memory] autoExtract added observations=${outcome.newObservations.length} expired=${outcome.expiredObservationIds.length}`,
+    );
   }
 
   private async generateEmbeddings(
     entry: MemoryCacheEntry,
     observations: NewObservation[]
   ): Promise<void> {
+    let failures = 0;
     for (const { id } of observations) {
       const embedText = buildEmbedText(entry, id);
       if (!embedText) {
@@ -628,7 +953,7 @@ export class MemoryManager {
         // the reverse index was just updated. If we hit this, the
         // graph mutated between apply and embed in a way we don't
         // expect — make it visible instead of silently skipping.
-        console.warn(
+        this.logger.warn(
           `[memory] generateEmbeddings: no embed text for obs=${id} in memoryId="${entry.memoryId}"; skipping`,
         );
         continue;
@@ -636,11 +961,23 @@ export class MemoryManager {
       try {
         const vector = await this._embed(embedText, {
           model: this.config.embeddings?.model,
+          phase: "new-observation",
         });
         entry.setEmbedding(id, vector);
-      } catch {
-        // Embedding failed — Tier 2 silently no-ops (resolved decision #8).
+      } catch (err) {
+        // Embedding failed — Tier 2 will silently no-op for this
+        // observation (resolved decision #8). Logged at debug here so
+        // a wave of failures shows up in `logLevel: "debug"` runs.
+        failures++;
+        this.logger.debug(
+          `[memory] generateEmbeddings: embed failed for obs=${id}: ${(err as Error).message}`,
+        );
       }
+    }
+    if (observations.length > 0) {
+      this.logger.debug(
+        `[memory] generateEmbeddings: ${observations.length - failures} embedded, ${failures} failed`,
+      );
     }
   }
 
@@ -680,8 +1017,15 @@ export class MemoryManager {
     try {
       queryVector = await this._embed(query, {
         model: this.config.embeddings?.model,
+        phase: "recall-query",
       });
-    } catch {
+    } catch (err) {
+      // Tier 2 degrades to zero hits when embedding the query fails;
+      // surfaced at debug so the caller can correlate the empty tier2
+      // line above with the underlying provider error.
+      this.logger.debug(
+        `[memory] embeddingRecallEntityIds: query embed failed: ${(err as Error).message}`,
+      );
       return [];
     }
     const similar = entry.getEmbeddings().findSimilar(
@@ -725,6 +1069,7 @@ export class MemoryManager {
     const response = await this._text(prompt, {
       model,
       responseFormat: StringArraySchema,
+      phase: "recall.tier3",
     });
     const ids = parseStringArray(response);
     if (!ids) {
@@ -732,8 +1077,8 @@ export class MemoryManager {
       // didn't parse as a JSON string array even though we asked for
       // one via `responseFormat`. That's a real signal (bad provider
       // response, schema not honoured, etc.) and worth surfacing.
-      console.warn(
-        `[memory] tier 3 (LLM filter) returned malformed response for query=${JSON.stringify(query)}: ${response.slice(0, 200)}`,
+      this.logger.warn(
+        `[memory] tier 3 (LLM filter) returned malformed response for query="${truncatePreview(query, QUERY_PREVIEW_CHARS)}": ${response.slice(0, 200)}`,
       );
       return [];
     }
@@ -784,21 +1129,43 @@ const ForgetResultSchema = z.object({
 
 export type ForgetResult = z.infer<typeof ForgetResultSchema>;
 
-function parseForgetResult(text: string): ForgetResult | null {
+/**
+ * Parse the JSON returned by the forget LLM call. Takes an optional
+ * logger so the parse-failure warning is gated by the user's
+ * `logLevel` — falling back to a no-op silently is fine for tests
+ * that don't care about diagnostics.
+ */
+function parseForgetResult(
+  text: string,
+  logger?: Logger,
+): ForgetResult | null {
   let raw: unknown;
   try {
     raw = JSON.parse(text);
-  } catch {
+  } catch (err) {
+    logger?.debug(
+      `[memory] forget: JSON.parse failed: ${(err as Error).message}`,
+    );
     return null;
   }
   const result = ForgetResultSchema.safeParse(raw);
   if (!result.success) {
-    console.warn(
+    logger?.warn(
       `[memory] forget parse failed: ${result.error.message}`,
     );
     return null;
   }
   return result.data;
+}
+
+/**
+ * Slice `text` to at most `max` characters, appending an ellipsis
+ * marker when truncated. Used for log/event previews so long inputs
+ * (e.g. embedded text, recall queries) don't dominate a line.
+ */
+function truncatePreview(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}…`;
 }
 
 /**

--- a/packages/agency-lang/lib/runtime/memory/manager.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.ts
@@ -308,6 +308,12 @@ export class MemoryManager {
           model: result.value.model ?? options?.model,
           dimensions: vector.length,
           timeTaken,
+          // Pass through provider-reported token/cost when available.
+          // Some embed providers (e.g. Ollama) don't report these, in
+          // which case they stay undefined and the viewer just omits
+          // them — same fallthrough as `promptCompletion`.
+          usage: result.value.tokenUsage,
+          cost: result.value.costEstimate,
           phase,
         });
       } catch (err) {
@@ -1162,10 +1168,25 @@ function parseForgetResult(
  * Slice `text` to at most `max` characters, appending an ellipsis
  * marker when truncated. Used for log/event previews so long inputs
  * (e.g. embedded text, recall queries) don't dominate a line.
+ *
+ * Also escapes newlines, tabs, embedded quotes, backslashes, and other
+ * control characters so the result is reliably single-line and safe to
+ * splat inside a `"..."` log template. Without this, a user-provided
+ * query containing a newline (`remember("a\nb")`) would emit a multi-line
+ * log entry that breaks line-oriented `grep`/`awk`/log-shipper pipelines.
  */
 function truncatePreview(text: string, max: number): string {
-  if (text.length <= max) return text;
-  return `${text.slice(0, max)}…`;
+  const sliced = text.length > max ? `${text.slice(0, max)}…` : text;
+  return sliced
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t")
+    .replace(
+      /[\x00-\x1f\x7f]/g,
+      (c) => `\\x${c.charCodeAt(0).toString(16).padStart(2, "0")}`,
+    );
 }
 
 /**

--- a/packages/agency-lang/lib/runtime/memory/store.ts
+++ b/packages/agency-lang/lib/runtime/memory/store.ts
@@ -12,6 +12,7 @@ import {
 import type { z } from "zod";
 import fs from "node:fs";
 import path from "node:path";
+import { createLogger, type Logger, type LogLevel } from "../../logger.js";
 
 // memoryIds become directory names, so anything that could escape the
 // configured baseDir (path separators, leading dots, control chars) must
@@ -33,7 +34,14 @@ function validateMemoryId(memoryId: string): void {
 }
 
 export class FileMemoryStore implements MemoryStore {
-  constructor(private baseDir: string) {}
+  /** Built once in the constructor from `logLevel`. Each line emitted
+   *  is `[memory]`-prefixed so it groups with the manager's output
+   *  when grepping. */
+  private logger: Logger;
+
+  constructor(private baseDir: string, logLevel?: LogLevel) {
+    this.logger = createLogger(logLevel ?? "info");
+  }
 
   private dir(memoryId: string): string {
     validateMemoryId(memoryId);
@@ -44,6 +52,7 @@ export class FileMemoryStore implements MemoryStore {
     const dir = this.dir(memoryId);
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
+      this.logger.debug(`[memory] FileMemoryStore: mkdir ${dir}`);
     }
   }
 
@@ -69,16 +78,22 @@ export class FileMemoryStore implements MemoryStore {
   }
 
   private async readJSON(filePath: string): Promise<unknown | null> {
-    if (!fs.existsSync(filePath)) return null;
+    if (!fs.existsSync(filePath)) {
+      this.logger.debug(`[memory] FileMemoryStore: read miss ${filePath}`);
+      return null;
+    }
     const content = await fs.promises.readFile(filePath, "utf-8");
+    this.logger.debug(
+      `[memory] FileMemoryStore: read ${filePath} (${content.length} bytes)`,
+    );
     return JSON.parse(content);
   }
 
   private async writeJSON(filePath: string, data: unknown): Promise<void> {
-    await fs.promises.writeFile(
-      filePath,
-      JSON.stringify(data, null, 2),
-      "utf-8"
+    const serialized = JSON.stringify(data, null, 2);
+    await fs.promises.writeFile(filePath, serialized, "utf-8");
+    this.logger.debug(
+      `[memory] FileMemoryStore: wrote ${filePath} (${serialized.length} bytes)`,
     );
   }
 

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1,5 +1,6 @@
 import * as smoltalk from "smoltalk";
 import { PromptResult, Result, StreamChunk, ToolCallJSON } from "smoltalk";
+import { createLogger } from "../logger.js";
 import { AgencyFunction } from "./agencyFunction.js";
 import { AgencyCancelledError, isAbortError } from "./errors.js";
 import { callHook } from "./hooks.js";
@@ -175,7 +176,11 @@ async function _runPrompt({
         messages.setMessages([...head, summary, ...tail]);
       }
     } catch (err) {
-      console.warn(
+      // The memory hook is best-effort: a failure here must never
+      // break the LLM call. Logged at `warn` so users see the failure
+      // by default; the manager already emitted finer-grained debug
+      // lines and a statelog `error` event if applicable.
+      createLogger(ctx.logLevel).warn(
         `[memory] post-turn hook failed: ${(err as Error).message}`,
       );
     }
@@ -350,7 +355,8 @@ export async function runPrompt(args: {
           messages.push(smoltalk.systemMessage(injectedFactsContent));
         }
       } catch (err) {
-        console.warn(
+        // Best-effort, same reasoning as the post-turn hook.
+        createLogger(ctx.logLevel).warn(
           `[memory] recall injection failed: ${(err as Error).message}`,
         );
       }

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -1,6 +1,7 @@
 import { nanoid } from "nanoid";
 import { SmolConfig } from "smoltalk";
 import type { DebuggerState } from "../../debugger/debuggerState.js";
+import type { LogLevel } from "../../logger.js";
 import { SimpleMachine } from "../../simplemachine/index.js";
 import { StatelogClient, StatelogConfig } from "../../statelogClient.js";
 import { AgencyFunction } from "../agencyFunction.js";
@@ -124,6 +125,16 @@ export class RuntimeContext<T> {
   traceConfig: TraceConfig;
   runId: string | null;
   verbose: boolean;
+  /**
+   * Log threshold used by ad-hoc subsystem loggers (memory, etc.).
+   * Plumbed in from `AgencyConfig.logLevel` so users can crank it up to
+   * `"debug"` when investigating issues without recompiling. The logger
+   * itself is stateless — consumers call `createLogger(execCtx.logLevel)`
+   * on demand rather than carrying a long-lived Logger instance, which
+   * lets each subsystem add its own prefix without coordinating an
+   * instance pool.
+   */
+  logLevel: LogLevel;
   getStaticVars?: () => Record<string, unknown>;
   coverageCollector: CoverageCollector | null = null;
 
@@ -147,6 +158,10 @@ export class RuntimeContext<T> {
     traceConfig?: TraceConfig;
     verbose?: boolean;
     memory?: MemoryConfig;
+    /** Threshold for ad-hoc subsystem loggers. Optional so existing
+     *  test/runtime constructors keep working; defaults to "info" to
+     *  match the established no-debug-by-default behavior. */
+    logLevel?: LogLevel;
   }) {
     const statelogConfig = {
       ...args.statelogConfig,
@@ -174,6 +189,7 @@ export class RuntimeContext<T> {
     this.traceConfig = args.traceConfig || {};
     this.runId = null;
     this.verbose = args.verbose ?? false;
+    this.logLevel = args.logLevel ?? "info";
     this.dirname = args.dirname;
 
     const graphConfig = {
@@ -196,7 +212,10 @@ export class RuntimeContext<T> {
 
     if (args.memory) {
       this.memoryConfig = args.memory;
-      this.memoryStore = new FileMemoryStore(args.memory.dir);
+      // Pass logLevel so the file store can chatter at debug about
+      // every read/write — handy for spotting "why isn't anything
+      // persisting?" without a debugger.
+      this.memoryStore = new FileMemoryStore(args.memory.dir, this.logLevel);
     }
   }
 
@@ -236,6 +255,7 @@ export class RuntimeContext<T> {
     execCtx.traceConfig = this.traceConfig;
     execCtx.runId = runId;
     execCtx.verbose = this.verbose;
+    execCtx.logLevel = this.logLevel;
     execCtx.pendingPromises = new PendingPromiseStore();
     execCtx.classRegistry = this.classRegistry;
     execCtx.abortController = new AbortController();
@@ -260,6 +280,13 @@ export class RuntimeContext<T> {
         llmClient: execCtx._llmClient,
         smoltalkDefaults: execCtx.smoltalkDefaults,
         source: this.traceConfig?.program ?? "agent",
+        // Reuse the per-execCtx StatelogClient so memory's own LLM/embed
+        // spans nest under the same trace as the agent's calls.
+        statelogClient: execCtx.statelogClient,
+        // Threshold for memory's internal logger; promoting this to
+        // "debug" in agency.json surfaces every tier/extract/compact
+        // step on stderr.
+        logLevel: execCtx.logLevel,
         memoryIdRef: {
           get: () => {
             const id = execCtx.stateStack?.other?.memoryId;

--- a/packages/agency-lang/lib/statelogClient.test.ts
+++ b/packages/agency-lang/lib/statelogClient.test.ts
@@ -494,6 +494,61 @@ describe("StatelogClient", () => {
       expect(evt.data.stream).toBe(false);
     });
 
+    /**
+     * Drives the new embed event end-to-end through the file sink.
+     * Asserts the shape we promised in the docstring: preview is the
+     * caller-supplied slice (we don't re-truncate on the client side),
+     * dimensions / inputCount / phase travel through, and vectors are
+     * never serialized — only their length.
+     */
+    it("embedCompletion includes preview, dimensions, phase", async () => {
+      const file = newLogFile("embed");
+      const client = fileClient(file);
+      await client.embedCompletion({
+        inputPreview: "Mom likes pottery",
+        inputCount: 1,
+        model: "text-embedding-3-small",
+        dimensions: 1536,
+        timeTaken: 42,
+        usage: { inputTokens: 4 },
+        phase: "new-observation",
+      });
+      const [evt] = readEvents(file);
+      expect(evt.data.type).toBe("embedCompletion");
+      expect(evt.data.inputPreview).toBe("Mom likes pottery");
+      expect(evt.data.inputCount).toBe(1);
+      expect(evt.data.model).toBe("text-embedding-3-small");
+      expect(evt.data.dimensions).toBe(1536);
+      expect(evt.data.timeTaken).toBe(42);
+      expect(evt.data.phase).toBe("new-observation");
+      // The on-the-wire payload must not carry the actual vector.
+      // (We don't pass `vector` at the API; this guards the field
+      // doesn't accidentally appear via some shared envelope.)
+      expect(evt.data).not.toHaveProperty("vector");
+      expect(evt.data).not.toHaveProperty("embeddings");
+    });
+
+    /**
+     * Lock-in that the new memory SpanTypes are accepted by `startSpan`
+     * (they're a closed union and a typo here would not be a runtime
+     * error, only a type error — this asserts the runtime behaviour
+     * for completeness).
+     */
+    it("startSpan accepts the new memory and embedding span types", async () => {
+      const file = newLogFile("memspans");
+      const client = fileClient(file);
+      const ids: (string | undefined)[] = [];
+      ids.push(client.startSpan("memoryRemember"));
+      ids.push(client.startSpan("memoryRecall"));
+      ids.push(client.startSpan("memoryForget"));
+      ids.push(client.startSpan("memoryCompaction"));
+      ids.push(client.startSpan("embedding"));
+      // All five returned a non-empty id (i.e. were not rejected).
+      for (const id of ids) expect(typeof id).toBe("string");
+      // Close in reverse order to match the stack discipline.
+      for (let i = ids.length - 1; i >= 0; i--) client.endSpan(ids[i]);
+    });
+
     it("interruptThrown emits only interruptId + interruptData", async () => {
       const file = newLogFile("intr-thrown");
       const client = fileClient(file);

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -18,7 +18,19 @@ export type SpanType =
   | "toolExecution"
   | "forkAll"
   | "race"
-  | "handlerChain";
+  | "handlerChain"
+  // Embedding-vector requests. Distinct from `llmCall` so cost
+  // roll-ups in the viewer don't conflate chat-completion cost with
+  // embedding cost, and so embeddings are filterable on their own.
+  | "embedding"
+  // Memory-subsystem umbrella spans. Each one wraps a single
+  // user-facing memory operation; the inner `llmCall`/`embedding`
+  // spans nest underneath via AsyncLocalStorage so a viewer can
+  // collapse the whole operation into one row.
+  | "memoryRemember"
+  | "memoryRecall"
+  | "memoryForget"
+  | "memoryCompaction";
 
 export type SpanContext = {
   spanId: string;
@@ -422,6 +434,61 @@ export class StatelogClient {
       cost,
       finishReason,
       stream,
+    });
+  }
+
+  /**
+   * Emit an `embedCompletion` event. Mirrors `promptCompletion` so the
+   * viewer can render the two with a shared formatter, but keeps the
+   * embedding-specific bits (dimensions, phase tag) separate.
+   *
+   * `inputPreview` is intentionally a short slice of the source text —
+   * the full text is kept off the wire so a transcript-with-PII never
+   * ends up in a remote sink by accident. Vectors are NEVER logged
+   * (only their length, via `dimensions`).
+   */
+  async embedCompletion({
+    inputPreview,
+    inputCount,
+    model,
+    dimensions,
+    timeTaken,
+    usage,
+    cost,
+    phase,
+  }: {
+    /** First ~200 chars of the embedded text, for human-readable tracing. */
+    inputPreview: string;
+    /** Number of input strings in the batch. Currently always 1 from
+     *  memory; left as a count so future batching changes don't
+     *  require a schema bump. */
+    inputCount: number;
+    /** Embedding model name (e.g. "text-embedding-3-small"). */
+    model?: string;
+    /** Vector length. Useful for catching index-vs-query model
+     *  mismatches at trace time without comparing the full vectors. */
+    dimensions?: number;
+    /** Wall-clock latency in ms (caller measures via `performance.now`). */
+    timeTaken?: number;
+    /** Optional provider-reported usage. Not all embed providers
+     *  return these; absent values stay undefined. */
+    usage?: TokenUsage;
+    cost?: TokenCost;
+    /** Free-form tag identifying the caller — e.g. "recall-query",
+     *  "new-observation". Lets a viewer filter "embed for recall"
+     *  vs "embed for storage" without parsing the parent span tree. */
+    phase?: string;
+  }): Promise<void> {
+    await this.post({
+      type: "embedCompletion",
+      inputPreview,
+      inputCount,
+      model,
+      dimensions,
+      timeTaken,
+      usage,
+      cost,
+      phase,
     });
   }
 

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -68,6 +68,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "tests/debugger/function-call-test.agency"
   }

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -68,6 +68,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "tests/debugger/if-else-test.agency"
   }

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -68,6 +68,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "tests/debugger/interrupt-test.agency"
   }

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -68,6 +68,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "tests/debugger/loop-test.agency"
   }

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -68,6 +68,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "tests/debugger/nested-calls-test.agency"
   }

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -68,6 +68,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "tests/debugger/step-test.agency"
   }

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "assignment.agency"
   }

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -67,6 +67,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "safe-function.agency"
   }

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "simple.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "array.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "arrayAndObject.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "assignment.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "asyncAssigned.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "asyncLlm.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "asyncUnassigned.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "bangParams.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "bangReturnType.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "bangValidation.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "blockBasic.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "blockParams.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "checkpoint-restore.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "class-basic.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "class-inheritance.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "comments.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "defaultValues.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "docstrings.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "euler-0001.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "euler-0002.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "euler-0003.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "euler-0004.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "euler-0005.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "euler-0006.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "euler-0007.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "euler-0008.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "euler-0009.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "euler-0010.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "forLoop.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "function-with-types.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "function.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "functionRef.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "goto.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "gotoWithArgs.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "graph-node-with-types.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "ifElse.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -81,6 +81,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "imports.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "inlineBlockBasic.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "inlineBlockParams.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "input.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "interpolation.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "interrupt-2-deep-in-function.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "interrupt-assignment.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "interrupt-in-node.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "llmConfigParam.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "matchBlock.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "multiLineComment.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "multipleNodes.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "namedArgs.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "namedArgsReorder.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "noResponseFormat.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "objectDescription.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "optionalParams.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "pipe-operator.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "result-basic.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "result-guards.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "returnValue.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "rewindCheckpoint.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -67,6 +67,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "safe.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "schemaAccess.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -67,6 +67,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "setLLMClient.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "simple.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "skill.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "slice.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "sliceAssign.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "sourceMap.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "splat.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "static.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "streaming.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "string-interpolation.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "stringConcat.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "threadsAndSubthreads.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "typeHints.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "exportedTypeAlias.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "literal.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "nestedTypeAlias.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "typeAlias.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "unitLiterals.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "valueAccessInterpolation.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "varTypes.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "variadic.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "withModifier.agency"
   }

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -66,6 +66,7 @@ const __globalCtx = new RuntimeContext({
     }
   },
   dirname: __dirname,
+  logLevel: "info",
   traceConfig: {
     program: "withParam.agency"
   }


### PR DESCRIPTION
## Summary

Wires the memory subsystem into the existing observability stack so users can see what's happening inside `remember`, `recall`, `forget`, and compaction without attaching a debugger.

## What's new

### Statelog
- New `SpanType` values: `embedding`, `memoryRemember`, `memoryRecall`, `memoryForget`, `memoryCompaction`.
- New `embedCompletion` event on `StatelogClient` that mirrors `llmCompletion` for embeddings (input preview, dimensions, model, tokens).

### MemoryManager / FileMemoryStore
- `MemoryManager` accepts `statelogClient` and `logLevel` in its options.
- Each high-level memory operation now opens an umbrella span; the internal `_text`/`_embed` calls open child spans and emit `llmCompletion`/`embedCompletion` events.
- `console.warn`/`error` calls replaced with a level-gated `Logger` (`lib/logger.ts`); every log line has a `[memory]` prefix so it groups cleanly when grepping.
- `FileMemoryStore` chatters at `debug` on every read/write/mkdir.

### Plumbing
- `RuntimeContext` carries `logLevel` (defaults to `"info"`) and forwards it (plus the per-execCtx `StatelogClient`) to `MemoryManager` and `FileMemoryStore`.
- `TypeScriptBuilder.configDefaults()` sets `logLevel: "info"` and `generateImports()` renders it into the generated `RuntimeContext` constructor call. Users opt in to debug logging by setting `logLevel: "debug"` in `agency.json` — no recompile needed beyond the normal build.

### Tests
- New unit tests in `lib/statelogClient.test.ts` for the new event + span types.
- New tests in `lib/runtime/memory/manager.test.ts` asserting that spans/events fire around recall, remember, forget, and compaction.
- 6 debugger fixtures regenerated to include `logLevel: "info"`.
- 88 `typescriptBuilder` + `typescriptGenerator` fixtures regenerated for the new constructor arg.

## Verification

- `pnpm test:run` — 3843/3843 tests pass (226 files).
- `pnpm vitest run lib/backends/typescriptGenerator.integration.test.ts` — 82/82 pass.
- `pnpm run lint:structure` — 2 pre-existing errors in unrelated files (`logsViewer/search.ts`, `lsp/hover.ts`); none introduced by this PR.
