### PR TITLE
Add stdlib agency AST/formatter/policy toolkit + assorted bug fixes

### DIFF
--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -81,6 +81,10 @@ export default defineConfig({
               link: "/appendix/agency-stdlib",
             },
             {
+              text: "Built-in Functions",
+              link: "/appendix/builtins",
+            },
+            {
               text: "Advanced Types",
               link: "/appendix/advanced-types",
             },
@@ -136,6 +140,10 @@ export default defineConfig({
             {
               text: "Agency's Standard Library",
               link: "/appendix/agency-stdlib",
+            },
+            {
+              text: "Built-in Functions",
+              link: "/appendix/builtins",
             },
           ],
         },

--- a/packages/agency-lang/docs/site/appendix/builtins.md
+++ b/packages/agency-lang/docs/site/appendix/builtins.md
@@ -1,0 +1,56 @@
+# Built-in Functions
+
+This page lists every user-facing built-in function and built-in language construct in Agency. These are available in every `.agency` file without an `import` statement.
+
+For the auto-imported standard library (`print`, `sleep`, `read`, `fetch`, `range`, ...) see [Agency's Standard Library](/appendix/agency-stdlib) and the [stdlib reference](/stdlib/).
+
+## LLM
+
+| Name | Signature | Description |
+|---|---|---|
+| `llm` | `llm(prompt: any, options?): T` | Send a message to an LLM and return its response. The return type `T` is inferred from the variable annotation at the call site and compiled to a JSON schema. `options` accepts `model`, `provider`, `apiKey`, `maxTokens`, `temperature`, `stream`, `reasoningEffort` (`"low"`/`"medium"`/`"high"`), `thinking` (`{ enabled, budgetTokens? }`), `tools`, `memory`, `metadata`. See [LLMs](/guide/llm). |
+
+## Checkpointing
+
+| Name | Signature | Description |
+|---|---|---|
+| `checkpoint` | `checkpoint(): number` | Take a snapshot of the current execution state and return a checkpoint ID. |
+| `getCheckpoint` | `getCheckpoint(id: number): any` | Return the full checkpoint object for a given ID. |
+| `restore` | `restore(checkpoint, options?): void` | Restore execution to a previously captured checkpoint. Accepts either a checkpoint object or ID, plus an options object (e.g. `{ maxRestores: 3 }` or variable overrides). See [Checkpointing](/guide/checkpointing). |
+
+## Interrupts and Handlers
+
+| Name | Signature | Description |
+|---|---|---|
+| `interrupt` | `interrupt <kind>(message, payload?)` | Statement (not a regular function call) that throws an interrupt of the given kind. Execution state is captured so that, once responded to, execution resumes from exactly this point. See [Interrupts](/guide/interrupts). |
+| `approve` | `approve(value?): any` | Used inside a `handle ... with` block to approve the wrapped action, optionally substituting a return value. |
+| `reject` | `reject(value?): any` | Used inside a `handle ... with` block to block the wrapped action. |
+| `propagate` | `propagate(): any` | Used inside a `handle ... with` block to pass the interrupt up to the next handler in the chain. See [Handlers](/guide/handlers). |
+
+## Concurrency
+
+| Name | Signature | Description |
+|---|---|---|
+| `fork` | `fork(labels) as <name> { ... }` | Run multiple branches in parallel and wait for all of them to finish. Returns an array of results, one per label. |
+| `race` | `race(labels) as <name> { ... }` | Like `fork`, but returns as soon as the first branch completes and cancels the rest. See [Concurrency](/guide/concurrency). |
+
+## Result Type
+
+| Name | Signature | Description |
+|---|---|---|
+| `success` | `success(value): Result` | Wrap a value in a successful `Result`. |
+| `failure` | `failure(error, value?): Result` | Wrap an error (and optionally a value) in a failed `Result`. |
+| `isSuccess` | `isSuccess(result): boolean` | Check whether a `Result` is a success. |
+| `isFailure` | `isFailure(result): boolean` | Check whether a `Result` is a failure. See [Error Handling](/guide/error-handling). |
+
+## Types and Schemas
+
+| Name | Signature | Description |
+|---|---|---|
+| `schema` | `schema<T>` | Expression that returns the Zod schema for a type `T`. Useful when passing a schema to a TypeScript function or validator. See [Schemas](/guide/schemas). |
+
+## Debugging
+
+| Name | Signature | Description |
+|---|---|---|
+| `debugger` | `debugger "<label>"?` | No-op when running the agent normally, but pauses execution when running under the Agency debugger. Accepts an optional label string. See [Debugger](/guide/debugger). |

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -12,6 +12,56 @@ type CompiledProgram = {
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L3))
 
+### SourceLocation
+
+```ts
+type SourceLocation = {
+  line: number;
+  col: number;
+  start: number;
+  end: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L7))
+
+### TypeCheckDiagnostic
+
+```ts
+type TypeCheckDiagnostic = {
+  severity: string;
+  message: string;
+  loc?: SourceLocation;
+  variableName?: string;
+  expectedType?: string;
+  actualType?: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L14))
+
+### TypeCheckReport
+
+```ts
+type TypeCheckReport = {
+  errors: TypeCheckDiagnostic[];
+  warnings: TypeCheckDiagnostic[]
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L23))
+
+### FilterImportsResult
+
+```ts
+type FilterImportsResult = {
+  source: string;
+  filtered: boolean
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L122))
+
 ## Functions
 
 ### compile
@@ -31,7 +81,7 @@ Compile Agency source code. Returns a CompiledProgram on success, or a failure w
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L7))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L28))
 
 ### run
 
@@ -67,7 +117,7 @@ Execute a compiled Agency program in a subprocess. The parent's handler chain ex
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L15))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L36))
 
 ### runFile
 
@@ -109,4 +159,313 @@ Compile and execute an Agency file in a subprocess. The file is read from dir/fi
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L68))
+
+### typecheck
+
+```ts
+typecheck(source: string): Result
+```
+
+Type-check Agency source code without compiling or running it. Returns a TypeCheckReport with separate `errors` and `warnings` arrays — a successful Result with a non-empty `errors` array means the type-checker ran and found problems. A failure Result means the type-checker could not run at all (parse error or unresolved import).
+
+  Unlike compile(), this does NOT restrict imports — type-checking is read-only and does not execute code. Note that std:: and pkg:: imports resolve normally, but relative imports (./foo.agency) cannot be resolved when calling typecheck() with a source string, since there is no on-disk location to resolve them against. Use typecheckFile() for source that contains relative imports.
+
+  @param source - Agency source code as a string
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L111))
+
+### parseAST
+
+```ts
+parseAST(source: string): Result
+```
+
+Parse Agency source code into an abstract syntax tree. Returns the raw AST as a JSON-serializable object on success, or a failure with the parse error message.
+
+  The AST shape is the parser output with `applyTemplate: false, lower: false`, which matches what the formatter consumes — so an AST round-tripped through writeAST() / format() produces canonical Agency source.
+
+  @param source - Agency source code as a string
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L127))
+
+### writeAST
+
+```ts
+writeAST(ast: any, dir: string, filename: string, overwrite: boolean): Result
+```
+
+Format an AST as Agency source and write it to dir/filename. The AST is typically obtained from parseAST() and optionally transformed before being written.
+
+  The output is canonical formatter output: comments are preserved (they live in the AST as nodes), but whitespace and formatting are normalized to the AgencyGenerator's style — the same style produced by `pnpm run fmt`.
+
+  The dir argument is the sandbox boundary: filename cannot escape it via absolute paths or .. segments (symlinks on existing files are followed and re-checked).
+
+  @param ast - The AST to write (typically from parseAST)
+  @param dir - The sandbox directory
+  @param filename - The agency file to write, resolved relative to dir
+  @param overwrite - If false, fail when the file already exists (default true)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| ast | `any` |  |
+| dir | `string` |  |
+| filename | `string` |  |
+| overwrite | `boolean` | true |
+
+**Returns:** `Result`
+
+**Throws:** `std::write`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L138))
+
+### format
+
+```ts
+format(source: string): Result
+```
+
+Format Agency source code using the standard Agency formatter (the same one used by `pnpm run fmt`). Returns the formatted source on success, or a failure with a parse error.
+
+  Comments are preserved. Whitespace and formatting are canonicalized — this is a lossy transformation for whitespace but not for semantics or comments.
+
+  @param source - Agency source code as a string
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L164))
+
+### formatFile
+
+```ts
+formatFile(dir: string, filename: string): Result
+```
+
+Format an Agency file in place. Reads dir/filename, formats it with the standard Agency formatter, and writes the result back to the same path. If the file is already formatted, no write occurs (mtime is preserved).
+
+  The dir argument is the sandbox boundary: filename cannot escape it via absolute paths or .. segments (symlinks are followed and re-checked). Both the read and the write happen inside the same interrupt — approving the interrupt approves both.
+
+  Returns success(true) on a successful format (whether or not a write was needed), or a failure if parsing or I/O fails.
+
+  @param dir - The sandbox directory. filename is resolved against this and must stay inside it.
+  @param filename - The agency file to format, resolved relative to dir
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| dir | `string` |  |
+| filename | `string` |  |
+
+**Returns:** `Result`
+
+**Throws:** `std::write`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L175))
+
+### walkAST
+
+```ts
+walkAST(ast: any, visitor: (any, any) => any): any
+```
+
+Walk every node in a deep-cloned copy of the AST, invoking the visitor with each (node, ancestors) pair. The visitor may mutate the node in place; mutations land in the returned AST. The original AST passed in is never modified.
+
+  Iteration order is pre-order: a node is visited before its children. The set of nodes to visit is determined upfront — if the visitor adds new children (e.g. by appending to a function's body), those new children will NOT be visited on this walk. Similarly, if the visitor replaces a child reference (e.g. node.body = [newNode]), the visitor will still be called on the OLD body's nodes (which are already in the buffered visit list). To re-walk a transformed AST, call walkAST again.
+
+  The ancestors array lists every enclosing node from the root outward (excluding `node` itself). For nodes inside a block argument (e.g. inside `map(arr) as x { ... }`), the block argument appears in ancestors as a node with `type: "blockArgument"`.
+
+  @param ast - The AST to walk (typically from parseAST)
+  @param visitor - Called once per node as visitor(node, ancestors). Return value is ignored.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| ast | `any` |  |
+| visitor | `(any, any) => any` |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L193))
+
+### getNodesOfType
+
+```ts
+getNodesOfType(source: string, types: string[]): Result
+```
+
+Parse Agency source code and return all AST nodes whose `type` field matches any of the provided types. Walks the entire tree (not just top-level), so e.g. getNodesOfType(src, ["functionCall"]) returns every function call anywhere in the program.
+
+  The returned nodes are references into a freshly-parsed AST; safe to mutate, but mutations do not write back to disk. Use writeAST() with the parsed AST to persist changes.
+
+  @param source - Agency source code as a string
+  @param types - List of AST type strings to match (e.g. ["function", "graphNode"])
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+| types | `string[]` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L211))
+
+### getImports
+
+```ts
+getImports(source: string): Result
+```
+
+Return all import statements in the source (i.e. `import { x } from "..."`).
+
+  @param source - Agency source code as a string
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L223))
+
+### getFunctions
+
+```ts
+getFunctions(source: string): Result
+```
+
+Return all function definitions (`def foo(...) { ... }`) in the source.
+
+  @param source - Agency source code as a string
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L232))
+
+### getGraphNodes
+
+```ts
+getGraphNodes(source: string): Result
+```
+
+Return all graph node definitions (`node main() { ... }`) in the source. Note: "graph nodes" here means Agency's `node` declarations, not generic AST nodes — see getNodesOfType for the latter.
+
+  @param source - Agency source code as a string
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L241))
+
+### filterImports
+
+```ts
+filterImports(source: string, allowedPackages: string[], excludedPackages: string[], allowKinds: string[], excludeKinds: string[]): Result
+```
+
+Parse Agency source, drop imports that fail the policy, and return the resulting source plus a flag indicating whether anything was dropped.
+
+  Imports are classified by `kind`:
+    - "stdlib" — `std::*` (e.g. `std::shell`)
+    - "pkg"    — `pkg::*` (e.g. `pkg::wikipedia`)
+    - "local"  — relative or absolute file paths (e.g. `./util.agency`)
+    - "node"   — bare specifiers resolved by Node (e.g. `fs`, `child_process`)
+
+  Policy:
+    - `allowedPackages` / `excludedPackages` are glob patterns (picomatch syntax) matched against the raw import path string.
+    - `allowKinds` / `excludeKinds` accept the kind strings above.
+    - Exclude rules always win: if a path matches anything in `excludedPackages` or `excludeKinds`, it is dropped.
+    - When all four lists are empty, every import is allowed (default-allow).
+    - When at least one allow list is non-empty, an import must match an allowed kind OR an allowed package glob (union across the two axes). Note that allowKinds=["stdlib"] is still a restriction even with the package lists empty — only stdlib passes.
+
+  The returned source is regenerated via the Agency formatter, so whitespace and formatting are canonicalized. Comments are preserved (see writeAST docstring for details).
+
+  @param source - Agency source code as a string
+  @param allowedPackages - Glob patterns; matched imports are allowed (subject to excludes)
+  @param excludedPackages - Glob patterns; matched imports are dropped
+  @param allowKinds - Kind strings ("stdlib" | "pkg" | "local" | "node") to allow
+  @param excludeKinds - Kind strings to drop
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| source | `string` |  |
+| allowedPackages | `string[]` | [] |
+| excludedPackages | `string[]` | [] |
+| allowKinds | `string[]` | [] |
+| excludeKinds | `string[]` | [] |
+
+**Returns:** `Result`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L250))
+
+### typecheckFile
+
+```ts
+typecheckFile(dir: string, filename: string): Result
+```
+
+Type-check an Agency file on disk. The file is read from dir/filename, and relative imports inside the file are resolved against the file's directory.
+
+  The dir argument is the sandbox boundary for the entry file: filename cannot escape it via absolute paths or .. segments (and symlinks are followed and re-checked). Note that transitive imports from the entry file are NOT confined to dir — type-checking is read-only, so the sandbox only governs which file the caller can ask to be type-checked.
+
+  Use partial application to bind dir once, e.g. const tc = typecheckFile.partial(dir: "/safe/dir").
+
+  Returns a TypeCheckReport with `errors` and `warnings` arrays on success; returns a failure when the file cannot be read, the sandbox is violated, or the source cannot be parsed.
+
+  @param dir - The sandbox directory. filename is resolved against this and must stay inside it.
+  @param filename - The agency file to type-check, resolved relative to dir
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| dir | `string` |  |
+| filename | `string` |  |
+
+**Returns:** `Result`
+
+**Throws:** `std::read`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L284))

--- a/packages/agency-lang/docs/site/stdlib/index.md
+++ b/packages/agency-lang/docs/site/stdlib/index.md
@@ -204,14 +204,20 @@ A tool for reading the contents of a file and returning it as a string. The file
 ### write
 
 ```ts
-write(filename: string, content: string, dir: string): Result
+write(filename: string, content: string, dir: string, mode: string): Result
 ```
 
 A tool for writing content to a file. The filename is resolved relative to dir.
 
+  The `mode` parameter controls how an existing file is handled:
+    - "overwrite" (default): replace the file if it exists, create it if not
+    - "append": append to the file if it exists, create it if not
+    - "create-only": fail if the file already exists
+
   @param filename - The file to write
   @param content - The content to write
   @param dir - The directory to resolve the filename against (defaults to ".")
+  @param mode - How to handle an existing file: "overwrite" | "append" | "create-only"
 
 **Parameters:**
 
@@ -220,6 +226,7 @@ A tool for writing content to a file. The filename is resolved relative to dir.
 | filename | `string` |  |
 | content | `string` |  |
 | dir | `string` | "." |
+| mode | `string` | "overwrite" |
 
 **Returns:** `Result`
 
@@ -249,7 +256,7 @@ A tool for reading an image file and returning its contents as a Base64-encoded 
 
 **Throws:** `std::readImage`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L123))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L135))
 
 ### notify
 
@@ -270,7 +277,7 @@ A tool for showing a native OS notification with a title and message. Returns tr
 
 **Throws:** `std::notify`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L137))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L149))
 
 ### range
 
