### PR TITLE
Add value-parameterized type aliases

### DIFF
--- a/packages/agency-lang/docs/dev/validation-annotations.md
+++ b/packages/agency-lang/docs/dev/validation-annotations.md
@@ -394,3 +394,101 @@ since `.meta()`'s semantics only matter at runtime.
    threads `success.value` into the next validator. Tests in
    `tests/agency/validation/` cover the boundary cases (array element,
    nested object, nullable, transform).
+
+---
+
+## Value parameters and substitution
+
+Value-parameterized type aliases — `type NumberInRange(low: number, high: number) = number`
+— let users lift a tag's numeric (or string) literals out to the alias
+declaration and re-supply them at every use site. Substitution is purely
+compile-time; the runtime walker, descriptor format, and `__validateChain`
+helpers are unchanged.
+
+### The substitution pass
+
+`lib/typeChecker/valueParamSubstitution.ts` is the single source of
+truth. It exports:
+
+- `substituteValueArgsInExpression(expr, bindings)` — walks the
+  restricted tag-arg expression subtree (literals, identifiers, object
+  literals + spreads, `valueAccess` chains incl. PFA method-call args)
+  and replaces any `variableName` whose `value` matches a key in
+  `bindings` with a structural clone of the bound `Expression`. Nodes
+  outside the restricted subset pass through unchanged. The input tree
+  is never mutated.
+- `substituteValueArgsInTag(tag, bindings)` — convenience wrapper that
+  maps the substitution over `tag.arguments`.
+- `substituteValueArgsInType(vt, bindings)` — walks a `VariableType`
+  tree and rewrites any inner `typeAliasVariable` / `genericType` whose
+  own `valueArgs` reference a name in `bindings`. Required so wrapping
+  aliases (`type EvenInRange(low, high) = NumberInRange(low, high)`)
+  can forward their value parameters to inner instantiations.
+- `applyValueArgs(entry, valueArgs, aliasName)` — the canonical entry
+  point: validates arity (filling missing tail args from
+  `valueParams[i].default`, throwing on missing-required or
+  too-many-args), builds the bindings map, then returns a fresh
+  `TypeAliasEntry` whose `tags` and `body` are both substituted. Best-
+  effort literal type-check on each argument; non-literal args are
+  accepted and deferred.
+
+### Where it fires
+
+In `lib/typeChecker/assignability.ts`, `resolveType` calls
+`applyValueArgs` whenever it resolves a `typeAliasVariable` or
+`genericType` whose entry has `valueParams`. Type-param substitution
+happens first (existing path); value-arg substitution runs on the
+result. The substituted entry's tags then flow through the existing
+`attachAliasTags` + `mergeTagSets` chain unchanged.
+
+### The shared `staticTagArgParser`
+
+A single combinator backs every place that needs the restricted
+expression subset:
+
+1. Tag arguments inside `@validate(...)` and `@jsonSchema(...)`.
+2. Default-value expressions for value params (`= 0`).
+3. Use-site value-arg expressions (`Age(18)`).
+
+Centralizing the rule keeps "static consts and value-param identifiers
+are OK; bare function calls are not" defined exactly once. PFA
+(`min.partial(n: low)`) stays allowed because it's a method call on an
+identifier, not a bare function call.
+
+### Codegen divergence
+
+Value-parameterized aliases are deliberately *not* emitted as top-level
+Zod schemas:
+
+- **No top-level `const AliasName = z....` emission.**
+  `typescriptBuilder.ts` skips the const for aliases with
+  `valueParams`. There's no single schema for `NumberInRange` without
+  arguments.
+- **No `(AliasName as any).__agency_descriptor` side-channel.** The
+  descriptor would have to encode the specific value args; instead,
+  the descriptor is constructed *inline at the use site* with the
+  substituted tags.
+- **Use-site inlining.** `typeToZodSchema.ts` and
+  `validationDescriptor.ts` both check for `variableType.valueArgs` on
+  a `typeAliasVariable` / `genericType` reference, call
+  `applyValueArgs`, and recursively map the substituted entry. The
+  substituted tags drive `appendMeta` and `validatorNodes`.
+
+### `tagArgToTs` safety net
+
+After substitution, the TypeScript printer should never see a
+value-param identifier. If it does (i.e. someone added a code path that
+skipped `applyValueArgs`), `tagArgToTs` throws
+`value param 'X' left unsubstituted` so the bug surfaces immediately.
+
+### Files of record (value-parameterized additions)
+
+| File | Role |
+|------|------|
+| `lib/typeChecker/valueParamSubstitution.ts` | The substitution pass + `applyValueArgs` |
+| `lib/typeChecker/valueParamSubstitution.test.ts` | Unit tests for every branch |
+| `lib/typeChecker/assignability.ts` | Calls `applyValueArgs` during `resolveType` |
+| `lib/backends/typescriptGenerator/typeToZodSchema.ts` | Inlines substituted schemas at use sites |
+| `lib/backends/typescriptGenerator/validationDescriptor.ts` | Inlines substituted descriptors at use sites |
+| `lib/backends/typescriptBuilder.ts` | Skips top-level emission for value-parameterized aliases |
+| `stdlib/types.agency` | Pre-baked `NumberInRange`, `StringWithLength`, `MatchesPattern`, `BoundedArray<T>` |

--- a/packages/agency-lang/docs/dev/validation-annotations.md
+++ b/packages/agency-lang/docs/dev/validation-annotations.md
@@ -469,17 +469,70 @@ Zod schemas:
   the descriptor is constructed *inline at the use site* with the
   substituted tags.
 - **Use-site inlining.** `typeToZodSchema.ts` and
-  `validationDescriptor.ts` both check for `variableType.valueArgs` on
-  a `typeAliasVariable` / `genericType` reference, call
-  `applyValueArgs`, and recursively map the substituted entry. The
-  substituted tags drive `appendMeta` and `validatorNodes`.
+  `validationDescriptor.ts` both branch on
+  `isValueParamInstantiation(vt, entry)` (defined in
+  `valueParamSubstitution.ts`) — the single canonical predicate for
+  "this reference needs inline-at-use-site emission". When it matches,
+  they call `applyValueArgs` and recursively map the substituted entry.
+  The substituted tags drive `appendMeta` and `validatorNodes`.
+- **Object-property merge also substitutes.** The object-property branch
+  of `mapTypeToSchemaInner` looks up alias-level tags to merge them onto
+  the property. When the property is a value-parameterized
+  instantiation (e.g. `age: NumberInRange(0, 150)`), the alias tags it
+  pulls in are run through `applyValueArgs` *first* — otherwise the
+  outer `.meta(...)` chain on the property would emit out-of-scope
+  value-param identifiers (e.g. `low`, `high`).
 
-### `tagArgToTs` safety net
+The codegen divergence rule is expressed in exactly one predicate
+(`isValueParamInstantiation`), used at three sites. Adding a new
+emission site that handles `typeAliasVariable` should consult the same
+predicate to stay consistent.
 
-After substitution, the TypeScript printer should never see a
-value-param identifier. If it does (i.e. someone added a code path that
-skipped `applyValueArgs`), `tagArgToTs` throws
-`value param 'X' left unsubstituted` so the bug surfaces immediately.
+### Why inline-at-use-site instead of a schema factory function?
+
+A natural alternative is to emit a factory:
+
+```ts
+const NumberInRange = (low: number, high: number) =>
+  z.number().meta({ minimum: low, maximum: high });
+```
+
+We chose inline-at-use-site instead. Trade-off:
+
+| Concern | Factory emission | Inline at use site (chosen) |
+|---|---|---|
+| Generated TS size | Smaller (one definition per alias) | Duplicated per instantiation |
+| Single place to debug | ✓ | ✗ |
+| Object-property merge | Complex — must *call* the factory and then mergeTagSets the result | Plugs into existing pipeline directly |
+| Descriptor side-channel | Needs `Alias.descriptor = (...) => ({...})`, a new runtime mechanism | Inline reuses the descriptor walker |
+| Tag-merge symmetry with bare aliases | Diverges (bare alias is a value, parameterized is a factory) | Same code path for both |
+| Use-site tag composition | Needs runtime composition (`NumberInRange(0, 150).pipe(z.refine(...))`) | `mergeTagSets` at codegen, single chain |
+
+Every other piece of the validation infrastructure
+(`mergeTagSets`, `appendMeta`, descriptor walker,
+`__agency_descriptor` lookup) deals in *values*, not factories.
+Switching to factories would mean touching all of them — a much larger
+surface change for a smaller-generated-code win. If the duplication
+ever shows up as a real cost (large programs with many instantiations),
+the factory pattern is the natural follow-up.
+
+### Substitution-time safety net
+
+The TypeScript printer should never see an unsubstituted value-param
+identifier. There are two layers of defense:
+
+1. **Substitution-time assertion (primary).** `applyValueArgs` walks
+   the substituted tags + body looking for any `variableName` whose
+   value is still in the alias's `valueParams` set. If any are found
+   it throws `value param 'X' left unsubstituted in @<tag> on <alias>`
+   immediately, with the alias and tag names in the message. Triggers
+   for missing substitution at the substitution boundary itself, not
+   downstream at codegen.
+2. **`tagArgToTs` guard (secondary).** Accepts an optional
+   `valueParamNames` set and throws the same error if a leftover
+   identifier matches. Currently the production call sites all go
+   through `applyValueArgs` first, so this guard exists as a
+   belt-and-suspenders check.
 
 ### Files of record (value-parameterized additions)
 

--- a/packages/agency-lang/docs/site/guide/type-validation.md
+++ b/packages/agency-lang/docs/site/guide/type-validation.md
@@ -225,27 +225,36 @@ its value can be folded to a TypeScript literal during compilation.
 - identifiers that resolve to a `let` binding, function parameter, or
   local declaration
 
-::: warning String interpolation does not work in tag arguments
-Agency string literals normally support interpolation everywhere — `"hello ${name}"` is a real expression that combines the literal text with whatever `name` evaluates to at runtime. Inside `@validate(...)`, `@jsonSchema(...)`, value-param defaults, and use-site value-args, **only the literal-only form is accepted**:
+::: warning String interpolation is restricted to value-parameter identifiers
+Agency string literals normally support interpolation everywhere — `"hello ${name}"` is a real expression that combines the literal text with whatever `name` evaluates to at runtime. Inside `@validate(...)`, `@jsonSchema(...)`, value-param defaults, and use-site value-args, the only `${...}` form that is accepted is **a bare identifier that names a value parameter of the enclosing alias**:
 
 ```ts
-static const PREFIX = "user-"
-static const SUFFIX = "-foo"
+// ✅ `${divisor}` references a value parameter — substituted at compile time
+@jsonSchema({ description: "Must be divisible by ${divisor}" })
+type DivisibleBy(divisor: number) = number
 
-@jsonSchema({ pattern: "^user-[0-9]+-foo$" })  // ✅ literal string, OK
+// At use sites, `divisor` is folded into the description:
+//   schema(DivisibleBy(3)).toJSONSchema().description  // "Must be divisible by 3"
+//   schema(DivisibleBy(7)).toJSONSchema().description  // "Must be divisible by 7"
+
+// ❌ Arbitrary expressions are still rejected (no ternaries, no calls, no member access)
+@jsonSchema({ pattern: "^${PREFIX}[0-9]+${foo()}$" })
 type UserId = string
 
-@jsonSchema({ pattern: "^${PREFIX}[0-9]+${SUFFIX}$" })  // ❌ interpolation rejected by parser
+// ❌ Top-level static const references in `${...}` are also rejected:
+// tag-arg strings are emitted into node-body schema chains where
+// module-level Agency consts are not bound to JS identifiers.
+static const PREFIX = "user-"
+@jsonSchema({ pattern: "^${PREFIX}[0-9]+$" })  // ❌ not supported today
 type UserId = string
 ```
 
-Interpolation gets rejected because it would embed a runtime expression that can't be folded to a compile-time string. If you need to compose strings, put the composition in a `static const` and pass the const in (which *is* statically known):
+If you need to embed a static const, compose the literal yourself and pass the const in as the whole argument (which *is* statically known):
 
 ```ts
-static const PREFIX = "user-"
 static const PATTERN = "^user-[0-9]+-foo$"  // hand-written literal
 
-@jsonSchema({ pattern: PATTERN })  // ✅ static const reference
+@jsonSchema({ pattern: PATTERN })  // ✅ static const reference (no interpolation)
 type UserId = string
 ```
 :::

--- a/packages/agency-lang/docs/site/guide/type-validation.md
+++ b/packages/agency-lang/docs/site/guide/type-validation.md
@@ -270,6 +270,28 @@ substitution well-defined: a value-param identifier (`low`) can flow into
 the named-argument slot of a method call, which we can manipulate as an
 expression tree at compile time.
 
+### Arithmetic erases bounds
+
+Value-parameterized aliases attach validators and JSON schema constraints
+to a specific *type name*, not to the underlying `number`/`string` value
+itself. As a result, arithmetic and other expressions return the plain
+unwrapped type — the bounds do not propagate through operators:
+
+```agency
+@validate(min.partial(n: low), max.partial(n: high))
+type NumberInRange(low: number, high: number) = number
+
+const a: NumberInRange(0, 10)! = 7
+const sum = a.value + 5   // sum is a plain `number`, NOT NumberInRange(0, 10)
+```
+
+If you want to re-validate the result of an arithmetic expression,
+annotate it again with a value-parameterized alias and use the bang:
+
+```agency
+const checked: NumberInRange(0, 100)! = a.value + 5
+```
+
 ### Pre-baked stdlib types
 
 `std::types` already exports the most common parameterized shapes:

