### PR TITLE
TypeScript Builder refactor: extract partitionProgram + assembleSections

### DIFF
--- a/packages/agency-lang/docs/dev/ts-ir-readability-backlog.md
+++ b/packages/agency-lang/docs/dev/ts-ir-readability-backlog.md
@@ -57,6 +57,20 @@ When reading code that consumes `TsNode`, it is hard to remember the full set of
 
 Picking the right one requires knowing what each compiles to. Worth documenting alongside each builder which compiled form they produce, and possibly consolidating.
 
+### 8. Module-init plumbing is mostly `ts.raw` strings
+
+While extracting `assembleSections`, almost everything in the static-init / `__initializeGlobals` plumbing fell out as `ts.raw("await __initializeStatic(__ctx)")`, `ts.raw("let __staticInitPromise = null")`, etc. The IR has builders for assignments, function declarations, and calls, but for these helpers we still drop to strings because of:
+
+- `await` as a leading keyword on a bare call: no `ts.await(call)` ergonomics that print as a statement.
+- Hand-built `(async () => { ... })()` IIFE: no `ts.iife({ async: true, body })` builder.
+- `let foo = null` initializer: `ts.letDecl(name)` exists but no `ts.letDecl(name, value)` form.
+
+**Direction:** Add at least `ts.iife({ body, async })`, `ts.letDecl(name, value?)`, and double-check `ts.await` produces statement-form output.
+
+### 9. Discriminator on assignment LHS in raw IR is asymmetric
+
+The IR has both `ts.assign(lhs, rhs)` and `ts.globalSet(moduleId, name, value)`. For a reader, it is not obvious that the latter exists; we accidentally hand-wrote `ts.raw("__ctx.globals.set(...)")` in a couple of places before standardizing on `ts.globalSet`. A short doc-comment on `ts.assign` pointing readers at the global variant would help.
+
 ---
 
 (Append more as we go.)

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -108,6 +108,10 @@ import { NameClassifier } from "./typescriptBuilder/nameClassifier.js";
 import { PipeChainEmitter } from "./typescriptBuilder/pipeChainEmitter.js";
 import { ClassEmitter } from "./typescriptBuilder/classEmitter.js";
 import { AssignmentEmitter } from "./typescriptBuilder/assignmentEmitter.js";
+import {
+  assembleSections,
+  partitionProgram,
+} from "./typescriptBuilder/sectionAssembler.js";
 import { resolveNamedArgs } from "./typescriptBuilder/namedArgsResolver.js";
 
 const DEFAULT_PROMPT_NAME = "__promptVar";