@@ -289,7 +296,7 @@ Generate an array of numbers. With one argument, generates from 0 to start-1. Wi
 
 **Returns:** `number[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L148))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L160))
 
 ### mostCommon
 
@@ -307,7 +314,7 @@ Return the most common element in an array. Uses JSON serialization for comparis
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L158))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L170))
 
 ### keys
 
@@ -325,7 +332,7 @@ Return an array of an object's own enumerable property names.
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L165))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L177))
 
 ### values
 
@@ -343,7 +350,7 @@ Return an array of an object's own enumerable property values.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L172))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L184))
 
 ### entries
 
@@ -361,7 +368,7 @@ Return an array of an object's own enumerable entries, each as { key, value }.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L179))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L191))
 
 ### emit
 
@@ -377,4 +384,4 @@ Emit a custom event to the calling TypeScript code via the onEmit callback.
 |---|---|---|
 | data |  |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L186))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L198))

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-21-stdlib-agency-ast-functions.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-21-stdlib-agency-ast-functions.md
@@ -1,0 +1,962 @@
+# Stdlib `agency` Module — AST + Formatter + Import Policy toolkit
+
+**Goal:** Add a coherent set of AST-, formatter-, and import-policy functions to `stdlib/agency.agency`:
+- `parseAST(source)` → raw AST as a plain JSON-serializable object
+- `writeAST(ast, dir, filename, overwrite=true)` → format the AST as Agency source and write it to disk (sandbox-contained, interrupt-gated)
+- `format(source)` → format Agency source code, returning the formatted source (pure string-in, string-out)
+- `formatFile(dir, filename)` → read a file, format it, and write the result back in place (sandbox-contained, interrupt-gated)
+- `walkAST(ast, visitor)` → walk every node in a deep-cloned AST; visitor may mutate nodes in place
+- `getNodesOfType(source, types[])` plus convenience wrappers `getImports`, `getFunctions`, `getGraphNodes`
+- `filterImports(source, allowedPackages, excludedPackages, allowKinds, excludeKinds)` → drop disallowed imports, return new source + a filtered flag
+
+Plus two cross-cutting changes:
+- Extend `std::write` (`stdlib/index.agency`) with a `mode: "overwrite" | "append" | "create-only"` parameter, defaulting to `"overwrite"` for backward compatibility.
+- Replace `compileSource`'s boolean `restrictImports` with the shared `ImportPolicy` shape that `filterImports` uses, so the compiler and the new function go through one classifier.
+
+**Strategy:** Each task is independently committable. Order matters where there are dependencies:
+1. `parseAST` (no filesystem)
+2. `std::write` mode (used by `writeAST` and `formatFile`)
+3. `writeAST` (introduces `generateSource` helper and `resolveInSandbox` refactor)
+4. `format` / `formatFile` (build on Tasks 1, 3)
+5. `walkAST` (depends on Task 1's AST type knowledge)
+6. `getNodesOfType` + convenience wrappers (depend on Task 1)
+7. `filterImports` (depends on Tasks 1, 3, and introduces the shared `ImportPolicy` classifier in `lib/importPaths.ts`)
+8. `compileSource` consolidation onto the shared classifier (depends on Task 7)
+
+Tasks 1, 5, 6 are independent enough to ship in any order. Task 8 is the only task that touches existing behavior — schedule it last so the new surface area lands first and the migration of `restrictImports` is a clean follow-on.
+
+---
+
+## Background / references
+
+- AST type: `AgencyProgram` from `lib/types.ts`. JSON-serializable today (it's what `pnpm run ast` prints). Comments are preserved as nodes (`AgencyComment`, `multiLineComment`).
+- Parser entry point: `parseAgency(source, config, isProgram)` from `lib/parser.ts`. Returns `{ success: true, result: AgencyProgram } | { success: false, message }`.
+- Formatter / AST → source: `AgencyGenerator` in `lib/backends/agencyGenerator.ts`. This is what `pnpm run fmt` uses. **Comments round-trip; whitespace is canonicalized to the formatter's style.** Verify by reading `agencyGenerator.test.ts` before writing the docstring.
+- Existing sandbox helper: `resolveInSandbox(dir, filename)` in `lib/stdlib/agency.ts` (added in the previous task — realpath + `+ sep` containment).
+- Existing `_write` lives in `lib/stdlib/builtins.ts`, not `lib/stdlib/agency.ts`.
+- Existing `write` signature in `stdlib/index.agency`: `write(filename, content, dir=".")` — note the order is filename-first, inconsistent with `_compileFile` / `_typecheckFile`'s `(dir, filename)`. **Don't fix this here.** New params get appended.
+
+---
+
+## Pre-flight
+
+- [ ] Confirm tree is green: `pnpm test:run 2>&1 | tee /tmp/preflight.log`
+- [ ] Confirm `pnpm run typecheck` is clean
+- [ ] Skim `lib/backends/agencyGenerator.ts` and `agencyGenerator.test.ts` to confirm the comment-preservation / whitespace-canonicalization claim before writing the `writeAST` docstring. If it turns out comments are dropped or order changes, update the docstring caveat accordingly.
+
+---
+
+## Task 1 — `parseAST`
+
+**Goal:** Add `parseAST(source: string): Result` returning the raw AST.
+
+- [ ] **Step 1: TS side — `lib/stdlib/agency.ts`**
+
+  Add:
+  ```ts
+  import { parseAgency } from "../parser.js";
+  import type { AgencyProgram } from "../types.js";
+
+  export function _parseAST(source: string): AgencyProgram {
+    const result = parseAgency(source, {}, true);
+    if (!result.success) {
+      throw new Error(result.message ?? "Failed to parse Agency source");
+    }
+    return result.result;
+  }
+  ```
+
+  Don't strip locations or other metadata — return the parser's output verbatim so the round trip through `writeAST` has everything the generator needs.
+
+- [ ] **Step 2: Agency side — `stdlib/agency.agency`**
+
+  Add to the import line: `_parseAST`.
+
+  Add:
+  ```ts
+  export def parseAST(source: string): Result {
+    """
+    Parse Agency source code into an abstract syntax tree. Returns the raw AST as a JSON-serializable object on success, or a failure with the parse error message.
+
+    The AST is the same structure printed by `pnpm run ast`. It is suitable for inspection, transformation, or round-tripping back to source via writeAST().
+
+    @param source - Agency source code as a string
+    """
+    return try _parseAST(source)
+  }
+  ```
+
+  No interrupt — `parseAST` doesn't touch disk and doesn't run anything.
+
+- [ ] **Step 3: Tests — `lib/stdlib/agency.test.ts`**
+
+  Add unit tests:
+  - `_parseAST("node main() { return 1 }")` returns an object with `nodes` array; first node has `type: "graphNodeDefinition"` and `name: "main"`
+  - `_parseAST("def x")` (invalid) throws with a message that includes parse-related text
+  - The returned AST is JSON-serializable: `JSON.parse(JSON.stringify(ast))` deep-equals `ast` (catches accidental class instances)
+
+- [ ] **Step 4: Regenerate stdlib JS**
+
+  ```bash
+  make
+  ```
+
+  Verify `stdlib/agency.js` picks up `_parseAST` in its import line and emits `parseAST`.
+
+- [ ] **Step 5: Agency execution test — `tests/agency/`**
+
+  Add a small `.agency` test that calls `parseAST` and asserts on the result shape. Confirms the function survives the Agency runtime layer.
+
+---
+
+## Task 2 — `mode` parameter on `std::write`
+
+**Goal:** Add `mode: "overwrite" | "append" | "create-only"` to `std::write`. Default `"overwrite"` preserves existing behavior.
+
+- [ ] **Step 1: TS side — `lib/stdlib/builtins.ts`**
+
+  Update `_write`:
+  ```ts
+  export type WriteMode = "overwrite" | "append" | "create-only";
+
+  export async function _write(
+    dir: string,
+    filename: string,
+    content: string,
+    mode: WriteMode = "overwrite",
+  ): Promise<boolean> {
+    const filePath = await resolvePath(dir, filename);
+    if (mode === "create-only") {
+      if (existsSync(filePath)) {
+        throw new Error(`File already exists: '${filePath}' (mode is 'create-only').`);
+      }
+      await writeFile(filePath, content, "utf8");
+      return true;
+    }
+    if (mode === "append") {
+      await appendFile(filePath, content, "utf8");
+      return true;
+    }
+    await writeFile(filePath, content, "utf8");
+    return true;
+  }
+  ```
+  Import `appendFile` and `existsSync` accordingly.
+
+- [ ] **Step 2: Agency side — `stdlib/index.agency`**
+
+  Extend `write`:
+  ```ts
+  export def write(
+    filename: string,
+    content: string,
+    dir: string = ".",
+    mode: string = "overwrite",
+  ): Result {
+    """
+    Write content to a file. The filename is resolved relative to dir.
+
+    The `mode` parameter controls how an existing file is handled:
+      - "overwrite" (default): replace the file if it exists, create it if not
+      - "append": append to the file if it exists, create it if not
+      - "create-only": fail if the file already exists
+
+    @param filename - The file to write
+    @param content - The content to write
+    @param dir - The directory to resolve the filename against (defaults to ".")
+    @param mode - How to handle an existing file: "overwrite" | "append" | "create-only"
+    """
+    return interrupt std::write("Are you sure you want to write this file?", {
+      dir: dir,
+      filename: filename,
+      mode: mode,
+    })
+    return try _write(dir, filename, content, mode)
+  }
+  ```
+
+  Note: `mode: string` rather than a union literal, because Agency doesn't ship enum-narrowing across stdlib boundaries cleanly today (verify against `docs/site/guide/types.md`). Validate the value in `_write` — invalid `mode` throws → caller sees a `failure`.
+
+- [ ] **Step 3: Tests — `lib/stdlib/builtins.test.ts`** (or `lib/stdlib/index.test.ts` — match wherever existing `_write` tests live; check first)
+
+  - `_write` with no `mode` arg → backward compat, overwrites existing file
+  - `_write` with `"overwrite"` → replaces content
+  - `_write` with `"append"` → concatenates
+  - `_write` with `"create-only"` on missing file → succeeds
+  - `_write` with `"create-only"` on existing file → throws with "already exists"
+  - `_write` with `"bogus"` → throws with a clear "invalid mode" message (add this validation explicitly)
+
+- [ ] **Step 4: Regenerate stdlib JS**
+
+  ```bash
+  make
+  ```
+
+- [ ] **Step 5: Audit existing callers**
+
+  Run `grep -rn "std::write\b\|from \"std::index\"" stdlib/ tests/ docs/` to find anything that imports or interrupts on `std::write` — the interrupt payload now has a new `mode` field, which existing policies / handlers won't break on (they'll just see the extra key), but flag any policy file that filter-matches the exact payload shape.
+
+---
+
+## Task 3 — `writeAST`
+
+**Goal:** Add `writeAST(ast, dir, filename, overwrite=true)` that formats the AST and writes it to disk, sandbox-contained and interrupt-gated.
+
+- [ ] **Step 1: TS side — `lib/stdlib/agency.ts`**
+
+  Add:
+  ```ts
+  import { generateAgency } from "../backends/agencyGenerator.js";
+
+  export async function _writeAST(
+    ast: AgencyProgram,
+    dir: string,
+    filename: string,
+    overwrite: boolean,
+  ): Promise<boolean> {
+    // Use the refactored resolveInSandbox with mustExist:false because the
+    // target file may not yet exist. The new _write (Task 2) does its own
+    // path resolution + existence checks for the "create-only" mode.
+    const source = generateAgency(ast);
+    const mode = overwrite ? "overwrite" : "create-only";
+    return _write(dir, filename, source, mode);
+  }
+  ```
+
+  Delegating to `_write` from Task 2 means:
+  - All future improvements to `_write` (atomicity, perms, etc.) flow through `writeAST`.
+  - The `overwrite` boolean maps cleanly to `mode = overwrite ? "overwrite" : "create-only"`.
+  - Sandbox containment and existence checks live in one place (`_write` already does this via `resolvePath`).
+
+  Verify that `_write`'s sandbox containment is at least as strict as we want. If not, fold the stricter `resolveInSandbox` into `_write` itself rather than duplicating it here.
+
+  The `generateAgency(program)` helper at the bottom of `lib/backends/agencyGenerator.ts` returns a trimmed, trailing-newline-fixed string — exactly what we want to write to disk. Do NOT call `new AgencyGenerator().generate(program).output` directly; use the wrapper.
+
+- [ ] **Sub-task: Refactor `resolveInSandbox` to support missing targets**
+
+  In `lib/stdlib/agency.ts`:
+  ```ts
+  function resolveInSandbox(
+    dir: string,
+    filename: string,
+    opts: { mustExist?: boolean } = { mustExist: true },
+  ): string {
+    const sandboxRoot = realpathSync(resolve(dir));
+    const resolved = resolve(sandboxRoot, filename);
+    const target = opts.mustExist ? realpathSync(resolved) : resolved;
+    if (!target.startsWith(sandboxRoot + sep)) {
+      throw new Error(
+        `Sandbox violation: '${filename}' resolves to '${target}', which is outside the sandbox dir '${sandboxRoot}'.`,
+      );
+    }
+    return target;
+  }
+  ```
+  `_compileFile` and `_typecheckFile` keep their existing behavior (default `mustExist: true`). `_writeAST` calls with `mustExist: false`.
+
+  **Caveat:** With `mustExist: false`, a symlink at `dir/filename` won't be realpath-collapsed. If an attacker plants a symlink inside `dir` pointing outside, we'd write through it. Mitigation: if the file already exists, realpath it; if not, only the parent directory check matters. Document this in a comment on `resolveInSandbox` and decide whether to realpath the parent dir of the target instead of the target itself.
+
+- [ ] **Step 2: Agency side — `stdlib/agency.agency`**
+
+  Add to the import line: `_writeAST`.
+
+  Add:
+  ```ts
+  export def writeAST(
+    ast: any,
+    dir: string,
+    filename: string,
+    overwrite: boolean = true,
+  ): Result {
+    """
+    Format an AST as Agency source and write it to dir/filename. The AST is typically obtained from parseAST() and optionally transformed before being written.
+
+    The output is canonical formatter output: comments are preserved (they live in the AST as nodes), but whitespace and formatting are normalized to the AgencyGenerator's style — the same style produced by `pnpm run fmt`.
+
+    The dir argument is the sandbox boundary: filename cannot escape it via absolute paths or .. segments (symlinks on existing files are followed and re-checked).
+
+    @param ast - The AST to write (typically from parseAST)
+    @param dir - The sandbox directory
+    @param filename - The agency file to write, resolved relative to dir
+    @param overwrite - If false, fail when the file already exists (default true)
+    """
+    const mode = if (overwrite) { "overwrite" } else { "create-only" }
+    return interrupt std::write("Are you sure you want to write this file?", {
+      dir: dir,
+      filename: filename,
+      mode: mode,
+    })
+    return try _writeAST(ast, dir, filename, overwrite)
+  }
+  ```
+
+- [ ] **Step 3: Tests — `lib/stdlib/agency.test.ts`**
+
+  - Happy path: parse → write → re-parse → assert the second AST is structurally equivalent to the first (round-trip)
+  - `overwrite=true` (default) replaces existing file
+  - `overwrite=false` on missing file → writes successfully
+  - `overwrite=false` on existing file → throws with "already exists"
+  - Sandbox containment: same battery as `_compileFile` (absolute filename, `..` escape, sibling-prefix dir). The symlink-escape case is harder when the target doesn't yet exist — write the test for an *existing* file in a symlinked location to confirm the realpath-on-existing branch still catches escapes.
+  - AST → source spot-check: write a hand-built AST for `node main() { return 1 }` and assert the resulting file contains `node main`, `return 1`, with the formatter's canonical spacing.
+
+- [ ] **Step 4: Regenerate stdlib JS**
+
+  ```bash
+  make
+  ```
+
+- [ ] **Step 5: Agency execution test — `tests/agency/`**
+
+  End-to-end: `parseAST` → mutate the AST (e.g. rename a function via a small block of agency code that walks `ast.nodes`) → `writeAST` to a sandbox tmpdir → read the file back → assert content. Confirms the full round-trip through the Agency runtime.
+
+---
+
+## Task 4 — `format` / `formatFile`
+
+**Goal:** Add `format(source)` (pure source → source) and `formatFile(dir, filename)` (in-place file format).
+
+`format` is `parseAST` + `AgencyGenerator` composed. `formatFile` is `format` plus disk I/O with the same sandbox + interrupt pattern as `writeAST`.
+
+Depends on: Task 1 (`_parseAST`) and Task 3 (refactored `resolveInSandbox` with `mustExist`, and the verified `AgencyGenerator` API shape). Land Task 4 last.
+
+- [ ] **Step 1: TS side — `lib/stdlib/agency.ts`**
+
+  `generateAgency` from `lib/backends/agencyGenerator.ts` is the single source-of-truth helper for AST → source. Use it directly here and in `_writeAST` — no need for a separate `generateSource` wrapper.
+
+  ```ts
+  import { generateAgency } from "../backends/agencyGenerator.js";
+
+  export function _format(source: string): string {
+    return generateAgency(_parseAST(source));
+  }
+
+  export function _formatFile(dir: string, filename: string): boolean {
+    // formatFile *requires* the file to exist — it reads then writes.
+    // Use the existing-target branch (mustExist: true) so symlinks get
+    // realpath-collapsed. Same as _typecheckFile.
+    const target = resolveInSandbox(dir, filename, { mustExist: true });
+    const source = readFileSync(target, "utf-8");
+    const formatted = generateAgency(_parseAST(source));
+    // Skip the write if formatting is a no-op — avoids touching mtime
+    // when nothing actually changed. Match Prettier / rustfmt behavior.
+    if (formatted !== source) {
+      writeFileSync(target, formatted, "utf-8");
+    }
+    return true;
+  }
+  ```
+
+  Notes:
+  - `_format` throws on parse failure (callers wrap in `try`). No filesystem access at all.
+  - `_formatFile` uses `mustExist: true` because the file *has* to exist to read it. This is the existing-target sandbox path so symlinks are realpath-collapsed and the missing-target caveat from Task 3 doesn't apply here.
+  - The "skip write if unchanged" optimization is worth doing — keeps `pnpm run fmt` idempotent without poking file mtimes. If the user disagrees, drop it; either is defensible.
+
+- [ ] **Step 2: Agency side — `stdlib/agency.agency`**
+
+  Add to the import line: `_format`, `_formatFile`.
+
+  Add:
+  ```ts
+  export def format(source: string): Result {
+    """
+    Format Agency source code using the standard Agency formatter (the same one used by `pnpm run fmt`). Returns the formatted source on success, or a failure with a parse error.
+
+    Comments are preserved. Whitespace and formatting are canonicalized — this is a lossy transformation for whitespace but not for semantics or comments.
+
+    @param source - Agency source code as a string
+    """
+    return try _format(source)
+  }
+
+  export def formatFile(dir: string, filename: string): Result {
+    """
+    Format an Agency file in place. Reads dir/filename, formats it with the standard Agency formatter, and writes the result back to the same path. If the file is already formatted, no write occurs (mtime is preserved).
+
+    The dir argument is the sandbox boundary: filename cannot escape it via absolute paths or .. segments (symlinks are followed and re-checked). Both the read and the write happen inside the same interrupt — approving the interrupt approves both.
+
+    Returns success(true) on a successful format (whether or not a write was needed), or a failure if parsing or I/O fails.
+
+    @param dir - The sandbox directory. filename is resolved against this and must stay inside it.
+    @param filename - The agency file to format, resolved relative to dir
+    """
+    return interrupt std::write("Are you sure you want to format this file in place?", {
+      dir: dir,
+      filename: filename,
+      mode: "overwrite",
+    })
+    return try _formatFile(dir, filename)
+  }
+  ```
+
+  Decisions to flag for review:
+  - **One interrupt or two?** `formatFile` does both a read and a write. I picked a single `std::write` interrupt (it's the more destructive of the two — the read is the same source we'd return from format anyway). Alternative: chain `std::read` then `std::write`. Pick one; document.
+  - **Interrupt message wording** — `"Are you sure you want to format this file in place?"` is more accurate than the default write message because the user might not realize formatting overwrites the file. Worth the divergence.
+
+- [ ] **Step 3: Tests — `lib/stdlib/agency.test.ts`**
+
+  For `_format`:
+  - Idempotence: `_format(_format(src)) === _format(src)` for a few source samples
+  - Parse error: `_format("def x")` throws (caller wraps in `try`)
+  - Comments survive: `_format("// hi\nnode main() {}")` still contains `// hi`
+  - Whitespace canonicalizes: a deliberately ugly source (mixed indentation, extra blank lines) → formatted output matches what `pnpm run fmt` would produce. Use a fixture so the expected output is checked into the repo and visible in diffs.
+
+  For `_formatFile`:
+  - Happy path: write an ugly source into a sandbox file, call `_formatFile`, read it back, assert formatted
+  - No-op skip: if file already matches formatter output, file mtime is unchanged (capture mtime before/after; assert equal). If the no-op optimization is dropped, drop this test too.
+  - Sandbox containment: absolute filename, `..` escape, sibling-prefix dir, symlink escape — same battery as `_compileFile`. Reuse the test scaffold.
+  - Missing file → throws (sandbox helper uses `mustExist: true` so this falls out for free)
+
+- [ ] **Step 4: Regenerate stdlib JS**
+
+  ```bash
+  make
+  ```
+
+  Spot-check `stdlib/agency.js` for `_format` / `_formatFile` in the import line and `format` / `formatFile` in the emitted code.
+
+- [ ] **Step 5: Agency execution tests — `tests/agency/`**
+
+  - End-to-end `format`: pass an ugly source, assert formatted output
+  - End-to-end `formatFile`: write a fixture to a tmpdir under cwd's `.agency-tmp/`, call `formatFile`, read back, assert
+  - Use `safeDeleteDirectory(path, false)` for cleanup, not raw `rmSync`
+
+---
+
+## Task 5 — `walkAST`
+
+**Goal:** Add `walkAST(ast, visitor)` that walks every node in a deep clone of the AST and invokes `visitor(node, ancestors)` for each one. The visitor may mutate the node in place; mutations land in the returned clone, the original is untouched.
+
+Depends on: Task 1 (`_parseAST`) for source-of-truth on the AST shape, but otherwise independent — could ship before Tasks 2–4.
+
+**Design summary (settled):**
+- Deep-clone the AST upfront; original is never mutated.
+- Visitor receives `(node, ancestors)` and may mutate `node` freely.
+- Visitor's return value is ignored (no replace semantics — keeps this simple).
+- Iteration is **pre-order**: visitor runs on a node *before* we descend into its children. So a visitor that swaps a function's body for new content will see its replacement walked on the next ticks.
+- All `AgencyNode` positions are visited, including those reached via `walkNodes`' inline-child traversal (conditions, expressions inside `valueAccess.chain`, block-argument bodies, etc.). `blockArgument` nodes appear in `ancestors`.
+- Non-`AgencyNode` substructures (e.g. `valueAccess.chain[i].kind === "property"` records, raw text segments inside strings) are **not** passed to the visitor — only actual AgencyNode values are.
+- The function returns the deep-cloned (and possibly mutated) AST.
+
+### Step 1: TS side — `lib/stdlib/agency.ts`
+
+Add:
+
+```ts
+import { walkNodes } from "../utils/node.js";
+import { deepCopy } from "../utils.js";
+
+export type WalkASTVisit = {
+  node: AgencyNode;
+  ancestors: AgencyNode[]; // includes block arguments — see WalkAncestor in lib/utils/node.ts
+};
+
+// Deep-clone the AST, enumerate every visit (pre-order) into a flat array,
+// and hand both back. The Agency wrapper iterates `visits` calling the
+// user's block; the visits hold references into `clone`, so in-place
+// mutation in the block lands in `clone` and is returned. We use the
+// existing `walkNodes` generator from lib/utils/node.ts as the single
+// source of truth for traversal — don't reimplement the node-type
+// dispatch.
+export function _walkAST(ast: AgencyProgram): {
+  clone: AgencyProgram;
+  visits: WalkASTVisit[];
+} {
+  const clone = deepCopy(ast);
+  const visits: WalkASTVisit[] = [];
+  for (const { node, ancestors } of walkNodes(clone.nodes)) {
+    visits.push({ node, ancestors: ancestors as AgencyNode[] });
+  }
+  return { clone, visits };
+}
+```
+
+Notes:
+- `deepCopy` is already exported from `lib/utils.ts` and uses `JSON.parse(JSON.stringify(...))`. The AST is JSON-serializable (verified by Task 1's round-trip test), so this is safe.
+- `walkNodes` walks every node position the agency-generator cares about. Reusing it means `walkAST` will pick up any new node kinds the parser learns about for free.
+- The visits array holds **references** into `clone`. In-place mutation by the user is visible in the returned clone. This is intentional and is the whole point of "modify in place if you'd like."
+- **Iteration order vs mutation:** if the visitor mutates a node *before* its children have been visited, the children we visit next are the **new** ones (because `walkNodes` is a generator that descends from the current node — but we've already buffered the visits into a flat array). **Wait — verify this.** Two possibilities:
+  - (a) `walkNodes` yields nodes lazily; reifying the generator into an array before the visitor runs means we've already captured references to the *original* children. Mutating the parent later doesn't change which child references are in our array.
+  - (b) If the user replaces a child reference (e.g. `node.body = newBody`), the array still holds a reference to the old `body`, so the visitor will still be called on the orphaned children.
+
+  This is the most important semantic question. **My recommendation: document (b) as the behavior.** It's predictable: "we computed the walk order before any mutations." If the user wants their mutations to influence the walk, they should drive the iteration themselves with their own recursion. Document this clearly in the docstring with an example.
+
+  Alternative: stream the visitor lazily through the generator. That makes mutations affect the walk but creates a confusing semantic where "visit before mutate" and "visit after mutate" interleave. Hard to reason about. Don't do this.
+
+### Step 2: Agency side — `stdlib/agency.agency`
+
+Add to the import line: `_walkAST`.
+
+**Block-invocation pattern (verified against `stdlib/array.agency`):** higher-order stdlib functions take their callback as a typed parameter (e.g. `func: (any) => any` for `map`, `func: (any, any) => any` for `reduce`) and invoke it with a plain function call inside a `for ... in` loop. There is no special block syntax — just a typed function parameter and a normal call.
+
+```ts
+export def walkAST(ast: any, visitor: (any, any) => any): any {
+  """
+  Walk every node in a deep-cloned copy of the AST, invoking the visitor with each (node, ancestors) pair. The visitor may mutate the node in place; mutations land in the returned AST. The original AST passed in is never modified.
+
+  Iteration order is pre-order: a node is visited before its children. The set of nodes to visit is determined upfront — if the visitor adds new children (e.g. by appending to a function's body), those new children will NOT be visited on this walk. Similarly, if the visitor replaces a child reference (e.g. `node.body = [newNode]`), the visitor will still be called on the OLD body's nodes (which are already in the buffered visit list). To re-walk a transformed AST, call walkAST again.
+
+  The ancestors array lists every enclosing node from the root outward (excluding `node` itself). For nodes inside a block argument (e.g. inside `map(arr) as x { ... }`), the block argument appears in ancestors as a node with `type: "blockArgument"`.
+
+  @param ast - The AST to walk (typically from parseAST)
+  @param visitor - Called once per node as visitor(node, ancestors). Return value is ignored.
+  """
+  const result = _walkAST(ast)
+  for (visit in result.visits) {
+    visitor(visit.node, visit.ancestors)
+  }
+  return result.clone
+}
+```
+
+Notes on the signature:
+- Parameter type `(any, any) => any` matches `reduce`'s shape in `stdlib/array.agency`. Return type is `any` even though the visitor's return value is ignored, because there's no `void` in Agency function types today (verify against `docs/site/guide/types.md` — if a more precise type exists for "ignored return," use it).
+- Callers use it like:
+  ```ts
+  const newAst = walkAST(ast) as (node, ancestors) {
+    if (node.type == "variableName" && node.value == "foo") {
+      node.value = "bar"
+    }
+  }
+  ```
+  The `as (params) { ... }` form is Agency's block-argument syntax, which desugars to a function value matching the typed parameter. This is the same surface Agency users already know from `map` / `filter` / `reduce`.
+
+### Step 3: Tests — `lib/stdlib/agency.test.ts`
+
+For `_walkAST`:
+- Original is not mutated: parse → `_walkAST` → mutate every visited node's `.type` to `"MUTATED"` → original AST still has its real types.
+- Returned `clone` IS mutated: same setup, but assert `clone.nodes[0].type === "MUTATED"`.
+- Visit order is pre-order: parse `node main() { return 1 }`, push each visit's `node.type` into an array, assert `["graphNode", ..., "returnStatement", ...]` (graphNode comes before returnStatement).
+- Ancestors are populated correctly: for the `returnStatement` inside `node main()`, assert `ancestors.map(a => a.type)` ends with `"graphNode"`.
+- `blockArgument` ancestors appear for nodes inside `as x { ... }` blocks. Use `[1, 2, 3].map() as x { x + 1 }` (or whatever the syntax is) as a fixture.
+- Mutating a parent's body during the walk does NOT affect the remaining iteration (verifies the "buffered visits" semantic). Write the test to lock in (b) above.
+- Replacing a child entirely (`node.body = [newNode]`) — assert the visitor is still called on the OLD body's nodes (they're in the buffered visit list). This locks in the contract.
+
+### Step 4: Regenerate stdlib JS
+
+```bash
+make
+```
+
+### Step 5: Agency execution test — `tests/agency/`
+
+End-to-end: parse a small program, call `walkAST` with a block that renames every `variableName.value` matching `foo` to `bar`, then `writeAST` the result and assert the file contains `bar` and not `foo`. This is the kind of refactor `walkAST` exists to enable.
+
+---
+
+## Task 6 — Convenience queries on source
+
+**Goal:** Add four convenience functions that take Agency source code (not an AST) and return matching AST nodes. These are the "I just want the imports out of this file" ergonomic layer on top of `parseAST`.
+
+```ts
+export def getNodesOfType(source: string, types: string[]): Result
+export def getImports(source: string): Result
+export def getFunctions(source: string): Result
+export def getGraphNodes(source: string): Result
+```
+
+All return `Result<AgencyNode[], string>` — a `failure` if parsing fails, a `success` with the (possibly empty) array of matching nodes otherwise.
+
+**Naming note:** `getGraphNodes` rather than `getNodes` to disambiguate from "AST nodes." The string passed to the underlying AST type filter is `"graphNode"` (the parser's type tag for `node main() { ... }` definitions — verify against `lib/types.ts`).
+
+Depends on: Task 1 (`_parseAST`). Independent of Tasks 2–5.
+
+### Step 1: TS side — `lib/stdlib/agency.ts`
+
+There's already a `getNodesOfType` in `lib/utils/node.ts` with a slightly different shape — it takes a node array plus a *single* type string, and walks the tree returning nodes that match. We want a source-string-in version that accepts *multiple* types. Don't duplicate the walking logic; build on `walkNodes` (or `walkNodesArray`) directly.
+
+```ts
+import { walkNodesArray } from "../utils/node.js";
+
+export function _getNodesOfType(
+  source: string,
+  types: string[],
+): AgencyNode[] {
+  const ast = _parseAST(source);
+  const wanted = new Set(types);
+  return walkNodesArray(ast.nodes)
+    .map((v) => v.node)
+    .filter((n) => wanted.has(n.type));
+}
+```
+
+Notes:
+- Walks the entire tree, not just top-level. For `"functionCall"` this matters (calls live inside bodies). For `"importStatement"` / `"function"` / `"graphNode"`, top-level is the only place they appear anyway — but using the full walker keeps the contract uniform.
+- `_parseAST` throws on parse failure → caller wraps in `try` → Agency callers see a `failure` Result.
+- Returns plain `AgencyNode` objects. They're references into the parser output. Mutating them mutates the parsed AST — but since `_parseAST` is called fresh each invocation here, there's no shared state to corrupt. Document this as "the returned nodes are not deep-cloned; treat them as read-only unless you specifically want to mutate the AST before writing it back."
+
+The convenience wrappers are one-liners:
+
+```ts
+export function _getImports(source: string): AgencyNode[] {
+  return _getNodesOfType(source, ["importStatement"]);
+}
+
+export function _getFunctions(source: string): AgencyNode[] {
+  return _getNodesOfType(source, ["function"]);
+}
+
+export function _getGraphNodes(source: string): AgencyNode[] {
+  return _getNodesOfType(source, ["graphNode"]);
+}
+```
+
+**Verify against `lib/types.ts` before coding:**
+- The AST type tag for a `def` is likely `"function"` — but confirm.
+- The AST type tag for a `node` is likely `"graphNode"` — but confirm.
+- `_getImports` includes only `"importStatement"`. The older `importNodeStatement` form (`import nodes { ... }`) is deprecated and slated for removal — do not include it. If you find it still present in `lib/types.ts` during implementation, that's expected (removal happens separately); we just don't surface it here.
+
+### Step 2: Agency side — `stdlib/agency.agency`
+
+Add to the import line: `_getNodesOfType`, `_getImports`, `_getFunctions`, `_getGraphNodes`.
+
+```ts
+export def getNodesOfType(source: string, types: string[]): Result {
+  """
+  Parse Agency source code and return all AST nodes whose `type` field matches any of the provided types. Walks the entire tree (not just top-level), so e.g. getNodesOfType(src, ["functionCall"]) returns every function call anywhere in the program.
+
+  The returned nodes are references into a freshly-parsed AST; safe to mutate, but mutations do not write back to disk. Use writeAST() with the parsed AST to persist changes.
+
+  @param source - Agency source code as a string
+  @param types - List of AST type strings to match (e.g. ["function", "graphNode"])
+  """
+  return try _getNodesOfType(source, types)
+}
+
+export def getImports(source: string): Result {
+  """
+  Return all import statements in the source (i.e. `import { x } from "..."`).
+
+  @param source - Agency source code as a string
+  """
+  return try _getImports(source)
+}
+
+export def getFunctions(source: string): Result {
+  """
+  Return all function definitions (`def foo(...) { ... }`) in the source.
+
+  @param source - Agency source code as a string
+  """
+  return try _getFunctions(source)
+}
+
+export def getGraphNodes(source: string): Result {
+  """
+  Return all graph node definitions (`node main() { ... }`) in the source. Note: "graph nodes" here means Agency's `node` declarations, not generic AST nodes — see getNodesOfType for the latter.
+
+  @param source - Agency source code as a string
+  """
+  return try _getGraphNodes(source)
+}
+```
+
+No interrupts — these are pure read-only operations on a source string.
+
+### Step 3: Tests — `lib/stdlib/agency.test.ts`
+
+For `_getNodesOfType`:
+- Empty types array → empty result
+- Single type that matches one occurrence
+- Single type that matches multiple occurrences (`"functionCall"` inside a body)
+- Multiple types in one call → union of matches, preserving walk order
+- Unknown type string → empty result (no error)
+- Parse failure → throws (caller wraps in `try`)
+
+For each convenience wrapper:
+- Fixture: a small source with one import (regular + node-import), two functions, two graph nodes. Assert each wrapper returns exactly the expected count and correct type tags.
+- Empty source → empty arrays from all three wrappers.
+
+### Step 4: Regenerate stdlib JS
+
+```bash
+make
+```
+
+### Step 5: Agency execution test — `tests/agency/`
+
+One end-to-end test: parse a fixture source, call `getFunctions` and `getImports` on it, assert lengths and names. Confirms the Result wrapping survives the runtime boundary.
+
+---
+
+## Task 7 — `filterImports`
+
+**Goal:** Add `filterImports(source, allowedPackages, excludedPackages, allowKinds, excludeKinds)` that returns Agency source with disallowed imports removed, plus a boolean flag indicating whether anything was filtered.
+
+```ts
+export def filterImports(
+  source: string,
+  allowedPackages: string[] = [],
+  excludedPackages: string[] = [],
+  allowKinds: string[] = [],
+  excludeKinds: string[] = [],
+): Result   // success: { source: string, filtered: boolean }
+```
+
+Depends on: Task 1 (`_parseAST`), Task 3's `generateSource` helper, Task 6's `_getImports` (only for the test fixtures — implementation walks the AST directly).
+
+### Step 1: Shared classifier — `lib/importPaths.ts`
+
+The classifier is shared between `filterImports` (Task 7) and `compileSource`'s policy check (Task 8). Put it next to the existing `isStdlibImport` / `isPkgImport` helpers.
+
+```ts
+export type ImportKind = "stdlib" | "pkg" | "local" | "node";
+
+export function importKind(modulePath: string): ImportKind {
+  if (isStdlibImport(modulePath)) return "stdlib";
+  if (isPkgImport(modulePath)) return "pkg";
+  if (
+    modulePath.startsWith("./") ||
+    modulePath.startsWith("../") ||
+    modulePath.startsWith("/") ||
+    modulePath.endsWith(".agency")
+  ) return "local";
+  return "node";
+}
+
+export type ImportPolicy = {
+  allowedPackages?: string[];
+  excludedPackages?: string[];
+  allowKinds?: ImportKind[];
+  excludeKinds?: ImportKind[];
+};
+
+export function isImportAllowed(modulePath: string, policy: ImportPolicy): boolean {
+  const kind = importKind(modulePath);
+  const allowKinds = policy.allowKinds ?? [];
+  const allowPkgs = policy.allowedPackages ?? [];
+  const excludeKinds = policy.excludeKinds ?? [];
+  const excludePkgs = policy.excludedPackages ?? [];
+
+  // Exclude rules — any match wins, regardless of allow rules.
+  if (excludeKinds.includes(kind)) return false;
+  if (excludePkgs.some((g) => matchGlob(g, modulePath))) return false;
+
+  // No allow rules of either kind → default-allow.
+  // IMPORTANT: only the *combination* of empty allow-lists counts as "no
+  // restriction". `allowKinds: ["stdlib"]` with `allowedPackages: []` is
+  // still a restriction — only stdlib passes.
+  if (allowKinds.length === 0 && allowPkgs.length === 0) return true;
+
+  // Union across the two axes: match either an allowed kind OR an
+  // allowed package glob. So `allowKinds: ["stdlib"]` + `allowedPackages: ["pkg::foo"]`
+  // allows stdlib and pkg::foo.
+  const kindMatched = allowKinds.includes(kind);
+  const pkgMatched = allowPkgs.some((g) => matchGlob(g, modulePath));
+  return kindMatched || pkgMatched;
+}
+```
+
+**Verify before coding:**
+- The `local` heuristic above (`./`, `../`, `/`, `.agency`) is my guess. Check `lib/importPaths.ts` for any existing `isLocalImport` or similar predicate the parser/compiler already uses; reuse it if found.
+- Glob library: `lib/stdlib/policy.ts` already does pattern matching for the policy DSL. Read it to see which library Agency standardizes on (likely `minimatch` or `picomatch` — verify which). Use the same one here. If none is already a dependency, prefer `picomatch` (faster, smaller); if `minimatch` is already present, use that to avoid adding a dep.
+
+### Step 2: TS side — `lib/stdlib/agency.ts`
+
+```ts
+import { isImportAllowed, ImportKind, ImportPolicy } from "../importPaths.js";
+
+export function _filterImports(
+  source: string,
+  allowedPackages: string[],
+  excludedPackages: string[],
+  allowKinds: string[],
+  excludeKinds: string[],
+): { source: string; filtered: boolean } {
+  const ast = _parseAST(source);
+  const policy: ImportPolicy = {
+    allowedPackages,
+    excludedPackages,
+    allowKinds: allowKinds as ImportKind[],
+    excludeKinds: excludeKinds as ImportKind[],
+  };
+  const originalCount = ast.nodes.length;
+  ast.nodes = ast.nodes.filter(
+    (n) => n.type !== "importStatement" || isImportAllowed(n.modulePath, policy),
+  );
+  const filtered = ast.nodes.length !== originalCount;
+  return { source: generateAgency(ast), filtered };
+}
+```
+
+Notes:
+- Reassigns `ast.nodes` to a filtered array. `_parseAST` returns a fresh parse, so there's no shared state to corrupt.
+- Uses `generateAgency` from `lib/backends/agencyGenerator.ts` — the single AST → source helper.
+- The kind-string cast (`as ImportKind[]`) is a type-narrowing convenience. Unknown values in `allowKinds`/`excludeKinds` won't match `kind` (which is constrained to the union), so they're inert. Worth a comment: "unknown kind strings are silently ignored — they can't match anything anyway."
+
+### Step 3: Agency side — `stdlib/agency.agency`
+
+Add to import line: `_filterImports`.
+
+```ts
+type FilterImportsResult = {
+  source: string,
+  filtered: boolean,
+}
+
+export def filterImports(
+  source: string,
+  allowedPackages: string[] = [],
+  excludedPackages: string[] = [],
+  allowKinds: string[] = [],
+  excludeKinds: string[] = [],
+): Result {
+  """
+  Parse Agency source, drop imports that fail the policy, and return the resulting source plus a flag indicating whether anything was dropped.
+
+  Imports are classified by `kind`:
+    - "stdlib" — `std::*` (e.g. `std::shell`)
+    - "pkg"    — `pkg::*` (e.g. `pkg::wikipedia`)
+    - "local"  — relative or absolute file paths (e.g. `./util.agency`)
+    - "node"   — bare specifiers resolved by Node (e.g. `fs`, `child_process`)
+
+  Policy:
+    - `allowedPackages` / `excludedPackages` are glob patterns matched against the raw import path string.
+    - `allowKinds` / `excludeKinds` accept the kind strings above.
+    - Exclude rules always win: if a path matches anything in `excludedPackages` or `excludeKinds`, it is dropped.
+    - When all four lists are empty, every import is allowed (default-allow).
+    - When at least one allow list is non-empty, an import must match an allowed kind OR an allowed package glob (union across the two axes). Note that allowKinds=["stdlib"] is still a restriction even with the package lists empty — only stdlib passes.
+
+  The returned source is regenerated via the Agency formatter, so whitespace and formatting are canonicalized. Comments are preserved (see writeAST docstring for details).
+
+  @param source - Agency source code as a string
+  @param allowedPackages - Glob patterns; matched imports are allowed (subject to excludes)
+  @param excludedPackages - Glob patterns; matched imports are dropped
+  @param allowKinds - Kind strings ("stdlib" | "pkg" | "local" | "node") to allow
+  @param excludeKinds - Kind strings to drop
+  """
+  return try _filterImports(source, allowedPackages, excludedPackages, allowKinds, excludeKinds)
+}
+```
+
+No interrupt — pure string-in / string-out, no filesystem.
+
+### Step 4: Tests — `lib/stdlib/agency.test.ts`
+
+Cover the policy matrix:
+- All four lists empty → `filtered: false`, source byte-equivalent after formatting normalization (use `_format(source)` as the expected baseline)
+- `allowKinds: ["stdlib"]` on a source with one stdlib + one local import → local dropped, `filtered: true`
+- `excludeKinds: ["node"]` → all bare-specifier imports dropped
+- `allowedPackages: ["std::shell", "pkg::foo"]` → exact-list allow
+- `excludedPackages: ["std::shell"]` with `allowKinds: ["stdlib"]` → exclude wins (std::shell dropped, other stdlib imports kept)
+- Union semantics: `allowKinds: ["stdlib"]` + `allowedPackages: ["pkg::foo"]` → both stdlib AND pkg::foo pass
+- Unknown kind string in `allowKinds: ["bogus"]` → no match, behaves like an empty allow list contribution (but if `allowKinds` is non-empty, default-allow does NOT kick in — verify the test reflects this corner)
+- Glob behavior: `allowedPackages: ["std::*"]` → all stdlib imports pass
+- Empty source / no imports → `filtered: false`, source matches formatter output
+
+### Step 5: Regenerate stdlib JS
+
+```bash
+make
+```
+
+### Step 6: Agency execution test — `tests/agency/`
+
+End-to-end: a source with a mix of stdlib, pkg, local, and node imports. Call `filterImports` with `allowKinds: ["stdlib", "pkg"]`. Assert the resulting source contains the stdlib/pkg imports and does not contain `fs` or `./util.agency`. Confirms the round-trip through the Agency runtime.
+
+---
+
+## Task 8 — Consolidate `compileSource`'s `restrictImports` onto the import policy
+
+**Goal:** Replace `compileSource`'s boolean `restrictImports` with the shared `ImportPolicy`. Compile-time policy violations still **fail the compile** (security-critical — we can't silently drop disallowed imports inside `compileSource`, since that would quietly trim the compiled output's tool surface).
+
+Depends on: Task 7 (shared classifier + `_filterImports`).
+
+### Step 1: Add `imports` to `CompileSourceOptions` — `lib/compiler/compile.ts`
+
+```ts
+import { ImportPolicy, isImportAllowed } from "../importPaths.js";
+
+export type CompileSourceOptions = AgencyConfig & {
+  /** @deprecated Use `imports: { allowKinds: ["stdlib"] }` instead. */
+  restrictImports?: boolean;
+  /** Import policy. Disallowed imports cause the compile to fail with
+   *  one error per violation. See lib/importPaths.ts for the shape. */
+  imports?: ImportPolicy;
+};
+```
+
+### Step 2: Resolve the effective policy
+
+`restrictImports: true` is sugar for `{ allowKinds: ["stdlib"] }`. Resolve before the rest of the pipeline runs:
+
+```ts
+function resolveImportPolicy(config: CompileSourceOptions): ImportPolicy | null {
+  if (config.imports && config.restrictImports) {
+    throw new Error(
+      "compileSource: pass either `imports` or `restrictImports`, not both. `restrictImports` is the deprecated shorthand.",
+    );
+  }
+  if (config.imports) return config.imports;
+  if (config.restrictImports) return { allowKinds: ["stdlib"] };
+  return null;
+}
+```
+
+### Step 3: Check imports against policy; produce per-violation errors on rejection
+
+The shared primitive is `isImportAllowed`, not the parse-and-regenerate pipeline. `compileSource` has already parsed the program, so just walk the existing AST and collect violations. **Do not call `_filterImports`** — re-parsing and re-generating source we already have on hand is pure waste, and stripping imports from a compiled program would silently shrink the tool surface.
+
+```ts
+// 2. Check imports against policy.
+const policy = resolveImportPolicy(config);
+if (policy) {
+  const violations = program.nodes
+    .filter((n): n is ImportStatement => n.type === "importStatement")
+    .filter((n) => !isImportAllowed(n.modulePath, policy))
+    .map((n) => `Import '${n.modulePath}' is not allowed under the configured import policy.`);
+  if (violations.length > 0) {
+    return { success: false, errors: violations };
+  }
+}
+```
+
+Both `compileSource` and `_filterImports` go through `isImportAllowed` — that's the real reuse, and it's free.
+
+**Open question to flag for the implementer:** the return shape `{ source, filtered }` is intentionally minimal per the user's spec. If experience with this code shows that callers (especially `compileSource`) keep wanting to know *which* paths were dropped, consider widening to `{ source, filtered, removedPaths: string[] }` in a follow-up. Don't do it now — the boolean is what was asked for and the second walk in `compileSource` is cheap.
+
+### Step 4: Remove `checkRestrictedImports`
+
+The old `checkRestrictedImports(program)` helper in `lib/compiler/compile.ts` is now dead. Remove it and its helper `classifyImport(importPath)` (the human-readable label classifier — different from the new `importKind`, which returns the enum).
+
+### Step 5: Tests
+
+- `lib/compiler/compile.test.ts` (or wherever existing `restrictImports` tests live):
+  - All existing `restrictImports: true` tests still pass (backward compat via the resolver)
+  - New `imports: { allowKinds: ["stdlib"] }` tests cover the same ground
+  - Error messages name every violating import (not just the first one) — verify against the old behavior, which only reported one
+  - Passing both `restrictImports` and `imports` throws
+
+- `lib/stdlib/agency.test.ts`:
+  - Existing `_compile` tests using `restrictImports: true` keep working
+
+### Step 6: Caller audit
+
+`grep -rn 'restrictImports' lib/ stdlib/ tests/ docs/` to find every caller. The only in-tree user should be `compileAndPersist` in `lib/stdlib/agency.ts` (passed via `_compile` / `_compileFile`). Update it to use the new `imports` shape; leave the boolean alone in `compileAndPersist` if you want zero behavior change, or migrate it for cleanliness. I'd migrate.
+
+### Step 7: Regenerate stdlib JS
+
+```bash
+make
+```
+
+---
+
+## Anti-pattern review (before opening PR)
+
+Check the diff against `docs/dev/anti-patterns.md`:
+- Don't duplicate the sandbox containment logic — extend `resolveInSandbox`, don't copy-paste it again.
+- `_format`, `_formatFile`, `_writeAST` all share the AST → source step. Make sure they go through one helper (`generateSource`), not three call sites.
+- `_getImports` / `_getFunctions` / `_getGraphNodes` must delegate to `_getNodesOfType` — don't reimplement the parse-and-walk dance three times.
+- The existing `getNodesOfType` in `lib/utils/node.ts` and our new `_getNodesOfType` have different signatures (single-type-string + nodes-array vs. multi-type-string + source-string). That's intentional, not duplication — but check whether they could reasonably converge during this work, and if so, do it.
+- `_filterImports` and `compileSource`'s policy check **must** share `isImportAllowed` from `lib/importPaths.ts`. If you find yourself writing a second classifier, stop.
+- Don't reintroduce `checkRestrictedImports` or `classifyImport` (the old `compile.ts` helpers). They're gone in Task 8 and the new policy machinery replaces them.
+- Keep `_parseAST` / `_writeAST` / `_format` / `_formatFile` / `_getNodesOfType` declarative — no for-loop scaffolding around the parse/generate/filter calls.
+- Cleanup paths (if any tempdirs get created in tests) must go through `safeDeleteDirectory(path, false)` — not raw `fs.rmSync`.
+- No empty `catch (_) {}` blocks.
+
+---
+
+## Open follow-ups (out of scope for this plan)
+
+- `read` / `write` parameter order is `(filename, content, dir)`, inconsistent with `_compileFile` / `_typecheckFile` / `writeAST`'s `(dir, filename)`. Worth a separate breaking-change discussion.
+- Exposing a typed `ASTNode` hierarchy in Agency (instead of `any`) — large surface, would drift from the TS side. Deferred unless real callers ask for it.

--- a/packages/agency-lang/lib/agents/policy/agent.agency
+++ b/packages/agency-lang/lib/agents/policy/agent.agency
@@ -1,4 +1,3 @@
-import { map } from "std::array"
 import { writePolicyFile } from "std::policy"
 import { args } from "std::system"
 import { systemMessage } from "std::thread"

--- a/packages/agency-lang/lib/agents/policy/agent.agency
+++ b/packages/agency-lang/lib/agents/policy/agent.agency
@@ -1,6 +1,7 @@
 import { writePolicyFile } from "std::policy"
 import { args } from "std::system"
 import { systemMessage } from "std::thread"
+import { map } from "std::array"
 
 // crap these comments dont stay in place! So can't ignore a type error
 // in an import

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -78,6 +78,17 @@ export class AgencyGenerator {
   protected functionsUsed: Set<string> = new Set();
   protected importNodes: ImportStatement[] = [];
   protected importedNodes: ImportNodeStatement[] = [];
+  /** Comments / blank lines at the very top of the file that must stay
+   *  above the (sorted) imports block — e.g. file-level `// @tc-nocheck`,
+   *  shebangs, module docstrings. Populated by `partitionImports()`. */
+  protected importHeaderNodes: AgencyNode[] = [];
+  /** Comments attached to each import statement (no blank line between
+   *  them and the import). Travel with the import when imports get
+   *  sorted, so `// @tc-ignore` above an import keeps suppressing it. */
+  protected importAttachedComments: Map<
+    ImportStatement | ImportNodeStatement,
+    AgencyNode[]
+  > = new Map();
   protected functionDefinitions: Record<string, FunctionDefinition> = {};
   protected currentScope: Scope[] = [{ type: "global" }];
   protected program: AgencyProgram | null = null;
@@ -120,6 +131,12 @@ export class AgencyGenerator {
         this.processGraphNodeName(node);
       }
     }
+
+    // Partition the node stream: pull out the header (top-of-file
+    // comments/blanks) and each import statement (with any comments
+    // directly attached to it). This lets the imports block be sorted
+    // while preserving `// @tc-ignore` / `// @tc-nocheck` placement.
+    program.nodes = this.partitionImports(program.nodes);
 
     // Pass 3: Collect all node imports
     for (const node of program.nodes) {
@@ -169,6 +186,7 @@ export class AgencyGenerator {
 
     const output: string[] = [];
 
+    this.addIfNonEmpty(this.renderImportHeader(), output);
     this.addIfNonEmpty(this.sortAndRenderImports(), output);
     this.addIfNonEmpty(this.generatedTypeAliases.join("\n"), output);
     this.addIfNonEmpty(stmtLines.join("\n"), output);
@@ -176,6 +194,106 @@ export class AgencyGenerator {
     return {
       output: output.join("\n"),
     };
+  }
+
+  /**
+   * Split the node stream into three pieces:
+   *
+   *   1. `importHeaderNodes` — contiguous comments/blank lines at the
+   *      very top of the file (before any code or any import-attached
+   *      comment). These render unchanged above the sorted imports block.
+   *   2. Imports + comments attached to each one — tracked in
+   *      `importAttachedComments`. A comment is "attached" iff it sits
+   *      directly above its import with no blank line between them. This
+   *      keeps `// @tc-ignore` above an import even when the import is
+   *      moved by sorting.
+   *   3. Everything else — returned as the new node stream for the
+   *      remaining passes to process normally.
+   *
+   * Imports themselves are kept in `program.nodes` (returned here) so the
+   * existing collection pass for `importNodes` / `importedNodes` still
+   * sees them. The render path skips them because `processNode` for an
+   * import returns "".
+   */
+  private partitionImports(nodes: AgencyNode[]): AgencyNode[] {
+    const isImport = (n: AgencyNode): boolean =>
+      n.type === "importStatement" || n.type === "importNodeStatement";
+    const isComment = (n: AgencyNode): boolean =>
+      n.type === "comment" || n.type === "multiLineComment";
+
+    // 1) Eat top-of-file header (comments + blank lines, stopping at any
+    //    non-(comment|newLine) node).
+    let i = 0;
+    const header: AgencyNode[] = [];
+    while (i < nodes.length) {
+      const n = nodes[i];
+      if (isComment(n) || n.type === "newLine") {
+        header.push(n);
+        i++;
+      } else {
+        break;
+      }
+    }
+
+    // 2) Everything eaten as header stays at the top. We do NOT pop the
+    //    trailing comments back to attach them to the first import: the
+    //    whole contiguous top-of-file region is sacred (per spec: comments
+    //    at the top of the file stay at the top). For `@tc-ignore` to
+    //    travel with an import, the user separates it from the header
+    //    region with a blank line.
+    this.importHeaderNodes = header;
+
+    // 3) Process the rest: for any imports, pull off their directly-
+    //    preceding comments (no blank line between). Comments separated
+    //    by a blank line stay in the stream.
+    const rest: AgencyNode[] = [];
+    let commentBuf: AgencyNode[] = [];
+    while (i < nodes.length) {
+      const n = nodes[i];
+      if (isComment(n)) {
+        commentBuf.push(n);
+        i++;
+        continue;
+      }
+      if (n.type === "newLine") {
+        // Blank line — any buffered comments are not "attached" to a
+        // following import; flush them back into the stream.
+        rest.push(...commentBuf, n);
+        commentBuf = [];
+        i++;
+        continue;
+      }
+      if (isImport(n)) {
+        this.importAttachedComments.set(
+          n as ImportStatement | ImportNodeStatement,
+          commentBuf,
+        );
+        commentBuf = [];
+        rest.push(n);
+        i++;
+        continue;
+      }
+      // Other code — comment buffer wasn't attached to an import.
+      rest.push(...commentBuf, n);
+      commentBuf = [];
+      i++;
+    }
+    rest.push(...commentBuf);
+    return rest;
+  }
+
+  /**
+   * Render the top-of-file header (comments + blank lines that sit above
+   * the imports block). Returns an empty string when there are none.
+   */
+  private renderImportHeader(): string {
+    if (this.importHeaderNodes.length === 0) return "";
+    const lines: string[] = [];
+    for (const n of this.importHeaderNodes) {
+      const code = this.processNode(n);
+      if (code !== "" || n.type === "newLine") lines.push(code);
+    }
+    return lines.join("\n");
   }
 
   addIfNonEmpty(str: string, lines: string[]): void {
@@ -787,6 +905,10 @@ export class AgencyGenerator {
       }
       const kv = entry as AgencyObjectKV;
       const valueCode = this.processNode(kv.value).trim();
+      if (kv.computedKey) {
+        const keyCode = this.processNode(kv.computedKey).trim();
+        return this.indentStr(`[${keyCode}]: ${valueCode}`);
+      }
       return this.indentStr(`${this.addQuotesToKey(kv.key)}: ${valueCode}`);
     });
     this.decreaseIndent();
@@ -1016,12 +1138,26 @@ export class AgencyGenerator {
   private sortAndRenderImports(): string {
     type ImportEntry = { modulePath: string; render: () => string };
 
+    const renderWithAttached = (
+      node: ImportStatement | ImportNodeStatement,
+      body: string,
+    ): string => {
+      const attached = this.importAttachedComments.get(node) ?? [];
+      if (attached.length === 0) return body;
+      const commentLines = attached.map((c) => this.processNode(c));
+      return [...commentLines, body].join("\n");
+    };
+
     const stdlib: ImportEntry[] = [];
     const packages: ImportEntry[] = [];
     const relative: ImportEntry[] = [];
 
     for (const node of this.importNodes) {
-      const entry: ImportEntry = { modulePath: node.modulePath, render: () => this.processImportStatement(node) };
+      const entry: ImportEntry = {
+        modulePath: node.modulePath,
+        render: () =>
+          renderWithAttached(node, this.processImportStatement(node)),
+      };
       if (node.modulePath.startsWith("std::")) {
         stdlib.push(entry);
       } else if (node.modulePath.startsWith("pkg::")) {
@@ -1032,7 +1168,11 @@ export class AgencyGenerator {
     }
 
     for (const node of this.importedNodes) {
-      relative.push({ modulePath: node.agencyFile, render: () => this.processImportNodeStatement(node) });
+      relative.push({
+        modulePath: node.agencyFile,
+        render: () =>
+          renderWithAttached(node, this.processImportNodeStatement(node)),
+      });
     }
 
     const sort = (arr: ImportEntry[]) =>

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -221,18 +221,33 @@ export class AgencyGenerator {
     const isComment = (n: AgencyNode): boolean =>
       n.type === "comment" || n.type === "multiLineComment";
 
-    // 1) Eat top-of-file header (comments + blank lines, stopping at any
-    //    non-(comment|newLine) node).
+    // 1) Eat top-of-file header. The header is the contiguous run of
+    //    comment lines at the very top, terminated by either:
+    //      - a blank line (newLine) — included in the header so the
+    //        visual separation between header and imports is preserved,
+    //      - any other node (code, import) — header ends just before it.
+    //
+    //    A blank line *terminates* header eating. Comments below the
+    //    blank line are NOT header; they participate in import-comment
+    //    attachment instead. This is what lets a user park `// @tc-ignore`
+    //    above an import: separate it from the header region with a
+    //    blank line, and it travels with its import when imports are
+    //    sorted.
     let i = 0;
     const header: AgencyNode[] = [];
     while (i < nodes.length) {
       const n = nodes[i];
-      if (isComment(n) || n.type === "newLine") {
+      if (isComment(n)) {
         header.push(n);
         i++;
-      } else {
-        break;
+        continue;
       }
+      if (n.type === "newLine") {
+        header.push(n);
+        i++;
+        break; // blank line ends the header
+      }
+      break; // any other node — header ends here
     }
 
     // 2) Everything eaten as header stays at the top. We do NOT pop the

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -695,6 +695,12 @@ export class TypeScriptBuilder {
         return ts.setSpread(this.processNode(entry.value));
       }
       const kv = entry as AgencyObjectKV;
+      if (kv.computedKey) {
+        return ts.setComputed(
+          this.processNode(kv.computedKey),
+          this.processNode(kv.value),
+        );
+      }
       const keyCode = kv.key.replace(/"/g, '\\"');
       return ts.set(`"${keyCode}"`, this.processNode(kv.value));
     });

--- a/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator/tagArgToTs.ts
@@ -205,6 +205,11 @@ function objectLiteralToTs(
   const entries = obj.entries.map((entry) => {
     if ("key" in entry) {
       const kv = entry as AgencyObjectKV;
+      if (kv.computedKey) {
+        throw new Error(
+          "Computed object keys are not supported in @tag arguments.",
+        );
+      }
       // Quote keys with non-identifier characters; bare identifiers stay bare.
       const key = /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(kv.key)
         ? kv.key

--- a/packages/agency-lang/lib/compiler/compile.test.ts
+++ b/packages/agency-lang/lib/compiler/compile.test.ts
@@ -30,12 +30,12 @@ node main() { return foo(42) }
     expect(result.success).toBe(false);
   });
 
-  it("rejects local relative imports when restrictImports is set", () => {
+  it("rejects local relative imports when imports policy is stdlib-only", () => {
     const source = `
 import { foo } from "./bar.agency"
 node main() { return foo() }
 `;
-    const result = compileSource(source, { restrictImports: true });
+    const result = compileSource(source, { imports: { allowKinds: ["stdlib"] } });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.errors[0]).toContain("not allowed");
@@ -43,12 +43,12 @@ node main() { return foo() }
     }
   });
 
-  it("rejects absolute-path .agency imports when restrictImports is set", () => {
+  it("rejects absolute-path .agency imports when imports policy is stdlib-only", () => {
     const source = `
 import { foo } from "/abs/path/bar.agency"
 node main() { return foo() }
 `;
-    const result = compileSource(source, { restrictImports: true });
+    const result = compileSource(source, { imports: { allowKinds: ["stdlib"] } });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.errors[0]).toContain("not allowed");
@@ -56,24 +56,24 @@ node main() { return foo() }
     }
   });
 
-  it("allows stdlib imports with restrictImports", () => {
+  it("allows stdlib imports with stdlib-only imports policy", () => {
     const source = `
 import { exists } from "std::shell"
 node main() { return exists("/tmp") }
 `;
-    const result = compileSource(source, { restrictImports: true });
+    const result = compileSource(source, { imports: { allowKinds: ["stdlib"] } });
     expect(result.success).toBe(true);
   });
 
   // --- Coverage for the previously-undetected hole: getImports() filters
   // out non-agency imports, which let raw npm/Node modules sail past the
   // restriction. compileSource now uses getAllImports() instead.
-  it("rejects raw npm/Node module imports when restrictImports is set", () => {
+  it("rejects raw npm/Node module imports when imports policy is stdlib-only", () => {
     const source = `
 import * as fs from "fs"
 node main() { return "hi" }
 `;
-    const result = compileSource(source, { restrictImports: true });
+    const result = compileSource(source, { imports: { allowKinds: ["stdlib"] } });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.errors[0]).toContain("not allowed");
@@ -81,24 +81,24 @@ node main() { return "hi" }
     }
   });
 
-  it("rejects child_process imports when restrictImports is set", () => {
+  it("rejects child_process imports when imports policy is stdlib-only", () => {
     const source = `
 import { execSync } from "child_process"
 node main() { return "hi" }
 `;
-    const result = compileSource(source, { restrictImports: true });
+    const result = compileSource(source, { imports: { allowKinds: ["stdlib"] } });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.errors[0]).toContain("'child_process'");
     }
   });
 
-  it("rejects pkg:: imports when restrictImports is set", () => {
+  it("rejects pkg:: imports when imports policy is stdlib-only", () => {
     const source = `
 import { foo } from "pkg::some-package"
 node main() { return foo() }
 `;
-    const result = compileSource(source, { restrictImports: true });
+    const result = compileSource(source, { imports: { allowKinds: ["stdlib"] } });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.errors[0]).toContain("not allowed");
@@ -106,10 +106,10 @@ node main() { return foo() }
     }
   });
 
-  // Negative control: without restrictImports, raw npm/Node imports must
+  // Negative control: without imports policy, raw npm/Node imports must
   // be allowed. This proves the rejection in the tests above is gated by
   // the flag, not happening unconditionally.
-  it("allows raw npm/Node module imports when restrictImports is NOT set", () => {
+  it("allows raw npm/Node module imports when imports policy is unset", () => {
     const source = `
 import * as fs from "fs"
 node main() { return "hi" }
@@ -118,12 +118,12 @@ node main() { return "hi" }
     expect(result.success).toBe(true);
   });
 
-  it("rejects 'import nodes' (importNodeStatement) when restrictImports is set", () => {
+  it("rejects 'import nodes' (importNodeStatement) when imports policy is stdlib-only", () => {
     const source = `
 import nodes { helper } from "./helpers.agency"
 node main() { return "hi" }
 `;
-    const result = compileSource(source, { restrictImports: true });
+    const result = compileSource(source, { imports: { allowKinds: ["stdlib"] } });
     expect(result.success).toBe(false);
     if (!result.success) {
       expect(result.errors[0]).toContain("not allowed");
@@ -133,7 +133,7 @@ node main() { return "hi" }
 });
 
 describe("compileSource imports policy (Task 8)", () => {
-  it("imports: { allowKinds: ['stdlib'] } matches restrictImports: true behavior", () => {
+  it("imports: { allowKinds: ['stdlib'] } matches legacy behavior", () => {
     const source = `
 import { foo } from "./bar.agency"
 node main() { return foo() }
@@ -161,20 +161,6 @@ node main() { return foo() }
       expect(all).toContain("'./bar.agency'");
       expect(all).toContain("'fs'");
       expect(all).toContain("'pkg::y'");
-    }
-  });
-
-  it("passing both restrictImports and imports fails the compile with a clear message", () => {
-    const source = `node main() { return 1 }`;
-    const result = compileSource(source, {
-      restrictImports: true,
-      imports: { allowKinds: ["stdlib"] },
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.errors.join("\n")).toMatch(
-        /either `imports` or `restrictImports`/,
-      );
     }
   });
 

--- a/packages/agency-lang/lib/compiler/compile.test.ts
+++ b/packages/agency-lang/lib/compiler/compile.test.ts
@@ -38,7 +38,7 @@ node main() { return foo() }
     const result = compileSource(source, { restrictImports: true });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.errors[0]).toContain(".agency file import");
+      expect(result.errors[0]).toContain("not allowed");
       expect(result.errors[0]).toContain("'./bar.agency'");
     }
   });
@@ -51,7 +51,7 @@ node main() { return foo() }
     const result = compileSource(source, { restrictImports: true });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.errors[0]).toContain(".agency file import");
+      expect(result.errors[0]).toContain("not allowed");
       expect(result.errors[0]).toContain("'/abs/path/bar.agency'");
     }
   });
@@ -76,7 +76,7 @@ node main() { return "hi" }
     const result = compileSource(source, { restrictImports: true });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.errors[0]).toContain("npm/Node module import");
+      expect(result.errors[0]).toContain("not allowed");
       expect(result.errors[0]).toContain("'fs'");
     }
   });
@@ -101,7 +101,7 @@ node main() { return foo() }
     const result = compileSource(source, { restrictImports: true });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.errors[0]).toContain("package import");
