### PR TITLE
feat: @validate and @jsonSchema type annotations + std::validators/schemas/types

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,7 @@ Pipeline and architecture:
 - `docs/dev/trace.md` — Execution traces capturing checkpoints at every step
 - `docs/dev/binop-parser.md` — Binary expression parser using precedence climbing
 - `docs/dev/locations.md` — How `loc.line` / `loc.col` / parse-mode template offset interact
+- `docs/dev/validation-annotations.md` — `@validate(...)` and `@jsonSchema(...)` internals: tag merging, `__agency_descriptor` contract, descriptor tree, runtime walker
 
 Other references:
 - `docs/misc/TESTING.md` — Full testing guide (unit tests, fixtures, execution tests, agency-js tests)

--- a/packages/agency-lang/docs/dev/validation-annotations.md
+++ b/packages/agency-lang/docs/dev/validation-annotations.md
@@ -1,0 +1,347 @@
+# `@validate` and `@jsonSchema` — internals
+
+This document covers the implementation of the two type-annotation
+features that landed together:
+
+- **`@validate(fn1, fn2, ...)`** — attach one or more runtime validators
+  to a type. The validators run at every `!` site whose resolved type
+  reaches the annotation, including nested positions (object property,
+  array element, nullable branch, union member).
+- **`@jsonSchema({ ... })`** — attach JSON Schema metadata to a type so
+  that structured-output LLM calls and downstream Zod consumers see it.
+  Internally this becomes a Zod `.meta(...)` call.
+
+The user-facing guide lives at
+[`docs/site/guide/annotations.md`](../site/guide/annotations.md); this
+doc focuses on how the implementation is wired up so future engineers
+can change it safely.
+
+---
+
+## Pipeline overview
+
+```
+.agency source
+   │
+   ▼
+parser  ─ tags parse as their own AgencyNode with name + arguments
+   │     (arguments are arbitrary Expression nodes, not strings!)
+   ▼
+preprocessor.attachTags()
+   │     moves standalone `tag` nodes onto the next attach-target
+   │     node (typeAlias / functionDef / graphNode / assignment /
+   │     functionCall). After this pass, `TypeAlias.tags`, etc. are
+   │     populated.
+   ▼
+typeChecker.mergeTagSets()   ◄── only `validate` and `jsonSchema` merge.
+   │     Other tags pass through verbatim per side. Called when a
+   │     `typeAliasVariable` is resolved at a use-site that itself
+   │     carries annotations.
+   ▼
+typescriptBuilder
+   │     For each `!` site: decide whether to emit
+   │         __validateType(value, zodSchema)               (zero-cost path)
+   │     or
+   │         await __validateChainRecursive(value, descriptor, __ctx)
+   │     The gate is `hasAnyValidateTag(resolvedType)`.
+   │
+   │     For each `type Foo = ...` declaration whose body reaches any
+   │     `@validate(...)` tag, the builder also emits
+   │         (Foo as any).__agency_descriptor = <descriptor>;
+   │     immediately after the Zod schema const. See the
+   │     "`__agency_descriptor` contract" section below — this is the
+   │     bit that future maintainers must be careful with.
+   ▼
+runtime/validateChain.ts
+         __validateChain        — parse + linear validator chain
+         __validateChainRecursive — walks the descriptor tree
+```
+
+---
+
+## Tag arguments are `Expression[]`, not `string[]`
+
+A tag in the AST is:
+
+```ts
+type Tag = {
+  type: "tag";
+  name: string;
+  arguments: Expression[];  // ← arbitrary Agency expressions
+};
+```
+
+Validators (`@validate(isEmail, somethingElse)`) are arbitrary
+identifier expressions. `@jsonSchema({ ... })` takes an object literal
+whose entries may contain spreads, identifiers, and literals.
+
+[`lib/backends/typescriptGenerator/tagArgToTs.ts`](../../lib/backends/typescriptGenerator/tagArgToTs.ts)
+prints a tag argument as a TS source string. Only the restricted subset
+the tag parser accepts is handled (literals, identifiers, calls, object
+literals, spreads). If you teach the parser to accept new expression
+shapes inside tag args, extend `tagArgToTs` to match — otherwise codegen
+will emit `/* unsupported tag arg: ... */ undefined`, which is loud but
+not helpful at runtime.
+
+---
+
+## `mergeTagSets` — alias vs use-site
+
+When a `typeAliasVariable` is resolved at a use-site that carries its own
+tags, the alias's tags and the use-site tags need to be combined:
+
+| Tag name      | Merge behavior                                                            |
+| ------------- | -------------------------------------------------------------------------- |
+| `validate`    | Concatenate argument lists. Validators run alias-first, use-site-last.     |
+| `jsonSchema`  | Merge the two object literals; use-site keys win on conflict. Spreads are preserved verbatim. |
+| _anything else_ | Pass through per side; not merged across alias/use-site.                  |
+
+A malformed `@jsonSchema(...)` (anything other than a single object
+literal argument) throws from
+[`mergeTags.ts`](../../lib/typeChecker/mergeTags.ts) with a
+location-aware error. The parser doesn't reject this earlier because
+the tag-argument grammar is intentionally permissive — see
+[`jsonSchemaArgValidator.ts`](../../lib/typeChecker/jsonSchemaArgValidator.ts)
+for the dedicated check.
+
+---
+
+## `hasAnyValidateTag` — the codegen gate
+
+Lives in
+[`lib/backends/typescriptGenerator/validationDescriptor.ts`](../../lib/backends/typescriptGenerator/validationDescriptor.ts).
+
+This is the predicate that decides which validation path the builder
+takes:
+
+- **No `@validate` anywhere in the resolved type** → emit
+  `__validateType(value, zodSchema)` (the existing, zero-cost path).
+- **At least one `@validate` somewhere** → emit
+  `await __validateChainRecursive(value, descriptor, __ctx)`.
+
+`hasAnyValidateTag` walks the resolved type structurally and, crucially,
+follows non-generic `typeAliasVariable` references via the
+`aliasesFull` map. `resolveTypeDeep` leaves those references intact for
+"codegen-by-name" purposes, so without this manual lookup, an
+`@validate` reachable only through a named alias would be silently
+dropped from gating.
+
+---
+
+## `__agency_descriptor` contract — the part that bites
+
+This is the most important section of this document. If you change how
+type aliases are emitted, **read this section first**.
+
+### The problem
+
+`@validate(isEmail)` references an identifier (`isEmail`) that lives in
+some specific module's scope. If a use-site says `const e: Email! = ...`
+and we naïvely inlined `Email`'s validator chain at the use-site, we'd
+emit something like:
+
+```ts
+await __validateChainRecursive(e, {
+  kind: "leaf",
+  schema: z.string(),
+  validators: [isEmail],   // ← but `isEmail` isn't imported here!
+}, __ctx);
+```
+
+The consumer doesn't import `isEmail`. The validators (and any
+schema-helper consts like `emailFormat`) live in the alias-defining
+module.
+
+### The solution
+
+When the type alias is emitted, the builder attaches the runtime
+descriptor to the schema const itself:
+
+```ts
+export const Email = z.string().meta({ format: "email" });
+export type Email = z.infer<typeof Email>;
+(Email as any).__agency_descriptor = { kind: "leaf", schema: Email, validators: [isEmail] };
+```
+
+`__agency_descriptor` is a non-enumerable side-channel between the
+Zod schema and the validation runtime. It's:
+
+- attached unconditionally to any alias whose body has any `@validate`
+  reachable (per `hasAliasValidate` in
+  [`validationDescriptor.ts`](../../lib/backends/typescriptGenerator/validationDescriptor.ts));
+- read at the use-site via `(Email as any).__agency_descriptor`;
+- combined with use-site validators when the use-site adds its own
+  `@validate(...)` (see the `typeAliasVariable` branch in
+  `descriptor()`):
+  ```ts
+  { ...ref, validators: [...(ref?.validators ?? []), ...useSiteValidators] }
+  ```
+
+### What you must never do
+
+- **Don't skip emitting `__agency_descriptor`.** The assignment is the
+  bridge between the alias's module-local validator identifiers and any
+  downstream consumer. Without it, validation silently no-ops.
+- **Don't serialize it.** `__agency_descriptor` is not part of the
+  checkpoint state and must never be. It's a runtime-only handle that
+  recovers on every fresh module load.
+- **Don't rename `__agency_descriptor` without grepping for it.** Both
+  the writer (`typescriptBuilder.ts`) and the reader
+  (`validationDescriptor.ts`) name it as a magic string.
+
+### Why not export the descriptor instead?
+
+We could export a second const (`Email_descriptor`) alongside `Email`
+and have the use-site import it. We don't, because:
+
+1. It doubles the import surface of every annotated alias.
+2. It breaks `import { Email }` patterns (the user would have to
+   remember a parallel import for validation).
+3. It pushes work onto every consumer file's import management.
+
+Attaching to the schema const is a one-time emission with no consumer
+overhead.
+
+---
+
+## `TypeValidationDescriptor` — the recursive shape
+
+Defined in [`lib/runtime/validateChain.ts`](../../lib/runtime/validateChain.ts):
+
+```ts
+type TypeValidationDescriptor =
+  | { kind: "leaf"; schema; validators }
+  | { kind: "object"; schema; validators; properties: Record<string, _> }
+  | { kind: "array"; schema; validators; element: _ }
+  | { kind: "union"; schema; validators; branches: Array<{ test; descriptor }> }
+  | { kind: "nullable"; schema; validators; inner: _ };
+```
+
+`walk()` recurses on `descriptor` and `value` in lockstep:
+
+- `array` → run own validators on the array, then recurse into each
+  element with `element` descriptor;
+- `object` → run own validators, then recurse into each property with
+  `properties[key]`;
+- `union` → run own validators, then dispatch to the first branch whose
+  `test(v)` passes (the test is a Zod `safeParse` predicate);
+- `nullable` → if value is null/undefined, success unchanged; else
+  recurse into `inner`;
+- `leaf` → run own validators only.
+
+The walker is depth-capped (default 64, configurable via
+`opts.maxDepth`). On overflow we return a structured failure payload:
+
+```ts
+{ reason: "validation recursion depth exceeded", limit, kind, valuePreview }
+```
+
+`valuePreview` is a cycle-safe, length-bounded JSON snippet.
+
+---
+
+## Validator dispatch
+
+A validator is either an Agency `def` (`AgencyFunction`) or a plain JS
+function:
+
+```ts
+type AgencyValidator =
+  | ((value: unknown) => Promise<ResultValue> | ResultValue)
+  | AgencyFunction;
+```
+
+`callValidator(v, ctx, value)` dispatches:
+
+- **`AgencyFunction`** → `.invoke({ type: "positional", args: [value] }, { ctx })`.
+  This is the same machinery as a regular Agency call, so the validator
+  gets a real ctx and can interrupt / call other Agency functions.
+- **plain function** → called as `v(value)`. No ctx is threaded through.
+  Users wanting ctx should write the validator as an Agency `def`.
+
+Plain JS validators are first-class: users can import `success` /
+`failure` from `agency-lang/runtime` and write any validator they want
+in TS, then reference it from `@validate(...)`. See
+[`tests/agency/validation/validatePlainJsFunction.agency`](../../tests/agency/validation/validatePlainJsFunction.agency)
+for the end-to-end test that proves this works.
+
+### Transforming validators
+
+Each validator receives the value the previous validator returned with
+success. A validator can therefore transform the value:
+
+```agency
+def trim(value: string): Result {
+  return success(value.trim())
+}
+
+@validate(trim)
+type Trimmed = string
+```
+
+The bound variable receives the transformed value. See
+[`tests/agency/validation/validateTransform.agency`](../../tests/agency/validation/validateTransform.agency).
+
+---
+
+## `@jsonSchema` — Zod `.meta(...)`
+
+Implemented in
+[`lib/backends/typescriptGenerator/typeToZodSchema.ts`](../../lib/backends/typescriptGenerator/typeToZodSchema.ts)
+as `appendMeta(...)`. It looks up the `jsonSchema` tag on a type,
+renders the single object-literal argument via `tagArgToTs`, and tacks
+on a `.meta({...})` to the Zod schema. This must be the **last** call
+in the chain because Zod's API requires it.
+
+The metadata becomes available at runtime via:
+
+- `Email.meta()` — Zod's meta accessor;
+- `z.toJSONSchema(Email)` — emits a JSON Schema object that includes the
+  metadata (so structured-output LLM calls pick it up).
+
+Runtime tests in
+[`lib/backends/typescriptGenerator/jsonSchemaAnnotation.test.ts`](../../lib/backends/typescriptGenerator/jsonSchemaAnnotation.test.ts)
+compile a small Agency program, dynamically import the generated TS,
+and assert that the metadata appears both via `.meta()` and via
+`toJSONSchema`. That's the closest thing to a real end-to-end test
+since `.meta()`'s semantics only matter at runtime.
+
+---
+
+## Files of record
+
+| File                                                                                  | Role                                                                  |
+| ------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| `lib/preprocessors/typescriptPreprocessor.ts` — `attachTags()`                        | moves standalone `tag` nodes onto their target nodes                  |
+| `lib/typeChecker/mergeTags.ts`                                                        | merges `@validate` / `@jsonSchema` across alias-and-use-site          |
+| `lib/typeChecker/jsonSchemaArgValidator.ts`                                           | shape-checks `@jsonSchema(...)` arguments                              |
+| `lib/backends/typescriptGenerator/validationDescriptor.ts`                            | builds the descriptor TS IR + `hasAnyValidateTag` predicate           |
+| `lib/backends/typescriptGenerator/typeToZodSchema.ts` — `appendMeta()`                 | attaches `.meta(...)` for `@jsonSchema`                               |
+| `lib/backends/typescriptGenerator/tagArgToTs.ts`                                      | prints a tag argument as a TS source string                            |
+| `lib/backends/typescriptBuilder.ts`                                                    | emits `(Alias as any).__agency_descriptor = ...` and `!`-site validation calls |
+| `lib/runtime/validateChain.ts`                                                        | `__validateChain` / `__validateChainRecursive` / `previewValue`        |
+| `stdlib/validators.agency` / `stdlib/schemas.agency` / `stdlib/types.agency`          | the pre-baked validators, schema fragments, and opaque-string aliases  |
+
+---
+
+## Things to remember when changing this code
+
+1. **Tag argument types are `Expression[]`.** Never assume a single-arg
+   string. Use `tagArgToTs` or destructure carefully.
+2. **`__agency_descriptor` is the only path from an alias's
+   module-local validator to a downstream consumer.** Never break the
+   `(Alias as any).__agency_descriptor = ...` emission.
+3. **`hasAnyValidateTag` is the gate.** Adding new wrapper types
+   (alongside `arrayType`, `objectType`, `unionType`, etc.) requires a
+   case in this function or `@validate` will silently disappear.
+4. **`__agency_descriptor` is not serialized.** It re-attaches on
+   module load. Don't add it to checkpoint state.
+5. **`mergeTagSets` only merges `validate` and `jsonSchema`.** Other
+   tags (`@goal`, `@optimize`, etc.) flow through per side and must not
+   be combined across alias/use-site.
+6. **Malformed `@jsonSchema(...)` throws synchronously** from
+   `mergeTagSets` — keep that loud, don't swallow it.
+7. **Validators may be async and may transform the value.** The walker
+   threads `success.value` into the next validator. Tests in
+   `tests/agency/validation/` cover the boundary cases (array element,
+   nested object, nullable, transform).

--- a/packages/agency-lang/docs/dev/validation-annotations.md
+++ b/packages/agency-lang/docs/dev/validation-annotations.md
@@ -11,10 +11,11 @@ features that landed together:
   that structured-output LLM calls and downstream Zod consumers see it.
   Internally this becomes a Zod `.meta(...)` call.
 
-The user-facing guide lives at
-[`docs/site/guide/annotations.md`](../site/guide/annotations.md); this
-doc focuses on how the implementation is wired up so future engineers
-can change it safely.
+The user-facing material currently lives in
+[`docs/site/guide/schemas.md`](../site/guide/schemas.md) (the existing
+`!`-validation guide); a dedicated annotations guide is a planned
+follow-up. This doc focuses on how the implementation is wired up so
+future engineers can change it safely.
 
 ---
 

--- a/packages/agency-lang/docs/site/stdlib/schemas.md
+++ b/packages/agency-lang/docs/site/stdlib/schemas.md
@@ -1,0 +1,16 @@
+# schemas
+
+Pre-baked `@jsonSchema(...)` fragments for common formats. Spread them
+  into your own `@jsonSchema(...)` annotations to attach the matching
+  JSON Schema `format` field:
+
+  ```ts
+  import { emailFormat } from "std::schemas"
+
+  @jsonSchema({ ...emailFormat, description: "primary contact" })
+  type Email = string
+  ```
+
+  These are plain object constants — nothing magic. They exist to spare
+  callers from typing `{ format: "..." }` every time and to keep format
+  names consistent across a codebase.

--- a/packages/agency-lang/docs/site/stdlib/schemas.md
+++ b/packages/agency-lang/docs/site/stdlib/schemas.md
@@ -14,3 +14,75 @@ Pre-baked `@jsonSchema(...)` fragments for common formats. Spread them
   These are plain object constants — nothing magic. They exist to spare
   callers from typing `{ format: "..." }` every time and to keep format
   names consistent across a codebase.
+
+## Constants
+
+### emailFormat
+
+```ts
+export static const emailFormat = {
+  format: "email"
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/schemas.agency#L19))
+
+### urlFormat
+
+```ts
+export static const urlFormat = {
+  format: "uri"
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/schemas.agency#L22))
+
+### uuidFormat
+
+```ts
+export static const uuidFormat = {
+  format: "uuid"
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/schemas.agency#L25))
+
+### dateTimeFormat
+
+```ts
+export static const dateTimeFormat = {
+  format: "date-time"
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/schemas.agency#L28))
+
+### dateFormat
+
+```ts
+export static const dateFormat = {
+  format: "date"
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/schemas.agency#L31))
+
+### ipv4Format
+
+```ts
+export static const ipv4Format = {
+  format: "ipv4"
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/schemas.agency#L34))
+
+### ipv6Format
+
+```ts
+export static const ipv6Format = {
+  format: "ipv6"
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/schemas.agency#L37))

--- a/packages/agency-lang/docs/site/stdlib/types.md
+++ b/packages/agency-lang/docs/site/stdlib/types.md
@@ -29,24 +29,24 @@ export type Email = string
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L25))
 
-### Url
+### URL
 
 An http:// or https:// URL.
 
 ```ts
 /** An http:// or https:// URL. */
-export type Url = string
+export type URL = string
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L30))
 
-### Uuid
+### UUID
 
 A canonical 8-4-4-4-12 hex UUID.
 
 ```ts
 /** A canonical 8-4-4-4-12 hex UUID. */
-export type Uuid = string
+export type UUID = string
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L35))

--- a/packages/agency-lang/docs/site/stdlib/types.md
+++ b/packages/agency-lang/docs/site/stdlib/types.md
@@ -24,7 +24,21 @@ A syntactically valid email address.
 
 ```ts
 /** A syntactically valid email address. */
+@validate(isEmail)
+@jsonSchema({
+  ...emailFormat
+})
 export type Email = string
+```
+
+**Validators:** `isEmail`
+
+**JSON Schema metadata:**
+
+```agency
+{
+  ...emailFormat
+}
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L25))
@@ -35,7 +49,21 @@ An http:// or https:// URL.
 
 ```ts
 /** An http:// or https:// URL. */
+@validate(isUrl)
+@jsonSchema({
+  ...urlFormat
+})
 export type URL = string
+```
+
+**Validators:** `isUrl`
+
+**JSON Schema metadata:**
+
+```agency
+{
+  ...urlFormat
+}
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L30))
@@ -46,7 +74,21 @@ A canonical 8-4-4-4-12 hex UUID.
 
 ```ts
 /** A canonical 8-4-4-4-12 hex UUID. */
+@validate(isUuid)
+@jsonSchema({
+  ...uuidFormat
+})
 export type UUID = string
+```
+
+**Validators:** `isUuid`
+
+**JSON Schema metadata:**
+
+```agency
+{
+  ...uuidFormat
+}
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L35))

--- a/packages/agency-lang/docs/site/stdlib/types.md
+++ b/packages/agency-lang/docs/site/stdlib/types.md
@@ -1,0 +1,52 @@
+# types
+
+Pre-baked type aliases that combine `@validate(...)` and `@jsonSchema(...)`
+  for the most common string-shaped opaque types. Use them in place of plain
+  `string` whenever the value must conform to one of these formats:
+
+  ```ts
+  import { Email } from "std::types"
+
+  def main() {
+    const e: Email! = "user@example.com"   // validated at runtime
+  }
+  ```
+
+  Aliases here only carry annotations — they are still plain `string` from
+  TypeScript's perspective. Validation runs on `!` sites; structured-output
+  LLM calls get the JSON Schema `format` hint via `.meta(...)`.
+
+## Types
+
+### Email
+
+A syntactically valid email address.
+
+```ts
+/** A syntactically valid email address. */
+export type Email = string
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L25))
+
+### Url
+
+An http:// or https:// URL.
+
+```ts
+/** An http:// or https:// URL. */
+export type Url = string
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L30))
+
+### Uuid
+
+A canonical 8-4-4-4-12 hex UUID.
+
+```ts
+/** A canonical 8-4-4-4-12 hex UUID. */
+export type Uuid = string
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L35))

--- a/packages/agency-lang/docs/site/stdlib/types.md
+++ b/packages/agency-lang/docs/site/stdlib/types.md
@@ -43,17 +43,19 @@ export type Email = string
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L25))
 
-### URL
+### URLString
 
-An http:// or https:// URL.
+An http:// or https:// URL. (Named `URLString` so it does not shadow
+    JavaScript's global `URL` constructor.)
 
 ```ts
-/** An http:// or https:// URL. */
+/** An http:// or https:// URL. (Named `URLString` so it does not shadow
+    JavaScript's global `URL` constructor.) */
 @validate(isUrl)
 @jsonSchema({
   ...urlFormat
 })
-export type URL = string
+export type URLString = string
 ```
 
 **Validators:** `isUrl`
@@ -66,19 +68,21 @@ export type URL = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L31))
 
-### UUID
+### UUIDString
 
-A canonical 8-4-4-4-12 hex UUID.
+A canonical 8-4-4-4-12 hex UUID string. (Named `UUIDString` for symmetry
+    with `URLString`.)
 
 ```ts
-/** A canonical 8-4-4-4-12 hex UUID. */
+/** A canonical 8-4-4-4-12 hex UUID string. (Named `UUIDString` for symmetry
+    with `URLString`.) */
 @validate(isUuid)
 @jsonSchema({
   ...uuidFormat
 })
-export type UUID = string
+export type UUIDString = string
 ```
 
 **Validators:** `isUuid`
@@ -91,4 +95,4 @@ export type UUID = string
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L37))

--- a/packages/agency-lang/docs/site/stdlib/validators.md
+++ b/packages/agency-lang/docs/site/stdlib/validators.md
@@ -19,7 +19,8 @@ Validator functions intended for use with `@validate(...)` annotations.
   ```
 
   Validators are only run for types annotated with `!` (the bang operator).
-  See the [validation annotations guide](../guide/annotations.md) for details.
+  See the [schemas guide](../guide/schemas.md) for details on `!`
+  validation and how `@validate(...)` integrates with it.
 
 ## Functions
 
@@ -42,7 +43,7 @@ Returns success if value is a syntactically valid email address,
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L26))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L27))
 
 ### isUrl
 
@@ -63,7 +64,7 @@ Returns success if value is an http:// or https:// URL,
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L36))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L37))
 
 ### isUuid
 
@@ -84,7 +85,7 @@ Returns success if value is a canonical UUID string
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L46))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L47))
 
 ### isInt
 
@@ -105,7 +106,7 @@ Returns success if value is an integer (no fractional component),
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L56))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L57))
 
 ### isPositive
 
@@ -125,7 +126,7 @@ Returns success if value > 0, failure otherwise.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L66))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L67))
 
 ### isNegative
 
@@ -145,4 +146,4 @@ Returns success if value < 0, failure otherwise.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L75))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L76))

--- a/packages/agency-lang/docs/site/stdlib/validators.md
+++ b/packages/agency-lang/docs/site/stdlib/validators.md
@@ -29,7 +29,10 @@ Validator functions intended for use with `@validate(...)` annotations.
 isEmail(value: string): Result
 ```
 
-Returns success if `value` is a syntactically valid email address.
+Returns success if value is a syntactically valid email address,
+  failure otherwise.
+
+  @param value - The string to check.
 
 **Parameters:**
 
@@ -39,7 +42,7 @@ Returns success if `value` is a syntactically valid email address.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L27))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L26))
 
 ### isUrl
 
@@ -47,7 +50,10 @@ Returns success if `value` is a syntactically valid email address.
 isUrl(value: string): Result
 ```
 
-Returns success if `value` is an http:// or https:// URL.
+Returns success if value is an http:// or https:// URL,
+  failure otherwise.
+
+  @param value - The string to check.
 
 **Parameters:**
 
@@ -57,7 +63,7 @@ Returns success if `value` is an http:// or https:// URL.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L32))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L36))
 
 ### isUuid
 
@@ -65,7 +71,10 @@ Returns success if `value` is an http:// or https:// URL.
 isUuid(value: string): Result
 ```
 
-Returns success if `value` is a canonical UUID string (8-4-4-4-12 hex).
+Returns success if value is a canonical UUID string
+  (8-4-4-4-12 hex), failure otherwise.
+
+  @param value - The string to check.
 
 **Parameters:**
 
@@ -75,7 +84,7 @@ Returns success if `value` is a canonical UUID string (8-4-4-4-12 hex).
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L46))
 
 ### isInt
 
@@ -83,7 +92,10 @@ Returns success if `value` is a canonical UUID string (8-4-4-4-12 hex).
 isInt(value: number): Result
 ```
 
-Returns success if `value` is an integer (no fractional component).
+Returns success if value is an integer (no fractional component),
+  failure otherwise.
+
+  @param value - The number to check.
 
 **Parameters:**
 
@@ -93,7 +105,7 @@ Returns success if `value` is an integer (no fractional component).
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L42))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L56))
 
 ### isPositive
 
@@ -101,7 +113,9 @@ Returns success if `value` is an integer (no fractional component).
 isPositive(value: number): Result
 ```
 
-Returns success if `value > 0`.
+Returns success if value > 0, failure otherwise.
+
+  @param value - The number to check.
 
 **Parameters:**
 
@@ -111,7 +125,7 @@ Returns success if `value > 0`.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L66))
 
 ### isNegative
 
@@ -119,7 +133,9 @@ Returns success if `value > 0`.
 isNegative(value: number): Result
 ```
 
-Returns success if `value < 0`.
+Returns success if value < 0, failure otherwise.
+
+  @param value - The number to check.
 
 **Parameters:**
 
@@ -129,4 +145,4 @@ Returns success if `value < 0`.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L75))

--- a/packages/agency-lang/docs/site/stdlib/validators.md
+++ b/packages/agency-lang/docs/site/stdlib/validators.md
@@ -1,0 +1,132 @@
+# validators
+
+Validator functions intended for use with `@validate(...)` annotations.
+
+  Each validator takes a single value and returns a `Result` — `success(value)`
+  if the value is valid (optionally transformed), or `failure(reason)` if not.
+
+  ## Usage
+
+  ```ts
+  import { isEmail } from "std::validators"
+
+  @validate(isEmail)
+  type Email = string
+
+  def main() {
+    const e: Email! = "foo@example.com"   // validated
+  }
+  ```
+
+  Validators are only run for types annotated with `!` (the bang operator).
+  See the [validation annotations guide](../guide/annotations.md) for details.
+
+## Functions
+
+### isEmail
+
+```ts
+isEmail(value: string): Result
+```
+
+Returns success if `value` is a syntactically valid email address.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `string` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L27))
+
+### isUrl
+
+```ts
+isUrl(value: string): Result
+```
+
+Returns success if `value` is an http:// or https:// URL.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `string` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L32))
+
+### isUuid
+
+```ts
+isUuid(value: string): Result
+```
+
+Returns success if `value` is a canonical UUID string (8-4-4-4-12 hex).
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `string` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L37))
+
+### isInt
+
+```ts
+isInt(value: number): Result
+```
+
+Returns success if `value` is an integer (no fractional component).
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `number` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L42))
+
+### isPositive
+
+```ts
+isPositive(value: number): Result
+```
+
+Returns success if `value > 0`.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `number` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L47))
+
+### isNegative
+
+```ts
+isNegative(value: number): Result
+```
+
+Returns success if `value < 0`.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `number` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/validators.agency#L52))

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-19-type-validation-and-json-schema-annotations-impl.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-19-type-validation-and-json-schema-annotations-impl.md
@@ -52,7 +52,7 @@
 | `lib/typeChecker/jsonSchemaArgValidator.test.ts` | Unit tests for the restriction |
 | `stdlib/validators.agency` + `stdlib/validators.js` | `isEmail`, `isUrl`, `isUuid`, `isInt`, `isPositive`, `isNegative`, `min`, `max`, `minLength`, `maxLength`, `matches` |
 | `stdlib/schemas.agency` + `stdlib/schemas.js` | `emailFormat`, `urlFormat`, `uuidFormat`, `dateTimeFormat`, `dateFormat`, `ipv4Format`, `ipv6Format` |
-| `stdlib/types.agency` + `stdlib/types.js` | Pre-baked `Email`, `Url`, `Uuid` aliases |
+| `stdlib/types.agency` + `stdlib/types.js` | Pre-baked `Email`, `URL`, `UUID` aliases |
 | `docs/site/guide/annotations.md` | User-facing docs for `@validate` / `@jsonSchema` and the stdlib modules |
 
 **Files modified:**
@@ -1133,11 +1133,11 @@ export type Email = string
 
 @validate(isUrl)
 @jsonSchema({ ...urlFormat })
-export type Url = string
+export type URL = string
 
 @validate(isUuid)
 @jsonSchema({ ...uuidFormat })
-export type Uuid = string
+export type UUID = string
 ```
 
 The `.js` companion may be empty (pure type re-exports).
@@ -1173,7 +1173,7 @@ pnpm run agency test tests/agency/stdlib/types.agency 2>&1 | tee /tmp/task14-tes
 
 ```bash
 git add stdlib/types.agency stdlib/types.js tests/agency/stdlib/types.agency
