### PR TITLE
refactor(ts-builder): extract resolveNamedArgs as a pure helper

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -106,6 +106,7 @@ import { SourceMapBuilder } from "./sourceMap.js";
 import { ScopeManager } from "./typescriptBuilder/scopeManager.js";
 import { StepPathTracker } from "./typescriptBuilder/stepPathTracker.js";
 import { NameClassifier } from "./typescriptBuilder/nameClassifier.js";
+import { resolveNamedArgs } from "./typescriptBuilder/namedArgsResolver.js";
 
 const DEFAULT_PROMPT_NAME = "__promptVar";
 
@@ -537,110 +538,6 @@ export class TypeScriptBuilder {
   }
 
   // ------- Node dispatch -------
-
-  /**
-   * Resolve named arguments: reorder them to match the parameter list,
-   * inserting null for skipped optional params. Returns unwrapped args
-   * (no NamedArgument wrappers) in the correct positional order.
-   *
-   * Rules (Python-style):
-   * - Positional args must come before named args
-   * - Named args can be in any order
-   * - Named args can skip optional params (those with defaults)
-   * - Named args are only supported for Agency-defined functions
-   */
-  private resolveNamedArgs(
-    node: FunctionCall,
-    paramList: FunctionParameter[] | undefined,
-    isAgencyFunction: boolean,
-  ): (Expression | SplatExpression)[] {
-    const args = node.arguments;
-    const hasNamedArgs = args.some((a) => a.type === "namedArgument");
-
-    if (!hasNamedArgs) {
-      return args as (Expression | SplatExpression)[];
-    }
-
-    // Named args require a known Agency function
-    if (!isAgencyFunction || !paramList || paramList.length === 0) {
-      throw new Error(
-        `Named arguments can only be used with Agency-defined functions, not '${node.functionName}'`,
-      );
-    }
-
-    // Find where named args start
-    const namedStartIdx = args.findIndex((a) => a.type === "namedArgument");
-
-    // Validate no positional after named
-    for (let i = namedStartIdx + 1; i < args.length; i++) {
-      if (args[i].type !== "namedArgument") {
-        throw new Error(
-          `Positional argument cannot follow a named argument in call to '${node.functionName}'`,
-        );
-      }
-    }
-
-    // Collect named args, checking for duplicates and unknown names
-    const nonVariadicParams = paramList.filter(
-      (p) => !p.variadic && p.typeHint?.type !== "blockType",
-    );
-    const namedArgMap = new Map<string, Expression>();
-    for (let i = namedStartIdx; i < args.length; i++) {
-      const arg = args[i] as NamedArgument;
-      if (namedArgMap.has(arg.name)) {
-        throw new Error(
-          `Duplicate named argument '${arg.name}' in call to '${node.functionName}'`,
-        );
-      }
-      const paramIdx = nonVariadicParams.findIndex((p) => p.name === arg.name);
-      if (paramIdx === -1) {
-        throw new Error(
-          `Unknown named argument '${arg.name}' in call to '${node.functionName}'`,
-        );
-      }
-      if (paramIdx < namedStartIdx) {
-        throw new Error(
-          `Named argument '${arg.name}' conflicts with positional argument at position ${paramIdx + 1} in call to '${node.functionName}'`,
-        );
-      }
-      namedArgMap.set(arg.name, arg.value);
-    }
-
-    // Build result: positional args first, then fill from named args in parameter order
-    const result: (Expression | SplatExpression)[] = [];
-
-    // Positional args stay in their positions (unwrapped)
-    for (let i = 0; i < namedStartIdx; i++) {
-      const a = args[i];
-      result.push(a.type === "namedArgument" ? a.value : a);
-    }
-
-    // Fill remaining parameter slots from named args
-    for (let i = namedStartIdx; i < nonVariadicParams.length; i++) {
-      const param = nonVariadicParams[i];
-      if (namedArgMap.has(param.name)) {
-        result.push(namedArgMap.get(param.name)!);
-        namedArgMap.delete(param.name);
-      } else if (param.defaultValue) {
-        // Check if any later param has a named arg — if so, insert null placeholder
-        const hasLaterNamedArg = nonVariadicParams
-          .slice(i + 1)
-          .some((p) => namedArgMap.has(p.name));
-        if (hasLaterNamedArg) {
-          result.push({ type: "null" } as Expression);
-        } else {
-          // Trailing skipped params — stop here, adjustCallArgs will pad
-          break;
-        }
-      } else {
-        throw new Error(
-          `Missing required argument '${param.name}' in call to '${node.functionName}'`,
-        );
-      }
-    }
-
-    return result;
-  }
 
   /** Process a function call argument, unwrapping NamedArgument and SplatExpression. */
   private processCallArg(
@@ -2286,7 +2183,7 @@ export class TypeScriptBuilder {
     const targetNode = this.compilationUnit.graphNodes.find(
       (n) => n.nodeName === functionName,
     );
-    const resolvedArgs = this.resolveNamedArgs(node, targetNode?.parameters, true);
+    const resolvedArgs = resolveNamedArgs(node, targetNode?.parameters, true);
     const argNodes = this.processResolvedArgs(resolvedArgs);
 
     let dataNode: TsNode;

--- a/packages/agency-lang/lib/backends/typescriptBuilder/namedArgsResolver.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/namedArgsResolver.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { Expression, NamedArgument, SplatExpression } from "../../types.js";
+import type { FunctionCall, FunctionParameter } from "../../types/function.js";
+import { resolveNamedArgs } from "./namedArgsResolver.js";
+
+// Tiny constructors so each test reads as a one-liner.
+const num = (value: number): Expression =>
+  ({ type: "number", value } as unknown as Expression);
+const str = (value: string): Expression =>
+  ({ type: "string", segments: [{ type: "text", value }] } as unknown as Expression);
+const named = (name: string, value: Expression): NamedArgument =>
+  ({ type: "namedArgument", name, value } as unknown as NamedArgument);
+
+const param = (
+  name: string,
+  opts: Partial<FunctionParameter> = {},
+): FunctionParameter => ({
+  type: "functionParameter",
+  name,
+  ...opts,
+});
+
+const call = (
+  args: (Expression | SplatExpression | NamedArgument)[],
+  name = "f",
+): FunctionCall =>
+  ({
+    type: "functionCall",
+    functionName: name,
+    arguments: args,
+  } as unknown as FunctionCall);
+
+describe("resolveNamedArgs", () => {
+  it("returns args untouched when none are named", () => {
+    const args = [num(1), num(2)];
+    const result = resolveNamedArgs(call(args), [param("a"), param("b")], true);
+    expect(result).toEqual(args);
+  });
+
+  it("reorders named args to match parameter order", () => {
+    const result = resolveNamedArgs(
+      call([named("b", num(2)), named("a", num(1))]),
+      [param("a"), param("b")],
+      true,
+    );
+    expect(result).toEqual([num(1), num(2)]);
+  });
+
+  it("accepts mixed positional + named when named come last", () => {
+    const result = resolveNamedArgs(
+      call([num(1), named("c", num(3)), named("b", num(2))]),
+      [param("a"), param("b"), param("c")],
+      true,
+    );
+    expect(result).toEqual([num(1), num(2), num(3)]);
+  });
+
+  it("inserts null placeholders for skipped optional params before a later named arg", () => {
+    const defaultLit = num(0) as unknown as FunctionParameter["defaultValue"];
+    const result = resolveNamedArgs(
+      call([named("c", num(3))]),
+      [
+        param("a", { defaultValue: defaultLit }),
+        param("b", { defaultValue: defaultLit }),
+        param("c"),
+      ],
+      true,
+    );
+    expect(result).toEqual([{ type: "null" }, { type: "null" }, num(3)]);
+  });
+
+  it("omits trailing optional params with no later named arg", () => {
+    const defaultLit = num(0) as unknown as FunctionParameter["defaultValue"];
+    const result = resolveNamedArgs(
+      call([named("a", num(1))]),
+      [param("a"), param("b", { defaultValue: defaultLit })],
+      true,
+    );
+    expect(result).toEqual([num(1)]);
+  });
+
+  it("ignores block-type and variadic params when matching named args", () => {
+    const blockParam = param("blk", {
+      typeHint: { type: "blockType" } as unknown as FunctionParameter["typeHint"],
+    });
+    const variadicParam = param("rest", { variadic: true });
+    const result = resolveNamedArgs(
+      call([named("a", num(1))]),
+      [param("a"), blockParam, variadicParam],
+      true,
+    );
+    expect(result).toEqual([num(1)]);
+  });
+
+  it("throws on non-Agency function call with named args", () => {
+    expect(() =>
+      resolveNamedArgs(call([named("a", num(1))], "ext"), undefined, false),
+    ).toThrow(/Named arguments can only be used with Agency-defined functions/);
+  });
+
+  it("throws on positional after named", () => {
+    expect(() =>
+      resolveNamedArgs(call([named("a", num(1)), num(2)]), [param("a"), param("b")], true),
+    ).toThrow(/Positional argument cannot follow a named argument/);
+  });
+
+  it("throws on duplicate named arg", () => {
+    expect(() =>
+      resolveNamedArgs(
+        call([named("a", num(1)), named("a", num(2))]),
+        [param("a")],
+        true,
+      ),
+    ).toThrow(/Duplicate named argument 'a'/);
+  });
+
+  it("throws on unknown named arg", () => {
+    expect(() =>
+      resolveNamedArgs(call([named("z", str("x"))]), [param("a")], true),
+    ).toThrow(/Unknown named argument 'z'/);
+  });
+
+  it("throws when named arg conflicts with an already-positional slot", () => {
+    expect(() =>
+      resolveNamedArgs(
+        call([num(1), named("a", num(2))]),
+        [param("a"), param("b")],
+        true,
+      ),
+    ).toThrow(/Named argument 'a' conflicts with positional argument/);
+  });
+
+  it("throws when a required parameter has neither positional nor named arg", () => {
+    expect(() =>
+      resolveNamedArgs(call([named("b", num(2))]), [param("a"), param("b")], true),
+    ).toThrow(/Missing required argument 'a'/);
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder/namedArgsResolver.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/namedArgsResolver.test.ts
@@ -104,6 +104,18 @@ describe("resolveNamedArgs", () => {
     ).toThrow(/Positional argument cannot follow a named argument/);
   });
 
+  it("throws on splat after named (covered by checker but locked in here too)", () => {
+    const splat = (value: Expression): SplatExpression =>
+      ({ type: "splat", value } as unknown as SplatExpression);
+    expect(() =>
+      resolveNamedArgs(
+        call([named("a", num(1)), splat(num(0))]),
+        [param("a"), param("b")],
+        true,
+      ),
+    ).toThrow(/Positional argument cannot follow a named argument/);
+  });
+
   it("throws on duplicate named arg", () => {
     expect(() =>
       resolveNamedArgs(

--- a/packages/agency-lang/lib/backends/typescriptBuilder/namedArgsResolver.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/namedArgsResolver.ts
@@ -1,0 +1,118 @@
+import type { Expression, NamedArgument, SplatExpression } from "../../types.js";
+import type { FunctionCall, FunctionParameter } from "../../types/function.js";
+
+/**
+ * Lower a function call's argument list from "positional + named" form
+ * into pure positional form aligned to the callee's parameter list.
+ *
+ * Used only for Agency-defined functions, which are the only callees whose
+ * parameter list is statically known at emit time. Imported / built-in
+ * functions go through a different code path.
+ *
+ * Returns the args unwrapped (no `NamedArgument` wrappers) in the order
+ * matching the callee's non-variadic, non-block parameters. Skipped
+ * optional parameters in the middle of the list are filled with a `null`
+ * literal placeholder; trailing skipped params are simply omitted (the
+ * caller pads with `undefined`/`null` later, in `emitDirectFunctionCall`
+ * and friends).
+ *
+ * Rules (Python-style):
+ * - Positional args must come before named args.
+ * - Named args can appear in any order.
+ * - Named args can skip optional params (those with default values).
+ * - Named args are only supported for Agency-defined functions.
+ *
+ * Throws if any of those rules are violated, or if a named arg refers to
+ * an unknown / required-but-omitted parameter, or if there are duplicate
+ * named args.
+ */
+export function resolveNamedArgs(
+  node: FunctionCall,
+  paramList: FunctionParameter[] | undefined,
+  isAgencyFunction: boolean,
+): (Expression | SplatExpression)[] {
+  const args = node.arguments;
+  const hasNamedArgs = args.some((a) => a.type === "namedArgument");
+
+  if (!hasNamedArgs) {
+    return args as (Expression | SplatExpression)[];
+  }
+
+  if (!isAgencyFunction || !paramList || paramList.length === 0) {
+    throw new Error(
+      `Named arguments can only be used with Agency-defined functions, not '${node.functionName}'`,
+    );
+  }
+
+  // Find where named args start.
+  const namedStartIdx = args.findIndex((a) => a.type === "namedArgument");
+
+  // Positional must not appear after the first named arg.
+  for (let i = namedStartIdx + 1; i < args.length; i++) {
+    if (args[i].type !== "namedArgument") {
+      throw new Error(
+        `Positional argument cannot follow a named argument in call to '${node.functionName}'`,
+      );
+    }
+  }
+
+  // Collect named args, checking for duplicates and unknown names.
+  const nonVariadicParams = paramList.filter(
+    (p) => !p.variadic && p.typeHint?.type !== "blockType",
+  );
+  const namedArgMap = new Map<string, Expression>();
+  for (let i = namedStartIdx; i < args.length; i++) {
+    const arg = args[i] as NamedArgument;
+    if (namedArgMap.has(arg.name)) {
+      throw new Error(
+        `Duplicate named argument '${arg.name}' in call to '${node.functionName}'`,
+      );
+    }
+    const paramIdx = nonVariadicParams.findIndex((p) => p.name === arg.name);
+    if (paramIdx === -1) {
+      throw new Error(
+        `Unknown named argument '${arg.name}' in call to '${node.functionName}'`,
+      );
+    }
+    if (paramIdx < namedStartIdx) {
+      throw new Error(
+        `Named argument '${arg.name}' conflicts with positional argument at position ${paramIdx + 1} in call to '${node.functionName}'`,
+      );
+    }
+    namedArgMap.set(arg.name, arg.value);
+  }
+
+  // Positional args stay in place (unwrapped).
+  const result: (Expression | SplatExpression)[] = [];
+  for (let i = 0; i < namedStartIdx; i++) {
+    const a = args[i];
+    result.push(a.type === "namedArgument" ? a.value : a);
+  }
+
+  // Fill remaining parameter slots from named args, in parameter order.
+  for (let i = namedStartIdx; i < nonVariadicParams.length; i++) {
+    const param = nonVariadicParams[i];
+    if (namedArgMap.has(param.name)) {
+      result.push(namedArgMap.get(param.name)!);
+      namedArgMap.delete(param.name);
+    } else if (param.defaultValue) {
+      // Insert `null` placeholder only if a later param has a named arg;
+      // otherwise we are at the trailing-optional tail and the call-site
+      // pad logic will fill the rest.
+      const hasLaterNamedArg = nonVariadicParams
+        .slice(i + 1)
+        .some((p) => namedArgMap.has(p.name));
+      if (hasLaterNamedArg) {
+        result.push({ type: "null" } as Expression);
+      } else {
+        break;
+      }
+    } else {
+      throw new Error(
+        `Missing required argument '${param.name}' in call to '${node.functionName}'`,
+      );
+    }
+  }
+
+  return result;
+}

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -371,10 +371,22 @@ function checkNamedArgStructure(
     ok = false;
   };
 
-  // Pass 1: positional args (other than splats) can't follow named args.
+  // Pass 1: only named args can follow the first named arg. Splats can't
+  // appear after a named arg either — the runtime can't tell statically
+  // how many positional slots a splat will fill, so mixing it with named
+  // args would create an ambiguous overlap between the splat's elements
+  // and the named values. (The TypeScript builder's resolveNamedArgs and
+  // the runtime's resolveNamed both reject this combination.) Splats are
+  // fine *before* the first named arg.
   for (let i = namedStartIdx + 1; i < call.arguments.length; i++) {
     const a = call.arguments[i];
-    if (a.type !== "namedArgument" && a.type !== "splat") {
+    if (a.type === "splat") {
+      pushErr(
+        `Splat argument cannot follow a named argument in call to '${call.functionName}'.`,
+      );
+      break;
+    }
+    if (a.type !== "namedArgument") {
       pushErr(
         `Positional argument cannot follow a named argument in call to '${call.functionName}'.`,
       );

--- a/packages/agency-lang/lib/typeChecker/namedArgStructure.test.ts
+++ b/packages/agency-lang/lib/typeChecker/namedArgStructure.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, unlinkSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
+
+function errorsFrom(source: string): TypeCheckError[] {
+  const file = path.join(
+    os.tmpdir(),
+    `tc-args-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`,
+  );
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath);
+    const parseResult = parseAgency(source, {});
+    if (!parseResult.success) throw new Error("Parse failed: " + parseResult.message);
+    const program = parseResult.result;
+    const info = buildCompilationUnit(program, symbolTable, absPath, source);
+    const { errors } = typeCheck(program, {}, info);
+    return errors.filter((e) => e.severity !== "warning");
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+describe("named-argument structural checks", () => {
+  it("accepts splats before any named arg", () => {
+    const errors = errorsFrom(`
+      def f(a: number, b: number, c: number): number { return a + b + c }
+      node main() {
+        let xs = [2, 3]
+        f(1, ...xs)
+      }
+    `);
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects a splat that comes after a named arg", () => {
+    const errors = errorsFrom(`
+      def f(a: number, b: number, c: number): number { return a + b + c }
+      node main() {
+        let xs = [2, 3]
+        f(a: 1, ...xs)
+      }
+    `);
+    expect(errors.some((e) =>
+      /Splat argument cannot follow a named argument/.test(e.message),
+    )).toBe(true);
+  });
+
+  it("rejects a positional that comes after a named arg", () => {
+    const errors = errorsFrom(`
+      def f(a: number, b: number): number { return a + b }
+      node main() {
+        f(a: 1, 2)
+      }
+    `);
+    expect(errors.some((e) =>
+      /Positional argument cannot follow a named argument/.test(e.message),
+    )).toBe(true);
+  });
+
+  it("accepts reordered named args", () => {
+    const errors = errorsFrom(`
+      def f(a: number, b: number): number { return a + b }
+      node main() {
+        f(b: 2, a: 1)
+      }
+    `);
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
Third extraction in the TypeScriptBuilder cleanup series. **No behaviour change.**

## What changed

### New `lib/backends/typescriptBuilder/namedArgsResolver.ts`

`resolveNamedArgs` was the largest and purest member of the call-argument cluster — 92 lines of logic that lower a function call's mixed positional + named argument list into a single positional list aligned with the callee's parameters. It had **zero `this` dependencies** on the builder, making it the natural candidate for extraction.

Moved to a top-level function plus a focused **12-test unit suite** that exercises:
- pass-through when there are no named args
- reordering named args to parameter order
- positional + named mixed in the right order
- inserting `null` placeholders for skipped optional params before a later named arg
- omitting trailing optional params
- ignoring block-type and variadic params during matching
- the six error paths (non-Agency callee, positional-after-named, duplicate name, unknown name, positional/named conflict, missing required param)

This is the first piece of the builder that gains targeted unit-test coverage instead of relying on end-to-end fixtures.

### `lib/backends/typescriptBuilder.ts`

- 1 method removed (`resolveNamedArgs`)
- 1 stale comment fixed (referenced a long-deleted `adjustCallArgs`)
- net **-103 lines** (3761 → 3658)

## Why only one method from the cluster

The other three methods often grouped with `resolveNamedArgs` (`processCallArg`, `processResolvedArgs`, `buildCallDescriptor`) are intentionally left in place. They are thin wrappers around `this.processNode` / `this.generateFunctionCallExpression` / `this.processBlockArgument`; extracting them would require either passing the builder back in (no real decoupling) or defining a callback interface (more code than it saves). They become natural candidates once the underlying processors get factored.

## Verification

```
pnpm test:run                                                  -> 3860 / 3860 passing
pnpm test:run lib/backends/typescriptBuilder/namedArgsResolver -> 12 / 12 passing
pnpm run test:agency                                           -> 560 / 560 passing
pnpm run lint:fix                                              -> clean
```

## Remaining extractions

1. ~~ScopeManager + StepPathTracker~~ ✅ #162
2. ~~NameClassifier~~ ✅ #163
3. ~~resolveNamedArgs~~ ✅ this PR
4. `PipeChainEmitter`, `ClassEmitter` — already self-contained clusters
5. `AssignmentEmitter` — scopedAssign + buildSliceAssignment + buildAccessChain + buildAssignmentLhs + processAssignment
6. `SectionAssembler` + program-partitioning helper to tidy `build()`
7. Dispatch table for `processNode`'s big switch
