### PR TITLE
TypeScript Builder refactor: extract AssignmentEmitter

### DIFF
--- a/packages/agency-lang/docs/dev/ts-ir-readability-backlog.md
+++ b/packages/agency-lang/docs/dev/ts-ir-readability-backlog.md
@@ -1,0 +1,62 @@
+# TS IR readability — running list
+
+Observations and pain points spotted while refactoring `TypeScriptBuilder`. These are NOT actioned yet; this is a backlog to discuss later.
+
+## Patterns that hurt readability
+
+### 1. `ts.raw(...)` with embedded template strings
+
+We frequently fall out of the IR to do something that the IR could express, e.g.
+
+```ts
+return ts.raw(`${baseStr}.splice(${startStr}, ${deleteCountStr}, ...${this.str(value)})`);
+```
+
+This loses type-safety, sourcemap potential, and pretty-printing control. Two failure modes:
+
+- We `printTs` a node, splice it into a template string, then wrap the result in `ts.raw`. The node round-trips through a string for no reason.
+- We pre-compute precedence/paren-wrapping manually (e.g. wrapping `await` in parens before applying `.foo`) instead of letting the printer handle it.
+
+**Direction:** Audit `ts.raw(...)` call sites; promote each to a structured builder. Add new builders where they would replace a recurring raw-string pattern.
+
+### 2. Method-call chains require `$(...).prop().call().done()`
+
+The fluent helper works, but readers always have to mentally translate `$(receiver).prop("foo").call(args).done()` into `receiver.foo(args)`. For very common shapes (`obj.method(args)`, `obj.prop`), a one-shot `ts.methodCall(obj, "foo", args)` reads better and is shorter.
+
+**Direction:** Consider `ts.methodCall(receiver, name, args, opts?)` and `ts.awaitedCall(receiver, name, args)` for the chain emitters that always await.
+
+### 3. Multiple ways to spell "an await of a call"
+
+We have `ts.await(ts.call(...))`, `$(...).done()` (with `.await()` modifier?), and inline `ts.raw("await ...")` in some places. Picking one canonical form would help.
+
+### 4. Object literals with mixed regular and spread entries are verbose
+
+```ts
+ts.obj([ts.setSpread(ts.runtime.state), ts.set("data", varRef)])
+```
+
+vs. what would be ideal:
+
+```ts
+ts.obj({ ...ts.runtime.state, data: varRef })
+```
+
+Today the array-form is needed when spreading. A small helper that accepts a mix would round off this rough edge.
+
+### 5. `printTs` reaching into the IR from outside the IR module
+
+Code in `TypeScriptBuilder` calls `printTs(node, 2)` mid-build to splice the output into another string template. That breaks the IR abstraction — once you stringify, you cannot re-traverse or transform. See the class-method body assembly in `ClassEmitter.buildMethodCode` for the canonical example.
+
+**Direction:** Provide an IR-level "wrap as async method member" or similar so we never pretty-print mid-build.
+
+### 6. `TsNode` is a discriminated union with ~25 cases
+
+When reading code that consumes `TsNode`, it is hard to remember the full set of `kind` values without opening `tsIR.ts`. A short summary comment at the top of `tsIR.ts`, or a generated docs page, would help. Some kinds also overlap (e.g. `runnerStep` / `runnerPipe` / `runnerBranchStep` all describe runner-step shapes — could share a discriminator?).
+
+### 7. Scope/identifier helpers are split across `ts.id`, `ts.scopedVar`, `ts.self`, `ts.raw(name)`
+
+Picking the right one requires knowing what each compiles to. Worth documenting alongside each builder which compiled form they produce, and possibly consolidating.
+
+---
+
+(Append more as we go.)

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -107,6 +107,7 @@ import { StepPathTracker } from "./typescriptBuilder/stepPathTracker.js";
 import { NameClassifier } from "./typescriptBuilder/nameClassifier.js";
 import { PipeChainEmitter } from "./typescriptBuilder/pipeChainEmitter.js";
 import { ClassEmitter } from "./typescriptBuilder/classEmitter.js";