@@ -345,179 +349,32 @@ export class TypeScriptBuilder {
     // Generate tool registry (empty — AgencyFunction.create() populates it)
     this.generatedStatements.push(this.generateToolRegistry());
 
-    // Collect static variable names and their init statements.
-    // Static vars are declared as `let` at module level and initialized inside
-    // a separate `__initializeStatic(__ctx)` function (called once from __initializeGlobals).
-    // This gives them access to __ctx for handlers and function dispatch.
-    const staticVarNames = new Set<string>();
-    const exportedStaticVarNames = new Set<string>();
-    const staticInitStatements: TsNode[] = [];
-    for (const node of program.nodes) {
-      if (node.type === "assignment" && node.scope === "static") {
-        staticVarNames.add(node.variableName);
-        if (node.exported) exportedStaticVarNames.add(node.variableName);
-        const valueNode = this.processNodeInGlobalInit(node.value);
-        staticInitStatements.push(
-          ts.assign(ts.id(node.variableName), ts.call(ts.id("__deepFreeze"), [valueNode]))
-        );
-      } else if (
-        node.type === "withModifier" &&
-        node.statement.type === "assignment" &&
-        node.statement.scope === "static"
-      ) {
-        const stmt = node.statement;
-        staticVarNames.add(stmt.variableName);
-        if (stmt.exported) exportedStaticVarNames.add(stmt.variableName);
-        const valueNode = this.processNodeInGlobalInit(stmt.value);
-        const handler = this.buildHandlerArrow(node.handlerName);
-        staticInitStatements.push(
-          ts.withHandler(handler, ts.assign(ts.id(stmt.variableName), ts.call(ts.id("__deepFreeze"), [valueNode])))
-        );
-      }
-    }
+    // Sort program nodes into static-init / global-init / top-level buckets.
+    const partition = partitionProgram(program, {
+      processNode: (n) => this.processNode(n),
+      processNodeInGlobalInit: (n) => this.processNodeInGlobalInit(n),
+      buildHandlerArrow: (h) => this.buildHandlerArrow(h),
+      isTopLevelDeclaration: (n) => this.names.isTopLevelDeclaration(n),
+      moduleId: this.moduleId,
+    });
+    this.generatedStatements.push(...partition.topLevelStatements);
 
-    // Pass 7: Process all nodes and generate code
-    // Separate global-scope assignments into __initializeGlobals function.
-    const globalInitStatements: TsNode[] = [];
-    for (const node of program.nodes) {
-      if (node.type === "assignment" && node.scope === "global") {
-        const valueNode = this.processNodeInGlobalInit(node.value);
-        globalInitStatements.push(
-          ts.globalSet(this.moduleId, node.variableName, valueNode),
-        );
-      } else if (
-        node.type === "withModifier" &&
-        node.statement.type === "assignment" &&
-        node.statement.scope === "global"
-      ) {
-        const stmt = node.statement;
-        const valueNode = this.processNodeInGlobalInit(stmt.value);
-        const setNode = ts.globalSet(
-          this.moduleId,
-          stmt.variableName,
-          valueNode,
-        );
-        const handler = this.buildHandlerArrow(node.handlerName);
-
-        globalInitStatements.push(ts.withHandler(handler, setNode));
-      } else if (node.type === "assignment" && node.scope === "static") {
-        // Already handled above in staticDeclarations — skip
-      } else if (
-        node.type === "withModifier" &&
-        node.statement.type === "assignment" &&
-        node.statement.scope === "static"
-      ) {
-        // Already handled above in staticDeclarations — skip
-      } else if (this.names.isTopLevelDeclaration(node)) {
-        const result = this.processNode(node);
-        this.generatedStatements.push(result);
-      } else {
-        // Top-level statements (function calls, etc.) go into __initializeGlobals
-        // so they can access the execution context and global variables.
-        const result = this.processNodeInGlobalInit(node);
-        globalInitStatements.push(result);
-      }
-    }
-
-    // Assemble output
-    const sections: TsNode[] = [];
-
-    sections.push(...this.preprocess());
-
-    if (this.importStatements.length > 0) {
-      sections.push(ts.statements(this.importStatements));
-    }
-
-    const importsResult = this.generateImports();
-    if (importsResult.trim() !== "") {
-      sections.push(ts.raw(importsResult));
-    }
-
-    const builtinsResult = this.generateBuiltins();
-    if (builtinsResult.trim() !== "") {
-      sections.push(ts.raw(builtinsResult));
-    }
-
-    // Register imported AgencyFunction instances (after __toolRegistry is declared)
-    if (this.toolRegistrations.length > 0) {
-      sections.push(ts.statements(this.toolRegistrations));
-    }
-
-    for (const alias of this.generatedTypeAliases) {
-      sections.push(alias);
-    }
-
-    // Emit static variable `let` declarations at module level + __initializeStatic function
-    if (staticVarNames.size > 0) {
-      const staticLetDecls = [...staticVarNames].map(name =>
-        exportedStaticVarNames.has(name) ? ts.export(ts.letDecl(name)) : ts.letDecl(name)
-      );
-      sections.push(ts.statements([
-        ts.raw("let __staticInitPromise = null"),
-        ...staticLetDecls,
-      ]));
-
-      // Use a Promise-based guard: concurrent callers await the same init promise.
-      sections.push(
-        ts.functionDecl(
-          "__initializeStatic",
-          [{ name: "__ctx" }],
-          ts.statements([
-            ts.raw("if (__staticInitPromise) return __staticInitPromise"),
-            ts.raw(`__staticInitPromise = (async () => {`),
-            ...staticInitStatements,
-            ts.raw(`})()`),
-            ts.raw("return __staticInitPromise"),
-          ]),
-          { async: true },
-        ),
-      );
-
-      const staticVarObj = ts.obj([...staticVarNames].map(n => ts.set(n, ts.id(n))));
-      sections.push(ts.statements([
-        ts.functionDecl("__getStaticVars", [], ts.return(staticVarObj)),
-        ts.raw("__globalCtx.getStaticVars = __getStaticVars;"),
-      ]));
-    }
-
-    // Generate __initializeGlobals function for per-execution global variable initialization
-    sections.push(
-      ts.functionDecl(
-        "__initializeGlobals",
-        [{ name: "__ctx" }],
-        ts.statements([
-          // Mark this module as initialized BEFORE running init statements.
-          // This prevents infinite recursion when a global init expression
-          // calls a function defined in the same module (which would trigger
-          // __initializeGlobals again via the isInitialized check).
-          ts.call(
-            $(ts.runtime.ctx).prop("globals").prop("markInitialized").done(),
-            [ts.str(this.moduleId)],
-          ),
-          ...(staticVarNames.size > 0 ? [
-            ts.raw("await __initializeStatic(__ctx)"),
-            ts.raw("await __ctx.writeStaticStateToTrace(__globalCtx.getStaticVars())"),
-          ] : []),
-          ...globalInitStatements,
-        ]),
-        { async: true },
-      ),
-    );
-
-    sections.push(ts.statements(this.generatedStatements));
-
-    const postprocessNodes = this.postprocess();
-    if (postprocessNodes.length > 0) {
-      sections.push(ts.statements(postprocessNodes));
-    }
-
-    sections.push(
-      ts.raw(
-        `export const __sourceMap = ${JSON.stringify(this._sourceMapBuilder.build())};`,
-      ),
-    );
-
-    return ts.statements(sections);
+    return assembleSections({
+      moduleId: this.moduleId,
+      preprocess: this.preprocess(),
+      importStatements: this.importStatements,
+      generatedImports: this.generateImports(),
+      generatedBuiltins: this.generateBuiltins(),
+      toolRegistrations: this.toolRegistrations,
+      typeAliases: this.generatedTypeAliases,
+      staticVarNames: partition.staticVarNames,
+      exportedStaticVarNames: partition.exportedStaticVarNames,
+      staticInitStatements: partition.staticInitStatements,
+      globalInitStatements: partition.globalInitStatements,
+      generatedStatements: this.generatedStatements,
+      postprocess: this.postprocess(),
+      sourceMapJson: JSON.stringify(this._sourceMapBuilder.build()),
+    });
   }
 
   // ------- Node dispatch -------