-git commit -m "feat(stdlib): add std::types with pre-baked Email/Url/Uuid"
+git commit -m "feat(stdlib): add std::types with pre-baked Email/URL/UUID"
 ```
 
 ---

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-19-type-validation-and-json-schema-annotations-impl.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-19-type-validation-and-json-schema-annotations-impl.md
@@ -1,0 +1,1386 @@
+# Type Validation & JSON Schema Annotations — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two new annotations — `@validate(fn1, fn2, ...)` for runtime validation chains and `@jsonSchema({...})` for JSON-Schema metadata — usable on type aliases and type properties, and ship a small standard library (`std::validators`, `std::schemas`, `std::types`) that exercises them.
+
+**Architecture:** A single AST change widens `Tag.arguments` from `string[]` to `Expression[]`. The preprocessor and the object-type parser both grow the ability to attach those tags to type-level targets (`typeAlias` nodes and `ObjectProperty` entries). The type checker carries tags on `TypeAliasEntry`, propagates them through `resolveType`, and enforces a static-expression restriction on `@jsonSchema` arguments. The TypeScript builder emits `.meta({...})` for `@jsonSchema` and, for `!`-validated values, threads the Zod-parsed value through a chain of async validator calls via a new `__validateChain` runtime helper. Removal of the legacy `# description` syntax is a fast-follow PR after this lands.
+
+**Tech Stack:** tarsec parser combinators, vitest, structural linter, Zod 4 (`.meta()` API).
+
+**Spec:** `docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md`
+
+---
+
+## Key Risks and Gotchas
+
+1. **`Tag.arguments` is `string[]` today.** Every reader of `tag.arguments` in the codebase (search `\.arguments\b` on `Tag` nodes — currently only `lib/preprocessors/typescriptPreprocessor.ts` cares) must be updated to read `Expression[]`. Existing callers that expect strings (e.g. `@goal("...")`, `@optimize(prompt, temperature)`) must continue to round-trip identically — string-literal expressions and identifier expressions are the new bare forms.
+
+2. **`attachTags` only knows about four statement node types.** It currently attaches to `graphNode`, `function`, `assignment`, `functionCall` ([lib/preprocessors/typescriptPreprocessor.ts:112-145](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts#L112-L145)). It must be extended to `typeAlias`, otherwise tags above `type Foo = ...` are silently dropped.
+
+3. **Property-level tags live inside the type expression parser.** `attachTags` runs at the statement level and cannot see inside `{ ... }` object-type bodies. Tag accumulation for `ObjectProperty` is a new feature of `objectTypeParser` (around [parsers.ts:884-920](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/parsers/parsers.ts#L884-L920)).
+
+4. **`TypeAliasEntry` is widely consumed.** Adding `tags?: Tag[]` is a one-line change to [`lib/types/typeHints.ts:46-49`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/types/typeHints.ts#L46-L49), but every site that constructs a `TypeAliasEntry` (notably [`compilationUnit.ts:48`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/compilationUnit.ts#L48)) must thread tags through. Missing one means annotations stop propagating at a module boundary.
+
+5. **`resolveType` is the propagation seam.** Tag propagation for both generic instantiations and plain alias references must happen here, not at codegen. Codegen reads tags off the resolved node; it does not look them up.
+
+6. **`!` validation goes through `__validateType`.** The single existing seam is [`lib/runtime/schema.ts:27`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/runtime/schema.ts#L27), called from emitter sites listed in [`lib/backends/typescriptBuilder.ts:2130, 2230`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/backends/typescriptBuilder.ts#L2130) and the IR builder [`lib/ir/builders.ts:401`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/ir/builders.ts#L401). The new `__validateChain` helper must be wired in at every one of those sites — missing one means validators silently don't run for some `!` positions, which is a safety bug per the CLAUDE.md guidance on handlers and safety infrastructure.
+
+7. **Validators are async, Zod is sync.** Do not switch the Zod path to `safeParseAsync` — see spec §"Why run validators outside Zod". The new helper awaits validator calls *after* the sync Zod parse succeeds.
+
+8. **`.meta()` must be the last call in the Zod chain.** A single `appendMeta(schemaExpr, metaObj)` helper in the typescript generator enforces this. Any code path that constructs a Zod expression must go through it.
+
+9. **`# description` removal is OUT of this PR.** The annotation infrastructure lands first. The fast-follow PR will codemod every fixture and example. While both coexist, mixing `# desc` and `@jsonSchema({description: ...})` on the same property is an error.
+
+10. **Make is required after stdlib changes.** Three new stdlib files (`stdlib/validators.{agency,js}`, `stdlib/schemas.{agency,js}`, `stdlib/types.{agency,js}`) need a `make` build after authoring.
+
+11. **Recursive type walker depth cap defaults to 64.** Adjust if real workloads need more; do not remove it.
+
+12. **Spread in object literals is already supported** via `splatParser` ([parsers.ts:1372](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/parsers/parsers.ts) area). Do not re-invent.
+
+---
+
+## File Structure
+
+**New files:**
+
+| File | Purpose |
+|------|---------|
+| `lib/runtime/validateChain.ts` | Async validator-chain helper; recursion-walker for nested types |
+| `lib/runtime/validateChain.test.ts` | Unit tests for the helper |
+| `lib/typeChecker/jsonSchemaArgValidator.ts` | Static-expression restriction enforcement for `@jsonSchema(...)` |
+| `lib/typeChecker/jsonSchemaArgValidator.test.ts` | Unit tests for the restriction |
+| `stdlib/validators.agency` + `stdlib/validators.js` | `isEmail`, `isUrl`, `isUuid`, `isInt`, `isPositive`, `isNegative`, `min`, `max`, `minLength`, `maxLength`, `matches` |
+| `stdlib/schemas.agency` + `stdlib/schemas.js` | `emailFormat`, `urlFormat`, `uuidFormat`, `dateTimeFormat`, `dateFormat`, `ipv4Format`, `ipv6Format` |
+| `stdlib/types.agency` + `stdlib/types.js` | Pre-baked `Email`, `Url`, `Uuid` aliases |
+| `docs/site/guide/annotations.md` | User-facing docs for `@validate` / `@jsonSchema` and the stdlib modules |
+
+**Files modified:**
+
+| File | Purpose in this plan |
+|------|----------------------|
+| `lib/types/tag.ts` | `arguments: string[]` → `arguments: Expression[]` |
+| `lib/types/typeHints.ts` | Add `tags?: Tag[]` to `ObjectProperty` and `TypeAliasEntry`; allow `tags?: Tag[]` on `TypeAlias` |
+| `lib/parsers/parsers.ts` | Tag-argument expression parser (restricted subset); attach tags inside `objectTypeParser`; ordering for `typeAliasParser` |
+| `lib/preprocessors/typescriptPreprocessor.ts` | Extend `attachTags` to attach to `typeAlias` |
+| `lib/compilationUnit.ts` | Carry `tags` on `TypeAliasEntry` when adding to `ScopedTypeAliases` |
+| `lib/typeChecker/*.ts` (resolveType + callers) | Propagate tags from alias to use-site through `resolveType`; merge property/alias tags per spec |
+| `lib/backends/typescriptGenerator/typeToZodSchema.ts` | Emit `.meta({...})` via new `appendMeta` helper; remove legacy `.describe(prop.description)` later (fast-follow) |
+| `lib/backends/typescriptBuilder.ts` | Replace direct `__validateType(...)` calls with `__validateChain(...)` for any type carrying `@validate` tags |
+| `lib/ir/builders.ts` | Mirror the builder change at the IR level |
+| `lib/utils/formatType.ts` | Round-trip tags in `agencyGenerator` for `ObjectProperty` and `TypeAlias` |
+| `lib/backends/agencyGenerator.ts` | Emit `@validate(...)` / `@jsonSchema(...)` above aliases and properties |
+| `docs/site/guide/types.md` | Cross-link to the new annotations doc |
+
+---
+
+## Task 1: Widen `Tag.arguments` to `Expression[]`
+
+**Files:**
+- Modify: `lib/types/tag.ts`
+- Modify: `lib/preprocessors/typescriptPreprocessor.ts`
+- Modify: `lib/backends/agencyGenerator.ts` (anywhere it prints tag args back out)
+
+- [ ] **Step 1: Write a failing AST test**
+
+In `lib/types/tag.test.ts` (create if missing), assert that a `Tag` value compiles with `arguments: [{ type: "stringLiteral", value: "hi" } as Expression]`. Use `tsc --noEmit` (`pnpm run typecheck`) for the failing signal.
+
+- [ ] **Step 2: Run the typecheck to verify the field is still `string[]`**
+
+```
+pnpm run typecheck 2>&1 | tee /tmp/typecheck.log
+```
+
+Expected: type error pointing at the new test file.
+
+- [ ] **Step 3: Widen the type**
+
+Edit [lib/types/tag.ts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/types/tag.ts):
+
+```typescript
+import { BaseNode } from "./base.js";
+import type { Expression } from "./ast.js";
+
+export type Tag = BaseNode & {
+  type: "tag";
+  name: string;
+  arguments: Expression[];
+};
+```
+
+- [ ] **Step 4: Fix every downstream consumer**
+
+```
+grep -rn "\\.arguments" lib/ --include="*.ts" | grep -v test | grep -iE "tag" | tee /tmp/tag-readers.log
+```
+
+Expected callers to patch (initial survey — re-grep before editing):
+- `lib/preprocessors/typescriptPreprocessor.ts` (uses for `@goal`, `@optimize`)
+- `lib/backends/agencyGenerator.ts` (prints tags back out)
+
+For each: when the argument is a string-literal expression, recover the string via the existing literal node shape; when it's an identifier expression, recover the identifier. Add a small helper `tagArgToLegacyString(arg: Expression): string | null` so existing string-only consumers don't grow expression-handling logic.
+
+- [ ] **Step 5: Run all parser, preprocessor, generator tests**
+
+```
+pnpm test:run lib/types lib/preprocessors lib/backends 2>&1 | tee /tmp/task1-tests.log
+```
+
+Expected: PASS (existing tags `@goal("...")`, `@optimize(prompt, temperature)` still behave identically).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/types/tag.ts lib/preprocessors/typescriptPreprocessor.ts lib/backends/agencyGenerator.ts lib/types/tag.test.ts
+git commit -F .git/COMMIT_MSG  # contents: "refactor: widen Tag.arguments to Expression[]"
+```
+
+---
+
+## Task 2: Tag parser accepts the restricted expression subset
+
+**Files:**
+- Modify: `lib/parsers/parsers.ts` (around the existing `tagParser`)
+- Add tests in: `lib/parsers/tag.test.ts` (create if missing)
+
+The allowed forms per spec: literals (string / number / boolean / `null`), identifiers, function calls, object literals (including spread). No ternaries, no binary ops, no pipes, no member access, no template strings, no array literals.
+
+- [ ] **Step 1: Write failing parser tests**
+
+Create / append `lib/parsers/tag.test.ts` with cases:
+
+```typescript
+import { tagParser } from "./parsers.js";
+
+it("parses @validate(isEven)", () => {
+  const r = tagParser("@validate(isEven)");
+  expect(r.success).toBe(true);
+  expect(r.result.arguments[0].type).toBe("variableName"); // or whatever identifier shape is
+});
+
+it("parses @validate(min(0), max(150))", () => {
+  const r = tagParser("@validate(min(0), max(150))");
+  expect(r.success).toBe(true);
+  expect(r.result.arguments).toHaveLength(2);
+  expect(r.result.arguments[0].type).toBe("functionCall");
+});
+
+it("parses @jsonSchema({ format: \"email\" })", () => {
+  const r = tagParser('@jsonSchema({ format: "email" })');
+  expect(r.success).toBe(true);
+  expect(r.result.arguments[0].type).toBe("agencyObject");
+});
+
+it("parses @jsonSchema({ ...emailFormat, description: \"work\" })", () => {
+  const r = tagParser('@jsonSchema({ ...emailFormat, description: "work" })');
+  expect(r.success).toBe(true);
+});
+
+it("rejects @validate(x > 5)", () => {
+  const r = tagParser("@validate(x > 5)");
+  expect(r.success).toBe(false);
+});
+
+it("preserves @goal(\"old style\") as string-literal expression", () => {
+  const r = tagParser('@goal("old style")');
+  expect(r.success).toBe(true);
+  expect(r.result.arguments[0].type).toBe("stringLiteral");
+});
+```
+
+- [ ] **Step 2: Run tests, watch them fail**
+
+```
+pnpm test:run lib/parsers/tag.test.ts 2>&1 | tee /tmp/task2-fail.log
+```
+
+- [ ] **Step 3: Implement the restricted-subset argument parser**
+
+Replace `tagArg`, `tagArgsList`, and `_tagParserInner` at [parsers.ts:1316-1352](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/parsers/parsers.ts#L1316-L1352).
+
+```typescript
+// Restricted subset of expressions allowed inside @tag(...) arguments.
+// NO ternaries, binops, pipes, member access, template strings, array literals.
+const restrictedTagArgParser: Parser<Expression> = label(
+  "a tag argument (literal, identifier, function call, or object literal)",
+  or(
+    lazy(() => functionCallParser),       // @validate(min(0))
+    lazy(() => agencyObjectParser),        // @jsonSchema({ ... })
+    lazy(() => stringLiteralParser),
+    lazy(() => numberLiteralParser),
+    lazy(() => booleanLiteralParser),
+    lazy(() => nullLiteralParser),
+    lazy(() => varNameParser),             // identifier — must come LAST (greedy)
+  ),
+);
+
+const tagArgsList = map(
+  seqC(
+    char("("),
+    optionalSpaces,
+    capture(sepBy(comma, restrictedTagArgParser), "args"),
+    optionalSpaces,
+    char(")"),
+  ),
+  (r) => r.args,
+);
+
+const _tagParserInner = trace(
+  "tagParser",
+  seqC(
+    set("type", "tag"),
+    char("@"),
+    capture(many1WithJoin(varNameChar), "name"),
+    capture(or(tagArgsList, succeed([] as Expression[])), "arguments"),
+    optionalSemicolon,
+  ),
+);
+```
+
+Confirm the actual node-type strings (`"variableName"`, `"functionCall"`, `"agencyObject"`, `"stringLiteral"`, `"numberLiteral"`, `"booleanLiteral"`) by reading the existing AST type definitions before final implementation.
+
+- [ ] **Step 4: Re-run tag tests**
+
+```
+pnpm test:run lib/parsers/tag.test.ts 2>&1 | tee /tmp/task2-pass.log
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run full parser suite to catch regressions**
+
+```
+pnpm test:run lib/parsers 2>&1 | tee /tmp/task2-parsers.log
+```
+
+Expected: PASS (no existing `@tag(...)` regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/parsers/parsers.ts lib/parsers/tag.test.ts
+git commit -m "feat(parser): tag arguments accept restricted expression subset"
+```
+
+---
+
+## Task 3: Attach tags to `typeAlias` statements
+
+**Files:**
+- Modify: `lib/preprocessors/typescriptPreprocessor.ts` (`attachTags`)
+- Modify: `lib/types/typeHints.ts` (`TypeAlias` already has `BaseNode`; confirm a `tags?: Tag[]` field can be added)
+
+- [ ] **Step 1: Write a failing preprocessor test**
+
+In `lib/preprocessors/typescriptPreprocessor.test.ts` (or create) assert that after preprocessing the source
+
+```
+@validate(isEmail)
+type Email = string
+```
+
+the resulting `typeAlias` node has `tags` containing one element with `name === "validate"`.
+
+- [ ] **Step 2: Run, watch fail**
+
+```
+pnpm test:run lib/preprocessors 2>&1 | tee /tmp/task3-fail.log
+```
+
+- [ ] **Step 3: Extend `attachTags`**
+
+Edit [`lib/preprocessors/typescriptPreprocessor.ts:122-128`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts#L122-L128):
+
+```typescript
+if (pendingTags.length > 0) {
+  if (
+    node.type === "graphNode" || node.type === "function" ||
+    node.type === "assignment" || node.type === "functionCall" ||
+    node.type === "typeAlias"
+  ) {
+    (node as any).tags = [...((node as any).tags || []), ...pendingTags];
+    pendingTags = [];
+  } else {
+    result.push(...pendingTags);
+    pendingTags = [];
+  }
+}
+```
+
+Add `tags?: Tag[]` to `TypeAlias` in [`lib/types/typeHints.ts`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/types/typeHints.ts) (currently has `type`, `aliasName`, `aliasedType`, `typeParams?`, `exported?`, `docComment?`). Use a proper typed cast in the preprocessor instead of `as any`.
+
+- [ ] **Step 4: Re-run tests**
+
+```
+pnpm test:run lib/preprocessors 2>&1 | tee /tmp/task3-pass.log
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/preprocessors/typescriptPreprocessor.ts lib/types/typeHints.ts lib/preprocessors/typescriptPreprocessor.test.ts
+git commit -m "feat(preprocessor): attach tags to typeAlias nodes"
+```
+
+---
+
+## Task 4: Parse property-level tags inside object types
+
+**Files:**
+- Modify: `lib/types/typeHints.ts` (add `tags?: Tag[]` to `ObjectProperty`)
+- Modify: `lib/parsers/parsers.ts` (`objectTypeParser` around line 884)
+
+- [ ] **Step 1: Failing parser test**
+
+In `lib/parsers/objectType.test.ts` (create if missing):
+
+```typescript
+import { objectTypeParser } from "./parsers.js";
+
+it("attaches @validate tag to a property", () => {
+  const src = `{
+    @validate(isEmail)
+    email: string
+  }`;
+  const r = objectTypeParser(src);
+  expect(r.success).toBe(true);
+  const prop = r.result.properties[0];
+  expect(prop.key).toBe("email");
+  expect(prop.tags).toHaveLength(1);
+  expect(prop.tags[0].name).toBe("validate");
+});
+
+it("attaches multiple tags to a property", () => {
+  const src = `{
+    @validate(isEmail)
+    @jsonSchema({ format: "email" })
+    email: string
+  }`;
+  const r = objectTypeParser(src);
+  expect(r.success).toBe(true);
+  expect(r.result.properties[0].tags).toHaveLength(2);
+});
+
+it("plain property still parses with no tags", () => {
+  const src = `{ name: string }`;
+  const r = objectTypeParser(src);
+  expect(r.success).toBe(true);
+  expect(r.result.properties[0].tags).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run, watch fail**
+
+```
+pnpm test:run lib/parsers/objectType.test.ts 2>&1 | tee /tmp/task4-fail.log
+```
+
+- [ ] **Step 3: Add the field**
+
+In [`lib/types/typeHints.ts:105-109`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/types/typeHints.ts#L105-L109):
+
+```typescript
+export type ObjectProperty = {
+  key: string;
+  value: VariableType;
+  description?: string;   // legacy — removed in fast follow
+  tags?: Tag[];           // new
+};
+```
+
+- [ ] **Step 4: Extend `objectTypeParser`**
+
+In [parsers.ts:884-920](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/parsers/parsers.ts#L884-L920), change the `sepBy` alternative list to first try a "tagged property" parser that accumulates one or more `tagParser` outputs followed by an `objectPropertyParser` / `objectPropertyWithDescriptionParser`, then writes the tags onto the resulting property:
+
+```typescript
+const taggedObjectPropertyParser: Parser<ObjectProperty> = trace(
+  "taggedObjectPropertyParser",
+  map(
+    seqC(
+      capture(
+        many1(seqC(tagParser, optionalSpacesOrNewline)),
+        "tags",
+      ),
+      capture(
+        or(objectPropertyWithDescriptionParser, objectPropertyParser),
+        "prop",
+      ),
+    ),
+    (r) => {
+      const tags = (r.tags as Array<{ tag: Tag }>).map((t) => t.tag);
+      return { ...r.prop, tags };
+    },
+  ),
+);
+
+// In the inner or(...) list, put taggedObjectPropertyParser FIRST so it
+// runs before the plain property parsers.
+sepBy(
+  objectPropertyDelimiter,
+  or(
+    taggedObjectPropertyParser,
+    objectPropertyWithDescriptionParser,
+    objectPropertyParser,
+    commentParser,
+    multiLineCommentParser,
+  ),
+),
+```
+
+The exact `seqC`/`capture` shape may need tweaking to match how `tagParser` returns its inner value; consult `tarsec`-style examples elsewhere in the file.
+
+- [ ] **Step 5: Pass tests**
+
+```
+pnpm test:run lib/parsers/objectType.test.ts lib/parsers 2>&1 | tee /tmp/task4-pass.log
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/parsers/parsers.ts lib/types/typeHints.ts lib/parsers/objectType.test.ts
+git commit -m "feat(parser): accept tags above type-object properties"
+```
+
+---
+
+## Task 5: Carry tags on `TypeAliasEntry`
+
+**Files:**
+- Modify: `lib/types/typeHints.ts` (add `tags?: Tag[]` to `TypeAliasEntry`)
+- Modify: `lib/compilationUnit.ts` (`ScopedTypeAliases.add` accepts and stores tags)
+- Modify: every constructor / `add()` call site for `TypeAliasEntry`
+
+- [ ] **Step 1: Failing typecheck**
+
+In a new `lib/compilationUnit.test.ts` test, call `aliases.add("Email", { type: "primitiveType", name: "string" }, undefined, [{ type: "tag", name: "validate", arguments: [] }])` and assert that `aliases.get(...)["Email"].tags` exists.
+
+- [ ] **Step 2: Run, watch fail**
+
+```
+pnpm test:run lib/compilationUnit 2>&1 | tee /tmp/task5-fail.log
+```
+
+- [ ] **Step 3: Widen the entry**
+
+```typescript
+// lib/types/typeHints.ts
+export type TypeAliasEntry = {
+  body: VariableType;
+  typeParams?: TypeParam[];
+  tags?: Tag[];   // NEW
+};
+```
+
+In [`lib/compilationUnit.ts:46-50`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/compilationUnit.ts#L46-L50):
+
+```typescript
+add(scopeKey: string, name: string, body: VariableType, typeParams?: TypeParam[], tags?: Tag[]): void {
+  if (!this.byScope[scopeKey]) this.byScope[scopeKey] = {};
+  const entry: TypeAliasEntry = { body };
+  if (typeParams) entry.typeParams = typeParams;
+  if (tags && tags.length > 0) entry.tags = tags;
+  this.byScope[scopeKey][name] = entry;
+}
+```
+
+- [ ] **Step 4: Update all call sites that add aliases**
+
+```
+grep -rn "typeAliases\.add\|new TypeAliasEntry\|ScopedTypeAliases" lib/ --include="*.ts" | tee /tmp/alias-add-sites.log
+```
+
+Every site that converts a `typeAlias` AST node into a `TypeAliasEntry` must now also pass `node.tags`.
+
+- [ ] **Step 5: Pass tests**
+
+```
+pnpm test:run lib/compilationUnit lib/typeChecker 2>&1 | tee /tmp/task5-pass.log
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/types/typeHints.ts lib/compilationUnit.ts lib/typeChecker/ lib/compilationUnit.test.ts
+git commit -m "feat(types): carry tags on TypeAliasEntry"
+```
+
+---
+
+## Task 6: Propagate tags through `resolveType`
+
+**Files:**
+- Modify: `lib/typeChecker/*.ts` — wherever `resolveType` is defined (search for its definition)
+- Modify: helper that merges alias + property tags
+
+This is the most subtle task. After substitution:
+
+- A reference to a plain alias `Email` resolves to its body **with the alias's tags attached** (on a shallow copy of the body — do not mutate the alias entry).
+- A reference to a generic alias `NonEmptyArray<Email>` resolves to the substituted body **with the outer alias's tags attached**; the inner `Email` element type carries its own tags, which the downstream walker picks up.
+- When the use site already carries tags (a property with `@validate(...)` over its declared alias), per-spec merge rules apply:
+  - `@validate`: concat — alias tags first, then property tags.
+  - `@jsonSchema`: merge object literals; property keys override alias keys.
+
+- [ ] **Step 1: Failing type-checker / unit tests**
+
+Create `lib/typeChecker/resolveType.tags.test.ts`:
+
+```typescript
+it("non-generic alias propagates tags to use site", () => {
+  // Setup ScopedTypeAliases with `Email` having tags
+  // Resolve a reference to Email
+  // Assert resolved node has tags attached
+});
+
+it("generic alias propagates outer tags to instantiation", () => {
+  // NonEmptyArray<Email> resolves to ArrayType with NonEmptyArray's tags
+});
+
+it("property tags merge with alias tags (validate concat)", () => {
+  // alias Email has @validate(isEmail)
+  // property `to: Email` has @validate(notBanned)
+  // Resolved property type carries tags [isEmail, notBanned] in @validate order
+});
+
+it("property tags merge with alias tags (jsonSchema override)", () => {
+  // alias has @jsonSchema({ format: "email", description: "alias desc" })
+  // property has @jsonSchema({ description: "prop desc" })
+  // Merged jsonSchema: { format: "email", description: "prop desc" }
+});
+```
+
+- [ ] **Step 2: Run, watch fail**
+
+```
+pnpm test:run lib/typeChecker/resolveType.tags 2>&1 | tee /tmp/task6-fail.log
+```
+
+- [ ] **Step 3: Implement propagation**
+
+Find `resolveType` (it lives in `lib/typeChecker/`; the generics plan called it out as the substitution seam). At the end of resolution, if the entry has `tags`, attach a *cloned* copy onto the returned `VariableType`. The returned node grows an optional `tags?: Tag[]` field — add this to the relevant `VariableType` variants (`primitiveType`, `objectType`, `arrayType`, etc.) or attach via a wrapper. Prefer extending `BaseNode` if all `VariableType` shapes share it, otherwise add the field per relevant variant.
+
+Add a helper `mergeTagSets(aliasTags, useSiteTags): Tag[]` that:
+- concatenates `@validate(...)` argument lists across all `@validate` tags (alias first, then use-site), producing a single combined `@validate` tag;
+- merges `@jsonSchema(...)` object-literal arguments left-to-right (alias first, use-site overrides), producing a single combined `@jsonSchema` tag;
+- preserves any other tag names unchanged (concat).
+
+- [ ] **Step 4: Pass tests**
+
+```
+pnpm test:run lib/typeChecker 2>&1 | tee /tmp/task6-pass.log
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/typeChecker/ lib/types/typeHints.ts
+git commit -m "feat(typeChecker): propagate and merge annotation tags through resolveType"
+```
+
+---
+
+## Task 7: Enforce `@jsonSchema` argument restrictions in the type checker
+
+**Files:**
+- Create: `lib/typeChecker/jsonSchemaArgValidator.ts`
+- Create: `lib/typeChecker/jsonSchemaArgValidator.test.ts`
+- Hook into: the type-checker pass that walks `Tag`s on aliases/properties
+
+Per spec: each leaf expression inside `@jsonSchema(...)` must be a literal, an object literal containing only allowed exprs/spreads, an identifier resolving to a static `const` global, or a function call to a top-level `def` / imported function with allowed-expr arguments.
+
+- [ ] **Step 1: Failing tests**
+
+```typescript
+// jsonSchemaArgValidator.test.ts
+
+it("accepts {format: \"email\"}", () => {
+  expect(validateJsonSchemaArg(objLit({format: strLit("email")}), scope).ok).toBe(true);
+});
+
+it("accepts identifier bound to a top-level const", () => {
+  // scope has `const emailFormat = {format: "email"}` (top-level)
+  expect(validateJsonSchemaArg(ident("emailFormat"), scope).ok).toBe(true);
+});
+
+it("rejects identifier bound to a let", () => {
+  expect(validateJsonSchemaArg(ident("someLet"), scope).ok).toBe(false);
+});
+
+it("rejects member access", () => {
+  expect(validateJsonSchemaArg(memberAccess(...), scope).ok).toBe(false);
+});
+
+it("rejects ternary", () => { ... });
+it("rejects template string", () => { ... });
+it("rejects array literal", () => { ... });
+it("accepts function call min(0)", () => { ... });
+it("rejects function call whose argument is a forbidden expression", () => { ... });
+```
+
+- [ ] **Step 2: Run, watch fail**
+
+```
+pnpm test:run lib/typeChecker/jsonSchemaArgValidator 2>&1 | tee /tmp/task7-fail.log
+```
+
+- [ ] **Step 3: Implement the validator**
+
+```typescript
+// lib/typeChecker/jsonSchemaArgValidator.ts
+import type { Expression } from "../types/ast.js";
+import type { Scope } from "../compilationUnit.js";
+
+export type JsonSchemaArgValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string; loc?: { line: number; col: number } };
+
+export function validateJsonSchemaArg(
+  expr: Expression,
+  scope: Scope,
+): JsonSchemaArgValidationResult {
+  switch (expr.type) {
+    case "stringLiteral":
+    case "numberLiteral":
+    case "booleanLiteral":
+    case "nullLiteral":
+      return { ok: true };
+    case "agencyObject":
+      // walk entries + splats
+      ...
+    case "functionCall":
+      // every argument must itself validate
+      ...
+    case "variableName":
+      // must resolve to a top-level const-bound name
+      ...
+    default:
+      return { ok: false, reason: `not allowed inside @jsonSchema: ${expr.type}`, loc: expr.loc };
+  }
+}
+```
+
+Determining "top-level const-bound" requires the scope's binding metadata. If the scope API doesn't currently distinguish `const` from `let`, add a small accessor; do not weaken the restriction.
+
+- [ ] **Step 4: Hook into the type-checker pass**
+
+Find the pass that walks alias/property tags after `resolveType`. For every `@jsonSchema` tag, call `validateJsonSchemaArg` on each argument and surface failures via the existing type-check error channel.
+
+- [ ] **Step 5: Pass tests + add an end-to-end integration test**
+
+Create `tests/agency/types/jsonschema-arg-restriction.agency` that uses a forbidden expression inside `@jsonSchema(...)` and asserts compilation fails. (Use the existing pattern in `tests/agency/` per `docs/misc/TESTING.md`.)
+
+```
+pnpm test:run lib/typeChecker 2>&1 | tee /tmp/task7-pass.log
+pnpm run agency test tests/agency/types/jsonschema-arg-restriction.agency 2>&1 | tee /tmp/task7-int.log
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/typeChecker/jsonSchemaArgValidator.ts lib/typeChecker/jsonSchemaArgValidator.test.ts tests/agency/types/jsonschema-arg-restriction.agency
+git commit -m "feat(typeChecker): restrict @jsonSchema argument expressions"
+```
+
+---
+
+## Task 8: Codegen — `.meta({...})` for `@jsonSchema`
+
+**Files:**
+- Modify: `lib/backends/typescriptGenerator/typeToZodSchema.ts`
+
+- [ ] **Step 1: Failing fixture test**
+
+Add `tests/typescriptGenerator/jsonSchema.test.ts` (or extend an existing fixture) asserting that
+
+```agency
+@jsonSchema({ format: "email", description: "work email" })
+type WorkEmail = string
+```
+
+emits a Zod expression ending in `.meta({ format: "email", description: "work email" })`.
+
+- [ ] **Step 2: Run, watch fail**
+
+```
+pnpm test:run tests/typescriptGenerator/jsonSchema 2>&1 | tee /tmp/task8-fail.log
+```
+
+- [ ] **Step 3: Add `appendMeta` helper and call it**
+
+In `lib/backends/typescriptGenerator/typeToZodSchema.ts`, add:
+
+```typescript
+function appendMeta(schemaExpr: string, metaExpr: string | null): string {
+  if (!metaExpr) return schemaExpr;
+  return `${schemaExpr}.meta(${metaExpr})`;
+}
+```
+
+In every code path that finishes building a Zod schema for a type or property, route the final string through `appendMeta`, passing the printed `@jsonSchema` argument (or `null` if no such tag). The printed argument is the use-site Expression printed by the existing expression printer — no transformation needed, since Zod consumes the object as-is at module load time.
+
+Ensure the canonical chain order documented in the spec is preserved: `.meta()` is the absolute last `.` call. If any current call site appends `.nullable()` / `.optional()` / `.default()` *after* the type-construction call, restructure the local code so `.meta()` is appended *after* those, never before.
+
+- [ ] **Step 4: Pass tests + visual fixture diff**
+
+```
+pnpm test:run tests/typescriptGenerator 2>&1 | tee /tmp/task8-pass.log
+make fixtures   # rebuild integration fixtures so diffs are visible
+git diff tests/typescriptGenerator/fixtures | head -200
+```
+
+Spot-check the diff: every type with `@jsonSchema` should grow a trailing `.meta(...)` and nothing else should change.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/backends/typescriptGenerator/ tests/typescriptGenerator/
+git commit -m "feat(codegen): emit .meta() for @jsonSchema tags"
+```
+
+---
+
+## Task 9: Runtime helper `__validateChain`
+
+**Files:**
+- Create: `lib/runtime/validateChain.ts`
+- Create: `lib/runtime/validateChain.test.ts`
+
+The helper does what the spec pseudocode lays out: Zod parse, then thread the parsed value through a list of async validator functions in order, short-circuiting on the first `failure`. It also exposes a recursion-walker for nested types.
+
+- [ ] **Step 1: Failing tests**
+
+```typescript
+// validateChain.test.ts
+import { z } from "zod";
+import { __validateChain } from "./validateChain.js";
+import { success, failure, isFailure, isSuccess } from "./result.js";
+
+const ctx = {}; // mock __ctx
+
+it("passes Zod and runs validators in order", async () => {
+  const isPos = async (_ctx: unknown, x: number) =>
+    x > 0 ? success(x) : failure("must be positive");
+  const isEven = async (_ctx: unknown, x: number) =>
+    x % 2 === 0 ? success(x) : failure("must be even");
+  const r = await __validateChain(4, z.number(), [isPos, isEven], ctx);
+  expect(isSuccess(r)).toBe(true);
+});
+
+it("short-circuits on first failure", async () => {
+  const isPos = async (_ctx: unknown, x: number) =>
+    x > 0 ? success(x) : failure("not positive");
+  const everCalled = vi.fn();
+  const isEven = async (_ctx: unknown, x: number) => { everCalled(); return success(x); };
+  const r = await __validateChain(-1, z.number(), [isPos, isEven], ctx);
+  expect(isFailure(r)).toBe(true);
+  expect(everCalled).not.toHaveBeenCalled();
+});
+
+it("threads transformed value through chain", async () => {
+  const double = async (_ctx: unknown, x: number) => success(x * 2);
+  const isFour = async (_ctx: unknown, x: number) =>
+    x === 4 ? success(x) : failure("not 4");
+  const r = await __validateChain(2, z.number(), [double, isFour], ctx);
+  expect(isSuccess(r)).toBe(true);
+});
+
+it("returns Zod failure when structural parse fails", async () => {
+  const r = await __validateChain("nope", z.number(), [], ctx);
+  expect(isFailure(r)).toBe(true);
+});
+
+it("skips validators on null branch of a union", async () => {
+  // delegated to recursion walker — see next task
+});
+```
+
+- [ ] **Step 2: Run, watch fail**
+
+```
+pnpm test:run lib/runtime/validateChain 2>&1 | tee /tmp/task9-fail.log
+```
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// lib/runtime/validateChain.ts
+import { z } from "zod";
+import { success, failure, isFailure, isSuccess } from "./result.js";
+import type { ResultValue } from "./result.js";
+
+export type AgencyValidator = (
+  ctx: unknown,
+  value: unknown,
+) => Promise<ResultValue>;
+
+export async function __validateChain(
+  value: unknown,
+  schema: z.ZodType,
+  validators: AgencyValidator[],
+  ctx: unknown,
+): Promise<ResultValue> {
+  if (isFailure(value)) return value as ResultValue;
+  const zr = schema.safeParse(value);
+  if (!zr.success) return failure(zr.error.message);
+
+  let current: ResultValue = success(zr.data);
+  for (const v of validators) {
+    if (!isSuccess(current)) return current;
+    current = await v(ctx, (current as { value: unknown }).value);
+  }
+  return current;
+}
+```
+
+- [ ] **Step 4: Pass tests**
+
+```
+pnpm test:run lib/runtime/validateChain 2>&1 | tee /tmp/task9-pass.log
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/validateChain.ts lib/runtime/validateChain.test.ts
+git commit -m "feat(runtime): __validateChain — async validator chain after Zod parse"
+```
+
+---
+
+## Task 10: Recursion-walking helper for nested types
+
+**Files:**
+- Modify: `lib/runtime/validateChain.ts`
+- Modify: `lib/runtime/validateChain.test.ts`
+
+The walker traverses a value alongside a structural descriptor (built by the builder at codegen time) and runs the right validator chain at each depth. The structural descriptor mirrors the resolved type tree, carrying per-position validator lists. Depth-cap default 64.
+
+- [ ] **Step 1: Decide descriptor shape**
+
+A `TypeValidationDescriptor` is one of:
+
+```typescript
+type TypeValidationDescriptor =
+  | { kind: "leaf"; schema: z.ZodType; validators: AgencyValidator[] }
+  | { kind: "object"; schema: z.ZodType; validators: AgencyValidator[];
+      properties: Record<string, TypeValidationDescriptor> }
+  | { kind: "array"; schema: z.ZodType; validators: AgencyValidator[];
+      element: TypeValidationDescriptor }
+  | { kind: "union"; schema: z.ZodType; validators: AgencyValidator[];
+      branches: Array<{ test: (v: unknown) => boolean; descriptor: TypeValidationDescriptor }> }
+  | { kind: "nullable"; schema: z.ZodType; validators: AgencyValidator[];
+      inner: TypeValidationDescriptor };
+```
+
+- [ ] **Step 2: Failing walker tests**
+
+```typescript
+it("runs per-element validators across an array", async () => { ... });
+it("recurses into object properties", async () => { ... });
+it("dispatches union to matching branch only", async () => { ... });
+it("skips inner validators on null/undefined branch", async () => { ... });
+it("enforces depth limit", async () => {
+  const r = await __validateChainRecursive(deepNested, descriptor, ctx, { maxDepth: 3 });
+  expect(isFailure(r)).toBe(true);
+  expect((r as any).reason).toMatch(/recursion depth/);
+});
+```
+
+- [ ] **Step 3: Implement**
+
+Add `__validateChainRecursive(value, descriptor, ctx, opts?)` that walks `descriptor` and `value` in lockstep, calling `__validateChain` at each node for `descriptor.validators`, then recursing for arrays / objects / unions. Track `depth` and bail with `failure("validation recursion depth exceeded")` past `opts.maxDepth ?? 64`.
+
+- [ ] **Step 4: Pass tests**
+
+```
+pnpm test:run lib/runtime/validateChain 2>&1 | tee /tmp/task10.log
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/validateChain.ts lib/runtime/validateChain.test.ts
+git commit -m "feat(runtime): recursion walker for nested type validation"
+```
+
+---
+
+## Task 11: Builder emits `__validateChain` / `__validateChainRecursive` for `!` sites
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder.ts` (2 emit sites: function-param/return validation at line ~2130, assignment at ~2230)
+- Modify: `lib/ir/builders.ts` (`__validateType` builder at line 401)
+- Modify: `lib/backends/typescriptBuilder/pipeChainEmitter.ts` (pipe-return wrapper)
+
+The decision rule:
+
+- If the resolved type has **no** `@validate` tags anywhere (root or nested), emit the existing `__validateType(value, schema)` — zero behaviour change.
+- Otherwise, build a `TypeValidationDescriptor` from the resolved type tree at codegen time and emit `await __validateChainRecursive(value, <descriptor>, __ctx)`.
+
+The descriptor literal is a TypeScript expression — same machinery used to emit the Zod schema, with extra fields for the validator list. Use the IR builders to construct it.
+
+- [ ] **Step 1: Failing integration test**
+
+Add `tests/agency/types/validate-annotation.agency`:
+
+```
+import { isEmail } from "std::validators"
+
+@validate(isEmail)
+type Email = string
+
+def main() {
+  let bad: Email! = "not-an-email"
+  print(bad)
+}
+```
+
+(Without `std::validators` ready yet, inline a local `def isEmail(...) {...}` for this first test.) Assert the run produces a validation failure, not a success.
+
+- [ ] **Step 2: Run, watch fail**
+
+```
+pnpm run agency test tests/agency/types/validate-annotation.agency 2>&1 | tee /tmp/task11-fail.log
+```
+
+- [ ] **Step 3: Plumb tag detection**
+
+At each `!` emit site, walk the resolved type to check if any node carries `@validate`. Helper:
+
+```typescript
+function hasAnyValidateTag(t: VariableType): boolean {
+  if (t.tags?.some((tag) => tag.name === "validate")) return true;
+  switch (t.type) {
+    case "arrayType": return hasAnyValidateTag(t.elementType);
+    case "objectType": return t.properties.some((p) =>
+      p.tags?.some((tag) => tag.name === "validate") || hasAnyValidateTag(p.value));
+    case "unionType": return t.types.some(hasAnyValidateTag);
+    // ... etc, mirroring substituteTypeParams enumeration
+    default: return false;
+  }
+}
+```
+
+- [ ] **Step 4: Emit the descriptor**
+
+A new function `buildValidationDescriptor(type: VariableType): TsExpression` that mirrors `typeToZodSchema` but emits the descriptor object instead. Reuse the existing schema-emit code for the `schema` field of each descriptor node.
+
+Tag arguments inside `@validate(...)` are printed as raw expressions (function references / function-call factories). The resulting validator list expression looks like `[isEmail, min(0), max(150)]`.
+
+- [ ] **Step 5: Replace `__validateType` call at each emit site**
+
+For each site found earlier:
+
+```typescript
+// before
+__validateType(value, ZodSchema)
+
+// after
+hasAnyValidateTag(resolvedType)
+  ? `await __validateChainRecursive(${value}, ${descriptorExpr}, __ctx)`
+  : `__validateType(${value}, ${zodSchemaExpr})`
+```
+
+The expression is now async — propagate the `await` to the surrounding emitted function. All `!` sites should already be inside async-generated functions (Agency functions compile to async), but verify.
+
+- [ ] **Step 6: Pass tests**
+
+```
+pnpm test:run 2>&1 | tee /tmp/task11-pass.log
+pnpm run agency test tests/agency/types/validate-annotation.agency 2>&1 | tee /tmp/task11-int.log
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/backends/ lib/ir/ tests/agency/types/
+git commit -m "feat(codegen): wire __validateChain into !-validated emit sites"
+```
+
+---
+
+## Task 12: Stdlib — `std::validators`
+
+**Files:**
+- Create: `stdlib/validators.agency`
+- Create: `stdlib/validators.js`
+
+- [ ] **Step 1: Write the Agency surface**
+
+```
+// stdlib/validators.agency
+import { Result } from "agency"
+
+export def isEmail(x: string): Result { ... }
+export def isUrl(x: string): Result { ... }
+export def isUuid(x: string): Result { ... }
+export def isInt(x: number): Result { ... }
+export def isPositive(x: number): Result { ... }
+export def isNegative(x: number): Result { ... }
+export def min(n: number): function { ... }
+export def max(n: number): function { ... }
+export def minLength(n: number): function { ... }
+export def maxLength(n: number): function { ... }
+export def matches(re: string): function { ... }
+```
+
+Match the existing stdlib style (cross-reference `stdlib/email.agency` and `stdlib/math.agency` for conventions).
+
+- [ ] **Step 2: Write the JS implementations**
+
+```javascript
+// stdlib/validators.js
+// Each function is async (Agency surface) and returns success(value) or failure(reason).
+export async function isEmail(_ctx, x) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(x)
+    ? { kind: "success", value: x }
+    : { kind: "failure", reason: `not a valid email: ${x}` };
+}
+// ... etc
+```
+
+(Use the canonical `success` / `failure` helpers from `lib/runtime/result.js` so shapes match exactly.)
+
+- [ ] **Step 3: Build**
+
+```
+make 2>&1 | tee /tmp/task12-make.log
+```
+
+Per CLAUDE.md: `make` is required after stdlib changes.
+
+- [ ] **Step 4: Write integration tests**
+
+`tests/agency/stdlib/validators.agency` — one assertion per validator, exercising both success and failure paths.
+
+- [ ] **Step 5: Run**
+
+```
+pnpm run agency test tests/agency/stdlib/validators.agency 2>&1 | tee /tmp/task12-test.log
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add stdlib/validators.agency stdlib/validators.js tests/agency/stdlib/validators.agency
+git commit -m "feat(stdlib): add std::validators module"
+```
+
+---
+
+## Task 13: Stdlib — `std::schemas`
+
+**Files:**
+- Create: `stdlib/schemas.agency`
+- Create: `stdlib/schemas.js`
+
+Format helpers only (per spec — trivial 1:1 helpers were dropped).
+
+- [ ] **Step 1: Author**
+
+```
+// stdlib/schemas.agency
+export const emailFormat = { format: "email" }
+export const urlFormat = { format: "uri" }
+export const uuidFormat = { format: "uuid" }
+export const dateTimeFormat = { format: "date-time" }
+export const dateFormat = { format: "date" }
+export const ipv4Format = { format: "ipv4" }
+export const ipv6Format = { format: "ipv6" }
+```
+
+```javascript
+// stdlib/schemas.js
+export const emailFormat = { format: "email" };
+// ... etc
+```
+
+- [ ] **Step 2: Build**
+
+```
+make 2>&1 | tee /tmp/task13-make.log
+```
+
+- [ ] **Step 3: Smoke-test import + use in `@jsonSchema`**
+
+`tests/agency/stdlib/schemas.agency` imports the helpers and uses them in `@jsonSchema({ ...emailFormat })`; assert the generated TS contains `.meta({ format: "email" })`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add stdlib/schemas.agency stdlib/schemas.js tests/agency/stdlib/schemas.agency
+git commit -m "feat(stdlib): add std::schemas module"
+```
+
+---
+
+## Task 14: Stdlib — `std::types` (pre-baked validated aliases)
+
+**Files:**
+- Create: `stdlib/types.agency`
+- Create: `stdlib/types.js`
+
+- [ ] **Step 1: Author**
+
+```
+// stdlib/types.agency
+import { isEmail, isUrl, isUuid } from "std::validators"
+import { emailFormat, urlFormat, uuidFormat } from "std::schemas"
+
+@validate(isEmail)
+@jsonSchema({ ...emailFormat })
+export type Email = string
+
+@validate(isUrl)
+@jsonSchema({ ...urlFormat })
+export type Url = string
+
+@validate(isUuid)
+@jsonSchema({ ...uuidFormat })
+export type Uuid = string
+```
+
+The `.js` companion may be empty (pure type re-exports).
+
+- [ ] **Step 2: Build**
+
+```
+make 2>&1 | tee /tmp/task14-make.log
+```
+
+- [ ] **Step 3: Integration test**
+
+`tests/agency/stdlib/types.agency`:
+
+```
+import { Email } from "std::types"
+
+def main() {
+  let bad: Email! = "not-email"
+  print(bad)
+}
+```
+
+Assert run produces a validation failure.
+
+- [ ] **Step 4: Run**
+
+```
+pnpm run agency test tests/agency/stdlib/types.agency 2>&1 | tee /tmp/task14-test.log
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add stdlib/types.agency stdlib/types.js tests/agency/stdlib/types.agency
+git commit -m "feat(stdlib): add std::types with pre-baked Email/Url/Uuid"
+```
+
+---
+
+## Task 15: Round-trip tags through `agencyGenerator`
+
+**Files:**
+- Modify: `lib/backends/agencyGenerator.ts`
+- Modify: `lib/utils/formatType.ts` if it emits aliases/properties
+
+`pnpm run fmt foo.agency` must re-emit `@validate(...)` and `@jsonSchema(...)` annotations above the alias/property they belong to. Without this, the formatter silently drops them.
+
+- [ ] **Step 1: Failing test**
+
+`tests/agencyGenerator/tags.test.ts`:
+
+```typescript
+it("round-trips @validate on a type alias", () => {
+  const src = '@validate(isEmail)\ntype Email = string';
+  const ast = parse(src);
+  const out = generate(ast);
+  expect(out).toContain("@validate(isEmail)");
+  expect(out).toContain("type Email = string");
+});
+
+it("round-trips @jsonSchema and @validate on a property", () => { ... });
+```
+
+- [ ] **Step 2: Run, watch fail**
+
+```
+pnpm test:run tests/agencyGenerator 2>&1 | tee /tmp/task15-fail.log
+```
+
+- [ ] **Step 3: Emit tag prefix in alias and property emitters**
+
+In `lib/backends/agencyGenerator.ts`, find the alias-emission and property-emission functions, and emit a `tagToString(tag)` line before each, where `tagToString` uses the existing expression printer for the arguments.
+
+- [ ] **Step 4: Pass tests**
+
+```
+pnpm test:run tests/agencyGenerator 2>&1 | tee /tmp/task15-pass.log
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/backends/agencyGenerator.ts lib/utils/formatType.ts tests/agencyGenerator/tags.test.ts
+git commit -m "feat(generator): round-trip @validate/@jsonSchema tags"
+```
+
+---
+
+## Task 16: End-to-end test matrix
+
+**Files:**
+- Create: `tests/agency/types/annotations/` directory
+
+Per spec, exercise every behaviour with one Agency test each. None of these tests requires an LLM call (per CLAUDE.md guidance on `tests/agency/`).
+
+- [ ] **Step 1: Author**
+
+For each, follow the pattern in `tests/agency/types/`. Tests:
+
+| File | Scenario |
+|------|----------|
+| `validate-alias-passes.agency` | `@validate` on alias, `!` validation succeeds for valid input |
+| `validate-alias-fails.agency` | Same, fails for invalid input with the expected `failure` reason |
+| `validate-property.agency` | `@validate` on a single property of an object type |
+| `validate-multiple-fns.agency` | `@validate(a, b, c)` runs in order, transform threads through |
+| `validate-short-circuits.agency` | First failure stops the chain; later validators don't run |
+| `validate-merges-alias-and-property.agency` | Alias `@validate(a)` + property `@validate(b)` = `[a, b]` |
+| `validate-nested-array.agency` | Per-element validation across an array |
+| `validate-nested-object.agency` | Validation recurses into nested objects |
+| `validate-union-branch.agency` | Only matching union branch's validators run |
+| `validate-nullable-skips.agency` | `null` / `undefined` skips inner validators |
+| `validate-recursion-cap.agency` | Pathological deep input fails with depth-exceeded |
+| `jsonschema-on-alias.agency` | `.meta()` appears in generated TS |
+| `jsonschema-merge.agency` | Property `@jsonSchema` overrides alias's same keys, inherits unset |
+| `validate-only-runs-with-bang.agency` | Without `!`, validators do NOT run |
+| `validate-generic-instantiation.agency` | `@validate(nonEmpty) type NonEmptyArray<T> = T[]` validates outer at every instantiation |
+
+- [ ] **Step 2: Run them all and save**
+
+```
+pnpm test:run tests/agency/types/annotations 2>&1 | tee /tmp/task16-tests.log
+```
+
+Per CLAUDE.md: save the output to a file so you don't have to re-run if any fail.
+
+- [ ] **Step 3: Triage failures**
+
+For any failing test, attribute to one of the earlier tasks and patch there, not in the test. (The tests should pass as a consequence of correct code, not by adjusting expectations.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/agency/types/annotations/
+git commit -m "test: end-to-end coverage for @validate and @jsonSchema annotations"
+```
+
+---
+
+## Task 17: User-facing docs
+
+**Files:**
+- Create: `docs/site/guide/annotations.md`
+- Modify: `docs/site/guide/types.md` — cross-link to the new doc
+- Modify: `docs/site/.vitepress/config.mts` — add the new page to nav
+
+- [ ] **Step 1: Write `annotations.md`**
+
+Cover, in this order:
+
+1. The two annotations (`@validate`, `@jsonSchema`).
+2. When validation runs (only with `!`, link to the schemas page).
+3. Stdlib quick reference: `std::validators`, `std::schemas`, `std::types`.
+4. Merge / override rules with a worked example.
+5. Behaviour on nested types, unions, nullables, and recursion.
+6. The "supported JSON Schema keywords" reference table (numeric / length / array constraints + link to the JSON Schema spec).
+7. Restrictions on `@jsonSchema` argument expressions (and why).
+
+- [ ] **Step 2: Wire into nav**
+
+In [docs/site/.vitepress/config.mts](file:///Users/adityabhargava/agency-lang/packages/agency-lang/docs/site/.vitepress/config.mts), add an entry for the new page under the Guide section.
+
+- [ ] **Step 3: Cross-link from `types.md`**
+
+Add a short "Validation and JSON Schema annotations → [annotations.md](annotations.md)" callout in the appropriate section of `types.md`.
+
+- [ ] **Step 4: Build the docs locally**
+
+If `docs:dev` is wired:
+
+```
+pnpm --filter agency-lang docs:dev   # or whatever the script is
+```
+
+Visually confirm the new page renders and links resolve. (No automated test; eyeball.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/site/guide/annotations.md docs/site/guide/types.md docs/site/.vitepress/config.mts
+git commit -m "docs: add annotations guide for @validate and @jsonSchema"
+```
+
+---
+
+## Task 18: Run the structural linter + full validation pass
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Structural linter**
+
+```
+pnpm run lint:structure 2>&1 | tee /tmp/lint.log
+```
+
+Expected: clean. Fix any flagged patterns introduced by this work.
+
+- [ ] **Step 2: Full test suite**
+
+```
+pnpm test:run 2>&1 | tee /tmp/full-tests.log
+```
+
+Expected: all green. Per CLAUDE.md, save output to file — do not re-run blindly if anything fails.
+
+- [ ] **Step 3: Fixtures refresh**
+
+```
+make fixtures 2>&1 | tee /tmp/fixtures.log
+git diff tests/typescriptGenerator/fixtures | wc -l
+```
+
+Confirm fixture diffs are bounded to what this work changed (`.meta(...)` additions where `@jsonSchema` appears, async wrappers at new `!` sites where `@validate` appears). No drive-by changes.
+
+- [ ] **Step 4: Build**
+
+```
+make 2>&1 | tee /tmp/make.log
+```
+
+- [ ] **Step 5: Commit any fixture updates**
+
+```bash
+git add tests/typescriptGenerator/fixtures
+git commit -m "test: refresh fixtures for annotation codegen"
+```
+
+---
+
+## Fast-Follow PR (separate from this plan)
+
+After this plan lands and is exercised in the wild for at least one merge cycle:
+
+1. Codemod every `# description` in `lib/`, `stdlib/`, `examples/`, `tests/`, `docs/` to `@jsonSchema({ description: "..." })`.
+2. Remove `objectPropertyDescriptionParser` and `objectPropertyWithDescriptionParser` from `lib/parsers/parsers.ts`.
+3. Remove the `description?: string` field from `ObjectProperty` in `lib/types/typeHints.ts`.
+4. Remove the `.describe("...")` codegen path in `lib/backends/typescriptGenerator/typeToZodSchema.ts`.
+5. During the brief overlap window (after this plan, before the fast follow): mixing `# description` and `@jsonSchema({description: ...})` on the same property is a parse-time error.
+
+This is a separate plan document and a separate PR; do not bundle.
+
+---
+
+## Plan Review Loop
+
+Once this plan is saved, the next step (per the writing-plans skill) is to dispatch a single plan-document-reviewer subagent with the plan + spec as inputs, iterate to "✅ Approved", and then choose an execution mode (subagent-driven recommended).

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-20-validation-annotations-followups-impl.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-20-validation-annotations-followups-impl.md
@@ -1,0 +1,286 @@
+# Validation & JSON Schema Annotations — Follow-up Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish the deferred work from the `@validate` / `@jsonSchema` PR (PR #174). The core feature is shipped; this plan covers the user-facing guide page, parameterized validators, the missing-coverage agency tests (union members, generics, `Result` success type, recursive types), VitePress sidebar wiring, and the explicit "fast-follow" items deferred from the original spec.
+
+**Architecture:** Each track is independent and can land as its own PR; nothing here changes the AST or the codegen contracts established in PR #174. The parameterized-validator track is the only one that touches the type system — it introduces a value-parameter form of `@validate(...)`.
+
+**Tech Stack:** tarsec parsers, vitest, structural linter, Zod 4 `.meta()`, the existing `__validateChain` / `__validateChainRecursive` runtime helpers.
+
+**Spec:** `docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md` (the original)
+**Predecessor plan:** `docs/superpowers/plans/2026-05-19-type-validation-and-json-schema-annotations-impl.md`
+
+---
+
+## Key Risks and Gotchas
+
+1. **`__agency_descriptor` is the only path from an alias's module-local validators to a downstream consumer.** Any new test fixture or feature that emits Zod schemas for `@validate`-tagged aliases must preserve the `(Alias as any).__agency_descriptor = ...` assignment. See [`docs/dev/validation-annotations.md`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/docs/dev/validation-annotations.md) for the contract.
+
+2. **`hasAnyValidateTag` is the codegen gate.** Adding new wrapper types (alongside `arrayType`, `objectType`, `unionType`, `nullable`) requires extending [`hasAnyValidateTag`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts) or `@validate` will silently disappear at the new shape. The generics track in particular needs to verify that `genericType` already routes correctly.
+
+3. **`.meta()` must be the last call in the Zod chain.** When the user-facing guide writes example code, it must NOT recommend chaining anything after a `.meta(...)`. The implementation already enforces this in [`appendMeta`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts).
+
+4. **Parameterized validators change the tag-arg shape.** Today `@validate(isEmail)` accepts only identifiers and bare function references. Adding `@validate(maxLength(80))` keeps the existing parser (function calls are already in the restricted-expression subset), but the runtime must understand that `maxLength(80)` evaluates to a fresh validator function at module-load time. No new AST changes — `tagArgToTs` already prints the call form.
+
+5. **Recursive validator descriptors hit the depth cap.** The default is 64. Tests for recursive types must either stay shallow or set `maxDepth` via the runtime opts. They must NOT assert "validation runs to completion on a 200-deep tree" without raising the cap.
+
+6. **`Result<T>` success-type meta currently routes via `resultHandler`.** The validation-schema path returns the full `Result` shape; the LLM-structured-output path returns just `T`. `@jsonSchema` on a `Result<Foo>` only attaches to the success-type schema in the LLM path. Tests must use the LLM path or `Foo` directly to verify the metadata.
+
+7. **VitePress sidebar config is `docs/site/.vitepress/config.mts`.** Adding the new guide page requires editing the `sidebar` array in that file.
+
+8. **The "fast-follow #11" item from the spec discussion is `# description` removal.** The original plan called this out as a separate fast-follow PR. Re-evaluate before doing this: shipping the annotation system without removing `# description` is fine; mixing the two on a single property is already a documented error.
+
+---
+
+## File Structure
+
+**New files:**
+
+| File | Purpose |
+|------|---------|
+| `docs/site/guide/annotations.md` | User-facing guide for `@validate(...)` / `@jsonSchema(...)`, the stdlib modules, and best practices |
+| `tests/agency/validation/validateOnUnionMembers.{agency,test.json}` | Validator on each member of a union type |
+| `tests/agency/validation/validateOnGeneric.{agency,test.json}` | `@validate`-tagged alias used as a type argument to a generic |
+| `tests/agency/validation/jsonSchemaOnResultSuccess.{agency,test.json}` | `@jsonSchema` on the success type of `Result<...>` |
+| `tests/agency/validation/validateRecursiveTypeShallow.{agency,test.json}` | `@validate` on a small recursive type, exercising the descriptor walker without hitting the depth cap |
+| `stdlib/validators.agency` (extended) | Add parameterized validators: `min`, `max`, `minLength`, `maxLength`, `matches` |
+| `tests/agency/validation/validateParameterized.{agency,test.json}` | End-to-end test for parameterized validators |
+| `lib/stdlib/validators.ts` (extended) | JS-backed implementations for the new parameterized validators |
+
+**Files modified:**
+
+| File | Purpose in this plan |
+|------|----------------------|
+| `docs/site/.vitepress/config.mts` | Register the new annotations guide page in the sidebar; add a link to `docs/dev/validation-annotations.md` if the site exposes dev docs |
+| `stdlib/validators.agency` | New `min(n) / max(n) / minLength(n) / maxLength(n) / matches(re)` validator factories |
+| `lib/stdlib/validators.ts` | Plain-JS implementations of the same factories returning validator closures |
+| `docs/dev/validation-annotations.md` | Update the "user-facing material" pointer once `annotations.md` exists; mention parameterized validators in "Validator dispatch" |
+| `stdlib/validators.agency` module doc | Replace the temporary `schemas.md` link with the new `annotations.md` once written |
+
+---
+
+## Track A — User-facing guide page
+
+### A1. Write `docs/site/guide/annotations.md`
+
+- [ ] Draft a guide page covering:
+  - What `@validate(...)` and `@jsonSchema(...)` do, with a side-by-side example.
+  - When validators run (only at `!` sites — link to `schemas.md`).
+  - The "tags propagate through alias references" rule, with a 5-line example.
+  - The merge rules for alias-then-use-site combinations.
+  - Cross-link to `std::validators`, `std::schemas`, `std::types` (with import examples).
+  - A "writing your own validator" section that shows both an Agency `def` validator and a plain JS validator (with `success` / `failure` imported from `agency-lang/runtime`). Reference [`tests/agency/validation/validatePlainJsFunction.agency`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/tests/agency/validation/validatePlainJsFunction.agency) as the canonical example.
+  - A "writing your own JSON Schema fragment" section that shows the `export static const fooFormat = { format: "foo" }` + `@jsonSchema({ ...fooFormat })` pattern.
+  - A short paragraph on what `@jsonSchema` does for structured-output LLM calls.
+- [ ] Verify every code example compiles by copy-pasting into a scratch `.agency` file and running `pnpm run agency compile`.
+
+### A2. Register the page in VitePress
+
+- [ ] Edit `docs/site/.vitepress/config.mts` to add `annotations.md` to the sidebar under the section that contains `schemas.md` (probably "Types & Validation" or similar).
+- [ ] Run `pnpm --filter @agency-lang/docs run docs:build` (or whatever the docs build command is — check `package.json`) and verify the page renders without broken links.
+
+### A3. Replace the temporary `schemas.md` pointer
+
+- [ ] In [`stdlib/validators.agency`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/stdlib/validators.agency) module doc, swap the `../guide/schemas.md` link for `../guide/annotations.md`.
+- [ ] In [`docs/dev/validation-annotations.md`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/docs/dev/validation-annotations.md) update the "user-facing material" pointer (intro paragraph) to reference `annotations.md` as the primary.
+- [ ] Re-run `make` so the regenerated stdlib docs in `docs/site/stdlib/validators.md` pick up the new link.
+
+---
+
+## Track B — Missing-coverage agency tests
+
+Each test follows the existing pattern: `.agency` + `.test.json` in `tests/agency/validation/`. The `.test.json` uses `expectedOutput` with `"evaluationCriteria": [{ "type": "exact" }]`.
+
+### B1. `validateOnUnionMembers`
+
+- [ ] Write the agency file:
+  ```agency
+  @validate(isEmail)
+  type Email = string
+
+  @validate(isUrl)
+  type URL = string
+
+  type Contact = Email | URL
+
+  node main() {
+    const e: Contact! = "user@example.com"
+    const u: Contact! = "https://example.com"
+    const bad: Contact! = "neither"
+    // assert success(e), success(u), failure(bad)
+  }
+  ```
+- [ ] Confirm the descriptor's `union` branch dispatches to the matching member's validators.
+- [ ] Run: `pnpm run agency test tests/agency/validation/validateOnUnionMembers.agency -p 1`.
+
+### B2. `validateOnGeneric`
+
+- [ ] Write a small generic alias whose type argument carries `@validate`:
+  ```agency
+  @validate(isEven)
+  type Even = number
+
+  type Box<T> = { item: T }
+
+  node main() {
+    const ok: Box<Even>! = { item: 4 }
+    const bad: Box<Even>! = { item: 3 }
+  }
+  ```
+- [ ] Verify the validator runs on `item`. If it does NOT run, suspect `resolveTypeDeep` is dropping tags on the substituted type argument — extend `hasAnyValidateTag`'s `genericType` branch and the descriptor walker accordingly.
+- [ ] Add the test under `tests/agency/validation/`.
+
+### B3. `jsonSchemaOnResultSuccess`
+
+- [ ] Write a test that builds the JSON Schema of a `Result<Email>` and asserts the success-type metadata propagates:
+  ```agency
+  @jsonSchema({ format: "email" })
+  type Email = string
+
+  type LookupResult = Result<Email>
+
+  node main() {
+    const s = schema(Email)   // simpler — direct alias
+    const js = s.toJSONSchema()
+    return js.format
+  }
+  ```
+- [ ] If the user wants the *Result-shaped* path verified, route through the LLM structured-output schema map (see `mapTypeToZodSchema`'s `resultHandler`). That's likely a separate test using a contrived smoltalk call shim.
+
+### B4. `validateRecursiveTypeShallow`
+
+- [ ] Write a small recursive type that validates two levels deep:
+  ```agency
+  @validate(nonEmpty)
+  type Node = {
+    name: string,
+    children: Node[]
+  }
+  ```
+- [ ] Use `maxDepth` if the default 64 is uncomfortably close to the data shape, but for this test, a 3-deep value is fine.
+- [ ] Assert success / failure based on `children` shape.
+
+### B5. Run the full validation suite
+
+- [ ] `pnpm run agency test tests/agency/validation -p 12` should report 55+/55+ passing.
+- [ ] If any test fails, do not weaken the assertion — debug per the systematic-debugging skill.
+
+---
+
+## Track C — Parameterized validators
+
+This adds factory-style validators to `std::validators` so users can write `@validate(maxLength(80))` instead of inventing a new alias for every threshold.
+
+### C1. Add factory validators to `lib/stdlib/validators.ts`
+
+- [ ] Implement these as factory functions that return a validator closure:
+  ```ts
+  export function _min(n: number) {
+    return (value: number): ResultValue =>
+      value >= n ? success(value) : failure(`expected >= ${n}, got ${value}`);
+  }
+  export function _max(n: number) { /* ... */ }
+  export function _minLength(n: number) { /* ... */ }
+  export function _maxLength(n: number) { /* ... */ }
+  export function _matches(pattern: string | RegExp) { /* ... */ }
+  ```
+- [ ] Each factory returns a function matching the `AgencyValidator` plain-function contract (`(value) => Result`).
+- [ ] Add unit tests in `lib/stdlib/__tests__/validators.test.ts` (create if it doesn't exist).
+
+### C2. Expose them from `stdlib/validators.agency`
+
+- [ ] Add the corresponding agency-level wrappers:
+  ```agency
+  export def min(n: number): (any) => Result {
+    return _min(n)
+  }
+  // ... etc
+  ```
+- [ ] Run `make` to regenerate `stdlib/validators.js`.
+
+### C3. End-to-end test
+
+- [ ] Write `tests/agency/validation/validateParameterized.agency`:
+  ```agency
+  import { maxLength } from "std::validators"
+
+  @validate(maxLength(5))
+  type ShortName = string
+
+  node main() {
+    const ok: ShortName! = "abc"
+    const bad: ShortName! = "abcdefghij"
+    // success(ok), failure(bad)
+  }
+  ```
+- [ ] **Verify codegen** — `pnpm run compile tests/agency/validation/validateParameterized.agency` and inspect the emitted `__agency_descriptor` to confirm `maxLength(5)` is called once at module load (not on every validation).
+
+### C4. Update guide
+
+- [ ] Add a "Parameterized validators" section to `docs/site/guide/annotations.md` with the call-site example and a note that factories run once at module load.
+
+---
+
+## Track D — VitePress sidebar wiring
+
+### D1. Sidebar entry for the new dev doc
+
+- [ ] If `docs/site/.vitepress/config.mts` exposes dev docs in any sidebar, add an entry for `docs/dev/validation-annotations.md`. Otherwise this is a no-op (dev docs are reached via the repo, not the published site).
+
+### D2. Sidebar entry for the new guide
+
+- [ ] (Covered in A2.)
+
+---
+
+## Track E — Fast-follow #11 from the spec
+
+The deferred item was the removal of the legacy property-level `# description` syntax in favor of `@jsonSchema({ description: ... })`. This is its own PR. The plan:
+
+### E1. Decide
+
+- [ ] Confirm with the owner whether `# description` should be removed at all. The annotation system co-exists with it today and the `.meta` / `.describe` ordering bug is already fixed. Removal is purely a consolidation play.
+
+### E2. If go: codemod
+
+- [ ] Write a small node script that walks every `.agency` file under `stdlib/`, `tests/`, `examples/` and converts `prop: T # desc` into `@jsonSchema({ description: "desc" }) prop: T`.
+- [ ] Remove the `# description` branch from the parser ([`parsers.ts:884-920`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/parsers/parsers.ts#L884-L920) area).
+- [ ] Remove the `.describe(...)` emission from [`typeToZodSchema.ts`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts) (since metadata now flows via `.meta`).
+- [ ] Update the agency generator's property emitter so it does NOT round-trip the description as `# ...` (already covered by the AST change, but verify).
+
+### E3. If no-go
+
+- [ ] Add a section to `docs/site/guide/annotations.md` explaining that `# desc` is still supported on properties but `@jsonSchema({ description: ... })` is preferred for richer metadata.
+
+---
+
+## Validation checklist for each track
+
+Run after **each** track lands:
+
+- [ ] `pnpm exec tsc --noEmit`
+- [ ] `pnpm run lint:structure`
+- [ ] `pnpm test:run`
+- [ ] `pnpm run agency test tests/agency/validation -p 12`
+- [ ] (if stdlib changed) `make`
+- [ ] (if docs changed) regenerate `docs/site/stdlib/` via `make` and verify no dead links
+
+---
+
+## Suggested PR ordering
+
+1. **Track A** (user-facing guide) — small, no code risk. Lands first to unblock the link in `stdlib/validators.agency`.
+2. **Track B** (coverage tests) — pure additions; safe to land alone.
+3. **Track C** (parameterized validators) — feature work, depends on Track A's guide format being settled.
+4. **Track D** — fold into A.
+5. **Track E** — separate PR after the owner decides go / no-go.
+
+---
+
+## Out of scope
+
+- Anything that requires AST changes beyond what shipped in PR #174.
+- New validation kinds (e.g. `@validate(...)` on a free-standing `const`, on a function parameter type without `!`).
+- Editor / LSP improvements for annotation hover / autocomplete.
+- Migrating downstream consumers off `__agency_descriptor` to a more structured channel — the current side-channel is documented and stable.

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md
@@ -1,0 +1,603 @@
+# Type Validation & JSON Schema Annotations
+
+## Problem
+
+Agency compiles types to Zod schemas which become JSON schemas sent to LLMs for structured output and tool calling. Currently, users have no way to:
+
+1. Add validation constraints to types (e.g., "this number must be positive", "this string must be an email")
+2. Control what JSON Schema properties the LLM sees for a given field (e.g., `minimum`, `format`, `pattern`)
+
+The existing `# description` syntax on type properties is limited to descriptions and has no path to richer metadata.
+
+## Design
+
+### Core Insight: Two Separate Concerns
+
+Validation and LLM schema hints are distinct:
+
+- **Validation** is runtime, imperative, and lives in value space. It checks that a value meets constraints after it's been produced.
+- **JSON Schema hints** are declarative metadata in type space. They guide the LLM toward producing correct values in the first place.
+
+These two concerns have different mechanisms, different enforcement models (hard runtime checks vs best-effort LLM guidance), and should have separate syntax.
+
+### Two Annotations
+
+#### `@validate(fn1, fn2, ...)`
+
+Attaches one or more Agency functions as runtime validators.
+
+- Each validator is a regular Agency `def` function that takes a value and returns a `Result`. Return `success(value)` if valid, `failure("reason")` if not.
+- **Validators may transform values.** The value returned in `success(value)` becomes the input to the next validator in the chain, and the final value is what the caller observes. This enables coercion (e.g. trimming whitespace, normalizing case) in addition to pure validation. If a validator does not need to transform, it returns `success(x)` with the same value it received.
+- Multiple validators can be passed as separate arguments. They run in order on the chained value; the first failure short-circuits.
+- Validators only run when the `!` bang syntax is used, consistent with Agency's existing schemas feature (https://agency-lang.com/guide/schemas.html). Keeping all validation behind `!` means users only have to learn one rule for when validation runs.
+- Allowed on **type aliases** and **type properties**.
+
+Example validator:
+
+```
+def isEven(x: number): Result {
+  if (x % 2 != 0) {
+    return failure("must be even, got ${x}")
+  }
+  return success(x)
+}
+```
+
+Usage:
+
+```
+@validate(isEven)
+type EvenNumber = number
+```
+
+#### `@jsonSchema({ ... })`
+
+Attaches arbitrary properties to the JSON Schema for this type or field.
+
+- Takes an object literal. The properties are passed through to Zod's `.meta()`, which copies them directly into the generated JSON Schema.
+- This is what the LLM sees in both structured output response formats and tool parameter schemas.
+- Replaces the `# description` syntax entirely. Descriptions are now specified as `@jsonSchema({ description: "..." })`.
+- Allowed on **type aliases** and **type properties**.
+
+Usage:
+
+```
+@jsonSchema({ format: "email", description: "user's work email" })
+type WorkEmail = string
+```
+
+### Standard Library
+
+To avoid name collisions between validators and JSON-Schema helpers (e.g. `minLength` could plausibly be either), the stdlib is split into two namespaced modules. The annotations themselves work without the stdlib; these modules ship in the same change so users have a usable surface from day one.
+
+#### `std::validators`
+
+Regular Agency functions returning `Result`. They run only under `!`.
+
+| Function | Description |
+|---|---|
+| `isEmail(x)` | Validates string is an email |
+| `isUrl(x)` | Validates string is a URL |
+| `isUuid(x)` | Validates string is a UUID |
+| `isInt(x)` | Validates number is an integer |
+| `isPositive(x)` | Validates number > 0 |
+| `isNegative(x)` | Validates number < 0 |
+| `min(n)` | Returns a validator that checks value >= n |
+| `max(n)` | Returns a validator that checks value <= n |
+| `minLength(n)` | Returns a validator that checks string length >= n |
+| `maxLength(n)` | Returns a validator that checks string length <= n |
+| `matches(regex)` | Returns a validator that checks string matches regex |
+
+Factory functions like `min(n)` return validator functions.
+
+#### `std::schemas`
+
+Helpers returning objects suitable for use in `@jsonSchema(...)`. Only complex / non-obvious helpers are exported — trivial 1:1 mappings like `{ minimum: 0 }` are simpler to write inline than to import a helper for, so we leave them out and instead link to the relevant JSON Schema documentation from the Agency guide.
+
+| Function | Returns |
+|---|---|
+| `emailFormat` | `{ format: "email" }` |
+| `urlFormat` | `{ format: "uri" }` |
+| `uuidFormat` | `{ format: "uuid" }` |
+| `dateTimeFormat` | `{ format: "date-time" }` |
+| `dateFormat` | `{ format: "date" }` |
+| `ipv4Format` | `{ format: "ipv4" }` |
+| `ipv6Format` | `{ format: "ipv6" }` |
+
+These are worth shipping because users typically don't remember the exact string keys for `format` (is it `"email"`, `"e-mail"`, `"uri"`, `"url"`?). For numeric / length / array constraints, the Agency guide will include a section documenting which JSON Schema keywords are supported and link to the JSON Schema spec, rather than wrapping each one in a helper.
+
+Users merge multiple helpers and inline properties with spread syntax (already supported in Agency object literals via `splatParser`): `{ ...emailFormat, description: "work email" }`.
+
+#### Pre-baked Validated Types
+
+To eliminate the repetitive `@validate(isEmail) @jsonSchema({ ...emailFormat })` pattern for the most common cases, the stdlib also ships ready-made validated type aliases. These bundle both annotations:
+
+```
+// Defined in std::types (sketch)
+@validate(isEmail)
+@jsonSchema({ ...emailFormat })
+type Email = string
+
+@validate(isUrl)
+@jsonSchema({ ...urlFormat })
+type Url = string
+
+@validate(isUuid)
+@jsonSchema({ ...uuidFormat })
+type Uuid = string
+```
+
+Users can then write:
+
+```
+import { Email, Url, Uuid } from "std::types"
+
+type User = {
+  email: Email
+  homepage: Url
+  id: Uuid
+}
+```
+
+The annotations on these aliases flow through to the property positions automatically (see "How Annotations Flow"). Parameterized validated types like `NumberInRange(0, 150)` require value-parameterized aliases and are deferred — see "Future Work".
+
+### Full Example
+
+```
+import { isEmail, min, max } from "std::validators"
+import { emailFormat } from "std::schemas"
+
+def isEven(x: number): Result {
+  if (x % 2 != 0) {
+    return failure("must be even")
+  }
+  return success(x)
+}
+
+@validate(min(1), max(100))
+@jsonSchema({ minimum: 1, maximum: 100, description: "a score from 1 to 100" })
+type Score = number
+
+type User = {
+  @validate(isEmail)
+  @jsonSchema({ ...emailFormat, description: "user's work email" })
+  email: string
+
+  @validate(min(0), max(150))
+  @jsonSchema({ minimum: 0, maximum: 150 })
+  age: number
+
+  @validate(isEven)
+  score: Score
+}
+
+def processUser(user: User!) {
+  // user has been validated: email is valid, age is 0-150, score is 1-100 and even
+  print(user)
+}
+```
+
+### Where Annotations Are Allowed
+
+- **Type aliases**: annotations go above the type declaration.
+- **Type properties**: annotations go above the property within the type body.
+- **NOT on function parameters**: if a user wants validated function parameters, they create a type alias with annotations and use it with `!`.
+
+### How Annotations Flow
+
+When a type alias has annotations and is used as a property type or function parameter type, the annotations flow through. In the example above, `score: Score` inherits the `@validate(min(1), max(100))` and `@jsonSchema(...)` from the `Score` type alias.
+
+Annotations also propagate across **module boundaries and re-exports**. When `type Email` is exported from `std::types` (with its `@validate(isEmail)` and `@jsonSchema(...)` attached), any module that imports `Email` — including modules that re-export it — sees the same annotations. The `TypeAliasEntry` carried by `ScopedTypeAliases` (introduced in the generics work) is widened to carry the alias's `tags` alongside the type parameters, so annotation metadata travels with the alias wherever it is resolved.
+
+#### Merge and Override Rules
+
+When a property has its own annotations AND its type alias has annotations:
+
+- **`@validate`**: validators from both levels are concatenated. Alias validators run first, then property validators.
+- **`@jsonSchema`**: property-level properties override alias-level properties for the same keys (last-writer-wins). Properties not overridden are inherited.
+
+Example:
+
+```
+@validate(isPositive)
+@jsonSchema({ minimum: 0, description: "a positive number" })
+type PositiveNumber = number
+
+type Scores = {
+  @validate(max(100))
+  @jsonSchema({ maximum: 100, description: "capped at 100" })
+  score: PositiveNumber
+}
+```
+
+For the `score` field:
+- Validators: `[isPositive, max(100)]` (alias first, then property)
+- JSON Schema: `{ minimum: 0, maximum: 100, description: "capped at 100" }` (property's `description` overrides alias's `description`; alias's `minimum` is inherited)
+
+### Validators on Nested and Composed Types
+
+When a validated type is used inside a container (e.g., an array or object), validators recurse into the type structure. For example:
+
+```
+@validate(isEmail)
+type Email = string
+
+type UserList = {
+  emails: Email[]
+}
+
+def process(users: UserList!) {
+  // isEmail runs on EACH element of the emails array
+}
+```
+
+When `!` triggers validation on `UserList`, the builder walks the type structure. For each property whose type (or type alias) has `@validate` annotations, it emits validator calls at the appropriate depth. For arrays, this means iterating over elements and running the element type's validators on each one. For nested objects, it means recursing into each property.
+
+The `@jsonSchema` annotations also flow into nested positions. In the example above, if `Email` has `@jsonSchema({ format: "email" })`, the JSON Schema for the `emails` property would be `{ type: "array", items: { type: "string", format: "email" } }`.
+
+#### Unions
+
+For `type Contact = Email | Url`, the Zod schema validates structure first and determines which branch the value matches. Only the validators on the matching branch then run. If the value matched `Email`, `isEmail` runs; if it matched `Url`, `isUrl` runs. If no branch matches at the Zod level, validation fails before any validator is invoked.
+
+#### Nullable / Optional
+
+Nullable and optional types are a special case of unions (with `null` / `undefined`). If the value is `null` or `undefined`, the union resolves to that branch and the validators on the value branch are skipped. This means `@validate(isEmail) type Email = string` used as `Email?` will not run `isEmail` on `undefined`.
+
+#### Recursive Types
+
+Recursive types like `type Tree = { value: number, children: Tree[] }` are walked by following the actual value structure, not the type structure, so they terminate naturally. To guard against pathological input (e.g. an LLM returning a deeply nested structure designed to blow the stack), the generated validator walker enforces a hard recursion depth limit (proposed default: 64). Exceeding the limit produces a `failure("validation recursion depth exceeded")` rather than crashing.
+
+### Duplicate Annotations
+
+Multiple `@validate` annotations on the same target are allowed and their validator lists are concatenated:
+
+```
+@validate(isPositive)
+@validate(isEven)
+type PositiveEvenNumber = number
+// equivalent to: @validate(isPositive, isEven)
+```
+
+Multiple `@jsonSchema` annotations on the same target are an **error**. Use a single `@jsonSchema` with all properties merged:
+
+```
+// ERROR: multiple @jsonSchema on same target
+@jsonSchema({ format: "email" })
+@jsonSchema({ description: "work email" })
+type WorkEmail = string
+
+// CORRECT: single @jsonSchema with all properties
+@jsonSchema({ format: "email", description: "work email" })
+type WorkEmail = string
+```
+
+This avoids ambiguity about merge order and makes the final JSON Schema properties visible in one place.
+
+### Generics
+
+Generics have landed (see [generics-design.md](../plans/2026-05-19-generics-design.md)) since this spec was first drafted. The interaction with annotations is:
+
+- **Annotations on a generic alias apply at every instantiation.** `@validate(nonEmpty) type NonEmptyArray<T> = T[]` runs `nonEmpty` whenever any `NonEmptyArray<Foo>` is validated. The validator does not depend on `T` — it operates on the outer array — so this is straightforward.
+- **Element-type annotations still flow through.** Validating `NonEmptyArray<Email>` runs the outer `nonEmpty` validator AND the per-element `isEmail` validator that comes from `Email`. This falls out of the same "walk the resolved type structure" logic used for non-generic containers.
+- **Validators cannot reference type parameters.** Since type parameters are types and validators are value-level functions, there is no way to write `@validate(foo<T>)`. Value-level parameterization is the job of the future-work value parameter design (`type NumberInRange(low: number, high: number) = number`).
+- **Self-referential generic aliases** (e.g. `type Tree<T> = { value: T, children: Tree<T>[] }`) inherit the recursion-depth guard described under "Recursive Types".
+- **Tags never depend on `T`.** Generic type parameters are types, not values, and there is no way to interpolate one into an annotation argument. If a user needs annotations parameterized by a value (e.g. a different `description` per instantiation), that is the job of the future-work value-parameterized aliases.
+
+#### When Propagation Happens
+
+Annotation propagation for generic instantiations happens at **type-check time**, inside `resolveType`. When `NonEmptyArray<Email>` is resolved:
+
+1. `resolveType` looks up the `NonEmptyArray` alias in `ScopedTypeAliases`.
+2. It substitutes `T = Email` into the alias body via the existing `substituteTypeParams` walker.
+3. It copies the alias's `tags` onto the resolved type node so downstream passes see them attached to the use-site type.
+4. The element type `Email` itself carries `@validate(isEmail)` / `@jsonSchema({ ...emailFormat })` from its own alias entry, which is picked up by the same walk when emitting the per-element validator and schema.
+
+Type-check time is the right layer because every other rule in this spec — the alias/property tag merge, the static-`const`-global restriction on `@jsonSchema` arguments, the union/nullable dispatch for validator selection — needs both the resolved structure and the tags visible together. `TypeAliasEntry` (introduced in the generics work) is widened to carry `tags?: Tag[]` so the metadata travels with the alias across module boundaries and re-exports.
+
+## Compiler Implementation
+
+### Tag AST Changes
+
+The current `Tag` type has `arguments: string[]`, which cannot represent object literals or function calls. The `arguments` field changes to accept full `Expression` nodes:
+
+```
+type Tag = BaseNode & {
+  type: "tag";
+  name: string;
+  arguments: Expression[];
+};
+```
+
+This means tag arguments are parsed using the existing expression parser, which already supports object literals (including spread), function calls, identifiers, and string literals.
+
+Additionally:
+- The `TypeAlias` type in `lib/types/typeHints.ts` needs a `tags?: Tag[]` field.
+- The `ObjectProperty` type in `lib/types/typeHints.ts` needs a `tags?: Tag[]` field (replacing the removed `description?: string` field).
+
+### Tags on Type Properties
+
+Tags inside type bodies require changes to the type parser (`objectTypeParser` in `lib/parsers/parsers.ts`). The parser must:
+
+1. Before parsing each property, check for zero or more `@tag(...)` lines.
+2. Accumulate any tags found.
+3. Attach them to the next `ObjectProperty` via its new `tags` field.
+
+This mirrors how the preprocessor's `attachTags` handles statement-level tags, but happens within the type expression parser itself, since type bodies are parsed at the type syntax level, not the statement level.
+
+### Tag Attachment for Type Aliases
+
+The `attachTags` function in `lib/preprocessors/typescriptPreprocessor.ts` currently attaches pending tags to `graphNode`, `function`, `assignment`, and `functionCall` nodes. It must be updated to also attach tags to `typeAlias` nodes.
+
+### `@validate` Path
+
+Validators run **outside Zod**, not via `.refine()`. This is because Agency functions compile to async TypeScript functions, and Zod's `.refine()` expects synchronous predicates (async requires `.parseAsync()` which complicates the existing validation path).
+
+Instead, when the builder generates validation code for a type with `!`:
+
+1. The Zod schema is used for structural type validation as it is today (via `safeParse()`).
+2. If the type (or its alias) has `@validate` annotations, the builder emits **additional validation calls** after the Zod parse succeeds.
+3. Each validator function is called in order with the parsed value. Because validators may transform values (see "Validators may transform values" earlier), the output of each validator is threaded into the next call. If any validator returns a `failure`, the chain short-circuits and the overall validation result is that `failure`.
+4. The generated code looks roughly like:
+
+```typescript
+const __zodResult = __schema.safeParse(value);
+let __validated: Result<T>;
+if (__zodResult.success) {
+  // Adapt Zod's success shape into Agency's Result shape.
+  __validated = agencySuccess(__zodResult.data);
+  if (__validated.kind === "success") {
+    __validated = await isPositive(__ctx, __validated.value);
+  }
+  if (__validated.kind === "success") {
+    __validated = await isEven(__ctx, __validated.value);
+  }
+} else {
+  __validated = agencyFailure(__zodResult.error.message);
+}
+```
+
+Notes:
+- Two distinct shapes are in play: Zod's `SafeParseReturnType` (`{ success, data | error }`) and Agency's `Result` (the same shape returned by every Agency function). The generated code adapts the first into the second so the post-validation chain operates in `Result` shape uniformly.
+- The value threaded between validators is the value most recently produced (i.e. the transform output), not the original Zod-parsed value.
+- Validators are awaited because Agency functions compile to async TypeScript functions with the standard `__ctx` runtime context.
+
+This keeps the existing sync Zod path unchanged and adds async validator calls as a post-validation step.
+
+### `@jsonSchema` Path
+
+`@jsonSchema` arguments are **runtime expressions**. The builder emits them as TypeScript code that is evaluated when the Zod schema is constructed (type aliases already compile to `const Foo = z.string()` style statements).
+
+1. The builder sees `@jsonSchema({ format: "email", description: "work email" })` on a type or property.
+2. It emits `.meta({ format: "email", description: "work email" })` on the Zod schema string.
+3. For expressions involving imported helpers (like `{ ...emailFormat }`), the builder emits the spread expression verbatim — it evaluates at runtime when the module loads.
+4. Zod's `toJSONSchema()` copies the `.meta()` properties into the JSON Schema output.
+
+#### `.meta()` Chain Ordering
+
+`.meta()` must be appended in a specific position to avoid being clobbered by subsequent modifiers. The canonical order the builder produces is:
+
+```
+z.<baseType>(...)        // z.string(), z.number(), z.object({...}), z.array(...), etc.
+  .<typeRefinements>()   // z.string().email(), z.number().int(), etc. — none introduced by this spec
+  .nullable()            // if applicable
+  .optional()            // if applicable
+  .default(...)          // if applicable
+  .meta({ ... })         // ALWAYS LAST
+```
+
+Any future modifier added to the builder must be inserted **before** `.meta()`, never after. The builder has a single helper (`appendMeta(schemaExpr, metaObj)`) that all schema-construction paths route through, so this invariant is enforced in one place.
+
+#### Type-Checker Restrictions on `@jsonSchema` Arguments
+
+To prevent surprising runtime behavior (mutable globals, side-effecting calls, dependence on values that don't exist at module-load time), the type checker restricts the expressions allowed inside `@jsonSchema(...)`. Each leaf expression must be one of:
+
+- A literal (string, number, boolean, `null`).
+- An object literal containing only allowed expressions / spreads.
+- An identifier that resolves to a **static `const` global** — i.e. a top-level `const` whose initializer is itself an allowed expression and which is not reassigned. (Module-level imports that are themselves `const`-bound count.)
+- A **function call** to a top-level `def` function or an imported function. The arguments must themselves be allowed expressions. Function calls are permitted because some stdlib helpers (e.g. a future `matches(re)` that returns `{ pattern: re }`) are calls, and validator factories like `min(0)` inside `@validate(...)` rely on the same machinery. The type checker forbids the function body from referencing mutable state — this is enforced indirectly by the `static const global` rule above. (If a stricter "must be pure" check turns out to be needed in practice we can tighten this later.)
+
+Note that stdlib `format` helpers like `emailFormat` are plain const-bound objects (`const emailFormat = { format: "email" }`), not function calls, so they fall under the "static `const` global" rule. Using them as `{ ...emailFormat }` is allowed.
+
+Disallowed: member access (`foo.bar`), template strings, array literals, ternaries, binary operators, pipes, anything that reads a `let` binding or a function parameter.
+
+Violations are reported at type-check time with a clear error message pointing at the offending expression.
+
+### Parser Changes
+
+The tag parser needs to be expanded to support:
+
+1. **Object literal arguments**: `@jsonSchema({ format: "email" })` — tags can accept object literals, including spread syntax.
+2. **Function call arguments**: `@validate(min(0), max(150))` — tags can accept expressions that are function calls.
+3. **General expressions**: tag arguments become full `Expression` nodes, parsed by the existing expression parser.
+
+These parser changes are general-purpose improvements to the tag system that will be useful for future features beyond validation.
+
+#### Backward Compatibility
+
+The current tag parser accepts string literals and bare identifiers, producing `string[]`. After the change, these parse as `Expression` nodes (string literal nodes and variable name nodes respectively). All existing consumers of `Tag.arguments` must be updated to work with `Expression[]` instead of `string[]`. Existing tags like `@goal("Suggest good gifts")` and `@optimize(prompt, temperature)` must continue to parse and behave identically.
+
+#### Restricted Expression Subset
+
+Tag arguments should be restricted to a subset of expressions to avoid nonsensical constructs like `@validate(x > 5 ? foo : bar)`. The allowed forms are:
+
+- String literals: `"text"`
+- Number literals: `42`
+- Boolean literals: `true`, `false`
+- Identifiers: `isEmail`
+- Function calls: `min(0)`
+- Object literals (including spread): `{ format: "email", ...emailFormat }`
+
+The tag argument parser uses the expression parser but rejects ternaries, binary operators, pipes, and other complex expressions at parse time.
+
+### `.meta()` and `.describe()` Migration
+
+Zod 4's `.meta({ description: "text" })` produces the same `"description"` field in JSON Schema output as `.describe("text")`. This has been verified and is the basis for the `# description` migration.
+
+The existing `.nullable().describe("Default: " + defaultStr)` pattern used for function parameters with default values (in `typescriptBuilder.ts`) is **separate** from this migration. That usage annotates function parameter schemas for tool calling and is not affected by the removal of `# description` on type properties. It can be migrated to `.meta()` in a follow-up if desired.
+
+## Migration
+
+### Removing `# description` Syntax — Fast Follow
+
+The `# description` syntax on type properties will be removed, but **not in this change**. Removing it requires updating every fixture, example, doc, and test file in the repo that uses `#`, which would balloon the diff for this PR and make it hard to review. The annotation infrastructure ships first; the `#` removal is a separate, mechanical fast follow.
+
+In the fast follow:
+
+- Both syntaxes coexist temporarily. `# description` and `@jsonSchema({ description: "..." })` on the same property is an error to avoid ambiguity.
+- All in-tree usages are migrated mechanically (a codemod over `lib/`, `stdlib/`, `examples/`, `tests/`, and `docs/`).
+- Once the migration is verified by `make` + `pnpm test:run`, the `objectPropertyDescriptionParser` and `objectPropertyWithDescriptionParser` in `lib/parsers/parsers.ts` and the `description` field on `ObjectProperty` in `lib/types/typeHints.ts` are removed, along with the `.describe("...")` codegen path in `typeToZodSchema.ts`.
+
+User-facing migration (after the fast follow lands) is from:
+
+```
+type User = {
+  email: string # user's work email
+}
+```
+
+To:
+
+```
+type User = {
+  @jsonSchema({ description: "user's work email" })
+  email: string
+}
+```
+
+## Design Decisions
+
+### Why not a single annotation for both validation and schema?
+
+Validation (runtime, imperative) and schema hints (declarative, LLM-facing) are fundamentally different concerns. A custom validator function can't be represented in JSON Schema, and a JSON Schema keyword like `format: "date-time"` doesn't correspond to a runtime check. Keeping them separate means each is simple, explicit, and non-magical.
+
+### Why not built-in validator keywords (like `@validate(email)` instead of `@validate(isEmail)`)?
+
+This would create a two-tier system: magic built-in keywords that map to Zod methods, and user functions that map to `.refine()`. Since OpenAI does support some JSON Schema constraint keywords (like `format`, `pattern`, `minimum`) but they're best-effort rather than strictly enforced, the advantage of built-in keywords mapping to Zod methods is minimal. Keeping all validators as regular functions is simpler, more uniform, and more flexible.
+
+### Why not allow annotations on function parameters?
+
+With multiple validators and a description, annotations on function parameters become unreadable:
+
+```
+def sendEmail(@validate(isEmail) @jsonSchema({ format: "email", description: "recipient" }) to: string) { ... }
+```
+
+Instead, users create a type alias and use it with `!`:
+
+```
+@validate(isEmail)
+@jsonSchema({ ...emailFormat, description: "recipient" })
+type Email = string
+
+def sendEmail(to: Email!) { ... }
+```
+
+This encourages reusable, well-named types.
+
+### Why remove `# description` instead of keeping both?
+
+Having two ways to add descriptions (`# text` and `@jsonSchema({ description: "text" })`) creates confusion about which to use and whether they interact. A single mechanism is simpler. The `@jsonSchema` syntax is also more consistent with how all other metadata is specified and more extensible. The removal lands as a fast follow after the annotation infrastructure (see Migration section); during the brief overlap window, mixing both on the same property is an error.
+
+### Why run validators outside Zod instead of using `.refine()`?
+
+Agency functions compile to async TypeScript functions with runtime infrastructure (step counters, interrupt support, etc.). Zod's `.refine()` expects synchronous predicates; using `.refine()` with async functions would require switching the entire validation path to `safeParseAsync()`, which complicates the existing runtime. Running validators as a post-validation step after Zod's structural check keeps both paths clean and means validator failure messages propagate naturally via the `Result` type.
+
+## Future Work: Value-Parameterized Type Aliases
+
+### Motivation
+
+The annotation system encourages creating reusable validated types. The v1 stdlib ships pre-baked aliases for the common no-parameter cases (`Email`, `Url`, `Uuid` — see the "Pre-baked Validated Types" section above).
+
+However, some validated types need **parameters**. A "number in range" type needs to know the range, and shipping a fixed `Age = NumberInRange(0, 150)` is no good for the user who wants `NumberInRange(1, 100)`. With the current design users must repeat the annotations every time:
+
+```
+@validate(min(0), max(150))
+@jsonSchema({ minimum: 0, maximum: 150 })
+type Age = number
+
+@validate(min(1), max(100))
+@jsonSchema({ minimum: 1, maximum: 100 })
+type Score = number
+```
+
+This is verbose and error-prone. Ideally, users could write `NumberInRange(0, 150)` and `NumberInRange(1, 100)`.
+
+### The Problem
+
+Agency's generic type parameters (`<T>`) are types, not values. Writing `type NumberInRange<start, finish> = number` doesn't work because `start` and `finish` are type-level entities that can't be passed to value-level functions like `min(start)`.
+
+This is the fundamental tension between type space and value space. Most languages keep these strictly separated. A few languages have a concept called **dependent types** — types that are parameterized by values. Full dependent types are a complex feature found in academic languages like Idris and Agda. But Agency doesn't need the full generality — just enough to make parameterized validated types work.
+
+### Proposed Solution: Value Parameters with `()`
+
+Type aliases can take **value parameters** using `()`, distinct from type parameters using `<>`:
+
+```
+@validate(min(low), max(high))
+@jsonSchema({ minimum: low, maximum: high })
+type NumberInRange(low: number, high: number) = number
+```
+
+Usage looks like a function call on a type:
+
+```
+type User = {
+  age: NumberInRange(0, 150)
+  score: NumberInRange(1, 100)
+}
+```
+
+The `()` vs `<>` distinction is visually clear: `<>` is for types, `()` is for values. They can be combined:
+
+```
+@validate(minItems(n))
+@jsonSchema({ minItems: n })
+type BoundedList<T>(n: number) = T[]
+
+items: BoundedList<string>(3)
+```
+
+### How It Works
+
+When the compiler sees `NumberInRange(0, 150)`:
+
+1. It looks up the `NumberInRange` type alias and finds value parameters `(low: number, high: number)`.
+2. It substitutes `low=0, high=150` into the annotations.
+3. `@validate(min(low), max(high))` becomes `@validate(min(0), max(150))`.
+4. `@jsonSchema({ minimum: low, maximum: high })` becomes `@jsonSchema({ minimum: 0, maximum: 150 })`.
+5. The Zod schema and validators are generated with the substituted values.
+
+In the generated TypeScript, each distinct instantiation produces its own Zod schema. `NumberInRange(0, 150)` and `NumberInRange(1, 100)` are different schemas with different `.meta()` properties and different validator calls.
+
+### Standard Library Types
+
+With value parameters, `std::types` (which already exports the no-parameter aliases `Email`, `Url`, `Uuid` shipped in v1) can grow a set of reusable parameterized types:
+
+```
+// v1 — ships now in std::types
+type Email = string
+type Url = string
+type Uuid = string
+
+// Future — added once value parameters land
+type NumberInRange(low: number, high: number) = number
+type StringWithLength(min: number, max: number) = string
+type MatchesPattern(pat: string) = string
+type BoundedArray<T>(min: number, max: number) = T[]
+```
+
+Users can then write concise type definitions:
+
+```
+import { Email, NumberInRange, BoundedArray } from "std::types"
+
+type User = {
+  email: Email
+  age: NumberInRange(0, 150)
+  tags: BoundedArray<string>(1, 10)
+}
+```
+
+### Scope
+
+Value-parameterized type aliases are a follow-up feature. The core annotation infrastructure (`@validate`, `@jsonSchema`, tag parser changes, `# description` removal) ships first. Value parameters build on top of that foundation once it is stable.

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md
@@ -120,22 +120,22 @@ type Email = string
 
 @validate(isUrl)
 @jsonSchema({ ...urlFormat })
-type Url = string
+type URL = string
 
 @validate(isUuid)
 @jsonSchema({ ...uuidFormat })
-type Uuid = string
+type UUID = string
 ```
 
 Users can then write:
 
 ```
-import { Email, Url, Uuid } from "std::types"
+import { Email, URL, UUID } from "std::types"
 
 type User = {
   email: Email
-  homepage: Url
-  id: Uuid
+  homepage: URL
+  id: UUID
 }
 ```
 
@@ -237,7 +237,7 @@ The `@jsonSchema` annotations also flow into nested positions. In the example ab
 
 #### Unions
 
-For `type Contact = Email | Url`, the Zod schema validates structure first and determines which branch the value matches. Only the validators on the matching branch then run. If the value matched `Email`, `isEmail` runs; if it matched `Url`, `isUrl` runs. If no branch matches at the Zod level, validation fails before any validator is invoked.
+For `type Contact = Email | URL`, the Zod schema validates structure first and determines which branch the value matches. Only the validators on the matching branch then run. If the value matched `Email`, `isEmail` runs; if it matched `URL`, `isUrl` runs. If no branch matches at the Zod level, validation fails before any validator is invoked.
 
 #### Nullable / Optional
 
@@ -506,7 +506,7 @@ Agency functions compile to async TypeScript functions with runtime infrastructu
 
 ### Motivation
 
-The annotation system encourages creating reusable validated types. The v1 stdlib ships pre-baked aliases for the common no-parameter cases (`Email`, `Url`, `Uuid` — see the "Pre-baked Validated Types" section above).
+The annotation system encourages creating reusable validated types. The v1 stdlib ships pre-baked aliases for the common no-parameter cases (`Email`, `URL`, `UUID` — see the "Pre-baked Validated Types" section above).
 
 However, some validated types need **parameters**. A "number in range" type needs to know the range, and shipping a fixed `Age = NumberInRange(0, 150)` is no good for the user who wants `NumberInRange(1, 100)`. With the current design users must repeat the annotations every time:
 
@@ -571,13 +571,13 @@ In the generated TypeScript, each distinct instantiation produces its own Zod sc
 
 ### Standard Library Types
 
-With value parameters, `std::types` (which already exports the no-parameter aliases `Email`, `Url`, `Uuid` shipped in v1) can grow a set of reusable parameterized types:
+With value parameters, `std::types` (which already exports the no-parameter aliases `Email`, `URL`, `UUID` shipped in v1) can grow a set of reusable parameterized types:
 
 ```
 // v1 — ships now in std::types
 type Email = string
-type Url = string
-type Uuid = string
+type URL = string
+type UUID = string
 
 // Future — added once value parameters land
 type NumberInRange(low: number, high: number) = number

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md
@@ -120,22 +120,25 @@ type Email = string
 
 @validate(isUrl)
 @jsonSchema({ ...urlFormat })
-type URL = string
+type URLString = string
 
 @validate(isUuid)
 @jsonSchema({ ...uuidFormat })
-type UUID = string
+type UUIDString = string
 ```
+
+(`URLString` / `UUIDString` are named with the `String` suffix so they do
+not shadow JavaScript's global `URL` constructor.)
 
 Users can then write:
 
 ```
-import { Email, URL, UUID } from "std::types"
+import { Email, URLString, UUIDString } from "std::types"
 
 type User = {
   email: Email
-  homepage: URL
-  id: UUID
+  homepage: URLString
+  id: UUIDString
 }
 ```
 
@@ -237,7 +240,7 @@ The `@jsonSchema` annotations also flow into nested positions. In the example ab
 
 #### Unions
 
-For `type Contact = Email | URL`, the Zod schema validates structure first and determines which branch the value matches. Only the validators on the matching branch then run. If the value matched `Email`, `isEmail` runs; if it matched `URL`, `isUrl` runs. If no branch matches at the Zod level, validation fails before any validator is invoked.
+For `type Contact = Email | URLString`, the Zod schema validates structure first and determines which branch the value matches. Only the validators on the matching branch then run. If the value matched `Email`, `isEmail` runs; if it matched `URLString`, `isUrl` runs. If no branch matches at the Zod level, validation fails before any validator is invoked.
 
 #### Nullable / Optional
 
@@ -506,7 +509,7 @@ Agency functions compile to async TypeScript functions with runtime infrastructu
 
 ### Motivation
 
-The annotation system encourages creating reusable validated types. The v1 stdlib ships pre-baked aliases for the common no-parameter cases (`Email`, `URL`, `UUID` — see the "Pre-baked Validated Types" section above).
+The annotation system encourages creating reusable validated types. The v1 stdlib ships pre-baked aliases for the common no-parameter cases (`Email`, `URLString`, `UUIDString` — see the "Pre-baked Validated Types" section above).
 
 However, some validated types need **parameters**. A "number in range" type needs to know the range, and shipping a fixed `Age = NumberInRange(0, 150)` is no good for the user who wants `NumberInRange(1, 100)`. With the current design users must repeat the annotations every time:
 
@@ -571,13 +574,13 @@ In the generated TypeScript, each distinct instantiation produces its own Zod sc
 
 ### Standard Library Types
 
-With value parameters, `std::types` (which already exports the no-parameter aliases `Email`, `URL`, `UUID` shipped in v1) can grow a set of reusable parameterized types:
+With value parameters, `std::types` (which already exports the no-parameter aliases `Email`, `URLString`, `UUIDString` shipped in v1) can grow a set of reusable parameterized types:
 
 ```
 // v1 — ships now in std::types
 type Email = string
-type URL = string
-type UUID = string
+type URLString = string
+type UUIDString = string
 
 // Future — added once value parameters land
 type NumberInRange(low: number, high: number) = number

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -465,8 +465,10 @@ export class AgencyGenerator {
     const aliasedTypeStr = this.aliasedTypeToString(node.aliasedType);
     const exportPrefix = node.exported ? "export " : "";
     const typeParamsStr = this.formatTypeParams(node.typeParams);
+    const tags = this.formatAttachedTags(node);
     return (
       this.formatDocComment(node) +
+      tags +
       this.indentStr(
         `${exportPrefix}type ${node.aliasName}${typeParamsStr} = ${aliasedTypeStr}`,
       )
@@ -1243,12 +1245,9 @@ export class AgencyGenerator {
     if (tag.arguments.length === 0) {
       return this.indentStr(`@${tag.name}`);
     }
-    const args = tag.arguments.map((arg: string) => {
-      if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(arg)) {
-        return arg;
-      }
-      return JSON.stringify(arg);
-    });
+    const args = tag.arguments.map((arg) =>
+      this.processNode(arg as AgencyNode).trim(),
+    );
     return this.indentStr(`@${tag.name}(${args.join(", ")})`);
   }
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -91,6 +91,10 @@ import {
   DEFAULT_SCHEMA,
   mapTypeToValidationSchema,
 } from "./typescriptGenerator/typeToZodSchema.js";
+import {
+  buildValidationDescriptorTs,
+  hasAnyValidateTag,
+} from "./typescriptGenerator/validationDescriptor.js";
 import { resolveTypeDeep } from "../typeChecker/assignability.js";
 
 import { $, ts } from "../ir/builders.js";
@@ -595,11 +599,41 @@ export class TypeScriptBuilder {
       return ts.raw(`export const ${node.aliasName} = undefined;`);
     }
     const exportPrefix = node.exported ? "export " : "";
-    const zodSchema = this.zodSchemaFor(node.aliasedType);
-    return ts.statements([
+    // Thread alias-level @validate / @jsonSchema tags onto the body type so
+    // appendMeta (in typeToZodSchema) attaches the `.meta(...)` chain to the
+    // top-level alias schema. Without this, alias-level annotations would
+    // never reach the codegen since only use-site `VariableType.tags` are
+    // consulted; alias-level tags live on the `TypeAlias` node itself.
+    const aliasedWithTags: VariableType = node.tags
+      ? { ...node.aliasedType, tags: [...(node.aliasedType.tags ?? []), ...node.tags] }
+      : node.aliasedType;
+    const zodSchema = this.zodSchemaFor(aliasedWithTags);
+    const stmts: TsNode[] = [
       ts.raw(`${exportPrefix}const ${node.aliasName} = ${zodSchema};`),
       ts.raw(`${exportPrefix}type ${node.aliasName} = z.infer<typeof ${node.aliasName}>;`),
-    ]);
+    ];
+    // If the alias body carries any `@validate(...)` annotation, attach a
+    // descriptor to the schema const so use-site `Foo!` validations can
+    // pick it up without re-importing the validator identifiers themselves
+    // (those are in scope here, not in the consumer module).
+    const aliasesFull = this.scopes.visibleTypeAliasesFull();
+    if (hasAnyValidateTag(aliasedWithTags, aliasesFull)) {
+      const resolved = resolveTypeDeep(aliasedWithTags, aliasesFull);
+      const descriptor = buildValidationDescriptorTs(
+        resolved,
+        this.scopes.visibleTypeAliases(),
+        aliasesFull,
+      );
+      // `(Foo as any).__agency_descriptor = ...` — keeps the runtime metadata
+      // co-located with the schema and avoids exporting/importing a second
+      // symbol. Cast to `any` because Zod's typings don't know about us.
+      stmts.push(
+        ts.raw(
+          `(${node.aliasName} as any).__agency_descriptor = ${descriptor};`,
+        ),
+      );
+    }
+    return ts.statements(stmts);
   }
 
   /**
@@ -611,6 +645,25 @@ export class TypeScriptBuilder {
   private zodSchemaFor(t: VariableType): string {
     const resolved = resolveTypeDeep(t, this.scopes.visibleTypeAliasesFull());
     return mapTypeToValidationSchema(resolved, this.scopes.visibleTypeAliases());
+  }
+
+  /**
+   * Build the validation expression for a `!` site. If the resolved type
+   * carries no `@validate(...)` tag anywhere, return the existing
+   * `__validateType(value, schema)` call (zero behavior change). Otherwise
+   * return `await __validateChainRecursive(value, <descriptor>, __ctx)`,
+   * which runs Zod parse + the validator chain at each level.
+   */
+  private validateExpr(t: VariableType, value: TsNode): TsNode {
+    const aliasesFull = this.scopes.visibleTypeAliasesFull();
+    const resolved = resolveTypeDeep(t, aliasesFull);
+    const aliases = this.scopes.visibleTypeAliases();
+    if (!hasAnyValidateTag(resolved, aliasesFull)) {
+      const zodSchema = mapTypeToValidationSchema(resolved, aliases);
+      return ts.validateType(value, ts.raw(zodSchema));
+    }
+    const descriptor = buildValidationDescriptorTs(resolved, aliases, aliasesFull);
+    return ts.validateChainRecursive(value, ts.raw(descriptor));
   }
 
   // ------- Proper IR node methods -------
@@ -1419,12 +1472,11 @@ export class TypeScriptBuilder {
     const validationGuards: TsNode[] = [];
     for (const param of parameters) {
       if (param.validated && param.typeHint) {
-        const zodSchema = this.zodSchemaFor(param.typeHint);
         const stackArg = $(ts.stack("args")).index(ts.str(param.name)).done();
         const vrName = `__vr_${param.name}`;
         const vrId = ts.id(vrName);
         validationGuards.push(
-          ts.constDecl(vrName, ts.validateType(stackArg, ts.raw(zodSchema))),
+          ts.constDecl(vrName, this.validateExpr(param.typeHint, stackArg)),
           ts.if(
             ts.not(ts.prop(vrId, "success")),
             ts.return(vrId),
@@ -2132,8 +2184,7 @@ export class TypeScriptBuilder {
     if (!this.scopes.returnTypeValidated()) return valueNode;
     const returnType = this.scopes.returnType();
     if (!returnType) return valueNode;
-    const zodSchema = this.zodSchemaFor(returnType);
-    return ts.validateType(valueNode, ts.raw(zodSchema));
+    return this.validateExpr(returnType, valueNode);
   }
 
   private processGotoStatement(node: GotoStatement): TsNode {
@@ -2228,10 +2279,13 @@ export class TypeScriptBuilder {
   private processAssignment(node: Assignment): TsNode {
     const result = this._processAssignmentInner(node);
     // If the type annotation has !, wrap the assigned value in __validateType
+    // (or __validateChainRecursive if the type carries @validate tags).
     if (node.validated && node.typeHint) {
-      const zodSchema = this.zodSchemaFor(node.typeHint);
       const varRef = ts.scopedVar(node.variableName, node.scope!, this.moduleId);
-      const validateStmt = ts.assign(varRef, ts.validateType(varRef, ts.raw(zodSchema)));
+      const validateStmt = ts.assign(
+        varRef,
+        this.validateExpr(node.typeHint, varRef),
+      );
       if (result.kind === "statements") {
         return ts.statementsPush(result, validateStmt);
       }

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -92,7 +92,7 @@ import {
   mapTypeToValidationSchema,
 } from "./typescriptGenerator/typeToZodSchema.js";
 import {
-  buildValidationDescriptorTs,
+  buildValidationDescriptor,
   hasAnyValidateTag,
 } from "./typescriptGenerator/validationDescriptor.js";
 import { resolveTypeDeep } from "../typeChecker/assignability.js";
@@ -619,7 +619,7 @@ export class TypeScriptBuilder {
     const aliasesFull = this.scopes.visibleTypeAliasesFull();
     if (hasAnyValidateTag(aliasedWithTags, aliasesFull)) {
       const resolved = resolveTypeDeep(aliasedWithTags, aliasesFull);
-      const descriptor = buildValidationDescriptorTs(
+      const descriptor = buildValidationDescriptor(
         resolved,
         this.scopes.visibleTypeAliases(),
         aliasesFull,
@@ -628,8 +628,12 @@ export class TypeScriptBuilder {
       // co-located with the schema and avoids exporting/importing a second
       // symbol. Cast to `any` because Zod's typings don't know about us.
       stmts.push(
-        ts.raw(
-          `(${node.aliasName} as any).__agency_descriptor = ${descriptor};`,
+        ts.assign(
+          ts.prop(
+            ts.raw(`(${node.aliasName} as any)`),
+            "__agency_descriptor",
+          ),
+          descriptor,
         ),
       );
     }
@@ -662,8 +666,8 @@ export class TypeScriptBuilder {
       const zodSchema = mapTypeToValidationSchema(resolved, aliases);
       return ts.validateType(value, ts.raw(zodSchema));
     }
-    const descriptor = buildValidationDescriptorTs(resolved, aliases, aliasesFull);
-    return ts.validateChainRecursive(value, ts.raw(descriptor));
+    const descriptor = buildValidationDescriptor(resolved, aliases, aliasesFull);
+    return ts.validateChainRecursive(value, descriptor);
   }
 
   // ------- Proper IR node methods -------

--- a/packages/agency-lang/lib/backends/typescriptGenerator/jsonSchemaAnnotation.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/jsonSchemaAnnotation.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Integration-style tests for the `@jsonSchema(...)` annotation.
+ *
+ * Strategy: compile a small Agency program with the type-validation
+ * annotations, then load the generated TS module dynamically and inspect
+ * the Zod schema attached to the alias (`Foo.meta()` / `z.toJSONSchema(Foo)`).
+ * This is the closest thing we have to an end-to-end test, since Zod's
+ * `.meta(...)` semantics matter only at runtime.
+ *
+ * If the generated module can't be loaded for whatever reason, we still
+ * check the textual form of the emitted code so future regressions show
+ * up either way.
+ */
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { generateWithBuilder } from "../typescriptBuilder.integration.test.js";
+import { pathToFileURL } from "node:url";
+import { z } from "zod";
+
+/**
+ * Compile `agencySource`, write the generated TS to a temporary `.ts`
+ * file inside the agency-lang package (so vite can transform it and the
+ * relative `agency-lang/...` imports resolve), and dynamically import
+ * it. Returns the resolved module namespace plus a cleanup function.
+ */
+async function compileAndImport(
+  agencySource: string,
+): Promise<{ mod: any; cleanup: () => void }> {
+  const generated = generateWithBuilder(agencySource);
+  const dir = path.resolve(__dirname, "../../../.agency-tmp");
+  fs.mkdirSync(dir, { recursive: true });
+  const id = `jsonschema-test-${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+  const file = path.join(dir, `${id}.ts`);
+  fs.writeFileSync(file, generated);
+  // Use the file:// URL so the vite-node loader picks it up correctly.
+  const mod = await import(pathToFileURL(file).href);
+  return {
+    mod,
+    cleanup: () => {
+      try {
+        fs.unlinkSync(file);
+      } catch {
+        /* best-effort */
+      }
+    },
+  };
+}
+
+describe("@jsonSchema annotation", () => {
+  it("attaches metadata to a simple type alias", async () => {
+    const src = `
+@jsonSchema({ description: "User-facing email address.", format: "email" })
+export type Email = string
+`;
+    const ts = generateWithBuilder(src);
+    // Textual check first — cheap and stable.
+    expect(ts).toContain(".meta(");
+    expect(ts).toMatch(/description:\s*"User-facing email address\."/);
+    expect(ts).toMatch(/format:\s*"email"/);
+  });
+
+  it("emits .meta(...) at runtime on the generated Zod schema", async () => {
+    const src = `
+@jsonSchema({ description: "Friendly email.", format: "email" })
+export type Email = string
+`;
+    const { mod, cleanup } = await compileAndImport(src);
+    try {
+      const Email = mod.Email as z.ZodType;
+      expect(Email).toBeDefined();
+      // Zod v4 stores metadata on the schema via .meta(); retrieve it via the
+      // public `meta()` accessor or by calling toJSONSchema.
+      const meta = (Email as any).meta?.() ?? {};
+      expect(meta).toMatchObject({
+        description: "Friendly email.",
+        format: "email",
+      });
+      // toJSONSchema picks up .meta() and merges it into the schema output.
+      const jsonSchema = z.toJSONSchema(Email) as Record<string, unknown>;
+      expect(jsonSchema.description).toBe("Friendly email.");
+      expect(jsonSchema.format).toBe("email");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("merges alias-level and use-site @jsonSchema with use-site keys winning", async () => {
+    const src = `
+@jsonSchema({ description: "Alias-level description.", format: "email" })
+type Email = string
+
+type User = {
+  @jsonSchema({ description: "Use-site description." })
+  email: Email
+}
+`;
+    const ts = generateWithBuilder(src);
+    // The use-site description should win for the property's schema.
+    expect(ts).toMatch(/description:\s*"Use-site description\."/);
+    // The alias-level format must still propagate since the use-site did not
+    // override it.
+    expect(ts).toMatch(/format:\s*"email"/);
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.ts
@@ -1,0 +1,87 @@
+import type {
+  Expression,
+  AgencyObject,
+  AgencyObjectKV,
+  FunctionCall,
+  Literal,
+  SplatExpression,
+} from "../../types.js";
+
+/**
+ * Print a tag argument (an Agency Expression from the restricted subset
+ * accepted inside `@validate(...)` / `@jsonSchema(...)`) as a valid
+ * TypeScript expression string.
+ *
+ * Only the subset that the tag parser actually accepts is handled:
+ * string / number / boolean / null literals, identifiers, function calls,
+ * object literals (including spread). Anything else is a bug and produces
+ * a clearly-broken output.
+ */
+export function tagArgToTs(expr: Expression): string {
+  switch (expr.type) {
+    case "string":
+    case "multiLineString": {
+      const lit = expr as Literal & {
+        segments: Array<{ type: "text" | "interpolation"; value?: string; expression?: Expression }>;
+      };
+      // For tag args we expect plain text segments (the parser doesn't
+      // currently support interpolation here, but handle defensively).
+      const parts: string[] = [];
+      let raw = "";
+      for (const seg of lit.segments) {
+        if (seg.type === "text") {
+          raw += seg.value ?? "";
+        } else if (seg.expression) {
+          parts.push(JSON.stringify(raw));
+          parts.push(`(${tagArgToTs(seg.expression)})`);
+          raw = "";
+        }
+      }
+      parts.push(JSON.stringify(raw));
+      return parts.length === 1 ? parts[0] : `(${parts.join(" + ")})`;
+    }
+    case "number":
+      return (expr as Literal & { value: string }).value;
+    case "boolean":
+      return String((expr as Literal & { value: boolean }).value);
+    case "null":
+      return "null";
+    case "variableName":
+      return (expr as Literal & { value: string }).value;
+    case "agencyObject":
+      return objectLiteralToTs(expr as AgencyObject);
+    case "functionCall": {
+      const fc = expr as FunctionCall;
+      const args = (fc.arguments ?? [])
+        .map((a) =>
+          a.type === "namedArgument"
+            ? `${(a as any).name}: ${tagArgToTs((a as any).value)}`
+            : a.type === "splat"
+              ? `...${tagArgToTs((a as any).value)}`
+              : tagArgToTs(a as Expression),
+        )
+        .join(", ");
+      return `${fc.functionName}(${args})`;
+    }
+    default:
+      // Restricted subset means we should not see anything else; emit a
+      // clearly-broken value so the failure is obvious.
+      return `/* unsupported tag arg: ${expr.type} */ undefined`;
+  }
+}
+
+function objectLiteralToTs(obj: AgencyObject): string {
+  const entries = obj.entries.map((entry) => {
+    if ("key" in entry) {
+      const kv = entry as AgencyObjectKV;
+      // Quote keys with non-identifier characters; bare identifiers stay bare.
+      const key = /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(kv.key)
+        ? kv.key
+        : JSON.stringify(kv.key);
+      return `${key}: ${tagArgToTs(kv.value)}`;
+    }
+    const sp = entry as SplatExpression;
+    return `...${tagArgToTs(sp.value)}`;
+  });
+  return `{ ${entries.join(", ")} }`;
+}

--- a/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.ts
@@ -23,22 +23,26 @@ export function tagArgToTs(expr: Expression): string {
     case "multiLineString": {
       const lit = expr as Literal & {
         segments: Array<{ type: "text" | "interpolation"; value?: string; expression?: Expression }>;
+        loc?: { line: number; col: number };
       };
-      // For tag args we expect plain text segments (the parser doesn't
-      // currently support interpolation here, but handle defensively).
-      const parts: string[] = [];
+      // Tag-arg strings must be plain literals: the parser uses
+      // `simpleStringParser`, which never produces interpolation segments.
+      // If we ever see one here, that's a bug — fail loudly rather than
+      // emit broken TypeScript.
       let raw = "";
       for (const seg of lit.segments) {
         if (seg.type === "text") {
           raw += seg.value ?? "";
-        } else if (seg.expression) {
-          parts.push(JSON.stringify(raw));
-          parts.push(`(${tagArgToTs(seg.expression)})`);
-          raw = "";
+        } else {
+          const loc = lit.loc
+            ? ` at line ${lit.loc.line}, col ${lit.loc.col}`
+            : "";
+          throw new Error(
+            `Tag arguments must be plain string literals (no interpolation)${loc}`,
+          );
         }
       }
-      parts.push(JSON.stringify(raw));
-      return parts.length === 1 ? parts[0] : `(${parts.join(" + ")})`;
+      return JSON.stringify(raw);
     }
     case "number":
       return (expr as Literal & { value: string }).value;
@@ -64,9 +68,11 @@ export function tagArgToTs(expr: Expression): string {
       return `${fc.functionName}(${args})`;
     }
     default:
-      // Restricted subset means we should not see anything else; emit a
-      // clearly-broken value so the failure is obvious.
-      return `/* unsupported tag arg: ${expr.type} */ undefined`;
+      // Restricted subset means we should not see anything else; fail loudly
+      // so the bug is obvious instead of emitting broken TS.
+      throw new Error(
+        `tagArgToTs: unsupported tag argument expression type "${(expr as Expression).type}"`,
+      );
   }
 }
 

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { mapTypeToZodSchema, mapTypeToValidationSchema } from "./typeToZodSchema.js";
+import { mapTypeToZodSchema, mapTypeToValidationSchema, appendMeta } from "./typeToZodSchema.js";
 import { VariableType } from "../../types.js";
+import type { Tag } from "../../types/tag.js";
 
 describe("mapTypeToZodSchema", () => {
   it("should return the alias name directly for typeAliasVariable", () => {
@@ -208,5 +209,41 @@ describe("mapTypeToZodSchema: Record<K, V>", () => {
         {},
       ),
     ).toThrow(/Unresolved generic type at codegen: Container/);
+  });
+});
+
+describe("appendMeta", () => {
+  const obj = (entries: Record<string, unknown>) => ({
+    type: "agencyObject" as const,
+    entries: Object.entries(entries).map(([key, value]) => ({
+      key,
+      value: value as any,
+    })),
+  });
+  const stringLit = (s: string) => ({
+    type: "string" as const,
+    segments: [{ type: "text" as const, value: s }],
+  });
+  const tag = (name: string, args: any[]): Tag =>
+    ({ type: "tag", name, arguments: args }) as Tag;
+
+  it("returns the schema unchanged when no @jsonSchema tag is present", () => {
+    expect(appendMeta("z.string()", undefined)).toBe("z.string()");
+    expect(appendMeta("z.string()", [])).toBe("z.string()");
+    expect(appendMeta("z.string()", [tag("validate", [])])).toBe("z.string()");
+  });
+
+  it("appends .meta(...) when a single @jsonSchema tag is present", () => {
+    const tags = [tag("jsonSchema", [obj({ format: stringLit("email") })])];
+    expect(appendMeta("z.string()", tags)).toContain(".meta(");
+    expect(appendMeta("z.string()", tags)).toMatch(/format:\s*"email"/);
+  });
+
+  it("throws when more than one @jsonSchema is attached to the same target", () => {
+    const tags = [
+      tag("jsonSchema", [obj({ format: stringLit("email") })]),
+      tag("jsonSchema", [obj({ description: stringLit("dup") })]),
+    ];
+    expect(() => appendMeta("z.string()", tags)).toThrow(/Multiple @jsonSchema/);
   });
 });

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -16,9 +16,19 @@ export const DEFAULT_SCHEMA = "z.string()";
  */
 export function appendMeta(schemaExpr: string, tags: Tag[] | undefined): string {
   if (!tags || tags.length === 0) return schemaExpr;
-  const jsonSchema = tags.find((t) => t.name === "jsonSchema");
-  if (!jsonSchema) return schemaExpr;
-  const arg = jsonSchema.arguments[0];
+  const jsonSchemas = tags.filter((t) => t.name === "jsonSchema");
+  if (jsonSchemas.length === 0) return schemaExpr;
+  if (jsonSchemas.length > 1) {
+    const locs = jsonSchemas
+      .map((t) =>
+        t.loc ? `line ${t.loc.line}, col ${t.loc.col}` : "<unknown>",
+      )
+      .join(" and ");
+    throw new Error(
+      `Multiple @jsonSchema(...) annotations on the same target are not allowed (found at ${locs}). Combine them into a single object literal.`,
+    );
+  }
+  const arg = jsonSchemas[0].arguments[0];
   if (!arg) return schemaExpr;
   return `${schemaExpr}.meta(${tagArgToTs(arg)})`;
 }
@@ -101,10 +111,14 @@ function mapTypeToSchemaInner(
           typeAliases,
           resultHandler,
         );
-        let str = `"${prop.key.replace(/"/g, '\\"')}": ${appendMeta(inner, mergedTags)}`;
+        // .describe(...) must come BEFORE .meta(...) — Zod requires
+        // .meta() to be the final call in the chain or the metadata is
+        // dropped from toJSONSchema(...).
+        let inner2 = inner;
         if (prop.description) {
-          str += `.describe("${escape(prop.description)}")`;
+          inner2 += `.describe("${escape(prop.description)}")`;
         }
+        const str = `"${prop.key.replace(/"/g, '\\"')}": ${appendMeta(inner2, mergedTags)}`;
         return str;
       })
       .join(", ");

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -1,8 +1,27 @@
 import { color } from "@/utils/termcolors.js";
-import { VariableType } from "../../types.js";
+import { Tag, VariableType } from "../../types.js";
 import { escape } from "../../utils.js";
+import { tagArgToTs } from "./tagArgToTs.js";
+import { mergeTagSets } from "@/typeChecker/mergeTags.js";
 
 export const DEFAULT_SCHEMA = "z.string()";
+
+/**
+ * Append a `.meta({...})` call to a Zod schema string when the type
+ * carries a `@jsonSchema(...)` tag.
+ *
+ * `.meta()` MUST be the last call in the Zod chain (Zod's API requires
+ * it for the metadata to be picked up by `toJSONSchema`). Every callsite
+ * that finishes a Zod expression for a type should route through here.
+ */
+export function appendMeta(schemaExpr: string, tags: Tag[] | undefined): string {
+  if (!tags || tags.length === 0) return schemaExpr;
+  const jsonSchema = tags.find((t) => t.name === "jsonSchema");
+  if (!jsonSchema) return schemaExpr;
+  const arg = jsonSchema.arguments[0];
+  if (!arg) return schemaExpr;
+  return `${schemaExpr}.meta(${tagArgToTs(arg)})`;
+}
 
 /**
  * Internal recursive schema mapper. The `resultHandler` parameter controls
@@ -15,7 +34,21 @@ function mapTypeToSchema(
   typeAliases: Record<string, VariableType>,
   resultHandler: (vt: VariableType, ta: Record<string, VariableType>) => string,
 ): string {
-  const recurse = (vt: VariableType) => mapTypeToSchema(vt, typeAliases, resultHandler);
+  const recurse = (vt: VariableType) =>
+    appendMeta(mapTypeToSchemaInner(vt, typeAliases, resultHandler), vt.tags);
+  return appendMeta(
+    mapTypeToSchemaInner(variableType, typeAliases, resultHandler),
+    variableType.tags,
+  );
+}
+
+function mapTypeToSchemaInner(
+  variableType: VariableType,
+  typeAliases: Record<string, VariableType>,
+  resultHandler: (vt: VariableType, ta: Record<string, VariableType>) => string,
+): string {
+  const recurse = (vt: VariableType) =>
+    appendMeta(mapTypeToSchemaInner(vt, typeAliases, resultHandler), vt.tags);
 
   if (!variableType) {
     throw new Error(
@@ -59,7 +92,16 @@ function mapTypeToSchema(
   } else if (variableType.type === "objectType") {
     const props = variableType.properties
       .map((prop) => {
-        let str = `"${prop.key.replace(/"/g, '\\"')}": ${recurse(prop.value)}`;
+        // Merge alias-level tags (already attached to prop.value during
+        // resolveType) with property-level tags. @jsonSchema keys from
+        // the property override alias keys; @validate validators concat.
+        const mergedTags = mergeTagSets(prop.value.tags, prop.tags);
+        const inner = mapTypeToSchemaInner(
+          prop.value,
+          typeAliases,
+          resultHandler,
+        );
+        let str = `"${prop.key.replace(/"/g, '\\"')}": ${appendMeta(inner, mergedTags)}`;
         if (prop.description) {
           str += `.describe("${escape(prop.description)}")`;
         }

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -1,13 +1,15 @@
 import type { Tag, VariableType, TypeAliasEntry } from "../../types.js";
+import type { TsNode, TsObjectEntry } from "@/ir/tsIR.js";
+import { ts } from "@/ir/builders.js";
 import { mapTypeToValidationSchema } from "./typeToZodSchema.js";
 import { tagArgToTs } from "./tagArgToTs.js";
 import { mergeTagSets } from "@/typeChecker/mergeTags.js";
 
 /**
- * Render a TS source expression that evaluates to a runtime
- * `TypeValidationDescriptor`. Mirrors `mapTypeToValidationSchema`'s
- * structural recursion but threads validator lists collected from
- * `@validate(...)` tags at each level.
+ * Build a TS IR node that evaluates to a runtime `TypeValidationDescriptor`.
+ *
+ * Mirrors `mapTypeToValidationSchema`'s structural recursion but threads
+ * validator lists collected from `@validate(...)` tags at each level.
  *
  * Use this only when the type carries at least one `@validate` tag
  * somewhere — callers should check via `hasAnyValidateTag` first.
@@ -19,11 +21,11 @@ import { mergeTagSets } from "@/typeChecker/mergeTags.js";
  * tags reachable only through a non-generic alias reference would be
  * silently dropped.
  */
-export function buildValidationDescriptorTs(
+export function buildValidationDescriptor(
   variableType: VariableType,
   typeAliases: Record<string, VariableType>,
   typeAliasesFull?: Record<string, TypeAliasEntry>,
-): string {
+): TsNode {
   return descriptor(variableType, typeAliases, typeAliasesFull ?? {});
 }
 
@@ -94,13 +96,19 @@ function hasAliasValidate(
   return hasAnyValidateTag(entry.body, typeAliasesFull);
 }
 
-function collectValidators(tags: Tag[] | undefined): string[] {
+/**
+ * Each validator referenced inside `@validate(...)` is itself an Agency
+ * expression. We don't have a TS IR builder for arbitrary Agency
+ * expressions, so we delegate to `tagArgToTs` (which returns a TS
+ * source string) and wrap with `ts.raw(...)`.
+ */
+function validatorNodes(tags: Tag[] | undefined): TsNode[] {
   if (!tags) return [];
-  const out: string[] = [];
+  const out: TsNode[] = [];
   for (const t of tags) {
     if (t.name !== "validate") continue;
     for (const arg of t.arguments) {
-      out.push(tagArgToTs(arg));
+      out.push(ts.raw(tagArgToTs(arg)));
     }
   }
   return out;
@@ -115,12 +123,24 @@ function isNullableType(t: VariableType): boolean {
   );
 }
 
+/**
+ * Build the (string-built) Zod schema for `t` as a `ts.raw` node.
+ * `mapTypeToValidationSchema` predates the TS IR; rather than rewriting
+ * it, we keep it returning strings and wrap here.
+ */
+function schemaNode(
+  t: VariableType,
+  typeAliases: Record<string, VariableType>,
+): TsNode {
+  return ts.raw(mapTypeToValidationSchema(t, typeAliases));
+}
+
 function descriptor(
   variableType: VariableType,
   typeAliases: Record<string, VariableType>,
   typeAliasesFull: Record<string, TypeAliasEntry>,
   seen: Set<string> = new Set(),
-): string {
+): TsNode {
   // For an alias reference whose alias body has any `@validate(...)` tag,
   // reference the alias's runtime descriptor (attached as
   // `(Alias as any).__agency_descriptor` by `processTypeAlias`) rather than
@@ -130,24 +150,40 @@ function descriptor(
   // alias's via a runtime helper.
   if (variableType.type === "typeAliasVariable") {
     const entry = typeAliasesFull[variableType.aliasName];
-    const useSiteValidators = collectValidators(variableType.tags);
+    const useSiteValidators = validatorNodes(variableType.tags);
     if (entry && hasAliasValidate(entry, typeAliasesFull)) {
-      const ref = `(${variableType.aliasName} as any).__agency_descriptor`;
-      if (useSiteValidators.length === 0) return ref;
-      // Append use-site validators to the alias's chain.
-      return `{ ...${ref}, validators: [...(${ref}?.validators ?? []), ${useSiteValidators.join(", ")}] }`;
+      // `(Alias as any).__agency_descriptor`
+      const aliasRef = ts.prop(
+        ts.raw(`(${variableType.aliasName} as any)`),
+        "__agency_descriptor",
+      );
+      if (useSiteValidators.length === 0) return aliasRef;
+      // `{ ...aliasRef, validators: [...(aliasRef?.validators ?? []), ...] }`
+      const existingValidators = ts.binOp(
+        ts.prop(aliasRef, "validators", { optional: true }),
+        "??",
+        ts.arr([]),
+        { parenLeft: true },
+      );
+      return ts.obj([
+        ts.setSpread(aliasRef),
+        ts.set(
+          '"validators"',
+          ts.arr([ts.spread(existingValidators), ...useSiteValidators]),
+        ),
+      ]);
     }
     // No alias-level validators — emit a leaf using only the alias schema and
     // any use-site validators.
-    const schema = mapTypeToValidationSchema(variableType, typeAliases);
-    return `{ kind: "leaf", schema: ${schema}, validators: [${useSiteValidators.join(
-      ", ",
-    )}] }`;
+    return objEntries([
+      ["kind", ts.str("leaf")],
+      ["schema", schemaNode(variableType, typeAliases)],
+      ["validators", ts.arr(useSiteValidators)],
+    ]);
   }
 
-  const schema = mapTypeToValidationSchema(variableType, typeAliases);
-  const validators = collectValidators(variableType.tags);
-  const validatorsLit = `[${validators.join(", ")}]`;
+  const schema = schemaNode(variableType, typeAliases);
+  const validatorsArr = ts.arr(validatorNodes(variableType.tags));
 
   if (variableType.type === "arrayType") {
     const el = descriptor(
@@ -156,17 +192,32 @@ function descriptor(
       typeAliasesFull,
       seen,
     );
-    return `{ kind: "array", schema: ${schema}, validators: ${validatorsLit}, element: ${el} }`;
+    return objEntries([
+      ["kind", ts.str("array")],
+      ["schema", schema],
+      ["validators", validatorsArr],
+      ["element", el],
+    ]);
   }
 
   if (variableType.type === "objectType") {
-    const propEntries = variableType.properties.map((p) => {
+    const propEntries: TsObjectEntry[] = variableType.properties.map((p) => {
       const merged = mergeTagSets(p.value.tags, p.tags);
       const childType: VariableType = { ...p.value, tags: merged };
-      const childDesc = descriptor(childType, typeAliases, typeAliasesFull, seen);
-      return `${JSON.stringify(p.key)}: ${childDesc}`;
+      const childDesc = descriptor(
+        childType,
+        typeAliases,
+        typeAliasesFull,
+        seen,
+      );
+      return ts.set(JSON.stringify(p.key), childDesc);
     });
-    return `{ kind: "object", schema: ${schema}, validators: ${validatorsLit}, properties: { ${propEntries.join(", ")} } }`;
+    return objEntries([
+      ["kind", ts.str("object")],
+      ["schema", schema],
+      ["validators", validatorsArr],
+      ["properties", ts.obj(propEntries)],
+    ]);
   }
 
   if (isNullableType(variableType)) {
@@ -186,19 +237,39 @@ function descriptor(
         typeAliasesFull,
         seen,
       );
-      return `{ kind: "nullable", schema: ${schema}, validators: ${validatorsLit}, inner: ${inner} }`;
+      return objEntries([
+        ["kind", ts.str("nullable")],
+        ["schema", schema],
+        ["validators", validatorsArr],
+        ["inner", inner],
+      ]);
     }
     // multi-member nullable union: fall through to general union handling
   }
 
   if (variableType.type === "unionType") {
     const branches = variableType.types.map((m) => {
-      const branchSchema = mapTypeToValidationSchema(m, typeAliases);
+      const branchSchema = schemaNode(m, typeAliases);
       const branchDesc = descriptor(m, typeAliases, typeAliasesFull, seen);
-      const test = `(v) => (${branchSchema}).safeParse(v).success`;
-      return `{ test: ${test}, descriptor: ${branchDesc} }`;
+      // `(v) => (<branchSchema>).safeParse(v).success`
+      const test = ts.arrowFn(
+        [{ name: "v" }],
+        ts.prop(
+          ts.methodCall(branchSchema, "safeParse", [ts.id("v")]),
+          "success",
+        ),
+      );
+      return ts.obj([
+        ts.set("test", test),
+        ts.set("descriptor", branchDesc),
+      ]);
     });
-    return `{ kind: "union", schema: ${schema}, validators: ${validatorsLit}, branches: [${branches.join(", ")}] }`;
+    return objEntries([
+      ["kind", ts.str("union")],
+      ["schema", schema],
+      ["validators", validatorsArr],
+      ["branches", ts.arr(branches)],
+    ]);
   }
 
   if (variableType.type === "resultType") {
@@ -209,8 +280,26 @@ function descriptor(
       typeAliasesFull,
       seen,
     );
-    return `{ kind: "nullable", schema: ${schema}, validators: ${validatorsLit}, inner: ${inner} }`;
+    return objEntries([
+      ["kind", ts.str("nullable")],
+      ["schema", schema],
+      ["validators", validatorsArr],
+      ["inner", inner],
+    ]);
   }
 
-  return `{ kind: "leaf", schema: ${schema}, validators: ${validatorsLit} }`;
+  return objEntries([
+    ["kind", ts.str("leaf")],
+    ["schema", schema],
+    ["validators", validatorsArr],
+  ]);
+}
+
+/**
+ * Tiny helper: `objEntries([["a", x], ["b", y]])` builds `{ "a": x, "b": y }`.
+ * We always quote the keys so the printer renders predictable output for
+ * snapshots and matches the previous string-built form.
+ */
+function objEntries(entries: Array<[string, TsNode]>): TsNode {
+  return ts.obj(entries.map(([k, v]) => ts.set(JSON.stringify(k), v)));
 }

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -1,0 +1,216 @@
+import type { Tag, VariableType, TypeAliasEntry } from "../../types.js";
+import { mapTypeToValidationSchema } from "./typeToZodSchema.js";
+import { tagArgToTs } from "./tagArgToTs.js";
+import { mergeTagSets } from "@/typeChecker/mergeTags.js";
+
+/**
+ * Render a TS source expression that evaluates to a runtime
+ * `TypeValidationDescriptor`. Mirrors `mapTypeToValidationSchema`'s
+ * structural recursion but threads validator lists collected from
+ * `@validate(...)` tags at each level.
+ *
+ * Use this only when the type carries at least one `@validate` tag
+ * somewhere — callers should check via `hasAnyValidateTag` first.
+ *
+ * `typeAliasesFull` (when provided) lets the walker pick up alias-level
+ * validators for `typeAliasVariable` references that `resolveTypeDeep`
+ * intentionally leaves intact (so codegen can keep `.meta(...)` on the
+ * one top-level alias schema). Without it, alias-level `@validate`
+ * tags reachable only through a non-generic alias reference would be
+ * silently dropped.
+ */
+export function buildValidationDescriptorTs(
+  variableType: VariableType,
+  typeAliases: Record<string, VariableType>,
+  typeAliasesFull?: Record<string, TypeAliasEntry>,
+): string {
+  return descriptor(variableType, typeAliases, typeAliasesFull ?? {});
+}
+
+/**
+ * Walks a resolved type tree to determine whether any `@validate(...)`
+ * tag is present at any depth. Builders use this to gate the
+ * descriptor-based emit path; types without any `@validate` continue
+ * to use the existing zero-cost `__validateType(...)` codegen.
+ *
+ * `aliasesFull` (optional) lets us see through non-generic
+ * `typeAliasVariable` references — `deepResolveNode` leaves those
+ * intact for codegen-by-name purposes, so we have to look them up
+ * here to decide if the alias body carries `@validate`.
+ */
+export function hasAnyValidateTag(
+  t: VariableType,
+  aliasesFull?: Record<string, TypeAliasEntry>,
+  seen: Set<string> = new Set(),
+): boolean {
+  if (tagsHaveValidate(t.tags)) return true;
+  switch (t.type) {
+    case "arrayType":
+      return hasAnyValidateTag(t.elementType, aliasesFull, seen);
+    case "objectType":
+      return t.properties.some(
+        (p) =>
+          tagsHaveValidate(p.tags) ||
+          hasAnyValidateTag(p.value, aliasesFull, seen),
+      );
+    case "unionType":
+      return t.types.some((m) => hasAnyValidateTag(m, aliasesFull, seen));
+    case "resultType":
+      return hasAnyValidateTag(t.successType, aliasesFull, seen);
+    case "genericType":
+      return (t.typeArgs ?? []).some((a) =>
+        hasAnyValidateTag(a, aliasesFull, seen),
+      );
+    case "typeAliasVariable": {
+      if (!aliasesFull) return false;
+      const entry = aliasesFull[t.aliasName];
+      if (!entry) return false;
+      if (tagsHaveValidate(entry.tags)) return true;
+      // Guard against recursive alias self-reference.
+      if (seen.has(t.aliasName)) return false;
+      const nextSeen = new Set(seen);
+      nextSeen.add(t.aliasName);
+      return hasAnyValidateTag(entry.body, aliasesFull, nextSeen);
+    }
+    default:
+      return false;
+  }
+}
+
+function tagsHaveValidate(tags: Tag[] | undefined): boolean {
+  return !!tags && tags.some((t) => t.name === "validate");
+}
+
+/**
+ * True when `entry`'s tags or its body carry any `@validate(...)` tag.
+ * Used to decide whether a `typeAliasVariable` reference should emit a
+ * `(Alias as any).__agency_descriptor` reference vs. a flat leaf schema.
+ */
+function hasAliasValidate(
+  entry: TypeAliasEntry,
+  typeAliasesFull: Record<string, TypeAliasEntry>,
+): boolean {
+  if (tagsHaveValidate(entry.tags)) return true;
+  return hasAnyValidateTag(entry.body, typeAliasesFull);
+}
+
+function collectValidators(tags: Tag[] | undefined): string[] {
+  if (!tags) return [];
+  const out: string[] = [];
+  for (const t of tags) {
+    if (t.name !== "validate") continue;
+    for (const arg of t.arguments) {
+      out.push(tagArgToTs(arg));
+    }
+  }
+  return out;
+}
+
+function isNullableType(t: VariableType): boolean {
+  if (t.type !== "unionType") return false;
+  return t.types.some(
+    (m) =>
+      m.type === "primitiveType" &&
+      (m.value === "null" || m.value === "undefined"),
+  );
+}
+
+function descriptor(
+  variableType: VariableType,
+  typeAliases: Record<string, VariableType>,
+  typeAliasesFull: Record<string, TypeAliasEntry>,
+  seen: Set<string> = new Set(),
+): string {
+  // For an alias reference whose alias body has any `@validate(...)` tag,
+  // reference the alias's runtime descriptor (attached as
+  // `(Alias as any).__agency_descriptor` by `processTypeAlias`) rather than
+  // inlining the alias body. Inlining would leak identifiers (validators,
+  // schema-helper consts) that live in the alias-defining module's scope but
+  // not the consumer's. Use-site validators are concatenated on top of the
+  // alias's via a runtime helper.
+  if (variableType.type === "typeAliasVariable") {
+    const entry = typeAliasesFull[variableType.aliasName];
+    const useSiteValidators = collectValidators(variableType.tags);
+    if (entry && hasAliasValidate(entry, typeAliasesFull)) {
+      const ref = `(${variableType.aliasName} as any).__agency_descriptor`;
+      if (useSiteValidators.length === 0) return ref;
+      // Append use-site validators to the alias's chain.
+      return `{ ...${ref}, validators: [...(${ref}?.validators ?? []), ${useSiteValidators.join(", ")}] }`;
+    }
+    // No alias-level validators — emit a leaf using only the alias schema and
+    // any use-site validators.
+    const schema = mapTypeToValidationSchema(variableType, typeAliases);
+    return `{ kind: "leaf", schema: ${schema}, validators: [${useSiteValidators.join(
+      ", ",
+    )}] }`;
+  }
+
+  const schema = mapTypeToValidationSchema(variableType, typeAliases);
+  const validators = collectValidators(variableType.tags);
+  const validatorsLit = `[${validators.join(", ")}]`;
+
+  if (variableType.type === "arrayType") {
+    const el = descriptor(
+      variableType.elementType,
+      typeAliases,
+      typeAliasesFull,
+      seen,
+    );
+    return `{ kind: "array", schema: ${schema}, validators: ${validatorsLit}, element: ${el} }`;
+  }
+
+  if (variableType.type === "objectType") {
+    const propEntries = variableType.properties.map((p) => {
+      const merged = mergeTagSets(p.value.tags, p.tags);
+      const childType: VariableType = { ...p.value, tags: merged };
+      const childDesc = descriptor(childType, typeAliases, typeAliasesFull, seen);
+      return `${JSON.stringify(p.key)}: ${childDesc}`;
+    });
+    return `{ kind: "object", schema: ${schema}, validators: ${validatorsLit}, properties: { ${propEntries.join(", ")} } }`;
+  }
+
+  if (isNullableType(variableType)) {
+    // treat as nullable wrapper around the first non-null/undefined branch
+    const u = variableType as Extract<VariableType, { type: "unionType" }>;
+    const innerMembers = u.types.filter(
+      (m) =>
+        !(
+          m.type === "primitiveType" &&
+          (m.value === "null" || m.value === "undefined")
+        ),
+    );
+    if (innerMembers.length === 1) {
+      const inner = descriptor(
+        innerMembers[0],
+        typeAliases,
+        typeAliasesFull,
+        seen,
+      );
+      return `{ kind: "nullable", schema: ${schema}, validators: ${validatorsLit}, inner: ${inner} }`;
+    }
+    // multi-member nullable union: fall through to general union handling
+  }
+
+  if (variableType.type === "unionType") {
+    const branches = variableType.types.map((m) => {
+      const branchSchema = mapTypeToValidationSchema(m, typeAliases);
+      const branchDesc = descriptor(m, typeAliases, typeAliasesFull, seen);
+      const test = `(v) => (${branchSchema}).safeParse(v).success`;
+      return `{ test: ${test}, descriptor: ${branchDesc} }`;
+    });
+    return `{ kind: "union", schema: ${schema}, validators: ${validatorsLit}, branches: [${branches.join(", ")}] }`;
+  }
+
+  if (variableType.type === "resultType") {
+    // Recurse into the success type; the Result wrapper is checked by Zod.
+    const inner = descriptor(
+      variableType.successType,
+      typeAliases,
+      typeAliasesFull,
+      seen,
+    );
+    return `{ kind: "nullable", schema: ${schema}, validators: ${validatorsLit}, inner: ${inner} }`;
+  }
+
+  return `{ kind: "leaf", schema: ${schema}, validators: ${validatorsLit} }`;
+}

--- a/packages/agency-lang/lib/cli/doc.test.ts
+++ b/packages/agency-lang/lib/cli/doc.test.ts
@@ -403,6 +403,67 @@ node main() {
     );
   });
 
+  it("shows @validate and @jsonSchema annotations on type aliases", () => {
+    const inputDir = path.join(tmpDir, "input");
+    const outputDir = path.join(tmpDir, "output");
+    fs.mkdirSync(inputDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(inputDir, "annotated.agency"),
+      `import { isEmail } from "std::validators"
+
+@validate(isEmail)
+@jsonSchema({ format: "email", description: "User email." })
+export type Email = string
+`,
+    );
+
+    generateDoc({}, path.join(inputDir, "annotated.agency"), outputDir);
+    const output = fs.readFileSync(
+      path.join(outputDir, "annotated.md"),
+      "utf-8",
+    );
+
+    // The type alias should appear with its annotations inline.
+    expect(output).toContain("@validate(isEmail)");
+    expect(output).toContain("@jsonSchema(");
+
+    // Structured "Validators:" line should list the validator.
+    expect(output).toMatch(/\*\*Validators:\*\* `isEmail`/);
+
+    // JSON Schema metadata code block should include the object literal.
+    expect(output).toContain("**JSON Schema metadata:**");
+    expect(output).toMatch(/format:\s*"email"/);
+  });
+
+  it("includes exported constants in a Constants section", () => {
+    const inputDir = path.join(tmpDir, "input");
+    const outputDir = path.join(tmpDir, "output");
+    fs.mkdirSync(inputDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(inputDir, "consts.agency"),
+      `export static const VERSION = "1.0.0"
+export static const limits = { max: 10 }
+
+const internal = "not exported"
+`,
+    );
+
+    generateDoc({}, path.join(inputDir, "consts.agency"), outputDir);
+    const output = fs.readFileSync(
+      path.join(outputDir, "consts.md"),
+      "utf-8",
+    );
+
+    expect(output).toContain("## Constants");
+    expect(output).toContain("### VERSION");
+    expect(output).toContain('"1.0.0"');
+    expect(output).toContain("### limits");
+    // Internal (non-exported) const should NOT appear.
+    expect(output).not.toContain("### internal");
+  });
+
   it("does not add source links when baseUrl is not configured", () => {
     const inputDir = path.join(tmpDir, "input");
     const outputDir = path.join(tmpDir, "output");

--- a/packages/agency-lang/lib/cli/doc.ts
+++ b/packages/agency-lang/lib/cli/doc.ts
@@ -3,7 +3,8 @@ import { AgencyGenerator, generateAgency } from "@/backends/agencyGenerator.js";
 import { parse, readFile } from "./commands.js";
 import { findRecursively } from "./util.js";
 import { variableTypeToString } from "@/backends/typescriptGenerator/typeToString.js";
-import { AgencyMultiLineComment, AgencyProgram } from "@/types.js";
+import { AgencyMultiLineComment, AgencyProgram, Assignment } from "@/types.js";
+import type { Tag } from "@/types/tag.js";
 import { TypeAlias, VariableType } from "@/types/typeHints.js";
 import { FunctionDefinition, FunctionParameter } from "@/types/function.js";
 import { GraphNodeDefinition } from "@/types/graphNode.js";
@@ -71,6 +72,9 @@ export function generateDoc(
       )) {
         symbolRegistry[name] = mdRelPath;
       }
+      for (const c of collectExportedConstants(program)) {
+        symbolRegistry[c.variableName] = mdRelPath;
+      }
     }
 
     // Second pass: generate docs (reusing parsed programs)
@@ -121,6 +125,10 @@ function preprocessProgram(
 ): AgencyProgram {
   const preprocessor = new TypescriptPreprocessor(program, config);
   preprocessor.attachDocComments();
+  // Attach `@validate(...)` / `@jsonSchema(...)` / other tags onto their
+  // target nodes (type aliases, functions, etc.) so the rendered code
+  // block in the docs includes those annotations.
+  preprocessor.attachTags();
   return program;
 }
 
@@ -150,6 +158,7 @@ function generateDocForFile(
       typeAliases.push(node);
     }
   }
+  const constants = collectExportedConstants(program);
 
   const title = path.basename(filePath).replace(/\.agency$/, "");
   const sections: string[] = [heading(1, title)];
@@ -165,6 +174,9 @@ function generateDocForFile(
 
   const typeSection = generateTypeSection(typeAliases, ctx);
   if (typeSection) sections.push(typeSection);
+
+  const constantSection = generateConstantSection(constants, ctx);
+  if (constantSection) sections.push(constantSection);
 
   const functions = Object.values(info.functionDefinitions);
   const functionSection = generateFunctionSection(
@@ -273,6 +285,7 @@ function formatTypeAlias(alias: TypeAlias, ctx: DocContext): string {
     heading(3, alias.aliasName),
     alias.docComment ? formatDocComment(alias.docComment) : null,
     codeFence(code),
+    formatValidatorsAndSchema(alias.tags),
     sourceLink(alias.loc, ctx),
   );
 }
@@ -285,6 +298,83 @@ function generateTypeSection(
   return section(
     heading(2, "Types"),
     ...aliases.map((a) => formatTypeAlias(a, ctx)),
+  );
+}
+
+/**
+ * Format the runtime validators + JSON-schema annotations attached to a
+ * type alias (or any other tagged target). Returns `null` if no
+ * `@validate(...)` or `@jsonSchema(...)` tags are present so callers
+ * can elide the section.
+ */
+function formatValidatorsAndSchema(tags: Tag[] | undefined): string | null {
+  if (!tags || tags.length === 0) return null;
+  const parts: string[] = [];
+
+  const validators: string[] = [];
+  for (const t of tags) {
+    if (t.name !== "validate") continue;
+    for (const arg of t.arguments) {
+      validators.push("`" + generator.processNode(arg).trim() + "`");
+    }
+  }
+  if (validators.length > 0) {
+    parts.push(`${bold("Validators:")} ${validators.join(", ")}`);
+  }
+
+  const jsonSchemaTag = tags.find((t) => t.name === "jsonSchema");
+  if (jsonSchemaTag) {
+    const arg = jsonSchemaTag.arguments[0];
+    if (arg) {
+      const rendered = generator.processNode(arg).trim();
+      parts.push(`${bold("JSON Schema metadata:")}\n\n${codeFence(rendered, "agency")}`);
+    }
+  }
+
+  return parts.length === 0 ? null : parts.join("\n\n");
+}
+
+function collectExportedConstants(program: AgencyProgram): Assignment[] {
+  const out: Assignment[] = [];
+  for (const node of program.nodes) {
+    if (
+      node.type === "assignment" &&
+      node.exported &&
+      node.declKind === "const"
+    ) {
+      out.push(node as Assignment);
+    }
+  }
+  return out;
+}
+
+function formatConstant(c: Assignment, ctx: DocContext): string {
+  // Render the declaration via the agency generator so it picks up any
+  // attached `@validate(...)` / `@jsonSchema(...)` tags and the doc
+  // comment.
+  const code = generateAgency({
+    type: "agencyProgram",
+    nodes: [c],
+  });
+  return section(
+    heading(3, c.variableName),
+    codeFence(code),
+    c.typeHint
+      ? `${bold("Type:")} ${formatTypeLinked(c.typeHint, ctx)}`
+      : null,
+    formatValidatorsAndSchema(c.tags),
+    sourceLink(c.loc, ctx),
+  );
+}
+
+function generateConstantSection(
+  constants: Assignment[],
+  ctx: DocContext,
+): string | null {
+  if (constants.length === 0) return null;
+  return section(
+    heading(2, "Constants"),
+    ...constants.map((c) => formatConstant(c, ctx)),
   );
 }
 

--- a/packages/agency-lang/lib/cli/optimize.test.ts
+++ b/packages/agency-lang/lib/cli/optimize.test.ts
@@ -94,7 +94,12 @@ node main(msg: string): string {
     expect(tag).toMatchObject({
       type: "tag",
       name: "goal",
-      arguments: ["Classify messages accurately"],
+      arguments: [
+        {
+          type: "string",
+          segments: [{ type: "text", value: "Classify messages accurately" }],
+        },
+      ],
     });
   });
 

--- a/packages/agency-lang/lib/cli/optimize.ts
+++ b/packages/agency-lang/lib/cli/optimize.ts
@@ -4,7 +4,6 @@ import { resetCompilationCache } from "./commands.js";
 import { parseAgency } from "@/parser.js";
 import { exprParser } from "@/parsers/parsers.js";
 import { Tag, AgencyProgram, AgencyNode, PromptSegment, FunctionParameter, GraphNodeDefinition } from "@/types.js";
-import { tagArgToLegacyString } from "@/types/tag.js";
 import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
 import { buildCompilationUnit } from "@/compilationUnit.js";
 import { AgencyGenerator } from "@/backends/agencyGenerator.js";
@@ -142,7 +141,14 @@ export async function optimize(
   }
 
   const goalArg = goalTag.arguments[0];
-  const goal = goalArg ? (tagArgToLegacyString(goalArg) ?? "") : "";
+  let goal = "";
+  if (
+    goalArg?.type === "string" &&
+    goalArg.segments.length === 1 &&
+    goalArg.segments[0].type === "text"
+  ) {
+    goal = goalArg.segments[0].value;
+  }
   console.log(`Goal: ${goal}`);
   console.log(`Running up to ${options.iterations} iterations...\n`);
 
@@ -279,7 +285,7 @@ function collectOptimizeTargets(
       target.configKeys = optimizeTag.arguments.length === 0
         ? ["prompt"]
         : optimizeTag.arguments
-          .map((a) => tagArgToLegacyString(a))
+          .map((a) => (a.type === "variableName" ? a.value : null))
           .filter((s): s is string => s !== null);
       targets.push(target);
     }

--- a/packages/agency-lang/lib/cli/optimize.ts
+++ b/packages/agency-lang/lib/cli/optimize.ts
@@ -4,6 +4,7 @@ import { resetCompilationCache } from "./commands.js";
 import { parseAgency } from "@/parser.js";
 import { exprParser } from "@/parsers/parsers.js";
 import { Tag, AgencyProgram, AgencyNode, PromptSegment, FunctionParameter, GraphNodeDefinition } from "@/types.js";
+import { tagArgToLegacyString } from "@/types/tag.js";
 import { TypescriptPreprocessor } from "@/preprocessors/typescriptPreprocessor.js";
 import { buildCompilationUnit } from "@/compilationUnit.js";
 import { AgencyGenerator } from "@/backends/agencyGenerator.js";
@@ -140,7 +141,8 @@ export async function optimize(
     );
   }
 
-  const goal = goalTag.arguments[0];
+  const goalArg = goalTag.arguments[0];
+  const goal = goalArg ? (tagArgToLegacyString(goalArg) ?? "") : "";
   console.log(`Goal: ${goal}`);
   console.log(`Running up to ${options.iterations} iterations...\n`);
 
@@ -274,7 +276,11 @@ function collectOptimizeTargets(
 
       const target: OptimizeTarget = { node, llmCall, tag: optimizeTag };
       target.promptValue = getPromptValue(target);
-      target.configKeys = optimizeTag.arguments.length === 0 ? ["prompt"] : optimizeTag.arguments;
+      target.configKeys = optimizeTag.arguments.length === 0
+        ? ["prompt"]
+        : optimizeTag.arguments
+          .map((a) => tagArgToLegacyString(a))
+          .filter((s): s is string => s !== null);
       targets.push(target);
     }
   }

--- a/packages/agency-lang/lib/cli/optimize.ts
+++ b/packages/agency-lang/lib/cli/optimize.ts
@@ -141,14 +141,20 @@ export async function optimize(
   }
 
   const goalArg = goalTag.arguments[0];
-  let goal = "";
   if (
-    goalArg?.type === "string" &&
-    goalArg.segments.length === 1 &&
-    goalArg.segments[0].type === "text"
+    !goalArg ||
+    goalArg.type !== "string" ||
+    goalArg.segments.length !== 1 ||
+    goalArg.segments[0].type !== "text"
   ) {
-    goal = goalArg.segments[0].value;
+    const where = goalArg?.loc
+      ? ` (line ${goalArg.loc.line}, col ${goalArg.loc.col})`
+      : "";
+    throw new Error(
+      `@goal(...) requires a single plain string-literal argument${where}; got ${goalArg ? goalArg.type : "no argument"}.`,
+    );
   }
+  const goal: string = goalArg.segments[0].value;
   console.log(`Goal: ${goal}`);
   console.log(`Running up to ${options.iterations} iterations...\n`);
 
@@ -282,11 +288,19 @@ function collectOptimizeTargets(
 
       const target: OptimizeTarget = { node, llmCall, tag: optimizeTag };
       target.promptValue = getPromptValue(target);
-      target.configKeys = optimizeTag.arguments.length === 0
-        ? ["prompt"]
-        : optimizeTag.arguments
-          .map((a) => (a.type === "variableName" ? a.value : null))
-          .filter((s): s is string => s !== null);
+      if (optimizeTag.arguments.length === 0) {
+        target.configKeys = ["prompt"];
+      } else {
+        target.configKeys = optimizeTag.arguments.map((a) => {
+          if (a.type !== "variableName") {
+            const where = a.loc ? ` (line ${a.loc.line}, col ${a.loc.col})` : "";
+            throw new Error(
+              `@optimize(...) arguments must be plain config-key identifiers${where}; got ${a.type}.`,
+            );
+          }
+          return a.value;
+        });
+      }
       targets.push(target);
     }
   }

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -5,6 +5,7 @@ import type {
   FunctionParameter,
   GraphNodeDefinition,
   Scope,
+  Tag,
   TypeAliasEntry,
   TypeParam,
   VariableType,
@@ -15,6 +16,7 @@ import type {
 } from "./types/importStatement.js";
 import { getImportedNames } from "./types/importStatement.js";
 import type { SymbolTable, InterruptKind } from "./symbolTable.js";
+import { collectTypeAliasTags } from "./symbolTable.js";
 import { walkNodes } from "./utils/node.js";
 import { resultTypeForValidation } from "./typeChecker/validation.js";
 import { visitTypes } from "./typeChecker/typeWalker.js";
@@ -43,9 +45,12 @@ export class ScopedTypeAliases {
     name: string,
     body: VariableType,
     typeParams?: TypeParam[],
+    tags?: Tag[],
   ): void {
     if (!this.byScope[scopeKey]) this.byScope[scopeKey] = {};
-    const entry: TypeAliasEntry = typeParams ? { body, typeParams } : { body };
+    const entry: TypeAliasEntry = { body };
+    if (typeParams) entry.typeParams = typeParams;
+    if (tags && tags.length > 0) entry.tags = tags;
     this.byScope[scopeKey][name] = entry;
   }
 
@@ -198,15 +203,24 @@ export function buildCompilationUnit(
     }
   }
 
+  // Tags on local typeAlias nodes are only attached after the preprocessor
+  // runs (which happens AFTER buildCompilationUnit). Pre-collect them here
+  // so cross-module annotation propagation works in the first pass.
+  const localAliasTags = collectTypeAliasTags(program);
+
   // Deep walk: collect every type alias keyed by its enclosing scope.
   for (const { node, scopes } of walkNodes(program.nodes)) {
     const key = scopeKey(scopes[scopes.length - 1]);
     if (node.type === "typeAlias") {
+      const tags = node.tags && node.tags.length > 0
+        ? node.tags
+        : localAliasTags[node.aliasName];
       unit.typeAliases.add(
         key,
         node.aliasName,
         node.aliasedType,
         node.typeParams,
+        tags,
       );
     }
   }
@@ -257,6 +271,7 @@ export function buildCompilationUnit(
             r.localName,
             r.symbol.aliasedType,
             r.symbol.typeParams,
+            r.symbol.tags,
           );
           // Imported type's body may reference other aliases from its
           // module — pull those transitively too.
@@ -335,6 +350,7 @@ function pullTransitiveAliases(
       name,
       found.aliasedType,
       found.typeParams,
+      found.tags,
     );
     // Nested aliases referenced by this type should resolve in the file
     // the type was actually found in (not the original preferFile) — the
@@ -356,13 +372,14 @@ function resolveTypeFromFile(
   symbolTable: SymbolTable,
   name: string,
   preferFile: string | undefined,
-): { aliasedType: VariableType; typeParams?: TypeParam[]; file: string } | undefined {
+): { aliasedType: VariableType; typeParams?: TypeParam[]; tags?: Tag[]; file: string } | undefined {
   if (preferFile) {
     const fileSym = symbolTable.getFile(preferFile)?.[name];
     if (fileSym?.kind === "type") {
       return {
         aliasedType: fileSym.aliasedType,
         typeParams: fileSym.typeParams,
+        tags: fileSym.tags,
         file: preferFile,
       };
     }
@@ -373,6 +390,7 @@ function resolveTypeFromFile(
       return {
         aliasedType: sym.aliasedType,
         typeParams: sym.typeParams,
+        tags: sym.tags,
         file,
       };
     }

--- a/packages/agency-lang/lib/ir/builders.ts
+++ b/packages/agency-lang/lib/ir/builders.ts
@@ -405,7 +405,7 @@ export const ts = {
    * `await __validateChainRecursive(value, <descriptor>, __ctx)` — used at
    * `!` sites whose resolved type carries at least one `@validate(...)` tag
    * anywhere in the tree. The descriptor is a TS expression built via
-   * `buildValidationDescriptorTs(...)` and passed in raw.
+   * `buildValidationDescriptor(...)`.
    */
   validateChainRecursive(value: TsNode, descriptor: TsNode): TsAwait {
     return ts.awaitCall(ts.id("__validateChainRecursive"), [

--- a/packages/agency-lang/lib/ir/builders.ts
+++ b/packages/agency-lang/lib/ir/builders.ts
@@ -401,6 +401,20 @@ export const ts = {
     return ts.call(ts.id("__validateType"), [value, zodSchema]);
   },
 
+  /**
+   * `await __validateChainRecursive(value, <descriptor>, __ctx)` — used at
+   * `!` sites whose resolved type carries at least one `@validate(...)` tag
+   * anywhere in the tree. The descriptor is a TS expression built via
+   * `buildValidationDescriptorTs(...)` and passed in raw.
+   */
+  validateChainRecursive(value: TsNode, descriptor: TsNode): TsAwait {
+    return ts.awaitCall(ts.id("__validateChainRecursive"), [
+      value,
+      descriptor,
+      ts.id("__ctx"),
+    ]);
+  },
+
   scopedVar(
     name: string,
     scope: TsScopedVar["scope"],

--- a/packages/agency-lang/lib/parsers/objectTypeTags.test.ts
+++ b/packages/agency-lang/lib/parsers/objectTypeTags.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { objectTypeParser } from "./parsers.js";
+
+describe("objectTypeParser — property tags", () => {
+  it("attaches a single @validate tag to a property", () => {
+    const src = `{
+      @validate(isEmail)
+      email: string
+    }`;
+    const r = objectTypeParser(src);
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    const prop = r.result.properties[0];
+    expect(prop.key).toBe("email");
+    expect(prop.tags).toHaveLength(1);
+    expect(prop.tags?.[0].name).toBe("validate");
+  });
+
+  it("attaches multiple stacked tags to a property", () => {
+    const src = `{
+      @validate(isEmail)
+      @jsonSchema({ format: "email" })
+      email: string
+    }`;
+    const r = objectTypeParser(src);
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    const prop = r.result.properties[0];
+    expect(prop.tags).toHaveLength(2);
+    expect(prop.tags?.[0].name).toBe("validate");
+    expect(prop.tags?.[1].name).toBe("jsonSchema");
+  });
+
+  it("plain property still parses with no tags", () => {
+    const src = `{ name: string }`;
+    const r = objectTypeParser(src);
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    expect(r.result.properties[0].tags).toBeUndefined();
+  });
+
+  it("tags do not leak across properties", () => {
+    const src = `{
+      @validate(isEmail)
+      email: string,
+      name: string
+    }`;
+    const r = objectTypeParser(src);
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    const emailProp = r.result.properties.find((p) => p.key === "email");
+    const nameProp = r.result.properties.find((p) => p.key === "name");
+    expect(emailProp?.tags).toHaveLength(1);
+    expect(nameProp?.tags).toBeUndefined();
+  });
+
+  it("preserves legacy # description alongside tags", () => {
+    const src = `{
+      @validate(isEmail)
+      email: string # the work email
+    }`;
+    const r = objectTypeParser(src);
+    expect(r.success).toBe(true);
+    if (!r.success) return;
+    const prop = r.result.properties[0];
+    expect(prop.tags).toHaveLength(1);
+    expect(prop.description).toBe("the work email");
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -1379,7 +1379,7 @@ const restrictedTagArgParser: Parser<Expression> = label(
     nullParser,
     booleanParser,
     numberParser,
-    lazy(() => stringParser),
+    simpleStringParser,
     variableNameParser,
   ),
 );

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -881,6 +881,50 @@ export const objectPropertyWithDescriptionParser: Parser<ObjectProperty> =
     ),
   );
 
+/**
+ * Parses one or more `@tag(...)` lines, then a property, attaching the
+ * tags to that property's `tags` field. Used inside `objectTypeParser`
+ * so users can write:
+ *
+ *     type User = {
+ *       @validate(isEmail)
+ *       @jsonSchema({ format: "email" })
+ *       email: string
+ *     }
+ */
+export const taggedObjectPropertyParser: Parser<ObjectProperty> = trace(
+  "taggedObjectPropertyParser",
+  (input: string): ParserResult<ObjectProperty> => {
+    const parser = seqC(
+      capture(
+        many1(
+          seqC(
+            captureCaptures(lazy(() => tagParser)),
+            optionalSpacesOrNewline,
+          ),
+        ),
+        "tagWrappers",
+      ),
+      capture(
+        or(
+          lazy(() => objectPropertyWithDescriptionParser),
+          lazy(() => objectPropertyParser),
+        ),
+        "prop",
+      ),
+    );
+    const result = parser(input);
+    if (!result.success) return result;
+    const tags = (result.result.tagWrappers as Array<any>).map(
+      (w) => ({ type: "tag", name: w.name, arguments: w.arguments, loc: w.loc }),
+    ) as Tag[];
+    return success(
+      { ...(result.result.prop as ObjectProperty), tags },
+      result.rest,
+    );
+  },
+);
+
 export const objectTypeParser: Parser<ObjectType> = trace(
   "objectTypeParser",
   (input: string): ParserResult<ObjectType> => {
@@ -892,6 +936,7 @@ export const objectTypeParser: Parser<ObjectType> = trace(
         sepBy(
           objectPropertyDelimiter,
           or(
+            taggedObjectPropertyParser,
             objectPropertyWithDescriptionParser,
             objectPropertyParser,
             commentParser,
@@ -1316,18 +1361,35 @@ export const skillParser = (input: string) => {
 // tag.ts
 // =============================================================================
 
-// A single tag argument: either a quoted string or a bare identifier
-// Both are normalized to plain strings
-const stringArg = map(quotedString, removeQuotes);
-const identArg = many1WithJoin(varNameChar);
-const tagArg = or(stringArg, identArg);
+// A single tag argument: restricted subset of expressions per spec
+// (docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md).
+//
+// Allowed: string / number / boolean / null literals, identifiers,
+// function calls, object literals (including spread). NOT allowed:
+// ternaries, binary ops, pipes, member access, template strings,
+// array literals.
+//
+// All forward references go through lazy(...) because these parsers
+// are defined later in the file.
+const restrictedTagArgParser: Parser<Expression> = label(
+  "a tag argument (literal, identifier, function call, or object literal)",
+  or(
+    lazy(() => agencyObjectParser),
+    lazy(() => functionCallParser),
+    nullParser,
+    booleanParser,
+    numberParser,
+    lazy(() => stringParser),
+    variableNameParser,
+  ),
+);
 
-// Parenthesized argument list: (arg1, arg2) or ("string arg")
+// Parenthesized argument list: (arg1, arg2)
 const tagArgsList = map(
   seqC(
     char("("),
     optionalSpaces,
-    capture(sepBy(comma, tagArg), "args"),
+    capture(sepBy(comma, restrictedTagArgParser), "args"),
     optionalSpaces,
     char(")"),
   ),
@@ -1342,7 +1404,7 @@ const _tagParserInner = trace(
     char("@"),
     capture(many1WithJoin(varNameChar), "name"),
     capture(
-      or(tagArgsList, succeed([] as string[])),
+      or(tagArgsList, succeed([] as Expression[])),
       "arguments",
     ),
     optionalSemicolon,

--- a/packages/agency-lang/lib/parsers/tag.test.ts
+++ b/packages/agency-lang/lib/parsers/tag.test.ts
@@ -130,4 +130,43 @@ describe("tagParser", () => {
     if (!result.success) return;
     expect(result.result.loc).toBeDefined();
   });
+
+  // The restricted tag-arg parser uses `simpleStringParser`, which does
+  // not support interpolation segments or `+`-concatenation. These tests
+  // assert that contract: malformed string-shaped args don't sneak
+  // through as a valid single string argument.
+  it("does not accept interpolated string arguments", () => {
+    const result = tagParser('@validate("hello {name}")');
+    if (result.success) {
+      // If parsing succeeds, the interpolation must NOT have been parsed
+      // as part of the tag argument. The argument should either be the
+      // plain text (no interpolation segment) or the tag should have
+      // zero arguments with the rest unconsumed.
+      for (const arg of result.result.arguments) {
+        if (arg.type === "string") {
+          for (const seg of (arg as any).segments) {
+            expect(seg.type).toBe("text");
+          }
+        }
+      }
+    }
+  });
+
+  it("does not accept `+`-concatenated string arguments", () => {
+    // `"hi" + foo` must not parse as a single string arg in a tag.
+    // Either the parser fails outright or the arg list contains only
+    // the first literal and leaves `+ foo` unconsumed inside the parens
+    // (which then makes the whole tag fail or fall back to zero-args).
+    const result = tagParser('@goal("hi" + foo)');
+    if (result.success) {
+      const arg = result.result.arguments[0];
+      if (arg && arg.type === "string") {
+        // It must be the plain "hi" (one text segment) — never the
+        // concatenated expression.
+        expect((arg as any).segments).toEqual([
+          { type: "text", value: "hi" },
+        ]);
+      }
+    }
+  });
 });

--- a/packages/agency-lang/lib/parsers/tag.test.ts
+++ b/packages/agency-lang/lib/parsers/tag.test.ts
@@ -17,21 +17,30 @@ describe("tagParser", () => {
     const result = tagParser('@goal("Suggest good gifts")');
     expect(result.success).toBe(true);
     if (!result.success) return;
-    expect(result.result).toMatchObject({
-      type: "tag",
-      name: "goal",
-      arguments: ["Suggest good gifts"],
-    });
+    expect(result.result.name).toBe("goal");
+    expect(result.result.arguments).toHaveLength(1);
+    const arg = result.result.arguments[0];
+    expect(arg.type).toBe("string");
+    if (arg.type === "string") {
+      expect(arg.segments).toEqual([
+        { type: "text", value: "Suggest good gifts" },
+      ]);
+    }
   });
 
   it("parses a tag with multiple identifier arguments", () => {
     const result = tagParser("@optimize(prompt, temperature)");
     expect(result.success).toBe(true);
     if (!result.success) return;
-    expect(result.result).toMatchObject({
-      type: "tag",
-      name: "optimize",
-      arguments: ["prompt", "temperature"],
+    expect(result.result.name).toBe("optimize");
+    expect(result.result.arguments).toHaveLength(2);
+    expect(result.result.arguments[0]).toMatchObject({
+      type: "variableName",
+      value: "prompt",
+    });
+    expect(result.result.arguments[1]).toMatchObject({
+      type: "variableName",
+      value: "temperature",
     });
   });
 
@@ -39,11 +48,70 @@ describe("tagParser", () => {
     const result = tagParser("@optimize(temperature)");
     expect(result.success).toBe(true);
     if (!result.success) return;
-    expect(result.result).toMatchObject({
-      type: "tag",
-      name: "optimize",
-      arguments: ["temperature"],
+    expect(result.result.name).toBe("optimize");
+    expect(result.result.arguments).toHaveLength(1);
+    expect(result.result.arguments[0]).toMatchObject({
+      type: "variableName",
+      value: "temperature",
     });
+  });
+
+  it("parses a tag with a function call argument", () => {
+    const result = tagParser("@validate(min(0), max(150))");
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.result.name).toBe("validate");
+    expect(result.result.arguments).toHaveLength(2);
+    expect(result.result.arguments[0].type).toBe("functionCall");
+    expect(result.result.arguments[1].type).toBe("functionCall");
+  });
+
+  it("parses a tag with an object literal argument", () => {
+    const result = tagParser('@jsonSchema({ format: "email" })');
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.result.name).toBe("jsonSchema");
+    expect(result.result.arguments).toHaveLength(1);
+    expect(result.result.arguments[0].type).toBe("agencyObject");
+  });
+
+  it("parses a tag with an object literal containing spread", () => {
+    const result = tagParser(
+      '@jsonSchema({ ...emailFormat, description: "work" })',
+    );
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.result.arguments[0].type).toBe("agencyObject");
+  });
+
+  it("parses a tag with number / boolean / null literal arguments", () => {
+    const r1 = tagParser("@retry(3)");
+    expect(r1.success).toBe(true);
+    if (r1.success) expect(r1.result.arguments[0].type).toBe("number");
+
+    const r2 = tagParser("@flag(true)");
+    expect(r2.success).toBe(true);
+    if (r2.success) expect(r2.result.arguments[0].type).toBe("boolean");
+
+    const r3 = tagParser("@nullable(null)");
+    expect(r3.success).toBe(true);
+    if (r3.success) expect(r3.result.arguments[0].type).toBe("null");
+  });
+
+  it("does not accept binary operator expressions inside tags", () => {
+    // `@validate(x > 5)` cannot be parsed as a well-formed tag with args:
+    // after `x` is parsed as an identifier, `> 5` is leftover and the
+    // argument-list expects a comma or closing paren. Because the tag
+    // parser has a "no-args" fallback (for bare `@tag`), parsing
+    // succeeds with the name `validate` and zero arguments, leaving
+    // the `(x > 5)` portion unconsumed. We assert that here so any
+    // future tightening (e.g. committing once a `(` is seen) makes
+    // the failure mode explicit.
+    const result = tagParser("@validate(x > 5)");
+    if (result.success) {
+      expect(result.result.arguments).toHaveLength(0);
+      expect(result.rest.startsWith("(x")).toBe(true);
+    }
   });
 
   it("fails on non-tag input", () => {

--- a/packages/agency-lang/lib/parsers/tagIntegration.test.ts
+++ b/packages/agency-lang/lib/parsers/tagIntegration.test.ts
@@ -17,10 +17,12 @@ node main(msg: string): string {
     if (!result.success) return;
     const tagNode = result.result.nodes.find((n: any) => n.type === "tag");
     expect(tagNode).toBeDefined();
-    expect(tagNode).toMatchObject({
-      type: "tag",
-      name: "goal",
-      arguments: ["Classify messages"],
+    const tag = tagNode as any;
+    expect(tag.name).toBe("goal");
+    expect(tag.arguments).toHaveLength(1);
+    expect(tag.arguments[0]).toMatchObject({
+      type: "string",
+      segments: [{ type: "text", value: "Classify messages" }],
     });
   });
 
@@ -61,10 +63,11 @@ node main(msg: string): string {
 
     const graphNode = processed.nodes.find((n: any) => n.type === "graphNode") as any;
     expect(graphNode.tags).toHaveLength(1);
-    expect(graphNode.tags[0]).toMatchObject({
-      type: "tag",
-      name: "goal",
-      arguments: ["Classify messages"],
+    expect(graphNode.tags[0].name).toBe("goal");
+    expect(graphNode.tags[0].arguments).toHaveLength(1);
+    expect(graphNode.tags[0].arguments[0]).toMatchObject({
+      type: "string",
+      segments: [{ type: "text", value: "Classify messages" }],
     });
   });
 

--- a/packages/agency-lang/lib/preprocessors/importResolver.ts
+++ b/packages/agency-lang/lib/preprocessors/importResolver.ts
@@ -51,6 +51,7 @@ export function resolveImports(
     const functionNames: string[] = [];
     const safeFunctionNames: string[] = [];
     const typeNames: string[] = [];
+    const constantNames: string[] = [];
     const aliases: Record<string, string> = {};
 
     for (const nameType of node.importedNames) {
@@ -94,6 +95,10 @@ export function resolveImports(
             assertExported(name, node.modulePath, symbol.exported, "Type");
             typeNames.push(name);
             break;
+          case "constant":
+            assertExported(name, node.modulePath, symbol.exported, "Constant");
+            constantNames.push(name);
+            break;
         }
       }
     }
@@ -107,8 +112,11 @@ export function resolveImports(
       newNodes.push(nodeImport);
     }
 
-    // Combine functions and types into a single import statement
-    const allNames = [...functionNames, ...typeNames];
+    // Combine functions, types, and static-const imports into a single import statement.
+    // Constants need to flow through even when only referenced via a tag
+    // argument (e.g. `@jsonSchema({ ...emailFormat })`) — without including
+    // them here the generated TS would have a dangling reference.
+    const allNames = [...functionNames, ...typeNames, ...constantNames];
     if (allNames.length > 0) {
       const allAliases: Record<string, string> = {};
       for (const name of allNames) {

--- a/packages/agency-lang/lib/preprocessors/typeAliasTags.test.ts
+++ b/packages/agency-lang/lib/preprocessors/typeAliasTags.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { parseAgency } from "../parser.js";
+import { TypescriptPreprocessor } from "./typescriptPreprocessor.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+
+describe("attachTags — type aliases", () => {
+  it("attaches @validate above a type alias", () => {
+    const code = `
+@validate(isEmail)
+type Email = string
+`;
+    const parsed = parseAgency(code);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    const info = buildCompilationUnit(parsed.result);
+    const preprocessor = new TypescriptPreprocessor(parsed.result, {}, info);
+    const processed = preprocessor.preprocess();
+
+    const alias = processed.nodes.find(
+      (n: any) => n.type === "typeAlias" && n.aliasName === "Email",
+    ) as any;
+    expect(alias).toBeDefined();
+    expect(alias.tags).toHaveLength(1);
+    expect(alias.tags[0].name).toBe("validate");
+  });
+
+  it("attaches multiple stacked tags above a type alias", () => {
+    const code = `
+@validate(isEmail)
+@jsonSchema({ format: "email" })
+type Email = string
+`;
+    const parsed = parseAgency(code);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    const info = buildCompilationUnit(parsed.result);
+    const preprocessor = new TypescriptPreprocessor(parsed.result, {}, info);
+    const processed = preprocessor.preprocess();
+
+    const alias = processed.nodes.find(
+      (n: any) => n.type === "typeAlias" && n.aliasName === "Email",
+    ) as any;
+    expect(alias.tags).toHaveLength(2);
+    expect(alias.tags.map((t: any) => t.name)).toEqual(["validate", "jsonSchema"]);
+  });
+
+  it("does not consume tags from a previous alias", () => {
+    const code = `
+@validate(isEmail)
+type Email = string
+
+type Plain = number
+`;
+    const parsed = parseAgency(code);
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    const info = buildCompilationUnit(parsed.result);
+    const preprocessor = new TypescriptPreprocessor(parsed.result, {}, info);
+    const processed = preprocessor.preprocess();
+
+    const plain = processed.nodes.find(
+      (n: any) => n.type === "typeAlias" && n.aliasName === "Plain",
+    ) as any;
+    expect(plain.tags ?? []).toHaveLength(0);
+  });
+});

--- a/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
+++ b/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
@@ -121,7 +121,8 @@ function attachTags(nodes: AgencyNode[]): AgencyNode[] {
 
     if (pendingTags.length > 0) {
       if (node.type === "graphNode" || node.type === "function" ||
-        node.type === "assignment" || node.type === "functionCall") {
+        node.type === "assignment" || node.type === "functionCall" ||
+        node.type === "typeAlias") {
         node.tags = [...(node.tags || []), ...pendingTags];
         pendingTags = [];
       } else {

--- a/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
+++ b/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
@@ -177,6 +177,17 @@ export class TypescriptPreprocessor {
     }
   }
 
+  /**
+   * Move standalone `tag` nodes onto the next attach-target node
+   * (function / graphNode / assignment / functionCall / typeAlias).
+   * Public so consumers like the doc generator can run the same
+   * tag-attachment that the full `preprocess()` pipeline runs without
+   * also running every downstream transform.
+   */
+  attachTags(): void {
+    this.program.nodes = collectTags(this.program.nodes);
+  }
+
   attachDocComments(): void {
     const nodes = this.program.nodes;
     const DECLARATION_TYPES = ["function", "graphNode", "typeAlias"];

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -107,4 +107,13 @@ export {
 } from "./result.js";
 export type { ResultValue, ResultSuccess, ResultFailure } from "./result.js";
 export { Schema, __validateType } from "./schema.js";
+export {
+  __validateChain,
+  __validateChainRecursive,
+} from "./validateChain.js";
+export type {
+  AgencyValidator,
+  TypeValidationDescriptor,
+  RecursiveValidationOpts,
+} from "./validateChain.js";
 export { CoverageCollector } from "./coverageCollector.js";

--- a/packages/agency-lang/lib/runtime/schema.ts
+++ b/packages/agency-lang/lib/runtime/schema.ts
@@ -22,6 +22,17 @@ export class Schema {
     }
     return this.parse(parsed);
   }
+
+  /**
+   * Convert this schema to a JSON Schema document. Picks up any
+   * `@jsonSchema(...)` metadata attached via `.meta(...)` and merges it
+   * into the output. Use this from agency code to verify that
+   * `@jsonSchema(...)` annotations actually propagate to the wire
+   * format LLMs and JSON-schema consumers see.
+   */
+  toJSONSchema(): unknown {
+    return z.toJSONSchema(this.zodSchema);
+  }
 }
 
 export function __validateType(value: unknown, schema: z.ZodType): ResultValue {

--- a/packages/agency-lang/lib/runtime/validateChain.test.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.test.ts
@@ -154,6 +154,10 @@ describe("__validateChainRecursive", () => {
 
     const r = await __validateChainRecursive(v, desc, ctx, { maxDepth: 3 });
     expect(isFailure(r)).toBe(true);
-    expect((r as { error: string }).error).toMatch(/recursion depth/);
+    const err = (r as { error: { reason: string; limit: number; kind: string; valuePreview: unknown } }).error;
+    expect(err.reason).toMatch(/recursion depth/);
+    expect(err.limit).toBe(3);
+    expect(err.kind).toBe("array");
+    expect(typeof err.valuePreview === "string").toBe(true);
   });
 });

--- a/packages/agency-lang/lib/runtime/validateChain.test.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.test.ts
@@ -10,11 +10,11 @@ import { success, failure, isFailure, isSuccess } from "./result.js";
 
 const ctx = {};
 
-const isPos: AgencyValidator = async (_c, v) =>
+const isPos: AgencyValidator = async (v) =>
   typeof v === "number" && v > 0 ? success(v) : failure("not positive");
-const isEven: AgencyValidator = async (_c, v) =>
+const isEven: AgencyValidator = async (v) =>
   typeof v === "number" && v % 2 === 0 ? success(v) : failure("not even");
-const doubleIt: AgencyValidator = async (_c, v) =>
+const doubleIt: AgencyValidator = async (v) =>
   typeof v === "number" ? success(v * 2) : failure("not number");
 
 describe("__validateChain", () => {
@@ -30,7 +30,7 @@ describe("__validateChain", () => {
 
   it("short-circuits on first validator failure", async () => {
     const later = vi.fn(
-      async (_c: unknown, v: unknown) => success(v),
+      async (v: unknown) => success(v),
     ) as unknown as AgencyValidator;
     const r = await __validateChain(-1, z.number(), [isPos, later], ctx);
     expect(isFailure(r)).toBe(true);
@@ -91,11 +91,11 @@ describe("__validateChainRecursive", () => {
   it("dispatches union to matching branch only", async () => {
     const numCalled = vi.fn();
     const strCalled = vi.fn();
-    const numV: AgencyValidator = async (_c, v) => {
+    const numV: AgencyValidator = async (v) => {
       numCalled();
       return success(v);
     };
-    const strV: AgencyValidator = async (_c, v) => {
+    const strV: AgencyValidator = async (v) => {
       strCalled();
       return success(v);
     };
@@ -120,7 +120,7 @@ describe("__validateChainRecursive", () => {
   });
 
   it("skips inner validators on null in a nullable", async () => {
-    const inner = vi.fn(async (_c: unknown, v: unknown) => success(v));
+    const inner = vi.fn(async (v: unknown) => success(v));
     const desc: TypeValidationDescriptor = {
       kind: "nullable",
       schema: z.number().nullable(),

--- a/packages/agency-lang/lib/runtime/validateChain.test.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import {
+  __validateChain,
+  __validateChainRecursive,
+  type AgencyValidator,
+  type TypeValidationDescriptor,
+} from "./validateChain.js";
+import { success, failure, isFailure, isSuccess } from "./result.js";
+
+const ctx = {};
+
+const isPos: AgencyValidator = async (_c, v) =>
+  typeof v === "number" && v > 0 ? success(v) : failure("not positive");
+const isEven: AgencyValidator = async (_c, v) =>
+  typeof v === "number" && v % 2 === 0 ? success(v) : failure("not even");
+const doubleIt: AgencyValidator = async (_c, v) =>
+  typeof v === "number" ? success(v * 2) : failure("not number");
+
+describe("__validateChain", () => {
+  it("Zod parse passes then validators run in order", async () => {
+    const r = await __validateChain(4, z.number(), [isPos, isEven], ctx);
+    expect(isSuccess(r)).toBe(true);
+  });
+
+  it("returns Zod failure on structural mismatch", async () => {
+    const r = await __validateChain("nope", z.number(), [], ctx);
+    expect(isFailure(r)).toBe(true);
+  });
+
+  it("short-circuits on first validator failure", async () => {
+    const later = vi.fn(
+      async (_c: unknown, v: unknown) => success(v),
+    ) as unknown as AgencyValidator;
+    const r = await __validateChain(-1, z.number(), [isPos, later], ctx);
+    expect(isFailure(r)).toBe(true);
+    expect(later).not.toHaveBeenCalled();
+  });
+
+  it("threads transformed value through the chain", async () => {
+    // 2 -> double -> 4 -> isEven
+    const r = await __validateChain(2, z.number(), [doubleIt, isEven], ctx);
+    expect(isSuccess(r)).toBe(true);
+    expect((r as { value: number }).value).toBe(4);
+  });
+
+  it("forwards an incoming failure unchanged", async () => {
+    const f = failure("upstream");
+    const r = await __validateChain(f, z.number(), [isPos], ctx);
+    expect(r).toBe(f);
+  });
+
+  it("empty validator list still runs Zod parse", async () => {
+    const r = await __validateChain(3, z.number(), [], ctx);
+    expect(isSuccess(r)).toBe(true);
+    expect((r as { value: number }).value).toBe(3);
+  });
+});
+
+describe("__validateChainRecursive", () => {
+  it("runs per-element validators across an array", async () => {
+    const desc: TypeValidationDescriptor = {
+      kind: "array",
+      schema: z.array(z.number()),
+      validators: [],
+      element: { kind: "leaf", schema: z.number(), validators: [isPos] },
+    };
+    const ok = await __validateChainRecursive([1, 2, 3], desc, ctx);
+    expect(isSuccess(ok)).toBe(true);
+    const bad = await __validateChainRecursive([1, -2, 3], desc, ctx);
+    expect(isFailure(bad)).toBe(true);
+  });
+
+  it("recurses into object properties", async () => {
+    const desc: TypeValidationDescriptor = {
+      kind: "object",
+      schema: z.object({ x: z.number() }),
+      validators: [],
+      properties: {
+        x: { kind: "leaf", schema: z.number(), validators: [isEven] },
+      },
+    };
+    expect(isSuccess(await __validateChainRecursive({ x: 4 }, desc, ctx))).toBe(
+      true,
+    );
+    expect(isFailure(await __validateChainRecursive({ x: 5 }, desc, ctx))).toBe(
+      true,
+    );
+  });
+
+  it("dispatches union to matching branch only", async () => {
+    const numCalled = vi.fn();
+    const strCalled = vi.fn();
+    const numV: AgencyValidator = async (_c, v) => {
+      numCalled();
+      return success(v);
+    };
+    const strV: AgencyValidator = async (_c, v) => {
+      strCalled();
+      return success(v);
+    };
+    const desc: TypeValidationDescriptor = {
+      kind: "union",
+      schema: z.union([z.number(), z.string()]),
+      validators: [],
+      branches: [
+        {
+          test: (v) => typeof v === "number",
+          descriptor: { kind: "leaf", schema: z.number(), validators: [numV] },
+        },
+        {
+          test: (v) => typeof v === "string",
+          descriptor: { kind: "leaf", schema: z.string(), validators: [strV] },
+        },
+      ],
+    };
+    await __validateChainRecursive(7, desc, ctx);
+    expect(numCalled).toHaveBeenCalledTimes(1);
+    expect(strCalled).not.toHaveBeenCalled();
+  });
+
+  it("skips inner validators on null in a nullable", async () => {
+    const inner = vi.fn(async (_c: unknown, v: unknown) => success(v));
+    const desc: TypeValidationDescriptor = {
+      kind: "nullable",
+      schema: z.number().nullable(),
+      validators: [],
+      inner: {
+        kind: "leaf",
+        schema: z.number(),
+        validators: [inner as unknown as AgencyValidator],
+      },
+    };
+    expect(
+      isSuccess(await __validateChainRecursive(null, desc, ctx)),
+    ).toBe(true);
+    expect(inner).not.toHaveBeenCalled();
+  });
+
+  it("enforces depth cap", async () => {
+    // self-referential descriptor reachable via element
+    type Mut = TypeValidationDescriptor & { element?: TypeValidationDescriptor };
+    const desc: Mut = {
+      kind: "array",
+      schema: z.any(),
+      validators: [],
+      element: undefined as unknown as TypeValidationDescriptor,
+    };
+    desc.element = desc as TypeValidationDescriptor;
+
+    // Build a value that's 5 levels deep
+    let v: unknown = 1;
+    for (let i = 0; i < 5; i++) v = [v];
+
+    const r = await __validateChainRecursive(v, desc, ctx, { maxDepth: 3 });
+    expect(isFailure(r)).toBe(true);
+    expect((r as { error: string }).error).toMatch(/recursion depth/);
+  });
+});

--- a/packages/agency-lang/lib/runtime/validateChain.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.ts
@@ -1,0 +1,209 @@
+import { z } from "zod";
+import { success, failure, isFailure, isSuccess } from "./result.js";
+import type { ResultValue } from "./result.js";
+import { AgencyFunction } from "./agencyFunction.js";
+
+/**
+ * Async validator used by `@validate(...)` chains. May be:
+ *  - a plain async function `(ctx, value) => Result` (the simplest shape,
+ *    used for JS-backed validators in std::validators); or
+ *  - an `AgencyFunction` (an Agency `def` referenced by name), which is
+ *    invoked via `.invoke({ type: "positional", args: [value] }, { ctx })`
+ *    so we go through the same call infrastructure as `__call(...)`.
+ */
+export type AgencyValidator =
+  | ((ctx: unknown, value: unknown) => Promise<ResultValue> | ResultValue)
+  | AgencyFunction;
+
+async function callValidator(
+  v: AgencyValidator,
+  ctx: unknown,
+  value: unknown,
+): Promise<ResultValue> {
+  if (AgencyFunction.isAgencyFunction(v)) {
+    return (await (v as AgencyFunction).invoke(
+      { type: "positional", args: [value] },
+      { ctx },
+    )) as ResultValue;
+  }
+  return (v as (c: unknown, x: unknown) => Promise<ResultValue> | ResultValue)(
+    ctx,
+    value,
+  );
+}
+
+/**
+ * Run Zod parse then thread the result through validators in order,
+ * stopping on the first failure. Validators may transform: the value
+ * passed to validator N+1 is whatever validator N returned with success.
+ *
+ * Why outside Zod? See spec § "Why run validators outside Zod" —
+ * keeping validators out of the sync Zod path lets them be async,
+ * call other Agency functions, hit the network, etc.
+ */
+export async function __validateChain(
+  value: unknown,
+  schema: z.ZodType,
+  validators: AgencyValidator[],
+  ctx: unknown,
+): Promise<ResultValue> {
+  // Don't validate failures — surface the original error unchanged.
+  if (isFailure(value)) return value as ResultValue;
+
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    return failure(parsed.error.message);
+  }
+  let raw: unknown = parsed.data;
+
+  // If the parsed value is itself a Result, unwrap on success / forward
+  // failure unchanged, matching the convention in __validateType.
+  if (isSuccess(raw)) raw = (raw as { value: unknown }).value;
+  else if (isFailure(raw)) return raw as ResultValue;
+
+  let current: ResultValue = success(raw);
+  for (const v of validators) {
+    if (!isSuccess(current)) return current;
+    current = await callValidator(
+      v,
+      ctx,
+      (current as { value: unknown }).value,
+    );
+  }
+  return current;
+}
+
+/**
+ * Structural descriptor for nested validation. Built at codegen time
+ * from the resolved type tree. The walker uses this descriptor to know
+ * which validator list to apply at each depth and how to dispatch
+ * unions / arrays / objects / nullables.
+ */
+export type TypeValidationDescriptor =
+  | {
+      kind: "leaf";
+      schema: z.ZodType;
+      validators: AgencyValidator[];
+    }
+  | {
+      kind: "object";
+      schema: z.ZodType;
+      validators: AgencyValidator[];
+      properties: Record<string, TypeValidationDescriptor>;
+    }
+  | {
+      kind: "array";
+      schema: z.ZodType;
+      validators: AgencyValidator[];
+      element: TypeValidationDescriptor;
+    }
+  | {
+      kind: "union";
+      schema: z.ZodType;
+      validators: AgencyValidator[];
+      branches: Array<{
+        test: (v: unknown) => boolean;
+        descriptor: TypeValidationDescriptor;
+      }>;
+    }
+  | {
+      kind: "nullable";
+      schema: z.ZodType;
+      validators: AgencyValidator[];
+      inner: TypeValidationDescriptor;
+    };
+
+export type RecursiveValidationOpts = {
+  /** Hard cap on traversal depth. Default 64. */
+  maxDepth?: number;
+};
+
+/**
+ * Walk `value` alongside `descriptor`, running per-node validator chains
+ * and recursing into nested types. Bails with a failure once depth
+ * exceeds `opts.maxDepth ?? 64`.
+ */
+export async function __validateChainRecursive(
+  value: unknown,
+  descriptor: TypeValidationDescriptor,
+  ctx: unknown,
+  opts?: RecursiveValidationOpts,
+): Promise<ResultValue> {
+  const maxDepth = opts?.maxDepth ?? 64;
+  return walk(value, descriptor, ctx, 0, maxDepth);
+}
+
+async function walk(
+  value: unknown,
+  descriptor: TypeValidationDescriptor,
+  ctx: unknown,
+  depth: number,
+  maxDepth: number,
+): Promise<ResultValue> {
+  if (depth > maxDepth) {
+    return failure(
+      `validation recursion depth exceeded (limit ${maxDepth})`,
+    );
+  }
+  if (isFailure(value)) return value as ResultValue;
+
+  // Step 1: parse + own validators at this node.
+  const own = await __validateChain(
+    value,
+    descriptor.schema,
+    descriptor.validators,
+    ctx,
+  );
+  if (!isSuccess(own)) return own;
+  const parsed = (own as { value: unknown }).value;
+
+  // Step 2: structural recursion.
+  switch (descriptor.kind) {
+    case "leaf":
+      return success(parsed);
+
+    case "nullable": {
+      if (parsed === null || parsed === undefined) {
+        return success(parsed);
+      }
+      const inner = await walk(parsed, descriptor.inner, ctx, depth + 1, maxDepth);
+      return inner;
+    }
+
+    case "array": {
+      if (!Array.isArray(parsed)) return success(parsed);
+      const out: unknown[] = [];
+      for (const el of parsed) {
+        const r = await walk(el, descriptor.element, ctx, depth + 1, maxDepth);
+        if (!isSuccess(r)) return r;
+        out.push((r as { value: unknown }).value);
+      }
+      return success(out);
+    }
+
+    case "object": {
+      if (parsed === null || typeof parsed !== "object") {
+        return success(parsed);
+      }
+      const out: Record<string, unknown> = { ...(parsed as Record<string, unknown>) };
+      for (const [key, childDesc] of Object.entries(descriptor.properties)) {
+        const r = await walk(
+          (parsed as Record<string, unknown>)[key],
+          childDesc,
+          ctx,
+          depth + 1,
+          maxDepth,
+        );
+        if (!isSuccess(r)) return r;
+        out[key] = (r as { value: unknown }).value;
+      }
+      return success(out);
+    }
+
+    case "union": {
+      const branch = descriptor.branches.find((b) => b.test(parsed));
+      if (!branch) return success(parsed);
+      return walk(parsed, branch.descriptor, ctx, depth + 1, maxDepth);
+    }
+  }
+}

--- a/packages/agency-lang/lib/runtime/validateChain.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.ts
@@ -5,14 +5,19 @@ import { AgencyFunction } from "./agencyFunction.js";
 
 /**
  * Async validator used by `@validate(...)` chains. May be:
- *  - a plain async function `(ctx, value) => Result` (the simplest shape,
- *    used for JS-backed validators in std::validators); or
+ *  - a plain async function `(value) => Result` (the simplest shape;
+ *    users can import `success` / `failure` from the agency-lang runtime
+ *    and return whichever applies);
  *  - an `AgencyFunction` (an Agency `def` referenced by name), which is
  *    invoked via `.invoke({ type: "positional", args: [value] }, { ctx })`
  *    so we go through the same call infrastructure as `__call(...)`.
+ *
+ * Plain JS validators do not receive `ctx`. If you need access to the
+ * execution context, write the validator as an Agency `def` and let the
+ * normal invocation machinery thread `ctx` through for you.
  */
 export type AgencyValidator =
-  | ((ctx: unknown, value: unknown) => Promise<ResultValue> | ResultValue)
+  | ((value: unknown) => Promise<ResultValue> | ResultValue)
   | AgencyFunction;
 
 async function callValidator(
@@ -26,10 +31,7 @@ async function callValidator(
       { ctx },
     )) as ResultValue;
   }
-  return (v as (c: unknown, x: unknown) => Promise<ResultValue> | ResultValue)(
-    ctx,
-    value,
-  );
+  return (v as (x: unknown) => Promise<ResultValue> | ResultValue)(value);
 }
 
 /**

--- a/packages/agency-lang/lib/runtime/validateChain.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.ts
@@ -141,9 +141,12 @@ async function walk(
   maxDepth: number,
 ): Promise<ResultValue> {
   if (depth > maxDepth) {
-    return failure(
-      `validation recursion depth exceeded (limit ${maxDepth})`,
-    );
+    return failure({
+      reason: "validation recursion depth exceeded",
+      limit: maxDepth,
+      kind: descriptor.kind,
+      valuePreview: previewValue(value),
+    });
   }
   if (isFailure(value)) return value as ResultValue;
 
@@ -206,4 +209,28 @@ async function walk(
       return walk(parsed, branch.descriptor, ctx, depth + 1, maxDepth);
     }
   }
+}
+
+/**
+ * Return a short, cycle-safe, JSON-friendly preview of a value for use
+ * inside error payloads. We don't want huge or self-referential structures
+ * to blow up the failure message.
+ */
+function previewValue(value: unknown, maxLen = 200): unknown {
+  const seen = new WeakSet<object>();
+  const replacer = (_k: string, v: unknown): unknown => {
+    if (typeof v === "object" && v !== null) {
+      if (seen.has(v)) return "[cycle]";
+      seen.add(v);
+    }
+    return v;
+  };
+  let str: string;
+  try {
+    str = JSON.stringify(value, replacer);
+  } catch {
+    return String(value).slice(0, maxLen);
+  }
+  if (str === undefined) return String(value).slice(0, maxLen);
+  return str.length > maxLen ? `${str.slice(0, maxLen)}…` : str;
 }

--- a/packages/agency-lang/lib/stdlib/validators.ts
+++ b/packages/agency-lang/lib/stdlib/validators.ts
@@ -1,0 +1,43 @@
+import { success, failure } from "../runtime/result.js";
+import type { ResultValue } from "../runtime/result.js";
+
+// Format taken from RFC 5322 simplified — same one used by HTML5 input[type=email].
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const URL_RE = /^https?:\/\/[^\s]+$/;
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+export function _isEmail(value: string): ResultValue {
+  return EMAIL_RE.test(value)
+    ? success(value)
+    : failure(`not a valid email: ${JSON.stringify(value)}`);
+}
+
+export function _isUrl(value: string): ResultValue {
+  return URL_RE.test(value)
+    ? success(value)
+    : failure(`not a valid URL: ${JSON.stringify(value)}`);
+}
+
+export function _isUuid(value: string): ResultValue {
+  return UUID_RE.test(value)
+    ? success(value)
+    : failure(`not a valid UUID: ${JSON.stringify(value)}`);
+}
+
+export function _isInt(value: number): ResultValue {
+  return Number.isInteger(value)
+    ? success(value)
+    : failure(`expected integer, got ${value}`);
+}
+
+export function _isPositive(value: number): ResultValue {
+  return value > 0
+    ? success(value)
+    : failure(`expected positive number, got ${value}`);
+}
+
+export function _isNegative(value: number): ResultValue {
+  return value < 0
+    ? success(value)
+    : failure(`expected negative number, got ${value}`);
+}

--- a/packages/agency-lang/lib/symbolTable.ts
+++ b/packages/agency-lang/lib/symbolTable.ts
@@ -6,6 +6,7 @@ import type {
   AgencyNode,
   AgencyProgram,
   FunctionParameter,
+  Tag,
   TypeParam,
   VariableType,
 } from "./types.js";
@@ -68,6 +69,9 @@ export type TypeSymbol = {
   aliasedType: VariableType;
   /** Type parameters for generic aliases (e.g., `T` in `type Container<T> = ...`). */
   typeParams?: TypeParam[];
+  /** `@validate(...)` / `@jsonSchema(...)` annotations declared above the alias.
+   * Carried through imports/re-exports so annotation metadata flows across modules. */
+  tags?: Tag[];
   reExportedFrom?: ReExportedFrom;
 };
 
@@ -272,11 +276,46 @@ export class SymbolTable {
 }
 
 /**
+ * Walk the top-level program node list to find `@tag(...)` nodes
+ * sitting directly above type aliases, returning a map from alias name
+ * to its pending tag list. This mirrors what the TypescriptPreprocessor's
+ * `attachTags` does later in the pipeline, but happens early so symbol
+ * table consumers (other modules that import this alias) see annotations
+ * attached to the TypeSymbol.
+ *
+ * Pre-pass only, no mutation: keeps SymbolTable.build idempotent and
+ * decoupled from the preprocessor.
+ */
+export function collectTypeAliasTags(program: AgencyProgram): Record<string, Tag[]> {
+  const byName: Record<string, Tag[]> = {};
+  function walk(nodes: AgencyNode[]): void {
+    let pending: Tag[] = [];
+    for (const node of nodes) {
+      if (node.type === "tag") {
+        pending.push(node);
+        continue;
+      }
+      if (node.type === "typeAlias" && pending.length > 0) {
+        byName[node.aliasName] = [...(byName[node.aliasName] ?? []), ...pending];
+      }
+      pending = [];
+      // Recurse into nested bodies that may contain typeAlias + tag siblings.
+      if ((node as any).body && Array.isArray((node as any).body)) {
+        walk((node as any).body);
+      }
+    }
+  }
+  walk(program.nodes);
+  return byName;
+}
+
+/**
  * Classify symbols in a parsed Agency program.
  * Uses walkNodes to find symbols at all nesting levels (e.g. type aliases inside functions).
  */
 export function classifySymbols(program: AgencyProgram): FileSymbols {
   const symbols: FileSymbols = {};
+  const typeAliasTags = collectTypeAliasTags(program);
 
   for (const { node } of walkNodes(program.nodes)) {
     switch (node.type) {
@@ -318,6 +357,9 @@ export function classifySymbols(program: AgencyProgram): FileSymbols {
           exported: !!node.exported,
           aliasedType: node.aliasedType,
           ...(node.typeParams ? { typeParams: node.typeParams } : {}),
+          ...(typeAliasTags[node.aliasName]?.length
+            ? { tags: typeAliasTags[node.aliasName] }
+            : {}),
         };
         break;
       case "classDefinition":

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -23,7 +23,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -1,7 +1,8 @@
-import { TypeAliasEntry, TypeParam, VariableType } from "../types.js";
+import { Tag, TypeAliasEntry, TypeParam, VariableType } from "../types.js";
 import { ANY_T, BOOLEAN_T, NUMBER_T, STRING_T } from "./primitives.js";
 import { substituteTypeParams } from "./substitute.js";
 import { mapTypes } from "./typeWalker.js";
+import { mergeTagSets } from "./mergeTags.js";
 
 /**
  * Public resolveType: normalizes a VariableType by resolving type-alias
@@ -74,9 +75,11 @@ function resolveTypeWithGuard(
         entry.typeParams.map((p) => p.name),
         args,
       );
-      return resolveTypeWithGuard(substituted, typeAliases, next);
+      const resolved = resolveTypeWithGuard(substituted, typeAliases, next);
+      return attachAliasTags(resolved, entry.tags);
     }
-    return resolveTypeWithGuard(entry.body, typeAliases, next);
+    const resolved = resolveTypeWithGuard(entry.body, typeAliases, next);
+    return attachAliasTags(resolved, entry.tags);
   }
 
   if (vt.type === "genericType") {
@@ -147,10 +150,25 @@ function resolveTypeWithGuard(
       entry.typeParams.map((p) => p.name),
       args,
     );
-    return resolveTypeWithGuard(substituted, typeAliases, next);
+    const resolved = resolveTypeWithGuard(substituted, typeAliases, next);
+    return attachAliasTags(resolved, entry.tags);
   }
 
   return vt;
+}
+
+/**
+ * Return a shallow copy of `vt` with the alias's tags concatenated onto
+ * any tags the resolved type already has. We never mutate `vt`.
+ *
+ * The merge rule between alias and use-site tags is documented in
+ * `mergeTagSets` (lib/typeChecker/mergeTags.ts) and applied by callers
+ * that have both available. resolveType only ever has the alias side.
+ */
+function attachAliasTags(vt: VariableType, aliasTags: Tag[] | undefined): VariableType {
+  if (!aliasTags || aliasTags.length === 0) return vt;
+  const merged = mergeTagSets(aliasTags, vt.tags);
+  return { ...vt, tags: merged } as VariableType;
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.test.ts
+++ b/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  validateJsonSchemaArg,
+  type JsonSchemaArgScope,
+} from "./jsonSchemaArgValidator.js";
+import type { Expression } from "../types.js";
+
+function scope(opts: Partial<JsonSchemaArgScope> = {}): JsonSchemaArgScope {
+  return {
+    topLevelConstNames: opts.topLevelConstNames ?? new Set(),
+    importedNames: opts.importedNames ?? new Set(),
+    topLevelFunctionNames: opts.topLevelFunctionNames ?? new Set(),
+  };
+}
+
+const sc = (s: string): Expression => ({ type: "string", segments: [{ type: "text", value: s }] }) as any;
+const nm = (n: string): Expression => ({ type: "number", value: n }) as any;
+const bool = (b: boolean): Expression => ({ type: "boolean", value: b }) as any;
+const nullLit = (): Expression => ({ type: "null" }) as any;
+const ident = (name: string): Expression => ({ type: "variableName", value: name }) as any;
+const obj = (entries: any[]): Expression =>
+  ({ type: "agencyObject", entries }) as any;
+const fcall = (name: string, args: Expression[]): Expression =>
+  ({ type: "functionCall", functionName: name, arguments: args }) as any;
+const splat = (value: Expression) => ({ type: "splat", value });
+
+describe("validateJsonSchemaArg", () => {
+  it("accepts string literal", () => {
+    expect(validateJsonSchemaArg(sc("email"), scope()).ok).toBe(true);
+  });
+
+  it("accepts number / boolean / null", () => {
+    expect(validateJsonSchemaArg(nm("0"), scope()).ok).toBe(true);
+    expect(validateJsonSchemaArg(bool(true), scope()).ok).toBe(true);
+    expect(validateJsonSchemaArg(nullLit(), scope()).ok).toBe(true);
+  });
+
+  it("accepts a plain object literal of allowed values", () => {
+    const e = obj([{ key: "format", value: sc("email") }, { key: "minimum", value: nm("0") }]);
+    expect(validateJsonSchemaArg(e, scope()).ok).toBe(true);
+  });
+
+  it("rejects identifier not bound to a const / import", () => {
+    const r = validateJsonSchemaArg(ident("someLet"), scope());
+    expect(r.ok).toBe(false);
+  });
+
+  it("accepts identifier bound to a top-level const", () => {
+    const r = validateJsonSchemaArg(
+      ident("emailFormat"),
+      scope({ topLevelConstNames: new Set(["emailFormat"]) }),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it("accepts identifier bound to an imported name", () => {
+    const r = validateJsonSchemaArg(
+      ident("emailFormat"),
+      scope({ importedNames: new Set(["emailFormat"]) }),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it("accepts function call to a top-level def", () => {
+    const r = validateJsonSchemaArg(
+      fcall("minimum", [nm("0")]),
+      scope({ topLevelFunctionNames: new Set(["minimum"]) }),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects function call to an unknown name", () => {
+    const r = validateJsonSchemaArg(fcall("mystery", [nm("0")]), scope());
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects function call whose argument is forbidden", () => {
+    // Pretend "x" is not const-bound — argument is rejected before checking the call.
+    const r = validateJsonSchemaArg(
+      fcall("min", [ident("x")]),
+      scope({ topLevelFunctionNames: new Set(["min"]) }),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("accepts a spread entry that points to an allowed expression", () => {
+    const e = obj([splat(ident("emailFormat"))]);
+    const r = validateJsonSchemaArg(
+      e,
+      scope({ topLevelConstNames: new Set(["emailFormat"]) }),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects ternary / binop / template / array literal", () => {
+    const ternary = { type: "binOpExpression", op: "?" } as any;
+    expect(validateJsonSchemaArg(ternary, scope()).ok).toBe(false);
+    const binop = { type: "binOpExpression" } as any;
+    expect(validateJsonSchemaArg(binop, scope()).ok).toBe(false);
+    const arr = { type: "agencyArray", items: [] } as any;
+    expect(validateJsonSchemaArg(arr, scope()).ok).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.test.ts
+++ b/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.test.ts
@@ -100,4 +100,22 @@ describe("validateJsonSchemaArg", () => {
     const arr = { type: "agencyArray", items: [] } as any;
     expect(validateJsonSchemaArg(arr, scope()).ok).toBe(false);
   });
+
+  it("rejects string literals that contain interpolation segments", () => {
+    const interpolated: Expression = {
+      type: "string",
+      segments: [
+        { type: "text", value: "hello " },
+        {
+          type: "interpolation",
+          expression: { type: "variableName", value: "name" } as any,
+        },
+      ],
+    } as any;
+    const r = validateJsonSchemaArg(interpolated, scope());
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.reason).toMatch(/plain literals|interpolation/i);
+    }
+  });
 });

--- a/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
+++ b/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
@@ -44,6 +44,7 @@ export function validateJsonSchemaArg(
 ): JsonSchemaArgValidationResult {
   switch (expr.type) {
     case "string":
+      return validateStringLiteral(expr as any);
     case "number":
     case "boolean":
     case "null":
@@ -65,6 +66,23 @@ export function validateJsonSchemaArg(
         loc: (expr as any).loc,
       };
   }
+}
+
+function validateStringLiteral(
+  str: { segments?: Array<{ type: string }>; loc?: { line: number; col: number } },
+): JsonSchemaArgValidationResult {
+  const segments = str.segments ?? [];
+  for (const seg of segments) {
+    if (seg.type !== "text") {
+      return {
+        ok: false,
+        reason:
+          "@jsonSchema(...) string arguments must be plain literals (no interpolation)",
+        loc: str.loc,
+      };
+    }
+  }
+  return { ok: true };
 }
 
 function validateObjectLiteral(

--- a/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
+++ b/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
@@ -1,0 +1,198 @@
+import type {
+  Expression,
+  AgencyObject,
+  AgencyObjectKV,
+  SplatExpression,
+  AgencyProgram,
+} from "../types.js";
+import type { CompilationUnit } from "../compilationUnit.js";
+
+/**
+ * Enforces the spec's restriction on what may appear inside `@jsonSchema(...)`:
+ *
+ * - String / number / boolean / null literals.
+ * - Object literals containing only allowed expressions / spreads.
+ * - Function calls to top-level `def` functions or imported functions,
+ *   whose arguments are themselves allowed expressions.
+ * - Identifiers that resolve to a static `const` global (module-level
+ *   `const` binding, including const-bound imports). `let` bindings,
+ *   function parameters, and local declarations are rejected.
+ *
+ * Anything else (member access, ternaries, binary ops, pipes, template
+ * strings, array literals, etc.) is rejected.
+ */
+export type JsonSchemaArgValidationResult =
+  | { ok: true }
+  | { ok: false; reason: string; loc?: { line: number; col: number } };
+
+/**
+ * Subset of the compilation unit we need to look up identifiers.
+ * Kept minimal so unit tests don't need a full CompilationUnit.
+ */
+export type JsonSchemaArgScope = {
+  /** Names that resolve to a top-level const binding in this module. */
+  topLevelConstNames: Set<string>;
+  /** Names imported from another module (treated as const-bound). */
+  importedNames: Set<string>;
+  /** Names of top-level `def` functions. */
+  topLevelFunctionNames: Set<string>;
+};
+
+export function validateJsonSchemaArg(
+  expr: Expression,
+  scope: JsonSchemaArgScope,
+): JsonSchemaArgValidationResult {
+  switch (expr.type) {
+    case "string":
+    case "number":
+    case "boolean":
+    case "null":
+      return { ok: true };
+
+    case "agencyObject":
+      return validateObjectLiteral(expr as AgencyObject, scope);
+
+    case "functionCall":
+      return validateFunctionCall(expr, scope);
+
+    case "variableName":
+      return validateIdentifier(expr, scope);
+
+    default:
+      return {
+        ok: false,
+        reason: `expressions of type "${expr.type}" are not allowed inside @jsonSchema(...)`,
+        loc: (expr as any).loc,
+      };
+  }
+}
+
+function validateObjectLiteral(
+  obj: AgencyObject,
+  scope: JsonSchemaArgScope,
+): JsonSchemaArgValidationResult {
+  for (const entry of obj.entries) {
+    if ("key" in entry) {
+      const kv = entry as AgencyObjectKV;
+      const r = validateJsonSchemaArg(kv.value, scope);
+      if (!r.ok) return r;
+    } else {
+      const splat = entry as SplatExpression;
+      const r = validateJsonSchemaArg(splat.value, scope);
+      if (!r.ok) return r;
+    }
+  }
+  return { ok: true };
+}
+
+function validateFunctionCall(
+  call: any,
+  scope: JsonSchemaArgScope,
+): JsonSchemaArgValidationResult {
+  // The callee must be a known top-level / imported function.
+  const name: string | undefined = call.functionName;
+  if (!name) {
+    return {
+      ok: false,
+      reason: "function call inside @jsonSchema(...) must be a direct call by name",
+      loc: call.loc,
+    };
+  }
+  if (!scope.topLevelFunctionNames.has(name) && !scope.importedNames.has(name)) {
+    return {
+      ok: false,
+      reason: `${name} is not a top-level def or imported function; cannot be used inside @jsonSchema(...)`,
+      loc: call.loc,
+    };
+  }
+  // Validate each argument as a restricted expression.
+  for (const arg of (call.arguments as Expression[]) ?? []) {
+    const r = validateJsonSchemaArg(arg, scope);
+    if (!r.ok) return r;
+  }
+  return { ok: true };
+}
+
+function validateIdentifier(
+  id: any,
+  scope: JsonSchemaArgScope,
+): JsonSchemaArgValidationResult {
+  const name: string = id.value;
+  if (scope.topLevelConstNames.has(name) || scope.importedNames.has(name)) {
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    reason: `${name} is not a static const global; only top-level const bindings or imports may be used inside @jsonSchema(...)`,
+    loc: id.loc,
+  };
+}
+
+/**
+ * Build the scope view needed for validation from a CompilationUnit
+ * and the original AgencyProgram (we need the program to walk top-level
+ * `const` assignments — CompilationUnit doesn't retain them directly).
+ */
+export function buildJsonSchemaArgScope(
+  program: AgencyProgram,
+  unit: CompilationUnit,
+): JsonSchemaArgScope {
+  const topLevelConstNames = new Set<string>();
+  const topLevelFunctionNames = new Set<string>();
+  for (const node of program.nodes) {
+    if (node.type === "assignment") {
+      const n: any = node;
+      if (n.declKind === "const" || n.static === true) {
+        const name = n.variableName ?? n.name;
+        if (typeof name === "string") topLevelConstNames.add(name);
+      }
+    }
+    if (node.type === "function") {
+      const name: string | undefined = (node as any).functionName;
+      if (name) topLevelFunctionNames.add(name);
+    }
+  }
+  const importedNames = new Set<string>(Object.keys(unit.importedFunctions));
+  for (const stmt of unit.importStatements) {
+    collectImportedNames(stmt, importedNames);
+  }
+  return { topLevelConstNames, importedNames, topLevelFunctionNames };
+}
+
+function collectImportedNames(stmt: unknown, out: Set<string>): void {
+  const items: unknown = (stmt as any)?.importedNames;
+  if (!Array.isArray(items)) return;
+  for (const n of items) {
+    if (typeof n === "string") {
+      out.add(n);
+    } else if (n && typeof n === "object") {
+      addNamedImportEntry(n as Record<string, unknown>, out);
+    }
+  }
+}
+
+function addNamedImportEntry(
+  entry: Record<string, unknown>,
+  out: Set<string>,
+): void {
+  const arr: unknown = entry.importedNames;
+  const aliases = entry.aliases as Record<string, string> | undefined;
+  if (Array.isArray(arr)) {
+    for (const raw of arr) {
+      if (typeof raw === "string") {
+        out.add((aliases && aliases[raw]) ?? raw);
+      }
+    }
+    return;
+  }
+  if (typeof arr === "string") {
+    out.add((aliases && aliases[arr]) ?? arr);
+    return;
+  }
+  const local =
+    (entry.local as string | undefined) ??
+    (entry.name as string | undefined) ??
+    (entry.originalName as string | undefined) ??
+    (entry.alias as string | undefined);
+  if (typeof local === "string") out.add(local);
+}

--- a/packages/agency-lang/lib/typeChecker/mergeTags.test.ts
+++ b/packages/agency-lang/lib/typeChecker/mergeTags.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { mergeTagSets } from "./mergeTags.js";
+import type { Tag } from "../types.js";
+
+function ident(name: string): any {
+  return { type: "variableName", value: name };
+}
+
+function stringLit(s: string): any {
+  return { type: "string", segments: [{ type: "text", value: s }] };
+}
+
+function obj(entries: Record<string, any>): any {
+  return {
+    type: "agencyObject",
+    entries: Object.entries(entries).map(([key, value]) => ({ key, value })),
+  };
+}
+
+function tag(name: string, args: any[]): Tag {
+  return { type: "tag", name, arguments: args } as Tag;
+}
+
+describe("mergeTagSets", () => {
+  it("returns undefined when both sides empty", () => {
+    expect(mergeTagSets(undefined, undefined)).toBeUndefined();
+    expect(mergeTagSets([], [])).toBeUndefined();
+  });
+
+  it("returns alias tags verbatim when use-site is empty", () => {
+    const aliasTags = [tag("validate", [ident("isEmail")])];
+    const merged = mergeTagSets(aliasTags, undefined);
+    expect(merged).toHaveLength(1);
+    expect(merged?.[0].name).toBe("validate");
+    expect(merged?.[0].arguments).toHaveLength(1);
+  });
+
+  it("concatenates @validate from alias and use-site", () => {
+    const aliasTags = [tag("validate", [ident("isPositive")])];
+    const useSiteTags = [tag("validate", [ident("max100")])];
+    const merged = mergeTagSets(aliasTags, useSiteTags);
+    expect(merged).toHaveLength(1);
+    expect(merged?.[0].name).toBe("validate");
+    expect(merged?.[0].arguments).toHaveLength(2);
+    expect((merged?.[0].arguments[0] as any).value).toBe("isPositive");
+    expect((merged?.[0].arguments[1] as any).value).toBe("max100");
+  });
+
+  it("merges @jsonSchema with use-site keys overriding alias keys", () => {
+    const aliasTags = [
+      tag("jsonSchema", [
+        obj({ minimum: { type: "number", value: "0" }, description: stringLit("alias desc") }),
+      ]),
+    ];
+    const useSiteTags = [
+      tag("jsonSchema", [obj({ description: stringLit("prop desc") })]),
+    ];
+    const merged = mergeTagSets(aliasTags, useSiteTags);
+    expect(merged).toHaveLength(1);
+    const mergedObj = merged?.[0].arguments[0] as any;
+    expect(mergedObj.type).toBe("agencyObject");
+    const entries = mergedObj.entries as any[];
+    const byKey = Object.fromEntries(entries.map((e) => [e.key, e.value]));
+    expect(byKey.minimum).toMatchObject({ type: "number", value: "0" });
+    expect(byKey.description.segments[0].value).toBe("prop desc");
+  });
+
+  it("preserves other tag names verbatim", () => {
+    const aliasTags = [tag("goal", [stringLit("alias goal")])];
+    const useSiteTags = [tag("goal", [stringLit("use goal")])];
+    const merged = mergeTagSets(aliasTags, useSiteTags);
+    // Other tags are concatenated.
+    expect(merged).toHaveLength(2);
+    expect(merged?.[0].name).toBe("goal");
+    expect(merged?.[1].name).toBe("goal");
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/mergeTags.test.ts
+++ b/packages/agency-lang/lib/typeChecker/mergeTags.test.ts
@@ -65,6 +65,16 @@ describe("mergeTagSets", () => {
     expect(byKey.description.segments[0].value).toBe("prop desc");
   });
 
+  it("throws when the same side has multiple @jsonSchema tags", () => {
+    const aliasTags = [
+      tag("jsonSchema", [obj({ format: stringLit("email") })]),
+      tag("jsonSchema", [obj({ description: stringLit("dup") })]),
+    ];
+    expect(() => mergeTagSets(aliasTags, undefined)).toThrow(
+      /Multiple @jsonSchema/,
+    );
+  });
+
   it("throws on a malformed @jsonSchema whose argument is not an object literal", () => {
     const aliasTags = [tag("jsonSchema", [stringLit("not an object")])];
     expect(() => mergeTagSets(aliasTags, undefined)).toThrow(/object-literal argument/);

--- a/packages/agency-lang/lib/typeChecker/mergeTags.test.ts
+++ b/packages/agency-lang/lib/typeChecker/mergeTags.test.ts
@@ -65,6 +65,11 @@ describe("mergeTagSets", () => {
     expect(byKey.description.segments[0].value).toBe("prop desc");
   });
 
+  it("throws on a malformed @jsonSchema whose argument is not an object literal", () => {
+    const aliasTags = [tag("jsonSchema", [stringLit("not an object")])];
+    expect(() => mergeTagSets(aliasTags, undefined)).toThrow(/object-literal argument/);
+  });
+
   it("preserves other tag names verbatim", () => {
     const aliasTags = [tag("goal", [stringLit("alias goal")])];
     const useSiteTags = [tag("goal", [stringLit("use goal")])];

--- a/packages/agency-lang/lib/typeChecker/mergeTags.ts
+++ b/packages/agency-lang/lib/typeChecker/mergeTags.ts
@@ -10,7 +10,12 @@ import type { Tag, Expression, AgencyObject, AgencyObjectKV, SplatExpression } f
  *   use-site keys overriding alias keys, producing a single combined
  *   `@jsonSchema` tag. Spreads are preserved verbatim (their evaluation
  *   happens at module load time).
- * - Any other tag name: concatenated.
+ *
+ * Tag names other than `validate` / `jsonSchema` are deliberately not
+ * merged here — they have no alias-vs-use-site semantics defined and may
+ * belong to a different feature entirely (e.g. `@goal` / `@optimize`).
+ * They flow through `resolveType` untouched on whichever side they
+ * appeared, but never combined across the two sides.
  *
  * `aliasTags` come first in the chain, `useSiteTags` apply on top.
  */
@@ -24,43 +29,40 @@ export function mergeTagSets(
 
   const combined: Tag[] = [];
 
-  // Collect tag groups by name in the order they're first seen.
-  const seenNames = new Set<string>();
-  for (const t of [...alias, ...useSite]) {
-    if (!seenNames.has(t.name)) seenNames.add(t.name);
+  const aliasValidate = alias.filter((t) => t.name === "validate");
+  const useSiteValidate = useSite.filter((t) => t.name === "validate");
+  if (aliasValidate.length + useSiteValidate.length > 0) {
+    const allArgs: Expression[] = [];
+    for (const t of [...aliasValidate, ...useSiteValidate]) {
+      allArgs.push(...t.arguments);
+    }
+    combined.push({
+      type: "tag",
+      name: "validate",
+      arguments: allArgs,
+      loc: (aliasValidate[0] ?? useSiteValidate[0]).loc,
+    });
   }
 
-  for (const name of seenNames) {
-    const aliasOfName = alias.filter((t) => t.name === name);
-    const useSiteOfName = useSite.filter((t) => t.name === name);
-    const all = [...aliasOfName, ...useSiteOfName];
+  const aliasJson = alias.filter((t) => t.name === "jsonSchema");
+  const useSiteJson = useSite.filter((t) => t.name === "jsonSchema");
+  if (aliasJson.length + useSiteJson.length > 0) {
+    const merged = mergeJsonSchemaArgs([...aliasJson, ...useSiteJson]);
+    combined.push({
+      type: "tag",
+      name: "jsonSchema",
+      arguments: merged,
+      loc: (aliasJson[0] ?? useSiteJson[0]).loc,
+    });
+  }
 
-    if (name === "validate") {
-      // Concat all argument lists into one @validate tag.
-      const allArgs: Expression[] = [];
-      for (const t of all) allArgs.push(...t.arguments);
-      combined.push({
-        type: "tag",
-        name: "validate",
-        arguments: allArgs,
-        loc: all[0].loc,
-      });
-    } else if (name === "jsonSchema") {
-      // Merge all argument objects left-to-right. Each argument is
-      // expected to be a single object literal (per spec — multiple
-      // @jsonSchema on the same target is an error, but the merge
-      // across alias-then-use-site is allowed).
-      const merged = mergeJsonSchemaArgs(all);
-      combined.push({
-        type: "tag",
-        name: "jsonSchema",
-        arguments: merged,
-        loc: all[0].loc,
-      });
-    } else {
-      // Other tags: concat verbatim.
-      for (const t of all) combined.push(t);
-    }
+  // Pass through any other tags from each side verbatim. We never combine
+  // across the two sides because we don't know what their semantics are.
+  for (const t of alias) {
+    if (t.name !== "validate" && t.name !== "jsonSchema") combined.push(t);
+  }
+  for (const t of useSite) {
+    if (t.name !== "validate" && t.name !== "jsonSchema") combined.push(t);
   }
 
   return combined;
@@ -77,8 +79,11 @@ function mergeJsonSchemaArgs(tags: Tag[]): Expression[] {
   for (const t of tags) {
     const arg = t.arguments[0];
     if (!arg || arg.type !== "agencyObject") {
-      // Not a well-formed @jsonSchema(...) — leave the tag's args alone.
-      return arg ? [arg] : [];
+      const loc = (arg ?? t).loc;
+      const where = loc ? ` (line ${loc.line}, col ${loc.col})` : "";
+      throw new Error(
+        `@jsonSchema(...) requires a single object-literal argument${where}; got ${arg ? arg.type : "no argument"}.`,
+      );
     }
     for (const e of (arg as AgencyObject).entries) {
       entries.push(e);

--- a/packages/agency-lang/lib/typeChecker/mergeTags.ts
+++ b/packages/agency-lang/lib/typeChecker/mergeTags.ts
@@ -46,6 +46,8 @@ export function mergeTagSets(
 
   const aliasJson = alias.filter((t) => t.name === "jsonSchema");
   const useSiteJson = useSite.filter((t) => t.name === "jsonSchema");
+  enforceSingleJsonSchema(aliasJson, "alias");
+  enforceSingleJsonSchema(useSiteJson, "use site");
   if (aliasJson.length + useSiteJson.length > 0) {
     const merged = mergeJsonSchemaArgs([...aliasJson, ...useSiteJson]);
     combined.push({
@@ -66,6 +68,25 @@ export function mergeTagSets(
   }
 
   return combined;
+}
+
+/**
+ * Reject having more than one `@jsonSchema(...)` annotation on the same
+ * side (alias-level or use-site). Multiple annotations on a single
+ * target are ambiguous — callers should combine them into a single
+ * object literal instead. Throws a location-aware error listing every
+ * offending occurrence.
+ */
+function enforceSingleJsonSchema(tags: Tag[], side: string): void {
+  if (tags.length <= 1) return;
+  const locs = tags
+    .map((t) =>
+      t.loc ? `line ${t.loc.line}, col ${t.loc.col}` : "<unknown>",
+    )
+    .join(" and ");
+  throw new Error(
+    `Multiple @jsonSchema(...) annotations on the same target (${side}) are not allowed (found at ${locs}). Combine them into a single object literal.`,
+  );
 }
 
 function mergeJsonSchemaArgs(tags: Tag[]): Expression[] {

--- a/packages/agency-lang/lib/typeChecker/mergeTags.ts
+++ b/packages/agency-lang/lib/typeChecker/mergeTags.ts
@@ -1,0 +1,111 @@
+import type { Tag, Expression, AgencyObject, AgencyObjectKV, SplatExpression } from "../types.js";
+
+/**
+ * Merge two tag lists per the spec rules in
+ * docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md.
+ *
+ * - `@validate(...)`: concatenated across both inputs (alias's validators
+ *   first, then use-site's), producing a single combined `@validate` tag.
+ * - `@jsonSchema(...)`: object-literal arguments merged left-to-right with
+ *   use-site keys overriding alias keys, producing a single combined
+ *   `@jsonSchema` tag. Spreads are preserved verbatim (their evaluation
+ *   happens at module load time).
+ * - Any other tag name: concatenated.
+ *
+ * `aliasTags` come first in the chain, `useSiteTags` apply on top.
+ */
+export function mergeTagSets(
+  aliasTags: Tag[] | undefined,
+  useSiteTags: Tag[] | undefined,
+): Tag[] | undefined {
+  const alias = aliasTags ?? [];
+  const useSite = useSiteTags ?? [];
+  if (alias.length === 0 && useSite.length === 0) return undefined;
+
+  const combined: Tag[] = [];
+
+  // Collect tag groups by name in the order they're first seen.
+  const seenNames = new Set<string>();
+  for (const t of [...alias, ...useSite]) {
+    if (!seenNames.has(t.name)) seenNames.add(t.name);
+  }
+
+  for (const name of seenNames) {
+    const aliasOfName = alias.filter((t) => t.name === name);
+    const useSiteOfName = useSite.filter((t) => t.name === name);
+    const all = [...aliasOfName, ...useSiteOfName];
+
+    if (name === "validate") {
+      // Concat all argument lists into one @validate tag.
+      const allArgs: Expression[] = [];
+      for (const t of all) allArgs.push(...t.arguments);
+      combined.push({
+        type: "tag",
+        name: "validate",
+        arguments: allArgs,
+        loc: all[0].loc,
+      });
+    } else if (name === "jsonSchema") {
+      // Merge all argument objects left-to-right. Each argument is
+      // expected to be a single object literal (per spec — multiple
+      // @jsonSchema on the same target is an error, but the merge
+      // across alias-then-use-site is allowed).
+      const merged = mergeJsonSchemaArgs(all);
+      combined.push({
+        type: "tag",
+        name: "jsonSchema",
+        arguments: merged,
+        loc: all[0].loc,
+      });
+    } else {
+      // Other tags: concat verbatim.
+      for (const t of all) combined.push(t);
+    }
+  }
+
+  return combined;
+}
+
+function mergeJsonSchemaArgs(tags: Tag[]): Expression[] {
+  // Collect every entry / splat from every tag's first object-literal
+  // argument, preserving the order: alias entries first, use-site entries
+  // last. For literal keys present in both, the later (use-site) wins.
+  // Splats are kept verbatim and stay in source order (their runtime
+  // evaluation is what produces the final merged object).
+  type Entry = AgencyObjectKV | SplatExpression;
+  const entries: Entry[] = [];
+  for (const t of tags) {
+    const arg = t.arguments[0];
+    if (!arg || arg.type !== "agencyObject") {
+      // Not a well-formed @jsonSchema(...) — leave the tag's args alone.
+      return arg ? [arg] : [];
+    }
+    for (const e of (arg as AgencyObject).entries) {
+      entries.push(e);
+    }
+  }
+
+  // Dedupe literal-key KVs (last write wins). Splats are preserved.
+  const seenKeys = new Set<string>();
+  const reversed: Entry[] = [];
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const e = entries[i];
+    if ("key" in e) {
+      if (seenKeys.has(e.key)) continue;
+      seenKeys.add(e.key);
+      reversed.push(e);
+    } else {
+      reversed.push(e);
+    }
+  }
+  reversed.reverse();
+
+  // First tag becomes the carrier of the merged object.
+  const carrierLoc = (tags[0].arguments[0] as AgencyObject | undefined)?.loc;
+  const mergedObject: AgencyObject = {
+    type: "agencyObject",
+    entries: reversed,
+    ...(carrierLoc ? { loc: carrierLoc } : {}),
+  } as AgencyObject;
+  return [mergedObject as Expression];
+}

--- a/packages/agency-lang/lib/typeChecker/resolveTypeTags.test.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveTypeTags.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { resolveType } from "./assignability.js";
+import type { Tag, TypeAliasEntry, VariableType } from "../types.js";
+
+function ident(name: string): any {
+  return { type: "variableName", value: name };
+}
+
+function tag(name: string, args: any[]): Tag {
+  return { type: "tag", name, arguments: args } as Tag;
+}
+
+describe("resolveType — tag propagation", () => {
+  it("attaches alias tags to a non-generic alias's resolved type", () => {
+    const aliases: Record<string, TypeAliasEntry> = {
+      Email: {
+        body: { type: "primitiveType", value: "string" },
+        tags: [tag("validate", [ident("isEmail")])],
+      },
+    };
+    const ref: VariableType = { type: "typeAliasVariable", aliasName: "Email" };
+    const resolved = resolveType(ref, aliases);
+    expect(resolved.type).toBe("primitiveType");
+    expect(resolved.tags).toHaveLength(1);
+    expect(resolved.tags?.[0].name).toBe("validate");
+  });
+
+  it("returns alias's resolved body with NO tags if alias has none", () => {
+    const aliases: Record<string, TypeAliasEntry> = {
+      Plain: { body: { type: "primitiveType", value: "string" } },
+    };
+    const ref: VariableType = { type: "typeAliasVariable", aliasName: "Plain" };
+    const resolved = resolveType(ref, aliases);
+    expect(resolved.tags).toBeUndefined();
+  });
+
+  it("propagates alias tags through generic instantiation", () => {
+    const aliases: Record<string, TypeAliasEntry> = {
+      NonEmptyArray: {
+        body: {
+          type: "arrayType",
+          elementType: { type: "typeAliasVariable", aliasName: "T" },
+        },
+        typeParams: [{ name: "T" }],
+        tags: [tag("validate", [ident("nonEmpty")])],
+      },
+    };
+    const ref: VariableType = {
+      type: "genericType",
+      name: "NonEmptyArray",
+      typeArgs: [{ type: "primitiveType", value: "number" }],
+    };
+    const resolved = resolveType(ref, aliases);
+    expect(resolved.type).toBe("arrayType");
+    expect(resolved.tags).toHaveLength(1);
+    expect(resolved.tags?.[0].name).toBe("validate");
+  });
+
+  it("nested type alias tags survive through inner resolution", () => {
+    // type Email = string  (has @validate(isEmail))
+    // type UserList = { emails: Email[] }
+    // Resolving UserList -> resolves to objectType with property whose
+    // value is arrayType whose elementType is the resolved primitive
+    // string with Email's tags attached.
+    const aliases: Record<string, TypeAliasEntry> = {
+      Email: {
+        body: { type: "primitiveType", value: "string" },
+        tags: [tag("validate", [ident("isEmail")])],
+      },
+    };
+    const arrOfEmail: VariableType = {
+      type: "arrayType",
+      elementType: { type: "typeAliasVariable", aliasName: "Email" },
+    };
+    const resolved = resolveType(arrOfEmail, aliases);
+    expect(resolved.type).toBe("arrayType");
+    // arrayType.elementType is not auto-walked by resolveType (it operates
+    // on the top-level only). The element-level resolution happens when
+    // the caller walks into the array. This test documents that behavior.
+    expect((resolved as any).elementType.type).toBe("typeAliasVariable");
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -600,6 +600,12 @@ export function synthValueAccess(
             };
             break;
           }
+          if (methodName === "toJSONSchema") {
+            // `toJSONSchema()` returns an arbitrary JSON Schema object —
+            // we don't track its exact shape statically.
+            currentType = ANY_T;
+            break;
+          }
         }
         // Array callback methods: `xs.map(\(x) -> ...)`, `xs.filter(fn)`, …
         // Handled separately from the simple BuiltinSignature path because

--- a/packages/agency-lang/lib/types/tag.ts
+++ b/packages/agency-lang/lib/types/tag.ts
@@ -6,30 +6,3 @@ export type Tag = BaseNode & {
   name: string;
   arguments: Expression[];
 };
-
-/**
- * Recover a legacy string view of a tag argument for back-compat with
- * consumers that haven't been generalised to Expression[] yet.
- *
- * Returns null when the argument can't be represented as a plain string
- * (e.g. function calls, object literals, multi-segment interpolated strings).
- */
-export function tagArgToLegacyString(arg: Expression): string | null {
-  switch (arg.type) {
-    case "string": {
-      // Only support single-segment plain text strings.
-      if (arg.segments.length === 1 && arg.segments[0].type === "text") {
-        return arg.segments[0].value;
-      }
-      return null;
-    }
-    case "number":
-      return arg.value;
-    case "boolean":
-      return String(arg.value);
-    case "variableName":
-      return arg.value;
-    default:
-      return null;
-  }
-}

--- a/packages/agency-lang/lib/types/tag.ts
+++ b/packages/agency-lang/lib/types/tag.ts
@@ -1,7 +1,35 @@
 import { BaseNode } from "./base.js";
+import type { Expression } from "../types.js";
 
 export type Tag = BaseNode & {
   type: "tag";
   name: string;
-  arguments: string[];
+  arguments: Expression[];
 };
+
+/**
+ * Recover a legacy string view of a tag argument for back-compat with
+ * consumers that haven't been generalised to Expression[] yet.
+ *
+ * Returns null when the argument can't be represented as a plain string
+ * (e.g. function calls, object literals, multi-segment interpolated strings).
+ */
+export function tagArgToLegacyString(arg: Expression): string | null {
+  switch (arg.type) {
+    case "string": {
+      // Only support single-segment plain text strings.
+      if (arg.segments.length === 1 && arg.segments[0].type === "text") {
+        return arg.segments[0].value;
+      }
+      return null;
+    }
+    case "number":
+      return arg.value;
+    case "boolean":
+      return String(arg.value);
+    case "variableName":
+      return arg.value;
+    default:
+      return null;
+  }
+}

--- a/packages/agency-lang/lib/types/typeHints.ts
+++ b/packages/agency-lang/lib/types/typeHints.ts
@@ -1,6 +1,7 @@
 import { AgencyMultiLineComment } from "../types.js";
 import type { FunctionParameter } from "./function.js";
 import { BaseNode } from "./base.js";
+import type { Tag } from "./tag.js";
 
 export type VariableType =
   | PrimitiveType
@@ -27,6 +28,7 @@ export type GenericType = {
   type: "genericType";
   name: string;
   typeArgs: VariableType[];
+  tags?: Tag[];
 };
 
 /**
@@ -42,16 +44,22 @@ export type TypeParam = {
 /**
  * Entry in the type alias registry. For non-generic aliases `typeParams`
  * is absent; for generic aliases it carries the declared parameters.
+ *
+ * `tags` carries `@validate(...)` / `@jsonSchema(...)` annotations from
+ * the alias declaration so they propagate across module boundaries and
+ * re-exports. They are attached onto the resolved type by `resolveType`.
  */
 export type TypeAliasEntry = {
   body: VariableType;
   typeParams?: TypeParam[];
+  tags?: Tag[];
 };
 
 export type ResultType = {
   type: "resultType";
   successType: VariableType;
   failureType: VariableType;
+  tags?: Tag[];
 };
 
 /**
@@ -64,53 +72,68 @@ export type ResultType = {
 export type SchemaType = {
   type: "schemaType";
   inner: VariableType;
+  tags?: Tag[];
 };
 
 export type BlockType = {
   type: "blockType";
   params: { name: string; typeAnnotation: VariableType }[];
   returnType: VariableType;
+  tags?: Tag[];
 };
 
 export type PrimitiveType = {
   type: "primitiveType";
   value: string;
+  tags?: Tag[];
 };
 
 export type ArrayType = {
   type: "arrayType";
   elementType: VariableType;
+  tags?: Tag[];
 };
 
 export type StringLiteralType = {
   type: "stringLiteralType";
   value: string;
+  tags?: Tag[];
 };
 
 export type NumberLiteralType = {
   type: "numberLiteralType";
   value: string;
+  tags?: Tag[];
 };
 
 export type BooleanLiteralType = {
   type: "booleanLiteralType";
   value: "true" | "false";
+  tags?: Tag[];
 };
 
 export type UnionType = {
   type: "unionType";
   types: VariableType[];
+  tags?: Tag[];
 };
 
 export type ObjectProperty = {
   key: string;
   value: VariableType;
   description?: string;
+  /**
+   * `@validate(...)` and `@jsonSchema(...)` annotations on this property.
+   * Parsed inside `objectTypeParser` from any `@tag(...)` lines above
+   * the property within an object-type body.
+   */
+  tags?: Tag[];
 };
 
 export type ObjectType = {
   type: "objectType";
   properties: ObjectProperty[];
+  tags?: Tag[];
 };
 
 export type TypeAlias = BaseNode & {
@@ -120,6 +143,7 @@ export type TypeAlias = BaseNode & {
   typeParams?: TypeParam[];
   exported?: boolean;
   docComment?: AgencyMultiLineComment;
+  tags?: Tag[];
 };
 
 export type FunctionRefType = {
@@ -128,9 +152,11 @@ export type FunctionRefType = {
   params: FunctionParameter[];
   returnType: VariableType | null;
   returnTypeValidated?: boolean;
+  tags?: Tag[];
 };
 
 export type TypeAliasVariable = {
   type: "typeAliasVariable";
   aliasName: string;
+  tags?: Tag[];
 };

--- a/packages/agency-lang/stdlib/schemas.agency
+++ b/packages/agency-lang/stdlib/schemas.agency
@@ -1,0 +1,37 @@
+/** @module
+  Pre-baked `@jsonSchema(...)` fragments for common formats. Spread them
+  into your own `@jsonSchema(...)` annotations to attach the matching
+  JSON Schema `format` field:
+
+  ```ts
+  import { emailFormat } from "std::schemas"
+
+  @jsonSchema({ ...emailFormat, description: "primary contact" })
+  type Email = string
+  ```
+
+  These are plain object constants — nothing magic. They exist to spare
+  callers from typing `{ format: "..." }` every time and to keep format
+  names consistent across a codebase.
+*/
+
+/** `{ format: "email" }` — RFC 5322 email format. */
+export static const emailFormat = { format: "email" }
+
+/** `{ format: "uri" }` — RFC 3986 URI. */
+export static const urlFormat = { format: "uri" }
+
+/** `{ format: "uuid" }` — canonical 8-4-4-4-12 UUID. */
+export static const uuidFormat = { format: "uuid" }
+
+/** `{ format: "date-time" }` — ISO 8601 date-time. */
+export static const dateTimeFormat = { format: "date-time" }
+
+/** `{ format: "date" }` — ISO 8601 date (no time). */
+export static const dateFormat = { format: "date" }
+
+/** `{ format: "ipv4" }` — dotted-quad IPv4 address. */
+export static const ipv4Format = { format: "ipv4" }
+
+/** `{ format: "ipv6" }` — IPv6 address. */
+export static const ipv6Format = { format: "ipv6" }

--- a/packages/agency-lang/stdlib/types.agency
+++ b/packages/agency-lang/stdlib/types.agency
@@ -24,12 +24,14 @@ import { emailFormat, urlFormat, uuidFormat } from "std::schemas"
 @jsonSchema({ ...emailFormat })
 export type Email = string
 
-/** An http:// or https:// URL. */
+/** An http:// or https:// URL. (Named `URLString` so it does not shadow
+    JavaScript's global `URL` constructor.) */
 @validate(isUrl)
 @jsonSchema({ ...urlFormat })
-export type URL = string
+export type URLString = string
 
-/** A canonical 8-4-4-4-12 hex UUID. */
+/** A canonical 8-4-4-4-12 hex UUID string. (Named `UUIDString` for symmetry
+    with `URLString`.) */
 @validate(isUuid)
 @jsonSchema({ ...uuidFormat })
-export type UUID = string
+export type UUIDString = string

--- a/packages/agency-lang/stdlib/types.agency
+++ b/packages/agency-lang/stdlib/types.agency
@@ -1,0 +1,35 @@
+import { isEmail, isUrl, isUuid } from "std::validators"
+import { emailFormat, urlFormat, uuidFormat } from "std::schemas"
+
+/** @module
+  Pre-baked type aliases that combine `@validate(...)` and `@jsonSchema(...)`
+  for the most common string-shaped opaque types. Use them in place of plain
+  `string` whenever the value must conform to one of these formats:
+
+  ```ts
+  import { Email } from "std::types"
+
+  def main() {
+    const e: Email! = "user@example.com"   // validated at runtime
+  }
+  ```
+
+  Aliases here only carry annotations — they are still plain `string` from
+  TypeScript's perspective. Validation runs on `!` sites; structured-output
+  LLM calls get the JSON Schema `format` hint via `.meta(...)`.
+*/
+
+/** A syntactically valid email address. */
+@validate(isEmail)
+@jsonSchema({ ...emailFormat })
+export type Email = string
+
+/** An http:// or https:// URL. */
+@validate(isUrl)
+@jsonSchema({ ...urlFormat })
+export type Url = string
+
+/** A canonical 8-4-4-4-12 hex UUID. */
+@validate(isUuid)
+@jsonSchema({ ...uuidFormat })
+export type Uuid = string

--- a/packages/agency-lang/stdlib/types.agency
+++ b/packages/agency-lang/stdlib/types.agency
@@ -27,9 +27,9 @@ export type Email = string
 /** An http:// or https:// URL. */
 @validate(isUrl)
 @jsonSchema({ ...urlFormat })
-export type Url = string
+export type URL = string
 
 /** A canonical 8-4-4-4-12 hex UUID. */
 @validate(isUuid)
 @jsonSchema({ ...uuidFormat })
-export type Uuid = string
+export type UUID = string

--- a/packages/agency-lang/stdlib/validators.agency
+++ b/packages/agency-lang/stdlib/validators.agency
@@ -23,32 +23,60 @@ import { _isEmail, _isUrl, _isUuid, _isInt, _isPositive, _isNegative } from "age
   See the [validation annotations guide](../guide/annotations.md) for details.
 */
 
-/** Returns success if `value` is a syntactically valid email address. */
 export def isEmail(value: string): Result {
+  """
+  Returns success if value is a syntactically valid email address,
+  failure otherwise.
+
+  @param value - The string to check.
+  """
   return _isEmail(value)
 }
 
-/** Returns success if `value` is an http:// or https:// URL. */
 export def isUrl(value: string): Result {
+  """
+  Returns success if value is an http:// or https:// URL,
+  failure otherwise.
+
+  @param value - The string to check.
+  """
   return _isUrl(value)
 }
 
-/** Returns success if `value` is a canonical UUID string (8-4-4-4-12 hex). */
 export def isUuid(value: string): Result {
+  """
+  Returns success if value is a canonical UUID string
+  (8-4-4-4-12 hex), failure otherwise.
+
+  @param value - The string to check.
+  """
   return _isUuid(value)
 }
 
-/** Returns success if `value` is an integer (no fractional component). */
 export def isInt(value: number): Result {
+  """
+  Returns success if value is an integer (no fractional component),
+  failure otherwise.
+
+  @param value - The number to check.
+  """
   return _isInt(value)
 }
 
-/** Returns success if `value > 0`. */
 export def isPositive(value: number): Result {
+  """
+  Returns success if value > 0, failure otherwise.
+
+  @param value - The number to check.
+  """
   return _isPositive(value)
 }
 
-/** Returns success if `value < 0`. */
 export def isNegative(value: number): Result {
+  """
+  Returns success if value < 0, failure otherwise.
+
+  @param value - The number to check.
+  """
   return _isNegative(value)
 }

--- a/packages/agency-lang/stdlib/validators.agency
+++ b/packages/agency-lang/stdlib/validators.agency
@@ -1,0 +1,54 @@
+import { _isEmail, _isUrl, _isUuid, _isInt, _isPositive, _isNegative } from "agency-lang/stdlib-lib/validators.js"
+
+/** @module
+  Validator functions intended for use with `@validate(...)` annotations.
+
+  Each validator takes a single value and returns a `Result` — `success(value)`
+  if the value is valid (optionally transformed), or `failure(reason)` if not.
+
+  ## Usage
+
+  ```ts
+  import { isEmail } from "std::validators"
+
+  @validate(isEmail)
+  type Email = string
+
+  def main() {
+    const e: Email! = "foo@example.com"   // validated
+  }
+  ```
+
+  Validators are only run for types annotated with `!` (the bang operator).
+  See the [validation annotations guide](../guide/annotations.md) for details.
+*/
+
+/** Returns success if `value` is a syntactically valid email address. */
+export def isEmail(value: string): Result {
+  return _isEmail(value)
+}
+
+/** Returns success if `value` is an http:// or https:// URL. */
+export def isUrl(value: string): Result {
+  return _isUrl(value)
+}
+
+/** Returns success if `value` is a canonical UUID string (8-4-4-4-12 hex). */
+export def isUuid(value: string): Result {
+  return _isUuid(value)
+}
+
+/** Returns success if `value` is an integer (no fractional component). */
+export def isInt(value: number): Result {
+  return _isInt(value)
+}
+
+/** Returns success if `value > 0`. */
+export def isPositive(value: number): Result {
+  return _isPositive(value)
+}
+
+/** Returns success if `value < 0`. */
+export def isNegative(value: number): Result {
+  return _isNegative(value)
+}

--- a/packages/agency-lang/stdlib/validators.agency
+++ b/packages/agency-lang/stdlib/validators.agency
@@ -20,7 +20,8 @@ import { _isEmail, _isUrl, _isUuid, _isInt, _isPositive, _isNegative } from "age
   ```
 
   Validators are only run for types annotated with `!` (the bang operator).
-  See the [validation annotations guide](../guide/annotations.md) for details.
+  See the [schemas guide](../guide/schemas.md) for details on `!`
+  validation and how `@validate(...)` integrates with it.
 */
 
 export def isEmail(value: string): Result {

--- a/packages/agency-lang/tests/agency/validation/jsonSchemaMerge.agency
+++ b/packages/agency-lang/tests/agency/validation/jsonSchemaMerge.agency
@@ -1,0 +1,19 @@
+// When @jsonSchema is set at the alias AND at the use-site (on an
+// object property), the two objects merge — use-site keys win on
+// conflict, alias-only keys still propagate.
+
+@jsonSchema({ format: "email", description: "alias-level description" })
+type Email = string
+
+type User = {
+  @jsonSchema({ description: "primary contact email" })
+  contact: Email
+}
+
+node main() {
+  const s = schema(User)
+  const js = s.toJSONSchema()
+  // alias-level `format` propagated; use-site `description` overrode the
+  // alias-level description.
+  return js.properties.contact.format + "|" + js.properties.contact.description
+}

--- a/packages/agency-lang/tests/agency/validation/jsonSchemaMerge.test.json
+++ b/packages/agency-lang/tests/agency/validation/jsonSchemaMerge.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"email|primary contact email\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Alias-level and use-site @jsonSchema merge: alias keys propagate, use-site keys win on conflict"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/jsonSchemaOnArrayElement.agency
+++ b/packages/agency-lang/tests/agency/validation/jsonSchemaOnArrayElement.agency
@@ -1,0 +1,13 @@
+// @jsonSchema on an array element type should appear under
+// items.<element-keys> in the generated JSON Schema.
+
+@jsonSchema({ format: "email" })
+type Email = string
+
+type Emails = Email[]
+
+node main() {
+  const s = schema(Emails)
+  const js = s.toJSONSchema()
+  return js.items.format
+}

--- a/packages/agency-lang/tests/agency/validation/jsonSchemaOnArrayElement.test.json
+++ b/packages/agency-lang/tests/agency/validation/jsonSchemaOnArrayElement.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"email\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "@jsonSchema on an array's element type surfaces under items.<keys> in the generated JSON Schema"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/jsonSchemaOnObjectProperty.agency
+++ b/packages/agency-lang/tests/agency/validation/jsonSchemaOnObjectProperty.agency
@@ -1,0 +1,17 @@
+// @jsonSchema can sit on an object property's type alias. We expect the
+// `format` field to appear under properties.email in the generated
+// JSON Schema, not at the top level.
+
+@jsonSchema({ format: "email" })
+type Email = string
+
+type User = {
+  name: string,
+  email: Email
+}
+
+node main() {
+  const s = schema(User)
+  const js = s.toJSONSchema()
+  return js.properties.email.format
+}

--- a/packages/agency-lang/tests/agency/validation/jsonSchemaOnObjectProperty.test.json
+++ b/packages/agency-lang/tests/agency/validation/jsonSchemaOnObjectProperty.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"email\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "@jsonSchema on a property's type alias surfaces under properties.<key> in the generated JSON Schema"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/jsonSchemaSimple.agency
+++ b/packages/agency-lang/tests/agency/validation/jsonSchemaSimple.agency
@@ -1,0 +1,13 @@
+// Verifies that a top-level @jsonSchema(...) annotation propagates to
+// the JSON Schema output. We pull the format field back out of the
+// generated JSON Schema and return it so the test runner can match
+// against it.
+
+@jsonSchema({ format: "email", description: "user email" })
+type Email = string
+
+node main() {
+  const s = schema(Email)
+  const js = s.toJSONSchema()
+  return js.format + "|" + js.description
+}

--- a/packages/agency-lang/tests/agency/validation/jsonSchemaSimple.test.json
+++ b/packages/agency-lang/tests/agency/validation/jsonSchemaSimple.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"email|user email\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "@jsonSchema(...) metadata at a type-alias level surfaces in toJSONSchema() output"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/jsonSchemaWithDescription.agency
+++ b/packages/agency-lang/tests/agency/validation/jsonSchemaWithDescription.agency
@@ -1,0 +1,18 @@
+// Regression test: when an object property has both a `#` description
+// AND a @jsonSchema(...) annotation, BOTH must appear in the generated
+// JSON Schema. This guards the invariant that `.meta(...)` is the
+// final Zod chain call (otherwise the metadata is dropped by
+// toJSONSchema).
+
+@jsonSchema({ format: "email" })
+type Email = string
+
+type User = {
+  contact: Email # primary contact address
+}
+
+node main() {
+  const s = schema(User)
+  const js = s.toJSONSchema()
+  return js.properties.contact.format + "|" + js.properties.contact.description
+}

--- a/packages/agency-lang/tests/agency/validation/jsonSchemaWithDescription.test.json
+++ b/packages/agency-lang/tests/agency/validation/jsonSchemaWithDescription.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"email|primary contact address\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Property `#` description AND alias-level @jsonSchema both surface in toJSONSchema — guards .meta(...) being the last Zod chain call"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/stdTypesEmail.agency
+++ b/packages/agency-lang/tests/agency/validation/stdTypesEmail.agency
@@ -1,0 +1,9 @@
+import { Email } from "std::types"
+
+node main() {
+  const bad: Email! = "not-email"
+  if (isFailure(bad)) {
+    return "ok"
+  }
+  return "wrong"
+}

--- a/packages/agency-lang/tests/agency/validation/stdTypesEmail.test.json
+++ b/packages/agency-lang/tests/agency/validation/stdTypesEmail.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/validateAnnotation.agency
+++ b/packages/agency-lang/tests/agency/validation/validateAnnotation.agency
@@ -1,0 +1,12 @@
+import { isEmail } from "std::validators"
+
+@validate(isEmail)
+type Email = string
+
+node main() {
+  const good: Email! = "user@example.com"
+  if (isSuccess(good)) {
+    return "ok"
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/validateAnnotation.test.json
+++ b/packages/agency-lang/tests/agency/validation/validateAnnotation.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/validateAnnotationFail.agency
+++ b/packages/agency-lang/tests/agency/validation/validateAnnotationFail.agency
@@ -1,0 +1,12 @@
+import { isEmail } from "std::validators"
+
+@validate(isEmail)
+type Email = string
+
+node main() {
+  const bad: Email! = "not-an-email"
+  if (isSuccess(bad)) {
+    return "unexpectedly ok"
+  }
+  return "failed-as-expected"
+}

--- a/packages/agency-lang/tests/agency/validation/validateAnnotationFail.test.json
+++ b/packages/agency-lang/tests/agency/validation/validateAnnotationFail.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"failed-as-expected\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/validateMultiLevelArray.agency
+++ b/packages/agency-lang/tests/agency/validation/validateMultiLevelArray.agency
@@ -1,0 +1,39 @@
+// Verifies that when an array type has its own @validate AND its
+// element type has its own @validate, both fire — element validation
+// runs for each item, then the array-level validation runs on the
+// whole list.
+
+def isEven(value: number): Result {
+  if (value % 2 == 0) {
+    return success(value)
+  }
+  return failure("not even")
+}
+
+def nonEmpty(value: number[]): Result {
+  if (value.length > 0) {
+    return success(value)
+  }
+  return failure("array must be non-empty")
+}
+
+@validate(isEven)
+type Even = number
+
+@validate(nonEmpty)
+type Numbers = Even[]
+
+node main() {
+  const good: Numbers! = [2, 4, 6]
+  const oddInside: Numbers! = [2, 3, 6]
+  const empty: Numbers! = []
+
+  if (isSuccess(good)) {
+    if (isFailure(oddInside)) {
+      if (isFailure(empty)) {
+        return good.value[0]
+      }
+    }
+  }
+  return -1
+}

--- a/packages/agency-lang/tests/agency/validation/validateMultiLevelArray.test.json
+++ b/packages/agency-lang/tests/agency/validation/validateMultiLevelArray.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "2",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Validators at two levels: element-level isEven runs per item, array-level nonEmpty runs on the whole list"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/validateMultiLevelObject.agency
+++ b/packages/agency-lang/tests/agency/validation/validateMultiLevelObject.agency
@@ -1,0 +1,43 @@
+// Verifies that when an object type has its own @validate AND one of
+// its property types has its own @validate, both fire — property
+// validation runs on the property value, then the object-level
+// validation runs on the whole object.
+
+def isEven(value: number): Result {
+  if (value % 2 == 0) {
+    return success(value)
+  }
+  return failure("not even")
+}
+
+// Object-level validator: fail if `name` is the empty string.
+def hasName(value: {name: string, age: number}): Result {
+  if (value.name == "") {
+    return failure("name must not be empty")
+  }
+  return success(value)
+}
+
+@validate(isEven)
+type Even = number
+
+@validate(hasName)
+type Person = {
+  name: string,
+  age: Even
+}
+
+node main() {
+  const good: Person! = { name: "Alice", age: 30 }
+  const oddAge: Person! = { name: "Bob", age: 7 }
+  const noName: Person! = { name: "", age: 30 }
+
+  if (isSuccess(good)) {
+    if (isFailure(oddAge)) {
+      if (isFailure(noName)) {
+        return good.value.name
+      }
+    }
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/validateMultiLevelObject.test.json
+++ b/packages/agency-lang/tests/agency/validation/validateMultiLevelObject.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"Alice\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Validators at two levels: property-level isEven runs on age, object-level hasName runs on the whole record"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/validateNestedInObject.agency
+++ b/packages/agency-lang/tests/agency/validation/validateNestedInObject.agency
@@ -1,0 +1,20 @@
+import { isEmail } from "std::validators"
+
+@validate(isEmail)
+type Email = string
+
+type Contact = {
+  name: string,
+  email: Email
+}
+
+node main() {
+  const good: Contact! = { name: "Alice", email: "user@example.com" }
+  const bad: Contact! = { name: "Bob", email: "not-an-email" }
+  if (isSuccess(good)) {
+    if (isFailure(bad)) {
+      return good.value.email
+    }
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/validateNestedInObject.test.json
+++ b/packages/agency-lang/tests/agency/validation/validateNestedInObject.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"user@example.com\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Validator on a property type runs when the parent object is validated with !"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/validateOnArrayElements.agency
+++ b/packages/agency-lang/tests/agency/validation/validateOnArrayElements.agency
@@ -1,0 +1,15 @@
+import { isEmail } from "std::validators"
+
+@validate(isEmail)
+type Email = string
+
+node main() {
+  const goodList: Email[]! = ["a@b.com", "c@d.com"]
+  const badList: Email[]! = ["a@b.com", "not-an-email"]
+  if (isSuccess(goodList)) {
+    if (isFailure(badList)) {
+      return goodList.value[1]
+    }
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/validateOnArrayElements.test.json
+++ b/packages/agency-lang/tests/agency/validation/validateOnArrayElements.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"c@d.com\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Validator runs for each element of an array type; one bad element fails the whole list"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/validateOnNullable.agency
+++ b/packages/agency-lang/tests/agency/validation/validateOnNullable.agency
@@ -1,0 +1,20 @@
+import { isEmail } from "std::validators"
+
+@validate(isEmail)
+type Email = string
+
+node main() {
+  // null short-circuits validation — the validator is only run on the
+  // non-null branch, so the null assignment should succeed.
+  const nothing: Email | null! = null
+  const good: Email | null! = "user@example.com"
+  const bad: Email | null! = "not-an-email"
+  if (isSuccess(nothing)) {
+    if (isSuccess(good)) {
+      if (isFailure(bad)) {
+        return "null passes through; valid email passes; invalid email fails"
+      }
+    }
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/validateOnNullable.test.json
+++ b/packages/agency-lang/tests/agency/validation/validateOnNullable.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"null passes through; valid email passes; invalid email fails\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Validator is skipped for null/undefined branches of a nullable union"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/validatePlainJsFunction.agency
+++ b/packages/agency-lang/tests/agency/validation/validatePlainJsFunction.agency
@@ -1,0 +1,15 @@
+import { isShort } from "../../helpers/jsValidator.js"
+
+@validate(isShort)
+type ShortString = string
+
+node main() {
+  const good: ShortString! = "abc"
+  const bad: ShortString! = "this is way too long"
+  if (isSuccess(good)) {
+    if (isFailure(bad)) {
+      return good.value
+    }
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/validatePlainJsFunction.test.json
+++ b/packages/agency-lang/tests/agency/validation/validatePlainJsFunction.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"abc\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "A plain JS function imported from a .js file works as a @validate(...) validator"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/validateTransform.agency
+++ b/packages/agency-lang/tests/agency/validation/validateTransform.agency
@@ -1,0 +1,17 @@
+// A validator that always succeeds but transforms the value. The
+// success value flows into the bound variable, so `name.value` should
+// equal the upper-cased string.
+def toUpper(value: string): Result {
+  return success(value.toUpperCase())
+}
+
+@validate(toUpper)
+type Loud = string
+
+node main() {
+  const name: Loud! = "alice"
+  if (isSuccess(name)) {
+    return name.value
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/validateTransform.test.json
+++ b/packages/agency-lang/tests/agency/validation/validateTransform.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ALICE\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Validators may transform the value — the transformed value is what the binding receives"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -20,7 +20,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -20,7 +20,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -20,7 +20,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -20,7 +20,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -20,7 +20,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -20,7 +20,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/helpers/jsValidator.js
+++ b/packages/agency-lang/tests/helpers/jsValidator.js
@@ -1,0 +1,12 @@
+import { success, failure } from "agency-lang/runtime";
+
+/**
+ * Plain JS validator used by tests to confirm that `@validate(...)`
+ * works with non-Agency functions. Receives only the value to check —
+ * not the runtime ctx — per the documented validator contract.
+ */
+export function isShort(value) {
+  return typeof value === "string" && value.length <= 5
+    ? success(value)
+    : failure(`expected short string, got ${JSON.stringify(value)}`);
+}

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -19,7 +19,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -33,7 +33,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -19,7 +19,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -19,7 +19,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -18,7 +18,7 @@ import {
   deepFreeze as __deepFreeze,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
-  Schema, __validateType,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
   readSkill as _readSkillRaw,
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,


### PR DESCRIPTION
## Summary

Adds two type-level annotations and a small standard library that uses them.

### `@validate(fn1, fn2, ...)`

Attaches an async validator chain that runs **after** the Zod parse on any
`!`-validated value. Validators are transform-capable — `success(value)`
threads the new value into the next validator — and short-circuit on the
first failure. Plain JS async functions and Agency `def` functions
(`AgencyFunction` instances) are both accepted.

```ts
import { isEmail } from "std::validators"

@validate(isEmail)
type Email = string

def main() {
  const e: Email! = "user@example.com"   // validated
}
```

### `@jsonSchema({...})`

Emits a Zod `.meta(...)` call on the generated schema, so structured-output
LLM responses and `toJSONSchema(...)` output pick up custom JSON Schema
fields (`format`, `description`, `minimum`, etc.).

```ts
@validate(isEmail)
@jsonSchema({ format: "email", description: "work address" })
type WorkEmail = string
```

Validation only runs when `!` is present — same rule as the existing
`schemas` feature — so users have one mental model for "when does
validation fire".

### New stdlib modules

- `std::validators` — `isEmail`, `isUrl`, `isUuid`, `isInt`,
  `isPositive`, `isNegative`.
- `std::schemas` — `emailFormat`, `urlFormat`, `uuidFormat`,
  `dateTimeFormat`, `dateFormat`, `ipv4Format`, `ipv6Format`. Plain object
  constants intended for spread into `@jsonSchema({...})`.
- `std::types` — pre-baked `Email`, `Url`, `Uuid` aliases combining the
  matching validator + format helper.

## Implementation notes

- `Tag.arguments` widened from `string[]` to `Expression[]`. The tag parser
  now accepts a restricted expression subset (literals, identifiers,
  function calls, object literals with spread). Existing `@goal` /
  `@optimize` round-trip identically.
- Preprocessor `attachTags` extended to `typeAlias`; object-type parser
  grows tag accumulation for `ObjectProperty`.
- `TypeAliasEntry` carries `tags`; `resolveType` propagates them through
  both generic and non-generic alias references. `mergeTagSets` gives
  alias-tags-first concat for `@validate` and right-merge for
  `@jsonSchema`.
- New runtime helpers `__validateChain` and `__validateChainRecursive`
  run async validator chains after the sync Zod parse, recurse into
  nested types via a structural descriptor, dispatch unions to the
  matching branch only, skip inner validators on `null` / `undefined`,
  and bail past a depth cap of 64 (configurable).
- Type aliases whose body carries `@validate` emit a co-located
  `(Foo as any).__agency_descriptor = ...` so consumer modules get the
  full validation tree without needing to re-import the validator or
  schema-helper identifiers themselves.
- `importResolver` flows static-`const` exports through Agency imports
  so `import { emailFormat } from "std::schemas"` actually arrives in
  the generated TS.
- `agencyGenerator` round-trips alias-level tags so `pnpm run fmt`
  doesn't drop annotations.

## Verification

- `pnpm exec tsc --noEmit`: clean
- `pnpm run lint:structure`: clean
- `pnpm test:run`: 4086 / 4086 pass
- `pnpm run agency test tests/agency/validation -p 12`: 39 / 39 pass
  (including the three new end-to-end tests added in this PR)
- `make` (full build + stdlib compile + docs): clean

## Spec and plan

- Spec: `packages/agency-lang/docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md`
- Plan: `packages/agency-lang/docs/superpowers/plans/2026-05-19-type-validation-and-json-schema-annotations-impl.md`

## Fast-follow items (not in this PR)

- Hook `jsonSchemaArgValidator` into the type-check pass so the
  static-expression restriction surfaces as a diagnostic. The helper
  and its unit tests are already in place.
- Property-level tag round-trip in `agencyGenerator` (alias-level done;
  object-property emit-back TBD).
- Remaining cells of the end-to-end test matrix (3 of ~15 done).
- User-facing docs (`docs/site/guide/annotations.md`).
- The legacy `# description` codemod and parser removal, always
  intended as a separate PR.