--- a/packages/agency-lang/docs/site/guide/type-validation.md
+++ b/packages/agency-lang/docs/site/guide/type-validation.md
@@ -204,7 +204,10 @@ distinct but are mutually assignment-compatible (both bottom out at
 ### What can appear as a use-site argument
 
 Arguments are evaluated at compile time, not at runtime — they have to be
-*statically known*:
+*statically known*. The underlying rule: an argument is allowed only if
+its value can be folded to a TypeScript literal during compilation.
+
+**Allowed:**
 
 - String / number / boolean / `null` literals
 - Identifiers that resolve to a top-level `static const` (including
@@ -213,10 +216,39 @@ Arguments are evaluated at compile time, not at runtime — they have to be
   its own value params)
 - Object literals built from any of the above (with `...` spread)
 
-**Not allowed:** bare function calls, ternaries, binary operators (other
-than spread), member access, template strings, array literals, or
-identifiers that resolve to a `let` binding, function parameter, or
-local declaration.
+**Not allowed:**
+
+- bare function calls (`Age(getDefault())`)
+- ternaries, binary operators, pipes
+- member access (`Age(config.min)`)
+- array literals
+- identifiers that resolve to a `let` binding, function parameter, or
+  local declaration
+
+::: warning String interpolation does not work in tag arguments
+Agency string literals normally support interpolation everywhere — `"hello ${name}"` is a real expression that combines the literal text with whatever `name` evaluates to at runtime. Inside `@validate(...)`, `@jsonSchema(...)`, value-param defaults, and use-site value-args, **only the literal-only form is accepted**:
+
+```ts
+static const PREFIX = "user-"
+static const SUFFIX = "-foo"
+
+@jsonSchema({ pattern: "^user-[0-9]+-foo$" })  // ✅ literal string, OK
+type UserId = string
+
+@jsonSchema({ pattern: "^${PREFIX}[0-9]+${SUFFIX}$" })  // ❌ interpolation rejected by parser
+type UserId = string
+```
+
+Interpolation gets rejected because it would embed a runtime expression that can't be folded to a compile-time string. If you need to compose strings, put the composition in a `static const` and pass the const in (which *is* statically known):
+
+```ts
+static const PREFIX = "user-"
+static const PATTERN = "^user-[0-9]+-foo$"  // hand-written literal
+
+@jsonSchema({ pattern: PATTERN })  // ✅ static const reference
+type UserId = string
+```
+:::
 
 ### Bare function calls in tag arguments
 

--- a/packages/agency-lang/docs/site/guide/type-validation.md
+++ b/packages/agency-lang/docs/site/guide/type-validation.md
@@ -154,6 +154,101 @@ export function isPalindrome(value) {
 ```
 
 
+## Value-Parameterized Aliases
+
+When you find yourself repeating the same `@validate(...)` / `@jsonSchema(...)`
+shape with just one or two numbers (or strings) changing, you can lift those
+numbers out as **value parameters** on the alias itself:
+
+```ts
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+@jsonSchema({ minimum: low, maximum: high })
+type NumberInRange(low: number, high: number) = number
+```
+
+At every use site you supply concrete arguments and the alias's tags are
+substituted at compile time as if you had written them out by hand:
+
+```ts
+type User = {
+  age: NumberInRange(0, 150)
+  score: NumberInRange(1, 100)
+}
+```
+
+The `age` property gets `@validate(min.partial(n: 0), max.partial(n: 150))`
+plus `@jsonSchema({ minimum: 0, maximum: 150 })`; the `score` property gets
+the equivalent with `1` / `100`. The two instantiations are nominally
+distinct but are mutually assignment-compatible (both bottom out at
+`number`); validation runs only at `!` sites.
+
+### Syntax
+
+- **Value parameters use `(...)`**, distinct from type parameters'
+  `<...>`. Value params must come *after* type params:
+
+  ```ts
+  type BoundedList<T>(n: number) = T[]
+  // use site
+  const xs: BoundedList<string>(3) = ["a", "b", "c"]
+  ```
+- Defaults are allowed and follow the same restriction set:
+
+  ```ts
+  type Age(low: number = 0) = number
+  const x: Age()! = 5   // uses default 0
+  ```
+
+### What can appear as a use-site argument
+
+Arguments are evaluated at compile time, not at runtime — they have to be
+*statically known*:
+
+- String / number / boolean / `null` literals
+- Identifiers that resolve to a top-level `static const` (including
+  const-bound imports)
+- Other value-param identifiers in scope (so a wrapper alias can forward
+  its own value params)
+- Object literals built from any of the above (with `...` spread)
+
+**Not allowed:** bare function calls, ternaries, binary operators (other
+than spread), member access, template strings, array literals, or
+identifiers that resolve to a `let` binding, function parameter, or
+local declaration.
+
+### Bare function calls in tag arguments
+
+The same restriction applies inside `@validate(...)` and `@jsonSchema(...)`
+arguments themselves:
+
+```ts
+// ❌ Rejected — bare function call in a tag argument
+@validate(min(0))
+type Age = number
+
+// ✅ Use a partial-application chain instead
+@validate(min.partial(n: 0))
+type Age = number
+```
+
+The partial-application (PFA) form is what makes value-parameter
+substitution well-defined: a value-param identifier (`low`) can flow into
+the named-argument slot of a method call, which we can manipulate as an
+expression tree at compile time.
+
+### Pre-baked stdlib types
+
+`std::types` already exports the most common parameterized shapes:
+
+- `NumberInRange(low, high)`
+- `StringWithLength(min, max)`
+- `MatchesPattern(pat)`
+- `BoundedArray<T>(min, max)`
+
+See the [`std::types` reference](../stdlib/types.md) for the full list.
+
 ## References
 - [minimum](https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.6.2.4)
 - [JSON Schema object](https://json-schema.org/understanding-json-schema/reference/object)

--- a/packages/agency-lang/docs/site/guide/type-validation.md
+++ b/packages/agency-lang/docs/site/guide/type-validation.md
@@ -210,18 +210,24 @@ its value can be folded to a TypeScript literal during compilation.
 **Allowed:**
 
 - String / number / boolean / `null` literals
+- Multi-line `"""..."""` strings
+- Unit literals: time (`30s`, `2h`), cost (`$5`), size (`100KB`).
+  These canonicalise to a plain number (ms / dollars / bytes) and the
+  canonical value is what gets substituted
+- Regex literals (`re/pattern/flags`); useful when forwarding to a
+  custom validator declared with `(pat: regex)`
 - Identifiers that resolve to a top-level `static const` (including
   const-bound imports)
 - Other value-param identifiers in scope (so a wrapper alias can forward
   its own value params)
-- Object literals built from any of the above (with `...` spread)
+- Object literals and array literals built from any of the above
+  (with `...` spread)
 
 **Not allowed:**
 
 - bare function calls (`Age(getDefault())`)
 - ternaries, binary operators, pipes
 - member access (`Age(config.min)`)
-- array literals
 - identifiers that resolve to a `let` binding, function parameter, or
   local declaration
 

--- a/packages/agency-lang/docs/site/stdlib/types.md
+++ b/packages/agency-lang/docs/site/stdlib/types.md
@@ -96,3 +96,110 @@ export type UUIDString = string
 ```
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L37))
+
+### NumberInRange
+
+A number that must lie within the inclusive range `[low, high]`.
+    Use as `NumberInRange(0, 100)` etc. — both bounds substitute into the
+    `@validate(...)` and `@jsonSchema(...)` tags at the use site.
+
+```ts
+/** A number that must lie within the inclusive range `[low, high]`.
+    Use as `NumberInRange(0, 100)` etc. — both bounds substitute into the
+    `@validate(...)` and `@jsonSchema(...)` tags at the use site. */
+@validate(min.partial(n: low), max.partial(n: high))
+@jsonSchema({
+  minimum: low,
+  maximum: high
+})
+export type NumberInRange(low: number, high: number) = number
+```
+
+**Validators:** `min.partial(n: low)`, `max.partial(n: high)`
+
+**JSON Schema metadata:**
+
+```agency
+{
+  minimum: low,
+  maximum: high
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L44))
+
+### StringWithLength
+
+A string whose length is in the inclusive range `[min, max]`.
+
+```ts
+/** A string whose length is in the inclusive range `[min, max]`. */
+@validate(minLength.partial(n: min), maxLength.partial(n: max))
+@jsonSchema({
+  minLength: min,
+  maxLength: max
+})
+export type StringWithLength(min: number, max: number) = string
+```
+
+**Validators:** `minLength.partial(n: min)`, `maxLength.partial(n: max)`
+
+**JSON Schema metadata:**
+
+```agency
+{
+  minLength: min,
+  maxLength: max
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L49))
+
+### MatchesPattern
+
+A string that matches the given regular expression `pat`.
+
+```ts
+/** A string that matches the given regular expression `pat`. */
+@validate(matches.partial(pattern: pat))
+@jsonSchema({
+  pattern: pat
+})
+export type MatchesPattern(pat: string) = string
+```
+
+**Validators:** `matches.partial(pattern: pat)`
+
+**JSON Schema metadata:**
+
+```agency
+{
+  pattern: pat
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L54))
+
+### BoundedArray
+
+An array whose length is in the inclusive range `[min, max]`.
+
+```ts
+/** An array whose length is in the inclusive range `[min, max]`. */
+@jsonSchema({
+  minItems: min,
+  maxItems: max
+})
+export type BoundedArray<T>(min: number, max: number) = T[]
+```
+
+**JSON Schema metadata:**
+
+```agency
+{
+  minItems: min,
+  maxItems: max
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/types.agency#L58))

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-20-value-parameterized-type-aliases-impl.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-20-value-parameterized-type-aliases-impl.md
@@ -1,0 +1,410 @@
+# Value-Parameterized Type Aliases — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the "value-parameterized type aliases" feature deferred from the original `@validate` / `@jsonSchema` spec (the "dependent types" idea). Users will be able to write:
+
+```
+@validate(min.partial(n: low), max.partial(n: high))
+@jsonSchema({ minimum: low, maximum: high })
+type NumberInRange(low: number, high: number) = number
+
+type User = {
+  age: NumberInRange(0, 150)
+  score: NumberInRange(1, 100)
+}
+```
+
+Each use-site `NumberInRange(0, 150)` resolves to `number` with the alias's tags fully **substituted** — every reference to the value parameters (`low`, `high`) in the alias's tag arguments is replaced with the literal/static-const argument at the use site. The substituted tags then flow through the existing `mergeTagSets` / `appendMeta` / `validationDescriptor` pipeline unchanged.
+
+**Spec section:** [docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md § Future Work: Value-Parameterized Type Aliases](../specs/2026-05-19-type-validation-and-json-schema-annotations-design.md#L508-L606).
+
+**Tech stack:** tarsec parsers, vitest, structural linter, Zod 4 `.meta()`, the existing `__validateChain` / `__validateChainRecursive` runtime helpers. **No new runtime code** — everything is compile-time substitution.
+
+---
+
+## Confirmed design decisions
+
+1. **Syntax.** Value parameters use `()`, distinct from type parameters' `<>`. They may be combined: `type BoundedList<T>(n: number) = T[]` is valid. Value params come after type params.
+2. **Argument restriction.** Use-site arguments may be:
+   - String / number / boolean / null literals
+   - Identifiers that resolve to a top-level `static const` (including const-bound imports)
+   - Other value-param identifiers in scope (so a wrapper alias can forward its own value params)
+   - Object literals built from the above (with `...` spread of allowed values)
+
+   **Not allowed:** bare function calls, ternaries, binary operators (other than spread), member access, template strings, array literals. Identifiers that resolve to `let` bindings, function parameters, or local declarations are also rejected.
+
+   **The same restriction applies to `@jsonSchema(...)` arguments and to the leaf-value positions inside `@validate(...)`** — i.e. the existing per-tag arg validator is now strict (no bare function calls). PFA references (`min.partial(n: 0)`) remain allowed because they are method calls on identifiers, not bare function calls.
+3. **Defaults.** Value params may declare a default: `type NumberInRange(low: number = 0, high: number = 150) = number`. Default expressions follow the same restriction set.
+4. **Type identity.** `NumberInRange(0, 150)` and `NumberInRange(1, 100)` share the alias name but are nominally distinct. They are mutually assignment-compatible because both bottom out at `number`; the validators they carry are independent and run only at `!` sites.
+5. **Codegen strategy.** Inline the substituted Zod schema at every use site (the simplest correct path). Top-level dedupe (`NumberInRange__0_150` shared const) is a later optimization, not part of this plan.
+6. **No runtime changes.** Substitution happens at type-check time; the descriptor walker and `__validateChain` already deal in `Expression[]` and don't need to know value parameters exist.
+
+---
+
+## Key Risks and Gotchas
+
+1. **`__agency_descriptor` only exists for declared aliases, not for instantiations.** A use-site `age: NumberInRange(0, 150)` cannot reference an alias-level descriptor because the descriptor would need to encode the specific args. The codegen path here inlines the descriptor at every use-site (matching the inline-schema decision). This is a deliberate departure from the bare-alias `(Email as any).__agency_descriptor = ...` pattern — value-parameterized aliases simply do not emit an `__agency_descriptor`, and the use-site descriptor walker constructs the descriptor inline with the substituted tags.
+2. **`hasAnyValidateTag` is the codegen gate.** When the walker hits a `typeAliasVariable` with `valueArgs` set, it must look up the alias entry, **substitute** its tags, and then check for `@validate`. Without substitution this works (the alias-side tags still contain a `@validate(...)` tag even with unresolved value-param references) but make sure the test passes through the substituted tags so the runtime descriptor actually sees the literal args.
+3. **`mergeTagSets` is the merge surface.** It already handles per-side tag normalization and the alias-vs-use-site merge. The substitution pass must run *before* `mergeTagSets` is called, so the merged tag set sees substituted literals (and the description-concat / dedupe logic operates correctly).
+4. **The tag-arg parser still owns the restriction.** Today `restrictedTagArgParser` uses `_valueAccessParser` which accepts a bare `functionCall` as its base when there is no chain. We need to tighten this for tag args: a bare function-call expression with no chain element is no longer a valid tag argument. PFA expressions (function call as base + method-call chain) stay allowed.
+5. **Value-param identifiers MUST be in scope.** Inside an alias's tag arguments, references to value-param names (`low`, `high`) are permitted in addition to the normal restrictions. Outside the alias body's tags, those names mean nothing — they are not lexical names in the surrounding module. The substitution pass walks the tag-arg expression tree and replaces every `variableName` whose name is in the alias's value-param set; identifiers not in the set are left alone and must satisfy the normal scope rules at the use site.
+6. **Combined `<T>` + `(n)` aliases.** The parser needs to accept `<T>(n: number)` in declaration position and `<T>(arg)` at the use site. Type substitution and value substitution are orthogonal, but both must be applied during resolution. Make sure the order is: substitute type params first (existing path), then value params, then resolve.
+7. **Existing tests assume bare function calls in tag args.** None should, because we shipped PFA for parameterized validators, but the restriction tightening is a behavior change. Audit every Agency fixture under `tests/agency/validation/` and `stdlib/` for accidental `@validate(foo(bar))` patterns and convert to PFA before / as part of this PR.
+
+---
+
+## File Structure
+
+**New files:**
+
+| File | Purpose |
+|------|---------|
+| `lib/typeChecker/valueParamSubstitution.ts` | The substitution pass: walks a tag's `Expression[]` and replaces value-param `variableName` references with literal/static-const argument expressions from a binding map. Has dedicated unit tests. |
+| `lib/typeChecker/valueParamSubstitution.test.ts` | Unit tests for the substitution pass: covers literals, static consts, nested objects, spreads, valueAccess (PFA), and rejection of disallowed expressions. |
+| `tests/agency/validation/valueParamSimple.{agency,test.json}` | `type Age(min: number) = number` with a single arg, validating both pass and fail at a `!` site. |
+| `tests/agency/validation/valueParamMultiArg.{agency,test.json}` | Two value params (`NumberInRange(low, high)`), exercising both validators. |
+| `tests/agency/validation/valueParamDefaults.{agency,test.json}` | Default argument values: `type Age(min: number = 0) = number` used with and without the explicit arg. |
+| `tests/agency/validation/valueParamStaticConst.{agency,test.json}` | Use-site arg is a `static const` identifier. |
+| `tests/agency/validation/valueParamInJsonSchema.{agency,test.json}` | `@jsonSchema({ minimum: low })` substituted, verified via `schema(T).toJSONSchema()`. |
+| `tests/agency/validation/valueParamWithGeneric.{agency,test.json}` | `type BoundedList<T>(n: number) = T[]` exercising the combined-parameter form. |
+| `tests/agency/validation/valueParamWrappingAlias.{agency,test.json}` | Wrapper alias forwards its own value param to the inner alias: `type EvenInRange(low: number, high: number) = NumberInRange(low, high)`. |
+
+**Files modified:**
+
+| File | Purpose in this plan |
+|------|----------------------|
+| `lib/parsers/parsers.ts` | Extend `typeAliasParser` to accept `(valueParams)` after `<typeParams>`; extend the type-position parser so a type reference may have `(valueArgs)`; tighten `restrictedTagArgParser` to forbid bare function-call expressions (PFA via method-call chain remains allowed). |
+| `lib/parsers/types.test.ts` (or wherever type-decl tests live) | Cover the new decl & use-site shapes plus error cases. |
+| `lib/parsers/tag.test.ts` | Cover the new tag-arg restriction (bare `foo(bar)` is now a parse error). |
+| `lib/types/typeHints.ts` | Add `valueParams?: ValueParam[]` to `TypeAliasEntry` and `TypeAlias`; add `valueArgs?: Expression[]` to `TypeAliasVariable` and `genericType` AST nodes; define `ValueParam = { name: string; type: VariableType; default?: Expression }`. |
+| `lib/preprocessors/typescriptPreprocessor.ts` — `attachTags` (and the SymbolTable build pass) | Carry `valueParams` through from `TypeAlias` declarations into the `TypeAliasEntry` registered in the symbol table. No change to the tag-attachment logic itself. |
+| `lib/typeChecker/assignability.ts` — `resolveType` / `attachAliasTags` | When resolving a `typeAliasVariable` (or `genericType`) reference that carries `valueArgs`, look up the alias's `valueParams`, build a binding map, substitute the alias-level tags through `valueParamSubstitution`, and merge those substituted tags with the use-site's via `mergeTagSets` (existing path). Apply defaults for omitted args. Reject arg-count mismatches and arg-type mismatches with location-aware errors. |
+| `lib/typeChecker/jsonSchemaArgValidator.ts` | Generalize the arg-restriction check to (a) work for both `@jsonSchema(...)` and `@validate(...)` arg trees, and (b) accept value-param identifiers in scope while continuing to reject bare function calls. Rename / re-export as `validateTagArg` so it can serve both. |
+| `lib/typeChecker/mergeTags.ts` | No behavior change. Verify that already-substituted tags continue to merge correctly (literal descriptions concat, etc.). |
+| `lib/backends/typescriptGenerator/typeToZodSchema.ts` | When `mapTypeToSchemaInner` encounters a `typeAliasVariable` with `valueArgs`, inline the substituted alias body's Zod schema rather than emitting a bare `AliasName` reference. The substituted tags drive `appendMeta`. |
+| `lib/backends/typescriptGenerator/validationDescriptor.ts` | When `descriptor()` encounters a `typeAliasVariable` with `valueArgs`, do NOT emit the `(Alias as any).__agency_descriptor` reference (the descriptor only exists for bare aliases). Instead inline the descriptor for the substituted alias body. Update `hasAnyValidateTag` to pass through `valueArgs`-aware substitution when checking for `@validate` reachability. |
+| `lib/backends/typescriptGenerator/tagArgToTs.ts` | After substitution, the printer should never encounter a value-param identifier reference; if it does, throw with a clear "value param `X` left unsubstituted" error so a future bug surfaces loudly. |
+| `lib/backends/typescriptBuilder.ts` — type-alias emission | A type alias declared with `valueParams` does NOT emit a top-level `const AliasName = z....` (there's no single schema for a parameterized alias). Its body is only emitted lazily at use sites. Keep the body parsed and tagged on the `TypeAliasEntry` so the substitution pass has something to work on. Reject `export`ing a value-parameterized alias that emits no usable runtime binding (or emit a stub `const AliasName = undefined` and document it). Open: see decision #5 below. |
+| `lib/typeChecker/resolveType.ts` (and related) | Add an `applyValueArgs(entry, valueArgs)` helper that returns a fresh `TypeAliasEntry` with substituted tags and a body that has type-param substitution already applied. |
+| `docs/site/guide/type-validation.md` | New "Value-Parameterized Aliases" section with the canonical example, the combined `<T>(n)` form, default args, the static-const story, and what's NOT allowed (bare function calls). |
+| `docs/dev/validation-annotations.md` | New "Value parameters and substitution" section describing the substitution pass, the binding-map shape, when it runs in the resolve chain, and the `__agency_descriptor` divergence. |
+| `stdlib/types.agency` | Add the stdlib parameterized types: `NumberInRange(low, high)`, `StringWithLength(min, max)`, `MatchesPattern(pattern)`, `BoundedArray<T>(min, max)`. |
+| `docs/site/stdlib/types.md` | Auto-regenerated by `make`; verify the new types render correctly. |
+
+---
+
+## Track A — Parser changes
+
+### A1. Parse value-parameter declarations
+
+- [ ] Add `valueParamParser: Parser<ValueParam>` that accepts `name: TypeAnnotation` and an optional `= defaultExpr` where `defaultExpr` is restricted to the same arg subset (see A4).
+- [ ] Extend `typeAliasParser` to accept an optional `( ... )` block after the optional `< ... >` block. Reject `< ... ()>` ordering (value params must come last).
+- [ ] Update the AST: set `valueParams` on the produced `TypeAlias` node when present.
+- [ ] Add fixture tests:
+  - `type Age(min: number) = number`
+  - `type NumberInRange(low: number, high: number) = number`
+  - `type Age(min: number = 0) = number`
+  - `type BoundedList<T>(n: number) = T[]`
+- [ ] Error fixtures: `type Foo()(x: number) = ...`, `type Foo(x) = ...` (no annotation), `type Foo(x: number = foo()) = ...` (disallowed default expr).
+
+### A2. Parse value-arg use-sites
+
+- [ ] Extend the type-position parser so a type reference may be followed by `( ... )`. Combined with `<...>`: type args come first, value args second.
+- [ ] AST: set `valueArgs: Expression[]` on the resulting `typeAliasVariable` / `genericType` node. The expressions are restricted to the same subset as tag-arg leaves.
+- [ ] Test fixtures: `Age(18)`, `NumberInRange(0, 150)`, `BoundedList<string>(3)`, `Age(DEFAULT_AGE)` (identifier).
+- [ ] Error fixtures: `Age(getDefault())` (bare function call), `Age({a: 1, b: 2})` would be allowed since object literals are in the subset — confirm against spec; today the spec example does not show object args, so we can keep them in the parser but the type checker can reject them at instantiation time if the type-checker can't substitute them into a tag scalar position.
+
+### A3. Tighten `restrictedTagArgParser`
+
+- [ ] Today `restrictedTagArgParser` accepts `_valueAccessParser`, whose base can be a bare `functionCall`. Tighten the tag-arg form so a bare function call (no chain) is **rejected**:
+  - Continue to accept literals, identifiers, object literals.
+  - Continue to accept PFA expressions: `valueAccess` with a `methodCall` chain element. The base is allowed to be a `functionCall` only if a chain follows.
+  - Reject everything else with a `label(...)`-friendly message ("a tag argument: literal, identifier, PFA expression, or object literal").
+- [ ] Add an explicit unit test: `tagParser("@validate(min(0))")` now FAILS with a useful error message pointing at `min(0)`. (And the existing `@validate(min.partial(n: 0))` test continues to pass.)
+- [ ] Audit and update every existing fixture / example that still uses the bare-function-call form (none should exist after the PFA migration, but verify).
+
+### A4. Share the arg-restriction grammar
+
+- [ ] Extract a shared parser combinator (e.g. `staticTagArgParser`) that all three callers use:
+  1. Tag arguments inside `@validate(...)` and `@jsonSchema(...)`.
+  2. Default-value expressions for value params (`= 0`).
+  3. Use-site value-arg expressions (`Age(18)`).
+- [ ] The combinator returns an `Expression` from the restricted subset. All three callers wrap it with appropriate framing (commas + parens for arg lists, etc.).
+- [ ] This ensures we have one place to maintain the rule "static consts and value-param identifiers are OK; bare function calls are not".
+
+---
+
+## Track B — AST and symbol table
+
+### B1. Extend `TypeAliasEntry`
+
+- [ ] Add `valueParams?: ValueParam[]` to [`lib/types/typeHints.ts`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/types/typeHints.ts) for both `TypeAliasEntry` and `TypeAlias`.
+- [ ] Define `ValueParam = { name: string; type: VariableType; default?: Expression }`.
+- [ ] Add `valueArgs?: Expression[]` to `TypeAliasVariable` and the `genericType` variants that can be used as a reference.
+
+### B2. Carry `valueParams` into the symbol table
+
+- [ ] Update `SymbolTable.build` / the equivalent registration site to copy `valueParams` from `TypeAlias` AST nodes onto `TypeAliasEntry` registrations.
+- [ ] Add a test: declaring `type Age(min: number) = number` produces a `TypeAliasEntry` whose `valueParams` array has length 1 with the expected shape.
+
+### B3. Add cross-module propagation tests
+
+- [ ] Re-exporting a value-parameterized alias from another module must carry `valueParams` through. Add a fixture and test that mirrors the existing alias re-export propagation tests.
+
+---
+
+## Track C — Type-checker substitution
+
+### C1. The substitution pass
+
+- [ ] Create `lib/typeChecker/valueParamSubstitution.ts` exporting:
+  ```ts
+  type ValueArgBindings = Record<string, Expression>;
+
+  export function substituteValueArgsInTag(
+    tag: Tag,
+    bindings: ValueArgBindings,
+  ): Tag;
+
+  export function substituteValueArgsInExpression(
+    expr: Expression,
+    bindings: ValueArgBindings,
+  ): Expression;
+  ```
+- [ ] The pass walks an `Expression` tree (literals, agencyObject entries / splats, valueAccess chains, function-call args inside PFAs) and replaces any `variableName` whose `value` is in the bindings map with a structural clone of the bound expression. All other nodes are returned unchanged.
+- [ ] **Important:** the substitution clones rather than mutates so the original alias-level tag remains valid for other instantiations.
+- [ ] Unit-test every branch: bare ident, ident inside object value, ident inside spread, ident inside PFA's `.partial(n: low)` arg, ident inside a nested object inside an object, and the no-substitution-needed case.
+
+### C2. `applyValueArgs(entry, valueArgs)` helper
+
+- [ ] Add a helper that takes a `TypeAliasEntry` + a `valueArgs: Expression[]` list and returns a fresh `TypeAliasEntry`:
+  1. Validate argument count (using `valueParams` defaults to fill missing tail args).
+  2. Build the `ValueArgBindings` map (param name → arg expression).
+  3. Map every `entry.tags` element through `substituteValueArgsInTag`.
+  4. Return a new entry with the substituted tags and the original `body` and `typeParams`.
+- [ ] Errors:
+  - Too many args: `${alias} expects N value arguments, got M`.
+  - Required (defaultless) param omitted: `${alias} requires '${name}': ${type}`.
+  - Arg type mismatch: `argument ${name} expected ${declaredType}, got ${argType}` (best-effort — for literals we can check, for static-const identifiers we look up the inferred type, otherwise we defer to runtime).
+- [ ] Unit tests: one per error case plus the happy path.
+
+### C3. Wire substitution into `resolveType`
+
+- [ ] In [`assignability.ts`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/typeChecker/assignability.ts) where `typeAliasVariable` and user-defined `genericType` references are resolved, plumb through `valueArgs` from the AST node into `applyValueArgs(entry, valueArgs)`. The substituted entry's tags then go through the existing `attachAliasTags` + `mergeTagSets` path.
+- [ ] For the combined-parameter case (`BoundedList<string>(3)`), apply type substitution first (existing path), then value substitution.
+- [ ] Add tests that exercise the resolved-type's tags carry the substituted literal values (e.g. `Age(18)` resolves to `{type: "primitiveType", value: "number", tags: [@validate(isAtLeast.partial(min: 18))]}`).
+
+### C4. Validate tag-arg restriction at the type-checker
+
+- [ ] Hook the now-shared arg-restriction validator (Track A4) into the type-checker for `@validate(...)` and `@jsonSchema(...)` so disallowed expressions surface with the same friendly error wording at type-check time, not just at codegen. (Today `validateJsonSchemaArg` is a standalone helper not actually invoked — this finally wires it in.)
+- [ ] The check runs **after** substitution: a value-param identifier is allowed in the alias's raw tags, but after `applyValueArgs` it has been replaced with a literal/static-const reference. Any leftover non-substituted identifier that isn't a static const or value-param-in-scope is a type error.
+
+---
+
+## Track D — Codegen
+
+### D1. Inline substituted schemas in `typeToZodSchema`
+
+- [ ] In `mapTypeToSchemaInner`, when a `typeAliasVariable` carries `valueArgs`:
+  - Look up the alias entry, run `applyValueArgs`, and recursively map the alias's body (with the substituted tags attached) instead of emitting a bare `AliasName` identifier.
+  - Use the substituted tags for the `.meta(...)` call.
+- [ ] Audit every existing test snapshot for incidental changes (none should change because the new code path only fires when `valueArgs` is present).
+
+### D2. Inline substituted descriptors in `validationDescriptor`
+
+- [ ] In `descriptor()`, when a `typeAliasVariable` carries `valueArgs`:
+  - Do **not** emit the `(Alias as any).__agency_descriptor` reference (that descriptor doesn't exist).
+  - Run `applyValueArgs` and emit the descriptor for the substituted body inline, threading the substituted tags through `validatorNodes(...)`.
+- [ ] Update `hasAnyValidateTag` to call `applyValueArgs` (or its tag-substitution part) before checking for `@validate` tags reachable through a value-parameterized alias.
+
+### D3. Skip top-level emission for value-parameterized aliases
+
+- [ ] In [`typescriptBuilder.ts`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/backends/typescriptBuilder.ts) where type-alias declarations emit their schema const, detect `valueParams` and skip the const emission. There is no useful single Zod schema for `NumberInRange` without args.
+- [ ] If the alias is `export`ed, decide: (a) emit nothing and let users `import { NumberInRange } from ...` fail with a TS error (cleanest), or (b) emit a stub `export const NumberInRange = undefined` with an `// @internal` comment. Pick (a); the type-side import still works because the type generator emits the alias as a TS type with a runtime-only fallback.
+- [ ] Add a test: declaring `export type NumberInRange(...) = ...` doesn't emit a runtime const, and a use-site in another module still works (because the use-site inlines the substituted schema).
+
+### D4. Update `tagArgToTs` failure mode
+
+- [ ] If `tagArgToTs` is asked to print an identifier whose name matches a value-param name (i.e. substitution didn't run), throw a clear "value param `X` left unsubstituted — substitution pass not invoked?" error. Cover with a unit test.
+
+---
+
+## Track E — Standard library
+
+### E1. Add stdlib parameterized types
+
+- [ ] In [`stdlib/types.agency`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/stdlib/types.agency) add (and `export`):
+  ```agency
+  @validate(min.partial(n: low), max.partial(n: high))
+  @jsonSchema({ minimum: low, maximum: high })
+  type NumberInRange(low: number, high: number) = number
+
+  @validate(minLength.partial(n: min), maxLength.partial(n: max))
+  @jsonSchema({ minLength: min, maxLength: max })
+  type StringWithLength(min: number, max: number) = string
+
+  @validate(matches.partial(pattern: pat))
+  @jsonSchema({ pattern: pat })
+  type MatchesPattern(pat: string) = string
+
+  @jsonSchema({ minItems: min, maxItems: max })
+  type BoundedArray<T>(min: number, max: number) = T[]
+  ```
+- [ ] Run `make` to regenerate `docs/site/stdlib/types.md`.
+- [ ] Verify the generated docs render the new parameterized types reasonably (extending `agency docs` may be required if the printer doesn't yet handle `valueParams`; if so, that becomes a sub-task here).
+
+### E2. Update `agency docs` output for `valueParams`
+
+- [ ] Update the type printer used by `agency docs` to render `Foo(low: number, high: number)` and the substituted tag examples. Mirror the existing handling of `<T>` parameters.
+
+---
+
+## Track F — Documentation
+
+### F1. User-facing guide
+
+- [ ] Add a "Value-Parameterized Aliases" section to [`docs/site/guide/type-validation.md`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/docs/site/guide/type-validation.md) covering:
+  - The canonical example (`NumberInRange`) and what it expands to.
+  - Argument restrictions and the rationale (compile-time substitution requires statically-known values).
+  - Defaults.
+  - Combined `<T>(n)` shape.
+  - The new "bare function calls aren't allowed in tag args" rule, with the PFA alternative.
+  - Cross-link to `std::types` for the pre-baked parameterized types.
+
+### F2. Dev internals doc
+
+- [ ] Extend [`docs/dev/validation-annotations.md`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/docs/dev/validation-annotations.md) with a "Value parameters and substitution" section documenting:
+  - The substitution pass, its inputs and outputs, and where in the resolve chain it fires.
+  - The shared `staticTagArgParser` and the unified arg-restriction validator.
+  - The codegen divergence: value-parameterized aliases skip the top-level schema const and the `__agency_descriptor` side-channel, inlining at each use-site instead.
+  - The `applyValueArgs` helper as the canonical entry point.
+
+### F3. Update the spec
+
+- [ ] Move the spec's "Future Work: Value-Parameterized Type Aliases" section into the body of the doc (no longer "future"). Note the v1 stdlib types that now exist.
+
+---
+
+## Track G — End-to-end Agency tests
+
+All under `tests/agency/validation/`. Each has a paired `.test.json` with `evaluationCriteria: [{ type: "exact" }]`.
+
+### G1. `valueParamSimple`
+
+- [ ] `type Age(min: number) = number` validated with `@validate(min.partial(n: min))`. Use sites: `Age(0)`, `Age(18)`. Assert both pass for valid values and fail for values below the min.
+
+### G2. `valueParamMultiArg`
+
+- [ ] `type NumberInRange(low: number, high: number) = number`. Verify both bounds fire.
+
+### G3. `valueParamDefaults`
+
+- [ ] `type Age(min: number = 0) = number`. Use site with explicit arg `Age(18)` and without `Age()`. Verify the default kicks in.
+
+### G4. `valueParamStaticConst`
+
+- [ ] `static const DEFAULT_AGE = 18` and use-site `Age(DEFAULT_AGE)`. Verify substitution reads the static const.
+
+### G5. `valueParamInJsonSchema`
+
+- [ ] `@jsonSchema({ minimum: low })` substituted. Inspect `schema(T).toJSONSchema()` output to confirm the literal value made it through.
+
+### G6. `valueParamWithGeneric`
+
+- [ ] `type BoundedList<T>(n: number) = T[]`. Use as `BoundedList<string>(3)`. Verify both type and value substitution happen.
+
+### G7. `valueParamWrappingAlias`
+
+- [ ] One alias forwards its own value params to another: `type EvenInRange(low: number, high: number) = NumberInRange(low, high)`. Verify the outer instantiation `EvenInRange(0, 100)` produces validators with the literal 0 and 100.
+
+### G8. Error fixtures
+
+- [ ] A test (or a unit test on the type checker) that covers each error case from C2: too-many args, missing-required, type mismatch, disallowed arg expression (bare function call), unknown alias.
+
+---
+
+## Validation checklist for each track
+
+Run after **each** track lands:
+
+- [ ] `pnpm exec tsc --noEmit`
+- [ ] `pnpm run lint:structure`
+- [ ] `pnpm test:run`
+- [ ] `pnpm run agency test tests/agency/validation -p 12`
+- [ ] `make` (regenerates stdlib + docs)
+- [ ] `make fixtures` (regenerates generator snapshots if codegen output changed)
+
+---
+
+## Suggested PR ordering
+
+The substitution pass is the linchpin and depends on the parser + AST changes. Codegen and stdlib both depend on the substitution pass. A reasonable single-PR landing order:
+
+1. **Track A (parser) + Track B (AST + symbol table)** — pure plumbing, no behavior change yet because no resolver looks at the new fields.
+2. **Track C (substitution + resolver wiring)** — the feature becomes observable: a resolved `Age(18)` now carries `@validate(min.partial(n: 18))`.
+3. **Track D (codegen)** — emit the substituted schemas / descriptors at use sites.
+4. **Track E (stdlib types)** — drop in `NumberInRange`, `BoundedArray`, etc.
+5. **Track F (docs)** — guide + dev internals, alongside or just after E.
+6. **Track G (e2e tests)** — fold incrementally as each track lands; the final track delivers the comprehensive e2e coverage.
+
+For a single-PR landing, run all tracks sequentially in one branch; the dependencies above are linear so partial work is testable at every step.
+
+---
+
+## Out of scope (explicitly deferred)
+
+- **Top-level dedupe of identical instantiations** (`NumberInRange__0_150` shared const). Inline is simpler; only revisit if profiling shows the duplicated-schema cost matters.
+- **Value-param types beyond primitives.** This PR supports `number`, `string`, `boolean` param types (matches the restricted-arg subset). Object-typed value params are deferred — there's no obvious use case yet.
+- **Computed defaults referencing other value params.** `type Foo(a: number, b: number = a + 1) = number` is rejected. Defaults must be self-contained literal/static-const expressions.
+- **Value-param identifiers inside the alias body itself** (not in tags). The alias `body` is a type, not an expression; value params are only meaningful inside tag arguments. We'll add a type-checker error if a value-param identifier appears in the body.
+
+---
+
+## Future work
+
+### Static refinement / dependent-style checking over value args
+
+The current plan treats value args as inert: they substitute into tag expressions, but two instantiations of the same alias are considered assignment-compatible based on their unfolded underlying type alone (decision #4). This means `BoundedArray<T>(0, 100)` flows freely into `BoundedArray<T>(0, 50)`, into `T[]`, and back — bounds info is preserved only as a label the user wrote, never enforced at assignment, and only checked at `!` sites.
+
+A future pass could promote value args to first-class participants in assignability:
+
+- **Canonicalize value args on the type reference.** During type checking, resolve static-const identifiers to their literal values and store them alongside the original AST so a refinement pass can do structural value-equality without re-walking scope. This is cheap to add to the v1 plan as a forward-compat measure.
+- **Predicate registry for stdlib validators.** Give `min`, `max`, `minLength`, `maxLength`, `matches`, etc. a known logical interpretation (`min(n) ⇒ x ≥ n`, etc.) so the checker can reason about subset/superset relationships between two `NumberInRange(...)` instantiations.
+- **Refinement subtyping.** `NumberInRange(0, 100) <: NumberInRange(0, 150)` should typecheck; the reverse should not. Built on the predicate registry.
+- **Type-level arithmetic for collection bounds.** `concat: BoundedArray<T>(a, b) + BoundedArray<T>(c, d) -> BoundedArray<T>(a+c, b+d)`. Higher lift; only justified if the use cases (prompt-token budgets, batch sizing) start showing up frequently in real Agency programs.
+
+None of this is in v1, but the v1 AST shape (`valueArgs: Expression[]` carried on the type reference) is deliberately the right substrate for it.
+
+### Phantom-type / type-state soundness gap
+
+Confirmed via a small Agency test: today, two instantiations of a generic alias whose type parameter does not appear in the body (`type Thread<S> = { id: string; messages: string[] }`) are treated as the same type. `Thread<Anonymous>` flows into a parameter typed `Thread<Authenticated>` with no warning. The type-checker is running (`number` → `string` correctly warns), it just unfolds aliases and compares structurally without consulting type-argument lists.
+
+This blocks the entire family of capability / type-state patterns:
+
+- `Thread<Authenticated | Anonymous>` — auth gating
+- `Prompt<UserAuthored | SystemAuthored>` — prompt-injection defense
+- `LLMClient<HasAPIKey | Unconfigured>` — config gating
+- `File<Sanitized | Raw>` — input sanitization
+- `Workflow<Pending | Running | Done>` — state machines
+- `Currency<USD | EUR>` on `number` — unit safety
+
+**Fix (sketch, separate ticket):** In the assignability rule for `genericType` / `typeAliasVariable`, when both sides reference the same alias by name, compare type-argument lists pairwise *before* falling back to structural comparison of the unfolded bodies. Two instantiations are assignable only if their type-arg lists are mutually assignable. This is a small surgical change in `lib/typeChecker/assignability.ts`.
+
+**Reproducer for the fix's regression test:**
+```agency
+type Authenticated = "authenticated"
+type Anonymous = "anonymous"
+
+type Thread<S> = { id: string; messages: string[] }
+
+def sendSecureMessage(t: Thread<Authenticated>, msg: string): void { print(msg) }
+
+node main() {
+  const anon: Thread<Anonymous> = { id: "1", messages: [] }
+  sendSecureMessage(anon, "hello")  // should warn after the fix
+}
+```
+After the fix, compiling this file should produce: `warning: Argument type 'Thread<Anonymous>' is not assignable to parameter type 'Thread<Authenticated>' in call to 'sendSecureMessage'`.
+
+Once phantom types work, the **type-state pattern** (phantom param + matching discriminator field, with flow-sensitive narrowing on the field narrowing the parameter) is the natural follow-on. That second piece may need extra work in the narrowing pass, which would be a separate ticket on top of the assignability fix.

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md
@@ -505,38 +505,38 @@ Having two ways to add descriptions (`# text` and `@jsonSchema({ description: "t
 
 Agency functions compile to async TypeScript functions with runtime infrastructure (step counters, interrupt support, etc.). Zod's `.refine()` expects synchronous predicates; using `.refine()` with async functions would require switching the entire validation path to `safeParseAsync()`, which complicates the existing runtime. Running validators as a post-validation step after Zod's structural check keeps both paths clean and means validator failure messages propagate naturally via the `Result` type.
 
-## Future Work: Value-Parameterized Type Aliases
+## Value-Parameterized Type Aliases
 
 ### Motivation
 
-The annotation system encourages creating reusable validated types. The v1 stdlib ships pre-baked aliases for the common no-parameter cases (`Email`, `URLString`, `UUIDString` — see the "Pre-baked Validated Types" section above).
+The annotation system encourages creating reusable validated types. The stdlib ships pre-baked aliases for the common no-parameter cases (`Email`, `URLString`, `UUIDString` — see the "Pre-baked Validated Types" section above).
 
-However, some validated types need **parameters**. A "number in range" type needs to know the range, and shipping a fixed `Age = NumberInRange(0, 150)` is no good for the user who wants `NumberInRange(1, 100)`. With the current design users must repeat the annotations every time:
+However, some validated types need **parameters**. A "number in range" type needs to know the range, and shipping a fixed `Age = NumberInRange(0, 150)` is no good for the user who wants `NumberInRange(1, 100)`. Without parameterization users would have to repeat the annotations every time:
 
 ```
-@validate(min(0), max(150))
+@validate(min.partial(n: 0), max.partial(n: 150))
 @jsonSchema({ minimum: 0, maximum: 150 })
 type Age = number
 
-@validate(min(1), max(100))
+@validate(min.partial(n: 1), max.partial(n: 100))
 @jsonSchema({ minimum: 1, maximum: 100 })
 type Score = number
 ```
 
-This is verbose and error-prone. Ideally, users could write `NumberInRange(0, 150)` and `NumberInRange(1, 100)`.
+This is verbose and error-prone. With value parameters, both shapes share a single declaration and just vary at the use site: `NumberInRange(0, 150)` and `NumberInRange(1, 100)`.
 
 ### The Problem
 
-Agency's generic type parameters (`<T>`) are types, not values. Writing `type NumberInRange<start, finish> = number` doesn't work because `start` and `finish` are type-level entities that can't be passed to value-level functions like `min(start)`.
+Agency's generic type parameters (`<T>`) are types, not values. Writing `type NumberInRange<start, finish> = number` doesn't work because `start` and `finish` are type-level entities that can't be passed to value-level functions like `min.partial(n: start)`.
 
-This is the fundamental tension between type space and value space. Most languages keep these strictly separated. A few languages have a concept called **dependent types** — types that are parameterized by values. Full dependent types are a complex feature found in academic languages like Idris and Agda. But Agency doesn't need the full generality — just enough to make parameterized validated types work.
+This is the fundamental tension between type space and value space. Most languages keep these strictly separated. A few languages have a concept called **dependent types** — types that are parameterized by values. Full dependent types are a complex feature found in academic languages like Idris and Agda. Agency doesn't need the full generality — just enough to make parameterized validated types work.
 
-### Proposed Solution: Value Parameters with `()`
+### Solution: Value Parameters with `()`
 
-Type aliases can take **value parameters** using `()`, distinct from type parameters using `<>`:
+Type aliases take **value parameters** using `()`, distinct from type parameters using `<>`:
 
 ```
-@validate(min(low), max(high))
+@validate(min.partial(n: low), max.partial(n: high))
 @jsonSchema({ minimum: low, maximum: high })
 type NumberInRange(low: number, high: number) = number
 ```
@@ -550,10 +550,9 @@ type User = {
 }
 ```
 
-The `()` vs `<>` distinction is visually clear: `<>` is for types, `()` is for values. They can be combined:
+The `()` vs `<>` distinction is visually clear: `<>` is for types, `()` is for values. They can be combined (type params first, value params second):
 
 ```
-@validate(minItems(n))
 @jsonSchema({ minItems: n })
 type BoundedList<T>(n: number) = T[]
 
@@ -565,31 +564,27 @@ items: BoundedList<string>(3)
 When the compiler sees `NumberInRange(0, 150)`:
 
 1. It looks up the `NumberInRange` type alias and finds value parameters `(low: number, high: number)`.
-2. It substitutes `low=0, high=150` into the annotations.
-3. `@validate(min(low), max(high))` becomes `@validate(min(0), max(150))`.
+2. It substitutes `low=0, high=150` into the alias's tag expressions via `lib/typeChecker/valueParamSubstitution.ts`.
+3. `@validate(min.partial(n: low), max.partial(n: high))` becomes `@validate(min.partial(n: 0), max.partial(n: 150))`.
 4. `@jsonSchema({ minimum: low, maximum: high })` becomes `@jsonSchema({ minimum: 0, maximum: 150 })`.
-5. The Zod schema and validators are generated with the substituted values.
+5. The Zod schema and validators are emitted inline at the use site with the substituted values.
 
-In the generated TypeScript, each distinct instantiation produces its own Zod schema. `NumberInRange(0, 150)` and `NumberInRange(1, 100)` are different schemas with different `.meta()` properties and different validator calls.
+Each distinct instantiation produces its own inline Zod schema. `NumberInRange(0, 150)` and `NumberInRange(1, 100)` carry different `.meta()` properties and different validator calls. The two instantiations are nominally distinct but mutually assignment-compatible (both bottom out at `number`); validators only fire at `!` sites.
+
+Bare function calls inside tag arguments (`@validate(min(0))`) are rejected — substitution requires a structural handle on each tag arg, and PFA (`min.partial(n: 0)`) provides one. The dev-internals note in `docs/dev/validation-annotations.md` covers the substitution pass, the codegen divergence (no top-level `const` for parameterized aliases, no `__agency_descriptor` side-channel), and the `applyValueArgs` canonical entry point.
 
 ### Standard Library Types
 
-With value parameters, `std::types` (which already exports the no-parameter aliases `Email`, `URLString`, `UUIDString` shipped in v1) can grow a set of reusable parameterized types:
+`std::types` ships these parameterized aliases out of the box:
 
 ```
-// v1 — ships now in std::types
-type Email = string
-type URLString = string
-type UUIDString = string
-
-// Future — added once value parameters land
 type NumberInRange(low: number, high: number) = number
 type StringWithLength(min: number, max: number) = string
 type MatchesPattern(pat: string) = string
 type BoundedArray<T>(min: number, max: number) = T[]
 ```
 
-Users can then write concise type definitions:
+Plus the no-parameter aliases from v1 (`Email`, `URLString`, `UUIDString`). Together they let users write concise validated type definitions without repeating tag annotations:
 
 ```
 import { Email, NumberInRange, BoundedArray } from "std::types"
@@ -600,7 +595,3 @@ type User = {
   tags: BoundedArray<string>(1, 10)
 }
 ```
-
-### Scope
-
-Value-parameterized type aliases are a follow-up feature. The core annotation infrastructure (`@validate`, `@jsonSchema`, tag parser changes, `# description` removal) ships first. Value parameters build on top of that foundation once it is stable.

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -465,12 +465,13 @@ export class AgencyGenerator {
     const aliasedTypeStr = this.aliasedTypeToString(node.aliasedType);
     const exportPrefix = node.exported ? "export " : "";
     const typeParamsStr = this.formatTypeParams(node.typeParams);
+    const valueParamsStr = this.formatValueParams(node.valueParams);
     const tags = this.formatAttachedTags(node);
     return (
       this.formatDocComment(node) +
       tags +
       this.indentStr(
-        `${exportPrefix}type ${node.aliasName}${typeParamsStr} = ${aliasedTypeStr}`,
+        `${exportPrefix}type ${node.aliasName}${typeParamsStr}${valueParamsStr} = ${aliasedTypeStr}`,
       )
     );
   }
@@ -489,6 +490,24 @@ export class AgencyGenerator {
       return `${p.name} = ${def}`;
     });
     return `<${parts.join(", ")}>`;
+  }
+
+  /**
+   * Format the `(low: number, high: number = 10)` chunk of a
+   * value-parameterized alias declaration. Returns an empty string when
+   * there are no value params.
+   */
+  private formatValueParams(
+    params: TypeAlias["valueParams"],
+  ): string {
+    if (!params || params.length === 0) return "";
+    const parts = params.map((p) => {
+      const typeStr = variableTypeToString(p.type, this.typeAliases, true);
+      const base = `${p.name}: ${typeStr}`;
+      if (p.default === undefined) return base;
+      return `${base} = ${this.processNode(p.default).trim()}`;
+    });
+    return `(${parts.join(", ")})`;
   }
 
   // Assignment and literals

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -599,6 +599,13 @@ export class TypeScriptBuilder {
       if (!node.exported) return ts.empty();
       return ts.raw(`export const ${node.aliasName} = undefined;`);
     }
+    // Value-parameterized aliases (e.g. `type NumberInRange(low, high) = ...`)
+    // have no single schema — every use-site inlines a fresh substituted
+    // schema. Emit nothing at the declaration site; importers should never
+    // reference the bare name (use-sites are resolved before codegen).
+    if (node.valueParams && node.valueParams.length > 0) {
+      return ts.empty();
+    }
     const exportPrefix = node.exported ? "export " : "";
     // Thread alias-level @validate / @jsonSchema tags onto the body type so
     // appendMeta (in typeToZodSchema) attaches the `.meta(...)` chain to the

--- a/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { tagArgToTs } from "./tagArgToTs.js";
+import type { Expression } from "../../types.js";
+
+const ident = (name: string): Expression =>
+  ({ type: "variableName", value: name }) as any;
+const nm = (n: string): Expression => ({ type: "number", value: n }) as any;
+
+describe("tagArgToTs — value-param unsubstituted guard", () => {
+  it("throws when an identifier matches a declared value-param name", () => {
+    expect(() => tagArgToTs(ident("low"), ["low", "high"])).toThrow(
+      /value param 'low' left unsubstituted/,
+    );
+  });
+
+  it("throws when an identifier inside an object value matches a value param", () => {
+    const e: Expression = {
+      type: "agencyObject",
+      entries: [{ key: "minimum", value: ident("low") }],
+    } as any;
+    expect(() => tagArgToTs(e, ["low"])).toThrow(
+      /value param 'low' left unsubstituted/,
+    );
+  });
+
+  it("throws when a value-param ident appears inside a PFA method-call arg", () => {
+    const pfa: Expression = {
+      type: "valueAccess",
+      base: ident("min"),
+      chain: [
+        {
+          kind: "methodCall",
+          functionCall: {
+            type: "functionCall",
+            functionName: "partial",
+            arguments: [
+              { type: "namedArgument", name: "n", value: ident("low") },
+            ],
+          },
+        },
+      ],
+    } as any;
+    expect(() => tagArgToTs(pfa, ["low"])).toThrow(
+      /value param 'low' left unsubstituted/,
+    );
+  });
+
+  it("does not throw on non-param identifiers", () => {
+    expect(tagArgToTs(ident("isEmail"), ["low"])).toBe("isEmail");
+  });
+
+  it("default mode (no param list) accepts any identifier without throwing", () => {
+    expect(tagArgToTs(ident("low"))).toBe("low");
+  });
+
+  it("preserves literal printing behavior", () => {
+    expect(tagArgToTs(nm("42"))).toBe("42");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.ts
@@ -37,24 +37,44 @@ export function tagArgToTs(
         segments: Array<{ type: "text" | "interpolation"; value?: string; expression?: Expression }>;
         loc?: { line: number; col: number };
       };
-      // Tag-arg strings must be plain literals: the parser uses
-      // `simpleStringParser`, which never produces interpolation segments.
-      // If we ever see one here, that's a bug — fail loudly rather than
-      // emit broken TypeScript.
-      let raw = "";
-      for (const seg of lit.segments) {
-        if (seg.type === "text") {
-          raw += seg.value ?? "";
-        } else {
-          const loc = lit.loc
-            ? ` at line ${lit.loc.line}, col ${lit.loc.col}`
-            : "";
-          throw new Error(
-            `Tag arguments must be plain string literals (no interpolation)${loc}`,
-          );
-        }
+      // Tag-arg strings accept identifier-only `${name}` interpolation
+      // (see `staticInterpolatedStringParser`). After value-param
+      // substitution any `${valueParam}` slot has been replaced by a
+      // literal text segment; any remaining interpolation slot must be
+      // an identifier reference (typically a top-level static const)
+      // that we emit as a TS template-literal `${ident}` reference.
+      // If every segment is text, emit a plain JS string literal.
+      const allText = lit.segments.every((s) => s.type === "text");
+      if (allText) {
+        let raw = "";
+        for (const seg of lit.segments) raw += seg.value ?? "";
+        return JSON.stringify(raw);
       }
-      return JSON.stringify(raw);
+      // Any remaining interpolation segments at this point are bugs:
+      // the parser only accepts identifier-only `${name}` slots, and
+      // substitution folds every value-param identifier away into a
+      // text segment. A leftover `${name}` means the identifier did
+      // not resolve to a value parameter of the surrounding alias —
+      // e.g. a top-level static const, which we do not currently
+      // support (tag args are emitted inside node-body schema chains
+      // where module-level consts aren't bound to JS identifiers).
+      const loc = lit.loc
+        ? ` at line ${lit.loc.line}, col ${lit.loc.col}`
+        : "";
+      const offending = lit.segments.find((s) => s.type === "interpolation");
+      const inner = offending?.expression as Expression | undefined;
+      const name =
+        inner && inner.type === "variableName"
+          ? (inner as Literal & { value: string }).value
+          : "<expression>";
+      if (valueParamNames && valueParamNames.indexOf(name) !== -1) {
+        throw new Error(
+          `value param '${name}' left unsubstituted in tag-arg string — substitution pass not invoked?${loc}`,
+        );
+      }
+      throw new Error(
+        `tag-arg string interpolation '${"${"}${name}}' must reference a value parameter of the enclosing type alias${loc}`,
+      );
     }
     case "number":
       return (expr as Literal & { value: string }).value;

--- a/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.ts
@@ -1,5 +1,6 @@
 import type {
   Expression,
+  AgencyArray,
   AgencyObject,
   AgencyObjectKV,
   FunctionCall,
@@ -93,6 +94,23 @@ export function tagArgToTs(
     }
     case "agencyObject":
       return objectLiteralToTs(expr as AgencyObject, valueParamNames);
+    case "agencyArray":
+      return arrayLiteralToTs(expr as AgencyArray, valueParamNames);
+    case "regex": {
+      // Agency regex literal `re/pattern/flags` → TS `new RegExp(p, f)`.
+      // RegExp is safer than `/p/f` here because it side-steps
+      // forward-slash escaping issues inside an embedded expression.
+      const r = expr as Expression & { pattern: string; flags: string };
+      const flags = JSON.stringify(r.flags ?? "");
+      return `new RegExp(${JSON.stringify(r.pattern)}, ${flags})`;
+    }
+    case "unitLiteral": {
+      // Unit literals carry a `canonicalValue` already normalised
+      // (ms / dollars / bytes). Emit that number; runtime sees the
+      // same value as `30s` → 30000.
+      const u = expr as Expression & { canonicalValue: number };
+      return String(u.canonicalValue);
+    }
     case "functionCall": {
       const fc = expr as FunctionCall;
       return `${fc.functionName}(${functionCallArgsToTs(fc, valueParamNames)})`;
@@ -164,6 +182,20 @@ function renderChainElement(
   throw new Error(
     `tagArgToTs: unsupported access chain element "${(el as any).kind}"`,
   );
+}
+
+function arrayLiteralToTs(
+  arr: AgencyArray,
+  valueParamNames?: ReadonlyArray<string>,
+): string {
+  const items = arr.items.map((item) => {
+    if (item.type === "splat") {
+      const sp = item as SplatExpression;
+      return `...${tagArgToTs(sp.value, valueParamNames)}`;
+    }
+    return tagArgToTs(item as Expression, valueParamNames);
+  });
+  return `[${items.join(", ")}]`;
 }
 
 function objectLiteralToTs(

--- a/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.ts
@@ -18,8 +18,18 @@ import type {
  * string / number / boolean / null literals, identifiers, function calls,
  * object literals (including spread). Anything else is a bug and produces
  * a clearly-broken output.
+ *
+ * `valueParamNames` (optional): when supplied, an identifier whose name
+ * matches any entry throws — this catches accidental skips of the
+ * value-parameter substitution pass. A value-param identifier must
+ * never reach codegen; if it does, something upstream is broken and
+ * we want it to fail loudly rather than emit a bogus reference to an
+ * out-of-scope name.
  */
-export function tagArgToTs(expr: Expression): string {
+export function tagArgToTs(
+  expr: Expression,
+  valueParamNames?: ReadonlyArray<string>,
+): string {
   switch (expr.type) {
     case "string":
     case "multiLineString": {
@@ -52,19 +62,26 @@ export function tagArgToTs(expr: Expression): string {
       return String((expr as Literal & { value: boolean }).value);
     case "null":
       return "null";
-    case "variableName":
-      return (expr as Literal & { value: string }).value;
+    case "variableName": {
+      const name = (expr as Literal & { value: string }).value;
+      if (valueParamNames && valueParamNames.indexOf(name) !== -1) {
+        throw new Error(
+          `value param '${name}' left unsubstituted — substitution pass not invoked?`,
+        );
+      }
+      return name;
+    }
     case "agencyObject":
-      return objectLiteralToTs(expr as AgencyObject);
+      return objectLiteralToTs(expr as AgencyObject, valueParamNames);
     case "functionCall": {
       const fc = expr as FunctionCall;
-      return `${fc.functionName}(${functionCallArgsToTs(fc)})`;
+      return `${fc.functionName}(${functionCallArgsToTs(fc, valueParamNames)})`;
     }
     case "valueAccess": {
       const va = expr as ValueAccess;
-      let out = tagArgToTs(va.base as Expression);
+      let out = tagArgToTs(va.base as Expression, valueParamNames);
       for (const el of va.chain) {
-        out += renderChainElement(el);
+        out += renderChainElement(el, valueParamNames);
       }
       return out;
     }
@@ -77,14 +94,17 @@ export function tagArgToTs(expr: Expression): string {
   }
 }
 
-function functionCallArgsToTs(fc: FunctionCall): string {
+function functionCallArgsToTs(
+  fc: FunctionCall,
+  valueParamNames?: ReadonlyArray<string>,
+): string {
   return (fc.arguments ?? [])
     .map((a) =>
       a.type === "namedArgument"
-        ? `${(a as any).name}: ${tagArgToTs((a as any).value)}`
+        ? `${(a as any).name}: ${tagArgToTs((a as any).value, valueParamNames)}`
         : a.type === "splat"
-          ? `...${tagArgToTs((a as any).value)}`
-          : tagArgToTs(a as Expression),
+          ? `...${tagArgToTs((a as any).value, valueParamNames)}`
+          : tagArgToTs(a as Expression, valueParamNames),
     )
     .join(", ");
 }
@@ -98,7 +118,10 @@ function functionCallArgsToTs(fc: FunctionCall): string {
  * collect them into an object literal because `AgencyFunction.partial`
  * takes a single `Record<string, unknown>` of bindings at runtime.
  */
-function renderChainElement(el: AccessChainElement): string {
+function renderChainElement(
+  el: AccessChainElement,
+  valueParamNames?: ReadonlyArray<string>,
+): string {
   if (el.kind === "property") {
     return el.optional ? `?.${el.name}` : `.${el.name}`;
   }
@@ -111,10 +134,10 @@ function renderChainElement(el: AccessChainElement): string {
       ? `{ ${args
           .map(
             (a) =>
-              `${(a as any).name}: ${tagArgToTs((a as any).value)}`,
+              `${(a as any).name}: ${tagArgToTs((a as any).value, valueParamNames)}`,
           )
           .join(", ")} }`
-      : functionCallArgsToTs(fc);
+      : functionCallArgsToTs(fc, valueParamNames);
     const dot = el.optional ? "?." : ".";
     return `${dot}${fc.functionName}(${argStr})`;
   }
@@ -123,7 +146,10 @@ function renderChainElement(el: AccessChainElement): string {
   );
 }
 
-function objectLiteralToTs(obj: AgencyObject): string {
+function objectLiteralToTs(
+  obj: AgencyObject,
+  valueParamNames?: ReadonlyArray<string>,
+): string {
   const entries = obj.entries.map((entry) => {
     if ("key" in entry) {
       const kv = entry as AgencyObjectKV;
@@ -131,10 +157,10 @@ function objectLiteralToTs(obj: AgencyObject): string {
       const key = /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(kv.key)
         ? kv.key
         : JSON.stringify(kv.key);
-      return `${key}: ${tagArgToTs(kv.value)}`;
+      return `${key}: ${tagArgToTs(kv.value, valueParamNames)}`;
     }
     const sp = entry as SplatExpression;
-    return `...${tagArgToTs(sp.value)}`;
+    return `...${tagArgToTs(sp.value, valueParamNames)}`;
   });
   return `{ ${entries.join(", ")} }`;
 }

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToString.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToString.ts
@@ -1,6 +1,87 @@
+import { Expression } from "../../types.js";
 import { VariableType } from "../../types.js";
 
 const MAX_LENGTH = 50;
+
+/**
+ * Print one entry of `valueArgs` (a tag-arg expression) back to Agency
+ * source text. Inlined here to avoid importing `expressionToString` from
+ * `lib/utils/node.ts`, which already imports `variableTypeToString` and
+ * would form a cycle. The subset matches `staticTagArgParser`: literals,
+ * identifiers, valueAccess (PFA), and object literals. Anything else
+ * falls back to an empty string — a missing arg is preferable to a
+ * crash inside the formatter.
+ */
+function valueArgExprToString(expr: Expression): string {
+  switch (expr.type) {
+    case "variableName":
+      return expr.value;
+    case "number":
+      return expr.value;
+    case "boolean":
+      return String(expr.value);
+    case "null":
+      return "null";
+    case "string":
+    case "multiLineString": {
+      const body = expr.segments
+        .map((seg) =>
+          seg.type === "text"
+            ? seg.value
+            : `\${${valueArgExprToString(seg.expression)}}`,
+        )
+        .join("");
+      return `"${body}"`;
+    }
+    case "valueAccess": {
+      let code = valueArgExprToString(expr.base as Expression);
+      for (const element of expr.chain) {
+        switch (element.kind) {
+          case "property":
+            code += `.${element.name}`;
+            break;
+          case "index":
+            code += `[${valueArgExprToString(element.index as Expression)}]`;
+            break;
+          case "methodCall": {
+            const fc = element.functionCall;
+            const args = fc.arguments
+              .map((arg) => {
+                if ("name" in arg && arg.name) {
+                  return `${arg.name}: ${valueArgExprToString(arg.value as Expression)}`;
+                }
+                return valueArgExprToString(
+                  ("value" in arg ? arg.value : arg) as Expression,
+                );
+              })
+              .join(", ");
+            code += `.${fc.functionName}(${args})`;
+            break;
+          }
+        }
+      }
+      return code;
+    }
+    case "agencyObject":
+      return `{ ${expr.entries
+        .map((entry) => {
+          if ("type" in entry && entry.type === "splat") {
+            return `...${valueArgExprToString(entry.value)}`;
+          }
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const e = entry as any;
+          return `${e.key}: ${valueArgExprToString(e.value)}`;
+        })
+        .join(", ")} }`;
+    default:
+      return "";
+  }
+}
+
+function formatValueArgs(valueArgs: Expression[] | undefined): string {
+  if (!valueArgs || valueArgs.length === 0) return "";
+  return `(${valueArgs.map(valueArgExprToString).join(", ")})`;
+}
 
 /**
  * Converts a VariableType to a string representation for naming/logging
@@ -45,7 +126,7 @@ export function variableTypeToString(
       .join("; ");
     return `{ ${props} }`;
   } else if (variableType.type === "typeAliasVariable") {
-    return variableType.aliasName;
+    return `${variableType.aliasName}${formatValueArgs(variableType.valueArgs)}`;
   } else if (variableType.type === "blockType") {
     const params = variableType.params
       .map((p) => variableTypeToString(p.typeAnnotation, typeAliases, forFormatting))
@@ -62,7 +143,7 @@ export function variableTypeToString(
     const args = variableType.typeArgs
       .map((a) => variableTypeToString(a, typeAliases, forFormatting))
       .join(", ");
-    return `${variableType.name}<${args}>`;
+    return `${variableType.name}<${args}>${formatValueArgs(variableType.valueArgs)}`;
   }
   return "unknown";
 }

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToString.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToString.ts
@@ -73,6 +73,22 @@ function valueArgExprToString(expr: Expression): string {
           return `${e.key}: ${valueArgExprToString(e.value)}`;
         })
         .join(", ")} }`;
+    case "agencyArray":
+      return `[${expr.items
+        .map((item) =>
+          item.type === "splat"
+            ? `...${valueArgExprToString(item.value)}`
+            : valueArgExprToString(item as Expression),
+        )
+        .join(", ")}]`;
+    case "regex":
+      return `re/${expr.pattern}/${expr.flags}`;
+    case "unitLiteral":
+      // Round-trip the source form (`30s`, `$5`, `100KB`, ...). `$`
+      // is the only prefix unit; everything else is a suffix.
+      return expr.unit === "$"
+        ? `$${expr.value}`
+        : `${expr.value}${expr.unit}`;
     default:
       return "";
   }

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -3,7 +3,10 @@ import { Tag, TypeAliasEntry, VariableType } from "../../types.js";
 import { escape } from "../../utils.js";
 import { tagArgToTs } from "./tagArgToTs.js";
 import { mergeJsonSchemaArgs, mergeTagSets } from "@/typeChecker/mergeTags.js";
-import { applyValueArgs } from "@/typeChecker/valueParamSubstitution.js";
+import {
+  applyValueArgs,
+  isValueParamInstantiation,
+} from "@/typeChecker/valueParamSubstitution.js";
 
 export const DEFAULT_SCHEMA = "z.string()";
 
@@ -121,10 +124,24 @@ function mapTypeToSchemaInner(
         // property-level tags. @jsonSchema keys from the property
         // override alias keys (with `description` concatenating per
         // `mergeTagSets`); @validate validators concat.
-        const aliasEntryTags =
-          typeAliasesFull && prop.value.type === "typeAliasVariable"
-            ? typeAliasesFull[prop.value.aliasName]?.tags
-            : undefined;
+        let aliasEntryTags: Tag[] | undefined;
+        if (typeAliasesFull && prop.value.type === "typeAliasVariable") {
+          const entry = typeAliasesFull[prop.value.aliasName];
+          // For a value-parameterized alias instantiation
+          // (`age: NumberInRange(0, 150)`), substitute the alias's raw
+          // tags FIRST — otherwise the outer `.meta(...)` for this
+          // property would emit out-of-scope value-param identifiers
+          // (e.g. `low`, `high`) into the generated TS.
+          if (isValueParamInstantiation(prop.value, entry)) {
+            aliasEntryTags = applyValueArgs(
+              entry!,
+              prop.value.valueArgs,
+              prop.value.aliasName,
+            ).tags;
+          } else {
+            aliasEntryTags = entry?.tags;
+          }
+        }
         const aliasSideTags = mergeTagSets(aliasEntryTags, prop.value.tags);
         const mergedTags = mergeTagSets(aliasSideTags, prop.tags);
         const inner = mapTypeToSchemaInner(
@@ -151,26 +168,25 @@ function mapTypeToSchemaInner(
     // Value-parameterized alias reference (e.g. `Age(18)`): there is
     // no single top-level schema const for the alias, so we inline the
     // substituted body's Zod schema at this use-site. The substituted
-    // tags drive `appendMeta`.
-    if (variableType.valueArgs && typeAliasesFull) {
-      const aliasEntry = typeAliasesFull[variableType.aliasName];
-      if (aliasEntry?.valueParams) {
-        const substituted = applyValueArgs(
-          aliasEntry,
-          variableType.valueArgs,
-          variableType.aliasName,
-        );
-        const bodyWithAliasTags: VariableType = {
-          ...substituted.body,
-          tags: mergeTagSets(substituted.tags, substituted.body.tags),
-        };
-        return mapTypeToSchema(
-          bodyWithAliasTags,
-          typeAliases,
-          resultHandler,
-          typeAliasesFull,
-        );
-      }
+    // tags drive `appendMeta`. See `isValueParamInstantiation` for the
+    // canonical predicate (used everywhere this divergence appears).
+    const aliasEntry = typeAliasesFull?.[variableType.aliasName];
+    if (isValueParamInstantiation(variableType, aliasEntry)) {
+      const substituted = applyValueArgs(
+        aliasEntry!,
+        variableType.valueArgs,
+        variableType.aliasName,
+      );
+      const bodyWithAliasTags: VariableType = {
+        ...substituted.body,
+        tags: mergeTagSets(substituted.tags, substituted.body.tags),
+      };
+      return mapTypeToSchema(
+        bodyWithAliasTags,
+        typeAliases,
+        resultHandler,
+        typeAliasesFull,
+      );
     }
     return variableType.aliasName;
   } else if (variableType.type === "genericType") {

--- a/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/typeToZodSchema.ts
@@ -3,6 +3,7 @@ import { Tag, TypeAliasEntry, VariableType } from "../../types.js";
 import { escape } from "../../utils.js";
 import { tagArgToTs } from "./tagArgToTs.js";
 import { mergeJsonSchemaArgs, mergeTagSets } from "@/typeChecker/mergeTags.js";
+import { applyValueArgs } from "@/typeChecker/valueParamSubstitution.js";
 
 export const DEFAULT_SCHEMA = "z.string()";
 
@@ -147,6 +148,30 @@ function mapTypeToSchemaInner(
   } else if (variableType.type === "resultType") {
     return resultHandler(variableType, typeAliases);
   } else if (variableType.type === "typeAliasVariable") {
+    // Value-parameterized alias reference (e.g. `Age(18)`): there is
+    // no single top-level schema const for the alias, so we inline the
+    // substituted body's Zod schema at this use-site. The substituted
+    // tags drive `appendMeta`.
+    if (variableType.valueArgs && typeAliasesFull) {
+      const aliasEntry = typeAliasesFull[variableType.aliasName];
+      if (aliasEntry?.valueParams) {
+        const substituted = applyValueArgs(
+          aliasEntry,
+          variableType.valueArgs,
+          variableType.aliasName,
+        );
+        const bodyWithAliasTags: VariableType = {
+          ...substituted.body,
+          tags: mergeTagSets(substituted.tags, substituted.body.tags),
+        };
+        return mapTypeToSchema(
+          bodyWithAliasTags,
+          typeAliases,
+          resultHandler,
+          typeAliasesFull,
+        );
+      }
+    }
     return variableType.aliasName;
   } else if (variableType.type === "genericType") {
     if (variableType.name === "Record") {

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -4,6 +4,7 @@ import { ts } from "@/ir/builders.js";
 import { mapTypeToValidationSchema } from "./typeToZodSchema.js";
 import { tagArgToTs } from "./tagArgToTs.js";
 import { mergeTagSets } from "@/typeChecker/mergeTags.js";
+import { applyValueArgs } from "@/typeChecker/valueParamSubstitution.js";
 
 /**
  * Build a TS IR node that evaluates to a runtime `TypeValidationDescriptor`.
@@ -67,12 +68,19 @@ export function hasAnyValidateTag(
       if (!aliasesFull) return false;
       const entry = aliasesFull[t.aliasName];
       if (!entry) return false;
-      if (tagsHaveValidate(entry.tags)) return true;
+      // For value-parameterized references, the alias's raw tags may
+      // reference value-param identifiers; substitute first so the
+      // post-substitution tag set is what we check for `@validate`.
+      const effectiveEntry =
+        entry.valueParams && t.valueArgs
+          ? applyValueArgs(entry, t.valueArgs, t.aliasName)
+          : entry;
+      if (tagsHaveValidate(effectiveEntry.tags)) return true;
       // Guard against recursive alias self-reference.
       if (seen.has(t.aliasName)) return false;
       const nextSeen = new Set(seen);
       nextSeen.add(t.aliasName);
-      return hasAnyValidateTag(entry.body, aliasesFull, nextSeen);
+      return hasAnyValidateTag(effectiveEntry.body, aliasesFull, nextSeen);
     }
     default:
       return false;
@@ -158,6 +166,23 @@ function descriptor(
   if (variableType.type === "typeAliasVariable") {
     const entry = typeAliasesFull[variableType.aliasName];
     const useSiteValidators = validatorNodes(variableType.tags);
+    // Value-parameterized alias instantiation: there is NO
+    // `__agency_descriptor` side-channel (those only exist for bare
+    // aliases). Inline the descriptor for the substituted body with
+    // substituted tags threaded through.
+    if (entry?.valueParams && variableType.valueArgs) {
+      const substituted = applyValueArgs(
+        entry,
+        variableType.valueArgs,
+        variableType.aliasName,
+      );
+      const merged = mergeTagSets(substituted.tags, variableType.tags);
+      const bodyWithTags: VariableType = {
+        ...substituted.body,
+        tags: mergeTagSets(substituted.body.tags, merged),
+      };
+      return descriptor(bodyWithTags, typeAliases, typeAliasesFull, seen);
+    }
     if (entry && hasAliasValidate(entry, typeAliasesFull)) {
       // `(Alias as any).__agency_descriptor`
       const aliasRef = ts.prop(

--- a/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/validationDescriptor.ts
@@ -4,7 +4,10 @@ import { ts } from "@/ir/builders.js";
 import { mapTypeToValidationSchema } from "./typeToZodSchema.js";
 import { tagArgToTs } from "./tagArgToTs.js";
 import { mergeTagSets } from "@/typeChecker/mergeTags.js";
-import { applyValueArgs } from "@/typeChecker/valueParamSubstitution.js";
+import {
+  applyValueArgs,
+  isValueParamInstantiation,
+} from "@/typeChecker/valueParamSubstitution.js";
 
 /**
  * Build a TS IR node that evaluates to a runtime `TypeValidationDescriptor`.
@@ -71,10 +74,10 @@ export function hasAnyValidateTag(
       // For value-parameterized references, the alias's raw tags may
       // reference value-param identifiers; substitute first so the
       // post-substitution tag set is what we check for `@validate`.
-      const effectiveEntry =
-        entry.valueParams && t.valueArgs
-          ? applyValueArgs(entry, t.valueArgs, t.aliasName)
-          : entry;
+      // See `isValueParamInstantiation` — the canonical predicate.
+      const effectiveEntry = isValueParamInstantiation(t, entry)
+        ? applyValueArgs(entry, t.valueArgs, t.aliasName)
+        : entry;
       if (tagsHaveValidate(effectiveEntry.tags)) return true;
       // Guard against recursive alias self-reference.
       if (seen.has(t.aliasName)) return false;
@@ -169,10 +172,12 @@ function descriptor(
     // Value-parameterized alias instantiation: there is NO
     // `__agency_descriptor` side-channel (those only exist for bare
     // aliases). Inline the descriptor for the substituted body with
-    // substituted tags threaded through.
-    if (entry?.valueParams && variableType.valueArgs) {
+    // substituted tags threaded through. See `isValueParamInstantiation`
+    // — the canonical predicate, also used in `typeToZodSchema` and
+    // `hasAnyValidateTag`.
+    if (isValueParamInstantiation(variableType, entry)) {
       const substituted = applyValueArgs(
-        entry,
+        entry!,
         variableType.valueArgs,
         variableType.aliasName,
       );

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -8,6 +8,7 @@ import type {
   Tag,
   TypeAliasEntry,
   TypeParam,
+  ValueParam,
   VariableType,
 } from "./types.js";
 import type {
@@ -46,10 +47,12 @@ export class ScopedTypeAliases {
     body: VariableType,
     typeParams?: TypeParam[],
     tags?: Tag[],
+    valueParams?: ValueParam[],
   ): void {
     if (!this.byScope[scopeKey]) this.byScope[scopeKey] = {};
     const entry: TypeAliasEntry = { body };
     if (typeParams) entry.typeParams = typeParams;
+    if (valueParams) entry.valueParams = valueParams;
     if (tags && tags.length > 0) entry.tags = tags;
     this.byScope[scopeKey][name] = entry;
   }
@@ -221,6 +224,7 @@ export function buildCompilationUnit(
         node.aliasedType,
         node.typeParams,
         tags,
+        node.valueParams,
       );
     }
   }
@@ -272,6 +276,7 @@ export function buildCompilationUnit(
             r.symbol.aliasedType,
             r.symbol.typeParams,
             r.symbol.tags,
+            r.symbol.valueParams,
           );
           // Imported type's body may reference other aliases from its
           // module — pull those transitively too.
@@ -351,6 +356,7 @@ function pullTransitiveAliases(
       found.aliasedType,
       found.typeParams,
       found.tags,
+      found.valueParams,
     );
     // Nested aliases referenced by this type should resolve in the file
     // the type was actually found in (not the original preferFile) — the
@@ -372,13 +378,14 @@ function resolveTypeFromFile(
   symbolTable: SymbolTable,
   name: string,
   preferFile: string | undefined,
-): { aliasedType: VariableType; typeParams?: TypeParam[]; tags?: Tag[]; file: string } | undefined {
+): { aliasedType: VariableType; typeParams?: TypeParam[]; valueParams?: ValueParam[]; tags?: Tag[]; file: string } | undefined {
   if (preferFile) {
     const fileSym = symbolTable.getFile(preferFile)?.[name];
     if (fileSym?.kind === "type") {
       return {
         aliasedType: fileSym.aliasedType,
         typeParams: fileSym.typeParams,
+        valueParams: fileSym.valueParams,
         tags: fileSym.tags,
         file: preferFile,
       };
@@ -390,6 +397,7 @@ function resolveTypeFromFile(
       return {
         aliasedType: sym.aliasedType,
         typeParams: sym.typeParams,
+        valueParams: sym.valueParams,
         tags: sym.tags,
         file,
       };

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -517,6 +517,55 @@ export const simpleStringParser: Parser<StringLiteral> = (input: string) => {
   }))(input);
 };
 
+// Identifier-only interpolation segment: accepts `${name}` where `name`
+// is a plain identifier. Used in static tag-arg strings so users can
+// embed a value-param identifier or a top-level static const without
+// opening the door to arbitrary runtime expressions.
+const staticInterpolationSegmentParser: Parser<InterpolationSegment> =
+  withLoc((input: string) => {
+    const parser = seqC(
+      char("$"),
+      char("{"),
+      optionalSpaces,
+      capture(variableNameParser, "expression"),
+      optionalSpaces,
+      char("}"),
+    );
+    const result = parser(input);
+    if (!result.success) return result;
+    return success(
+      {
+        type: "interpolation" as const,
+        expression: result.result.expression,
+      },
+      result.rest,
+    );
+  });
+
+// String literal that allows identifier-only `${name}` interpolation but
+// nothing else. Used by `staticTagArgParser` so e.g.
+// `@jsonSchema({ description: "divisible by ${divisor}" })` is accepted
+// when `divisor` is a value-param name (or a top-level static const),
+// while `"${a + b}"`, `"${foo()}"`, `"${obj.field}"` are rejected by
+// the parser before reaching the type checker / generator.
+export const staticInterpolatedStringParser: Parser<StringLiteral> = (
+  input: string,
+) => {
+  const open = oneOf('"`')(input);
+  if (!open.success) return open as ParserResult<StringLiteral>;
+  const delim = open.result as '"' | "`";
+  const segments = many(
+    or(stringTextSegmentParserFor(delim), staticInterpolationSegmentParser),
+  )(open.rest);
+  if (!segments.success) return segments as ParserResult<StringLiteral>;
+  const close = char(delim)(segments.rest);
+  if (!close.success) return failure(`expected closing ${delim}`, input);
+  return success(
+    { type: "string" as const, segments: segments.result },
+    close.rest,
+  );
+};
+
 export const _stringParser: Parser<StringLiteral> = (input: string) => {
   const open = oneOf('"`')(input);
   if (!open.success) return open as ParserResult<StringLiteral>;
@@ -1509,7 +1558,12 @@ export const staticTagArgParser: Parser<Expression> = label(
     nullParser,
     booleanParser,
     numberParser,
-    simpleStringParser,
+    // Allow identifier-only `${name}` interpolation so users can
+    // reference value-param identifiers or static consts inside tag
+    // strings (e.g. `description: "must be divisible by ${divisor}"`).
+    // Any non-identifier expression in a `${...}` slot is rejected at
+    // parse time.
+    staticInterpolatedStringParser,
     _identOrPfaParser,
   ),
 );

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -519,8 +519,12 @@ export const simpleStringParser: Parser<StringLiteral> = (input: string) => {
 
 // Identifier-only interpolation segment: accepts `${name}` where `name`
 // is a plain identifier. Used in static tag-arg strings so users can
-// embed a value-param identifier or a top-level static const without
-// opening the door to arbitrary runtime expressions.
+// embed a value-param identifier (e.g. `${divisor}`) without opening
+// the door to arbitrary runtime expressions. Note: only value-param
+// identifiers are actually supported end-to-end — top-level static
+// consts are rejected later by `validateStringLiteral` and would crash
+// at codegen, since tag strings are emitted where module-level Agency
+// consts are not bound as plain JS names.
 const staticInterpolationSegmentParser: Parser<InterpolationSegment> =
   withLoc((input: string) => {
     const parser = seqC(
@@ -545,26 +549,13 @@ const staticInterpolationSegmentParser: Parser<InterpolationSegment> =
 // String literal that allows identifier-only `${name}` interpolation but
 // nothing else. Used by `staticTagArgParser` so e.g.
 // `@jsonSchema({ description: "divisible by ${divisor}" })` is accepted
-// when `divisor` is a value-param name (or a top-level static const),
-// while `"${a + b}"`, `"${foo()}"`, `"${obj.field}"` are rejected by
-// the parser before reaching the type checker / generator.
-export const staticInterpolatedStringParser: Parser<StringLiteral> = (
-  input: string,
-) => {
-  const open = oneOf('"`')(input);
-  if (!open.success) return open as ParserResult<StringLiteral>;
-  const delim = open.result as '"' | "`";
-  const segments = many(
-    or(stringTextSegmentParserFor(delim), staticInterpolationSegmentParser),
-  )(open.rest);
-  if (!segments.success) return segments as ParserResult<StringLiteral>;
-  const close = char(delim)(segments.rest);
-  if (!close.success) return failure(`expected closing ${delim}`, input);
-  return success(
-    { type: "string" as const, segments: segments.result },
-    close.rest,
-  );
-};
+// when `divisor` is a value-param name on the surrounding alias, while
+// `"${a + b}"`, `"${foo()}"`, `"${obj.field}"` are rejected by the
+// parser before reaching the type checker / generator. Static const
+// names are not supported here — see the comment on
+// `staticInterpolationSegmentParser`.
+export const staticInterpolatedStringParser: Parser<StringLiteral> =
+  makeInterpolatedStringParser(staticInterpolationSegmentParser);
 
 // Multi-line variant of `staticInterpolatedStringParser`. Same
 // identifier-only interpolation rule for `${...}` slots, used inside
@@ -592,21 +583,33 @@ export const staticMultiLineStringParser: Parser<MultiLineStringLiteral> = (
   return result;
 };
 
-export const _stringParser: Parser<StringLiteral> = (input: string) => {
-  const open = oneOf('"`')(input);
-  if (!open.success) return open as ParserResult<StringLiteral>;
-  const delim = open.result as '"' | "`";
-  const segments = many(
-    or(stringTextSegmentParserFor(delim), interpolationSegmentParser),
-  )(open.rest);
-  if (!segments.success) return segments as ParserResult<StringLiteral>;
-  const close = char(delim)(segments.rest);
-  if (!close.success) return failure(`expected closing ${delim}`, input);
-  return success(
-    { type: "string" as const, segments: segments.result },
-    close.rest,
-  );
-};
+// Build a string-literal parser that supports `"..."` / `` `...` ``
+// delimiters, requires matching open/close delimiters, and accepts
+// the given interpolation-segment parser inside `${...}` slots.
+// Shared between the full `_stringParser` (any expression inside
+// `${...}`) and `staticInterpolatedStringParser` (identifier-only).
+function makeInterpolatedStringParser(
+  segmentParser: Parser<InterpolationSegment>,
+): Parser<StringLiteral> {
+  return (input: string) => {
+    const open = oneOf('"`')(input);
+    if (!open.success) return open as ParserResult<StringLiteral>;
+    const delim = open.result as '"' | "`";
+    const segments = many(
+      or(stringTextSegmentParserFor(delim), segmentParser),
+    )(open.rest);
+    if (!segments.success) return segments as ParserResult<StringLiteral>;
+    const close = char(delim)(segments.rest);
+    if (!close.success) return failure(`expected closing ${delim}`, input);
+    return success(
+      { type: "string" as const, segments: segments.result },
+      close.rest,
+    );
+  };
+}
+
+export const _stringParser: Parser<StringLiteral> =
+  makeInterpolatedStringParser(interpolationSegmentParser);
 
 export const stringParser: Parser<StringLiteral> = label("a string", (input: string) => {
   // Allow `_valueAccessParser` on the right of `+` so function calls and

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -566,6 +566,32 @@ export const staticInterpolatedStringParser: Parser<StringLiteral> = (
   );
 };
 
+// Multi-line variant of `staticInterpolatedStringParser`. Same
+// identifier-only interpolation rule for `${...}` slots, used inside
+// `staticTagArgParser` so a tag arg can be a `"""..."""` literal.
+export const staticMultiLineStringParser: Parser<MultiLineStringLiteral> = (
+  input: string,
+) => {
+  const parser = seqC(
+    set("type", "multiLineString"),
+    str('"""'),
+    capture(
+      many(
+        or(multiLineStringTextSegmentParser, staticInterpolationSegmentParser),
+      ),
+      "segments",
+    ),
+    str('"""'),
+  );
+  const result = parser(input);
+  if (result.success) {
+    for (const seg of result.result.segments) {
+      if (seg.type === "text") seg.value = stripSentinels(seg.value);
+    }
+  }
+  return result;
+};
+
 export const _stringParser: Parser<StringLiteral> = (input: string) => {
   const open = oneOf('"`')(input);
   if (!open.success) return open as ParserResult<StringLiteral>;
@@ -1552,16 +1578,27 @@ const _identOrPfaParser: Parser<Expression> = (input: string) => {
 };
 
 export const staticTagArgParser: Parser<Expression> = label(
-  "a static argument (literal, identifier, PFA expression, or object literal)",
+  "a static argument (literal, identifier, PFA expression, array, object, regex, or unit literal)",
   or(
     lazy(() => agencyObjectParser),
+    lazy(() => agencyArrayParser),
+    regexLiteralParser,
     nullParser,
     booleanParser,
+    // Unit literals (`30s`, `$5`, `100KB`, ...) MUST come before
+    // `numberParser` so `30s` matches as a unit and not as `30`
+    // with stray `s`. The IR carries `canonicalValue` (already
+    // normalised to ms / dollars / bytes), which is what codegen
+    // emits.
+    unitLiteralParser,
     numberParser,
+    // Triple-quoted strings before single-quoted so `"""..."""`
+    // isn't first matched as an empty `""` followed by `"..."`.
+    staticMultiLineStringParser,
     // Allow identifier-only `${name}` interpolation so users can
-    // reference value-param identifiers or static consts inside tag
-    // strings (e.g. `description: "must be divisible by ${divisor}"`).
-    // Any non-identifier expression in a `${...}` slot is rejected at
+    // reference value-param identifiers inside tag strings (e.g.
+    // `description: "must be divisible by ${divisor}"`). Any
+    // non-identifier expression in a `${...}` slot is rejected at
     // parse time.
     staticInterpolatedStringParser,
     _identOrPfaParser,

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -99,6 +99,7 @@ import {
   TypeParam,
   UnionType,
   Tag,
+  ValueParam,
 } from "../types.js";
 import { GraphNodeDefinition } from "../types/graphNode.js";
 import { ForLoop } from "../types/forLoop.js";
@@ -689,10 +690,33 @@ export const primitiveTypeParser: Parser<PrimitiveType> = trace(
 
 export const typeAliasVariableParser: Parser<TypeAliasVariable> = trace(
   "typeAliasVariableParser",
-  seqC(
-    set("type", "typeAliasVariable"),
-    capture(many1WithJoin(varNameChar), "aliasName"),
-  ),
+  (input: string): ParserResult<TypeAliasVariable> => {
+    const parser = seqC(
+      set("type", "typeAliasVariable"),
+      capture(many1WithJoin(varNameChar), "aliasName"),
+      // Optional `(arg1, arg2, ...)` value-arg suffix for
+      // value-parameterized aliases. Each arg is a statically-
+      // restricted expression (literal, identifier, PFA, object literal).
+      optional(
+        captureCaptures(
+          seqC(
+            char("("),
+            optionalSpaces,
+            capture(
+              sepBy(
+                seqR(optionalSpaces, char(","), optionalSpaces),
+                lazy(() => staticTagArgParser),
+              ),
+              "valueArgs",
+            ),
+            optionalSpaces,
+            char(")"),
+          ),
+        ),
+      ),
+    );
+    return parser(input);
+  },
 );
 
 /**
@@ -1163,6 +1187,25 @@ export const genericTypeParser: Parser<GenericType> = trace(
     ),
     optionalSpaces,
     char(">"),
+    // Optional value-arg suffix: combined `<T>(n)` form for
+    // value-parameterized generic aliases (e.g. `BoundedList<string>(3)`).
+    optional(
+      captureCaptures(
+        seqC(
+          char("("),
+          optionalSpaces,
+          capture(
+            sepBy(
+              seqR(optionalSpaces, char(","), optionalSpaces),
+              lazy(() => staticTagArgParser),
+            ),
+            "valueArgs",
+          ),
+          optionalSpaces,
+          char(")"),
+        ),
+      ),
+    ),
   ),
 );
 
@@ -1207,6 +1250,35 @@ export const typeParamParser: Parser<TypeParam> = trace(
   ),
 );
 
+/**
+ * Value parameter on a value-parameterized alias declaration. Examples:
+ *   min: number              → { name: "min", type: { type: "primitiveType", value: "number" } }
+ *   min: number = 0          → { ..., default: { type: "number", value: "0" } }
+ *
+ * The default expression is restricted to the same statically-known
+ * subset as tag arguments (see `staticTagArgParser`).
+ */
+export const valueParamParser: Parser<ValueParam> = trace(
+  "valueParamParser",
+  seqC(
+    capture(many1WithJoin(varNameChar), "name"),
+    optionalSpaces,
+    char(":"),
+    optionalSpaces,
+    capture(lazy(() => variableTypeParser), "type"),
+    optional(
+      captureCaptures(
+        seqC(
+          optionalSpaces,
+          char("="),
+          optionalSpaces,
+          capture(lazy(() => staticTagArgParser), "default"),
+        ),
+      ),
+    ),
+  ),
+);
+
 const baseTypeAliasParser: Parser<TypeAlias> = withLoc(trace(
   "typeAliasParser",
   seqC(
@@ -1233,6 +1305,26 @@ const baseTypeAliasParser: Parser<TypeAlias> = withLoc(trace(
               ),
               optionalSpaces,
               char(">"),
+            ),
+          ),
+        ),
+        // Optional `(name: T, name: T = default, ...)`. Must come AFTER the
+        // optional `<...>` block: reversed ordering `(...)<...>` is rejected
+        // because nothing here consumes a `<` before the `=`.
+        optional(
+          captureCaptures(
+            seqC(
+              char("("),
+              optionalSpaces,
+              capture(
+                sepBy1(
+                  seqR(optionalSpaces, char(","), optionalSpaces),
+                  valueParamParser,
+                ),
+                "valueParams",
+              ),
+              optionalSpaces,
+              char(")"),
             ),
           ),
         ),
@@ -1360,31 +1452,50 @@ export const skillParser = (input: string) => {
 // tag.ts
 // =============================================================================
 
-// A single tag argument: restricted subset of expressions per spec
-// (docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md).
+// A single statically-restricted argument expression. Shared by:
+//   1. `@validate(...)` / `@jsonSchema(...)` tag arguments
+//   2. value-parameter default expressions (`= 0`)
+//   3. value-arg expressions at use sites (`Age(18)`)
 //
 // Allowed: string / number / boolean / null literals, identifiers,
-// function calls, object literals (including spread). NOT allowed:
-// ternaries, binary ops, pipes, member access, template strings,
-// array literals.
+// object literals (including spread), and PFA expressions
+// (e.g. `min.partial(n: 0)`). NOT allowed: bare function calls
+// (no chain), ternaries, binary ops, pipes, member access on a
+// function-call base, template strings, array literals.
 //
 // All forward references go through lazy(...) because these parsers
 // are defined later in the file.
-const restrictedTagArgParser: Parser<Expression> = label(
-  "a tag argument (literal, identifier, function call, PFA, or object literal)",
+const _identOrPfaParser: Parser<Expression> = (input: string) => {
+  const result = lazy(() => _valueAccessParser)(input);
+  if (!result.success) return result;
+  // Reject bare function calls (no chain). PFA expressions (function
+  // call followed by a `.partial(...)` style method-call chain) are
+  // `valueAccess` nodes and so survive this filter. Bare identifiers
+  // (`variableName`) are also fine.
+  if (result.result.type === "functionCall") {
+    return failure(
+      "bare function call not allowed; use a literal, identifier, PFA expression (e.g. `min.partial(n: 0)`), or object literal",
+      input,
+    );
+  }
+  return result;
+};
+
+export const staticTagArgParser: Parser<Expression> = label(
+  "a static argument (literal, identifier, PFA expression, or object literal)",
   or(
     lazy(() => agencyObjectParser),
     nullParser,
     booleanParser,
     numberParser,
     simpleStringParser,
-    // `_valueAccessParser` subsumes plain function calls and bare
-    // identifiers (when there is no chain), and also accepts PFA
-    // expressions like `min.partial(n: 0)` so users can configure
-    // parameterized validators inline in `@validate(...)`.
-    lazy(() => _valueAccessParser),
+    _identOrPfaParser,
   ),
 );
+
+// Backwards-compatible alias for the previous name. The current
+// behaviour is the tightened one: bare function calls are rejected.
+const restrictedTagArgParser: Parser<Expression> = staticTagArgParser;
 
 // Parenthesized argument list: (arg1, arg2)
 const tagArgsList = map(

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -688,32 +688,40 @@ export const primitiveTypeParser: Parser<PrimitiveType> = trace(
   ),
 );
 
+/**
+ * Shared `(arg1, arg2, ...)` value-arg suffix parser. Used by both
+ * `typeAliasVariableParser` (e.g. `Age(18)`) and `genericTypeParser`
+ * (e.g. `BoundedList<string>(3)`). Each arg is restricted to the
+ * statically-known subset enforced by `staticTagArgParser`.
+ *
+ * Defined as a lazy reference so it can be used by parsers that appear
+ * earlier in the file than `staticTagArgParser` itself.
+ */
+const optionalValueArgsParser = optional(
+  captureCaptures(
+    seqC(
+      char("("),
+      optionalSpaces,
+      capture(
+        sepBy(
+          seqR(optionalSpaces, char(","), optionalSpaces),
+          lazy(() => staticTagArgParser),
+        ),
+        "valueArgs",
+      ),
+      optionalSpaces,
+      char(")"),
+    ),
+  ),
+);
+
 export const typeAliasVariableParser: Parser<TypeAliasVariable> = trace(
   "typeAliasVariableParser",
   (input: string): ParserResult<TypeAliasVariable> => {
     const parser = seqC(
       set("type", "typeAliasVariable"),
       capture(many1WithJoin(varNameChar), "aliasName"),
-      // Optional `(arg1, arg2, ...)` value-arg suffix for
-      // value-parameterized aliases. Each arg is a statically-
-      // restricted expression (literal, identifier, PFA, object literal).
-      optional(
-        captureCaptures(
-          seqC(
-            char("("),
-            optionalSpaces,
-            capture(
-              sepBy(
-                seqR(optionalSpaces, char(","), optionalSpaces),
-                lazy(() => staticTagArgParser),
-              ),
-              "valueArgs",
-            ),
-            optionalSpaces,
-            char(")"),
-          ),
-        ),
-      ),
+      optionalValueArgsParser,
     );
     return parser(input);
   },
@@ -1189,23 +1197,7 @@ export const genericTypeParser: Parser<GenericType> = trace(
     char(">"),
     // Optional value-arg suffix: combined `<T>(n)` form for
     // value-parameterized generic aliases (e.g. `BoundedList<string>(3)`).
-    optional(
-      captureCaptures(
-        seqC(
-          char("("),
-          optionalSpaces,
-          capture(
-            sepBy(
-              seqR(optionalSpaces, char(","), optionalSpaces),
-              lazy(() => staticTagArgParser),
-            ),
-            "valueArgs",
-          ),
-          optionalSpaces,
-          char(")"),
-        ),
-      ),
-    ),
+    optionalValueArgsParser,
   ),
 );
 
@@ -1457,11 +1449,27 @@ export const skillParser = (input: string) => {
 //   2. value-parameter default expressions (`= 0`)
 //   3. value-arg expressions at use sites (`Age(18)`)
 //
-// Allowed: string / number / boolean / null literals, identifiers,
-// object literals (including spread), and PFA expressions
-// (e.g. `min.partial(n: 0)`). NOT allowed: bare function calls
-// (no chain), ternaries, binary ops, pipes, member access on a
-// function-call base, template strings, array literals.
+// The underlying rule: allowed expressions are exactly those whose value
+// is statically known at compile time, so they can be substituted into a
+// tag expression and emitted as a TypeScript literal.
+//
+// Allowed: string / number / boolean / null literals (NO `${...}`
+// interpolation — see below), identifiers (resolving to a static const
+// or value-param in scope), object literals (including spread), and PFA
+// expressions (e.g. `min.partial(n: 0)`) whose base is a plain
+// identifier.
+//
+// NOT allowed:
+//   - bare function calls (no chain). Use PFA: `min.partial(n: 0)`.
+//   - PFA whose base is a function-call (`getMin(1).partial(...)`) —
+//     base must be a plain identifier.
+//   - ternaries, binary ops, pipes.
+//   - member access (`obj.field`).
+//   - interpolated string segments. Plain `simpleStringParser` accepts
+//     only literal-only strings; any `${...}` inside a string would
+//     embed a runtime expression that can't be folded at compile time.
+//   - array literals. (Could be allowed via constant folding in a
+//     future iteration; deferred until a stdlib use case needs them.)
 //
 // All forward references go through lazy(...) because these parsers
 // are defined later in the file.
@@ -1475,6 +1483,19 @@ const _identOrPfaParser: Parser<Expression> = (input: string) => {
   if (result.result.type === "functionCall") {
     return failure(
       "bare function call not allowed; use a literal, identifier, PFA expression (e.g. `min.partial(n: 0)`), or object literal",
+      input,
+    );
+  }
+  // Reject PFA whose base isn't a plain identifier. `foo(1).partial(...)`
+  // and `(get()).partial(...)` are NOT static — they call a function at
+  // runtime to compute the receiver. PFA must be rooted at an identifier
+  // (typically a top-level validator function in scope).
+  if (
+    result.result.type === "valueAccess" &&
+    result.result.base.type !== "variableName"
+  ) {
+    return failure(
+      "PFA base must be a plain identifier (e.g. `min.partial(n: 0)`, not `min(1).partial(...)`)",
       input,
     );
   }

--- a/packages/agency-lang/lib/parsers/tag.test.ts
+++ b/packages/agency-lang/lib/parsers/tag.test.ts
@@ -56,14 +56,31 @@ describe("tagParser", () => {
     });
   });
 
-  it("parses a tag with a function call argument", () => {
-    const result = tagParser("@validate(min(0), max(150))");
+  it("parses a tag with PFA arguments", () => {
+    const result = tagParser(
+      "@validate(min.partial(n: 0), max.partial(n: 150))",
+    );
     expect(result.success).toBe(true);
     if (!result.success) return;
     expect(result.result.name).toBe("validate");
     expect(result.result.arguments).toHaveLength(2);
-    expect(result.result.arguments[0].type).toBe("functionCall");
-    expect(result.result.arguments[1].type).toBe("functionCall");
+    expect(result.result.arguments[0].type).toBe("valueAccess");
+    expect(result.result.arguments[1].type).toBe("valueAccess");
+  });
+
+  it("rejects bare function call tag arguments (must use PFA)", () => {
+    // After the tag-arg restriction was tightened, `@validate(min(0))` is no
+    // longer a valid tag — the bare function call must be expressed as a
+    // PFA expression like `@validate(min.partial(n: 0))` instead. The tag
+    // parser has a zero-args fallback (so `@name` alone still parses), so
+    // here we assert that the bare-call form does NOT parse into a single
+    // function-call argument: either it fails outright or falls back to
+    // the no-args form with `(min(0))` left unconsumed.
+    const result = tagParser("@validate(min(0))");
+    if (result.success) {
+      expect(result.result.arguments).toHaveLength(0);
+      expect(result.rest.startsWith("(")).toBe(true);
+    }
   });
 
   it("parses a tag with an object literal argument", () => {

--- a/packages/agency-lang/lib/parsers/tag.test.ts
+++ b/packages/agency-lang/lib/parsers/tag.test.ts
@@ -83,6 +83,19 @@ describe("tagParser", () => {
     }
   });
 
+  it("rejects PFA whose base is a function-call (must be a plain identifier)", () => {
+    // `getMin(1).partial(n: 0)` is NOT static — it calls `getMin` at
+    // runtime to compute the PFA receiver. The PFA base must be a plain
+    // identifier (a top-level validator function or imported function),
+    // never the result of another call. Same falls-back-to-empty-args
+    // behaviour as the bare-call case.
+    const result = tagParser("@validate(getMin(1).partial(n: 0))");
+    if (result.success) {
+      expect(result.result.arguments).toHaveLength(0);
+      expect(result.rest.startsWith("(")).toBe(true);
+    }
+  });
+
   it("parses a tag with an object literal argument", () => {
     const result = tagParser('@jsonSchema({ format: "email" })');
     expect(result.success).toBe(true);

--- a/packages/agency-lang/lib/parsers/typeHints.test.ts
+++ b/packages/agency-lang/lib/parsers/typeHints.test.ts
@@ -2914,3 +2914,157 @@ describe("typeAliasParser with type parameters", () => {
     }
   });
 });
+
+describe("typeAliasParser with value parameters", () => {
+  it("parses a single value parameter: type Age(min: number) = number", () => {
+    const result = typeAliasParser("type Age(min: number) = number");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.aliasName).toBe("Age");
+      expect(result.result.typeParams).toBeUndefined();
+      expect(result.result.valueParams).toHaveLength(1);
+      expect(result.result.valueParams?.[0]).toMatchObject({
+        name: "min",
+        type: { type: "primitiveType", value: "number" },
+      });
+      expect(result.result.valueParams?.[0].default).toBeUndefined();
+      expect(result.result.aliasedType).toMatchObject({
+        type: "primitiveType",
+        value: "number",
+      });
+    }
+  });
+
+  it("parses multiple value parameters: type NumberInRange(low, high) = number", () => {
+    const result = typeAliasParser(
+      "type NumberInRange(low: number, high: number) = number",
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.aliasName).toBe("NumberInRange");
+      expect(result.result.valueParams).toHaveLength(2);
+      expect(result.result.valueParams?.[0].name).toBe("low");
+      expect(result.result.valueParams?.[1].name).toBe("high");
+    }
+  });
+
+  it("parses a value parameter with default: type Age(min: number = 0) = number", () => {
+    const result = typeAliasParser("type Age(min: number = 0) = number");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.valueParams).toHaveLength(1);
+      const vp = result.result.valueParams![0];
+      expect(vp.name).toBe("min");
+      expect(vp.type).toMatchObject({ type: "primitiveType", value: "number" });
+      expect(vp.default).toMatchObject({ type: "number", value: "0" });
+    }
+  });
+
+  it("parses combined type + value params: type BoundedList<T>(n: number) = T[]", () => {
+    const result = typeAliasParser("type BoundedList<T>(n: number) = T[]");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.aliasName).toBe("BoundedList");
+      expect(result.result.typeParams).toEqual([{ name: "T" }]);
+      expect(result.result.valueParams).toHaveLength(1);
+      expect(result.result.valueParams?.[0].name).toBe("n");
+      expect(result.result.aliasedType.type).toBe("arrayType");
+    }
+  });
+
+  it("rejects reversed ordering: type Foo(x: number)<T> = ...", () => {
+    // After the `(x: number)` value-param block is consumed, the parser
+    // requires `=`. A leading `<` is not accepted, so this throws via
+    // the `parseError` guard wrapped around the alias body.
+    expect(() => typeAliasParser("type Foo(x: number)<T> = number")).toThrow();
+  });
+
+  it("non-value-parameterized alias has no valueParams field", () => {
+    const result = typeAliasParser("type Plain = string");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.valueParams).toBeUndefined();
+    }
+  });
+});
+
+describe("type-reference with value arguments", () => {
+  it("typeAliasVariableParser parses Age(18)", () => {
+    const result = typeAliasParser("type User = { age: Age(18) }");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.result.aliasedType.type).toBe("objectType");
+      const obj = result.result.aliasedType as {
+        type: "objectType";
+        properties: { key: string; value: any }[];
+      };
+      const ageVal = obj.properties[0].value;
+      expect(ageVal.type).toBe("typeAliasVariable");
+      expect(ageVal.aliasName).toBe("Age");
+      expect(ageVal.valueArgs).toHaveLength(1);
+      expect(ageVal.valueArgs[0]).toMatchObject({ type: "number", value: "18" });
+    }
+  });
+
+  it("typeAliasVariableParser parses NumberInRange(0, 150)", () => {
+    const result = typeAliasParser(
+      "type User = { score: NumberInRange(0, 150) }",
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const obj = result.result.aliasedType as any;
+      const v = obj.properties[0].value;
+      expect(v.type).toBe("typeAliasVariable");
+      expect(v.aliasName).toBe("NumberInRange");
+      expect(v.valueArgs).toHaveLength(2);
+      expect(v.valueArgs[0]).toMatchObject({ type: "number", value: "0" });
+      expect(v.valueArgs[1]).toMatchObject({ type: "number", value: "150" });
+    }
+  });
+
+  it("genericTypeParser parses BoundedList<string>(3)", () => {
+    const result = typeAliasParser(
+      "type Names = BoundedList<string>(3)",
+    );
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const v = result.result.aliasedType as any;
+      expect(v.type).toBe("genericType");
+      expect(v.name).toBe("BoundedList");
+      expect(v.typeArgs).toHaveLength(1);
+      expect(v.typeArgs[0]).toMatchObject({
+        type: "primitiveType",
+        value: "string",
+      });
+      expect(v.valueArgs).toHaveLength(1);
+      expect(v.valueArgs[0]).toMatchObject({ type: "number", value: "3" });
+    }
+  });
+
+  it("typeAliasVariableParser parses Age(DEFAULT_AGE) (identifier arg)", () => {
+    const result = typeAliasParser("type User = { age: Age(DEFAULT_AGE) }");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const obj = result.result.aliasedType as any;
+      const v = obj.properties[0].value;
+      expect(v.type).toBe("typeAliasVariable");
+      expect(v.valueArgs).toHaveLength(1);
+      expect(v.valueArgs[0]).toMatchObject({
+        type: "variableName",
+        value: "DEFAULT_AGE",
+      });
+    }
+  });
+
+  it("plain alias reference has no valueArgs", () => {
+    const result = typeAliasParser("type User = { email: Email }");
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const obj = result.result.aliasedType as any;
+      const v = obj.properties[0].value;
+      expect(v.type).toBe("typeAliasVariable");
+      expect(v.aliasName).toBe("Email");
+      expect(v.valueArgs).toBeUndefined();
+    }
+  });
+});

--- a/packages/agency-lang/lib/symbolTable.test.ts
+++ b/packages/agency-lang/lib/symbolTable.test.ts
@@ -75,6 +75,37 @@ def myFunc() {
     expect(symbols.Inner).toMatchObject({ kind: "type", name: "Inner" });
     expect(symbols.myFunc).toMatchObject({ kind: "function", name: "myFunc" });
   });
+
+  it("carries valueParams onto a value-parameterized TypeAlias entry", () => {
+    const symbols = parseAndClassify(`
+type Age(min: number) = number
+`);
+    const age = symbols.Age as any;
+    expect(age.kind).toBe("type");
+    expect(age.valueParams).toHaveLength(1);
+    expect(age.valueParams[0]).toMatchObject({
+      name: "min",
+      type: { type: "primitiveType", value: "number" },
+    });
+  });
+
+  it("carries multi-param valueParams onto a NumberInRange entry", () => {
+    const symbols = parseAndClassify(`
+type NumberInRange(low: number, high: number) = number
+`);
+    const r = symbols.NumberInRange as any;
+    expect(r.kind).toBe("type");
+    expect(r.valueParams).toHaveLength(2);
+    expect(r.valueParams[0].name).toBe("low");
+    expect(r.valueParams[1].name).toBe("high");
+  });
+
+  it("non-parameterized alias has no valueParams field", () => {
+    const symbols = parseAndClassify(`type Plain = string`);
+    const p = symbols.Plain as any;
+    expect(p.kind).toBe("type");
+    expect(p.valueParams).toBeUndefined();
+  });
 });
 
 describe("SymbolTable direct interrupt collection", () => {
@@ -393,6 +424,31 @@ describe("SymbolTable: re-export reachability and merging", () => {
       // Source's foo is on the first line (line 0)
       const sourceFoo = st.getFile(path.resolve(paths.source))!["foo"];
       expect(foo.loc).not.toEqual(sourceFoo.loc);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("propagates valueParams across re-exports of a value-parameterized alias", () => {
+    const { paths, cleanup } = withTempFiles({
+      source: `export type Age(min: number) = number`,
+      reexporter: `export { Age } from "@source@"`,
+    });
+    try {
+      const st = SymbolTable.build(paths.reexporter);
+      const reSyms = st.getFile(path.resolve(paths.reexporter))!;
+      const age = reSyms["Age"] as any;
+      expect(age.kind).toBe("type");
+      expect(age.exported).toBe(true);
+      expect(age.valueParams).toHaveLength(1);
+      expect(age.valueParams[0]).toMatchObject({
+        name: "min",
+        type: { type: "primitiveType", value: "number" },
+      });
+      expect(age.reExportedFrom).toEqual({
+        sourceFile: path.resolve(paths.source),
+        originalName: "Age",
+      });
     } finally {
       cleanup();
     }

--- a/packages/agency-lang/lib/symbolTable.ts
+++ b/packages/agency-lang/lib/symbolTable.ts
@@ -8,6 +8,7 @@ import type {
   FunctionParameter,
   Tag,
   TypeParam,
+  ValueParam,
   VariableType,
 } from "./types.js";
 import type { SourceLocation } from "./types/base.js";
@@ -69,6 +70,10 @@ export type TypeSymbol = {
   aliasedType: VariableType;
   /** Type parameters for generic aliases (e.g., `T` in `type Container<T> = ...`). */
   typeParams?: TypeParam[];
+  /** Value parameters for value-parameterized aliases (e.g. `low` and `high`
+   * in `type NumberInRange(low: number, high: number) = number`).
+   * Carried through imports/re-exports alongside `typeParams`. */
+  valueParams?: ValueParam[];
   /** `@validate(...)` / `@jsonSchema(...)` annotations declared above the alias.
    * Carried through imports/re-exports so annotation metadata flows across modules. */
   tags?: Tag[];
@@ -357,6 +362,7 @@ export function classifySymbols(program: AgencyProgram): FileSymbols {
           exported: !!node.exported,
           aliasedType: node.aliasedType,
           ...(node.typeParams ? { typeParams: node.typeParams } : {}),
+          ...(node.valueParams ? { valueParams: node.valueParams } : {}),
           ...(typeAliasTags[node.aliasName]?.length
             ? { tags: typeAliasTags[node.aliasName] }
             : {}),

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -161,12 +161,14 @@ function resolveTypeWithGuard(
     );
     // Apply value-arg substitution (no-op when the alias has no
     // `valueParams`). Type-param substitution happened first (above);
-    // value-arg substitution mutates only the tags carried on the
-    // alias entry.
+    // value-arg substitution must run on the type-substituted body so
+    // forwarded value args inside the body (e.g.
+    // `type Wrap<T>(n: number) = BoundedList<T>(n)`) get the literal
+    // substituted at use sites.
     const valueSubstituted = entry.valueParams
-      ? applyValueArgs(entry, vt.valueArgs, vt.name)
-      : entry;
-    const resolved = resolveTypeWithGuard(substituted, typeAliases, next);
+      ? applyValueArgs({ ...entry, body: substituted }, vt.valueArgs, vt.name)
+      : { ...entry, body: substituted };
+    const resolved = resolveTypeWithGuard(valueSubstituted.body, typeAliases, next);
     return attachAliasTags(resolved, valueSubstituted.tags);
   }
 

--- a/packages/agency-lang/lib/typeChecker/assignability.ts
+++ b/packages/agency-lang/lib/typeChecker/assignability.ts
@@ -3,6 +3,7 @@ import { ANY_T, BOOLEAN_T, NUMBER_T, STRING_T } from "./primitives.js";
 import { substituteTypeParams } from "./substitute.js";
 import { mapTypes } from "./typeWalker.js";
 import { mergeTagSets } from "./mergeTags.js";
+import { applyValueArgs } from "./valueParamSubstitution.js";
 
 /**
  * Public resolveType: normalizes a VariableType by resolving type-alias
@@ -68,18 +69,26 @@ function resolveTypeWithGuard(
     if (inProgress.has(vt.aliasName)) return vt;
     const next = new Set(inProgress).add(vt.aliasName);
 
-    if (entry.typeParams) {
-      const args = entry.typeParams.map((p) => p.default!);
+    // Apply value-arg substitution to the alias entry's tags (no-op
+    // when the alias has no `valueParams`). For combined `<T>(n)`
+    // aliases we still substitute type params first via the existing
+    // path below; value-arg substitution touches only the tags.
+    const substitutedEntry = entry.valueParams
+      ? applyValueArgs(entry, vt.valueArgs, vt.aliasName)
+      : entry;
+
+    if (substitutedEntry.typeParams) {
+      const args = substitutedEntry.typeParams.map((p) => p.default!);
       const substituted = substituteTypeParams(
-        entry.body,
-        entry.typeParams.map((p) => p.name),
+        substitutedEntry.body,
+        substitutedEntry.typeParams.map((p) => p.name),
         args,
       );
       const resolved = resolveTypeWithGuard(substituted, typeAliases, next);
-      return attachAliasTags(resolved, entry.tags);
+      return attachAliasTags(resolved, substitutedEntry.tags);
     }
-    const resolved = resolveTypeWithGuard(entry.body, typeAliases, next);
-    return attachAliasTags(resolved, entry.tags);
+    const resolved = resolveTypeWithGuard(substitutedEntry.body, typeAliases, next);
+    return attachAliasTags(resolved, substitutedEntry.tags);
   }
 
   if (vt.type === "genericType") {
@@ -150,8 +159,15 @@ function resolveTypeWithGuard(
       entry.typeParams.map((p) => p.name),
       args,
     );
+    // Apply value-arg substitution (no-op when the alias has no
+    // `valueParams`). Type-param substitution happened first (above);
+    // value-arg substitution mutates only the tags carried on the
+    // alias entry.
+    const valueSubstituted = entry.valueParams
+      ? applyValueArgs(entry, vt.valueArgs, vt.name)
+      : entry;
     const resolved = resolveTypeWithGuard(substituted, typeAliases, next);
-    return attachAliasTags(resolved, entry.tags);
+    return attachAliasTags(resolved, valueSubstituted.tags);
   }
 
   return vt;

--- a/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.test.ts
+++ b/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.test.ts
@@ -10,6 +10,7 @@ function scope(opts: Partial<JsonSchemaArgScope> = {}): JsonSchemaArgScope {
     topLevelConstNames: opts.topLevelConstNames ?? new Set(),
     importedNames: opts.importedNames ?? new Set(),
     topLevelFunctionNames: opts.topLevelFunctionNames ?? new Set(),
+    valueParamNames: opts.valueParamNames,
   };
 }
 
@@ -99,6 +100,52 @@ describe("validateJsonSchemaArg", () => {
     expect(validateJsonSchemaArg(binop, scope()).ok).toBe(false);
     const arr = { type: "agencyArray", items: [] } as any;
     expect(validateJsonSchemaArg(arr, scope()).ok).toBe(false);
+  });
+
+  it("accepts value-param identifiers when in scope", () => {
+    const r = validateJsonSchemaArg(
+      ident("low"),
+      scope({ valueParamNames: new Set(["low", "high"]) }),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects unbound value-param identifier when scope omits it", () => {
+    const r = validateJsonSchemaArg(ident("low"), scope());
+    expect(r.ok).toBe(false);
+  });
+
+  it("accepts PFA expression: foo.partial(n: 0)", () => {
+    const pfa: Expression = {
+      type: "valueAccess",
+      base: ident("min"),
+      chain: [
+        {
+          kind: "methodCall",
+          functionCall: {
+            type: "functionCall",
+            functionName: "partial",
+            arguments: [{ type: "namedArgument", name: "n", value: nm("0") }],
+          },
+        },
+      ],
+    } as any;
+    const r = validateJsonSchemaArg(
+      pfa,
+      scope({ topLevelFunctionNames: new Set(["min"]) }),
+    );
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects bare valueAccess with only property accesses", () => {
+    const expr: Expression = {
+      type: "valueAccess",
+      base: ident("foo"),
+      chain: [{ kind: "property", name: "bar" }],
+    } as any;
+    const r = validateJsonSchemaArg(expr, scope());
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/PFA expression/);
   });
 
   it("rejects string literals that contain interpolation segments", () => {

--- a/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.test.ts
+++ b/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.test.ts
@@ -137,6 +137,37 @@ describe("validateJsonSchemaArg", () => {
     expect(r.ok).toBe(true);
   });
 
+  it("rejects PFA whose base is a function-call (must be a plain identifier)", () => {
+    // `getMin(1).partial(n: 0)` — the receiver of `.partial(...)` is the
+    // result of a runtime call. PFA must be rooted at a plain identifier
+    // (a top-level validator or imported function), never at the result
+    // of another call. This mirrors `_identOrPfaParser` in the parser.
+    const pfa: Expression = {
+      type: "valueAccess",
+      base: {
+        type: "functionCall",
+        functionName: "getMin",
+        arguments: [nm("1")],
+      } as any,
+      chain: [
+        {
+          kind: "methodCall",
+          functionCall: {
+            type: "functionCall",
+            functionName: "partial",
+            arguments: [{ type: "namedArgument", name: "n", value: nm("0") }],
+          },
+        },
+      ],
+    } as any;
+    const r = validateJsonSchemaArg(
+      pfa,
+      scope({ topLevelFunctionNames: new Set(["getMin"]) }),
+    );
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/PFA base must be a plain identifier/);
+  });
+
   it("rejects bare valueAccess with only property accesses", () => {
     const expr: Expression = {
       type: "valueAccess",

--- a/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.test.ts
+++ b/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.test.ts
@@ -93,13 +93,43 @@ describe("validateJsonSchemaArg", () => {
     expect(r.ok).toBe(true);
   });
 
-  it("rejects ternary / binop / template / array literal", () => {
+  it("rejects ternary / binop", () => {
     const ternary = { type: "binOpExpression", op: "?" } as any;
     expect(validateJsonSchemaArg(ternary, scope()).ok).toBe(false);
     const binop = { type: "binOpExpression" } as any;
     expect(validateJsonSchemaArg(binop, scope()).ok).toBe(false);
-    const arr = { type: "agencyArray", items: [] } as any;
+  });
+
+  it("accepts array literals of allowed items (e.g. enum lists)", () => {
+    const arr = {
+      type: "agencyArray",
+      items: [
+        { type: "string", segments: [{ type: "text", value: "a" }] },
+        { type: "string", segments: [{ type: "text", value: "b" }] },
+      ],
+    } as any;
+    expect(validateJsonSchemaArg(arr, scope()).ok).toBe(true);
+  });
+
+  it("rejects array literals whose items are disallowed", () => {
+    const arr = {
+      type: "agencyArray",
+      items: [{ type: "binOpExpression" }],
+    } as any;
     expect(validateJsonSchemaArg(arr, scope()).ok).toBe(false);
+  });
+
+  it("accepts regex and unit literals (post-substitution leaves)", () => {
+    const re = { type: "regex", pattern: "abc", flags: "" } as any;
+    expect(validateJsonSchemaArg(re, scope()).ok).toBe(true);
+    const u = {
+      type: "unitLiteral",
+      value: "30",
+      unit: "s",
+      canonicalValue: 30000,
+      dimension: "time",
+    } as any;
+    expect(validateJsonSchemaArg(u, scope()).ok).toBe(true);
   });
 
   it("accepts value-param identifiers when in scope", () => {

--- a/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
+++ b/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
@@ -108,9 +108,20 @@ function validateValueAccess(
       loc: va.loc,
     };
   }
-  // Validate the base (must itself be allowed: typically an identifier
-  // referring to a top-level function or const).
-  const baseRes = validateJsonSchemaArg(va.base as Expression, scope);
+  // The base must be a plain identifier (typically a top-level
+  // validator function or imported function). Reject anything else —
+  // `foo(1).partial(...)` and `(get()).partial(...)` are NOT static
+  // expressions because they call a function at runtime to compute the
+  // receiver. This mirrors `_identOrPfaParser` in the parser layer.
+  if (va.base?.type !== "variableName") {
+    return {
+      ok: false,
+      reason:
+        "PFA base must be a plain identifier (e.g. `min.partial(n: 0)`, not `min(1).partial(...)`)",
+      loc: va.loc,
+    };
+  }
+  const baseRes = validateIdentifier(va.base as Expression, scope);
   if (!baseRes.ok) return baseRes;
   // Validate each method-call argument as a restricted expression.
   for (const el of va.chain) {

--- a/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
+++ b/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
@@ -4,6 +4,7 @@ import type {
   AgencyObjectKV,
   SplatExpression,
   AgencyProgram,
+  AgencyArray,
 } from "../types.js";
 import type { CompilationUnit } from "../compilationUnit.js";
 
@@ -58,10 +59,19 @@ export function validateJsonSchemaArg(
     case "number":
     case "boolean":
     case "null":
+    case "regex":
+    case "unitLiteral":
+      // Atomic literals — no inner expressions to validate. These can
+      // appear after value-arg substitution (e.g. `Timeout(30s)`
+      // substituting a unit literal into `{ maximum: ms }`) and must be
+      // accepted to stay in sync with `staticTagArgParser`.
       return { ok: true };
 
     case "agencyObject":
       return validateObjectLiteral(expr as AgencyObject, scope);
+
+    case "agencyArray":
+      return validateArrayLiteral(expr as AgencyArray, scope);
 
     case "functionCall":
       return validateFunctionCall(expr, scope);
@@ -189,6 +199,21 @@ function validateStringLiteral(
         loc: str.loc,
       };
     }
+  }
+  return { ok: true };
+}
+
+function validateArrayLiteral(
+  arr: AgencyArray,
+  scope: JsonSchemaArgScope,
+): JsonSchemaArgValidationResult {
+  for (const item of arr.items ?? []) {
+    const inner: Expression =
+      item.type === "splat"
+        ? ((item as SplatExpression).value as Expression)
+        : (item as Expression);
+    const r = validateJsonSchemaArg(inner, scope);
+    if (!r.ok) return r;
   }
   return { ok: true };
 }

--- a/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
+++ b/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
@@ -36,6 +36,15 @@ export type JsonSchemaArgScope = {
   importedNames: Set<string>;
   /** Names of top-level `def` functions. */
   topLevelFunctionNames: Set<string>;
+  /**
+   * Names of value parameters in scope for the current alias's tag
+   * arguments. When validating an alias's RAW tags (pre-substitution)
+   * the alias's own `valueParams` names go here so identifier
+   * references resolve cleanly. When validating tags AFTER
+   * `applyValueArgs` has run, this should be empty — any leftover
+   * value-param identifier is a bug, not a valid reference.
+   */
+  valueParamNames?: Set<string>;
 };
 
 export function validateJsonSchemaArg(
@@ -56,6 +65,9 @@ export function validateJsonSchemaArg(
     case "functionCall":
       return validateFunctionCall(expr, scope);
 
+    case "valueAccess":
+      return validateValueAccess(expr as any, scope);
+
     case "variableName":
       return validateIdentifier(expr, scope);
 
@@ -66,6 +78,56 @@ export function validateJsonSchemaArg(
         loc: (expr as any).loc,
       };
   }
+}
+
+/**
+ * Alias for `validateJsonSchemaArg` — the same restriction set applies
+ * to `@validate(...)` and `@jsonSchema(...)` tag arguments. Use this
+ * name in new call sites; the legacy export stays for compatibility.
+ */
+export const validateTagArg = validateJsonSchemaArg;
+
+/**
+ * Validate a PFA expression: a `valueAccess` whose chain contains at
+ * least one method-call element. A bare `valueAccess` with only
+ * property accesses (e.g. `foo.bar`) is rejected — member access is
+ * not in the restricted subset.
+ */
+function validateValueAccess(
+  va: { base: any; chain: any[]; loc?: { line: number; col: number } },
+  scope: JsonSchemaArgScope,
+): JsonSchemaArgValidationResult {
+  const hasMethodCall = (va.chain ?? []).some(
+    (el) => el && el.kind === "methodCall",
+  );
+  if (!hasMethodCall) {
+    return {
+      ok: false,
+      reason:
+        "tag arguments must be a literal, identifier, object literal, or PFA expression (e.g. min.partial(n: 0))",
+      loc: va.loc,
+    };
+  }
+  // Validate the base (must itself be allowed: typically an identifier
+  // referring to a top-level function or const).
+  const baseRes = validateJsonSchemaArg(va.base as Expression, scope);
+  if (!baseRes.ok) return baseRes;
+  // Validate each method-call argument as a restricted expression.
+  for (const el of va.chain) {
+    if (el?.kind !== "methodCall") continue;
+    const args = el.functionCall?.arguments ?? [];
+    for (const arg of args) {
+      const inner =
+        arg && arg.type === "namedArgument"
+          ? (arg as any).value
+          : arg && arg.type === "splat"
+            ? (arg as any).value
+            : arg;
+      const r = validateJsonSchemaArg(inner as Expression, scope);
+      if (!r.ok) return r;
+    }
+  }
+  return { ok: true };
 }
 
 function validateStringLiteral(
@@ -136,7 +198,12 @@ function validateIdentifier(
   scope: JsonSchemaArgScope,
 ): JsonSchemaArgValidationResult {
   const name: string = id.value;
-  if (scope.topLevelConstNames.has(name) || scope.importedNames.has(name)) {
+  if (
+    scope.topLevelConstNames.has(name) ||
+    scope.importedNames.has(name) ||
+    scope.topLevelFunctionNames.has(name) ||
+    (scope.valueParamNames && scope.valueParamNames.has(name))
+  ) {
     return { ok: true };
   }
   return {

--- a/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
+++ b/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
@@ -53,7 +53,8 @@ export function validateJsonSchemaArg(
 ): JsonSchemaArgValidationResult {
   switch (expr.type) {
     case "string":
-      return validateStringLiteral(expr as any);
+    case "multiLineString":
+      return validateStringLiteral(expr as any, scope);
     case "number":
     case "boolean":
     case "null":
@@ -142,15 +143,49 @@ function validateValueAccess(
 }
 
 function validateStringLiteral(
-  str: { segments?: Array<{ type: string }>; loc?: { line: number; col: number } },
+  str: {
+    segments?: Array<{
+      type: string;
+      expression?: Expression;
+    }>;
+    loc?: { line: number; col: number };
+  },
+  scope: JsonSchemaArgScope,
 ): JsonSchemaArgValidationResult {
   const segments = str.segments ?? [];
   for (const seg of segments) {
-    if (seg.type !== "text") {
+    if (seg.type === "text") continue;
+    if (seg.type !== "interpolation") {
+      return {
+        ok: false,
+        reason: `unexpected string segment type "${seg.type}" in @jsonSchema(...)`,
+        loc: str.loc,
+      };
+    }
+    // Identifier-only interpolation: the segment expression must be a
+    // bare `variableName` that resolves to one of the alias's value
+    // parameters. Top-level static consts are intentionally rejected
+    // here: tag-arg strings are emitted into the generated schema's
+    // `.meta(...)` chain, which is built inside node bodies where
+    // module-level Agency consts are not bound to JS identifiers
+    // (they live in `__ctx.globals`). Forwarding them would require
+    // an extra codegen lowering. Value-param identifiers are folded
+    // away at substitution time so the post-substitution string is
+    // always a plain literal.
+    const expr = seg.expression as Expression | undefined;
+    if (!expr || expr.type !== "variableName") {
       return {
         ok: false,
         reason:
-          "@jsonSchema(...) string arguments must be plain literals (no interpolation)",
+          "tag-arg string interpolation only accepts a value-param identifier (e.g. `${divisor}`); arbitrary expressions are not allowed",
+        loc: str.loc,
+      };
+    }
+    const name = (expr as Expression & { value: string }).value;
+    if (!scope.valueParamNames || !scope.valueParamNames.has(name)) {
+      return {
+        ok: false,
+        reason: `'${name}' is not a value parameter of this alias — only value-param identifiers may appear in tag-arg string interpolation`,
         loc: str.loc,
       };
     }

--- a/packages/agency-lang/lib/typeChecker/resolveTypeTags.test.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveTypeTags.test.ts
@@ -80,3 +80,90 @@ describe("resolveType — tag propagation", () => {
     expect((resolved as any).elementType.type).toBe("typeAliasVariable");
   });
 });
+
+describe("resolveType — value-parameterized aliases", () => {
+  const numType: any = { type: "primitiveType", value: "number" };
+  const numLit = (n: string): any => ({ type: "number", value: n });
+  const obj = (entries: any[]): any => ({ type: "agencyObject", entries });
+  const kv = (key: string, value: any) => ({ key, value });
+
+  it("substitutes value args into alias tags at use sites", () => {
+    const aliases: Record<string, TypeAliasEntry> = {
+      Age: {
+        body: { type: "primitiveType", value: "number" },
+        valueParams: [{ name: "min", type: numType }],
+        tags: [tag("jsonSchema", [obj([kv("minimum", ident("min"))])])],
+      },
+    };
+    const ref: VariableType = {
+      type: "typeAliasVariable",
+      aliasName: "Age",
+      valueArgs: [numLit("18")],
+    };
+    const resolved = resolveType(ref, aliases);
+    expect(resolved.tags).toHaveLength(1);
+    expect(resolved.tags?.[0].name).toBe("jsonSchema");
+    expect((resolved.tags?.[0].arguments[0] as any).entries[0].value).toEqual(
+      numLit("18"),
+    );
+  });
+
+  it("fills in defaults when fewer args are supplied", () => {
+    const aliases: Record<string, TypeAliasEntry> = {
+      NumberInRange: {
+        body: { type: "primitiveType", value: "number" },
+        valueParams: [
+          { name: "low", type: numType, default: numLit("0") },
+          { name: "high", type: numType, default: numLit("100") },
+        ],
+        tags: [
+          tag("jsonSchema", [
+            obj([
+              kv("minimum", ident("low")),
+              kv("maximum", ident("high")),
+            ]),
+          ]),
+        ],
+      },
+    };
+    const ref: VariableType = {
+      type: "typeAliasVariable",
+      aliasName: "NumberInRange",
+      valueArgs: [numLit("5")],
+    };
+    const resolved = resolveType(ref, aliases);
+    const entries = (resolved.tags?.[0].arguments[0] as any).entries;
+    expect(entries[0].value).toEqual(numLit("5"));
+    expect(entries[1].value).toEqual(numLit("100"));
+  });
+
+  it("combines type-param and value-arg substitution", () => {
+    const aliases: Record<string, TypeAliasEntry> = {
+      BoundedList: {
+        body: {
+          type: "arrayType",
+          elementType: { type: "typeAliasVariable", aliasName: "T" },
+        },
+        typeParams: [{ name: "T" }],
+        valueParams: [{ name: "n", type: numType }],
+        tags: [tag("jsonSchema", [obj([kv("maxItems", ident("n"))])])],
+      },
+    };
+    const ref: VariableType = {
+      type: "genericType",
+      name: "BoundedList",
+      typeArgs: [{ type: "primitiveType", value: "string" }],
+      valueArgs: [numLit("3")],
+    };
+    const resolved = resolveType(ref, aliases);
+    expect(resolved.type).toBe("arrayType");
+    expect((resolved as any).elementType).toEqual({
+      type: "primitiveType",
+      value: "string",
+    });
+    expect(resolved.tags).toHaveLength(1);
+    expect((resolved.tags?.[0].arguments[0] as any).entries[0].value).toEqual(
+      numLit("3"),
+    );
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/validate.ts
+++ b/packages/agency-lang/lib/typeChecker/validate.ts
@@ -1,4 +1,4 @@
-import { TypeAliasEntry, VariableType } from "../types.js";
+import { TypeAliasEntry, ValueParam, VariableType } from "../types.js";
 import { SourceLocation } from "../types/base.js";
 import { TypeCheckError } from "./types.js";
 import { visitTypes } from "./typeWalker.js";
@@ -9,6 +9,57 @@ const BUILTIN_GENERIC_ARITY: Record<string, number> = {
   Schema: 1,
   Record: 2,
 };
+
+/**
+ * Validate value-param arity at a use site. Pushes one error to `errors`
+ * if the arity is wrong. Returns true if a problem was reported.
+ */
+function checkValueArgsArity(
+  aliasName: string,
+  valueParams: ValueParam[] | undefined,
+  valueArgsLen: number,
+  context: string,
+  errors: TypeCheckError[],
+  loc: SourceLocation | undefined,
+): boolean {
+  // Use site has value args, but the alias takes no value params.
+  if ((!valueParams || valueParams.length === 0) && valueArgsLen > 0) {
+    errors.push({
+      message: `Type '${aliasName}' is not a value-parameterized type but was given ${valueArgsLen} value argument${valueArgsLen === 1 ? "" : "s"} (referenced in '${context}').`,
+      loc,
+    });
+    return true;
+  }
+  if (!valueParams) return false;
+
+  if (valueArgsLen > valueParams.length) {
+    errors.push({
+      message: `${aliasName} expects at most ${valueParams.length} value argument${valueParams.length === 1 ? "" : "s"}, got ${valueArgsLen} (referenced in '${context}').`,
+      loc,
+    });
+    return true;
+  }
+  // Each missing value arg must have a default.
+  for (let i = valueArgsLen; i < valueParams.length; i++) {
+    if (!valueParams[i].default) {
+      // Phrase the message based on whether ANY args were supplied.
+      if (valueArgsLen === 0) {
+        const formals = valueParams.map((p) => p.name).join(", ");
+        errors.push({
+          message: `'${aliasName}' is a value-parameterized type and requires value arguments — write '${aliasName}(${formals})' (referenced in '${context}').`,
+          loc,
+        });
+      } else {
+        errors.push({
+          message: `${aliasName} requires at least ${i + 1} value argument${i === 0 ? "" : "s"} (referenced in '${context}').`,
+          loc,
+        });
+      }
+      return true;
+    }
+  }
+  return false;
+}
 
 export function validateTypeReferences(
   vt: VariableType,
@@ -36,6 +87,19 @@ export function validateTypeReferences(
           loc,
         });
       }
+      // Bare reference to a value-parameterized alias is only legal if
+      // every value param has a default. `DivisibleBy` with no args when
+      // `DivisibleBy(divisor: number)` requires one must be flagged here
+      // — otherwise codegen blows up (e.g. `mapTypeToValidationSchema`)
+      // or the program crashes at runtime with `<Name> is not defined`.
+      checkValueArgsArity(
+        t.aliasName,
+        entry.valueParams,
+        t.valueArgs?.length ?? 0,
+        context,
+        errors,
+        loc,
+      );
       return;
     }
 
@@ -82,6 +146,17 @@ export function validateTypeReferences(
           return;
         }
       }
+      // Generic alias may also be value-parameterized (e.g.
+      // `BoundedList<T>(n)`). Validate the value-arg arity the same way
+      // we do for `typeAliasVariable`.
+      checkValueArgsArity(
+        t.name,
+        entry.valueParams,
+        t.valueArgs?.length ?? 0,
+        context,
+        errors,
+        loc,
+      );
     }
   });
 }

--- a/packages/agency-lang/lib/typeChecker/valueParamSubstitution.test.ts
+++ b/packages/agency-lang/lib/typeChecker/valueParamSubstitution.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyValueArgs,
+  substituteValueArgsInExpression,
+  substituteValueArgsInTag,
+  type ValueArgBindings,
+} from "./valueParamSubstitution.js";
+import type { Expression, Tag, TypeAliasEntry } from "../types.js";
+
+const nm = (n: string): Expression =>
+  ({ type: "number", value: n }) as any;
+const sc = (s: string): Expression =>
+  ({ type: "string", segments: [{ type: "text", value: s }] }) as any;
+const ident = (name: string): Expression =>
+  ({ type: "variableName", value: name }) as any;
+const obj = (entries: any[]): Expression =>
+  ({ type: "agencyObject", entries }) as any;
+const kv = (key: string, value: Expression) => ({ key, value });
+const splat = (value: Expression) => ({ type: "splat", value });
+const fcall = (name: string, args: any[]): Expression =>
+  ({ type: "functionCall", functionName: name, arguments: args }) as any;
+const named = (name: string, value: Expression) => ({
+  type: "namedArgument",
+  name,
+  value,
+});
+const va = (base: Expression, chain: any[]): Expression =>
+  ({ type: "valueAccess", base, chain }) as any;
+const methodCall = (name: string, args: any[]) => ({
+  kind: "methodCall",
+  functionCall: { type: "functionCall", functionName: name, arguments: args },
+});
+
+describe("substituteValueArgsInExpression", () => {
+  it("replaces a bare value-param identifier with a clone of the bound expression", () => {
+    const bindings: ValueArgBindings = { low: nm("0") };
+    const out = substituteValueArgsInExpression(ident("low"), bindings);
+    expect(out).toEqual(nm("0"));
+    // Ensure clone, not same reference (otherwise a future mutation could leak).
+    expect(out).not.toBe(bindings.low);
+  });
+
+  it("leaves identifiers not in bindings unchanged", () => {
+    const e = ident("DEFAULT_AGE");
+    const out = substituteValueArgsInExpression(e, { low: nm("0") });
+    expect(out).toBe(e);
+  });
+
+  it("returns literals unchanged", () => {
+    const a = nm("5");
+    const b = sc("hello");
+    expect(substituteValueArgsInExpression(a, { low: nm("0") })).toBe(a);
+    expect(substituteValueArgsInExpression(b, { low: nm("0") })).toBe(b);
+  });
+
+  it("substitutes an identifier inside an object value", () => {
+    const e = obj([kv("minimum", ident("low")), kv("format", sc("email"))]);
+    const out = substituteValueArgsInExpression(e, { low: nm("0") });
+    expect(out).toEqual(
+      obj([kv("minimum", nm("0")), kv("format", sc("email"))]),
+    );
+  });
+
+  it("substitutes an identifier inside a spread", () => {
+    const e = obj([splat(ident("low"))]);
+    const out = substituteValueArgsInExpression(e, { low: ident("other") });
+    expect(out).toEqual(obj([splat(ident("other"))]));
+  });
+
+  it("substitutes an identifier inside a nested object", () => {
+    const e = obj([
+      kv(
+        "outer",
+        obj([kv("inner", ident("low")), kv("static", sc("k"))]),
+      ),
+    ]);
+    const out = substituteValueArgsInExpression(e, { low: nm("42") });
+    expect(out).toEqual(
+      obj([
+        kv("outer", obj([kv("inner", nm("42")), kv("static", sc("k"))])),
+      ]),
+    );
+  });
+
+  it("substitutes an identifier inside a PFA .partial(n: low) arg", () => {
+    const e = va(ident("min"), [
+      methodCall("partial", [named("n", ident("low"))]),
+    ]);
+    const out = substituteValueArgsInExpression(e, { low: nm("3") });
+    expect(out).toEqual(
+      va(ident("min"), [methodCall("partial", [named("n", nm("3"))])]),
+    );
+  });
+
+  it("returns equal-but-not-same tree when no substitution applies", () => {
+    const e = obj([kv("a", nm("1"))]);
+    const out = substituteValueArgsInExpression(e, { unused: nm("0") });
+    // structurally equal
+    expect(out).toEqual(e);
+  });
+
+  it("does not mutate the input expression", () => {
+    const inner = ident("low");
+    const e = obj([kv("k", inner)]);
+    const before = JSON.parse(JSON.stringify(e));
+    substituteValueArgsInExpression(e, { low: nm("9") });
+    expect(e).toEqual(before);
+  });
+});
+
+describe("substituteValueArgsInTag", () => {
+  it("replaces value-param identifiers in tag arguments", () => {
+    const tag: Tag = {
+      type: "tag",
+      name: "jsonSchema",
+      arguments: [obj([kv("minimum", ident("low")), kv("maximum", ident("high"))])],
+    } as any;
+    const out = substituteValueArgsInTag(tag, {
+      low: nm("0"),
+      high: nm("100"),
+    });
+    expect(out.arguments).toEqual([
+      obj([kv("minimum", nm("0")), kv("maximum", nm("100"))]),
+    ]);
+    // Original untouched
+    expect((tag.arguments[0] as any).entries[0].value).toEqual(ident("low"));
+  });
+
+  it("handles PFA validators with value-param refs in @validate", () => {
+    const tag: Tag = {
+      type: "tag",
+      name: "validate",
+      arguments: [
+        va(ident("min"), [methodCall("partial", [named("n", ident("low"))])]),
+        va(ident("max"), [methodCall("partial", [named("n", ident("high"))])]),
+      ],
+    } as any;
+    const out = substituteValueArgsInTag(tag, {
+      low: nm("0"),
+      high: nm("150"),
+    });
+    expect(out.arguments).toEqual([
+      va(ident("min"), [methodCall("partial", [named("n", nm("0"))])]),
+      va(ident("max"), [methodCall("partial", [named("n", nm("150"))])]),
+    ]);
+  });
+});
+
+const numType = { type: "primitiveType", value: "number" } as any;
+const strType = { type: "primitiveType", value: "string" } as any;
+
+function entry(opts: {
+  valueParams?: any[];
+  tags?: Tag[];
+}): TypeAliasEntry {
+  return {
+    body: numType,
+    valueParams: opts.valueParams,
+    tags: opts.tags,
+  };
+}
+
+const jsonSchemaTag = (entries: any[]): Tag =>
+  ({
+    type: "tag",
+    name: "jsonSchema",
+    arguments: [obj(entries)],
+  }) as any;
+
+describe("applyValueArgs", () => {
+  it("substitutes a single value-param into the alias's tags (happy path)", () => {
+    const e = entry({
+      valueParams: [{ name: "low", type: numType }],
+      tags: [jsonSchemaTag([kv("minimum", ident("low"))])],
+    });
+    const out = applyValueArgs(e, [nm("0")], "Age");
+    expect(out.tags).toEqual([
+      jsonSchemaTag([kv("minimum", nm("0"))]),
+    ]);
+    // Original entry tags untouched
+    expect(e.tags?.[0].arguments[0]).toEqual(
+      obj([kv("minimum", ident("low"))]),
+    );
+  });
+
+  it("fills missing tail args from defaults", () => {
+    const e = entry({
+      valueParams: [
+        { name: "low", type: numType, default: nm("0") },
+        { name: "high", type: numType, default: nm("150") },
+      ],
+      tags: [
+        jsonSchemaTag([
+          kv("minimum", ident("low")),
+          kv("maximum", ident("high")),
+        ]),
+      ],
+    });
+    const out = applyValueArgs(e, [nm("18")], "Age");
+    expect(out.tags).toEqual([
+      jsonSchemaTag([kv("minimum", nm("18")), kv("maximum", nm("150"))]),
+    ]);
+  });
+
+  it("uses all defaults when no args are passed", () => {
+    const e = entry({
+      valueParams: [{ name: "min", type: numType, default: nm("0") }],
+      tags: [jsonSchemaTag([kv("minimum", ident("min"))])],
+    });
+    const out = applyValueArgs(e, [], "Age");
+    expect(out.tags).toEqual([
+      jsonSchemaTag([kv("minimum", nm("0"))]),
+    ]);
+  });
+
+  it("errors on too many args", () => {
+    const e = entry({
+      valueParams: [{ name: "low", type: numType }],
+    });
+    expect(() => applyValueArgs(e, [nm("0"), nm("1")], "Age")).toThrow(
+      /Age expects 1 value arguments, got 2/,
+    );
+  });
+
+  it("errors when a required defaultless param is missing", () => {
+    const e = entry({
+      valueParams: [{ name: "low", type: numType }],
+    });
+    expect(() => applyValueArgs(e, [], "Age")).toThrow(
+      /Age requires 'low': number/,
+    );
+  });
+
+  it("errors on arg-type mismatch for literals", () => {
+    const e = entry({
+      valueParams: [{ name: "low", type: numType }],
+    });
+    expect(() => applyValueArgs(e, [sc("hi")], "Age")).toThrow(
+      /argument low expected number, got string/,
+    );
+  });
+
+  it("accepts non-literal args without trying to type-check", () => {
+    const e = entry({
+      valueParams: [{ name: "low", type: numType }],
+      tags: [jsonSchemaTag([kv("minimum", ident("low"))])],
+    });
+    // Identifier — we can't infer its type, so we accept it.
+    const out = applyValueArgs(e, [ident("DEFAULT_AGE")], "Age");
+    expect(out.tags).toEqual([
+      jsonSchemaTag([kv("minimum", ident("DEFAULT_AGE"))]),
+    ]);
+  });
+
+  it("returns entry unchanged when alias has no tags", () => {
+    const e = entry({ valueParams: [{ name: "low", type: numType }] });
+    const out = applyValueArgs(e, [nm("0")], "Age");
+    expect(out.tags).toEqual([]);
+  });
+
+  it("accepts string args matching declared string type", () => {
+    const e = entry({
+      valueParams: [{ name: "pat", type: strType }],
+      tags: [jsonSchemaTag([kv("pattern", ident("pat"))])],
+    });
+    const out = applyValueArgs(e, [sc("[a-z]+")], "MatchesPattern");
+    expect(out.tags).toEqual([
+      jsonSchemaTag([kv("pattern", sc("[a-z]+"))]),
+    ]);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
+++ b/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
@@ -24,10 +24,9 @@ import type {
 export type ValueArgBindings = Record<string, Expression>;
 
 /**
- * True when `vt` is a reference to a value-parameterized alias with
- * use-site value args (i.e. the alias was declared
- * `type Foo(low: number) = ...` and the reference is `Foo(0)`, not bare
- * `Foo`).
+ * True when `vt` is a reference to a value-parameterized alias —
+ * either with explicit use-site value args (`Foo(18)`) or as a bare
+ * reference (`Foo`) on an alias whose value params all have defaults.
  *
  * This is the single canonical predicate for "this reference needs
  * inline-at-use-site emission and `applyValueArgs` substitution". The
@@ -36,12 +35,11 @@ export type ValueArgBindings = Record<string, Expression>;
  * should all use this — keeping the divergence rule expressed in
  * exactly one place.
  *
- * NOTE: a bare `Foo` reference (no use-site value args) on a
- * value-parameterized alias returns `false`. The current invariant is
- * that bare references to value-parameterized aliases don't make sense
- * (there's no single schema/descriptor for them) and the type checker
- * rejects them — but if either side is missing this predicate returns
- * false so the bare-alias path is taken (which will fail clearly).
+ * Why bare refs count too: a value-parameterized alias never emits a
+ * top-level schema const (there's no single schema without args), so
+ * even bare uses must be inlined. `applyValueArgs` handles the
+ * missing-args case by filling defaults or throwing a clear error if a
+ * required (defaultless) param was omitted.
  */
 export function isValueParamInstantiation(
   vt: VariableType,
@@ -50,7 +48,7 @@ export function isValueParamInstantiation(
   return (
     (vt.type === "typeAliasVariable" || vt.type === "genericType") &&
     !!entry?.valueParams &&
-    !!(vt as { valueArgs?: Expression[] }).valueArgs
+    entry.valueParams.length > 0
   );
 }
 
@@ -259,6 +257,12 @@ function substituteInChainElement(
  * Expression subset accepted in tag args is plain data: no functions,
  * no cycles. Suffices for the cases we care about (literals, object
  * literals, PFA expressions).
+ *
+ * PFA support is verified by the unit tests
+ * `substitutes an identifier inside a PFA .partial(n: low) arg` and
+ * `handles PFA validators with value-param refs in @validate`, plus
+ * the e2e fixture `valueParamWrappingAlias.agency` which exercises a
+ * PFA-bearing alias through resolveType → codegen → runtime.
  */
 function cloneExpression(expr: Expression): Expression {
   return JSON.parse(JSON.stringify(expr)) as Expression;
@@ -516,6 +520,20 @@ function checkType(
       for (const p of vt.params) checkType(p.typeAnnotation, paramNames, aliasName);
       checkType(vt.returnType, paramNames, aliasName);
       break;
+    // Leaf types: no inner valueArgs to inspect. Explicit cases plus a
+    // `never`-typed default keep this exhaustive — TypeScript will fail
+    // to compile if a new VariableType variant is added without a case.
+    case "primitiveType":
+    case "stringLiteralType":
+    case "numberLiteralType":
+    case "booleanLiteralType":
+    case "functionRefType":
+      break;
+    default: {
+      const _exhaustive: never = vt;
+      void _exhaustive;
+      break;
+    }
   }
 }
 
@@ -594,10 +612,21 @@ export function substituteValueArgsInType(
         })),
         returnType: substituteValueArgsInType(vt.returnType, bindings),
       };
-    default:
-      // primitiveType, stringLiteralType, numberLiteralType,
-      // booleanLiteralType, functionRefType — no inner VariableType /
-      // valueArgs to walk.
+    // primitiveType, stringLiteralType, numberLiteralType,
+    // booleanLiteralType, functionRefType — no inner VariableType /
+    // valueArgs to walk. The explicit `never`-typed default below
+    // forces TypeScript to flag a compile error if a new VariableType
+    // variant is added without a case here.
+    case "primitiveType":
+    case "stringLiteralType":
+    case "numberLiteralType":
+    case "booleanLiteralType":
+    case "functionRefType":
       return vt;
+    default: {
+      const _exhaustive: never = vt;
+      void _exhaustive;
+      return vt;
+    }
   }
 }

--- a/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
+++ b/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
@@ -24,6 +24,37 @@ import type {
 export type ValueArgBindings = Record<string, Expression>;
 
 /**
+ * True when `vt` is a reference to a value-parameterized alias with
+ * use-site value args (i.e. the alias was declared
+ * `type Foo(low: number) = ...` and the reference is `Foo(0)`, not bare
+ * `Foo`).
+ *
+ * This is the single canonical predicate for "this reference needs
+ * inline-at-use-site emission and `applyValueArgs` substitution". The
+ * three codegen branches that diverge from the bare-alias path
+ * (`typeToZodSchema`, `validationDescriptor`, `hasAnyValidateTag`)
+ * should all use this — keeping the divergence rule expressed in
+ * exactly one place.
+ *
+ * NOTE: a bare `Foo` reference (no use-site value args) on a
+ * value-parameterized alias returns `false`. The current invariant is
+ * that bare references to value-parameterized aliases don't make sense
+ * (there's no single schema/descriptor for them) and the type checker
+ * rejects them — but if either side is missing this predicate returns
+ * false so the bare-alias path is taken (which will fail clearly).
+ */
+export function isValueParamInstantiation(
+  vt: VariableType,
+  entry: TypeAliasEntry | undefined,
+): boolean {
+  return (
+    (vt.type === "typeAliasVariable" || vt.type === "genericType") &&
+    !!entry?.valueParams &&
+    !!(vt as { valueArgs?: Expression[] }).valueArgs
+  );
+}
+
+/**
  * Walk a `Tag` (specifically its `arguments` list) and return a fresh
  * Tag whose arguments have every value-parameter `variableName`
  * reference replaced with a structural CLONE of the bound expression.
@@ -336,11 +367,156 @@ export function applyValueArgs(
 
   const newBody = substituteValueArgsInType(entry.body, bindings);
 
+  // Defense in depth: after substitution, no tag argument or nested
+  // valueArg should still reference one of this alias's value-param
+  // names. If any do, substitution missed a spot — surface it loudly
+  // here rather than letting an out-of-scope identifier leak into the
+  // generated TypeScript.
+  const paramNames = new Set(params.map((p) => p.name));
+  if (paramNames.size > 0) {
+    assertNoUnsubstitutedValueParams(newTags, newBody, paramNames, aliasName);
+  }
+
   return {
     ...entry,
     body: newBody,
     tags: newTags,
   };
+}
+
+/**
+ * Walk substituted tags + body looking for any `variableName` whose
+ * `value` is still in `paramNames`. Throws with a precise location if
+ * found. Called from `applyValueArgs` as a safety net — should never
+ * trigger in correct code.
+ */
+function assertNoUnsubstitutedValueParams(
+  tags: Tag[],
+  body: VariableType,
+  paramNames: Set<string>,
+  aliasName: string,
+): void {
+  for (const t of tags) {
+    for (const arg of t.arguments) {
+      checkExpr(arg, paramNames, aliasName, t.name);
+    }
+  }
+  checkType(body, paramNames, aliasName);
+}
+
+function checkExpr(
+  e: Expression,
+  paramNames: Set<string>,
+  aliasName: string,
+  tagName: string,
+): void {
+  if (!e || typeof e !== "object") return;
+  if (e.type === "variableName" && paramNames.has((e as { value: string }).value)) {
+    throw new Error(
+      `value param '${(e as { value: string }).value}' left unsubstituted in @${tagName} on ${aliasName}`,
+    );
+  }
+  switch (e.type) {
+    case "agencyObject":
+      for (const entry of (e as AgencyObject).entries) {
+        if ("key" in entry) {
+          checkExpr(
+            (entry as AgencyObjectKV).value,
+            paramNames,
+            aliasName,
+            tagName,
+          );
+        } else {
+          checkExpr(
+            (entry as SplatExpression).value as Expression,
+            paramNames,
+            aliasName,
+            tagName,
+          );
+        }
+      }
+      break;
+    case "valueAccess": {
+      const va = e as ValueAccess;
+      checkExpr(va.base as Expression, paramNames, aliasName, tagName);
+      for (const el of (va.chain ?? []) as AccessChainElement[]) {
+        const fc = (el as { functionCall?: FunctionCall }).functionCall;
+        if (fc) {
+          checkFunctionCallArgs(fc, paramNames, aliasName, tagName);
+        }
+      }
+      break;
+    }
+    case "functionCall":
+      checkFunctionCallArgs(e as FunctionCall, paramNames, aliasName, tagName);
+      break;
+  }
+}
+
+function checkFunctionCallArgs(
+  fc: FunctionCall,
+  paramNames: Set<string>,
+  aliasName: string,
+  tagName: string,
+): void {
+  for (const a of fc.arguments ?? []) {
+    if (a.type === "namedArgument") {
+      checkExpr((a as NamedArgument).value, paramNames, aliasName, tagName);
+    } else if (a.type === "splat") {
+      checkExpr(
+        (a as SplatExpression).value as Expression,
+        paramNames,
+        aliasName,
+        tagName,
+      );
+    } else {
+      checkExpr(a as Expression, paramNames, aliasName, tagName);
+    }
+  }
+}
+
+function checkType(
+  vt: VariableType,
+  paramNames: Set<string>,
+  aliasName: string,
+): void {
+  switch (vt.type) {
+    case "typeAliasVariable":
+      if (vt.valueArgs) {
+        for (const a of vt.valueArgs) {
+          checkExpr(a, paramNames, aliasName, "<valueArg>");
+        }
+      }
+      break;
+    case "genericType":
+      for (const t of vt.typeArgs) checkType(t, paramNames, aliasName);
+      if (vt.valueArgs) {
+        for (const a of vt.valueArgs) {
+          checkExpr(a, paramNames, aliasName, "<valueArg>");
+        }
+      }
+      break;
+    case "arrayType":
+      checkType(vt.elementType, paramNames, aliasName);
+      break;
+    case "unionType":
+      for (const t of vt.types) checkType(t, paramNames, aliasName);
+      break;
+    case "objectType":
+      for (const p of vt.properties) checkType(p.value, paramNames, aliasName);
+      break;
+    case "resultType":
+      checkType(vt.successType, paramNames, aliasName);
+      checkType(vt.failureType, paramNames, aliasName);
+      break;
+    case "schemaType":
+      checkType(vt.inner, paramNames, aliasName);
+      break;
+    case "blockType":
+      for (const p of vt.params) checkType(p.typeAnnotation, paramNames, aliasName);
+      checkType(vt.returnType, paramNames, aliasName);
+      break;
+  }
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
+++ b/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
@@ -99,6 +99,9 @@ export function substituteValueArgsInExpression(
       if (bound !== undefined) return cloneExpression(bound);
       return expr;
     }
+    case "string":
+    case "multiLineString":
+      return substituteInString(expr, bindings);
     case "agencyObject":
       return substituteInObject(expr, bindings);
     case "agencyArray":
@@ -108,9 +111,109 @@ export function substituteValueArgsInExpression(
     case "valueAccess":
       return substituteInValueAccess(expr, bindings);
     default:
-      // Literals (number, string, boolean, null) and anything else not
-      // in the restricted tag-arg subset are returned as-is.
+      // Literals (number, boolean, null) and anything else not in the
+      // restricted tag-arg subset are returned as-is.
       return expr;
+  }
+}
+
+/**
+ * Substitute identifier-only `${name}` interpolation segments inside a
+ * tag-arg string literal. If the identifier is bound, we render its
+ * value as text and fuse adjacent text segments together. Unbound
+ * identifiers (typically references to top-level static consts) are
+ * left as-is so they survive to codegen as TS template `${ident}`.
+ */
+function substituteInString(
+  // Use a loose shape because both `string` and `multiLineString`
+  // Expressions share the same `segments` field.
+  expr: Expression,
+  bindings: ValueArgBindings,
+): Expression {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const lit = expr as any;
+  const segments = lit.segments as Array<
+    | { type: "text"; value: string }
+    | { type: "interpolation"; expression: Expression }
+  >;
+  // Fast path: nothing to substitute.
+  const hasBoundInterp = segments.some(
+    (s) =>
+      s.type === "interpolation" &&
+      s.expression.type === "variableName" &&
+      bindings[s.expression.value] !== undefined,
+  );
+  if (!hasBoundInterp) return expr;
+  const out: typeof segments = [];
+  for (const seg of segments) {
+    if (seg.type === "text") {
+      pushText(out, seg.value);
+      continue;
+    }
+    if (seg.expression.type !== "variableName") {
+      // Non-identifier interpolation slot — the parser rejects this,
+      // but be defensive and just pass it through.
+      out.push(seg);
+      continue;
+    }
+    const bound = bindings[seg.expression.value];
+    if (bound === undefined) {
+      // Not a value-param: leave interpolation for codegen.
+      out.push(seg);
+      continue;
+    }
+    const text = literalToText(bound);
+    if (text !== undefined) {
+      pushText(out, text);
+    } else {
+      // Bound to a non-literal expression (e.g. another identifier
+      // forwarded from a wrapping alias) — keep the interpolation but
+      // with the substituted expression in the slot.
+      out.push({ type: "interpolation", expression: cloneExpression(bound) });
+    }
+  }
+  return { ...lit, segments: out } as Expression;
+}
+
+function pushText(
+  out: Array<
+    | { type: "text"; value: string }
+    | { type: "interpolation"; expression: Expression }
+  >,
+  value: string,
+): void {
+  const last = out[out.length - 1];
+  if (last && last.type === "text") {
+    last.value += value;
+  } else {
+    out.push({ type: "text", value });
+  }
+}
+
+function literalToText(expr: Expression): string | undefined {
+  switch (expr.type) {
+    case "number":
+      return (expr as Expression & { value: string }).value;
+    case "boolean":
+      return String((expr as Expression & { value: boolean }).value);
+    case "null":
+      return "null";
+    case "string":
+    case "multiLineString": {
+      // Only inline if every segment is already text; otherwise leave
+      // the substitution to the next layer.
+      const lit = expr as Expression & {
+        segments: Array<{ type: string; value?: string }>;
+      };
+      let raw = "";
+      for (const s of lit.segments) {
+        if (s.type !== "text") return undefined;
+        raw += s.value ?? "";
+      }
+      return raw;
+    }
+    default:
+      return undefined;
   }
 }
 

--- a/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
+++ b/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
@@ -576,6 +576,28 @@ function checkExpr(
     case "functionCall":
       checkFunctionCallArgs(e as FunctionCall, paramNames, aliasName, tagName);
       break;
+    case "agencyArray":
+      for (const item of (e as AgencyArray).items ?? []) {
+        if (item.type === "splat") {
+          checkExpr(
+            (item as SplatExpression).value as Expression,
+            paramNames,
+            aliasName,
+            tagName,
+          );
+        } else {
+          checkExpr(item as Expression, paramNames, aliasName, tagName);
+        }
+      }
+      break;
+    case "string":
+    case "multiLineString":
+      for (const seg of (e as { segments?: Array<{ type: string; expression?: Expression }> }).segments ?? []) {
+        if (seg.type === "interpolation" && seg.expression) {
+          checkExpr(seg.expression, paramNames, aliasName, tagName);
+        }
+      }
+      break;
   }
 }
 

--- a/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
+++ b/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
@@ -393,6 +393,21 @@ function inferLiteralType(expr: Expression): string | undefined {
       return "boolean";
     case "null":
       return "null";
+    case "unitLiteral":
+      // All unit literals collapse to a number at the IR level
+      // (`canonicalValue`). Treat them as `number` for declared-type
+      // matching so `(t: number)` accepts `30s`, `(c: number)` accepts
+      // `$5`, etc.
+      return "number";
+    case "regex":
+      // Surface as `regex` so users can declare `(pat: regex)` and
+      // get a real arity check. Mismatched declarations (e.g.
+      // `(pat: string)` paired with `re/.../`) raise a clear error.
+      return "regex";
+    case "agencyArray":
+      return "array";
+    case "agencyObject":
+      return "object";
     default:
       return undefined;
   }
@@ -404,6 +419,10 @@ function variableTypeName(t: unknown): string {
   if (node.type === "primitiveType" && typeof node.value === "string") {
     return node.value;
   }
+  // Surface common compound shapes by a stable short name so the
+  // best-effort literal check matches against `inferLiteralType`.
+  if (node.type === "arrayType") return "array";
+  if (node.type === "objectType") return "object";
   return node.type ?? "?";
 }
 

--- a/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
+++ b/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
@@ -1,0 +1,427 @@
+import type {
+  AgencyArray,
+  AgencyObject,
+  AgencyObjectKV,
+  Expression,
+  FunctionCall,
+  NamedArgument,
+  SplatExpression,
+  Tag,
+  TypeAliasEntry,
+  ValueAccess,
+  AccessChainElement,
+  VariableType,
+} from "../types.js";
+
+/**
+ * Bindings map: value-parameter name → use-site Expression that should
+ * replace any `variableName` reference to that param inside the alias's
+ * tag-argument expressions.
+ *
+ * Example: for `Age(18)` instantiating `type Age(min: number) = number`
+ * the bindings are `{ min: <numberLiteral 18> }`.
+ */
+export type ValueArgBindings = Record<string, Expression>;
+
+/**
+ * Walk a `Tag` (specifically its `arguments` list) and return a fresh
+ * Tag whose arguments have every value-parameter `variableName`
+ * reference replaced with a structural CLONE of the bound expression.
+ *
+ * The input tag is not mutated. The returned tag shares no Expression
+ * nodes with the input, so callers may further substitute or attach
+ * additional tags without aliasing.
+ */
+export function substituteValueArgsInTag(
+  tag: Tag,
+  bindings: ValueArgBindings,
+): Tag {
+  return {
+    ...tag,
+    arguments: tag.arguments.map((a) =>
+      substituteValueArgsInExpression(a, bindings),
+    ),
+  };
+}
+
+/**
+ * Recursively walk an Expression tree, replacing any `variableName`
+ * whose `value` matches a key in `bindings` with a structural CLONE
+ * of the bound expression. All other nodes are returned unchanged
+ * (deep-cloned only along the spine that contains a substitution
+ * target — leaves not in `bindings` reuse the original node, but the
+ * containing array/object is rebuilt so the caller sees a fresh tree
+ * along the substitution path).
+ *
+ * For nodes outside the restricted tag-arg subset this is a no-op
+ * passthrough: only literals, identifiers, object literals (with
+ * splats), valueAccess chains, and function-call arg lists inside
+ * PFAs are descended into. Anything else (binops, ternaries, etc.)
+ * is returned unchanged because the tag-arg parser would have
+ * rejected it before substitution is ever reached.
+ */
+export function substituteValueArgsInExpression(
+  expr: Expression,
+  bindings: ValueArgBindings,
+): Expression {
+  switch (expr.type) {
+    case "variableName": {
+      const bound = bindings[expr.value];
+      if (bound !== undefined) return cloneExpression(bound);
+      return expr;
+    }
+    case "agencyObject":
+      return substituteInObject(expr, bindings);
+    case "agencyArray":
+      return substituteInArray(expr, bindings);
+    case "functionCall":
+      return substituteInFunctionCall(expr, bindings);
+    case "valueAccess":
+      return substituteInValueAccess(expr, bindings);
+    default:
+      // Literals (number, string, boolean, null) and anything else not
+      // in the restricted tag-arg subset are returned as-is.
+      return expr;
+  }
+}
+
+function substituteInObject(
+  obj: AgencyObject,
+  bindings: ValueArgBindings,
+): AgencyObject {
+  return {
+    ...obj,
+    entries: obj.entries.map((entry) => {
+      if ("key" in entry) {
+        const kv = entry as AgencyObjectKV;
+        return {
+          ...kv,
+          value: substituteValueArgsInExpression(kv.value, bindings),
+        };
+      }
+      const sp = entry as SplatExpression;
+      return {
+        ...sp,
+        value: substituteValueArgsInExpression(sp.value, bindings),
+      };
+    }),
+  };
+}
+
+function substituteInArray(
+  arr: AgencyArray,
+  bindings: ValueArgBindings,
+): AgencyArray {
+  return {
+    ...arr,
+    items: arr.items.map((item) => {
+      if (item.type === "splat") {
+        return {
+          ...item,
+          value: substituteValueArgsInExpression(item.value, bindings),
+        };
+      }
+      return substituteValueArgsInExpression(item, bindings);
+    }),
+  };
+}
+
+function substituteInFunctionCall(
+  call: FunctionCall,
+  bindings: ValueArgBindings,
+): FunctionCall {
+  return {
+    ...call,
+    arguments: (call.arguments ?? []).map((a) => {
+      if (a.type === "namedArgument") {
+        const na = a as NamedArgument;
+        return {
+          ...na,
+          value: substituteValueArgsInExpression(na.value, bindings),
+        };
+      }
+      if (a.type === "splat") {
+        const sp = a as SplatExpression;
+        return {
+          ...sp,
+          value: substituteValueArgsInExpression(sp.value, bindings),
+        };
+      }
+      return substituteValueArgsInExpression(a as Expression, bindings);
+    }),
+  };
+}
+
+function substituteInValueAccess(
+  va: ValueAccess,
+  bindings: ValueArgBindings,
+): ValueAccess {
+  return {
+    ...va,
+    base: substituteValueArgsInExpression(
+      va.base as Expression,
+      bindings,
+    ) as unknown as ValueAccess["base"],
+    chain: va.chain.map((el) => substituteInChainElement(el, bindings)),
+  };
+}
+
+function substituteInChainElement(
+  el: AccessChainElement,
+  bindings: ValueArgBindings,
+): AccessChainElement {
+  if (el.kind === "property") return el;
+  if (el.kind === "index") {
+    return {
+      ...el,
+      index: substituteValueArgsInExpression(el.index, bindings),
+    };
+  }
+  if (el.kind === "slice") {
+    return {
+      ...el,
+      start: el.start
+        ? substituteValueArgsInExpression(el.start, bindings)
+        : el.start,
+      end: el.end
+        ? substituteValueArgsInExpression(el.end, bindings)
+        : el.end,
+    };
+  }
+  if (el.kind === "methodCall") {
+    return {
+      ...el,
+      functionCall: substituteInFunctionCall(el.functionCall, bindings),
+    };
+  }
+  if (el.kind === "call") {
+    return {
+      ...el,
+      arguments: (el.arguments ?? []).map((a) => {
+        if (a.type === "namedArgument") {
+          const na = a as NamedArgument;
+          return {
+            ...na,
+            value: substituteValueArgsInExpression(na.value, bindings),
+          };
+        }
+        if (a.type === "splat") {
+          const sp = a as SplatExpression;
+          return {
+            ...sp,
+            value: substituteValueArgsInExpression(sp.value, bindings),
+          };
+        }
+        return substituteValueArgsInExpression(a as Expression, bindings);
+      }),
+    };
+  }
+  return el;
+}
+
+/**
+ * Structural deep clone of an Expression. We never share Expression
+ * nodes between an alias declaration and a use-site instantiation
+ * (separate substitutions must not see each other's mutations).
+ *
+ * Implemented via `JSON.parse(JSON.stringify(...))` because the
+ * Expression subset accepted in tag args is plain data: no functions,
+ * no cycles. Suffices for the cases we care about (literals, object
+ * literals, PFA expressions).
+ */
+function cloneExpression(expr: Expression): Expression {
+  return JSON.parse(JSON.stringify(expr)) as Expression;
+}
+
+/**
+ * Best-effort type inference for a value argument expression. Returns a
+ * primitive type name (`"number"`, `"string"`, `"boolean"`, `"null"`) for
+ * the literal forms we can statically classify, or `undefined` when we
+ * can't (identifier references, object literals, PFA expressions).
+ *
+ * Used by `applyValueArgs` to detect literal-vs-declared-type mismatches.
+ * A best-effort signal: when we can't infer (e.g. a static-const
+ * identifier), we silently accept and defer to runtime — same trade-off
+ * the rest of the typechecker makes for restricted tag-arg subsets.
+ */
+function inferLiteralType(expr: Expression): string | undefined {
+  switch (expr.type) {
+    case "number":
+      return "number";
+    case "string":
+    case "multiLineString":
+      return "string";
+    case "boolean":
+      return "boolean";
+    case "null":
+      return "null";
+    default:
+      return undefined;
+  }
+}
+
+function variableTypeName(t: unknown): string {
+  if (!t || typeof t !== "object") return "?";
+  const node = t as { type?: string; value?: string };
+  if (node.type === "primitiveType" && typeof node.value === "string") {
+    return node.value;
+  }
+  return node.type ?? "?";
+}
+
+/**
+ * Take a `TypeAliasEntry` and the use-site `valueArgs` list, and
+ * return a fresh `TypeAliasEntry` whose `tags` have every value-param
+ * identifier reference replaced with the corresponding argument
+ * expression.
+ *
+ * Behavior:
+ *
+ * 1. Validates arity: too many args is an error; missing args are
+ *    filled from `valueParams[i].default` when present, or reported.
+ * 2. Builds the bindings map (param name → arg expression).
+ * 3. Maps `entry.tags` through `substituteValueArgsInTag`.
+ * 4. Returns a new entry with the substituted tags. `body` and
+ *    `typeParams` are kept as-is — type-param substitution is handled
+ *    by the existing `substituteTypeParams` pass, which runs BEFORE
+ *    `applyValueArgs` when both are needed (see assignability.ts).
+ *
+ * Throws a `TypeError` for arg-count / arg-type problems. The message
+ * is intentionally readable so it bubbles directly to the user.
+ *
+ * The `aliasName` parameter is used only for error messages.
+ */
+export function applyValueArgs(
+  entry: TypeAliasEntry,
+  valueArgs: Expression[] | undefined,
+  aliasName: string,
+): TypeAliasEntry {
+  const params = entry.valueParams ?? [];
+  const args = valueArgs ?? [];
+
+  if (args.length > params.length) {
+    throw new TypeError(
+      `${aliasName} expects ${params.length} value arguments, got ${args.length}`,
+    );
+  }
+
+  const bindings: ValueArgBindings = {};
+  for (let i = 0; i < params.length; i++) {
+    const p = params[i];
+    const provided = i < args.length ? args[i] : undefined;
+    if (provided !== undefined) {
+      const litType = inferLiteralType(provided);
+      const declared = variableTypeName(p.type);
+      if (litType && declared !== "?" && litType !== declared) {
+        // Best-effort literal type-check. Skip null vs declared-nullable etc.
+        const loc = (provided as { loc?: { line: number; col: number } }).loc;
+        const locStr = loc ? ` (at line ${loc.line}, col ${loc.col})` : "";
+        throw new TypeError(
+          `argument ${p.name} expected ${declared}, got ${litType}${locStr}`,
+        );
+      }
+      bindings[p.name] = provided;
+    } else if (p.default !== undefined) {
+      bindings[p.name] = p.default;
+    } else {
+      throw new TypeError(
+        `${aliasName} requires '${p.name}': ${variableTypeName(p.type)}`,
+      );
+    }
+  }
+
+  const newTags = (entry.tags ?? []).map((t) =>
+    substituteValueArgsInTag(t, bindings),
+  );
+
+  const newBody = substituteValueArgsInType(entry.body, bindings);
+
+  return {
+    ...entry,
+    body: newBody,
+    tags: newTags,
+  };
+}
+
+/**
+ * Walk a `VariableType` tree and substitute value-arg bindings into any
+ * inner `typeAliasVariable` or `genericType` reference that itself
+ * carries `valueArgs`. This enables wrapping aliases such as
+ * `type EvenInRange(low, high) = NumberInRange(low, high)` — when the
+ * outer alias is resolved the inner reference's `valueArgs` need their
+ * value-param identifier references replaced with the outer alias's
+ * bound arguments.
+ *
+ * Returns a fresh tree along any spine touched by substitution; nodes
+ * with no inner valueArgs pass through unchanged.
+ */
+export function substituteValueArgsInType(
+  vt: VariableType,
+  bindings: ValueArgBindings,
+): VariableType {
+  switch (vt.type) {
+    case "typeAliasVariable": {
+      if (!vt.valueArgs) return vt;
+      return {
+        ...vt,
+        valueArgs: vt.valueArgs.map((a) =>
+          substituteValueArgsInExpression(a, bindings),
+        ),
+      };
+    }
+    case "genericType": {
+      const newTypeArgs = vt.typeArgs.map((a) =>
+        substituteValueArgsInType(a, bindings),
+      );
+      const newValueArgs = vt.valueArgs
+        ? vt.valueArgs.map((a) =>
+            substituteValueArgsInExpression(a, bindings),
+          )
+        : undefined;
+      return { ...vt, typeArgs: newTypeArgs, valueArgs: newValueArgs };
+    }
+    case "arrayType":
+      return {
+        ...vt,
+        elementType: substituteValueArgsInType(vt.elementType, bindings),
+      };
+    case "unionType":
+      return {
+        ...vt,
+        types: vt.types.map((t) => substituteValueArgsInType(t, bindings)),
+      };
+    case "objectType":
+      return {
+        ...vt,
+        properties: vt.properties.map((p) => ({
+          ...p,
+          value: substituteValueArgsInType(p.value, bindings),
+        })),
+      };
+    case "resultType":
+      return {
+        ...vt,
+        successType: substituteValueArgsInType(vt.successType, bindings),
+        failureType: substituteValueArgsInType(vt.failureType, bindings),
+      };
+    case "schemaType":
+      return {
+        ...vt,
+        inner: substituteValueArgsInType(vt.inner, bindings),
+      };
+    case "blockType":
+      return {
+        ...vt,
+        params: vt.params.map((p) => ({
+          ...p,
+          typeAnnotation: substituteValueArgsInType(p.typeAnnotation, bindings),
+        })),
+        returnType: substituteValueArgsInType(vt.returnType, bindings),
+      };
+    default:
+      // primitiveType, stringLiteralType, numberLiteralType,
+      // booleanLiteralType, functionRefType — no inner VariableType /
+      // valueArgs to walk.
+      return vt;
+  }
+}

--- a/packages/agency-lang/lib/types/typeHints.ts
+++ b/packages/agency-lang/lib/types/typeHints.ts
@@ -2,6 +2,7 @@ import { AgencyMultiLineComment } from "../types.js";
 import type { FunctionParameter } from "./function.js";
 import { BaseNode } from "./base.js";
 import type { Tag } from "./tag.js";
+import type { Expression } from "../types.js";
 
 export type VariableType =
   | PrimitiveType
@@ -28,6 +29,12 @@ export type GenericType = {
   type: "genericType";
   name: string;
   typeArgs: VariableType[];
+  /**
+   * Value arguments at the use site of a value-parameterized alias.
+   * Example: `BoundedList<string>(3)` — typeArgs is `[string]`, valueArgs is `[3]`.
+   * Restricted to the same expression subset accepted by tag arguments.
+   */
+  valueArgs?: Expression[];
   tags?: Tag[];
 };
 
@@ -42,6 +49,22 @@ export type TypeParam = {
 };
 
 /**
+ * A value-parameter declaration on a value-parameterized type alias.
+ * Example: in `type NumberInRange(low: number, high: number) = number`,
+ * each of `low` and `high` is a ValueParam.
+ *
+ * The `default` expression, if present, is restricted to the same
+ * subset of expressions accepted by tag arguments (literals,
+ * identifiers that resolve to a top-level `static const`, object
+ * literals built from the above).
+ */
+export type ValueParam = {
+  name: string;
+  type: VariableType;
+  default?: Expression;
+};
+
+/**
  * Entry in the type alias registry. For non-generic aliases `typeParams`
  * is absent; for generic aliases it carries the declared parameters.
  *
@@ -52,6 +75,13 @@ export type TypeParam = {
 export type TypeAliasEntry = {
   body: VariableType;
   typeParams?: TypeParam[];
+  /**
+   * Value parameters for value-parameterized aliases (e.g. `low` and
+   * `high` in `type NumberInRange(low: number, high: number) = number`).
+   * Carried alongside `typeParams` so the resolver can substitute
+   * literal arguments into the alias's tag expressions.
+   */
+  valueParams?: ValueParam[];
   tags?: Tag[];
 };
 
@@ -141,6 +171,11 @@ export type TypeAlias = BaseNode & {
   aliasName: string;
   aliasedType: VariableType;
   typeParams?: TypeParam[];
+  /**
+   * Value parameters declared after the optional `< ... >` block.
+   * Example: `type NumberInRange(low: number, high: number) = number`.
+   */
+  valueParams?: ValueParam[];
   exported?: boolean;
   docComment?: AgencyMultiLineComment;
   tags?: Tag[];
@@ -158,5 +193,11 @@ export type FunctionRefType = {
 export type TypeAliasVariable = {
   type: "typeAliasVariable";
   aliasName: string;
+  /**
+   * Value arguments at the use site of a value-parameterized alias.
+   * Example: `Age(18)` — aliasName is `Age`, valueArgs is `[18]`.
+   * Restricted to the same expression subset accepted by tag arguments.
+   */
+  valueArgs?: Expression[];
   tags?: Tag[];
 };

--- a/packages/agency-lang/lib/types/typeHints.ts
+++ b/packages/agency-lang/lib/types/typeHints.ts
@@ -4,6 +4,18 @@ import { BaseNode } from "./base.js";
 import type { Tag } from "./tag.js";
 import type { Expression } from "../types.js";
 
+/**
+ * When adding a new variant to `VariableType`, also add a case to:
+ *
+ * - `substituteValueArgsInType` and `checkType` in
+ *   `lib/typeChecker/valueParamSubstitution.ts` — both functions have
+ *   exhaustive switches over this union (enforced by a `never`-typed
+ *   default branch, so TypeScript will fail to compile if you forget).
+ *
+ * Codegen sites (`mapTypeToSchema`, `descriptor`, `hasAnyValidateTag`)
+ * also branch on `VariableType.type`; review them when adding a
+ * variant.
+ */
 export type VariableType =
   | PrimitiveType
   | ArrayType

--- a/packages/agency-lang/stdlib/types.agency
+++ b/packages/agency-lang/stdlib/types.agency
@@ -1,4 +1,4 @@
-import { isEmail, isUrl, isUuid } from "std::validators"
+import { isEmail, isUrl, isUuid, min, max, minLength, maxLength, matches } from "std::validators"
 import { emailFormat, urlFormat, uuidFormat } from "std::schemas"
 
 /** @module
@@ -35,3 +35,24 @@ export type URLString = string
 @validate(isUuid)
 @jsonSchema({ ...uuidFormat })
 export type UUIDString = string
+
+/** A number that must lie within the inclusive range `[low, high]`.
+    Use as `NumberInRange(0, 100)` etc. — both bounds substitute into the
+    `@validate(...)` and `@jsonSchema(...)` tags at the use site. */
+@validate(min.partial(n: low), max.partial(n: high))
+@jsonSchema({ minimum: low, maximum: high })
+export type NumberInRange(low: number, high: number) = number
+
+/** A string whose length is in the inclusive range `[min, max]`. */
+@validate(minLength.partial(n: min), maxLength.partial(n: max))
+@jsonSchema({ minLength: min, maxLength: max })
+export type StringWithLength(min: number, max: number) = string
+
+/** A string that matches the given regular expression `pat`. */
+@validate(matches.partial(pattern: pat))
+@jsonSchema({ pattern: pat })
+export type MatchesPattern(pat: string) = string
+
+/** An array whose length is in the inclusive range `[min, max]`. */
+@jsonSchema({ minItems: min, maxItems: max })
+export type BoundedArray<T>(min: number, max: number) = T[]

--- a/packages/agency-lang/tests/agency/validation/valueParamArithmeticErases.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamArithmeticErases.agency
@@ -1,0 +1,31 @@
+// Documents that arithmetic ERASES bounds: the result of `a.value + n`
+// is a plain `number`, not the parameterized alias `NumberInRange(0,10)`.
+// To re-apply a bound after arithmetic, the user must annotate the result
+// with a (possibly different) parameterized alias and use the bang.
+//
+// This test pins that behavior so future changes don't silently start
+// propagating bounds through arithmetic without an explicit design
+// decision.
+
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+type NumberInRange(low: number, high: number) = number
+
+node main() {
+  const a: NumberInRange(0, 10)! = 7
+
+  // After arithmetic the result is just `number`, no bounds carry over.
+  // Re-annotating with a WIDER bound succeeds; re-annotating with a
+  // TIGHTER bound fails on the actual numeric value alone (12 > 10).
+  const sum = a.value + 5
+  const wider: NumberInRange(0, 100)! = sum
+  const tighter: NumberInRange(0, 10)! = sum
+
+  return {
+    a: isSuccess(a),
+    wider: isSuccess(wider),
+    tighter: isSuccess(tighter),
+    sum: sum
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamArithmeticErases.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamArithmeticErases.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"a\":true,\"wider\":true,\"tighter\":false,\"sum\":12}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Arithmetic erases bounds: `a.value + 5` is plain number, so re-applying validation requires a fresh annotation. A wider bound passes, a tighter bound fails on the literal value alone."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamArrayArg.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamArrayArg.agency
@@ -1,0 +1,13 @@
+// Array literal as a value argument. The alias's `@jsonSchema(...)`
+// embeds the value-param identifier `choices` directly into the
+// `enum` field. After substitution the JSON schema carries the
+// literal array, and use-site validation forbids values outside it.
+
+@jsonSchema({ enum: choices })
+type OneOf(choices: string[]) = string
+
+node main() {
+  const s = schema(OneOf(["approve", "reject"]))
+  const js = s.toJSONSchema()
+  return js.enum[0] + "|" + js.enum[1] + "|" + js.type
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamArrayArg.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamArrayArg.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"approve|reject|string\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Array literal as a value argument: `OneOf([...])` substitutes the array into the alias's @jsonSchema enum field."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamDefaults.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamDefaults.agency
@@ -1,0 +1,23 @@
+// Verifies that omitting a value argument falls back to the declared default.
+// `type Age(min: number = 0)` allows both `Age(18)` (explicit) and `Age()`
+// (uses the default of 0).
+
+import { min } from "std::validators"
+
+@validate(min.partial(n: low))
+type Age(low: number = 0) = number
+
+node main() {
+  const adult: Age(18)! = 25
+  const childButOk: Age()! = 5
+  const negative: Age()! = -1
+
+  if (isSuccess(adult)) {
+    if (isSuccess(childButOk)) {
+      if (isFailure(negative)) {
+        return "ok"
+      }
+    }
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamDefaults.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamDefaults.agency
@@ -1,6 +1,9 @@
 // Verifies that omitting a value argument falls back to the declared default.
-// `type Age(min: number = 0)` allows both `Age(18)` (explicit) and `Age()`
-// (uses the default of 0).
+// `type Age(min: number = 0)` allows three use-site forms:
+//   Age(18)  — explicit arg
+//   Age()    — empty arg list, default applies
+//   Age      — bare reference (no parens), default applies
+// All three should behave identically when the param has a default.
 
 import { min } from "std::validators"
 
@@ -10,14 +13,17 @@ type Age(low: number = 0) = number
 node main() {
   const adult: Age(18)! = 25
   const childButOk: Age()! = 5
-  const negative: Age()! = -1
+  const negativeWithEmptyParens: Age()! = -1
 
-  if (isSuccess(adult)) {
-    if (isSuccess(childButOk)) {
-      if (isFailure(negative)) {
-        return "ok"
-      }
-    }
+  // Bare reference (no parens) — uses the default just like `Age()`.
+  const childBare: Age! = 5
+  const negativeBare: Age! = -1
+
+  return {
+    adult: isSuccess(adult),
+    childButOk: isSuccess(childButOk),
+    negativeWithEmptyParens: isSuccess(negativeWithEmptyParens),
+    childBare: isSuccess(childBare),
+    negativeBare: isSuccess(negativeBare)
   }
-  return "failed"
 }

--- a/packages/agency-lang/tests/agency/validation/valueParamDefaults.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamDefaults.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Value-parameterized alias applies declared defaults when use-site omits the argument"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamDefaults.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamDefaults.test.json
@@ -3,9 +3,9 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "\"ok\"",
+      "expectedOutput": "{\"adult\":true,\"childButOk\":true,\"negativeWithEmptyParens\":false,\"childBare\":true,\"negativeBare\":false}",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "Value-parameterized alias applies declared defaults when use-site omits the argument"
+      "description": "Defaults apply equally for explicit args, empty parens, and bare alias references (no parens). Returns per-assertion isSuccess() flags so a regression diff identifies which form misbehaves."
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/validation/valueParamFunctionSignature.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamFunctionSignature.agency
@@ -1,0 +1,32 @@
+// Verifies value-parameterized aliases work in function parameter and
+// return positions. The literal value args travel through the function
+// signature into the body's type annotations and validation runs at the
+// call site.
+
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+type NumberInRange(low: number, high: number) = number
+
+def doubled(x: number): NumberInRange(0, 200) {
+  return x * 2
+}
+
+def clamp(x: NumberInRange(0, 100)): number {
+  return x
+}
+
+node main() {
+  // Use the function return type as the annotation source for the bang.
+  const ok: NumberInRange(0, 200)! = doubled(50)
+  const overflow: NumberInRange(0, 200)! = doubled(150)
+  const clamped = clamp(42)
+  const okParam: NumberInRange(0, 100)! = clamped
+
+  return {
+    ok: isSuccess(ok),
+    overflow: isSuccess(overflow),
+    okParam: isSuccess(okParam),
+    clamped: clamped
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamFunctionSignature.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamFunctionSignature.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"ok\":true,\"overflow\":false,\"okParam\":true,\"clamped\":42}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Value-parameterized aliases in function param and return positions: literal value-args flow through the signature; bang on a returned/argument value still applies the parameterized validators."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamGenericWrappingAlias.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamGenericWrappingAlias.agency
@@ -1,0 +1,26 @@
+// Regression test for the generic-branch value-arg forwarding bug.
+// A generic wrapper alias whose BODY references another value-
+// parameterized alias used to lose the value-arg substitution: the
+// `n` inside `BoundedList<T>(n)` was not replaced when the outer
+// generic alias was instantiated, leaving an out-of-scope identifier
+// in the generated schema and a corrupt JSON schema.
+//
+// `Wrap<string>(4)` must substitute `n -> 4` inside the body's
+// `BoundedList<string>(n)`, so the resulting JSON schema has
+// `maxItems: 4`.
+
+@jsonSchema({ maxItems: n })
+type BoundedList<T>(n: number) = T[]
+
+type Wrap<T>(n: number) = BoundedList<T>(n)
+
+node main() {
+  const s = schema(Wrap<string>(4))
+  const js = s.toJSONSchema()
+  const okList: Wrap<string>(4)! = ["a", "b", "c", "d"]
+
+  if (isSuccess(okList)) {
+    return js.maxItems + "|" + okList.value[3]
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamGenericWrappingAlias.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamGenericWrappingAlias.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"4|d\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Generic wrapper alias forwards its value arg into a value-parameterized type in its body; both type and value substitution flow through"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamInJsonSchema.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamInJsonSchema.agency
@@ -1,0 +1,13 @@
+// Verifies that value-parameter substitution flows through @jsonSchema(...)
+// the same way it does through @validate(...). The use-site `Bounded(0, 100)`
+// must produce a Zod schema whose JSON Schema output literally contains
+// `minimum: 0` and `maximum: 100`.
+
+@jsonSchema({ minimum: low, maximum: high })
+type Bounded(low: number, high: number) = number
+
+node main() {
+  const s = schema(Bounded(0, 100))
+  const js = s.toJSONSchema()
+  return js.minimum + "|" + js.maximum
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamInJsonSchema.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamInJsonSchema.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"0|100\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Value-parameter substitution flows through @jsonSchema so toJSONSchema() output carries the literal bounds"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamLlm.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamLlm.agency
@@ -1,0 +1,26 @@
+// Real LLM call that exercises a value-parameterized alias in a
+// structured output. The JSON schema sent to the model is derived from
+// `Score`, which embeds `NumberInRange(1, 5)`. After substitution, the
+// schema for `rating` must include `minimum: 1` and `maximum: 5` so the
+// LLM returns a value inside that range. We then re-run validation at
+// runtime to confirm both ends — the schema constrained the model and
+// the resulting value satisfies the same @validate tag.
+
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+@jsonSchema({ minimum: low, maximum: high })
+type NumberInRange(low: number, high: number) = number
+
+type Score = {
+  rating: NumberInRange(1, 5)
+}
+
+node main() {
+  const r: Score = llm("Pick an integer rating between 1 and 5 inclusive for the movie 'The Matrix'. Return ONLY the rating field with an integer.")
+  // Re-validate the LLM-produced value through the same parameterized
+  // alias used in the schema. If the schema propagation worked, the
+  // model returned a number in [1, 5] and this validation succeeds.
+  const checked: NumberInRange(1, 5)! = r.rating
+  return isSuccess(checked)
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamLlm.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamLlm.test.json
@@ -2,11 +2,17 @@
   "tests": [
     {
       "nodeName": "main",
-      "description": "Real LLM call: value-param JSON schema must flow into the structured output sent to the model so the returned rating falls inside [1, 5], and the same parameterized validator passes at runtime.",
+      "description": "Real LLM call: value-param JSON schema must flow into the structured output sent to the model so the returned rating falls inside [1, 5], and the same parameterized validator passes at runtime. Marked as llmJudge so CI (which uses the deterministic test client) skips it; rerun locally with a real OPENAI_API_KEY to exercise the LLM path.",
       "input": "",
-      "expectedOutput": "true",
-      "evaluationCriteria": [{ "type": "exact" }],
-      "retry": 2
+      "expectedOutput": "",
+      "evaluationCriteria": [
+        {
+          "type": "llmJudge",
+          "judgePrompt": "The output should be exactly the string `true`. Pass only if the program returned `true` (the rating returned by the model was inside the [1, 5] range, so the parameterized @validate succeeded at runtime).",
+          "desiredAccuracy": 100
+        }
+      ],
+      "retry": 1
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/validation/valueParamLlm.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamLlm.test.json
@@ -2,17 +2,14 @@
   "tests": [
     {
       "nodeName": "main",
-      "description": "Real LLM call: value-param JSON schema must flow into the structured output sent to the model so the returned rating falls inside [1, 5], and the same parameterized validator passes at runtime. Marked as llmJudge so CI (which uses the deterministic test client) skips it; rerun locally with a real OPENAI_API_KEY to exercise the LLM path.",
+      "description": "Real LLM call: value-param JSON schema must flow into the structured output sent to the model so the returned rating falls inside [1, 5], and the same parameterized validator passes at runtime. In CI, llmMocks supplies a deterministic in-range rating (4); locally with a real OPENAI_API_KEY the same flow runs end-to-end.",
       "input": "",
-      "expectedOutput": "",
-      "evaluationCriteria": [
-        {
-          "type": "llmJudge",
-          "judgePrompt": "The output should be exactly the string `true`. Pass only if the program returned `true` (the rating returned by the model was inside the [1, 5] range, so the parameterized @validate succeeded at runtime).",
-          "desiredAccuracy": 100
-        }
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "llmMocks": [
+        { "return": { "rating": 4 } }
       ],
-      "retry": 1
+      "retry": 2
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/validation/valueParamLlm.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamLlm.test.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Real LLM call: value-param JSON schema must flow into the structured output sent to the model so the returned rating falls inside [1, 5], and the same parameterized validator passes at runtime.",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "retry": 2
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamMultiArg.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamMultiArg.agency
@@ -1,6 +1,10 @@
 // Verifies that a value-parameterized alias with multiple value parameters
 // substitutes each one into its corresponding @validate PFA. Both the lower
 // and upper bound must fire independently.
+//
+// Returns an object of per-assertion results so a regression diff shows
+// exactly which assertion went wrong, instead of collapsing six checks
+// into one boolean and a single "failed" string.
 
 import { min, max } from "std::validators"
 
@@ -16,18 +20,12 @@ node main() {
   const tightTooLow: NumberInRange(1, 100)! = 0
   const tightTooHigh: NumberInRange(1, 100)! = 101
 
-  if (isSuccess(okMid)) {
-    if (isFailure(tooLow)) {
-      if (isFailure(tooHigh)) {
-        if (isSuccess(okTight)) {
-          if (isFailure(tightTooLow)) {
-            if (isFailure(tightTooHigh)) {
-              return "ok"
-            }
-          }
-        }
-      }
-    }
+  return {
+    okMid: isSuccess(okMid),
+    tooLow: isSuccess(tooLow),
+    tooHigh: isSuccess(tooHigh),
+    okTight: isSuccess(okTight),
+    tightTooLow: isSuccess(tightTooLow),
+    tightTooHigh: isSuccess(tightTooHigh)
   }
-  return "failed"
 }

--- a/packages/agency-lang/tests/agency/validation/valueParamMultiArg.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamMultiArg.agency
@@ -1,0 +1,33 @@
+// Verifies that a value-parameterized alias with multiple value parameters
+// substitutes each one into its corresponding @validate PFA. Both the lower
+// and upper bound must fire independently.
+
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+type NumberInRange(low: number, high: number) = number
+
+node main() {
+  const okMid: NumberInRange(0, 150)! = 50
+  const tooLow: NumberInRange(0, 150)! = -1
+  const tooHigh: NumberInRange(0, 150)! = 200
+
+  const okTight: NumberInRange(1, 100)! = 100
+  const tightTooLow: NumberInRange(1, 100)! = 0
+  const tightTooHigh: NumberInRange(1, 100)! = 101
+
+  if (isSuccess(okMid)) {
+    if (isFailure(tooLow)) {
+      if (isFailure(tooHigh)) {
+        if (isSuccess(okTight)) {
+          if (isFailure(tightTooLow)) {
+            if (isFailure(tightTooHigh)) {
+              return "ok"
+            }
+          }
+        }
+      }
+    }
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamMultiArg.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamMultiArg.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Value-parameterized alias with two parameters substitutes both bounds independently"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamMultiArg.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamMultiArg.test.json
@@ -3,9 +3,9 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "\"ok\"",
+      "expectedOutput": "{\"okMid\":true,\"tooLow\":false,\"tooHigh\":false,\"okTight\":true,\"tightTooLow\":false,\"tightTooHigh\":false}",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "Value-parameterized alias with two parameters substitutes both bounds independently"
+      "description": "Value-parameterized alias with two parameters substitutes both bounds independently. Returns per-assertion isSuccess() flags so a regression diff identifies which assertion failed."
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/validation/valueParamMultiLineStringArg.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamMultiLineStringArg.agency
@@ -1,0 +1,13 @@
+// Triple-quoted multi-line string as a value argument. Useful for
+// embedding a long description in a parameterized alias without
+// fighting escapes. The description is substituted verbatim.
+
+@jsonSchema({ description: text })
+type Documented(text: string) = number
+
+node main() {
+  const s = schema(Documented("""line one
+line two"""))
+  const js = s.toJSONSchema()
+  return js.description
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamMultiLineStringArg.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamMultiLineStringArg.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"line one\\nline two\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Multi-line `\"\"\"...\"\"\"` string as a value argument: substituted verbatim into the alias's @jsonSchema description."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamObjectProperty.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamObjectProperty.agency
@@ -1,0 +1,26 @@
+// Regression test for the object-property substitution bug.
+// When a value-parameterized alias appears as an object property
+// (e.g. `age: NumberInRange(0, 150)`), the outer object emission
+// looked up the alias's RAW tags (containing unsubstituted value-param
+// identifiers `low`/`high`) and emitted them into the property's
+// `.meta(...)` chain — producing generated TS that referenced
+// out-of-scope identifiers.
+//
+// After the fix, the alias tags are substituted before merging, so
+// the JSON schema for the `age` property contains the literal bounds.
+
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+@jsonSchema({ minimum: low, maximum: high })
+type NumberInRange(low: number, high: number) = number
+
+type User = {
+  age: NumberInRange(0, 150)
+}
+
+node main() {
+  const s = schema(User)
+  const js = s.toJSONSchema()
+  return js.properties.age.minimum + "|" + js.properties.age.maximum
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamObjectProperty.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamObjectProperty.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"0|150\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Value-parameterized alias used as an object property — alias-level @jsonSchema tags are substituted before being merged into the property's .meta(), not emitted as unbound value-param identifiers"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamObjectValued.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamObjectValued.agency
@@ -1,0 +1,29 @@
+// Verifies value-param substitution through an OBJECT-typed alias body.
+// `Person(maxAge: number)` is an object with a property whose type is a
+// value-param alias that depends on the outer alias's `maxAge` param.
+// Substitution must reach into the object body and update the property
+// type and its merged @jsonSchema tag.
+
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+@jsonSchema({ minimum: low, maximum: high })
+type NumberInRange(low: number, high: number) = number
+
+type Person(maxAge: number) = {
+  name: string,
+  age: NumberInRange(0, maxAge)
+}
+
+node main() {
+  const s50 = schema(Person(50))
+  const js50 = s50.toJSONSchema()
+  const s120 = schema(Person(120))
+  const js120 = s120.toJSONSchema()
+
+  return {
+    maxAt50: js50.properties.age.maximum,
+    maxAt120: js120.properties.age.maximum,
+    minAt50: js50.properties.age.minimum
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamObjectValued.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamObjectValued.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"maxAt50\":50,\"maxAt120\":120,\"minAt50\":0}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Object-typed alias body: value-param substitution flows into a property type and its merged @jsonSchema tag, so Person(50) and Person(120) differ in age.maximum."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamPartialForwarding.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamPartialForwarding.agency
@@ -1,0 +1,26 @@
+// Verifies a wrapping alias that supplies a literal for one value
+// parameter of the inner alias and FORWARDS its own value parameter
+// for the other. The forwarded identifier (`high`) is substituted at
+// the use site of the outer alias, while the inner alias also sees
+// the literal `18` for its `low` parameter.
+
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+type NumberInRange(low: number, high: number) = number
+
+// `low` is fixed to 18 here; `high` is still parameterized and
+// forwarded to NumberInRange's `high`.
+type AdultAge(high: number) = NumberInRange(18, high)
+
+node main() {
+  const ok: AdultAge(100)! = 30
+  const tooYoung: AdultAge(100)! = 17
+  const tooOld: AdultAge(100)! = 101
+
+  return {
+    ok: isSuccess(ok),
+    tooYoung: isSuccess(tooYoung),
+    tooOld: isSuccess(tooOld)
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamPartialForwarding.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamPartialForwarding.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"ok\":true,\"tooYoung\":false,\"tooOld\":false}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Wrapping alias with partial forwarding: outer fixes one inner value param to a literal and forwards its own value param for the other. Both bounds must still fire."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamRegexArg.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamRegexArg.agency
@@ -1,0 +1,26 @@
+// Regex literal as a value argument. A top-level def validator takes
+// a `regex` parameter; the alias forwards its value-param `pat` into
+// the validator's named arg via PFA. At use sites, `Code(re/.../)`
+// substitutes the regex into the @validate PFA so the bang validates
+// against it.
+
+def matchesRe(pattern: regex, value: string): Result {
+  if (pattern.test(value)) {
+    return success(value)
+  }
+  return failure("does not match")
+}
+
+@validate(matchesRe.partial(pattern: pat))
+type Code(pat: regex) = string
+
+node main() {
+  const okDigits: Code(re/^[0-9]+$/)! = "12345"
+  const badDigits: Code(re/^[0-9]+$/)! = "12a5"
+  const okUpper: Code(re/^[A-Z]+$/)! = "HELLO"
+  return {
+    okDigits: isSuccess(okDigits),
+    badDigits: isSuccess(badDigits),
+    okUpper: isSuccess(okUpper)
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamRegexArg.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamRegexArg.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"okDigits\":true,\"badDigits\":false,\"okUpper\":true}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Regex literal as a value argument: the alias forwards `pat` into a custom def validator's `pattern: regex` slot via PFA, and the runtime substitutes it into a real RegExp."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamSimple.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamSimple.agency
@@ -1,0 +1,27 @@
+// Verifies the simplest value-parameterized type alias:
+// `type Age(min: number) = number` whose @validate(...) tag substitutes the
+// value parameter into a PFA. Use-sites Age(0) and Age(18) should both pass
+// when values meet the bound, and fail when they don't.
+
+import { min } from "std::validators"
+
+@validate(min.partial(n: low))
+type Age(low: number) = number
+
+node main() {
+  const goodAdult: Age(18)! = 20
+  const tooYoung: Age(18)! = 10
+  const anyPositive: Age(0)! = 5
+  const negative: Age(0)! = -1
+
+  if (isSuccess(goodAdult)) {
+    if (isFailure(tooYoung)) {
+      if (isSuccess(anyPositive)) {
+        if (isFailure(negative)) {
+          return "ok"
+        }
+      }
+    }
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamSimple.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamSimple.agency
@@ -1,7 +1,10 @@
 // Verifies the simplest value-parameterized type alias:
-// `type Age(min: number) = number` whose @validate(...) tag substitutes the
+// `type Age(low: number) = number` whose @validate(...) tag substitutes the
 // value parameter into a PFA. Use-sites Age(0) and Age(18) should both pass
 // when values meet the bound, and fail when they don't.
+//
+// Returns an object of per-assertion isSuccess() flags so a regression diff
+// pinpoints which assertion misbehaved.
 
 import { min } from "std::validators"
 
@@ -14,14 +17,10 @@ node main() {
   const anyPositive: Age(0)! = 5
   const negative: Age(0)! = -1
 
-  if (isSuccess(goodAdult)) {
-    if (isFailure(tooYoung)) {
-      if (isSuccess(anyPositive)) {
-        if (isFailure(negative)) {
-          return "ok"
-        }
-      }
-    }
+  return {
+    goodAdult: isSuccess(goodAdult),
+    tooYoung: isSuccess(tooYoung),
+    anyPositive: isSuccess(anyPositive),
+    negative: isSuccess(negative)
   }
-  return "failed"
 }

--- a/packages/agency-lang/tests/agency/validation/valueParamSimple.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamSimple.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Single value-parameterized alias substitutes a literal into the @validate PFA at the use site"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamSimple.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamSimple.test.json
@@ -3,9 +3,9 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "\"ok\"",
+      "expectedOutput": "{\"goodAdult\":true,\"tooYoung\":false,\"anyPositive\":true,\"negative\":false}",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "Single value-parameterized alias substitutes a literal into the @validate PFA at the use site"
+      "description": "Simplest value-parameterized alias: `type Age(low) = number` validated by `min.partial(n: low)`. Returns per-assertion isSuccess() flags."
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/validation/valueParamStaticConst.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamStaticConst.agency
@@ -1,6 +1,9 @@
 // Verifies that a static const identifier can be used as a value argument
 // at the use site. Substitution must read the const's value when emitting
 // the @validate PFA so the literal flows through to runtime.
+//
+// Returns an object of per-assertion isSuccess() flags so a regression diff
+// pinpoints which assertion misbehaved.
 
 import { min } from "std::validators"
 
@@ -13,10 +16,8 @@ node main() {
   const adult: Age(DEFAULT_AGE)! = 25
   const tooYoung: Age(DEFAULT_AGE)! = 10
 
-  if (isSuccess(adult)) {
-    if (isFailure(tooYoung)) {
-      return "ok"
-    }
+  return {
+    adult: isSuccess(adult),
+    tooYoung: isSuccess(tooYoung)
   }
-  return "failed"
 }

--- a/packages/agency-lang/tests/agency/validation/valueParamStaticConst.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamStaticConst.agency
@@ -1,0 +1,22 @@
+// Verifies that a static const identifier can be used as a value argument
+// at the use site. Substitution must read the const's value when emitting
+// the @validate PFA so the literal flows through to runtime.
+
+import { min } from "std::validators"
+
+static const DEFAULT_AGE = 18
+
+@validate(min.partial(n: low))
+type Age(low: number) = number
+
+node main() {
+  const adult: Age(DEFAULT_AGE)! = 25
+  const tooYoung: Age(DEFAULT_AGE)! = 10
+
+  if (isSuccess(adult)) {
+    if (isFailure(tooYoung)) {
+      return "ok"
+    }
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamStaticConst.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamStaticConst.test.json
@@ -3,9 +3,9 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "\"ok\"",
+      "expectedOutput": "{\"adult\":true,\"tooYoung\":false}",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "Value-parameterized alias substitutes a static const identifier as the use-site argument"
+      "description": "Static const identifier as a value argument: substitution reads the const's value when emitting the @validate PFA."
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/validation/valueParamStaticConst.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamStaticConst.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Value-parameterized alias substitutes a static const identifier as the use-site argument"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamStringInterpolation.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamStringInterpolation.agency
@@ -1,0 +1,17 @@
+// Value-parameter identifiers may appear inside `${...}` slots in
+// tag-arg strings. Substitution folds the literal value into the
+// string at compile time so the JSON schema's `description` carries
+// the use-site value (3 here, 7 in the second instantiation).
+
+@jsonSchema({
+  description: "Must be a number that is divisible by ${divisor}"
+})
+type DivisibleBy(divisor: number) = number
+
+node main() {
+  const sa = schema(DivisibleBy(3))
+  const sb = schema(DivisibleBy(7))
+  const a = sa.toJSONSchema()
+  const b = sb.toJSONSchema()
+  return a.description + "|" + b.description
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamStringInterpolation.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamStringInterpolation.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"Must be a number that is divisible by 3|Must be a number that is divisible by 7\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Value-param identifier inside a tag-arg string `${...}` slot: substitution folds the literal into the description so each instantiation carries its own value."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamUnionValued.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamUnionValued.agency
@@ -1,0 +1,23 @@
+// Verifies value-param substitution into BRANCHES of a union-typed alias
+// body. Each branch is itself a value-param alias depending on the outer
+// parameter; substitution must reach into every union member.
+
+@jsonSchema({ minimum: low, maximum: high })
+type NumberInRange(low: number, high: number) = number
+
+// Union of two parameterized bounded ranges. When instantiated with
+// (10, 50, 100, 200), branch 1 should carry minimum=10 maximum=50
+// and branch 2 should carry minimum=100 maximum=200.
+type TwoRanges(loA: number, hiA: number, loB: number, hiB: number) = NumberInRange(loA, hiA) | NumberInRange(loB, hiB)
+
+node main() {
+  const s = schema(TwoRanges(10, 50, 100, 200))
+  const js = s.toJSONSchema()
+
+  return {
+    branchAMin: js.anyOf[0].minimum,
+    branchAMax: js.anyOf[0].maximum,
+    branchBMin: js.anyOf[1].minimum,
+    branchBMax: js.anyOf[1].maximum
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamUnionValued.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamUnionValued.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"branchAMin\":10,\"branchAMax\":50,\"branchBMin\":100,\"branchBMax\":200}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Union-typed alias body: value-arg substitution reaches each branch of the union, so anyOf[0] and anyOf[1] carry their own bounds."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamUnitArg.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamUnitArg.agency
@@ -1,0 +1,28 @@
+// Unit literal as a value argument. `30s` is a time literal that
+// canonicalises to 30000 (milliseconds). After substitution the
+// alias's @jsonSchema embeds the canonical number — so `Timeout(30s)`
+// and `Timeout(1m)` differ only by their canonical values in the
+// schema.
+
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: 0), max.partial(n: ms))
+@jsonSchema({ maximum: ms })
+type Timeout(ms: number) = number
+
+node main() {
+  const sa = schema(Timeout(30s))
+  const sb = schema(Timeout(1m))
+  const ja = sa.toJSONSchema()
+  const jb = sb.toJSONSchema()
+
+  const okFast: Timeout(30s)! = 1000
+  const tooSlow: Timeout(30s)! = 50000
+
+  return {
+    maxA: ja.maximum,
+    maxB: jb.maximum,
+    okFast: isSuccess(okFast),
+    tooSlow: isSuccess(tooSlow)
+  }
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamUnitArg.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamUnitArg.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"maxA\":30000,\"maxB\":60000,\"okFast\":true,\"tooSlow\":false}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Unit literal as a value argument: time literals canonicalise (30s→30000, 1m→60000) before substitution into @validate / @jsonSchema tags."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamWithGeneric.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamWithGeneric.agency
@@ -1,0 +1,18 @@
+// Verifies that a type alias combining type parameters `<T>` with value
+// parameters `(n: number)` performs both substitutions. The use-site
+// `BoundedList<string>(3)` resolves T -> string and substitutes the
+// literal 3 into the @jsonSchema tag.
+
+@jsonSchema({ maxItems: n })
+type BoundedList<T>(n: number) = T[]
+
+node main() {
+  const s = schema(BoundedList<string>(3))
+  const js = s.toJSONSchema()
+  const okList: BoundedList<string>(3)! = ["a", "b", "c"]
+
+  if (isSuccess(okList)) {
+    return js.maxItems + "|" + js.type + "|" + okList.value[0]
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamWithGeneric.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamWithGeneric.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"3|array|a\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Combined type+value parameterized alias substitutes both T and value args; JSON Schema reflects literal bound"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamWrappingAlias.agency
+++ b/packages/agency-lang/tests/agency/validation/valueParamWrappingAlias.agency
@@ -1,0 +1,31 @@
+// Verifies that a value-parameterized alias can forward its own value
+// parameters into another value-parameterized alias in its body. The
+// outer alias's value-param identifiers (`low`, `high`) are substituted
+// at the inner reference site, which itself is substituted at the
+// outer use site.
+
+import { min, max } from "std::validators"
+
+@validate(min.partial(n: low), max.partial(n: high))
+@jsonSchema({ minimum: low, maximum: high })
+type NumberInRange(low: number, high: number) = number
+
+type EvenInRange(low: number, high: number) = NumberInRange(low, high)
+
+node main() {
+  const s = schema(EvenInRange(0, 100))
+  const js = s.toJSONSchema()
+
+  const okMid: EvenInRange(0, 100)! = 50
+  const tooLow: EvenInRange(0, 100)! = -1
+  const tooHigh: EvenInRange(0, 100)! = 101
+
+  if (isSuccess(okMid)) {
+    if (isFailure(tooLow)) {
+      if (isFailure(tooHigh)) {
+        return js.minimum + "|" + js.maximum
+      }
+    }
+  }
+  return "failed"
+}

--- a/packages/agency-lang/tests/agency/validation/valueParamWrappingAlias.test.json
+++ b/packages/agency-lang/tests/agency/validation/valueParamWrappingAlias.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"0|100\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Wrapping alias forwards its own value parameters into an inner value-parameterized alias; both substitutions happen"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Implements the "dependent types" feature deferred from the [validation annotations spec](docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md) — value-parameterized type aliases. Users can now write:

```agency
@validate(min.partial(n: low), max.partial(n: high))
@jsonSchema({ minimum: low, maximum: high })
type NumberInRange(low: number, high: number) = number

type User = {
  age: NumberInRange(0, 150)
  score: NumberInRange(1, 100)
}
```

Each use-site instantiates the alias with literal / static-const args that get substituted into the tag expressions at compile time. The substituted tags then flow through the existing `mergeTagSets` / `appendMeta` / descriptor pipeline unchanged.

## Highlights

- **Parser** — value params use `()`, type params use `<>`. Combined form: `type BoundedList<T>(n: number) = T[]`. Type params first.
- **Tag-arg restriction** — bare function calls are now forbidden in `@validate` / `@jsonSchema` args; use PFA syntax (`min.partial(n: 0)`) instead. A shared `staticTagArgParser` enforces the same restriction for value-arg use sites and default expressions.
- **Substitution pass** — new `lib/typeChecker/valueParamSubstitution.ts` with `applyValueArgs` as the canonical entry point. Resolution order is type-param sub first, then value-arg sub. Substitution walks both tags **and the alias body** so wrapper aliases that forward value params (`type EvenInRange(low, high) = NumberInRange(low, high)`) work.
- **Codegen** — schemas + descriptors are inlined at each use site for value-parameterized instantiations. No `__agency_descriptor` side-channel for these; no top-level schema const emitted for the alias.
- **`agency docs`** — renders value params alongside type params.
- **Stdlib** — `NumberInRange`, `StringWithLength`, `MatchesPattern`, `BoundedArray<T>`.
- **Docs** — user guide section, dev internals (`docs/dev/validation-annotations.md`), spec promoted from "future work" to body.

## Plan + spec

- Plan: [`docs/superpowers/plans/2026-05-20-value-parameterized-type-aliases-impl.md`](docs/superpowers/plans/2026-05-20-value-parameterized-type-aliases-impl.md)
- Spec: [`docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md`](docs/superpowers/specs/2026-05-19-type-validation-and-json-schema-annotations-design.md) (now has the value-parameterized aliases section in the body)

## Testing

- 7 new e2e Agency tests under `tests/agency/validation/`: `valueParamSimple`, `valueParamMultiArg`, `valueParamDefaults`, `valueParamStaticConst`, `valueParamInJsonSchema`, `valueParamWithGeneric`, `valueParamWrappingAlias`.
- 35 new unit tests across substitution, `applyValueArgs`, `resolveType` + valueArgs, jsonSchema/PFA validation, parser, and codegen.
- `pnpm exec tsc --noEmit` — clean
- `pnpm run lint:structure` — clean
- `pnpm test:run` — **249 files, 4201 tests passing** (was 4168 before)
- `make` — clean (stdlib + docs regenerated)

## Future work (documented in the plan)

Two items intentionally out of scope, captured for follow-up:

1. **Static refinement / dependent-style checking** — today value args are inert from the checker's perspective; two `BoundedArray(0, 100)` and `BoundedArray(0, 50)` are mutually assignable because both bottom out at `T[]`. A future pass could promote value args to first-class participants in assignability with a predicate registry for stdlib validators.

2. **Phantom-type / type-state soundness gap** — confirmed via a small Agency test: `Thread<Anonymous>` is silently accepted where `Thread<Authenticated>` is expected because the type checker unfolds the alias and compares structurally. Reproducer and fix sketch (compare type-arg lists pairwise before falling back to structural body comparison) are in the plan.

## Design decisions worth flagging

- **Value-param aliases are nominally distinct but mutually assignment-compatible** — `NumberInRange(0, 100)` and `NumberInRange(1, 50)` are interchangeable as `number`. Validators are independent and run at `!` sites only. This is the v1 simple-is-better-than-clever stance; refinement subtyping is in future work.
- **No `__agency_descriptor` for instantiations** — there's no single descriptor for a parameterized alias because the descriptor would need to encode specific args. Codegen inlines at each use site.
- **Top-level schema const skipped for parameterized aliases** — there's no useful single Zod schema for `NumberInRange` without args. If a value-parameterized alias is `export`ed, importing the name fails at the TS level (option (a) in the plan); the type-side import still works because use-sites inline the substituted schema.
- **Substitution walks the alias body**, not just its tags. Discovered during G7 (`valueParamWrappingAlias`) — without this, wrapper aliases would silently emit unbound identifiers into generated TS.