+      expect(result.errors[0]).toContain("not allowed");
       expect(result.errors[0]).toContain("'pkg::some-package'");
     }
   });
@@ -126,7 +126,74 @@ node main() { return "hi" }
     const result = compileSource(source, { restrictImports: true });
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.errors[0].toLowerCase()).toContain("tool/node import");
+      expect(result.errors[0]).toContain("not allowed");
+      expect(result.errors[0]).toContain("helpers.agency");
+    }
+  });
+});
+
+describe("compileSource imports policy (Task 8)", () => {
+  it("imports: { allowKinds: ['stdlib'] } matches restrictImports: true behavior", () => {
+    const source = `
+import { foo } from "./bar.agency"
+node main() { return foo() }
+`;
+    const result = compileSource(source, { imports: { allowKinds: ["stdlib"] } });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors[0]).toContain("not allowed");
+      expect(result.errors[0]).toContain("'./bar.agency'");
+    }
+  });
+
+  it("imports policy reports EVERY violation, not just the first", () => {
+    const source = `
+import { foo } from "./bar.agency"
+import * as fs from "fs"
+import { x } from "pkg::y"
+node main() { return foo() }
+`;
+    const result = compileSource(source, { imports: { allowKinds: ["stdlib"] } });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors.length).toBe(3);
+      const all = result.errors.join("\n");
+      expect(all).toContain("'./bar.agency'");
+      expect(all).toContain("'fs'");
+      expect(all).toContain("'pkg::y'");
+    }
+  });
+
+  it("passing both restrictImports and imports fails the compile with a clear message", () => {
+    const source = `node main() { return 1 }`;
+    const result = compileSource(source, {
+      restrictImports: true,
+      imports: { allowKinds: ["stdlib"] },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.errors.join("\n")).toMatch(
+        /either `imports` or `restrictImports`/,
+      );
+    }
+  });
+
+  it("allows pkg:: imports when included in allowKinds", () => {
+    const source = `
+import { x } from "pkg::y"
+node main() { return 1 }
+`;
+    const result = compileSource(source, {
+      imports: { allowKinds: ["stdlib", "pkg"] },
+    });
+    // Should pass the import check; further compilation may still fail on
+    // missing pkg, but we expect the failure to NOT be about the import
+    // policy itself.
+    if (!result.success) {
+      // Make sure the failure (if any) is not the policy rejecting the pkg.
+      for (const err of result.errors) {
+        expect(err).not.toMatch(/'pkg::y' is not allowed/);
+      }
     }
   });
 });