+import { AssignmentEmitter } from "./typescriptBuilder/assignmentEmitter.js";
 import { resolveNamedArgs } from "./typescriptBuilder/namedArgsResolver.js";
 
 const DEFAULT_PROMPT_NAME = "__promptVar";
@@ -161,6 +162,7 @@ export class TypeScriptBuilder {
   private names: NameClassifier;
   private pipes: PipeChainEmitter;
   private classes: ClassEmitter;
+  private assigns: AssignmentEmitter;
 
   // Config
   private agencyConfig: AgencyConfig = {};
@@ -217,12 +219,18 @@ export class TypeScriptBuilder {
     this.pipes = new PipeChainEmitter({
       processNode: (n) => this.processNode(n),
       buildAssignmentLhs: (scope, varName, accessChain) =>
-        this.buildAssignmentLhs(scope, varName, accessChain),
+        this.assigns.lhs(scope, varName, accessChain),
       buildStateConfig: () => this.buildStateConfig(),
       generateFunctionCallExpression: (call, ctx) =>
         this.generateFunctionCallExpression(call, ctx),
       str: (n) => this.str(n),
       scopes: this.scopes,
+    });
+    this.assigns = new AssignmentEmitter({
+      moduleId,
+      processNode: (n) => this.processNode(n),
+      buildCallDescriptor: (call) => this.buildCallDescriptor(call),
+      buildStateConfig: () => this.buildStateConfig(),
     });
     this.classes = new ClassEmitter({
       scopes: this.scopes,
@@ -263,54 +271,6 @@ export class TypeScriptBuilder {
   /** Convert a TsNode to string (for use in template-based methods) */
   private str(node: TsNode): string {
     return printTs(node);
-  }
-
-  // ------- Assignment lowering -------
-
-  /**
-   * Assign a value to a scoped variable. For global scope, emits a
-   * `__ctx.globals.set(moduleId, name, value)` call. For all other scopes,
-   * emits a normal `lhs = rhs` assignment.
-   */
-  private scopedAssign(
-    scope: ScopeType,
-    varName: string,
-    value: TsNode,
-    accessChain?: AccessChainElement[],
-  ): TsNode {
-    if (accessChain && accessChain.length > 0 && accessChain[accessChain.length - 1].kind === "slice") {
-      return this.buildSliceAssignment(scope, varName, value, accessChain);
-    }
-    if (scope === "global" && (!accessChain || accessChain.length === 0)) {
-      return ts.globalSet(this.moduleId, varName, value);
-    }
-    const lhs = this.buildAssignmentLhs(scope, varName, accessChain);
-    return ts.assign(lhs, value);
-  }
-
-  /**
-   * arr[1:3] = [10, 20] → arr.splice(start, end - start, ...value)
-   * arr[2:] = [10]      → arr.splice(start, arr.length - start, ...value)
-   */
-  private buildSliceAssignment(
-    scope: ScopeType,
-    varName: string,
-    value: TsNode,
-    accessChain: AccessChainElement[],
-  ): TsNode {
-    const sliceEl = accessChain[accessChain.length - 1] as Extract<AccessChainElement, { kind: "slice" }>;
-    const baseChain = accessChain.length > 1 ? accessChain.slice(0, -1) : undefined;
-    const base = this.buildAssignmentLhs(scope, varName, baseChain);
-    const baseStr = this.str(base);
-
-    const startNode = sliceEl.start ? this.processNode(sliceEl.start) : ts.raw("0");
-    const startStr = this.str(startNode);
-
-    const deleteCountStr = sliceEl.end
-      ? `${this.str(this.processNode(sliceEl.end))} - ${startStr}`
-      : `${baseStr}.length - ${startStr}`;
-
-    return ts.raw(`${baseStr}.splice(${startStr}, ${deleteCountStr}, ...${this.str(value)})`);
   }
 
   // ------- Lookup helpers -------
@@ -2403,7 +2363,7 @@ export class TypeScriptBuilder {
 
     // `this.field = value` and `super.field = value` — emit as direct property assignment
     if (isClassKeyword(variableName)) {
-      const lhs = this.buildAccessChain(ts.id(variableName), node.accessChain);
+      const lhs = this.assigns.accessChain(ts.id(variableName), node.accessChain);
       return ts.assign(lhs, this.processNode(value));
     }
 
@@ -2414,7 +2374,7 @@ export class TypeScriptBuilder {
       const origin = moduleIdToOrigin(this.moduleId);
       const makeAssign = (val: string) =>
         this.str(
-          this.scopedAssign(
+          this.assigns.scopedAssign(
             node.scope!,
             variableName,
             ts.raw(val),
@@ -2434,13 +2394,13 @@ export class TypeScriptBuilder {
         }),
       );
     } else if (value.type === "functionCall") {
-      const varRef = this.buildAssignmentLhs(
+      const varRef = this.assigns.lhs(
         node.scope!,
         variableName,
         node.accessChain,
       );
       const stmts: TsNode[] = [
-        this.scopedAssign(
+        this.assigns.scopedAssign(
           node.scope!,
           variableName,
           this.processNode(value),
@@ -2454,7 +2414,7 @@ export class TypeScriptBuilder {
           this._asyncBranchCheckNeeded = true;
           const branchKey = this.steps.joined();
           stmts.unshift(...this.forkBranchSetup(branchKey));
-          stmts[stmts.length - 1] = this.scopedAssign(
+          stmts[stmts.length - 1] = this.assigns.scopedAssign(
             node.scope!,
             variableName,
             this.generateFunctionCallExpression(value, "topLevelStatement", {
@@ -2506,52 +2466,13 @@ export class TypeScriptBuilder {
     } else if (value.type === "messageThread") {
       return this.processMessageThread(value, node);
     } else {
-      return this.scopedAssign(
+      return this.assigns.scopedAssign(
         node.scope!,
         variableName,
         this.processNode(value),
         node.accessChain,
       );
     }
-  }
-
-  private buildAccessChain(base: TsNode, chain?: AccessChainElement[]): TsNode {
-    if (!chain || chain.length === 0) return base;
-    let result = base;
-    for (const el of chain) {
-      switch (el.kind) {
-        case "property":
-          result = ts.prop(result, el.name);
-          break;
-        case "index":
-          result = ts.index(result, this.processNode(el.index));
-          break;
-        case "methodCall": {
-          const fnCall = el.functionCall;
-          const descriptor = this.buildCallDescriptor(fnCall);
-          const configObj = this.buildStateConfig();
-
-          const callExpr = ts.call(
-            ts.id("__callMethod"),
-            [result, ts.str(fnCall.functionName), descriptor, configObj],
-          );
-          result = ts.await(callExpr);
-          break;
-        }
-      }
-    }
-    return result;
-  }
-
-  private buildAssignmentLhs(
-    scope: ScopeType,
-    variableName: string,
-    chain?: AccessChainElement[],
-  ): TsNode {
-    return this.buildAccessChain(
-      ts.scopedVar(variableName, scope, this.moduleId),
-      chain,
-    );
   }
 
   /**
@@ -2707,7 +2628,7 @@ export class TypeScriptBuilder {
     // INSIDE the callback (before popActive runs in the finally block).
     if (assignTo) {
       bodyNodes.push(
-        this.scopedAssign(
+        this.assigns.scopedAssign(
           assignTo.scope!,
           assignTo.variableName,
           $(ts.threads.active()).prop("cloneMessages").call().done(),

--- a/packages/agency-lang/lib/backends/typescriptBuilder/assignmentEmitter.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/assignmentEmitter.ts
@@ -1,0 +1,140 @@
+import type { AgencyNode, ScopeType } from "../../types.js";
+import type { AccessChainElement } from "../../types/access.js";
+import type { FunctionCall } from "../../types/function.js";
+import type { TsNode } from "../../ir/tsIR.js";
+import { $, ts } from "../../ir/builders.js";
+
+/**
+ * Callbacks AssignmentEmitter needs from the parent TypeScriptBuilder.
+ *
+ * Access chains and slice bounds can contain arbitrary expressions, so we
+ * take the relevant builder routines as dependencies rather than holding
+ * a reference to the whole builder.
+ */
+export type AssignmentEmitterDeps = {
+  moduleId: string;
+  processNode: (node: AgencyNode) => TsNode;
+  buildCallDescriptor: (call: FunctionCall) => TsNode;
+  buildStateConfig: () => TsNode;
+};
+
+/**
+ * Encapsulates the construction of assignment LHS nodes and assignment
+ * statements. This is the boring half of assignment lowering — building
+ * `obj.foo[i] = value` style nodes from a scope + variable name + access
+ * chain.
+ *
+ * The interesting / stateful half (handling llm calls, interrupts, async
+ * function calls, message threads, etc.) stays in TypeScriptBuilder
+ * because it touches most other subsystems; extracting it would not
+ * meaningfully reduce coupling.
+ *
+ * Public API:
+ *   - {@link scopedAssign} — build a full assignment statement
+ *     (`lhs = value`, or `__ctx.globals.set(...)` for globals, or
+ *     `.splice(...)` for slice assignment)
+ *   - {@link lhs}          — build just the assignment target node
+ *   - {@link accessChain}  — apply an access chain to an arbitrary base
+ *     expression (used for `this.field = value` lowering)
+ */
+export class AssignmentEmitter {
+  constructor(private deps: AssignmentEmitterDeps) {}
+
+  /**
+   * Assign a value to a scoped variable.
+   *
+   * - Global scope, no access chain → `__ctx.globals.set(moduleId, name, value)`
+   * - Slice as the last access element → array `.splice(...)` call
+   * - Otherwise → ordinary `lhs = value`
+   */
+  scopedAssign(
+    scope: ScopeType,
+    varName: string,
+    value: TsNode,
+    accessChain?: AccessChainElement[],
+  ): TsNode {
+    if (
+      accessChain &&
+      accessChain.length > 0 &&
+      accessChain[accessChain.length - 1].kind === "slice"
+    ) {
+      return this.sliceAssign(scope, varName, value, accessChain);
+    }
+    if (scope === "global" && (!accessChain || accessChain.length === 0)) {
+      return ts.globalSet(this.deps.moduleId, varName, value);
+    }
+    return ts.assign(this.lhs(scope, varName, accessChain), value);
+  }
+
+  /** Build the assignment target node (no value) for `scope.varName.chain`. */
+  lhs(scope: ScopeType, variableName: string, chain?: AccessChainElement[]): TsNode {
+    return this.accessChain(
+      ts.scopedVar(variableName, scope, this.deps.moduleId),
+      chain,
+    );
+  }
+
+  /**
+   * Apply an access chain (`.foo`, `[i]`, `.method(args)`) to an
+   * arbitrary base expression. Used both for ordinary LHS construction
+   * and for `this.field = value` / `super.field = value` lowering where
+   * the base is a bare identifier rather than a scoped variable.
+   */
+  accessChain(base: TsNode, chain?: AccessChainElement[]): TsNode {
+    if (!chain || chain.length === 0) return base;
+    let result = base;
+    for (const el of chain) {
+      switch (el.kind) {
+        case "property":
+          result = ts.prop(result, el.name);
+          break;
+        case "index":
+          result = ts.index(result, this.deps.processNode(el.index));
+          break;
+        case "methodCall": {
+          const fnCall = el.functionCall;
+          const callExpr = ts.call(ts.id("__callMethod"), [
+            result,
+            ts.str(fnCall.functionName),
+            this.deps.buildCallDescriptor(fnCall),
+            this.deps.buildStateConfig(),
+          ]);
+          result = ts.await(callExpr);
+          break;
+        }
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Slice assignment lowering:
+   *
+   *   arr[1:3] = [10, 20]  →  arr.splice(1, 3 - 1, ...[10, 20])
+   *   arr[2:]  = [10]      →  arr.splice(2, arr.length - 2, ...[10])
+   */
+  private sliceAssign(
+    scope: ScopeType,
+    varName: string,
+    value: TsNode,
+    accessChain: AccessChainElement[],
+  ): TsNode {
+    const sliceEl = accessChain[accessChain.length - 1] as Extract<
+      AccessChainElement,
+      { kind: "slice" }
+    >;
+    const baseChain = accessChain.length > 1 ? accessChain.slice(0, -1) : undefined;
+    const base = this.lhs(scope, varName, baseChain);
+
+    const startNode = sliceEl.start ? this.deps.processNode(sliceEl.start) : ts.raw("0");
+    const endNode = sliceEl.end
+      ? this.deps.processNode(sliceEl.end)
+      : ts.prop(base, "length");
+    const deleteCount = ts.binOp(endNode, "-", startNode);
+
+    return $(base)
+      .prop("splice")
+      .call([startNode, deleteCount, ts.spread(value)])
+      .done();
+  }
+}


### PR DESCRIPTION
Continuing the TypeScript Builder cleanup series (after `ScopeManager` / `StepPathTracker`, `NameClassifier`, `resolveNamedArgs`, `PipeChainEmitter`, and `ClassEmitter`), this PR extracts assignment LHS construction out of `TypeScriptBuilder` into a dedicated `AssignmentEmitter`.

## What moved (and what stays)

The boring half — building assignment targets and emitting the final statement — moves into the new emitter:

- `scopedAssign`           → `AssignmentEmitter.scopedAssign`
- `buildSliceAssignment`   → `AssignmentEmitter.sliceAssign` (private)
- `buildAccessChain`       → `AssignmentEmitter.accessChain`
- `buildAssignmentLhs`     → `AssignmentEmitter.lhs`

The interesting half — `processAssignment` / `_processAssignmentInner` — **stays in the builder**. Those methods are stateful orchestrators that touch most other subsystems (llm calls, interrupts, async dispatch, fork-branch setup, message threads, handler-body context, validated assignments, …). Extracting them would just move callbacks around for no real coupling win — the kind of fake extraction we explicitly avoided earlier in the series. After this PR they call into `this.assigns.scopedAssign(...)` and read more declaratively as a result.

## IR cleanup taken along the way

`buildSliceAssignment` used to hand-build the splice call as a raw string:

```ts
ts.raw(`${baseStr}.splice(${startStr}, ${deleteCountStr}, ...${this.str(value)})`);
```

The new `sliceAssign` uses proper IR builders:

```ts
return $(base)
  .prop("splice")
  .call([startNode, deleteCount, ts.spread(value)])
  .done();
```

with `deleteCount = ts.binOp(endNode, "-", startNode)`. Output is identical (verified by the existing `tests/typescriptGenerator/sliceAssign.*` fixture).

## TS IR readability backlog

While doing this refactor I keep bumping into the same TS IR rough edges (raw-string escape hatches, awkward method-call chains, opaque kind-unions, …). Per request, I started a running list at [docs/dev/ts-ir-readability-backlog.md](./packages/agency-lang/docs/dev/ts-ir-readability-backlog.md) so we can come back to them once the builder refactor is done. This is informational only — no code action in this PR.

## Size impact

`lib/backends/typescriptBuilder.ts`: **3350 → 3271 lines** (-79).

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm run build` + `make stdlib`
- `pnpm test:run` — 3865 / 3865 passed (includes `typescriptGenerator.integration.test.ts`, which covers the slice-assignment fixture)
- `pnpm run test:agency` — 560 / 560 passed
- `pnpm run lint:fix` — clean