--- a/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
@@ -1,0 +1,330 @@
+import type { AgencyNode, AgencyProgram } from "../../types.js";
+import type { TsNode } from "../../ir/tsIR.js";
+import { $, ts } from "../../ir/builders.js";
+
+/**
+ * Two helpers for the orchestration phase of `TypeScriptBuilder.build()`:
+ *
+ *   1. {@link partitionProgram} — single pass over the program nodes
+ *      that sorts them into the buckets the output assembly cares
+ *      about (static-var init, global init, top-level declarations).
+ *   2. {@link assembleSections} — concatenates the already-built
+ *      pieces (imports, builtins, type aliases, init functions,
+ *      generated statements, sourcemap) into the final TsNode in the
+ *      correct, fixed order.
+ *
+ * Both are functions, not classes — they hold no state of their own;
+ * the builder still owns all of the shared scratch state. Pulling
+ * them out makes `build()` read declaratively as
+ * "partition → assemble" rather than ~180 lines of inline glue.
+ */
+
+// ── Partition ──
+
+export type PartitionDeps = {
+  processNode: (node: AgencyNode) => TsNode;
+  processNodeInGlobalInit: (node: AgencyNode) => TsNode;
+  buildHandlerArrow: (handlerName: string) => TsNode;
+  isTopLevelDeclaration: (node: AgencyNode) => boolean;
+  moduleId: string;
+};
+
+export type ProgramPartition = {
+  /** Names of `static` variables declared at module level. */
+  staticVarNames: Set<string>;
+  /** Subset of `staticVarNames` that are `export`-ed. */
+  exportedStaticVarNames: Set<string>;
+  /** Statements that initialize static variables, run once. */
+  staticInitStatements: TsNode[];
+  /** Statements that initialize global variables / run top-level code per execution. */
+  globalInitStatements: TsNode[];
+  /** Top-level declarations (functions, graph nodes, type aliases, classes). */
+  topLevelStatements: TsNode[];
+};
+
+/**
+ * Walk the program once and route each node into the right bucket:
+ *
+ *   - `static` assignments (and `with handler { static x = ... }`)
+ *     contribute names + frozen init statements.
+ *   - `global` assignments (and their `with handler` form) contribute
+ *     `__ctx.globals.set(...)` calls.
+ *   - Top-level declarations (per `isTopLevelDeclaration`) become
+ *     module-scope generated statements.
+ *   - Anything else (bare expressions, function calls, …) goes into
+ *     `__initializeGlobals` so it can access `__ctx`.
+ */
+export function partitionProgram(
+  program: AgencyProgram,
+  deps: PartitionDeps,
+): ProgramPartition {
+  const staticVarNames = new Set<string>();
+  const exportedStaticVarNames = new Set<string>();
+  const staticInitStatements: TsNode[] = [];
+  const globalInitStatements: TsNode[] = [];
+  const topLevelStatements: TsNode[] = [];
+
+  // First pass: collect static variable info from `static` assignments
+  // (with or without `with handler`). We do this in a dedicated pass
+  // so static `let` declarations and init statements are gathered
+  // even though they are not emitted from the main walk.
+  for (const node of program.nodes) {
+    const staticAssign = unwrapStaticAssignment(node);
+    if (!staticAssign) continue;
+    const { stmt, handlerName } = staticAssign;
+
+    staticVarNames.add(stmt.variableName);
+    if (stmt.exported) exportedStaticVarNames.add(stmt.variableName);
+
+    const valueNode = deps.processNodeInGlobalInit(stmt.value);
+    const frozenAssign = ts.assign(
+      ts.id(stmt.variableName),
+      ts.call(ts.id("__deepFreeze"), [valueNode]),
+    );
+    staticInitStatements.push(
+      handlerName
+        ? ts.withHandler(deps.buildHandlerArrow(handlerName), frozenAssign)
+        : frozenAssign,
+    );
+  }
+
+  // Second pass: route every other node.
+  for (const node of program.nodes) {
+    if (unwrapStaticAssignment(node)) continue; // handled above
+
+    const globalAssign = unwrapGlobalAssignment(node);
+    if (globalAssign) {
+      const { stmt, handlerName } = globalAssign;
+      const valueNode = deps.processNodeInGlobalInit(stmt.value);
+      const setNode = ts.globalSet(deps.moduleId, stmt.variableName, valueNode);
+      globalInitStatements.push(
+        handlerName
+          ? ts.withHandler(deps.buildHandlerArrow(handlerName), setNode)
+          : setNode,
+      );
+      continue;
+    }
+
+    if (deps.isTopLevelDeclaration(node)) {
+      topLevelStatements.push(deps.processNode(node));
+    } else {
+      // Top-level statements (function calls, etc.) need __ctx access,
+      // so they live inside __initializeGlobals.
+      globalInitStatements.push(deps.processNodeInGlobalInit(node));
+    }
+  }
+
+  return {
+    staticVarNames,
+    exportedStaticVarNames,
+    staticInitStatements,
+    globalInitStatements,
+    topLevelStatements,
+  };
+}
+
+/** If `node` is a `static x = ...` (optionally wrapped in `with handler`), return its parts. */
+function unwrapStaticAssignment(node: AgencyNode):
+  | { stmt: Extract<AgencyNode, { type: "assignment" }>; handlerName?: string }
+  | null {
+  if (node.type === "assignment" && node.scope === "static") {
+    return { stmt: node };
+  }
+  if (
+    node.type === "withModifier" &&
+    node.statement.type === "assignment" &&
+    node.statement.scope === "static"
+  ) {
+    return { stmt: node.statement, handlerName: node.handlerName };
+  }
+  return null;
+}
+
+/** If `node` is a `global x = ...` (optionally wrapped in `with handler`), return its parts. */
+function unwrapGlobalAssignment(node: AgencyNode):
+  | { stmt: Extract<AgencyNode, { type: "assignment" }>; handlerName?: string }
+  | null {
+  if (node.type === "assignment" && node.scope === "global") {
+    return { stmt: node };
+  }
+  if (
+    node.type === "withModifier" &&
+    node.statement.type === "assignment" &&
+    node.statement.scope === "global"
+  ) {
+    return { stmt: node.statement, handlerName: node.handlerName };
+  }
+  return null;
+}
+
+// ── Assemble ──
+
+export type AssembleSectionsOpts = {
+  moduleId: string;
+  preprocess: TsNode[];
+  importStatements: TsNode[];
+  /** Raw string output of `generateImports()`. Already-rendered template. */
+  generatedImports: string;
+  /** Raw string output of `generateBuiltins()`. Already-rendered template. */
+  generatedBuiltins: string;
+  toolRegistrations: TsNode[];
+  typeAliases: TsNode[];
+  staticVarNames: Set<string>;
+  exportedStaticVarNames: Set<string>;
+  staticInitStatements: TsNode[];
+  globalInitStatements: TsNode[];
+  generatedStatements: TsNode[];
+  postprocess: TsNode[];
+  /** JSON-stringified source map, embedded into the generated module. */
+  sourceMapJson: string;
+};
+
+/**
+ * Concatenate the per-section outputs into the final generated module,
+ * in the canonical order:
+ *
+ *   preprocess
+ *   importStatements
+ *   generated imports (template)
+ *   generated builtins (template)
+ *   tool registrations
+ *   type aliases
+ *   static-var declarations + __initializeStatic + __getStaticVars (if any)
+ *   __initializeGlobals
+ *   generated statements
+ *   postprocess
+ *   __sourceMap export
+ */
+export function assembleSections(opts: AssembleSectionsOpts): TsNode {
+  const sections: TsNode[] = [];
+
+  sections.push(...opts.preprocess);
+
+  if (opts.importStatements.length > 0) {
+    sections.push(ts.statements(opts.importStatements));
+  }
+
+  if (opts.generatedImports.trim() !== "") {
+    sections.push(ts.raw(opts.generatedImports));
+  }
+
+  if (opts.generatedBuiltins.trim() !== "") {
+    sections.push(ts.raw(opts.generatedBuiltins));
+  }
+
+  if (opts.toolRegistrations.length > 0) {
+    sections.push(ts.statements(opts.toolRegistrations));
+  }
+
+  for (const alias of opts.typeAliases) {
+    sections.push(alias);
+  }
+
+  if (opts.staticVarNames.size > 0) {
+    sections.push(...buildStaticVarSetup(opts));
+  }
+
+  sections.push(buildInitializeGlobalsFn(opts));
+
+  sections.push(ts.statements(opts.generatedStatements));
+
+  if (opts.postprocess.length > 0) {
+    sections.push(ts.statements(opts.postprocess));
+  }
+
+  sections.push(
+    ts.raw(`export const __sourceMap = ${opts.sourceMapJson};`),
+  );
+
+  return ts.statements(sections);
+}
+
+/**
+ * Emit:
+ *   let __staticInitPromise = null
+ *   [export] let x        ←─── one per static var
+ *   async function __initializeStatic(__ctx) {
+ *     if (__staticInitPromise) return __staticInitPromise
+ *     __staticInitPromise = (async () => { …staticInitStatements })()
+ *     return __staticInitPromise
+ *   }
+ *   function __getStaticVars() { return { x, … } }
+ *   __globalCtx.getStaticVars = __getStaticVars;
+ */
+function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
+  const out: TsNode[] = [];
+  const staticLetDecls = [...opts.staticVarNames].map((name) =>
+    opts.exportedStaticVarNames.has(name)
+      ? ts.export(ts.letDecl(name))
+      : ts.letDecl(name),
+  );
+
+  out.push(ts.statements([
+    ts.raw("let __staticInitPromise = null"),
+    ...staticLetDecls,
+  ]));
+
+  // Promise-based guard: concurrent callers await the same init promise.
+  out.push(
+    ts.functionDecl(
+      "__initializeStatic",
+      [{ name: "__ctx" }],
+      ts.statements([
+        ts.raw("if (__staticInitPromise) return __staticInitPromise"),
+        ts.raw(`__staticInitPromise = (async () => {`),
+        ...opts.staticInitStatements,
+        ts.raw(`})()`),
+        ts.raw("return __staticInitPromise"),
+      ]),
+      { async: true },
+    ),
+  );
+
+  const staticVarObj = ts.obj(
+    [...opts.staticVarNames].map((n) => ts.set(n, ts.id(n))),
+  );
+  out.push(ts.statements([
+    ts.functionDecl("__getStaticVars", [], ts.return(staticVarObj)),
+    ts.raw("__globalCtx.getStaticVars = __getStaticVars;"),
+  ]));
+
+  return out;
+}
+
+/**
+ * Emit:
+ *   async function __initializeGlobals(__ctx) {
+ *     __ctx.globals.markInitialized(moduleId)
+ *     [await __initializeStatic(__ctx)]  ← only if there are static vars
+ *     [await __ctx.writeStaticStateToTrace(__globalCtx.getStaticVars())]
+ *     …globalInitStatements
+ *   }
+ */
+function buildInitializeGlobalsFn(opts: AssembleSectionsOpts): TsNode {
+  const body: TsNode[] = [
+    // Mark this module as initialized BEFORE running init statements.
+    // This prevents infinite recursion when a global init expression
+    // calls a function defined in the same module (which would trigger
+    // __initializeGlobals again via the isInitialized check).
+    ts.call(
+      $(ts.runtime.ctx).prop("globals").prop("markInitialized").done(),
+      [ts.str(opts.moduleId)],
+    ),
+  ];
+
+  if (opts.staticVarNames.size > 0) {
+    body.push(
+      ts.raw("await __initializeStatic(__ctx)"),
+      ts.raw("await __ctx.writeStaticStateToTrace(__globalCtx.getStaticVars())"),
+    );
+  }
+
+  body.push(...opts.globalInitStatements);
+
+  return ts.functionDecl(
+    "__initializeGlobals",
+    [{ name: "__ctx" }],
+    ts.statements(body),
+    { async: true },
+  );
+}