--- a/packages/agency-lang/lib/compiler/compile.ts
+++ b/packages/agency-lang/lib/compiler/compile.ts
@@ -16,11 +16,14 @@ import * as path from "path";
 import * as os from "os";
 import { parseAgency } from "@/parser.js";
 import {
+  ImportPolicy,
+  isImportAllowed,
   isStdlibImport,
   isPkgImport,
 } from "../importPaths.js";
 import { CompileStrategy } from "../importStrategy.js";
 import { getAllImports } from "../cli/util.js";
+import { safeDeleteDirectory } from "../utils.js";
 
 type CompileSuccess = {
   success: true;
@@ -41,52 +44,171 @@ export type CompileResult = CompileSuccess | CompileFailure;
 // because it's only meaningful at this entry point — used when compiling
 // agent-supplied source destined for subprocess execution.
 export type CompileSourceOptions = AgencyConfig & {
-  /** When true, reject every import that isn't a std:: import. This includes
-   *  relative .agency files, pkg:: imports, and raw npm/Node modules
-   *  (`fs`, `child_process`, etc.). Set by std::agency.compile so that the
-   *  compiled subprocess code can only call into the standard library. */
+  /**
+   * @deprecated Use `imports: { allowKinds: ["stdlib"] }` instead.
+   * When true, reject every import that isn't a std:: import. This is
+   * exactly equivalent to passing `imports: { allowKinds: ["stdlib"] }`.
+   */
   restrictImports?: boolean;
+  /**
+   * Declarative import policy. Disallowed imports cause compilation to
+   * fail with one error per violating import path.
+   * See `lib/importPaths.ts` for the ImportPolicy shape.
+   */
+  imports?: ImportPolicy;
 };
 
-// Human-readable label for the kind of disallowed import. Used in error
-// messages so the user knows whether they wrote an npm import, a pkg::
-// import, or a path-based .agency import. Note: ".agency file import"
-// covers both relative and absolute paths — we don't distinguish because
-// both are equally rejected here.
-function classifyImport(importPath: string): string {
-  if (isPkgImport(importPath)) return "package import";
-  if (importPath.endsWith(".agency")) return ".agency file import";
-  return "npm/Node module import";
+// Resolve the effective import policy from the (possibly-legacy) options.
+// `restrictImports: true` is sugar for `{ allowKinds: ["stdlib"] }`.
+// Passing both is a configuration error — fail loudly so callers don't
+// accidentally trust the wrong one.
+function resolveImportPolicy(config: CompileSourceOptions): ImportPolicy | null {
+  if (config.imports && config.restrictImports) {
+    throw new Error(
+      "compileSource: pass either `imports` or `restrictImports`, not both. " +
+        "`restrictImports` is the deprecated shorthand for " +
+        "`imports: { allowKinds: ['stdlib'] }`.",
+    );
+  }
+  if (config.imports) return config.imports;
+  if (config.restrictImports) return { allowKinds: ["stdlib"] };
+  return null;
 }
 
-// Walk every import in the program and reject anything that isn't a std::
-// import. Returns null if all imports pass, or a CompileFailure describing
-// the offender.
+// Walk every import in the program and reject anything that fails the
+// policy. Returns null if all imports pass, or a CompileFailure listing
+// every violating import (not just the first).
 //
 // IMPORTANT: uses getAllImports (NOT getImports) so we see EVERY import,
 // including raw npm/Node modules. getImports filters those out and would
 // let `import fs from "fs"` slip past the check — that was the bug this
-// helper exists to close.
-function checkRestrictedImports(program: AgencyProgram): CompileFailure | null {
+// check exists to close.
+//
+// `import nodes { ... }` (deprecated) is reported with kind "node" by
+// getAllImports — but to the policy that's a "local" import because it
+// always references another .agency file. Classify it that way so a
+// `allowKinds: ["stdlib"]` policy still rejects it (the legacy behavior).
+function checkImportPolicy(
+  program: AgencyProgram,
+  policy: ImportPolicy,
+): CompileFailure | null {
+  const violations: string[] = [];
   for (const { path: importPath, kind } of getAllImports(program)) {
-    if (kind === "node") {
-      // `import nodes { ... }` always references another .agency file.
-      // The path can be relative or absolute — we reject both forms here
-      // since neither is a stdlib import.
-      return {
-        success: false,
-        errors: [`Tool/node import '${importPath}' is not allowed when restrictImports is set. Only standard library (std::) imports are permitted.`],
-      };
-    }
-    if (!isStdlibImport(importPath)) {
-      const what = classifyImport(importPath);
-      return {
-        success: false,
-        errors: [`${what} '${importPath}' is not allowed. Only standard library (std::) imports are permitted.`],
-      };
+    // For the deprecated `import nodes { ... }` form, treat the path
+    // (which always points to a .agency file) as a local import so the
+    // policy classifier handles it the same way as `import x from "./y.agency"`.
+    const allowed =
+      kind === "node"
+        ? isImportAllowed(`./${importPath}`, policy)
+        : isImportAllowed(importPath, policy);
+    if (!allowed) {
+      violations.push(
+        `Import '${importPath}' is not allowed under the configured import policy.`,
+      );
     }
   }
-  return null;
+  if (violations.length === 0) return null;
+  return { success: false, errors: violations };
+}
+
+export type TypeCheckDiagnostic = {
+  severity: "error" | "warning";
+  message: string;
+  loc?: {
+    line: number;
+    col: number;
+    start: number;
+    end: number;
+  };
+  variableName?: string;
+  expectedType?: string;
+  actualType?: string;
+};
+
+export type TypeCheckReport = {
+  errors: TypeCheckDiagnostic[];
+  warnings: TypeCheckDiagnostic[];
+};
+
+// Provide a path the symbol table can use to resolve relative imports.
+// If `sourcePath` is supplied we use it directly; otherwise we synthesize
+// one in a tempdir that's cleaned up after `fn` returns. Used by
+// typeCheckSource — separates "where does this source live on disk" from
+// "what do we do once it's there."
+function withSourcePath<T>(
+  source: string,
+  sourcePath: string | undefined,
+  fn: (syntheticPath: string) => T,
+): T {
+  if (sourcePath) return fn(sourcePath);
+  // Place the tempdir under cwd's .agency-tmp/ (same pattern as
+  // compileAndPersist) so safeDeleteDirectory's project-containment check
+  // accepts it on cleanup. os.tmpdir() would be outside the project.
+  const moduleId = `agency_${nanoid()}`;
+  const tempDir = path.join(process.cwd(), ".agency-tmp", `typecheck-${nanoid()}`);
+  fs.mkdirSync(tempDir, { recursive: true });
+  const syntheticPath = path.join(tempDir, `${moduleId}.agency`);
+  fs.writeFileSync(syntheticPath, source, "utf-8");
+  try {
+    return fn(syntheticPath);
+  } finally {
+    safeDeleteDirectory(tempDir, false);
+  }
+}
+
+function toDiagnostic(err: TypeCheckErrorShape): TypeCheckDiagnostic {
+  return {
+    severity: err.severity ?? "error",
+    message: err.message,
+    loc: err.loc,
+    variableName: err.variableName,
+    expectedType: err.expectedType,
+    actualType: err.actualType,
+  };
+}
+
+type TypeCheckErrorShape = {
+  message: string;
+  severity?: "error" | "warning";
+  loc?: TypeCheckDiagnostic["loc"];
+  variableName?: string;
+  expectedType?: string;
+  actualType?: string;
+};
+
+// Run parse → symbol table → import resolution → type check over a source
+// string and return diagnostics. Errors thrown here (parse failure, import
+// resolution failure) propagate to the caller — they signal "we couldn't
+// type-check this", as opposed to "we type-checked it and found problems",
+// which is what the returned report represents.
+//
+// If `sourcePath` is supplied, it's used as the synthetic file path the
+// symbol table sees — letting relative imports in `source` resolve against
+// that directory. Otherwise a fresh tempdir is used and relative imports
+// will not resolve.
+export function typeCheckSource(
+  source: string,
+  sourcePath?: string,
+): TypeCheckReport {
+  const parseResult = parseAgency(source, {}, true);
+  if (!parseResult.success) {
+    throw new Error(parseResult.message ?? "Failed to parse Agency source");
+  }
+  const program: AgencyProgram = parseResult.result;
+
+  return withSourcePath(source, sourcePath, (syntheticPath) => {
+    const symbolTable = SymbolTable.build(syntheticPath, {});
+    const reExported = resolveReExports(program, symbolTable, syntheticPath);
+    const resolved = resolveImports(reExported, symbolTable, syntheticPath);
+    const info = buildCompilationUnit(resolved, symbolTable, syntheticPath, source);
+    const { errors } = typeCheck(resolved, { typechecker: { enabled: true } }, info);
+
+    const diagnostics = errors.map(toDiagnostic);
+    return {
+      errors: diagnostics.filter((d) => d.severity === "error"),
+      warnings: diagnostics.filter((d) => d.severity === "warning"),
+    };
+  });
 }
 
 export function compileSource(
@@ -111,9 +233,10 @@ export function compileSource(
     }
     const program: AgencyProgram = parseResult.result;
 
-    // 2. Check for restricted imports — only std:: allowed.
-    if (config.restrictImports) {
-      const failure = checkRestrictedImports(program);
+    // 2. Check imports against policy.
+    const policy = resolveImportPolicy(config);
+    if (policy) {
+      const failure = checkImportPolicy(program, policy);
       if (failure) return failure;
     }
 

--- a/packages/agency-lang/lib/compiler/compile.ts
+++ b/packages/agency-lang/lib/compiler/compile.ts
@@ -23,7 +23,6 @@ import {
 } from "../importPaths.js";
 import { CompileStrategy } from "../importStrategy.js";
 import { getAllImports } from "../cli/util.js";
-import { safeDeleteDirectory } from "../utils.js";
 
 type CompileSuccess = {
   success: true;
@@ -40,16 +39,10 @@ export type CompileResult = CompileSuccess | CompileFailure;
 
 // Options accepted by compileSource. Mostly the standard AgencyConfig that
 // the rest of the pipeline takes, plus one compileSource-specific knob:
-// `restrictImports`. We keep `restrictImports` out of the global AgencyConfig
-// because it's only meaningful at this entry point — used when compiling
+// `imports`. We keep `imports` out of the global AgencyConfig because it's
+// only meaningful at this entry point — used when compiling
 // agent-supplied source destined for subprocess execution.
 export type CompileSourceOptions = AgencyConfig & {
-  /**
-   * @deprecated Use `imports: { allowKinds: ["stdlib"] }` instead.
-   * When true, reject every import that isn't a std:: import. This is
-   * exactly equivalent to passing `imports: { allowKinds: ["stdlib"] }`.
-   */
-  restrictImports?: boolean;
   /**
    * Declarative import policy. Disallowed imports cause compilation to
    * fail with one error per violating import path.
@@ -57,23 +50,6 @@ export type CompileSourceOptions = AgencyConfig & {
    */
   imports?: ImportPolicy;
 };
-
-// Resolve the effective import policy from the (possibly-legacy) options.
-// `restrictImports: true` is sugar for `{ allowKinds: ["stdlib"] }`.
-// Passing both is a configuration error — fail loudly so callers don't
-// accidentally trust the wrong one.
-function resolveImportPolicy(config: CompileSourceOptions): ImportPolicy | null {
-  if (config.imports && config.restrictImports) {
-    throw new Error(
-      "compileSource: pass either `imports` or `restrictImports`, not both. " +
-        "`restrictImports` is the deprecated shorthand for " +
-        "`imports: { allowKinds: ['stdlib'] }`.",
-    );
-  }
-  if (config.imports) return config.imports;
-  if (config.restrictImports) return { allowKinds: ["stdlib"] };
-  return null;
-}
 
 // Walk every import in the program and reject anything that fails the
 // policy. Returns null if all imports pass, or a CompileFailure listing
@@ -93,15 +69,12 @@ function checkImportPolicy(
   policy: ImportPolicy,
 ): CompileFailure | null {
   const violations: string[] = [];
-  for (const { path: importPath, kind } of getAllImports(program)) {
-    // For the deprecated `import nodes { ... }` form, treat the path
-    // (which always points to a .agency file) as a local import so the
-    // policy classifier handles it the same way as `import x from "./y.agency"`.
-    const allowed =
-      kind === "node"
-        ? isImportAllowed(`./${importPath}`, policy)
-        : isImportAllowed(importPath, policy);
-    if (!allowed) {
+  // getAllImports surfaces both `importStatement` and the deprecated
+  // `import nodes { ... }` form. importKind() already classifies any
+  // path ending in `.agency` as "local", so we can pass paths through
+  // unchanged regardless of which import form they came from.
+  for (const { path: importPath } of getAllImports(program)) {
+    if (!isImportAllowed(importPath, policy)) {
       violations.push(
         `Import '${importPath}' is not allowed under the configured import policy.`,
       );
@@ -111,105 +84,8 @@ function checkImportPolicy(
   return { success: false, errors: violations };
 }
 
-export type TypeCheckDiagnostic = {
-  severity: "error" | "warning";
-  message: string;
-  loc?: {
-    line: number;
-    col: number;
-    start: number;
-    end: number;
-  };
-  variableName?: string;
-  expectedType?: string;
-  actualType?: string;
-};
-
-export type TypeCheckReport = {
-  errors: TypeCheckDiagnostic[];
-  warnings: TypeCheckDiagnostic[];
-};
-
-// Provide a path the symbol table can use to resolve relative imports.
-// If `sourcePath` is supplied we use it directly; otherwise we synthesize
-// one in a tempdir that's cleaned up after `fn` returns. Used by
-// typeCheckSource — separates "where does this source live on disk" from
-// "what do we do once it's there."
-function withSourcePath<T>(
-  source: string,
-  sourcePath: string | undefined,
-  fn: (syntheticPath: string) => T,
-): T {
-  if (sourcePath) return fn(sourcePath);
-  // Place the tempdir under cwd's .agency-tmp/ (same pattern as
-  // compileAndPersist) so safeDeleteDirectory's project-containment check
-  // accepts it on cleanup. os.tmpdir() would be outside the project.
-  const moduleId = `agency_${nanoid()}`;
-  const tempDir = path.join(process.cwd(), ".agency-tmp", `typecheck-${nanoid()}`);
-  fs.mkdirSync(tempDir, { recursive: true });
-  const syntheticPath = path.join(tempDir, `${moduleId}.agency`);
-  fs.writeFileSync(syntheticPath, source, "utf-8");
-  try {
-    return fn(syntheticPath);
-  } finally {
-    safeDeleteDirectory(tempDir, false);
-  }
-}
-
-function toDiagnostic(err: TypeCheckErrorShape): TypeCheckDiagnostic {
-  return {
-    severity: err.severity ?? "error",
-    message: err.message,
-    loc: err.loc,
-    variableName: err.variableName,
-    expectedType: err.expectedType,
-    actualType: err.actualType,
-  };
-}
-
-type TypeCheckErrorShape = {
-  message: string;
-  severity?: "error" | "warning";
-  loc?: TypeCheckDiagnostic["loc"];
-  variableName?: string;
-  expectedType?: string;
-  actualType?: string;
-};
-
-// Run parse → symbol table → import resolution → type check over a source
-// string and return diagnostics. Errors thrown here (parse failure, import
-// resolution failure) propagate to the caller — they signal "we couldn't
-// type-check this", as opposed to "we type-checked it and found problems",
-// which is what the returned report represents.
-//
-// If `sourcePath` is supplied, it's used as the synthetic file path the
-// symbol table sees — letting relative imports in `source` resolve against
-// that directory. Otherwise a fresh tempdir is used and relative imports
-// will not resolve.
-export function typeCheckSource(
-  source: string,
-  sourcePath?: string,
-): TypeCheckReport {
-  const parseResult = parseAgency(source, {}, true);
-  if (!parseResult.success) {
-    throw new Error(parseResult.message ?? "Failed to parse Agency source");
-  }
-  const program: AgencyProgram = parseResult.result;
-
-  return withSourcePath(source, sourcePath, (syntheticPath) => {
-    const symbolTable = SymbolTable.build(syntheticPath, {});
-    const reExported = resolveReExports(program, symbolTable, syntheticPath);
-    const resolved = resolveImports(reExported, symbolTable, syntheticPath);
-    const info = buildCompilationUnit(resolved, symbolTable, syntheticPath, source);
-    const { errors } = typeCheck(resolved, { typechecker: { enabled: true } }, info);
-
-    const diagnostics = errors.map(toDiagnostic);
-    return {
-      errors: diagnostics.filter((d) => d.severity === "error"),
-      warnings: diagnostics.filter((d) => d.severity === "warning"),
-    };
-  });
-}
+export { typeCheckSource } from "./typecheck.js";
+export type { TypeCheckDiagnostic, TypeCheckReport } from "./typecheck.js";
 
 export function compileSource(
   source: string,
@@ -234,9 +110,8 @@ export function compileSource(
     const program: AgencyProgram = parseResult.result;
 
     // 2. Check imports against policy.
-    const policy = resolveImportPolicy(config);
-    if (policy) {
-      const failure = checkImportPolicy(program, policy);
+    if (config.imports) {
+      const failure = checkImportPolicy(program, config.imports);
       if (failure) return failure;
     }
 

--- a/packages/agency-lang/lib/compiler/typecheck.ts
+++ b/packages/agency-lang/lib/compiler/typecheck.ts
@@ -1,0 +1,120 @@
+/**
+ * Pure type-checking entry point for Agency source strings.
+ * Returns diagnostics as data — never calls process.exit() or console.log().
+ */
+import { AgencyProgram } from "@/index.js";
+import { resolveImports } from "@/preprocessors/importResolver.js";
+import { resolveReExports } from "@/preprocessors/resolveReExports.js";
+import { buildCompilationUnit } from "@/compilationUnit.js";
+import { SymbolTable } from "@/symbolTable.js";
+import { typeCheck } from "@/typeChecker/index.js";
+import { nanoid } from "nanoid";
+import * as fs from "fs";
+import * as path from "path";
+import { parseAgency } from "@/parser.js";
+import { safeDeleteDirectory } from "../utils.js";
+
+export type TypeCheckDiagnostic = {
+  severity: "error" | "warning";
+  message: string;
+  loc?: {
+    line: number;
+    col: number;
+    start: number;
+    end: number;
+  };
+  variableName?: string;
+  expectedType?: string;
+  actualType?: string;
+};
+
+export type TypeCheckReport = {
+  errors: TypeCheckDiagnostic[];
+  warnings: TypeCheckDiagnostic[];
+};
+
+type TypeCheckErrorShape = {
+  message: string;
+  severity?: "error" | "warning";
+  loc?: TypeCheckDiagnostic["loc"];
+  variableName?: string;
+  expectedType?: string;
+  actualType?: string;
+};
+
+// Provide a path the symbol table can use to resolve relative imports.
+// If `sourcePath` is supplied we use it directly; otherwise we synthesize
+// one in a tempdir that's cleaned up after `fn` returns. Used by
+// typeCheckSource — separates "where does this source live on disk" from
+// "what do we do once it's there."
+function withSourcePath<T>(
+  source: string,
+  sourcePath: string | undefined,
+  fn: (syntheticPath: string) => T,
+): T {
+  if (sourcePath) return fn(sourcePath);
+  // Place the tempdir under cwd's .agency-tmp/ (same pattern as
+  // compileAndPersist) so safeDeleteDirectory's project-containment check
+  // accepts it on cleanup. os.tmpdir() would be outside the project.
+  const moduleId = `agency_${nanoid()}`;
+  const tempDir = path.join(process.cwd(), ".agency-tmp", `typecheck-${nanoid()}`);
+  fs.mkdirSync(tempDir, { recursive: true });
+  const syntheticPath = path.join(tempDir, `${moduleId}.agency`);
+  fs.writeFileSync(syntheticPath, source, "utf-8");
+  try {
+    return fn(syntheticPath);
+  } finally {
+    safeDeleteDirectory(tempDir, false);
+  }
+}
+
+function toDiagnostic(err: TypeCheckErrorShape): TypeCheckDiagnostic {
+  return {
+    severity: err.severity ?? "error",
+    message: err.message,
+    loc: err.loc,
+    variableName: err.variableName,
+    expectedType: err.expectedType,
+    actualType: err.actualType,
+  };
+}
+
+// Run parse → symbol table → import resolution → type check over a source
+// string and return diagnostics. Errors thrown here (parse failure, import
+// resolution failure) propagate to the caller — they signal "we couldn't
+// type-check this", as opposed to "we type-checked it and found problems",
+// which is what the returned report represents.
+//
+// If `sourcePath` is supplied, it's used as the synthetic file path the
+// symbol table sees — letting relative imports in `source` resolve against
+// that directory. Otherwise a fresh tempdir is used and relative imports
+// will not resolve.
+export function typeCheckSource(
+  source: string,
+  sourcePath?: string,
+): TypeCheckReport {
+  const parseResult = parseAgency(source, {}, true);
+  if (!parseResult.success) {
+    throw new Error(parseResult.message ?? "Failed to parse Agency source");
+  }
+  const program: AgencyProgram = parseResult.result;
+
+  return withSourcePath(source, sourcePath, (syntheticPath) => {
+    const symbolTable = SymbolTable.build(syntheticPath, {});
+    const reExported = resolveReExports(program, symbolTable, syntheticPath);
+    const resolved = resolveImports(reExported, symbolTable, syntheticPath);
+    const info = buildCompilationUnit(resolved, symbolTable, syntheticPath, source);
+    const { errors } = typeCheck(resolved, { typechecker: { enabled: true } }, info);
+
+    // Partition into errors and warnings in a single pass. The only severity
+    // values the type-checker emits are "error" and "warning" (see
+    // lib/typeChecker/types.ts), so anything not "warning" is treated as
+    // "error" by toDiagnostic's default.
+    const out: TypeCheckReport = { errors: [], warnings: [] };
+    for (const err of errors) {
+      const d = toDiagnostic(err);
+      (d.severity === "warning" ? out.warnings : out.errors).push(d);
+    }
+    return out;
+  });
+}

--- a/packages/agency-lang/lib/importPaths.test.ts
+++ b/packages/agency-lang/lib/importPaths.test.ts
@@ -401,3 +401,80 @@ describe("RunStrategy.prepareDependencies", () => {
     strategy.prepareDependencies(["nanoid"], fromFile);
   });
 });
+
+import { importKind, isImportAllowed } from "./importPaths.js";
+
+describe("importKind", () => {
+  it("classifies stdlib imports", () => {
+    expect(importKind("std::shell")).toBe("stdlib");
+    expect(importKind("std::index")).toBe("stdlib");
+  });
+  it("classifies pkg imports", () => {
+    expect(importKind("pkg::wikipedia")).toBe("pkg");
+  });
+  it("classifies local imports (relative, absolute, .agency)", () => {
+    expect(importKind("./foo.agency")).toBe("local");
+    expect(importKind("../bar.agency")).toBe("local");
+    expect(importKind("/abs/path/x.agency")).toBe("local");
+    expect(importKind("something.agency")).toBe("local");
+  });
+  it("classifies bare specifiers as node", () => {
+    expect(importKind("fs")).toBe("node");
+    expect(importKind("child_process")).toBe("node");
+    expect(importKind("nanoid")).toBe("node");
+  });
+  it("stdlib/pkg take precedence over .agency suffix", () => {
+    // Hypothetical pkg::foo.agency must be classified as pkg, not local.
+    expect(importKind("pkg::foo.agency")).toBe("pkg");
+    expect(importKind("std::index.agency")).toBe("stdlib");
+  });
+});
+
+describe("isImportAllowed", () => {
+  it("empty policy → default-allow", () => {
+    expect(isImportAllowed("fs", {})).toBe(true);
+    expect(isImportAllowed("./local.agency", {})).toBe(true);
+    expect(isImportAllowed("std::shell", {})).toBe(true);
+  });
+  it("excludeKinds wins over allowKinds", () => {
+    expect(
+      isImportAllowed("std::shell", {
+        allowKinds: ["stdlib"],
+        excludeKinds: ["stdlib"],
+      }),
+    ).toBe(false);
+  });
+  it("excludedPackages wins over allowedPackages", () => {
+    expect(
+      isImportAllowed("std::shell", {
+        allowedPackages: ["std::*"],
+        excludedPackages: ["std::shell"],
+      }),
+    ).toBe(false);
+  });
+  it("allowKinds=['stdlib'] only allows stdlib imports", () => {
+    expect(isImportAllowed("std::shell", { allowKinds: ["stdlib"] })).toBe(true);
+    expect(isImportAllowed("./bar.agency", { allowKinds: ["stdlib"] })).toBe(false);
+    expect(isImportAllowed("fs", { allowKinds: ["stdlib"] })).toBe(false);
+    expect(isImportAllowed("pkg::x", { allowKinds: ["stdlib"] })).toBe(false);
+  });
+  it("union: allowKinds + allowedPackages both pass", () => {
+    const policy = { allowKinds: ["stdlib" as const], allowedPackages: ["pkg::wikipedia"] };
+    expect(isImportAllowed("std::shell", policy)).toBe(true);
+    expect(isImportAllowed("pkg::wikipedia", policy)).toBe(true);
+    expect(isImportAllowed("pkg::other", policy)).toBe(false);
+    expect(isImportAllowed("./bar.agency", policy)).toBe(false);
+  });
+  it("glob matching: std::* covers all stdlib paths", () => {
+    expect(isImportAllowed("std::shell", { allowedPackages: ["std::*"] })).toBe(true);
+    expect(isImportAllowed("std::index", { allowedPackages: ["std::*"] })).toBe(true);
+    expect(isImportAllowed("./foo.agency", { allowedPackages: ["std::*"] })).toBe(false);
+  });
+  it("unknown kind strings in allowKinds match nothing", () => {
+    // With a non-empty allow list, all imports must match SOMETHING. Unknown
+    // kind strings can never match → all imports get rejected.
+    const policy = { allowKinds: ["bogus" as never] };
+    expect(isImportAllowed("std::shell", policy)).toBe(false);
+    expect(isImportAllowed("fs", policy)).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/importPaths.ts
+++ b/packages/agency-lang/lib/importPaths.ts
@@ -2,6 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { createRequire } from "module";
+import picomatch from "picomatch";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -141,15 +142,8 @@ export type ImportPolicy = {
   excludeKinds?: ImportKind[];
 };
 
-// Lazy-loaded picomatch — keeps module load cheap when no policy is used.
-let _picomatch: ((pattern: string) => (s: string) => boolean) | null = null;
 function matchGlob(pattern: string, value: string): boolean {
-  if (!_picomatch) {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const picomatch = createRequire(import.meta.url)("picomatch");
-    _picomatch = picomatch as (pattern: string) => (s: string) => boolean;
-  }
-  return _picomatch(pattern)(value);
+  return picomatch(pattern)(value);
 }
 
 export function isImportAllowed(modulePath: string, policy: ImportPolicy): boolean {

--- a/packages/agency-lang/lib/importPaths.ts
+++ b/packages/agency-lang/lib/importPaths.ts
@@ -95,6 +95,85 @@ export function isStdlibImport(importPath: string): boolean {
 }
 
 /**
+ * Classification of an import path. Used by ImportPolicy to allow / reject
+ * imports by category.
+ *
+ *   - "stdlib" — `std::*` (e.g. `std::shell`)
+ *   - "pkg"    — `pkg::*` (e.g. `pkg::wikipedia`)
+ *   - "local"  — relative or absolute file paths (e.g. `./util.agency`)
+ *   - "node"   — bare specifiers resolved by Node (e.g. `fs`, `child_process`)
+ *
+ * Order is load-bearing: stdlib and pkg are checked first so that a
+ * `pkg::foo.agency` style path is never mis-classified as "local".
+ */
+export type ImportKind = "stdlib" | "pkg" | "local" | "node";
+
+export function importKind(modulePath: string): ImportKind {
+  if (isStdlibImport(modulePath)) return "stdlib";
+  if (isPkgImport(modulePath)) return "pkg";
+  if (
+    modulePath.startsWith("./") ||
+    modulePath.startsWith("../") ||
+    modulePath.startsWith("/") ||
+    modulePath.endsWith(".agency")
+  ) {
+    return "local";
+  }
+  return "node";
+}
+
+/**
+ * Declarative import-allow-list / deny-list. Used by both `compileSource`
+ * (to reject disallowed imports up front) and `_filterImports` in the
+ * stdlib (to strip them from source).
+ *
+ * Semantics (see isImportAllowed):
+ *   - Exclude rules always win: if a path matches anything in
+ *     `excludedPackages` or `excludeKinds`, it is rejected.
+ *   - When all four lists are empty, every import is allowed (default-allow).
+ *   - When at least one allow list is non-empty, an import must match an
+ *     allowed kind OR an allowed package glob (union across the two axes).
+ */
+export type ImportPolicy = {
+  allowedPackages?: string[];
+  excludedPackages?: string[];
+  allowKinds?: ImportKind[];
+  excludeKinds?: ImportKind[];
+};
+
+// Lazy-loaded picomatch — keeps module load cheap when no policy is used.
+let _picomatch: ((pattern: string) => (s: string) => boolean) | null = null;
+function matchGlob(pattern: string, value: string): boolean {
+  if (!_picomatch) {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const picomatch = createRequire(import.meta.url)("picomatch");
+    _picomatch = picomatch as (pattern: string) => (s: string) => boolean;
+  }
+  return _picomatch(pattern)(value);
+}
+
+export function isImportAllowed(modulePath: string, policy: ImportPolicy): boolean {
+  const kind = importKind(modulePath);
+  const allowKinds = policy.allowKinds ?? [];
+  const allowPkgs = policy.allowedPackages ?? [];
+  const excludeKinds = policy.excludeKinds ?? [];
+  const excludePkgs = policy.excludedPackages ?? [];
+
+  // Exclude rules — any match wins, regardless of allow rules.
+  if (excludeKinds.includes(kind)) return false;
+  if (excludePkgs.some((g) => matchGlob(g, modulePath))) return false;
+
+  // No allow rules of either kind → default-allow.
+  if (allowKinds.length === 0 && allowPkgs.length === 0) return true;
+
+  // Union across the two axes: match either an allowed kind OR an
+  // allowed package glob.
+  const kindMatched = allowKinds.includes(kind);
+  const pkgMatched = allowPkgs.some((g) => matchGlob(g, modulePath));
+  return kindMatched || pkgMatched;
+}
+
+/**
  * Strip the "std::" prefix from a standard library import path.
  * If the path is not a std:: import, returns it unchanged.
  */

--- a/packages/agency-lang/lib/ir/builders.ts
+++ b/packages/agency-lang/lib/ir/builders.ts
@@ -294,6 +294,10 @@ export const ts = {
     return { spread: false, key, value };
   },
 
+  setComputed(key: TsNode, value: TsNode): TsObjectEntry {
+    return { spread: false, computed: true, key, value };
+  },
+
   arr(items: TsNode[]): TsArrayLiteral {
     return { kind: "arrayLiteral", items };
   },

--- a/packages/agency-lang/lib/ir/prettyPrint.ts
+++ b/packages/agency-lang/lib/ir/prettyPrint.ts
@@ -129,6 +129,9 @@ export function printTs(node: TsNode, indent = 0): string {
       const inner = node.entries.map((e) => {
         if (e.spread)
           return `${ind(indent + 1)}...${printTs(e.expr, indent + 1)}`;
+        if (e.computed) {
+          return `${ind(indent + 1)}[${printTs(e.key, indent + 1)}]: ${printTs(e.value, indent + 1)}`;
+        }
         return `${ind(indent + 1)}${e.key}: ${printTs(e.value, indent + 1)}`;
       });
       return `{\n${inner.join(",\n")}\n${ind(indent)}}`;

--- a/packages/agency-lang/lib/ir/tsIR.ts
+++ b/packages/agency-lang/lib/ir/tsIR.ts
@@ -140,7 +140,8 @@ export interface TsReturn {
 }
 
 export type TsObjectEntry =
-  | { spread: false; key: string; value: TsNode }
+  | { spread: false; computed?: false; key: string; value: TsNode }
+  | { spread: false; computed: true; key: TsNode; value: TsNode }
   | { spread: true; expr: TsNode };
 
 export interface TsObjectLiteral {

--- a/packages/agency-lang/lib/lsp/builtinHover.ts
+++ b/packages/agency-lang/lib/lsp/builtinHover.ts
@@ -22,13 +22,40 @@ function formatSig(sig: BuiltinSignature): string {
 }
 
 /**
+ * Hover info for keyword-like language constructs that don't parse as a
+ * regular function call (and so aren't in BUILTIN_FUNCTION_TYPES) but still
+ * deserve a hover doc.
+ */
+const KEYWORD_BUILTIN_HOVERS: Record<string, { sig: string; description: string }> = {
+  interrupt: {
+    sig: "interrupt <kind>(message, payload?)",
+    description:
+      "Throw an interrupt of the given kind. The current execution state is captured so that, once responded to, execution resumes from exactly this point.",
+  },
+  schema: {
+    sig: "schema<T>",
+    description:
+      "Expression that returns the Zod schema for a type `T`. Useful when passing a schema to a TypeScript function or validator.",
+  },
+  debugger: {
+    sig: 'debugger "<label>"?',
+    description:
+      "No-op when running the agent normally, but pauses execution when running under the Agency debugger. Accepts an optional label string.",
+  },
+};
+
+/**
  * Hover info for a name that may be a language primitive or JS global.
  * Returns a markdown-formatted string ready for `Hover.contents.value`,
  * or `null` if the name isn't recognized.
  *
  * Currently covers:
  *   - True language primitives in BUILTIN_FUNCTION_TYPES (success,
- *     failure, llm, …).
+ *     failure, llm, fork, race, …).
+ *   - Keyword-like constructs (interrupt, schema, debugger) via
+ *     KEYWORD_BUILTIN_HOVERS — these don't go through BUILTIN_FUNCTION_TYPES
+ *     because they parse as their own AST node, but we still want hover
+ *     docs for them.
  *   - Flat callable JS globals with a populated `sig` (parseInt, …).
  *   - JS namespace bases (JSON, Math, …) — describes the namespace.
  *
@@ -38,12 +65,28 @@ function formatSig(sig: BuiltinSignature): string {
 export function lookupBuiltinHover(name: string): string | null {
   if (Object.prototype.hasOwnProperty.call(BUILTIN_FUNCTION_TYPES, name)) {
     const sig = BUILTIN_FUNCTION_TYPES[name];
-    return [
+    const lines = [
       "```agency",
       `${name}: ${formatSig(sig)}`,
       "```",
       "",
       "_Agency language primitive._",
+    ];
+    if (sig.description) {
+      lines.push("", sig.description);
+    }
+    return lines.join("\n");
+  }
+  if (Object.prototype.hasOwnProperty.call(KEYWORD_BUILTIN_HOVERS, name)) {
+    const entry = KEYWORD_BUILTIN_HOVERS[name];
+    return [
+      "```agency",
+      entry.sig,
+      "```",
+      "",
+      "_Agency language construct._",
+      "",
+      entry.description,
     ].join("\n");
   }
   if (Object.prototype.hasOwnProperty.call(JS_GLOBALS, name)) {

--- a/packages/agency-lang/lib/lsp/builtinHover.ts
+++ b/packages/agency-lang/lib/lsp/builtinHover.ts
@@ -28,17 +28,17 @@ function formatSig(sig: BuiltinSignature): string {
  */
 const KEYWORD_BUILTIN_HOVERS: Record<string, { sig: string; description: string }> = {
   interrupt: {
-    sig: "interrupt <kind>(message, payload?)",
+    sig: "interrupt <kind>(message: string, payload?: Record<string, any>)",
     description:
       "Throw an interrupt of the given kind. The current execution state is captured so that, once responded to, execution resumes from exactly this point.",
   },
   schema: {
-    sig: "schema<T>",
+    sig: "schema(T)",
     description:
       "Expression that returns the Zod schema for a type `T`. Useful when passing a schema to a TypeScript function or validator.",
   },
   debugger: {
-    sig: 'debugger "<label>"?',
+    sig: 'debugger(label?: string)',
     description:
       "No-op when running the agent normally, but pauses execution when running under the Agency debugger. Accepts an optional label string.",
   },

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -1678,26 +1678,48 @@ export const agencyArrayParser: Parser<AgencyArray> = (
   return parser(input);
 };
 
+const agencyObjectComputedKVParser: Parser<AgencyObjectKV> = trace(
+  "agencyObjectComputedKVParser",
+  seqC(
+    optionalSpaces,
+    char("["),
+    optionalSpaces,
+    set("key", ""),
+    capture(
+      lazy(() => exprParser),
+      "computedKey",
+    ),
+    optionalSpaces,
+    char("]"),
+    optionalSpaces,
+    char(":"),
+    optionalSpaces,
+    capture(
+      lazy(() => exprParser),
+      "value",
+    ),
+  ),
+);
+
+const agencyObjectStaticKVParser: Parser<AgencyObjectKV> = trace(
+  "agencyObjectStaticKVParser",
+  seqC(
+    optionalSpaces,
+    capture(or(map(quotedString, removeQuotes), many1WithJoin(varNameChar)), "key"),
+    optionalSpaces,
+    char(":"),
+    optionalSpaces,
+    capture(
+      lazy(() => exprParser),
+      "value",
+    ),
+  ),
+);
+
 export const agencyObjectKVParser: Parser<AgencyObjectKV> = (
   input: string,
-): ParserResult<AgencyObjectKV> => {
-  const parser = trace(
-    "agencyObjectKVParser",
-    seqC(
-      optionalSpaces,
-      capture(or(map(quotedString, removeQuotes), many1WithJoin(varNameChar)), "key"),
-      optionalSpaces,
-      char(":"),
-      optionalSpaces,
-      capture(
-        lazy(() => exprParser),
-        "value",
-      ),
-    ),
-  );
-
-  return parser(input);
-};
+): ParserResult<AgencyObjectKV> =>
+  or(agencyObjectComputedKVParser, agencyObjectStaticKVParser)(input);
 
 export const agencyObjectParser: Parser<AgencyObject> = seqC(
   set("type", "agencyObject"),

--- a/packages/agency-lang/lib/preprocessors/parallelDesugar.ts
+++ b/packages/agency-lang/lib/preprocessors/parallelDesugar.ts
@@ -256,7 +256,9 @@ function walkForReferences(node: AgencyNode, refs: Set<string>): void {
         if ("type" in e && e.type === "splat") {
           walkForReferences(e.value as AgencyNode, refs);
         } else {
-          walkForReferences((e as any).value as AgencyNode, refs);
+          const kv = e as { computedKey?: AgencyNode; value: AgencyNode };
+          if (kv.computedKey) walkForReferences(kv.computedKey, refs);
+          walkForReferences(kv.value, refs);
         }
       }
       return;

--- a/packages/agency-lang/lib/stdlib/agency.test.ts
+++ b/packages/agency-lang/lib/stdlib/agency.test.ts
@@ -1,15 +1,30 @@
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from "vitest";
 import {
   mkdtempSync,
   mkdirSync,
   rmSync,
   writeFileSync,
   readFileSync,
+  existsSync,
   symlinkSync,
 } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { _compileFile } from "./agency.js";
+import {
+  _compileFile,
+  _parseAST,
+  _writeAST,
+  _format,
+  _formatFile,
+  _walkAST,
+  _getNodesOfType,
+  _getImports,
+  _getFunctions,
+  _getGraphNodes,
+  _filterImports,
+} from "./agency.js";
+import type { AgencyNode } from "../types.js";
+import type { ImportStatement } from "../types/importStatement.js";
 
 // Sentinel string baked into the inside-the-sandbox source. The compiled JS
 // has to contain it — that's what proves _compileFile actually read THIS
@@ -113,18 +128,438 @@ describe("_compileFile sandbox containment", () => {
     );
   });
 
-  it("calls compileSource with restrictImports: true (subprocess code can't import 'fs')", () => {
-    // If _compileFile ever stops passing restrictImports: true, this test
-    // catches it. We write an inside-the-sandbox file that imports 'fs'
-    // and assert _compileFile rejects it with the same error compileSource
-    // produces under restrictImports.
+  it("calls compileSource with stdlib-only import policy (subprocess code can't import 'fs')", () => {
+    // If _compileFile ever stops passing the stdlib-only import policy,
+    // this test catches it. We write an inside-the-sandbox file that
+    // imports 'fs' and assert _compileFile rejects it.
     writeFileSync(
       join(sandbox, "imports-fs.agency"),
       `import { readFileSync } from "fs"\nnode main() { return "x" }`,
       "utf-8",
     );
     expect(() => _compileFile(sandbox, "imports-fs.agency")).toThrowError(
-      /npm\/Node module import/,
+      /Import 'fs' is not allowed/,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _parseAST
+// ---------------------------------------------------------------------------
+describe("_parseAST", () => {
+  it("returns an AgencyProgram with parsed nodes", () => {
+    const ast = _parseAST("node main() { return 1 }");
+    expect(ast.type).toBe("agencyProgram");
+    expect(Array.isArray(ast.nodes)).toBe(true);
+    const graphNode = ast.nodes.find((n) => n.type === "graphNode");
+    expect(graphNode).toBeDefined();
+    expect((graphNode as { nodeName: string }).nodeName).toBe("main");
+  });
+
+  it("throws on invalid source", () => {
+    expect(() => _parseAST(")))")).toThrowError();
+  });
+
+  it("returns a JSON-serializable AST (deep-equal after stringify/parse)", () => {
+    const ast = _parseAST("node main() { return 42 }");
+    const roundtripped = JSON.parse(JSON.stringify(ast));
+    expect(roundtripped).toEqual(ast);
+  });
+
+  it("does NOT lower patterns (so the AST round-trips through writeAST)", () => {
+    // If `lower: true` were used, patterns would be desugared and the AST
+    // would no longer round-trip back to the original source via the
+    // formatter. We assert that fact indirectly by parsing+formatting and
+    // checking the result is byte-identical to the formatted input (i.e.
+    // the format function is idempotent — a property only the lower:false
+    // / applyTemplate:false combo preserves).
+    const src = `node main() { return 1 }`;
+    const formatted = _format(src);
+    expect(_format(formatted)).toBe(formatted);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _writeAST + _format + _formatFile
+// ---------------------------------------------------------------------------
+describe("_writeAST / _format / _formatFile", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "agency-fmt-"));
+  });
+
+  afterEach(() => {
+    try { rmSync(dir, { recursive: true }); } catch (_) { /* best effort */ }
+  });
+
+  it("_format is idempotent on already-formatted source", () => {
+    const formatted = _format(`node main() { return 1 }`);
+    expect(_format(formatted)).toBe(formatted);
+  });
+
+  it("_format throws on parse failure", () => {
+    expect(() => _format("def {")).toThrowError();
+  });
+
+  it("_format preserves single-line comments", () => {
+    const formatted = _format(`// keep me\nnode main() { return 1 }`);
+    expect(formatted).toContain("// keep me");
+  });
+
+  it("_format canonicalizes whitespace", () => {
+    const ugly = `node    main(  ) {return    1}`;
+    const formatted = _format(ugly);
+    // Whatever the exact canonical form is, formatting should produce a
+    // distinct shape from the ugly input.
+    expect(formatted).not.toBe(ugly);
+    // And re-formatting should be a no-op.
+    expect(_format(formatted)).toBe(formatted);
+  });
+
+  it("_writeAST round-trips: parse → write → re-parse produces structurally equivalent AST", async () => {
+    const src = `node main() { return 42 }`;
+    const ast = _parseAST(src);
+    await _writeAST(ast, dir, "out.agency", true);
+    const reparsed = _parseAST(readFileSync(join(dir, "out.agency"), "utf-8"));
+    // Compare structures modulo source locations — the formatter may add
+    // a trailing newline / shift positions, but the semantic AST must
+    // match.
+    const stripLoc = (x: unknown): unknown => {
+      if (Array.isArray(x)) return x.map(stripLoc);
+      if (x && typeof x === "object") {
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(x as Record<string, unknown>)) {
+          if (k === "loc") continue;
+          out[k] = stripLoc(v);
+        }
+        return out;
+      }
+      return x;
+    };
+    expect(stripLoc(reparsed)).toEqual(stripLoc(ast));
+  });
+
+  it("_writeAST with overwrite=true replaces an existing file", async () => {
+    writeFileSync(join(dir, "out.agency"), `node old() { return 0 }`, "utf-8");
+    const ast = _parseAST(`node fresh() { return 1 }`);
+    await _writeAST(ast, dir, "out.agency", true);
+    const written = readFileSync(join(dir, "out.agency"), "utf-8");
+    expect(written).toContain("node fresh");
+    expect(written).not.toContain("node old");
+  });
+
+  it("_writeAST with overwrite=false succeeds when file does not exist", async () => {
+    const ast = _parseAST(`node main() { return 1 }`);
+    await _writeAST(ast, dir, "new.agency", false);
+    expect(existsSync(join(dir, "new.agency"))).toBe(true);
+  });
+
+  it("_writeAST with overwrite=false fails when the file already exists", async () => {
+    writeFileSync(join(dir, "exists.agency"), `node x() {}`, "utf-8");
+    const ast = _parseAST(`node main() { return 1 }`);
+    await expect(_writeAST(ast, dir, "exists.agency", false)).rejects.toThrow(
+      /already exists/,
+    );
+  });
+
+  it("_writeAST rejects path traversal via .. segments", async () => {
+    const ast = _parseAST(`node main() { return 1 }`);
+    // resolvePath inside _write rejects this lexically.
+    await expect(_writeAST(ast, dir, "../escape.agency", true)).rejects.toThrow(
+      /escapes directory/,
+    );
+  });
+
+  it("_writeAST rejects absolute filenames", async () => {
+    const ast = _parseAST(`node main() { return 1 }`);
+    await expect(
+      _writeAST(ast, dir, "/etc/passwd", true),
+    ).rejects.toThrow(/absolute/);
+  });
+
+  it("_formatFile formats a file in place", () => {
+    const ugly = `node    main(  ) {return    1}`;
+    writeFileSync(join(dir, "x.agency"), ugly, "utf-8");
+    _formatFile(dir, "x.agency");
+    const after = readFileSync(join(dir, "x.agency"), "utf-8");
+    expect(after).not.toBe(ugly);
+    expect(_format(after)).toBe(after);
+  });
+
+  it("_formatFile does NOT touch mtime when the file is already formatted", async () => {
+    const src = _format(`node main() { return 1 }`);
+    writeFileSync(join(dir, "x.agency"), src, "utf-8");
+    const fs = await import("fs");
+    const before = fs.statSync(join(dir, "x.agency")).mtimeMs;
+    // Wait a moment so any actual write would yield a different mtime.
+    await new Promise((r) => setTimeout(r, 20));
+    _formatFile(dir, "x.agency");
+    const after = fs.statSync(join(dir, "x.agency")).mtimeMs;
+    expect(after).toBe(before);
+  });
+
+  it("_formatFile throws on missing file (mustExist:true sandbox)", () => {
+    expect(() => _formatFile(dir, "missing.agency")).toThrowError();
+  });
+
+  it("_formatFile rejects path traversal", () => {
+    // Create a file in the PARENT of the sandbox so `../outside.agency`
+    // would resolve to an existing file. The realpath check must still
+    // reject it because the resolved path lives outside `dir`.
+    const outsidePath = join(dir, "..", "outside.agency");
+    writeFileSync(outsidePath, `node x() {}`, "utf-8");
+    try {
+      expect(() => _formatFile(dir, "../outside.agency")).toThrowError(
+        /Sandbox violation/,
+      );
+    } finally {
+      try { rmSync(outsidePath); } catch (_) { /* best effort */ }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _walkAST
+// ---------------------------------------------------------------------------
+describe("_walkAST", () => {
+  it("returns a clone — original AST is not mutated", () => {
+    const ast = _parseAST(`node main() { return 1 }`);
+    const originalSnapshot = JSON.parse(JSON.stringify(ast));
+    const { visits } = _walkAST(ast);
+    for (const v of visits) {
+      (v.node as { type: string }).type = "MUTATED";
+    }
+    expect(ast).toEqual(originalSnapshot);
+  });
+
+  it("clone IS mutated through the visits' references", () => {
+    const ast = _parseAST(`node main() { return 1 }`);
+    const { clone, visits } = _walkAST(ast);
+    for (const v of visits) {
+      (v.node as { type: string }).type = "MUTATED";
+    }
+    // Every node in clone should now read as MUTATED via the visit refs.
+    expect(visits.every((v) => v.node.type === ("MUTATED" as never))).toBe(true);
+    // And the clone's top-level nodes reflect the mutation.
+    expect(clone.nodes.every((n) => n.type === ("MUTATED" as never))).toBe(true);
+  });
+
+  it("visits in pre-order: parent appears before its descendants", () => {
+    const ast = _parseAST(`node main() { return 1 }`);
+    const { visits } = _walkAST(ast);
+    const types = visits.map((v) => v.node.type);
+    const graphNodeIdx = types.indexOf("graphNode");
+    const returnIdx = types.indexOf("returnStatement");
+    expect(graphNodeIdx).toBeGreaterThanOrEqual(0);
+    expect(returnIdx).toBeGreaterThan(graphNodeIdx);
+  });
+
+  it("ancestors are populated correctly: returnStatement's ancestors end with graphNode", () => {
+    const ast = _parseAST(`node main() { return 1 }`);
+    const { visits } = _walkAST(ast);
+    const ret = visits.find((v) => v.node.type === "returnStatement");
+    expect(ret).toBeDefined();
+    const ancestorTypes = ret!.ancestors.map((a) => a.type);
+    expect(ancestorTypes).toContain("graphNode");
+  });
+
+  it("mutating a parent does NOT affect the rest of the iteration (visits are buffered)", () => {
+    const ast = _parseAST(`node main() { return 1 }`);
+    const { visits } = _walkAST(ast);
+    const originalCount = visits.length;
+    // Clobbering the graphNode's body shouldn't shrink the visit list — it's
+    // already been collected.
+    const graphNode = visits.find((v) => v.node.type === "graphNode")!.node as {
+      body: AgencyNode[];
+    };
+    graphNode.body = [];
+    // We can still iterate every original visit without crashing.
+    for (const v of visits) {
+      expect(v.node).toBeDefined();
+    }
+    expect(visits.length).toBe(originalCount);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _getNodesOfType + convenience wrappers
+// ---------------------------------------------------------------------------
+describe("_getNodesOfType and convenience wrappers", () => {
+  const fixture = `
+import { foo } from "./bar.agency"
+import { exists } from "std::shell"
+
+def helper(): number {
+  return 1
+}
+
+def other(): string {
+  return "x"
+}
+
+node main() {
+  return helper()
+}
+
+node aux() {
+  return 1
+}
+`;
+
+  it("_getNodesOfType with an empty types array returns []", () => {
+    expect(_getNodesOfType(fixture, [])).toEqual([]);
+  });
+
+  it("_getNodesOfType walks deeply (functionCall lives inside a body)", () => {
+    const calls = _getNodesOfType(fixture, ["functionCall"]);
+    expect(calls.length).toBeGreaterThan(0);
+    expect(calls.every((n) => n.type === "functionCall")).toBe(true);
+  });
+
+  it("_getNodesOfType accepts multiple types in one call (union)", () => {
+    const both = _getNodesOfType(fixture, ["function", "graphNode"]);
+    const types = both.map((n) => n.type).sort();
+    expect(types).toEqual(["function", "function", "graphNode", "graphNode"]);
+  });
+
+  it("_getNodesOfType returns [] for unknown type strings (no error)", () => {
+    expect(_getNodesOfType(fixture, ["definitely-not-a-real-type"])).toEqual([]);
+  });
+
+  it("_getNodesOfType throws on parse failure", () => {
+    expect(() => _getNodesOfType(")))", ["function"])).toThrowError();
+  });
+
+  it("_getImports returns all importStatement nodes", () => {
+    const imports = _getImports(fixture);
+    expect(imports.length).toBe(2);
+    const paths = imports
+      .map((n) => (n as ImportStatement).modulePath)
+      .sort();
+    expect(paths).toEqual(["./bar.agency", "std::shell"]);
+  });
+
+  it("_getFunctions returns all function definitions", () => {
+    const fns = _getFunctions(fixture);
+    expect(fns.length).toBe(2);
+    expect(fns.every((n) => n.type === "function")).toBe(true);
+  });
+
+  it("_getGraphNodes returns all graph node definitions", () => {
+    const nodes = _getGraphNodes(fixture);
+    expect(nodes.length).toBe(2);
+    expect(nodes.every((n) => n.type === "graphNode")).toBe(true);
+  });
+
+  it("returns empty arrays for an empty source", () => {
+    expect(_getImports("")).toEqual([]);
+    expect(_getFunctions("")).toEqual([]);
+    expect(_getGraphNodes("")).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// _filterImports
+// ---------------------------------------------------------------------------
+describe("_filterImports", () => {
+  const fixture = `import { foo } from "./bar.agency"
+import { exists } from "std::shell"
+import { thing } from "pkg::wikipedia"
+import * as fs from "fs"
+
+node main() { return 1 }`;
+
+  it("all four lists empty → no filtering, filtered=false", () => {
+    const result = _filterImports(fixture, [], [], [], []);
+    expect(result.filtered).toBe(false);
+    // Source should be the formatted version of the original.
+    expect(result.source).toBe(_format(fixture));
+  });
+
+  it("allowKinds=['stdlib'] keeps only stdlib imports", () => {
+    const result = _filterImports(fixture, [], [], ["stdlib"], []);
+    expect(result.filtered).toBe(true);
+    expect(result.source).toContain("std::shell");
+    expect(result.source).not.toContain("./bar.agency");
+    expect(result.source).not.toContain("pkg::wikipedia");
+    expect(result.source).not.toContain('"fs"');
+  });
+
+  it("excludeKinds=['node'] drops bare-specifier imports only", () => {
+    const result = _filterImports(fixture, [], [], [], ["node"]);
+    expect(result.filtered).toBe(true);
+    expect(result.source).not.toContain('"fs"');
+    expect(result.source).toContain("./bar.agency");
+    expect(result.source).toContain("std::shell");
+    expect(result.source).toContain("pkg::wikipedia");
+  });
+
+  it("allowedPackages exact-list passes only matching imports", () => {
+    const result = _filterImports(
+      fixture,
+      ["std::shell", "pkg::wikipedia"],
+      [],
+      [],
+      [],
+    );
+    expect(result.filtered).toBe(true);
+    expect(result.source).toContain("std::shell");
+    expect(result.source).toContain("pkg::wikipedia");
+    expect(result.source).not.toContain("./bar.agency");
+    expect(result.source).not.toContain('"fs"');
+  });
+
+  it("exclude wins over allow: excludedPackages=['std::shell'] + allowKinds=['stdlib']", () => {
+    const src = `import { exists } from "std::shell"
+import { print } from "std::index"
+
+node main() { return 1 }`;
+    const result = _filterImports(src, [], ["std::shell"], ["stdlib"], []);
+    expect(result.filtered).toBe(true);
+    expect(result.source).not.toContain("std::shell");
+    expect(result.source).toContain("std::index");
+  });
+
+  it("union semantics: allowKinds + allowedPackages both pass", () => {
+    const result = _filterImports(
+      fixture,
+      ["pkg::wikipedia"],
+      [],
+      ["stdlib"],
+      [],
+    );
+    expect(result.filtered).toBe(true);
+    expect(result.source).toContain("std::shell");
+    expect(result.source).toContain("pkg::wikipedia");
+    expect(result.source).not.toContain("./bar.agency");
+    expect(result.source).not.toContain('"fs"');
+  });
+
+  it("unknown kind in allowKinds is inert (matches nothing) — non-empty allow still gates", () => {
+    // allowKinds=['bogus'] + everything else empty = no allow rule matches
+    // anything → everything fails the allow check → all imports dropped.
+    const result = _filterImports(fixture, [], [], ["bogus"], []);
+    expect(result.filtered).toBe(true);
+    expect(result.source).not.toContain("std::shell");
+    expect(result.source).not.toContain("./bar.agency");
+    expect(result.source).not.toContain("pkg::wikipedia");
+    expect(result.source).not.toContain('"fs"');
+  });
+
+  it("glob: allowedPackages=['std::*'] passes all stdlib imports", () => {
+    const result = _filterImports(fixture, ["std::*"], [], [], []);
+    expect(result.filtered).toBe(true);
+    expect(result.source).toContain("std::shell");
+    expect(result.source).not.toContain("pkg::wikipedia");
+    expect(result.source).not.toContain("./bar.agency");
+    expect(result.source).not.toContain('"fs"');
+  });
+
+  it("empty source / no imports → filtered=false, byte-equal to format()", () => {
+    const src = `node main() { return 1 }`;
+    const result = _filterImports(src, [], [], ["stdlib"], []);
+    expect(result.filtered).toBe(false);
+    expect(result.source).toBe(_format(src));
   });
 });

--- a/packages/agency-lang/lib/stdlib/agency.test.ts
+++ b/packages/agency-lang/lib/stdlib/agency.test.ts
@@ -18,9 +18,6 @@ import {
   _formatFile,
   _walkAST,
   _getNodesOfType,
-  _getImports,
-  _getFunctions,
-  _getGraphNodes,
   _filterImports,
 } from "./agency.js";
 import type { AgencyNode } from "../types.js";
@@ -431,8 +428,13 @@ node aux() {
     expect(() => _getNodesOfType(")))", ["function"])).toThrowError();
   });
 
-  it("_getImports returns all importStatement nodes", () => {
-    const imports = _getImports(fixture);
+  // The Agency-level convenience wrappers (getImports / getFunctions /
+  // getGraphNodes) are one-liners that call getNodesOfType with a single
+  // type string. We exercise the underlying TS primitive here; the Agency
+  // wrappers themselves live in stdlib/agency.agency.
+
+  it("getNodesOfType(['importStatement']) returns all importStatement nodes", () => {
+    const imports = _getNodesOfType(fixture, ["importStatement"]);
     expect(imports.length).toBe(2);
     const paths = imports
       .map((n) => (n as ImportStatement).modulePath)
@@ -440,22 +442,22 @@ node aux() {
     expect(paths).toEqual(["./bar.agency", "std::shell"]);
   });
 
-  it("_getFunctions returns all function definitions", () => {
-    const fns = _getFunctions(fixture);
+  it("getNodesOfType(['function']) returns all function definitions", () => {
+    const fns = _getNodesOfType(fixture, ["function"]);
     expect(fns.length).toBe(2);
     expect(fns.every((n) => n.type === "function")).toBe(true);
   });
 
-  it("_getGraphNodes returns all graph node definitions", () => {
-    const nodes = _getGraphNodes(fixture);
+  it("getNodesOfType(['graphNode']) returns all graph node definitions", () => {
+    const nodes = _getNodesOfType(fixture, ["graphNode"]);
     expect(nodes.length).toBe(2);
     expect(nodes.every((n) => n.type === "graphNode")).toBe(true);
   });
 
   it("returns empty arrays for an empty source", () => {
-    expect(_getImports("")).toEqual([]);
-    expect(_getFunctions("")).toEqual([]);
-    expect(_getGraphNodes("")).toEqual([]);
+    expect(_getNodesOfType("", ["importStatement"])).toEqual([]);
+    expect(_getNodesOfType("", ["function"])).toEqual([]);
+    expect(_getNodesOfType("", ["graphNode"])).toEqual([]);
   });
 });
 

--- a/packages/agency-lang/lib/stdlib/agency.ts
+++ b/packages/agency-lang/lib/stdlib/agency.ts
@@ -69,11 +69,17 @@ function resolveInSandbox(
   const mustExist = opts.mustExist ?? true;
   const sandboxRoot = realpathSync(resolve(dir));
   const resolved = resolve(sandboxRoot, filename);
-  const target = mustExist
-    ? realpathSync(resolved)
-    : existsSync(resolved)
-      ? realpathSync(resolved)
-      : resolved;
+  // Realpath the target whenever it exists so symlinks get collapsed and
+  // can't punch out of the sandbox. The only branch that skips realpath
+  // is "the target doesn't exist yet AND the caller said that's fine" —
+  // used by write-style callers (writeAST) that are about to create the
+  // file.
+  let target: string;
+  if (mustExist || existsSync(resolved)) {
+    target = realpathSync(resolved);
+  } else {
+    target = resolved;
+  }
   if (!target.startsWith(sandboxRoot + sep)) {
     throw new Error(
       `Sandbox violation: '${filename}' resolves to '${target}', which is outside the sandbox dir '${sandboxRoot}'.`,
@@ -220,17 +226,9 @@ export function _getNodesOfType(
     .filter((n) => wanted.has(n.type));
 }
 
-export function _getImports(source: string): AgencyNode[] {
-  return _getNodesOfType(source, ["importStatement"]);
-}
-
-export function _getFunctions(source: string): AgencyNode[] {
-  return _getNodesOfType(source, ["function"]);
-}
-
-export function _getGraphNodes(source: string): AgencyNode[] {
-  return _getNodesOfType(source, ["graphNode"]);
-}
+// _getImports / _getFunctions / _getGraphNodes are convenience wrappers
+// around _getNodesOfType. They live in stdlib/agency.agency as Agency
+// functions that call getNodesOfType directly — no need for TS stubs.
 
 // ---------------------------------------------------------------------------
 // filterImports

--- a/packages/agency-lang/lib/stdlib/agency.ts
+++ b/packages/agency-lang/lib/stdlib/agency.ts
@@ -1,12 +1,24 @@
-import { compileSource } from "../compiler/compile.js";
-import { writeFileSync, mkdirSync, readFileSync, realpathSync } from "fs";
+import { compileSource, typeCheckSource, TypeCheckReport } from "../compiler/compile.js";
+import { writeFileSync, mkdirSync, readFileSync, realpathSync, existsSync } from "fs";
 import { join, resolve, sep } from "path";
 import { nanoid } from "nanoid";
+import { parseAgency, replaceBlankLines } from "../parser.js";
+import { generateAgency } from "../backends/agencyGenerator.js";
+import { walkNodesArray } from "../utils/node.js";
+import { deepCopy } from "../utils.js";
+import {
+  ImportKind,
+  ImportPolicy,
+  isImportAllowed,
+} from "../importPaths.js";
+import type { AgencyProgram, AgencyNode } from "../types.js";
+import type { ImportStatement } from "../types/importStatement.js";
+import { _write } from "./builtins.js";
 
 function compileAndPersist(source: string): { moduleId: string; path: string } {
   const result = compileSource(source, {
     typechecker: { enabled: true },
-    restrictImports: true,
+    imports: { allowKinds: ["stdlib"] },
   });
 
   if (!result.success) {
@@ -27,13 +39,11 @@ export function _compile(source: string): { moduleId: string; path: string } {
   return compileAndPersist(source);
 }
 
-// Read an agency source file from disk and compile it under the same
-// stdlib-only restriction as _compile. The (dir, filename) split mirrors
-// std::read / std::write so callers can use partial application to bind
-// `dir` to a sandbox path: `runFile.bind(dir: "/safe/dir")`.
+// Resolve `filename` against `dir`, requiring the result to live strictly
+// inside `dir` after symlinks are collapsed. Used by _compileFile,
+// _typecheckFile, and _formatFile to share one sandbox boundary.
 //
-// SECURITY: `filename` is forbidden from escaping `dir`. A naive
-// `path.resolve(dir, filename)` is unsafe in two ways:
+// SECURITY: A naive `path.resolve(dir, filename)` is unsafe in two ways:
 //   1. If `filename` is absolute (e.g. "/etc/passwd"), `resolve` ignores
 //      `dir` entirely.
 //   2. `filename` may contain `..` segments that walk out of `dir`.
@@ -43,17 +53,213 @@ export function _compile(source: string): { moduleId: string; path: string } {
 // be used as an escape hatch. The trailing `+ sep` on the prefix
 // prevents a sibling directory (e.g. `/safedir-evil/`) from passing the
 // startsWith check by sharing the same prefix string.
-export function _compileFile(
+//
+// When `mustExist` is false, the target file is allowed to not exist yet
+// (used by callers that are about to create the file). In that mode we
+// realpath the directory but only lexically resolve the file path —
+// symlinks INSIDE `dir` are not followed on the missing-target branch,
+// so if you let the user create a symlink and then write to it, that's
+// on you. For overwrite of an EXISTING symlink the realpath check still
+// applies because we hit the existing-target branch.
+function resolveInSandbox(
   dir: string,
   filename: string,
-): { moduleId: string; path: string } {
+  opts: { mustExist?: boolean } = {},
+): string {
+  const mustExist = opts.mustExist ?? true;
   const sandboxRoot = realpathSync(resolve(dir));
-  const target = realpathSync(resolve(sandboxRoot, filename));
+  const resolved = resolve(sandboxRoot, filename);
+  const target = mustExist
+    ? realpathSync(resolved)
+    : existsSync(resolved)
+      ? realpathSync(resolved)
+      : resolved;
   if (!target.startsWith(sandboxRoot + sep)) {
     throw new Error(
       `Sandbox violation: '${filename}' resolves to '${target}', which is outside the sandbox dir '${sandboxRoot}'.`,
     );
   }
-  const source = readFileSync(target, "utf-8");
+  return target;
+}
+
+// Read an agency source file from disk and compile it under the same
+// stdlib-only restriction as _compile. The (dir, filename) split mirrors
+// std::read / std::write so callers can use partial application to bind
+// `dir` to a sandbox path: `runFile.bind(dir: "/safe/dir")`.
+export function _compileFile(
+  dir: string,
+  filename: string,
+): { moduleId: string; path: string } {
+  const source = readFileSync(resolveInSandbox(dir, filename), "utf-8");
   return compileAndPersist(source);
+}
+
+export function _typecheck(source: string): TypeCheckReport {
+  return typeCheckSource(source);
+}
+
+// The real file path is handed to the type-checker so relative imports in
+// `source` resolve against `dir` (transitive imports may still walk outside
+// `dir` — typechecking is read-only so this is intentional).
+export function _typecheckFile(dir: string, filename: string): TypeCheckReport {
+  const target = resolveInSandbox(dir, filename);
+  return typeCheckSource(readFileSync(target, "utf-8"), target);
+}
+
+// ---------------------------------------------------------------------------
+// AST + formatter primitives
+// ---------------------------------------------------------------------------
+//
+// _parseAST / _writeAST / _format / _formatFile / _walkAST and friends are
+// all centered on a single principle: there is exactly one AST → source
+// path (`generateAgency`) and exactly one source → AST path
+// (`parseAgency` with `applyTemplate: false, lower: false`). That
+// combination matches what `pnpm run fmt` does and is what makes
+// round-tripping work: patterns aren't lowered to their desugared form,
+// so the generator can print them back as patterns.
+
+function parseSource(source: string): AgencyProgram {
+  // Match the format path: don't apply the template (we want source line
+  // numbers untouched) and don't lower patterns (the generator needs to
+  // print them back as patterns). `replaceBlankLines` preserves blank
+  // lines through the parser as it does in the CLI format command.
+  const result = parseAgency(replaceBlankLines(source), {}, false, false);
+  if (!result.success) {
+    throw new Error(result.message ?? "Failed to parse Agency source");
+  }
+  return result.result;
+}
+
+export function _parseAST(source: string): AgencyProgram {
+  return parseSource(source);
+}
+
+export async function _writeAST(
+  ast: AgencyProgram,
+  dir: string,
+  filename: string,
+  overwrite: boolean,
+): Promise<boolean> {
+  // Delegate to _write so all writes share path resolution, sandbox
+  // containment, and existence checks. `overwrite: false` maps to
+  // create-only mode.
+  const source = generateAgency(ast);
+  const mode = overwrite ? "overwrite" : "create-only";
+  return _write(dir, filename, source, mode);
+}
+
+export function _format(source: string): string {
+  return generateAgency(_parseAST(source));
+}
+
+export function _formatFile(dir: string, filename: string): boolean {
+  // formatFile *requires* the file to exist — it reads then writes.
+  // Use the existing-target branch (mustExist: true) so symlinks get
+  // realpath-collapsed before we touch the file.
+  const target = resolveInSandbox(dir, filename, { mustExist: true });
+  const source = readFileSync(target, "utf-8");
+  const formatted = generateAgency(_parseAST(source));
+  // Skip the write if formatting is a no-op — avoids touching mtime
+  // when nothing actually changed. Matches Prettier / rustfmt behavior.
+  if (formatted !== source) {
+    writeFileSync(target, formatted, "utf-8");
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// walkAST
+// ---------------------------------------------------------------------------
+
+export type WalkASTVisit = {
+  node: AgencyNode;
+  ancestors: AgencyNode[];
+};
+
+// Deep-clone the AST, enumerate every visit (pre-order) into a flat array,
+// and hand both back. The Agency wrapper iterates `visits` calling the
+// user's visitor; the visits hold references into `clone`, so in-place
+// mutation in the visitor lands in `clone` and is returned. We reuse the
+// existing `walkNodesArray` from lib/utils/node.ts as the single source
+// of truth for traversal — when the parser learns a new node kind, this
+// picks it up for free.
+//
+// SEMANTICS: The visit list is built BEFORE the visitor runs. If the
+// visitor mutates a parent during the walk, the children that were
+// already buffered into the visit list are still walked (against the
+// pre-mutation state). This is documented in walkAST's docstring.
+export function _walkAST(ast: AgencyProgram): {
+  clone: AgencyProgram;
+  visits: WalkASTVisit[];
+} {
+  const clone = deepCopy(ast);
+  const visits: WalkASTVisit[] = [];
+  for (const { node, ancestors } of walkNodesArray(clone.nodes)) {
+    visits.push({ node, ancestors: ancestors as AgencyNode[] });
+  }
+  return { clone, visits };
+}
+
+// ---------------------------------------------------------------------------
+// Convenience queries on source
+// ---------------------------------------------------------------------------
+//
+// Source-string-in helpers for the common "I just want the imports / the
+// function definitions / etc. out of this file" case. All three
+// convenience wrappers delegate to _getNodesOfType — do NOT reimplement
+// the parse-and-walk dance per wrapper.
+
+export function _getNodesOfType(
+  source: string,
+  types: string[],
+): AgencyNode[] {
+  const ast = _parseAST(source);
+  const wanted = new Set(types);
+  return walkNodesArray(ast.nodes)
+    .map((v) => v.node)
+    .filter((n) => wanted.has(n.type));
+}
+
+export function _getImports(source: string): AgencyNode[] {
+  return _getNodesOfType(source, ["importStatement"]);
+}
+
+export function _getFunctions(source: string): AgencyNode[] {
+  return _getNodesOfType(source, ["function"]);
+}
+
+export function _getGraphNodes(source: string): AgencyNode[] {
+  return _getNodesOfType(source, ["graphNode"]);
+}
+
+// ---------------------------------------------------------------------------
+// filterImports
+// ---------------------------------------------------------------------------
+
+export function _filterImports(
+  source: string,
+  allowedPackages: string[],
+  excludedPackages: string[],
+  allowKinds: string[],
+  excludeKinds: string[],
+): { source: string; filtered: boolean } {
+  const ast = _parseAST(source);
+  // Unknown kind strings in allowKinds/excludeKinds are silently ignored —
+  // `importKind` only ever returns one of the four canonical strings, so
+  // a bogus entry like "fish" can never match. The cast just satisfies
+  // the type system.
+  const policy: ImportPolicy = {
+    allowedPackages,
+    excludedPackages,
+    allowKinds: allowKinds as ImportKind[],
+    excludeKinds: excludeKinds as ImportKind[],
+  };
+  const originalCount = ast.nodes.length;
+  ast.nodes = ast.nodes.filter(
+    (n) =>
+      !(n.type === "importStatement") ||
+      isImportAllowed((n as ImportStatement).modulePath, policy),
+  );
+  const filtered = ast.nodes.length !== originalCount;
+  return { source: generateAgency(ast), filtered };
 }

--- a/packages/agency-lang/lib/stdlib/builtins.test.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { _write } from "./builtins.js";
+
+describe("_write mode parameter", () => {
+  let dir: string;
+  let target: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "agency-write-mode-"));
+    target = "out.txt";
+  });
+
+  afterEach(() => {
+    try { rmSync(dir, { recursive: true }); } catch (_) { /* best effort */ }
+  });
+
+  it("defaults to overwrite (backward compat: no mode arg)", async () => {
+    writeFileSync(join(dir, target), "existing", "utf-8");
+    await _write(dir, target, "replaced");
+    expect(readFileSync(join(dir, target), "utf-8")).toBe("replaced");
+  });
+
+  it("overwrite mode replaces existing content", async () => {
+    writeFileSync(join(dir, target), "existing", "utf-8");
+    await _write(dir, target, "replaced", "overwrite");
+    expect(readFileSync(join(dir, target), "utf-8")).toBe("replaced");
+  });
+
+  it("append mode concatenates to existing content", async () => {
+    writeFileSync(join(dir, target), "hello ", "utf-8");
+    await _write(dir, target, "world", "append");
+    expect(readFileSync(join(dir, target), "utf-8")).toBe("hello world");
+  });
+
+  it("append mode creates the file when it does not exist", async () => {
+    await _write(dir, target, "fresh", "append");
+    expect(readFileSync(join(dir, target), "utf-8")).toBe("fresh");
+  });
+
+  it("create-only mode creates a new file successfully", async () => {
+    expect(existsSync(join(dir, target))).toBe(false);
+    await _write(dir, target, "created", "create-only");
+    expect(readFileSync(join(dir, target), "utf-8")).toBe("created");
+  });
+
+  it("create-only mode throws when the file already exists", async () => {
+    writeFileSync(join(dir, target), "existing", "utf-8");
+    await expect(_write(dir, target, "should-fail", "create-only")).rejects.toThrow(
+      /already exists/,
+    );
+    // Original content must be untouched.
+    expect(readFileSync(join(dir, target), "utf-8")).toBe("existing");
+  });
+
+  it("rejects unknown mode strings with a clear message", async () => {
+    await expect(
+      _write(dir, target, "x", "bogus" as "overwrite"),
+    ).rejects.toThrow(/Invalid mode 'bogus'/);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/builtins.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.ts
@@ -59,9 +59,8 @@ export async function _read(dir: string, filename: string): Promise<string> {
   return data.toString("utf8");
 }
 
-export type WriteMode = "overwrite" | "append" | "create-only";
-
-const VALID_WRITE_MODES: WriteMode[] = ["overwrite", "append", "create-only"];
+const VALID_WRITE_MODES = ["overwrite", "append", "create-only"] as const;
+export type WriteMode = typeof VALID_WRITE_MODES[number];
 
 export async function _write(
   dir: string,

--- a/packages/agency-lang/lib/stdlib/builtins.ts
+++ b/packages/agency-lang/lib/stdlib/builtins.ts
@@ -1,6 +1,7 @@
 import * as readline from "readline";
 import process from "process";
-import { readFile, writeFile } from "fs/promises";
+import { readFile, writeFile, appendFile } from "fs/promises";
+import { existsSync } from "fs";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { detectPlatform } from "./utils.js";
@@ -58,8 +59,33 @@ export async function _read(dir: string, filename: string): Promise<string> {
   return data.toString("utf8");
 }
 
-export async function _write(dir: string, filename: string, content: string): Promise<boolean> {
+export type WriteMode = "overwrite" | "append" | "create-only";
+
+const VALID_WRITE_MODES: WriteMode[] = ["overwrite", "append", "create-only"];
+
+export async function _write(
+  dir: string,
+  filename: string,
+  content: string,
+  mode: WriteMode = "overwrite",
+): Promise<boolean> {
+  if (!VALID_WRITE_MODES.includes(mode)) {
+    throw new Error(
+      `Invalid mode '${mode}'. Must be one of: ${VALID_WRITE_MODES.join(", ")}.`,
+    );
+  }
   const filePath = await resolvePath(dir, filename);
+  if (mode === "create-only") {
+    if (existsSync(filePath)) {
+      throw new Error(`File already exists: '${filePath}' (mode is 'create-only').`);
+    }
+    await writeFile(filePath, content, "utf8");
+    return true;
+  }
+  if (mode === "append") {
+    await appendFile(filePath, content, "utf8");
+    return true;
+  }
   await writeFile(filePath, content, "utf8");
   return true;
 }

--- a/packages/agency-lang/lib/typeChecker/builtins.ts
+++ b/packages/agency-lang/lib/typeChecker/builtins.ts
@@ -78,25 +78,99 @@ const llmOptions: VariableType = {
  */
 export const BUILTIN_FUNCTION_TYPES: Record<string, BuiltinSignature> = {
   // --- LLM primitive ---
-  llm: { params: ["any", llmOptions], minParams: 1, returnType: string },
+  llm: {
+    params: ["any", llmOptions],
+    minParams: 1,
+    returnType: string,
+    description:
+      "Send a prompt to an LLM and return its response. The return type is inferred from the call-site annotation and compiled to a JSON schema for structured output.",
+  },
 
   // --- Result type (lib/runtime/result.ts) ---
-  success: { params: ["any"], returnType: "any" },
-  failure: { params: ["any", "any"], minParams: 1, returnType: "any" },
-  isSuccess: { params: ["any"], returnType: boolean },
-  isFailure: { params: ["any"], returnType: boolean },
+  success: {
+    params: ["any"],
+    returnType: "any",
+    description: "Wrap a value in a successful `Result`.",
+  },
+  failure: {
+    params: ["any", "any"],
+    minParams: 1,
+    returnType: "any",
+    description: "Wrap an error (and optionally a value) in a failed `Result`.",
+  },
+  isSuccess: {
+    params: ["any"],
+    returnType: boolean,
+    description: "Check whether a `Result` is a success.",
+  },
+  isFailure: {
+    params: ["any"],
+    returnType: boolean,
+    description: "Check whether a `Result` is a failure.",
+  },
 
   // --- Checkpoint / rewind ---
-  restore: { params: ["any", "any"], returnType: voidT },
+  restore: {
+    params: ["any", "any"],
+    returnType: voidT,
+    description:
+      "Restore execution to a previously captured checkpoint. Accepts a checkpoint object or ID and an options object (e.g. `{ maxRestores: 3 }` or variable overrides).",
+  },
 
   // --- Handler outcomes (reserved names) ---
-  approve: { params: ["any"], minParams: 0, returnType: "any" },
-  reject: { params: ["any"], minParams: 0, returnType: "any" },
-  propagate: { params: [], returnType: "any" },
+  approve: {
+    params: ["any"],
+    minParams: 0,
+    returnType: "any",
+    description:
+      "Inside a `handle ... with` block, approve the wrapped action (optionally substituting a return value).",
+  },
+  reject: {
+    params: ["any"],
+    minParams: 0,
+    returnType: "any",
+    description: "Inside a `handle ... with` block, block the wrapped action.",
+  },
+  propagate: {
+    params: [],
+    returnType: "any",
+    description:
+      "Inside a `handle ... with` block, pass the interrupt up to the next handler in the chain.",
+  },
 
   // --- Checkpointing ---
-  checkpoint: { params: [], returnType: number },
-  getCheckpoint: { params: [number], returnType: "any" },
+  checkpoint: {
+    params: [],
+    returnType: number,
+    description:
+      "Take a snapshot of the current execution state and return a checkpoint ID.",
+  },
+  getCheckpoint: {
+    params: [number],
+    returnType: "any",
+    description: "Return the full checkpoint object for a given checkpoint ID.",
+  },
+
+  // --- Concurrency (language constructs with block arguments) ---
+  // `fork` and `race` are special — they take a `string[]` of labels plus a
+  // block, and their return type depends on the block body. We type the
+  // return as `any` for now (no generic-block inference yet) but mark them
+  // `acceptsBlock` so the typechecker doesn't reject the call shape, and
+  // populate `description` so the LSP hover shows useful docs.
+  fork: {
+    params: [anyArray],
+    returnType: anyArray,
+    acceptsBlock: true,
+    description:
+      "Run multiple branches in parallel and wait for all of them to finish. Returns an array of results, one per item. Use as `fork(items) as <name> { ... }`.",
+  },
+  race: {
+    params: [anyArray],
+    returnType: "any",
+    acceptsBlock: true,
+    description:
+      "Like `fork`, but returns as soon as the first branch completes and cancels the rest. Use as `race(items) as <name> { ... }`.",
+  },
 
   // --- Context-injected builtins (codegen rewrites the call to inject __ctx) ---
   // The registry lives in lib/codegenBuiltins/contextInjected.ts and is the

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -246,7 +246,7 @@ function checkCallAgainstBuiltinSig(
     });
     return;
   }
-  if (call.block) {
+  if (call.block && !sig.acceptsBlock) {
     ctx.errors.push({
       message: `'${call.functionName}' does not accept a block argument.`,
       loc: call.block.loc ?? call.loc,

--- a/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
+++ b/packages/agency-lang/lib/typeChecker/jsonSchemaArgValidator.ts
@@ -6,6 +6,7 @@ import type {
   AgencyProgram,
   AgencyArray,
 } from "../types.js";
+import type { SourceLocation } from "../types/base.js";
 import type { CompilationUnit } from "../compilationUnit.js";
 
 /**
@@ -225,6 +226,13 @@ function validateObjectLiteral(
   for (const entry of obj.entries) {
     if ("key" in entry) {
       const kv = entry as AgencyObjectKV;
+      if (kv.computedKey) {
+        return {
+          ok: false,
+          reason: "computed object keys are not allowed inside @jsonSchema(...)",
+          loc: (kv.computedKey as { loc?: SourceLocation }).loc,
+        };
+      }
       const r = validateJsonSchemaArg(kv.value, scope);
       if (!r.ok) return r;
     } else {

--- a/packages/agency-lang/lib/typeChecker/resolveCall.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveCall.ts
@@ -54,6 +54,8 @@ export const RESERVED_FUNCTION_NAMES = new Set<string>([
   "propagate",
   "checkpoint",
   "getCheckpoint",
+  "fork",
+  "race",
 
   // Category 2 — parsed as their own AST node.
   "schema",

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -20,6 +20,7 @@ import {
 } from "./primitiveMembers.js";
 import type { BuiltinSignature } from "./types.js";
 import { walkNodes } from "../utils/node.js";
+import { uniqBy } from "../utils.js";
 import type { BlockArgument } from "../types/blockArgument.js";
 import { UNDEFINED_T, VOID_T } from "./primitives.js";
 
@@ -416,9 +417,7 @@ function synthObject(
       ...computedValueTypes,
     ];
     if (allValueTypes.length === 0) return "any";
-    const seen = new Map<string, VariableType>();
-    for (const t of allValueTypes) seen.set(JSON.stringify(t), t);
-    const unique = Array.from(seen.values());
+    const unique = uniqBy(allValueTypes, (t) => JSON.stringify(t));
     const valueType: VariableType =
       unique.length === 1
         ? unique[0]

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -380,6 +380,11 @@ function synthObject(
   // Use a Map so later entries overwrite earlier ones (later-wins for splats
   // followed by explicit keys, e.g. { ...a, x: "new" } produces x's literal type).
   const properties = new Map<string, VariableType>();
+  // Track value types from computed-key entries — we can't know the key
+  // statically, so the whole object degrades to a Record whose value type
+  // is the union of all entry value types (static + computed).
+  const computedValueTypes: VariableType[] = [];
+  let hasComputedKey = false;
   for (const entry of expr.entries) {
     if ("type" in entry && entry.type === "splat") {
       const splatType = synthType(entry.value, scope, ctx);
@@ -389,12 +394,40 @@ function synthObject(
         properties.set(prop.key, prop.value);
       continue;
     }
-    const kv = entry as { key: string; value: AgencyNode };
+    const kv = entry as {
+      key: string;
+      computedKey?: AgencyNode;
+      value: AgencyNode;
+    };
     const valueType = synthType(kv.value, scope, ctx);
     if (valueType === "any") {
       return "any";
     }
+    if (kv.computedKey) {
+      hasComputedKey = true;
+      computedValueTypes.push(valueType);
+      continue;
+    }
     properties.set(kv.key, valueType);
+  }
+  if (hasComputedKey) {
+    const allValueTypes = [
+      ...Array.from(properties.values()),
+      ...computedValueTypes,
+    ];
+    if (allValueTypes.length === 0) return "any";
+    const seen = new Map<string, VariableType>();
+    for (const t of allValueTypes) seen.set(JSON.stringify(t), t);
+    const unique = Array.from(seen.values());
+    const valueType: VariableType =
+      unique.length === 1
+        ? unique[0]
+        : { type: "unionType" as const, types: unique };
+    return {
+      type: "genericType",
+      name: "Record",
+      typeArgs: [{ type: "primitiveType", value: "string" }, valueType],
+    };
   }
   return {
     type: "objectType",

--- a/packages/agency-lang/lib/typeChecker/types.ts
+++ b/packages/agency-lang/lib/typeChecker/types.ts
@@ -42,6 +42,11 @@ export type BuiltinSignature = {
   returnType: VariableType | "any";
   minParams?: number; // if set, arity is [minParams, params.length]; otherwise exact
   restParam?: VariableType | "any"; // if set, accepts unlimited extra args of this type after the fixed params
+  /** One-line markdown description shown in LSP hover. */
+  description?: string;
+  /** If true, the typechecker allows a block argument on calls to this
+   *  builtin. Used by language-construct builtins like `fork` / `race`. */
+  acceptsBlock?: boolean;
 };
 
 export type TypeCheckerContext = {

--- a/packages/agency-lang/lib/typeChecker/utils.ts
+++ b/packages/agency-lang/lib/typeChecker/utils.ts
@@ -119,6 +119,7 @@ export function checkExcessObjectProperties(
   const known = new Set(resolved.properties.map((p) => p.key));
   for (const entry of literal.entries) {
     if ("type" in entry) continue; // splat
+    if (entry.computedKey) continue; // computed key — can't statically check
     if (!known.has(entry.key)) {
       ctx.errors.push({
         message: `Unknown property '${entry.key}' on type '${formatTypeHint(expectedType)}' (${context}).`,

--- a/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
+++ b/packages/agency-lang/lib/typeChecker/valueParamSubstitution.ts
@@ -228,6 +228,9 @@ function substituteInObject(
         const kv = entry as AgencyObjectKV;
         return {
           ...kv,
+          computedKey: kv.computedKey
+            ? substituteValueArgsInExpression(kv.computedKey, bindings)
+            : undefined,
           value: substituteValueArgsInExpression(kv.value, bindings),
         };
       }
@@ -546,12 +549,11 @@ function checkExpr(
     case "agencyObject":
       for (const entry of (e as AgencyObject).entries) {
         if ("key" in entry) {
-          checkExpr(
-            (entry as AgencyObjectKV).value,
-            paramNames,
-            aliasName,
-            tagName,
-          );
+          const kv = entry as AgencyObjectKV;
+          if (kv.computedKey) {
+            checkExpr(kv.computedKey, paramNames, aliasName, tagName);
+          }
+          checkExpr(kv.value, paramNames, aliasName, tagName);
         } else {
           checkExpr(
             (entry as SplatExpression).value as Expression,

--- a/packages/agency-lang/lib/types/dataStructures.ts
+++ b/packages/agency-lang/lib/types/dataStructures.ts
@@ -18,7 +18,13 @@ export type AgencyArray = BaseNode & {
 };
 
 export type AgencyObjectKV = {
+  /** Static key. When `computedKey` is set, this is `""` and consumers
+   *  should use `computedKey` instead. */
   key: string;
+  /** Computed key expression (`{ [expr]: value }`). When set, the entry's
+   *  key is determined at runtime; consumers that need a static key must
+   *  fall back to treating the containing object as `Record<string, V>`. */
+  computedKey?: Expression;
   value: Expression;
 };
 export type AgencyObject = BaseNode & {

--- a/packages/agency-lang/lib/utils.test.ts
+++ b/packages/agency-lang/lib/utils.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  symlinkSync,
+  existsSync,
+  realpathSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { safeDeleteFile, safeDeleteDirectory } from "./utils.js";
+import { findPackageRoot } from "./importPaths.js";
+
+// All tests here use dryRun=true (the default). We never exercise the
+// real-delete path: a regression that swept past the containment check
+// could otherwise erase real files.
+describe("safeDeleteFile / safeDeleteDirectory (dry-run only)", () => {
+  const projectRoot = realpathSync(findPackageRoot(__dirname));
+  // A scratch directory inside the project so containment passes.
+  let scratch: string;
+  let insideFile: string;
+  let insideDir: string;
+  // A directory outside the project (in os.tmpdir) for negative tests.
+  let outsideDir: string;
+  let outsideFile: string;
+
+  beforeAll(() => {
+    scratch = join(projectRoot, ".test-safe-delete-scratch");
+    mkdirSync(scratch, { recursive: true });
+    insideFile = join(scratch, "inside.txt");
+    writeFileSync(insideFile, "hello");
+    insideDir = join(scratch, "subdir");
+    mkdirSync(insideDir, { recursive: true });
+    writeFileSync(join(insideDir, "nested.txt"), "nested");
+
+    outsideDir = mkdtempSync(join(tmpdir(), "safe-delete-outside-"));
+    outsideFile = join(outsideDir, "outside.txt");
+    writeFileSync(outsideFile, "outside");
+  });
+
+  afterAll(() => {
+    // Clean up scratch areas using a direct rm — these tests created them,
+    // they're not testing rm.
+    rmSync(scratch, { recursive: true, force: true });
+    rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  describe("safeDeleteFile", () => {
+    it("returns success with [DRY RUN] message for a real file inside the project", () => {
+      const result = safeDeleteFile(insideFile);
+      expect(result.success).toBe(true);
+      expect(result.message).toBe(
+        `[DRY RUN]: would have deleted ${realpathSync(insideFile)}`,
+      );
+      // File still exists — we were in dry-run.
+      expect(existsSync(insideFile)).toBe(true);
+    });
+
+    it("refuses a directory (not a file)", () => {
+      const result = safeDeleteFile(insideDir);
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/Not a file/);
+    });
+
+    it("refuses a missing path", () => {
+      const result = safeDeleteFile(join(scratch, "does-not-exist.txt"));
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/does not exist/);
+    });
+
+    it("refuses a file outside the project", () => {
+      const result = safeDeleteFile(outsideFile);
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/outside project root|no project root found/);
+    });
+
+    it("refuses a symlink whose realpath escapes the project", () => {
+      const symlinkPath = join(scratch, "escape-link.txt");
+      symlinkSync(outsideFile, symlinkPath);
+      const result = safeDeleteFile(symlinkPath);
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/outside project root|no project root found/);
+      rmSync(symlinkPath, { force: true });
+    });
+  });
+
+  describe("safeDeleteDirectory", () => {
+    it("returns success with [DRY RUN] message for a real directory inside the project", () => {
+      const result = safeDeleteDirectory(insideDir);
+      expect(result.success).toBe(true);
+      expect(result.message).toBe(
+        `[DRY RUN]: would have deleted ${realpathSync(insideDir)}`,
+      );
+      // Directory still exists — we were in dry-run.
+      expect(existsSync(insideDir)).toBe(true);
+    });
+
+    it("refuses a file (not a directory)", () => {
+      const result = safeDeleteDirectory(insideFile);
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/Not a directory/);
+    });
+
+    it("refuses a missing path", () => {
+      const result = safeDeleteDirectory(join(scratch, "no-such-dir"));
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/does not exist/);
+    });
+
+    it("refuses a directory outside the project", () => {
+      const result = safeDeleteDirectory(outsideDir);
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/outside project root|no project root found/);
+    });
+
+    it("refuses a symlinked directory whose realpath escapes the project", () => {
+      const symlinkPath = join(scratch, "escape-link-dir");
+      symlinkSync(outsideDir, symlinkPath);
+      const result = safeDeleteDirectory(symlinkPath);
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/outside project root|no project root found/);
+      rmSync(symlinkPath, { force: true, recursive: true });
+    });
+  });
+});

--- a/packages/agency-lang/lib/utils.ts
+++ b/packages/agency-lang/lib/utils.ts
@@ -63,9 +63,21 @@ function safeDelete(
   if (dryRun) {
     return { success: true, message: `[DRY RUN]: would have deleted ${resolved}` };
   }
-  if (kind === "file") fs.unlinkSync(resolved);
-  else fs.rmSync(resolved, { recursive: true });
-  return { success: true };
+  // Best-effort: callers often use this in `finally` blocks where a
+  // throw would mask the real error or turn a clean exit into a crash.
+  // `force: true` swallows ENOENT/permission errors that race against
+  // the real delete; if anything else goes wrong, return the message
+  // instead of propagating.
+  try {
+    if (kind === "file") fs.unlinkSync(resolved);
+    else fs.rmSync(resolved, { recursive: true, force: true });
+    return { success: true };
+  } catch (err) {
+    return {
+      success: false,
+      message: `Failed to delete '${resolved}': ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
 }
 
 export function safeDeleteFile(
@@ -107,6 +119,24 @@ export function zip<T, U>(arr1: T[], arr2: U[]): Array<[T, U]> {
 
 export function uniq<T>(arr: T[]): T[] {
   return Array.from(new Set(arr));
+}
+
+/**
+ * Like `uniq`, but de-duplicates by a derived key. The first occurrence
+ * of each key is kept; later duplicates are dropped. Useful for de-duping
+ * structured values where identity-based Set comparison wouldn't work
+ * (e.g. compare-by-JSON.stringify).
+ */
+export function uniqBy<T, K>(arr: T[], keyFn: (item: T) => K): T[] {
+  const seen = new Set<K>();
+  const result: T[] = [];
+  for (const item of arr) {
+    const key = keyFn(item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(item);
+  }
+  return result;
 }
 
 /**

--- a/packages/agency-lang/lib/utils.ts
+++ b/packages/agency-lang/lib/utils.ts
@@ -1,4 +1,86 @@
 import { Message } from "smoltalk";
+import * as fs from "fs";
+import * as path from "path";
+import { findPackageRoot } from "@/importPaths.js";
+
+export type SafeDeleteResult = {
+  success: boolean;
+  message?: string;
+};
+
+// Confirm `target` (already realpath-ed) lives strictly inside the
+// realpath-ed project root for `target`. The trailing `+ path.sep` on the
+// prefix prevents a sibling directory sharing a string prefix from passing.
+// The project root is the nearest package.json walking up from `target`.
+// If no package.json is found above `target`, refuse (target is loose in
+// the filesystem with no project containing it).
+function checkInsideProject(target: string): SafeDeleteResult | null {
+  if (target === "/") {
+    return {
+      success: false,
+      message: `Refusing to delete root dir`,
+    };
+  }
+  let projectRoot: string;
+  try {
+    projectRoot = fs.realpathSync(findPackageRoot(path.dirname(target)));
+  } catch (err) {
+    return {
+      success: false,
+      message: `Refusing to delete '${target}': no project root found above it (${err instanceof Error ? err.message : String(err)}).`,
+    };
+  }
+  if (target === projectRoot || !target.startsWith(projectRoot + path.sep)) {
+    return {
+      success: false,
+      message: `Refusing to delete '${target}': outside project root '${projectRoot}'.`,
+    };
+  }
+  return null;
+}
+
+function safeDelete(
+  targetPath: string,
+  kind: "file" | "directory",
+  dryRun: boolean,
+): SafeDeleteResult {
+  if (!fs.existsSync(targetPath)) {
+    return { success: false, message: `Path does not exist: '${targetPath}'.` };
+  }
+  const resolved = fs.realpathSync(path.resolve(targetPath));
+  const stat = fs.statSync(resolved);
+  const isFile = stat.isFile();
+  const isDir = stat.isDirectory();
+  if (kind === "file" && !isFile) {
+    return { success: false, message: `Not a file: '${resolved}'.` };
+  }
+  if (kind === "directory" && !isDir) {
+    return { success: false, message: `Not a directory: '${resolved}'.` };
+  }
+  const containment = checkInsideProject(resolved);
+  if (containment) return containment;
+
+  if (dryRun) {
+    return { success: true, message: `[DRY RUN]: would have deleted ${resolved}` };
+  }
+  if (kind === "file") fs.unlinkSync(resolved);
+  else fs.rmSync(resolved, { recursive: true });
+  return { success: true };
+}
+
+export function safeDeleteFile(
+  targetPath: string,
+  dryRun: boolean = true,
+): SafeDeleteResult {
+  return safeDelete(targetPath, "file", dryRun);
+}
+
+export function safeDeleteDirectory(
+  targetPath: string,
+  dryRun: boolean = true,
+): SafeDeleteResult {
+  return safeDelete(targetPath, "directory", dryRun);
+}
 
 export function escape(str: string): string {
   return (

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -228,7 +228,11 @@ export function* getAllVariablesInBody(
         if ("type" in entry && entry.type === "splat") {
           yield* getAllVariablesInBody([entry.value]);
         } else {
-          yield* getAllVariablesInBody([(entry as any).value]);
+          const kv = entry as { computedKey?: any; value: any };
+          if (kv.computedKey) {
+            yield* getAllVariablesInBody([kv.computedKey]);
+          }
+          yield* getAllVariablesInBody([kv.value]);
         }
       }
     } else if (
@@ -417,10 +421,17 @@ export function* walkNodes(
         scopes,
       );
     } else if (node.type === "agencyObject") {
-      const objValues = node.entries.map((e) =>
-        "type" in e && e.type === "splat" ? e.value : (e as any).value,
-      );
-      yield* walkNodes(objValues as AgencyNode[], [...ancestors, node], scopes);
+      const objChildren: AgencyNode[] = [];
+      for (const e of node.entries) {
+        if ("type" in e && e.type === "splat") {
+          objChildren.push(e.value as AgencyNode);
+        } else {
+          const kv = e as { computedKey?: AgencyNode; value: AgencyNode };
+          if (kv.computedKey) objChildren.push(kv.computedKey);
+          objChildren.push(kv.value);
+        }
+      }
+      yield* walkNodes(objChildren, [...ancestors, node], scopes);
     } else if (
       node.type === "string" ||
       node.type === "multiLineString"

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -1,7 +1,28 @@
-import { _compile, _compileFile } from "agency-lang/stdlib-lib/agency.js"
+import { _compile, _compileFile, _typecheck, _typecheckFile, _parseAST, _writeAST, _format, _formatFile, _walkAST, _getNodesOfType, _getImports, _getFunctions, _getGraphNodes, _filterImports } from "agency-lang/stdlib-lib/agency.js"
 
 type CompiledProgram = {
   moduleId: string
+}
+
+type SourceLocation = {
+  line: number,
+  col: number,
+  start: number,
+  end: number,
+}
+
+type TypeCheckDiagnostic = {
+  severity: string,
+  message: string,
+  loc?: SourceLocation,
+  variableName?: string,
+  expectedType?: string,
+  actualType?: string,
+}
+
+type TypeCheckReport = {
+  errors: TypeCheckDiagnostic[],
+  warnings: TypeCheckDiagnostic[],
 }
 
 export def compile(source: string): Result {
@@ -85,4 +106,197 @@ export def runFile(
     ipcPayload: ipcPayload,
     stdout: stdout,
   )
+}
+
+export def typecheck(source: string): Result {
+  """
+  Type-check Agency source code without compiling or running it. Returns a TypeCheckReport with separate `errors` and `warnings` arrays — a successful Result with a non-empty `errors` array means the type-checker ran and found problems. A failure Result means the type-checker could not run at all (parse error or unresolved import).
+
+  Unlike compile(), this does NOT restrict imports — type-checking is read-only and does not execute code. Note that std:: and pkg:: imports resolve normally, but relative imports (./foo.agency) cannot be resolved when calling typecheck() with a source string, since there is no on-disk location to resolve them against. Use typecheckFile() for source that contains relative imports.
+
+  @param source - Agency source code as a string
+  """
+  return try _typecheck(source)
+}
+
+type FilterImportsResult = {
+  source: string,
+  filtered: boolean,
+}
+
+export def parseAST(source: string): Result {
+  """
+  Parse Agency source code into an abstract syntax tree. Returns the raw AST as a JSON-serializable object on success, or a failure with the parse error message.
+
+  The AST shape is the parser output with `applyTemplate: false, lower: false`, which matches what the formatter consumes — so an AST round-tripped through writeAST() / format() produces canonical Agency source.
+
+  @param source - Agency source code as a string
+  """
+  return try _parseAST(source)
+}
+
+export def writeAST(
+  ast: any,
+  dir: string,
+  filename: string,
+  overwrite: boolean = true,
+): Result {
+  """
+  Format an AST as Agency source and write it to dir/filename. The AST is typically obtained from parseAST() and optionally transformed before being written.
+
+  The output is canonical formatter output: comments are preserved (they live in the AST as nodes), but whitespace and formatting are normalized to the AgencyGenerator's style — the same style produced by `pnpm run fmt`.
+
+  The dir argument is the sandbox boundary: filename cannot escape it via absolute paths or .. segments (symlinks on existing files are followed and re-checked).
+
+  @param ast - The AST to write (typically from parseAST)
+  @param dir - The sandbox directory
+  @param filename - The agency file to write, resolved relative to dir
+  @param overwrite - If false, fail when the file already exists (default true)
+  """
+  return interrupt std::write("Are you sure you want to write this file?", {
+    dir: dir,
+    filename: filename,
+    overwrite: overwrite
+  })
+  return try _writeAST(ast, dir, filename, overwrite)
+}
+
+export def format(source: string): Result {
+  """
+  Format Agency source code using the standard Agency formatter (the same one used by `pnpm run fmt`). Returns the formatted source on success, or a failure with a parse error.
+
+  Comments are preserved. Whitespace and formatting are canonicalized — this is a lossy transformation for whitespace but not for semantics or comments.
+
+  @param source - Agency source code as a string
+  """
+  return try _format(source)
+}
+
+export def formatFile(dir: string, filename: string): Result {
+  """
+  Format an Agency file in place. Reads dir/filename, formats it with the standard Agency formatter, and writes the result back to the same path. If the file is already formatted, no write occurs (mtime is preserved).
+
+  The dir argument is the sandbox boundary: filename cannot escape it via absolute paths or .. segments (symlinks are followed and re-checked). Both the read and the write happen inside the same interrupt — approving the interrupt approves both.
+
+  Returns success(true) on a successful format (whether or not a write was needed), or a failure if parsing or I/O fails.
+
+  @param dir - The sandbox directory. filename is resolved against this and must stay inside it.
+  @param filename - The agency file to format, resolved relative to dir
+  """
+  return interrupt std::write("Are you sure you want to format this file in place?", {
+    dir: dir,
+    filename: filename
+  })
+  return try _formatFile(dir, filename)
+}
+
+export def walkAST(ast: any, visitor: (any, any) => any): any {
+  """
+  Walk every node in a deep-cloned copy of the AST, invoking the visitor with each (node, ancestors) pair. The visitor may mutate the node in place; mutations land in the returned AST. The original AST passed in is never modified.
+
+  Iteration order is pre-order: a node is visited before its children. The set of nodes to visit is determined upfront — if the visitor adds new children (e.g. by appending to a function's body), those new children will NOT be visited on this walk. Similarly, if the visitor replaces a child reference (e.g. node.body = [newNode]), the visitor will still be called on the OLD body's nodes (which are already in the buffered visit list). To re-walk a transformed AST, call walkAST again.
+
+  The ancestors array lists every enclosing node from the root outward (excluding `node` itself). For nodes inside a block argument (e.g. inside `map(arr) as x { ... }`), the block argument appears in ancestors as a node with `type: "blockArgument"`.
+
+  @param ast - The AST to walk (typically from parseAST)
+  @param visitor - Called once per node as visitor(node, ancestors). Return value is ignored.
+  """
+  const result = _walkAST(ast)
+  for (visit in result.visits) {
+    visitor(visit.node, visit.ancestors)
+  }
+  return result.clone
+}
+
+export def getNodesOfType(source: string, types: string[]): Result {
+  """
+  Parse Agency source code and return all AST nodes whose `type` field matches any of the provided types. Walks the entire tree (not just top-level), so e.g. getNodesOfType(src, ["functionCall"]) returns every function call anywhere in the program.
+
+  The returned nodes are references into a freshly-parsed AST; safe to mutate, but mutations do not write back to disk. Use writeAST() with the parsed AST to persist changes.
+
+  @param source - Agency source code as a string
+  @param types - List of AST type strings to match (e.g. ["function", "graphNode"])
+  """
+  return try _getNodesOfType(source, types)
+}
+
+export def getImports(source: string): Result {
+  """
+  Return all import statements in the source (i.e. `import { x } from "..."`).
+
+  @param source - Agency source code as a string
+  """
+  return try _getImports(source)
+}
+
+export def getFunctions(source: string): Result {
+  """
+  Return all function definitions (`def foo(...) { ... }`) in the source.
+
+  @param source - Agency source code as a string
+  """
+  return try _getFunctions(source)
+}
+
+export def getGraphNodes(source: string): Result {
+  """
+  Return all graph node definitions (`node main() { ... }`) in the source. Note: "graph nodes" here means Agency's `node` declarations, not generic AST nodes — see getNodesOfType for the latter.
+
+  @param source - Agency source code as a string
+  """
+  return try _getGraphNodes(source)
+}
+
+export def filterImports(
+  source: string,
+  allowedPackages: string[] = [],
+  excludedPackages: string[] = [],
+  allowKinds: string[] = [],
+  excludeKinds: string[] = [],
+): Result {
+  """
+  Parse Agency source, drop imports that fail the policy, and return the resulting source plus a flag indicating whether anything was dropped.
+
+  Imports are classified by `kind`:
+    - "stdlib" — `std::*` (e.g. `std::shell`)
+    - "pkg"    — `pkg::*` (e.g. `pkg::wikipedia`)
+    - "local"  — relative or absolute file paths (e.g. `./util.agency`)
+    - "node"   — bare specifiers resolved by Node (e.g. `fs`, `child_process`)
+
+  Policy:
+    - `allowedPackages` / `excludedPackages` are glob patterns (picomatch syntax) matched against the raw import path string.
+    - `allowKinds` / `excludeKinds` accept the kind strings above.
+    - Exclude rules always win: if a path matches anything in `excludedPackages` or `excludeKinds`, it is dropped.
+    - When all four lists are empty, every import is allowed (default-allow).
+    - When at least one allow list is non-empty, an import must match an allowed kind OR an allowed package glob (union across the two axes). Note that allowKinds=["stdlib"] is still a restriction even with the package lists empty — only stdlib passes.
+
+  The returned source is regenerated via the Agency formatter, so whitespace and formatting are canonicalized. Comments are preserved (see writeAST docstring for details).
+
+  @param source - Agency source code as a string
+  @param allowedPackages - Glob patterns; matched imports are allowed (subject to excludes)
+  @param excludedPackages - Glob patterns; matched imports are dropped
+  @param allowKinds - Kind strings ("stdlib" | "pkg" | "local" | "node") to allow
+  @param excludeKinds - Kind strings to drop
+  """
+  return try _filterImports(source, allowedPackages, excludedPackages, allowKinds, excludeKinds)
+}
+
+export def typecheckFile(dir: string, filename: string): Result {
+  """
+  Type-check an Agency file on disk. The file is read from dir/filename, and relative imports inside the file are resolved against the file's directory.
+
+  The dir argument is the sandbox boundary for the entry file: filename cannot escape it via absolute paths or .. segments (and symlinks are followed and re-checked). Note that transitive imports from the entry file are NOT confined to dir — type-checking is read-only, so the sandbox only governs which file the caller can ask to be type-checked.
+
+  Use partial application to bind dir once, e.g. const tc = typecheckFile.partial(dir: "/safe/dir").
+
+  Returns a TypeCheckReport with `errors` and `warnings` arrays on success; returns a failure when the file cannot be read, the sandbox is violated, or the source cannot be parsed.
+
+  @param dir - The sandbox directory. filename is resolved against this and must stay inside it.
+  @param filename - The agency file to type-check, resolved relative to dir
+  """
+  return interrupt std::read("Are you sure you want to read this file?", {
+    dir: dir,
+    filename: filename
+  })
+  return try _typecheckFile(dir, filename)
 }

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -1,4 +1,4 @@
-import { _compile, _compileFile, _typecheck, _typecheckFile, _parseAST, _writeAST, _format, _formatFile, _walkAST, _getNodesOfType, _getImports, _getFunctions, _getGraphNodes, _filterImports } from "agency-lang/stdlib-lib/agency.js"
+import { _compile, _compileFile, _typecheck, _typecheckFile, _parseAST, _writeAST, _format, _formatFile, _walkAST, _getNodesOfType, _filterImports } from "agency-lang/stdlib-lib/agency.js"
 
 type CompiledProgram = {
   moduleId: string
@@ -226,7 +226,7 @@ export def getImports(source: string): Result {
 
   @param source - Agency source code as a string
   """
-  return try _getImports(source)
+  return getNodesOfType(source, ["importStatement"])
 }
 
 export def getFunctions(source: string): Result {
@@ -235,7 +235,7 @@ export def getFunctions(source: string): Result {
 
   @param source - Agency source code as a string
   """
-  return try _getFunctions(source)
+  return getNodesOfType(source, ["function"])
 }
 
 export def getGraphNodes(source: string): Result {
@@ -244,7 +244,7 @@ export def getGraphNodes(source: string): Result {
 
   @param source - Agency source code as a string
   """
-  return try _getGraphNodes(source)
+  return getNodesOfType(source, ["graphNode"])
 }
 
 export def filterImports(

--- a/packages/agency-lang/stdlib/index.agency
+++ b/packages/agency-lang/stdlib/index.agency
@@ -104,20 +104,32 @@ export def read(filename: string, dir: string = "."): Result {
   return try _read(dir, filename)
 }
 
-export def write(filename: string, content: string, dir: string = "."): Result {
+export def write(
+  filename: string,
+  content: string,
+  dir: string = ".",
+  mode: string = "overwrite",
+): Result {
   """
   A tool for writing content to a file. The filename is resolved relative to dir.
+
+  The `mode` parameter controls how an existing file is handled:
+    - "overwrite" (default): replace the file if it exists, create it if not
+    - "append": append to the file if it exists, create it if not
+    - "create-only": fail if the file already exists
 
   @param filename - The file to write
   @param content - The content to write
   @param dir - The directory to resolve the filename against (defaults to ".")
+  @param mode - How to handle an existing file: "overwrite" | "append" | "create-only"
   """
   return interrupt std::write("Are you sure you want to write to this file?", {
     dir: dir,
     filename: filename,
-    content: content
+    content: content,
+    mode: mode
   })
-  return try _write(dir, filename, content)
+  return try _write(dir, filename, content, mode)
 }
 
 export def readImage(filename: string, dir: string = "."): Result {


### PR DESCRIPTION
This PR bundles the new stdlib `agency` AST/formatter/policy toolkit together with several unrelated quality-of-life bug fixes that were already staged on this branch.

---

## 1. Stdlib `agency` — AST + formatter + import policy toolkit

A coherent set of source-manipulation primitives on `std::agency`:

- `parseAST(source)` — raw AST as a JSON-serializable object.
- `writeAST(ast, dir, filename, overwrite=true)` — format the AST as Agency source and write it to disk (sandbox-contained, interrupt-gated).
- `format(source)` — format Agency source code, returning the formatted string (no I/O).
- `formatFile(dir, filename)` — read a file, format it, and write the result back in place (sandbox-contained, interrupt-gated, mtime preserved when the file is already formatted).
- `walkAST(ast, visitor)` — walk every node in a deep-cloned AST; the visitor may mutate nodes in place. Buffered pre-order traversal so mutations don't perturb the walk.
- `getNodesOfType(source, types[])` plus convenience wrappers `getImports`, `getFunctions`, `getGraphNodes`.
- `filterImports(source, allowedPackages, excludedPackages, allowKinds, excludeKinds)` — drop disallowed imports, return new source + a `filtered` flag.

Two cross-cutting changes underpin the toolkit:

- **`std::write` gains a `mode` parameter** (`"overwrite" | "append" | "create-only"`, defaulting to `"overwrite"` for backward compat). `writeAST(..., overwrite=false)` delegates to `_write` with `mode: "create-only"` so all writes share one path-resolution + existence-check path.
- **`compileSource` consolidated onto a shared `ImportPolicy`.** The legacy `restrictImports: true` is now a deprecated shorthand for `imports: { allowKinds: ["stdlib"] }`. Both `_filterImports` and `compileSource` route through one classifier (`isImportAllowed`) in `lib/importPaths.ts`. Compile-time violations are still hard failures, and now every violating import is reported (not just the first).

The plan that drove this work lives at `docs/superpowers/plans/2026-05-21-stdlib-agency-ast-functions.md`.

---

## 2. Imports formatter — keep `// @tc-ignore` / `// @tc-nocheck` comments with their imports

The formatter previously moved every `import` statement to the top of the file and sorted them. Comments above an import (including `// @tc-ignore` to silence a single import, or `// @tc-nocheck` to silence the whole file) got orphaned at the bottom, making it impossible to:

1. Suppress every error in a file that also has imports.
2. Suppress an error on a specific import.

The formatter now treats leading comments and shebang-style lines as "header" content that stays at the very top of the file. Imports get moved up but never ahead of any header comments the user placed at the top. `// @tc-ignore` directly above an import travels with that import when it moves.

---

## 3. Object literals with dynamic keys

`{ [key]: value }` now parses and type-checks. Previously the only workaround was:

```ts
const match: any = {}
match[matchArgName] = matchArgValue
```

You can now write:

```ts
const match = {
  [matchArgName]: matchArgValue
}
```

---

## 4. Type checker recognises built-ins; LSP hover shows their signatures

The type checker now knows about every Agency built-in (e.g. `fork`, `llm`, `checkpoint`, `restore`, `interrupt`, `handle`, `approve`, `reject`, `propagate`, etc.) instead of reporting them as unknown functions. The LSP hover surfaces the function signature and a short description for each.

---

## 5. New doc — every built-in in one place

`docs/site/appendix/builtins.md` lists every user-facing built-in function and language construct that Agency provides without an `import`. Grouped by category (LLM, checkpointing, interrupts, concurrency, etc.).

---

## Validation

```
pnpm test:run       4309 / 4309 passed
pnpm run typecheck  clean
pnpm run lint       clean
make                stdlib JS + docs regenerated
```

The PR adds ~64 new tests covering every new stdlib function plus the import policy classifier; existing tests for `restrictImports` were migrated to match the new error format.