--- a/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
@@ -64,33 +64,25 @@ export function partitionProgram(
   const globalInitStatements: TsNode[] = [];
   const topLevelStatements: TsNode[] = [];
 
-  // First pass: collect static variable info from `static` assignments
-  // (with or without `with handler`). We do this in a dedicated pass
-  // so static `let` declarations and init statements are gathered
-  // even though they are not emitted from the main walk.
   for (const node of program.nodes) {
     const staticAssign = unwrapStaticAssignment(node);
-    if (!staticAssign) continue;
-    const { stmt, handlerName } = staticAssign;
+    if (staticAssign) {
+      const { stmt, handlerName } = staticAssign;
+      staticVarNames.add(stmt.variableName);
+      if (stmt.exported) exportedStaticVarNames.add(stmt.variableName);
 
-    staticVarNames.add(stmt.variableName);
-    if (stmt.exported) exportedStaticVarNames.add(stmt.variableName);
-
-    const valueNode = deps.processNodeInGlobalInit(stmt.value);
-    const frozenAssign = ts.assign(
-      ts.id(stmt.variableName),
-      ts.call(ts.id("__deepFreeze"), [valueNode]),
-    );
-    staticInitStatements.push(
-      handlerName
-        ? ts.withHandler(deps.buildHandlerArrow(handlerName), frozenAssign)
-        : frozenAssign,
-    );
-  }
-
-  // Second pass: route every other node.
-  for (const node of program.nodes) {
-    if (unwrapStaticAssignment(node)) continue; // handled above
+      const valueNode = deps.processNodeInGlobalInit(stmt.value);
+      const frozenAssign = ts.assign(
+        ts.id(stmt.variableName),
+        ts.call(ts.id("__deepFreeze"), [valueNode]),
+      );
+      staticInitStatements.push(
+        handlerName
+          ? ts.withHandler(deps.buildHandlerArrow(handlerName), frozenAssign)
+          : frozenAssign,
+      );
+      continue;
+    }
 
     const globalAssign = unwrapGlobalAssignment(node);
     if (globalAssign) {


### PR DESCRIPTION
Continuing the TypeScript Builder cleanup series, this PR extracts the orchestration phase of `TypeScriptBuilder.build()` into two helpers under `lib/backends/typescriptBuilder/sectionAssembler.ts`:

1. **`partitionProgram`** — single pass over `program.nodes` that sorts them into static-init / global-init / top-level buckets.
2. **`assembleSections`** — concatenates the already-built pieces (imports, builtins, type aliases, init functions, generated statements, sourcemap) into the final `TsNode` in the canonical fixed order.

Both are plain functions, not classes — they hold no state of their own; the builder still owns all of the shared scratch state.

## Before / after

`TypeScriptBuilder.build()` used to be ~180 lines of inline partition + assembly. It is now ~30 lines of declarative orchestration:

```ts
build(program) {
  this.generatedStatements.push(this.generateToolRegistry());

  const partition = partitionProgram(program, {
    processNode: (n) => this.processNode(n),
    processNodeInGlobalInit: (n) => this.processNodeInGlobalInit(n),
    buildHandlerArrow: (h) => this.buildHandlerArrow(h),
    isTopLevelDeclaration: (n) => this.names.isTopLevelDeclaration(n),
    moduleId: this.moduleId,
  });
  this.generatedStatements.push(...partition.topLevelStatements);

  return assembleSections({
    moduleId: this.moduleId,
    preprocess: this.preprocess(),
    importStatements: this.importStatements,
    generatedImports: this.generateImports(),
    generatedBuiltins: this.generateBuiltins(),
    toolRegistrations: this.toolRegistrations,
    typeAliases: this.generatedTypeAliases,
    staticVarNames: partition.staticVarNames,
    exportedStaticVarNames: partition.exportedStaticVarNames,
    staticInitStatements: partition.staticInitStatements,
    globalInitStatements: partition.globalInitStatements,
    generatedStatements: this.generatedStatements,
    postprocess: this.postprocess(),
    sourceMapJson: JSON.stringify(this._sourceMapBuilder.build()),
  });
}
```

## Cleanup along the way

Partition also collapses the two repeated `if (node.type === "withModifier" && ...)` shapes into small `unwrapStaticAssignment` / `unwrapGlobalAssignment` helpers, removing the duplicate "static handled above — skip" branches in the second loop. Behavior is unchanged.

## TS IR readability backlog

Added two new entries to [`docs/dev/ts-ir-readability-backlog.md`](./packages/agency-lang/docs/dev/ts-ir-readability-backlog.md) for rough edges that kept making me drop into `ts.raw(...)` while doing this extraction:

- **#8** Module-init plumbing is mostly `ts.raw` strings (no `ts.iife({ body, async })`, no `ts.letDecl(name, value)` with initializer, awkward `await` on a bare statement).
- **#9** `ts.assign` vs. `ts.globalSet` discoverability.

## Size impact

`lib/backends/typescriptBuilder.ts`: **3271 → 3128 lines** (-143).

## Verification

- `pnpm exec tsc --noEmit` — clean
- `pnpm run build` + `make stdlib`
- `pnpm test:run` — 3865 / 3865 passed (includes `typescriptGenerator.integration.test.ts`, which covers full-module generation fixtures)
- `pnpm run test:agency` — 560 / 560 passed
- `pnpm run lint:fix` — clean
