### PR TITLE
Add schema parameter injection feature

### DIFF
--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -88,6 +88,10 @@ export default defineConfig({
               text: "Advanced Types",
               link: "/appendix/advanced-types",
             },
+            {
+              text: "Schema Parameter Injection",
+              link: "/appendix/schema-parameter-injection",
+            },
           ],
         },
       ],
@@ -144,6 +148,10 @@ export default defineConfig({
             {
               text: "Built-in Functions",
               link: "/appendix/builtins",
+            },
+            {
+              text: "Schema Parameter Injection",
+              link: "/appendix/schema-parameter-injection",
             },
           ],
         },

--- a/packages/agency-lang/docs/site/appendix/schema-parameter-injection.md
+++ b/packages/agency-lang/docs/site/appendix/schema-parameter-injection.md
@@ -1,0 +1,96 @@
+# Schema parameter injection
+
+Agency lets you write functions that take a `Schema<...>` parameter and then automatically passes a Zod schema in for that argument, generated from the call's expected type. This is the mechanism that makes calls like
+
+```agency
+const numbers: number[] = llm("Return the first 5 Fibonacci numbers")
+```
+
+work without the caller having to write `schema(number[])` themselves.
+
+You will probably not need this feature day-to-day — it's mostly useful when you're writing a structured-output wrapper of your own (a custom `llm`-style function, a typed JSON parser, etc.). When you do need it, here's how it works.
+
+## The rule
+
+When the compiler sees a call to a function that has a `Schema<...>` parameter, and:
+
+1. The caller did not supply a value for that parameter, and
+2. The call appears in a position where the compiler knows the expected type,
+
+then the compiler synthesizes a `schema(T)` expression — where `T` is the expected type — and inserts it as the missing argument.
+
+The two positions that count as "the compiler knows the expected type" are:
+
+- **The right-hand side of a typed `const` or `let` declaration.**
+  ```agency
+  const xs: number[] = parseValue("[1,2,3]")
+  // → parseValue("[1,2,3]", s: schema(number[]))
+  ```
+- **A `return` statement inside a function with a declared return type.**
+  ```agency
+  def wrapper(): number[] {
+    return parseValue("[1,2,3]")
+    // → return parseValue("[1,2,3]", s: schema(number[]))
+  }
+  ```
+
+If neither position applies — for example, a bare expression statement like `parseValue("[1,2,3]")` with no assignment and no `return` — no injection happens. The function receives `undefined` for the schema parameter, which will usually fail at runtime when the body tries to use it. The compiler does not currently produce a special error for this case; the assumption is that anyone defining a Schema-using function knows what the parameter is for.
+
+## Defining a Schema-using function
+
+```agency
+def parseValue(input: string, s: Schema<any>): any {
+  return s.parseJSON(input)
+}
+```
+
+A few constraints worth knowing:
+
+- **At most one `Schema<...>` parameter per function.** The injection mechanism only has one expected-type slot to draw from, so a function with two Schema parameters has no sensible meaning. Declaring two will produce a compile-time error.
+- **Schema parameters are optional from the type checker's point of view.** Even if you don't write `= <default>`, the type checker will not flag a call that omits the schema argument — the injection pass is expected to fill it in. (If neither injection nor a default supplies a value, the runtime sees `undefined`.)
+- **The return type of the function is independent of the LHS type.** A Schema-using function commonly returns `any` so that any LHS annotation is accepted. If your function returns something more specific (e.g. `Result<any, any>`), the LHS annotation still must be assignable from that return type.
+
+## Overriding the injection
+
+Pass the schema explicitly — by position or by name — to suppress injection:
+
+```agency
+// Positional
+const x = parseValue("[1,2,3]", schema(any))
+
+// Named
+const x = parseValue("[1,2,3]", s: schema(string))
+```
+
+## Defaults
+
+A Schema parameter can have a default value:
+
+```agency
+def parseString(input: string, s: Schema<any> = schema(string)): any {
+  return s.parseJSON(input)
+}
+```
+
+The precedence at the call site is:
+
+1. **Explicit argument wins** — if the caller passes the schema, it's used.
+2. **LHS hint wins over the default** — if the caller omits the schema and an LHS / return-position hint is available, the hint is injected.
+3. **Default wins** — if there's no explicit argument and no hint, the default runs at function entry.
+
+## Interaction with `!` validation
+
+`const x: number[]! = parseValue("[1,2,3]")` is fine. The injected schema is built from `number[]`; the `!` triggers a separate runtime validation pass at the assignment site, also built from `number[]`. The two schemas agree, so validation passes whenever the value matches the schema.
+
+## Known limitations
+
+These are intentional v1 limitations and may be relaxed in future versions:
+
+- **No argument-position injection.** Only LHS annotations and enclosing return types drive injection. A call like `foo(parseValue("hi"))` will not pick up a hint from `foo`'s parameter type.
+- **No injection through partial application.** `parseValue.partial(input: "fixed")` followed by `const x: number[] = partial()` does not inject. Pass the schema at the `partial(...)` call instead.
+- **No injection through pipe chains.** `"[1,2,3]" |> parseValue` does not inject. Write the assignment directly when you want injection.
+- **No injection through type aliases that name `Schema<T>`.** A parameter declared as `s: MySchemaAlias` (where `MySchemaAlias = Schema<any>`) is not currently recognized as a Schema parameter. Declare it with the `Schema<...>` form directly.
+
+## When NOT to use this
+
+Most Agency code should not declare `Schema<...>` parameters at all. The feature exists for a small population of structured-output wrappers — primarily `llm()` and similar — and is documented here mostly so you know what's happening when you read those functions' source.

--- a/packages/agency-lang/lib/preprocessors/injectSchemaArgs.test.ts
+++ b/packages/agency-lang/lib/preprocessors/injectSchemaArgs.test.ts
@@ -1,0 +1,332 @@
+import { describe, it, expect } from "vitest";
+import { injectSchemaArgsInProgram } from "./injectSchemaArgs.js";
+import type { AgencyProgram, FunctionDefinition } from "../types.js";
+import type { FunctionParameter } from "../types/function.js";
+
+/**
+ * Helper: builds a `def parseValue(input: string, s: Schema<any>): any` shape.
+ * The default returnType is `any`; pass a different one to test return-position
+ * scenarios where the function declares a more specific return type.
+ */
+function buildParseValueDef(): FunctionDefinition {
+  const params: FunctionParameter[] = [
+    {
+      type: "functionParameter",
+      name: "input",
+      typeHint: { type: "primitiveType", value: "string" },
+    },
+    {
+      type: "functionParameter",
+      name: "s",
+      typeHint: {
+        type: "genericType",
+        name: "Schema",
+        typeArgs: [{ type: "primitiveType", value: "any" }],
+      },
+    },
+  ];
+  return {
+    type: "function",
+    functionName: "parseValue",
+    parameters: params,
+    returnType: { type: "primitiveType", value: "any" },
+    body: [],
+  };
+}
+
+describe("injectSchemaArgsInProgram", () => {
+  it("injects a schema arg from an assignment's LHS type", () => {
+    // const xs: number[] = parseValue("[1,2,3]")
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        {
+          type: "assignment",
+          declKind: "const",
+          target: "xs",
+          typeHint: {
+            type: "arrayType",
+            elementType: { type: "primitiveType", value: "number" },
+          },
+          value: {
+            type: "functionCall",
+            functionName: "parseValue",
+            arguments: [
+              {
+                type: "string",
+                segments: [{ type: "text", value: "[1,2,3]" }],
+              },
+            ],
+          },
+        } as any,
+      ],
+    };
+
+    injectSchemaArgsInProgram(
+      program,
+      { parseValue: buildParseValueDef() },
+      {},
+    );
+
+    const call = (program.nodes[0] as any).value;
+    expect(call.arguments).toHaveLength(2);
+    expect(call.arguments[1].type).toBe("namedArgument");
+    expect(call.arguments[1].name).toBe("s");
+    expect(call.arguments[1].value.type).toBe("schemaExpression");
+    expect(call.arguments[1].value.typeArg).toEqual({
+      type: "arrayType",
+      elementType: { type: "primitiveType", value: "number" },
+    });
+  });
+
+  it("does not inject when the schema arg is supplied explicitly (positional)", () => {
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        {
+          type: "assignment",
+          declKind: "const",
+          target: "xs",
+          typeHint: {
+            type: "arrayType",
+            elementType: { type: "primitiveType", value: "number" },
+          },
+          value: {
+            type: "functionCall",
+            functionName: "parseValue",
+            arguments: [
+              {
+                type: "string",
+                segments: [{ type: "text", value: "[1,2,3]" }],
+              },
+              {
+                type: "schemaExpression",
+                typeArg: { type: "primitiveType", value: "string" },
+              },
+            ],
+          },
+        } as any,
+      ],
+    };
+
+    injectSchemaArgsInProgram(
+      program,
+      { parseValue: buildParseValueDef() },
+      {},
+    );
+
+    const call = (program.nodes[0] as any).value;
+    expect(call.arguments).toHaveLength(2);
+    // The user-supplied schema (string) is preserved.
+    expect(call.arguments[1].type).toBe("schemaExpression");
+    expect(call.arguments[1].typeArg).toEqual({
+      type: "primitiveType",
+      value: "string",
+    });
+  });
+
+  it("does not inject when the schema arg is supplied by name", () => {
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        {
+          type: "assignment",
+          declKind: "const",
+          target: "xs",
+          typeHint: { type: "primitiveType", value: "any" },
+          value: {
+            type: "functionCall",
+            functionName: "parseValue",
+            arguments: [
+              {
+                type: "string",
+                segments: [{ type: "text", value: "[1,2,3]" }],
+              },
+              {
+                type: "namedArgument",
+                name: "s",
+                value: {
+                  type: "schemaExpression",
+                  typeArg: { type: "primitiveType", value: "number" },
+                },
+              },
+            ],
+          },
+        } as any,
+      ],
+    };
+
+    injectSchemaArgsInProgram(
+      program,
+      { parseValue: buildParseValueDef() },
+      {},
+    );
+
+    const call = (program.nodes[0] as any).value;
+    expect(call.arguments).toHaveLength(2);
+    expect(call.arguments[1].value.typeArg).toEqual({
+      type: "primitiveType",
+      value: "number",
+    });
+  });
+
+  it("does not inject when there is no LHS annotation", () => {
+    // const xs = parseValue("[1,2,3]")   // no `: T` annotation
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        {
+          type: "assignment",
+          declKind: "const",
+          target: "xs",
+          // intentionally no typeHint
+          value: {
+            type: "functionCall",
+            functionName: "parseValue",
+            arguments: [
+              {
+                type: "string",
+                segments: [{ type: "text", value: "[1,2,3]" }],
+              },
+            ],
+          },
+        } as any,
+      ],
+    };
+
+    injectSchemaArgsInProgram(
+      program,
+      { parseValue: buildParseValueDef() },
+      {},
+    );
+
+    const call = (program.nodes[0] as any).value;
+    expect(call.arguments).toHaveLength(1);
+  });
+
+  it("injects from return-position when the enclosing function's return type is known", () => {
+    // def wrapper(): number[] { return parseValue("[1,2,3]") }
+    const wrapper: FunctionDefinition = {
+      type: "function",
+      functionName: "wrapper",
+      parameters: [],
+      returnType: {
+        type: "arrayType",
+        elementType: { type: "primitiveType", value: "number" },
+      },
+      body: [
+        {
+          type: "returnStatement",
+          value: {
+            type: "functionCall",
+            functionName: "parseValue",
+            arguments: [
+              {
+                type: "string",
+                segments: [{ type: "text", value: "[1,2,3]" }],
+              },
+            ],
+          },
+        } as any,
+      ],
+    };
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [wrapper],
+    };
+
+    injectSchemaArgsInProgram(
+      program,
+      { parseValue: buildParseValueDef(), wrapper },
+      {},
+    );
+
+    const ret = wrapper.body[0] as any;
+    const call = ret.value;
+    expect(call.arguments).toHaveLength(2);
+    expect(call.arguments[1].value.typeArg).toEqual({
+      type: "arrayType",
+      elementType: { type: "primitiveType", value: "number" },
+    });
+  });
+
+  it("throws when a function declares more than one Schema parameter", () => {
+    const twoSchemas: FunctionDefinition = {
+      type: "function",
+      functionName: "doubled",
+      parameters: [
+        {
+          type: "functionParameter",
+          name: "a",
+          typeHint: {
+            type: "genericType",
+            name: "Schema",
+            typeArgs: [{ type: "primitiveType", value: "any" }],
+          },
+        },
+        {
+          type: "functionParameter",
+          name: "b",
+          typeHint: {
+            type: "genericType",
+            name: "Schema",
+            typeArgs: [{ type: "primitiveType", value: "any" }],
+          },
+        },
+      ],
+      returnType: { type: "primitiveType", value: "any" },
+      body: [],
+    };
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        {
+          type: "assignment",
+          declKind: "const",
+          target: "x",
+          typeHint: { type: "primitiveType", value: "string" },
+          value: {
+            type: "functionCall",
+            functionName: "doubled",
+            arguments: [],
+          },
+        } as any,
+      ],
+    };
+
+    expect(() =>
+      injectSchemaArgsInProgram(
+        program,
+        { doubled: twoSchemas },
+        {},
+      ),
+    ).toThrowError(/more than one Schema parameter/);
+  });
+
+  it("leaves calls to unknown functions alone (e.g. JS / builtins)", () => {
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        {
+          type: "assignment",
+          declKind: "const",
+          target: "xs",
+          typeHint: {
+            type: "arrayType",
+            elementType: { type: "primitiveType", value: "number" },
+          },
+          value: {
+            type: "functionCall",
+            functionName: "unknownFn",
+            arguments: [],
+          },
+        } as any,
+      ],
+    };
+
+    injectSchemaArgsInProgram(program, {}, {});
+
+    const call = (program.nodes[0] as any).value;
+    expect(call.arguments).toHaveLength(0);
+  });
+});

--- a/packages/agency-lang/lib/preprocessors/injectSchemaArgs.test.ts
+++ b/packages/agency-lang/lib/preprocessors/injectSchemaArgs.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { injectSchemaArgsInProgram } from "./injectSchemaArgs.js";
-import type { AgencyProgram, FunctionDefinition } from "../types.js";
+import type {
+  AgencyProgram,
+  Assignment,
+  FunctionCall,
+  FunctionDefinition,
+} from "../types.js";
 import type { FunctionParameter } from "../types/function.js";
 
 /**
  * Helper: builds a `def parseValue(input: string, s: Schema<any>): any` shape.
- * The default returnType is `any`; pass a different one to test return-position
- * scenarios where the function declares a more specific return type.
  */
 function buildParseValueDef(): FunctionDefinition {
   const params: FunctionParameter[] = [
@@ -34,31 +37,59 @@ function buildParseValueDef(): FunctionDefinition {
   };
 }
 
+/**
+ * Helper: builds `const <name>: <typeHint> = <call>` as a real
+ * Assignment AST node. Uses the real `variableName` field — earlier
+ * versions of this test used a fictional `target` field, which
+ * worked only because the calls were cast to `any`.
+ */
+function buildConstAssignment(
+  name: string,
+  typeHint: Assignment["typeHint"],
+  call: FunctionCall,
+): Assignment {
+  return {
+    type: "assignment",
+    declKind: "const",
+    variableName: name,
+    typeHint,
+    value: call,
+  };
+}
+
+function buildCall(
+  functionName: string,
+  args: FunctionCall["arguments"] = [],
+): FunctionCall {
+  return {
+    type: "functionCall",
+    functionName,
+    arguments: args,
+  };
+}
+
+function buildStringLiteral(value: string) {
+  return {
+    type: "string" as const,
+    segments: [{ type: "text" as const, value }],
+  };
+}
+
 describe("injectSchemaArgsInProgram", () => {
   it("injects a schema arg from an assignment's LHS type", () => {
     // const xs: number[] = parseValue("[1,2,3]")
+    const call = buildCall("parseValue", [buildStringLiteral("[1,2,3]")]);
     const program: AgencyProgram = {
       type: "agencyProgram",
       nodes: [
-        {
-          type: "assignment",
-          declKind: "const",
-          target: "xs",
-          typeHint: {
+        buildConstAssignment(
+          "xs",
+          {
             type: "arrayType",
             elementType: { type: "primitiveType", value: "number" },
           },
-          value: {
-            type: "functionCall",
-            functionName: "parseValue",
-            arguments: [
-              {
-                type: "string",
-                segments: [{ type: "text", value: "[1,2,3]" }],
-              },
-            ],
-          },
-        } as any,
+          call,
+        ),
       ],
     };
 
@@ -68,11 +99,12 @@ describe("injectSchemaArgsInProgram", () => {
       {},
     );
 
-    const call = (program.nodes[0] as any).value;
     expect(call.arguments).toHaveLength(2);
     expect(call.arguments[1].type).toBe("namedArgument");
+    if (call.arguments[1].type !== "namedArgument") return;
     expect(call.arguments[1].name).toBe("s");
     expect(call.arguments[1].value.type).toBe("schemaExpression");
+    if (call.arguments[1].value.type !== "schemaExpression") return;
     expect(call.arguments[1].value.typeArg).toEqual({
       type: "arrayType",
       elementType: { type: "primitiveType", value: "number" },
@@ -80,32 +112,24 @@ describe("injectSchemaArgsInProgram", () => {
   });
 
   it("does not inject when the schema arg is supplied explicitly (positional)", () => {
+    const call = buildCall("parseValue", [
+      buildStringLiteral("[1,2,3]"),
+      {
+        type: "schemaExpression",
+        typeArg: { type: "primitiveType", value: "string" },
+      },
+    ]);
     const program: AgencyProgram = {
       type: "agencyProgram",
       nodes: [
-        {
-          type: "assignment",
-          declKind: "const",
-          target: "xs",
-          typeHint: {
+        buildConstAssignment(
+          "xs",
+          {
             type: "arrayType",
             elementType: { type: "primitiveType", value: "number" },
           },
-          value: {
-            type: "functionCall",
-            functionName: "parseValue",
-            arguments: [
-              {
-                type: "string",
-                segments: [{ type: "text", value: "[1,2,3]" }],
-              },
-              {
-                type: "schemaExpression",
-                typeArg: { type: "primitiveType", value: "string" },
-              },
-            ],
-          },
-        } as any,
+          call,
+        ),
       ],
     };
 
@@ -115,10 +139,10 @@ describe("injectSchemaArgsInProgram", () => {
       {},
     );
 
-    const call = (program.nodes[0] as any).value;
     expect(call.arguments).toHaveLength(2);
     // The user-supplied schema (string) is preserved.
     expect(call.arguments[1].type).toBe("schemaExpression");
+    if (call.arguments[1].type !== "schemaExpression") return;
     expect(call.arguments[1].typeArg).toEqual({
       type: "primitiveType",
       value: "string",
@@ -126,33 +150,25 @@ describe("injectSchemaArgsInProgram", () => {
   });
 
   it("does not inject when the schema arg is supplied by name", () => {
+    const call = buildCall("parseValue", [
+      buildStringLiteral("[1,2,3]"),
+      {
+        type: "namedArgument",
+        name: "s",
+        value: {
+          type: "schemaExpression",
+          typeArg: { type: "primitiveType", value: "number" },
+        },
+      },
+    ]);
     const program: AgencyProgram = {
       type: "agencyProgram",
       nodes: [
-        {
-          type: "assignment",
-          declKind: "const",
-          target: "xs",
-          typeHint: { type: "primitiveType", value: "any" },
-          value: {
-            type: "functionCall",
-            functionName: "parseValue",
-            arguments: [
-              {
-                type: "string",
-                segments: [{ type: "text", value: "[1,2,3]" }],
-              },
-              {
-                type: "namedArgument",
-                name: "s",
-                value: {
-                  type: "schemaExpression",
-                  typeArg: { type: "primitiveType", value: "number" },
-                },
-              },
-            ],
-          },
-        } as any,
+        buildConstAssignment(
+          "xs",
+          { type: "primitiveType", value: "any" },
+          call,
+        ),
       ],
     };
 
@@ -162,8 +178,11 @@ describe("injectSchemaArgsInProgram", () => {
       {},
     );
 
-    const call = (program.nodes[0] as any).value;
     expect(call.arguments).toHaveLength(2);
+    expect(call.arguments[1].type).toBe("namedArgument");
+    if (call.arguments[1].type !== "namedArgument") return;
+    expect(call.arguments[1].value.type).toBe("schemaExpression");
+    if (call.arguments[1].value.type !== "schemaExpression") return;
     expect(call.arguments[1].value.typeArg).toEqual({
       type: "primitiveType",
       value: "number",
@@ -172,25 +191,11 @@ describe("injectSchemaArgsInProgram", () => {
 
   it("does not inject when there is no LHS annotation", () => {
     // const xs = parseValue("[1,2,3]")   // no `: T` annotation
+    const call = buildCall("parseValue", [buildStringLiteral("[1,2,3]")]);
     const program: AgencyProgram = {
       type: "agencyProgram",
       nodes: [
-        {
-          type: "assignment",
-          declKind: "const",
-          target: "xs",
-          // intentionally no typeHint
-          value: {
-            type: "functionCall",
-            functionName: "parseValue",
-            arguments: [
-              {
-                type: "string",
-                segments: [{ type: "text", value: "[1,2,3]" }],
-              },
-            ],
-          },
-        } as any,
+        buildConstAssignment("xs", undefined, call),
       ],
     };
 
@@ -200,12 +205,12 @@ describe("injectSchemaArgsInProgram", () => {
       {},
     );
 
-    const call = (program.nodes[0] as any).value;
     expect(call.arguments).toHaveLength(1);
   });
 
   it("injects from return-position when the enclosing function's return type is known", () => {
     // def wrapper(): number[] { return parseValue("[1,2,3]") }
+    const call = buildCall("parseValue", [buildStringLiteral("[1,2,3]")]);
     const wrapper: FunctionDefinition = {
       type: "function",
       functionName: "wrapper",
@@ -217,17 +222,8 @@ describe("injectSchemaArgsInProgram", () => {
       body: [
         {
           type: "returnStatement",
-          value: {
-            type: "functionCall",
-            functionName: "parseValue",
-            arguments: [
-              {
-                type: "string",
-                segments: [{ type: "text", value: "[1,2,3]" }],
-              },
-            ],
-          },
-        } as any,
+          value: call,
+        },
       ],
     };
     const program: AgencyProgram = {
@@ -241,16 +237,57 @@ describe("injectSchemaArgsInProgram", () => {
       {},
     );
 
-    const ret = wrapper.body[0] as any;
-    const call = ret.value;
     expect(call.arguments).toHaveLength(2);
+    if (call.arguments[1].type !== "namedArgument") return;
+    if (call.arguments[1].value.type !== "schemaExpression") return;
     expect(call.arguments[1].value.typeArg).toEqual({
       type: "arrayType",
       elementType: { type: "primitiveType", value: "number" },
     });
   });
 
-  it("throws when a function declares more than one Schema parameter", () => {
+  it("injects from return-position when an enclosing graph node's return type is known", () => {
+    // node main(): number[] { return parseValue("[1,2,3]") }
+    const call = buildCall("parseValue", [buildStringLiteral("[1,2,3]")]);
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        {
+          type: "graphNode",
+          nodeName: "main",
+          parameters: [],
+          returnType: {
+            type: "arrayType",
+            elementType: { type: "primitiveType", value: "number" },
+          },
+          body: [
+            {
+              type: "returnStatement",
+              value: call,
+            },
+          ],
+        },
+      ],
+    };
+
+    injectSchemaArgsInProgram(
+      program,
+      { parseValue: buildParseValueDef() },
+      {},
+    );
+
+    expect(call.arguments).toHaveLength(2);
+    if (call.arguments[1].type !== "namedArgument") return;
+    if (call.arguments[1].value.type !== "schemaExpression") return;
+    expect(call.arguments[1].value.typeArg).toEqual({
+      type: "arrayType",
+      elementType: { type: "primitiveType", value: "number" },
+    });
+  });
+
+  it("throws at declaration time when a function declares more than one Schema parameter", () => {
+    // `doubled` is never called — the error should still fire because
+    // the structural validation pass scans every function definition.
     const twoSchemas: FunctionDefinition = {
       type: "function",
       functionName: "doubled",
@@ -279,54 +316,32 @@ describe("injectSchemaArgsInProgram", () => {
     };
     const program: AgencyProgram = {
       type: "agencyProgram",
-      nodes: [
-        {
-          type: "assignment",
-          declKind: "const",
-          target: "x",
-          typeHint: { type: "primitiveType", value: "string" },
-          value: {
-            type: "functionCall",
-            functionName: "doubled",
-            arguments: [],
-          },
-        } as any,
-      ],
+      nodes: [],
     };
 
     expect(() =>
-      injectSchemaArgsInProgram(
-        program,
-        { doubled: twoSchemas },
-        {},
-      ),
+      injectSchemaArgsInProgram(program, { doubled: twoSchemas }, {}),
     ).toThrowError(/more than one Schema parameter/);
   });
 
   it("leaves calls to unknown functions alone (e.g. JS / builtins)", () => {
+    const call = buildCall("unknownFn");
     const program: AgencyProgram = {
       type: "agencyProgram",
       nodes: [
-        {
-          type: "assignment",
-          declKind: "const",
-          target: "xs",
-          typeHint: {
+        buildConstAssignment(
+          "xs",
+          {
             type: "arrayType",
             elementType: { type: "primitiveType", value: "number" },
           },
-          value: {
-            type: "functionCall",
-            functionName: "unknownFn",
-            arguments: [],
-          },
-        } as any,
+          call,
+        ),
       ],
     };
 
     injectSchemaArgsInProgram(program, {}, {});
 
-    const call = (program.nodes[0] as any).value;
     expect(call.arguments).toHaveLength(0);
   });
 });

--- a/packages/agency-lang/lib/preprocessors/injectSchemaArgs.test.ts
+++ b/packages/agency-lang/lib/preprocessors/injectSchemaArgs.test.ts
@@ -344,4 +344,194 @@ describe("injectSchemaArgsInProgram", () => {
 
     expect(call.arguments).toHaveLength(0);
   });
+
+  it("injects for `let` assignments the same as `const`", () => {
+    // let xs: number[] = parseValue("[1,2,3]")
+    const call = buildCall("parseValue", [buildStringLiteral("[1,2,3]")]);
+    const assignment: Assignment = {
+      type: "assignment",
+      declKind: "let",
+      variableName: "xs",
+      typeHint: {
+        type: "arrayType",
+        elementType: { type: "primitiveType", value: "number" },
+      },
+      value: call,
+    };
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [assignment],
+    };
+
+    injectSchemaArgsInProgram(
+      program,
+      { parseValue: buildParseValueDef() },
+      {},
+    );
+
+    expect(call.arguments).toHaveLength(2);
+    if (call.arguments[1].type !== "namedArgument") return;
+    if (call.arguments[1].value.type !== "schemaExpression") return;
+    expect(call.arguments[1].value.typeArg).toEqual({
+      type: "arrayType",
+      elementType: { type: "primitiveType", value: "number" },
+    });
+  });
+
+  it("does not inject when a splat appears before the Schema slot", () => {
+    // const xs: number[] = parseValue(...args)
+    // We can't tell statically whether the splat fills the Schema slot,
+    // so injection must be conservative and skip.
+    const splat = {
+      type: "splat",
+      value: { type: "variableReference", name: "args" },
+    } as unknown as FunctionCall["arguments"][number];
+    const call = buildCall("parseValue", [splat]);
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        buildConstAssignment(
+          "xs",
+          {
+            type: "arrayType",
+            elementType: { type: "primitiveType", value: "number" },
+          },
+          call,
+        ),
+      ],
+    };
+
+    injectSchemaArgsInProgram(
+      program,
+      { parseValue: buildParseValueDef() },
+      {},
+    );
+
+    // Still just the splat — no synthetic Schema arg appended.
+    expect(call.arguments).toHaveLength(1);
+    expect(call.arguments[0].type).toBe("splat");
+  });
+
+  it("injects for calls to imported functions with a Schema parameter", () => {
+    // Same shape as parseValue, but reached via `importedFunctions`
+    // instead of `functionDefinitions`.
+    const call = buildCall("parseValue", [buildStringLiteral("[1,2,3]")]);
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        buildConstAssignment(
+          "xs",
+          {
+            type: "arrayType",
+            elementType: { type: "primitiveType", value: "number" },
+          },
+          call,
+        ),
+      ],
+    };
+
+    injectSchemaArgsInProgram(
+      program,
+      {},
+      {
+        parseValue: {
+          parameters: buildParseValueDef().parameters,
+          returnType: { type: "primitiveType", value: "any" },
+        },
+      },
+    );
+
+    expect(call.arguments).toHaveLength(2);
+    if (call.arguments[1].type !== "namedArgument") return;
+    expect(call.arguments[1].value.type).toBe("schemaExpression");
+  });
+
+  it("throws when an imported function declares more than one Schema parameter", () => {
+    // Same multi-Schema declaration as the earlier test, but reached
+    // through `importedFunctions`. Validates that the up-front
+    // uniqueness check scans imports too.
+    const params: FunctionParameter[] = [
+      {
+        type: "functionParameter",
+        name: "a",
+        typeHint: {
+          type: "genericType",
+          name: "Schema",
+          typeArgs: [{ type: "primitiveType", value: "any" }],
+        },
+      },
+      {
+        type: "functionParameter",
+        name: "b",
+        typeHint: {
+          type: "genericType",
+          name: "Schema",
+          typeArgs: [{ type: "primitiveType", value: "any" }],
+        },
+      },
+    ];
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [],
+    };
+
+    expect(() =>
+      injectSchemaArgsInProgram(
+        program,
+        {},
+        {
+          twoSchemas: {
+            parameters: params,
+            returnType: { type: "primitiveType", value: "any" },
+          },
+        },
+      ),
+    ).toThrowError(/more than one Schema parameter/);
+  });
+
+  it("injects inside a class method body using the method's return type", () => {
+    // class Foo { parse(): number[] { return parseValue("[1,2,3]") } }
+    const call = buildCall("parseValue", [buildStringLiteral("[1,2,3]")]);
+    const program: AgencyProgram = {
+      type: "agencyProgram",
+      nodes: [
+        {
+          type: "classDefinition",
+          className: "Foo",
+          fields: [],
+          methods: [
+            {
+              type: "classMethod",
+              name: "parse",
+              parameters: [],
+              returnType: {
+                type: "arrayType",
+                elementType: { type: "primitiveType", value: "number" },
+              },
+              body: [
+                {
+                  type: "returnStatement",
+                  value: call,
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    injectSchemaArgsInProgram(
+      program,
+      { parseValue: buildParseValueDef() },
+      {},
+    );
+
+    expect(call.arguments).toHaveLength(2);
+    if (call.arguments[1].type !== "namedArgument") return;
+    if (call.arguments[1].value.type !== "schemaExpression") return;
+    expect(call.arguments[1].value.typeArg).toEqual({
+      type: "arrayType",
+      elementType: { type: "primitiveType", value: "number" },
+    });
+  });
 });

--- a/packages/agency-lang/lib/preprocessors/injectSchemaArgs.ts
+++ b/packages/agency-lang/lib/preprocessors/injectSchemaArgs.ts
@@ -31,24 +31,31 @@ import { findSchemaParam } from "@/utils/schemaParam.js";
  *     for it already works (it's the same node `schema(T)` produces).
  *
  * Rules:
- *   - At most one Schema-typed parameter per function (enforced lazily,
- *     only when the function is actually called from a context where
- *     the rule matters; see `findSchemaParam`).
+ *   - At most one Schema-typed parameter per function. Enforced once
+ *     up front by `validateSchemaParamUniqueness`, so the error fires
+ *     at declaration time regardless of whether the function is ever
+ *     called from an injection-eligible context.
  *   - If the caller passes the Schema arg explicitly (positional or
  *     named), no injection happens.
- *   - If no expected type is available, no injection happens and the
- *     missing argument is reported as a normal type error elsewhere.
- *     (Practically, the type checker skips arity for Schema params,
- *     so the user would see a downstream runtime error when the
- *     function tries to use the missing schema. We trade that for a
- *     simpler implementation; the documentation in `appendix/`
- *     spells out the contract for users.)
+ *   - If no expected type is available, no injection happens. The
+ *     type checker also skips Schema params in its arity check, so
+ *     the missing argument is *not* surfaced as a compile error —
+ *     the function will fail at runtime when it tries to use the
+ *     undefined schema. The documentation in
+ *     `docs/site/appendix/schema-parameter-injection.md` describes
+ *     this contract for users.
  */
 export function injectSchemaArgsInProgram(
   program: AgencyProgram,
   functionDefinitions: Record<string, FunctionDefinition>,
   importedFunctions: Record<string, ImportedFunctionSignature>,
 ): void {
+  // Up-front structural validation: catch multi-Schema-param declarations
+  // before any call-site logic runs, so the error is surfaced even when
+  // the offending function is never called (or is only called in
+  // non-injecting contexts).
+  validateSchemaParamUniqueness(functionDefinitions, importedFunctions);
+
   const lookup = (name: string): FunctionParameter[] | undefined =>
     functionDefinitions[name]?.parameters ??
     importedFunctions[name]?.parameters;
@@ -65,8 +72,26 @@ export function injectSchemaArgsInProgram(
 
   for (const node of program.nodes) {
     if (node.type === "graphNode") {
-      walkBody(node.body, undefined, lookup);
+      walkBody(node.body, node.returnType ?? undefined, lookup);
     }
+  }
+}
+
+/**
+ * Scan every function we know about and ensure none declare more than
+ * one Schema parameter. Runs once at the start of the pass so the
+ * "at most one Schema parameter" rule is enforced at the source
+ * declaration rather than incidentally at the first matching call.
+ */
+function validateSchemaParamUniqueness(
+  functionDefinitions: Record<string, FunctionDefinition>,
+  importedFunctions: Record<string, ImportedFunctionSignature>,
+): void {
+  for (const [name, fn] of Object.entries(functionDefinitions)) {
+    findSchemaParam(fn.parameters, name);
+  }
+  for (const [name, sig] of Object.entries(importedFunctions)) {
+    findSchemaParam(sig.parameters, name);
   }
 }
 
@@ -145,14 +170,15 @@ function handleAssignment(
 }
 
 /**
- * Try to inject a schema arg into a call expression. The expression is
- * accepted as a function call directly, or as an `if`/`match` whose
- * branches each yield a call — recurses through those to inject in
- * every branch (each branch's call gets the same expected type).
+ * Try to inject a schema arg into a call expression. Only direct
+ * function calls are injection sites in v1; binary ops, value access,
+ * pipe chains, etc. are left alone — the user can always pass the
+ * schema explicitly when they need it in those positions.
  *
- * Other expression shapes (binary ops, value access, etc.) are not
- * recursed into. The user can always pass the schema explicitly when
- * they need it in those positions.
+ * (`ReturnStatement.value` is typed as `Expression`, which doesn't
+ * include `ifElse`/`matchBlock` — Agency parses `if`/`match` as
+ * statements, not expressions — so there's no need to recurse into
+ * branch bodies here.)
  */
 function handleExpectedAt(
   expr: AgencyNode,
@@ -161,22 +187,6 @@ function handleExpectedAt(
 ): void {
   if (expr.type === "functionCall") {
     maybeInject(expr, expectedType, lookup);
-    return;
-  }
-  if (expr.type === "ifElse") {
-    for (const stmt of expr.thenBody) {
-      if (stmt.type === "returnStatement" && stmt.value) {
-        handleExpectedAt(stmt.value, expectedType, lookup);
-      }
-    }
-    if (expr.elseBody) {
-      for (const stmt of expr.elseBody) {
-        if (stmt.type === "returnStatement" && stmt.value) {
-          handleExpectedAt(stmt.value, expectedType, lookup);
-        }
-      }
-    }
-    return;
   }
 }
 

--- a/packages/agency-lang/lib/preprocessors/injectSchemaArgs.ts
+++ b/packages/agency-lang/lib/preprocessors/injectSchemaArgs.ts
@@ -1,0 +1,247 @@
+import type {
+  AgencyNode,
+  AgencyProgram,
+  Assignment,
+  FunctionCall,
+  FunctionDefinition,
+  GraphNodeDefinition,
+} from "@/types.js";
+import type { ImportedFunctionSignature } from "@/compilationUnit.js";
+import type { VariableType } from "@/types/typeHints.js";
+import type { FunctionParameter } from "@/types/function.js";
+import type { SchemaExpression } from "@/types/schemaExpression.js";
+import { findSchemaParam } from "@/utils/schemaParam.js";
+
+/**
+ * Preprocessor pass: inject `schema(T)` arguments at call sites whose
+ * target function declares a `Schema<...>` parameter that the caller
+ * did not supply explicitly. The expected type `T` is derived from
+ * the call's context: the LHS annotation of a `const`/`let`, or the
+ * enclosing function's declared return type when the call is the
+ * value of a `return` statement.
+ *
+ * Why a preprocessor pass:
+ *   - Keeps the type checker simple (a Schema param is treated as
+ *     "always optional" — see `paramListSignature`).
+ *   - Keeps the TypeScript builder simple — calls reach the builder
+ *     with all arguments explicit. Downstream tools (`agency fmt`,
+ *     `pnpm run ast`) still see the original user-written AST because
+ *     this pass runs only inside the TS preprocessor.
+ *   - The injected node is a regular `schemaExpression`, so codegen
+ *     for it already works (it's the same node `schema(T)` produces).
+ *
+ * Rules:
+ *   - At most one Schema-typed parameter per function (enforced lazily,
+ *     only when the function is actually called from a context where
+ *     the rule matters; see `findSchemaParam`).
+ *   - If the caller passes the Schema arg explicitly (positional or
+ *     named), no injection happens.
+ *   - If no expected type is available, no injection happens and the
+ *     missing argument is reported as a normal type error elsewhere.
+ *     (Practically, the type checker skips arity for Schema params,
+ *     so the user would see a downstream runtime error when the
+ *     function tries to use the missing schema. We trade that for a
+ *     simpler implementation; the documentation in `appendix/`
+ *     spells out the contract for users.)
+ */
+export function injectSchemaArgsInProgram(
+  program: AgencyProgram,
+  functionDefinitions: Record<string, FunctionDefinition>,
+  importedFunctions: Record<string, ImportedFunctionSignature>,
+): void {
+  const lookup = (name: string): FunctionParameter[] | undefined =>
+    functionDefinitions[name]?.parameters ??
+    importedFunctions[name]?.parameters;
+
+  // Top-level program nodes (graph nodes, exported function defs, etc.)
+  // get walked through their bodies below — the program body itself
+  // doesn't host return statements, but it does host top-level `const`
+  // / `let` assignments.
+  walkBody(program.nodes, undefined, lookup);
+
+  for (const fn of Object.values(functionDefinitions)) {
+    walkBody(fn.body, fn.returnType ?? undefined, lookup);
+  }
+
+  for (const node of program.nodes) {
+    if (node.type === "graphNode") {
+      walkBody(node.body, undefined, lookup);
+    }
+  }
+}
+
+/**
+ * Walk a body recursively, processing each statement. `enclosingReturnType`
+ * is the declared return type of the function whose body we are inside;
+ * `undefined` means there is none (e.g. graph nodes, top-level, or a
+ * function with no return annotation).
+ */
+function walkBody(
+  body: AgencyNode[],
+  enclosingReturnType: VariableType | undefined,
+  lookup: (name: string) => FunctionParameter[] | undefined,
+): void {
+  for (const node of body) {
+    walkNode(node, enclosingReturnType, lookup);
+  }
+}
+
+function walkNode(
+  node: AgencyNode,
+  enclosingReturnType: VariableType | undefined,
+  lookup: (name: string) => FunctionParameter[] | undefined,
+): void {
+  if (node.type === "assignment") {
+    handleAssignment(node, lookup);
+  } else if (node.type === "returnStatement") {
+    if (node.value && enclosingReturnType) {
+      handleExpectedAt(node.value, enclosingReturnType, lookup);
+    }
+  } else if (node.type === "ifElse") {
+    walkBody(node.thenBody, enclosingReturnType, lookup);
+    if (node.elseBody) walkBody(node.elseBody, enclosingReturnType, lookup);
+  } else if (
+    node.type === "forLoop" ||
+    node.type === "whileLoop" ||
+    node.type === "messageThread"
+  ) {
+    walkBody(node.body, enclosingReturnType, lookup);
+  } else if (node.type === "matchBlock") {
+    for (const caseItem of node.cases) {
+      if (caseItem.type === "comment" || caseItem.type === "newLine") continue;
+      // Match case bodies are themselves nodes; treat as a 1-node body.
+      walkNode(caseItem.body, enclosingReturnType, lookup);
+    }
+  } else if (node.type === "handleBlock") {
+    walkBody(node.body, enclosingReturnType, lookup);
+    if (node.handler.kind === "inline") {
+      walkBody(node.handler.body, enclosingReturnType, lookup);
+    }
+  } else if (node.type === "withModifier") {
+    walkNode(node.statement, enclosingReturnType, lookup);
+  } else if (node.type === "functionCall" && node.block) {
+    walkBody(node.block.body, enclosingReturnType, lookup);
+  } else if (node.type === "parallelBlock" || node.type === "seqBlock") {
+    walkBody(node.body, enclosingReturnType, lookup);
+  } else if (node.type === "classDefinition") {
+    for (const method of node.methods) {
+      walkBody(method.body, method.returnType, lookup);
+    }
+  }
+}
+
+/**
+ * `const x: T = call(...)` — propagate `T` as the expected type into
+ * the call. Reassignments (`x = call(...)`) carry no annotation, so
+ * they are skipped (no injection from already-typed variable refs;
+ * could be added later if there's demand).
+ */
+function handleAssignment(
+  node: Assignment,
+  lookup: (name: string) => FunctionParameter[] | undefined,
+): void {
+  if (!node.typeHint) return;
+  handleExpectedAt(node.value, node.typeHint, lookup);
+}
+
+/**
+ * Try to inject a schema arg into a call expression. The expression is
+ * accepted as a function call directly, or as an `if`/`match` whose
+ * branches each yield a call — recurses through those to inject in
+ * every branch (each branch's call gets the same expected type).
+ *
+ * Other expression shapes (binary ops, value access, etc.) are not
+ * recursed into. The user can always pass the schema explicitly when
+ * they need it in those positions.
+ */
+function handleExpectedAt(
+  expr: AgencyNode,
+  expectedType: VariableType,
+  lookup: (name: string) => FunctionParameter[] | undefined,
+): void {
+  if (expr.type === "functionCall") {
+    maybeInject(expr, expectedType, lookup);
+    return;
+  }
+  if (expr.type === "ifElse") {
+    for (const stmt of expr.thenBody) {
+      if (stmt.type === "returnStatement" && stmt.value) {
+        handleExpectedAt(stmt.value, expectedType, lookup);
+      }
+    }
+    if (expr.elseBody) {
+      for (const stmt of expr.elseBody) {
+        if (stmt.type === "returnStatement" && stmt.value) {
+          handleExpectedAt(stmt.value, expectedType, lookup);
+        }
+      }
+    }
+    return;
+  }
+}
+
+function maybeInject(
+  call: FunctionCall,
+  expectedType: VariableType,
+  lookup: (name: string) => FunctionParameter[] | undefined,
+): void {
+  const params = lookup(call.functionName);
+  if (!params) return;
+
+  const schemaParam = findSchemaParam(params, call.functionName);
+  if (!schemaParam) return;
+
+  // Already supplied?
+  if (isSchemaArgSupplied(call, schemaParam.index, schemaParam.param.name)) {
+    return;
+  }
+
+  // Build a synthetic `schema(T)` AST node and append it. The codegen
+  // for `schemaExpression` already exists — `processSchemaExpression`
+  // in the TypeScript builder lowers it to a Zod schema reference.
+  //
+  // We name-tag the inject as a named arg so it doesn't fight ordering
+  // with later positional arguments (none today; defends against
+  // future calls that interleave positional and named).
+  const injected: SchemaExpression = {
+    type: "schemaExpression",
+    typeArg: expectedType,
+    loc: call.loc,
+  };
+  call.arguments.push({
+    type: "namedArgument",
+    name: schemaParam.param.name,
+    value: injected,
+  });
+}
+
+/**
+ * Decide whether the caller already supplied the Schema parameter:
+ *   - a positional arg at the right index (and the call is positional
+ *     up to that point — no named args appearing earlier)
+ *   - a named arg matching the param's name
+ *
+ * Splat args are conservative: we treat a splat anywhere before the
+ * Schema slot as "may have supplied it" and skip injection (the runtime
+ * would receive the unrolled splat values).
+ */
+function isSchemaArgSupplied(
+  call: FunctionCall,
+  paramIndex: number,
+  paramName: string,
+): boolean {
+  // Named arg match.
+  for (const arg of call.arguments) {
+    if (arg.type === "namedArgument" && arg.name === paramName) return true;
+  }
+  // Splat before the slot → can't tell statically.
+  for (let i = 0; i < Math.min(call.arguments.length, paramIndex); i++) {
+    if (call.arguments[i].type === "splat") return true;
+  }
+  // Positional fill — any non-named arg at the Schema slot counts.
+  if (paramIndex < call.arguments.length) {
+    const arg = call.arguments[paramIndex];
+    if (arg.type !== "namedArgument") return true;
+  }
+  return false;
+}

--- a/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
+++ b/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
@@ -30,6 +30,7 @@ import {
   walkNodesArray,
 } from "@/utils/node.js";
 import { desugarParallelInBody } from "./parallelDesugar.js";
+import { injectSchemaArgsInProgram } from "./injectSchemaArgs.js";
 
 /**
  * Recursively apply a transform function to all body arrays in a node tree.
@@ -323,6 +324,11 @@ export class TypescriptPreprocessor {
       this.getGraphNodeDefinitions();
     }
     this.propagateBlockTypes();
+    injectSchemaArgsInProgram(
+      this.program,
+      this.functionDefinitions,
+      this.importedFunctions,
+    );
     this.collectSkills();
     this.addAwaitPendingCalls();
     this.filterExcludedNodeTypes();

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -26,6 +26,7 @@ import {
 import { Scope } from "./scope.js";
 import { BOOLEAN_T, REGEX_T, STRING_T } from "./primitives.js";
 import type { BlockType } from "../types/typeHints.js";
+import { isSchemaTypeHint } from "../utils/schemaParam.js";
 
 /**
  * Derive arity bounds and per-position param types from a parameter list,
@@ -63,8 +64,15 @@ function paramListSignature(
 } {
   const lastParam = params[params.length - 1];
   const hasRest = lastParam?.variadic === true;
+  // Schema<...> parameters are injection-eligible: the preprocessor's
+  // `injectSchemaArgs` pass fills them in from the call's expected type
+  // (LHS annotation or enclosing return type) when omitted, so they are
+  // effectively optional from the type checker's perspective.
   const minArgs = params.filter(
-    (p) => p.defaultValue === undefined && !p.variadic,
+    (p) =>
+      p.defaultValue === undefined &&
+      !p.variadic &&
+      !isSchemaTypeHint(p.typeHint),
   ).length;
   const maxArgs = hasRest ? Infinity : params.length;
 

--- a/packages/agency-lang/lib/utils/schemaParam.test.ts
+++ b/packages/agency-lang/lib/utils/schemaParam.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import {
+  isSchemaTypeHint,
+  schemaInnerType,
+  findSchemaParam,
+} from "./schemaParam.js";
+import type { FunctionParameter } from "../types/function.js";
+
+describe("isSchemaTypeHint", () => {
+  it("detects the surface `Schema<T>` form", () => {
+    expect(
+      isSchemaTypeHint({
+        type: "genericType",
+        name: "Schema",
+        typeArgs: [{ type: "primitiveType", value: "any" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("detects the post-resolution `schemaType` form", () => {
+    expect(
+      isSchemaTypeHint({
+        type: "schemaType",
+        inner: { type: "primitiveType", value: "string" },
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects unrelated genericType names", () => {
+    expect(
+      isSchemaTypeHint({
+        type: "genericType",
+        name: "Array",
+        typeArgs: [{ type: "primitiveType", value: "number" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects primitives and arrays", () => {
+    expect(isSchemaTypeHint({ type: "primitiveType", value: "string" })).toBe(
+      false,
+    );
+    expect(
+      isSchemaTypeHint({
+        type: "arrayType",
+        elementType: { type: "primitiveType", value: "number" },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects undefined", () => {
+    expect(isSchemaTypeHint(undefined)).toBe(false);
+  });
+});
+
+describe("schemaInnerType", () => {
+  it("returns the inner type from `schemaType`", () => {
+    expect(
+      schemaInnerType({
+        type: "schemaType",
+        inner: { type: "primitiveType", value: "string" },
+      }),
+    ).toEqual({ type: "primitiveType", value: "string" });
+  });
+
+  it("returns the first typeArg from `genericType Schema<...>`", () => {
+    expect(
+      schemaInnerType({
+        type: "genericType",
+        name: "Schema",
+        typeArgs: [
+          {
+            type: "arrayType",
+            elementType: { type: "primitiveType", value: "number" },
+          },
+        ],
+      }),
+    ).toEqual({
+      type: "arrayType",
+      elementType: { type: "primitiveType", value: "number" },
+    });
+  });
+
+  it("returns undefined for non-Schema types", () => {
+    expect(
+      schemaInnerType({ type: "primitiveType", value: "string" }),
+    ).toBeUndefined();
+  });
+});
+
+describe("findSchemaParam", () => {
+  const stringParam: FunctionParameter = {
+    type: "functionParameter",
+    name: "input",
+    typeHint: { type: "primitiveType", value: "string" },
+  };
+  const schemaParam: FunctionParameter = {
+    type: "functionParameter",
+    name: "s",
+    typeHint: {
+      type: "genericType",
+      name: "Schema",
+      typeArgs: [{ type: "primitiveType", value: "any" }],
+    },
+  };
+  const schemaParam2: FunctionParameter = {
+    type: "functionParameter",
+    name: "t",
+    typeHint: {
+      type: "genericType",
+      name: "Schema",
+      typeArgs: [{ type: "primitiveType", value: "any" }],
+    },
+  };
+
+  it("returns the unique Schema parameter with its index", () => {
+    const result = findSchemaParam([stringParam, schemaParam], "parseValue");
+    expect(result).toEqual({ param: schemaParam, index: 1 });
+  });
+
+  it("returns undefined when there are no Schema parameters", () => {
+    expect(findSchemaParam([stringParam], "noSchema")).toBeUndefined();
+  });
+
+  it("throws when multiple Schema parameters are declared", () => {
+    expect(() =>
+      findSchemaParam([stringParam, schemaParam, schemaParam2], "twoSchemas"),
+    ).toThrowError(/more than one Schema parameter/);
+  });
+});

--- a/packages/agency-lang/lib/utils/schemaParam.test.ts
+++ b/packages/agency-lang/lib/utils/schemaParam.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  isSchemaTypeHint,
-  schemaInnerType,
-  findSchemaParam,
-} from "./schemaParam.js";
+import { isSchemaTypeHint, findSchemaParam } from "./schemaParam.js";
 import type { FunctionParameter } from "../types/function.js";
 
 describe("isSchemaTypeHint", () => {
@@ -50,41 +46,6 @@ describe("isSchemaTypeHint", () => {
 
   it("rejects undefined", () => {
     expect(isSchemaTypeHint(undefined)).toBe(false);
-  });
-});
-
-describe("schemaInnerType", () => {
-  it("returns the inner type from `schemaType`", () => {
-    expect(
-      schemaInnerType({
-        type: "schemaType",
-        inner: { type: "primitiveType", value: "string" },
-      }),
-    ).toEqual({ type: "primitiveType", value: "string" });
-  });
-
-  it("returns the first typeArg from `genericType Schema<...>`", () => {
-    expect(
-      schemaInnerType({
-        type: "genericType",
-        name: "Schema",
-        typeArgs: [
-          {
-            type: "arrayType",
-            elementType: { type: "primitiveType", value: "number" },
-          },
-        ],
-      }),
-    ).toEqual({
-      type: "arrayType",
-      elementType: { type: "primitiveType", value: "number" },
-    });
-  });
-
-  it("returns undefined for non-Schema types", () => {
-    expect(
-      schemaInnerType({ type: "primitiveType", value: "string" }),
-    ).toBeUndefined();
   });
 });
 

--- a/packages/agency-lang/lib/utils/schemaParam.ts
+++ b/packages/agency-lang/lib/utils/schemaParam.ts
@@ -26,23 +26,6 @@ export function isSchemaTypeHint(t: VariableType | undefined): boolean {
 }
 
 /**
- * Extract the `inner` type parameter from a Schema type hint, if any.
- * Returns undefined when the hint isn't a Schema type. Used by the
- * type checker to validate that the LHS-derived schema is structurally
- * assignable to the param's declared inner type.
- */
-export function schemaInnerType(
-  t: VariableType | undefined,
-): VariableType | undefined {
-  if (!t) return undefined;
-  if (t.type === "schemaType") return t.inner;
-  if (t.type === "genericType" && t.name === "Schema" && t.typeArgs[0]) {
-    return t.typeArgs[0];
-  }
-  return undefined;
-}
-
-/**
  * Find the unique Schema-typed parameter in a function's parameter list,
  * if any. Throws when more than one Schema parameter is declared — the
  * compiler currently restricts functions to at most one Schema parameter

--- a/packages/agency-lang/lib/utils/schemaParam.ts
+++ b/packages/agency-lang/lib/utils/schemaParam.ts
@@ -1,0 +1,70 @@
+import type { VariableType } from "../types/typeHints.js";
+import type { FunctionParameter } from "../types/function.js";
+
+/**
+ * A parameter is a "Schema-injectable" parameter when its declared type
+ * is `Schema<...>`. Two parser/checker representations show up in the wild:
+ *
+ *  - `genericType { name: "Schema", typeArgs: [...] }` — the surface form
+ *    a user writes (e.g. `s: Schema<any>`). `resolveType` later lowers
+ *    this to the `schemaType` shape, but in the preprocessor we still see
+ *    the genericType form because resolution happens during type-checking.
+ *  - `schemaType { inner: T }` — the post-resolution form. Listed here as
+ *    defense in depth so the helper works in both contexts.
+ *
+ * Schema-injectable parameters can be omitted at the call site when the
+ * compiler can synthesize a Zod schema from a known expected type (the
+ * LHS annotation of a `const`/`let`, the enclosing function's declared
+ * return type, etc.). The `typescriptPreprocessor`'s `injectSchemaArgs`
+ * pass inserts a synthetic `schema(T)` expression in those cases.
+ */
+export function isSchemaTypeHint(t: VariableType | undefined): boolean {
+  if (!t) return false;
+  if (t.type === "schemaType") return true;
+  if (t.type === "genericType" && t.name === "Schema") return true;
+  return false;
+}
+
+/**
+ * Extract the `inner` type parameter from a Schema type hint, if any.
+ * Returns undefined when the hint isn't a Schema type. Used by the
+ * type checker to validate that the LHS-derived schema is structurally
+ * assignable to the param's declared inner type.
+ */
+export function schemaInnerType(
+  t: VariableType | undefined,
+): VariableType | undefined {
+  if (!t) return undefined;
+  if (t.type === "schemaType") return t.inner;
+  if (t.type === "genericType" && t.name === "Schema" && t.typeArgs[0]) {
+    return t.typeArgs[0];
+  }
+  return undefined;
+}
+
+/**
+ * Find the unique Schema-typed parameter in a function's parameter list,
+ * if any. Throws when more than one Schema parameter is declared — the
+ * compiler currently restricts functions to at most one Schema parameter
+ * because there is only one expected-type slot at any call site.
+ *
+ * Returns:
+ *   - { param, index } when exactly one Schema param exists
+ *   - undefined when none exist
+ */
+export function findSchemaParam(
+  params: FunctionParameter[],
+  functionName: string,
+): { param: FunctionParameter; index: number } | undefined {
+  let found: { param: FunctionParameter; index: number } | undefined;
+  for (let i = 0; i < params.length; i++) {
+    if (!isSchemaTypeHint(params[i].typeHint)) continue;
+    if (found) {
+      throw new Error(
+        `Function '${functionName}' declares more than one Schema parameter ('${found.param.name}' and '${params[i].name}'). At most one Schema parameter is allowed.`,
+      );
+    }
+    found = { param: params[i], index: i };
+  }
+  return found;
+}

--- a/packages/agency-lang/tests/agency/schema-param-injection.agency
+++ b/packages/agency-lang/tests/agency/schema-param-injection.agency
@@ -1,0 +1,33 @@
+// End-to-end runtime test for the schema-parameter-injection feature.
+//
+// Each node exercises a different shape of injection:
+//   - LHS-annotation drives the schema (number[] → z.array(z.number()))
+//   - return-position drives the schema (outer function's return type)
+//   - explicit arg suppresses injection
+
+def parseValue(input: string, s: Schema<any>): any {
+  const r = s.parseJSON(input)
+  if (isSuccess(r)) {
+    return r.value
+  }
+  return "failed"
+}
+
+def parseInRet(): number[] {
+  // Return-position injection: outer return type provides the hint.
+  return parseValue("[1,2,3]")
+}
+
+node parseNumbersFromLHS() {
+  const xs: number[] = parseValue("[1,2,3]")
+  return xs
+}
+
+node parseNumbersFromReturn() {
+  return parseInRet()
+}
+
+node explicitOverride() {
+  // Explicit schema arg wins; injection does not fire.
+  return parseValue("[1,2,3]", schema(any))
+}

--- a/packages/agency-lang/tests/agency/schema-param-injection.test.json
+++ b/packages/agency-lang/tests/agency/schema-param-injection.test.json
@@ -1,0 +1,26 @@
+{
+  "sourceFile": "schema-param-injection.agency",
+  "tests": [
+    {
+      "nodeName": "parseNumbersFromLHS",
+      "input": "",
+      "expectedOutput": "[1,2,3]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "LHS annotation `number[]` drives Schema injection"
+    },
+    {
+      "nodeName": "parseNumbersFromReturn",
+      "input": "",
+      "expectedOutput": "[1,2,3]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Enclosing function's return type drives Schema injection"
+    },
+    {
+      "nodeName": "explicitOverride",
+      "input": "",
+      "expectedOutput": "[1,2,3]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Explicit schema arg wins; no injection happens"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.agency
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.agency
@@ -1,0 +1,43 @@
+// Verifies the schema-parameter-injection feature.
+//
+// When a function declares a Schema<...> parameter and the caller does
+// not pass it explicitly, the compiler injects a Zod schema synthesized
+// from the LHS type annotation.
+
+def parseValue(input: string, s: Schema<any>): any {
+  return s.parseJSON(input)
+}
+
+def wrapper(): number[] {
+  // Return-position injection: outer return type provides the hint.
+  return parseValue("[1,2,3]")
+}
+
+node main() {
+  // LHS-annotation injection — Schema<any> inside parseValue receives
+  // z.array(z.number()) synthesized from `number[]`.
+  const nums: number[] = parseValue("[1,2,3]")
+  print(nums)
+
+  // `any` LHS — degenerate but valid: injects `z.any()`. No assertion
+  // about runtime shape, just verifies it compiles.
+  const anything: any = parseValue("42")
+  print(anything)
+
+  // `!` validation on the LHS: injection still fires with the bare
+  // type. `!` triggers a separate runtime validation pass at the
+  // assignment site; the injected schema and the validator schema are
+  // built from the same LHS type, so they agree.
+  const validated: number[]! = parseValue("[1,2,3]")
+  print(validated)
+
+  // Explicit override: the user-supplied schema wins, no injection.
+  const explicit = parseValue("[1,2,3]", schema(any))
+  print(explicit)
+
+  // Bare expression statement — no LHS, no return position, no injection.
+  // The Schema param is omitted; the function would fail at runtime
+  // because s is undefined. This case exists to lock in "no spooky
+  // injection without a clear context."
+  parseValue("[1,2,3]")
+}

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -1,0 +1,645 @@
+import { fileURLToPath } from "url";
+import __process from "process";
+import { readFileSync, writeFileSync } from "fs";
+import { z } from "agency-lang/zod";
+import { goToNode, color, nanoid } from "agency-lang";
+import { smoltalk } from "agency-lang";
+import path from "path";
+import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import {
+  RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
+  setupNode, setupFunction, runNode, runPrompt, callHook,
+  checkpoint as __checkpoint_impl, getCheckpoint as __getCheckpoint_impl, restore as __restore_impl, _run as __runtime_run_impl,
+  interrupt, isInterrupt, hasInterrupts, isDebugger, isRejected, isApproved, interruptWithHandlers, debugStep,
+  respondToInterrupts as _respondToInterrupts,
+  rewindFrom as _rewindFrom,
+  RestoreSignal,
+  deepClone as __deepClone,
+  deepFreeze as __deepFreeze,
+  head, tail, empty,
+  success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
+  Schema, __validateType, __validateChain, __validateChainRecursive,
+  readSkill as _readSkillRaw,
+  readSkillTool as __readSkillTool,
+  readSkillToolParams as __readSkillToolParams,
+  AgencyFunction as __AgencyFunction, UNSET as __UNSET,
+  __call, __callMethod,
+  functionRefReviver as __functionRefReviver,
+  DeterministicClient as __DeterministicClient,
+} from "agency-lang/runtime";
+import {
+  __internal_applyExtractionResult,
+  __internal_applyForgetResult,
+  __internal_buildExtractionPrompt,
+  __internal_buildForgetPrompt,
+  __internal_forget,
+  __internal_recall,
+  __internal_remember,
+  __internal_setMemoryId,
+  __internal_shouldRunMemory,
+} from "agency-lang/stdlib-lib/memory.js";
+import {
+  __internal_assistantMessage,
+  __internal_getCost,
+  __internal_getTokens,
+  __internal_systemMessage,
+  __internal_userMessage,
+} from "agency-lang/stdlib-lib/thread.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const __cwd = __process.cwd();
+
+const getDirname = () => __dirname;
+
+const __globalCtx = new RuntimeContext({
+  statelogConfig: {
+    host: "https://statelog.adit.io",
+    apiKey: __process.env["STATELOG_API_KEY"] || "",
+    projectId: "",
+    debugMode: false,
+    observability: false
+  },
+  smoltalkDefaults: {
+    openAiApiKey: __process.env["OPENAI_API_KEY"] || "",
+    googleApiKey: __process.env["GEMINI_API_KEY"] || "",
+    model: "gpt-4o-mini",
+    logLevel: "warn",
+    statelog: {
+      host: "https://statelog.adit.io",
+      projectId: "smoltalk",
+      apiKey: __process.env["STATELOG_SMOLTALK_API_KEY"] || "",
+      traceId: nanoid()
+    }
+  },
+  dirname: __dirname,
+  logLevel: "info",
+  traceConfig: {
+    program: "schemaParamInjection.agency"
+  }
+});
+const graph = __globalCtx.graph;
+
+// Path-dependent builtin wrappers
+export function readSkill({filepath}: {filepath: string}): string {
+  return _readSkillRaw({ filepath, dirname: __dirname });
+}
+
+// Handler result builtins and interrupt response constructors (unified types)
+export function approve(value?: any) { return { type: "approve" as const, value }; }
+export function reject(value?: any) { return { type: "reject" as const, value }; }
+function propagate() { return { type: "propagate" as const }; }
+
+// Interrupt and rewind re-exports bound to this module's context
+export { interrupt, isInterrupt, hasInterrupts, isDebugger };
+export const respondToInterrupts = (interrupts: Interrupt[], responses: InterruptResponse[], opts?: { overrides?: Record<string, unknown>; metadata?: Record<string, any> }) => _respondToInterrupts({ ctx: __globalCtx, interrupts, responses, overrides: opts?.overrides, metadata: opts?.metadata });
+export const rewindFrom = (checkpoint: Checkpoint, overrides: Record<string, unknown>, opts?: { metadata?: Record<string, any> }) => _rewindFrom({ ctx: __globalCtx, checkpoint, overrides, metadata: opts?.metadata });
+
+export const __setDebugger = (dbg: any) => { __globalCtx.debuggerState = dbg; };
+// Reconfigure the trace file path at runtime. Mutates the module-level
+// traceConfig; the next call to runNode (mod.main / mod.someNode) will
+// truncate the file and per-execCtx writers will append to it for the
+// duration of that run. NOTE: traceFile is process-wide and cannot be
+// used safely with concurrent runs of the same agent — for production
+// concurrency, use traceDir instead (each run gets its own
+// {traceDir}/{runId}.agencytrace).
+export const __setTraceFile = (filePath: string) => {
+  __globalCtx.traceConfig.traceFile = filePath;
+};
+export const __setLLMClient = (client: LLMClient) => { __globalCtx.setLLMClient(client); };
+export const __getCheckpoints = () => __globalCtx.checkpoints;
+
+// Auto-activate the deterministic LLM client when AGENCY_LLM_MOCKS is set.
+// The test runner (lib/cli/util.ts) populates this env var as a JSON string
+// when AGENCY_USE_TEST_LLM_PROVIDER=1. Both the agency evaluate template
+// and the agency-js test.js paths import this module, so this single block
+// covers both code paths.
+if (__process.env.AGENCY_LLM_MOCKS) {
+  __globalCtx.setLLMClient(
+    new __DeterministicClient(JSON.parse(__process.env.AGENCY_LLM_MOCKS))
+  );
+}
+
+export const __toolRegistry: Record<string, any> = {};
+
+function __registerTool(value: unknown, name?: string) {
+  if (__AgencyFunction.isAgencyFunction(value)) {
+    __toolRegistry[name ?? value.name] = value;
+  }
+}
+
+// Wrap stateful runtime functions as AgencyFunction instances
+const checkpoint = __AgencyFunction.create({ name: "checkpoint", module: "__runtime", fn: __checkpoint_impl, params: [], toolDefinition: null }, __toolRegistry);
+const getCheckpoint = __AgencyFunction.create({ name: "getCheckpoint", module: "__runtime", fn: __getCheckpoint_impl, params: [{ name: "checkpointId", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const restore = __AgencyFunction.create({ name: "restore", module: "__runtime", fn: __restore_impl, params: [{ name: "checkpointIdOrCheckpoint", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "options", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+const _run = __AgencyFunction.create({ name: "_run", module: "__runtime", fn: __runtime_run_impl, params: [{ name: "compiled", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "node", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "args", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "wallClock", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "memory", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "ipcPayload", hasDefault: false, defaultValue: undefined, variadic: false }, { name: "stdout", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry);
+function setLLMClient(client: LLMClient) {
+  __globalCtx.setLLMClient(client);
+}
+
+
+function registerTools(tools: any[]) {
+  for (const tool of tools) {
+    if (__AgencyFunction.isAgencyFunction(tool)) {
+      __toolRegistry[tool.name] = tool;
+    }
+  }
+}
+
+async function __initializeGlobals(__ctx) {
+  __ctx.globals.markInitialized("schemaParamInjection.agency")
+}
+__toolRegistry["readSkill"] = __AgencyFunction.create({
+  name: "readSkill",
+  module: "schemaParamInjection.agency",
+  fn: readSkill,
+  params: __readSkillToolParams.map(p => ({ name: p, hasDefault: false, defaultValue: undefined, variadic: false })),
+  toolDefinition: __readSkillTool,
+}, __toolRegistry);
+__functionRefReviver.registry = __toolRegistry;
+//  Verifies the schema-parameter-injection feature.
+// 
+//  When a function declares a Schema<...> parameter and the caller does
+//  not pass it explicitly, the compiler injects a Zod schema synthesized
+//  from the LHS type annotation.
+async function __parseValue_impl(input: string, s: Schema<any>, __state: InternalFunctionState | undefined = undefined) {
+  const __setupData = setupFunction({
+    state: __state
+  });
+  // __state will be undefined if this function is being called as a tool by an llm
+  const __stateStack = __setupData.stateStack;
+const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state?.ctx || __globalCtx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("schemaParamInjection.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onFunctionStart",
+    data: {
+      functionName: "parseValue",
+      args: {
+        input: input,
+        s: s
+      },
+      isBuiltin: false,
+      moduleId: "schemaParamInjection.agency"
+    }
+  })
+  __stack.args["input"] = input;
+  __stack.args["s"] = s;
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "schemaParamInjection.agency", scopeName: "parseValue" });
+  let __resultCheckpointId = -1;
+if (__ctx.stateStack.currentNodeId()) {
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "schemaParamInjection.agency", scopeName: "parseValue", stepPath: "", label: "result-entry" });
+}
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+  if ("input" in __overrides) {
+    input = __overrides["input"];
+    __stack.args["input"] = input;
+  }
+  if ("s" in __overrides) {
+    s = __overrides["s"];
+    __stack.args["s"] = s;
+  }
+
+}
+
+  try {
+    await runner.step(0, async (runner) => {
+__functionCompleted = true;
+runner.halt(await __callMethod(__stack.args.s, "parseJSON", {
+        type: "positional",
+        args: [__stack.args.input]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      }))
+return;
+    });
+    if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: __ctx.getResultCheckpoint(),
+    retryable: __self.__retryable,
+    functionName: "parseValue",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    __stateStack.pop()
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "parseValue",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
+const parseValue = __AgencyFunction.create({
+  name: "parseValue",
+  module: "schemaParamInjection.agency",
+  fn: __parseValue_impl,
+  params: [{
+    name: "input",
+    hasDefault: false,
+    defaultValue: undefined,
+    variadic: false
+  }, {
+    name: "s",
+    hasDefault: false,
+    defaultValue: undefined,
+    variadic: false
+  }],
+  toolDefinition: {
+    name: "parseValue",
+    description: "No description provided.",
+    schema: z.object({"input": z.string(), "s": z.string(), })
+  },
+  safe: false,
+  exported: false
+}, __toolRegistry);
+async function __wrapper_impl(__state: InternalFunctionState | undefined = undefined) {
+  const __setupData = setupFunction({
+    state: __state
+  });
+  // __state will be undefined if this function is being called as a tool by an llm
+  const __stateStack = __setupData.stateStack;
+const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state?.ctx || __globalCtx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  if (!__ctx.globals.isInitialized("schemaParamInjection.agency")) {
+    await __initializeGlobals(__ctx)
+  }
+  let __funcStartTime: number = performance.now();
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onFunctionStart",
+    data: {
+      functionName: "wrapper",
+      args: {},
+      isBuiltin: false,
+      moduleId: "schemaParamInjection.agency"
+    }
+  })
+  __self.__retryable = __self.__retryable ?? true;
+  const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "schemaParamInjection.agency", scopeName: "wrapper" });
+  let __resultCheckpointId = -1;
+if (__ctx.stateStack.currentNodeId()) {
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "schemaParamInjection.agency", scopeName: "wrapper", stepPath: "", label: "result-entry" });
+}
+if (__ctx._pendingArgOverrides) {
+  const __overrides = __ctx._pendingArgOverrides;
+  __ctx._pendingArgOverrides = undefined;
+
+}
+
+  try {
+    await runner.step(0, async (runner) => {
+//  Return-position injection: outer return type provides the hint.
+    });
+    await runner.step(1, async (runner) => {
+__functionCompleted = true;
+runner.halt(await __call(parseValue, {
+        type: "named",
+        positionalArgs: [`[1,2,3]`],
+        namedArgs: {
+          s: new Schema(z.array(z.number()))
+        }
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      }))
+return;
+    });
+    if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+return failure(
+  __error instanceof Error ? __error.message : String(__error),
+  {
+    checkpoint: __ctx.getResultCheckpoint(),
+    retryable: __self.__retryable,
+    functionName: "wrapper",
+    args: __stack.args,
+  }
+);
+
+  } finally {
+    __stateStack.pop()
+    if (__functionCompleted) {
+      await callHook({
+        callbacks: __ctx.callbacks,
+        name: "onFunctionEnd",
+        data: {
+          functionName: "wrapper",
+          timeTaken: performance.now() - __funcStartTime
+        }
+      })
+    }
+  }
+}
+const wrapper = __AgencyFunction.create({
+  name: "wrapper",
+  module: "schemaParamInjection.agency",
+  fn: __wrapper_impl,
+  params: [],
+  toolDefinition: {
+    name: "wrapper",
+    description: "No description provided.",
+    schema: z.object({})
+  },
+  safe: false,
+  exported: false
+}, __toolRegistry);
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({
+    state: __state
+  });
+  const __stateStack = __state.ctx.stateStack;
+const __stack = __setupData.stack;
+const __step = __setupData.step;
+const __self = __setupData.self;
+const __threads = __setupData.threads;
+const __ctx = __state.ctx;
+const statelogClient = __ctx.statelogClient;
+const __graph = __ctx.graph;
+let __forked;
+let __functionCompleted = false;
+  await callHook({
+    callbacks: __ctx.callbacks,
+    name: "onNodeStart",
+    data: {
+      nodeName: "main"
+    }
+  })
+  const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "schemaParamInjection.agency", scopeName: "main" });
+  try {
+    await runner.step(0, async (runner) => {
+//  LHS-annotation injection — Schema<any> inside parseValue receives
+//  z.array(z.number()) synthesized from `number[]`.
+    });
+    await runner.step(1, async (runner) => {
+__stack.locals.nums = await __call(parseValue, {
+        type: "named",
+        positionalArgs: [`[1,2,3]`],
+        namedArgs: {
+          s: new Schema(z.array(z.number()))
+        }
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      });
+if (hasInterrupts(__stack.locals.nums)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __stack.locals.nums
+        })
+        return;
+      }
+    });
+    await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+        type: "positional",
+        args: [__stack.locals.nums]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      });
+if (hasInterrupts(__funcResult)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __funcResult
+        })
+        return;
+      }
+//  `any` LHS — degenerate but valid: injects `z.any()`. No assertion
+//  about runtime shape, just verifies it compiles.
+    });
+    await runner.step(3, async (runner) => {
+__stack.locals.anything = await __call(parseValue, {
+        type: "named",
+        positionalArgs: [`42`],
+        namedArgs: {
+          s: new Schema(z.any())
+        }
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      });
+if (hasInterrupts(__stack.locals.anything)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __stack.locals.anything
+        })
+        return;
+      }
+    });
+    await runner.step(4, async (runner) => {
+const __funcResult = await __call(print, {
+        type: "positional",
+        args: [__stack.locals.anything]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      });
+if (hasInterrupts(__funcResult)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __funcResult
+        })
+        return;
+      }
+//  `!` validation on the LHS: injection still fires with the bare
+//  type. `!` triggers a separate runtime validation pass at the
+//  assignment site; the injected schema and the validator schema are
+//  built from the same LHS type, so they agree.
+    });
+    await runner.step(5, async (runner) => {
+__stack.locals.validated = await __call(parseValue, {
+        type: "named",
+        positionalArgs: [`[1,2,3]`],
+        namedArgs: {
+          s: new Schema(z.array(z.number()))
+        }
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      });
+if (hasInterrupts(__stack.locals.validated)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __stack.locals.validated
+        })
+        return;
+      }
+__stack.locals.validated = __validateType(__stack.locals.validated, z.array(z.number()));
+    });
+    await runner.step(6, async (runner) => {
+const __funcResult = await __call(print, {
+        type: "positional",
+        args: [__stack.locals.validated]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      });
+if (hasInterrupts(__funcResult)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __funcResult
+        })
+        return;
+      }
+//  Explicit override: the user-supplied schema wins, no injection.
+    });
+    await runner.step(7, async (runner) => {
+__stack.locals.explicit = await __call(parseValue, {
+        type: "positional",
+        args: [`[1,2,3]`, new Schema(z.any())]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      });
+if (hasInterrupts(__stack.locals.explicit)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __stack.locals.explicit
+        })
+        return;
+      }
+    });
+    await runner.step(8, async (runner) => {
+const __funcResult = await __call(print, {
+        type: "positional",
+        args: [__stack.locals.explicit]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      });
+if (hasInterrupts(__funcResult)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __funcResult
+        })
+        return;
+      }
+//  Bare expression statement — no LHS, no return position, no injection.
+//  The Schema param is omitted; the function would fail at runtime
+//  because s is undefined. This case exists to lock in "no spooky
+//  injection without a clear context."
+    });
+    await runner.step(9, async (runner) => {
+const __funcResult = await __call(parseValue, {
+        type: "positional",
+        args: [`[1,2,3]`]
+      }, {
+        ctx: __ctx,
+        threads: __threads,
+        stateStack: __stateStack
+      });
+if (hasInterrupts(__funcResult)) {
+        await __ctx.pendingPromises.awaitAll()
+        runner.halt({
+          ...__state,
+          data: __funcResult
+        })
+        return;
+      }
+    });
+    if (runner.halted) return runner.haltResult;
+    await callHook({
+      callbacks: __ctx.callbacks,
+      name: "onNodeEnd",
+      data: {
+        nodeName: "main",
+        data: undefined
+      }
+    })
+    return {
+      messages: __threads,
+      data: undefined
+    };
+  } catch (__error) {
+    if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    console.error(`\nAgent crashed: ${__error.message}`)
+    console.error(__error.stack)
+    return {
+      messages: __threads,
+      data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })
+    };
+  }
+})
+export async function main({ messages, callbacks }: { messages?: any; callbacks?: any } = {}): Promise<RunNodeResult<any>> {
+  return runNode({
+    ctx: __globalCtx,
+    nodeName: "main",
+    data: {},
+    messages: messages,
+    callbacks: callbacks,
+    initializeGlobals: __initializeGlobals
+  });
+}
+export const __mainNodeParams = [];
+if (__process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    const initialState = {
+      messages: new ThreadStore(),
+      data: {}
+    };
+    await main(initialState)
+  } catch (__error: any) {
+    console.error(`\nAgent crashed: ${__error.message}`)
+    throw __error
+  }
+}
+export default graph
+export const __sourceMap = {"schemaParamInjection.agency:parseValue":{"0":{"line":7,"col":2}},"schemaParamInjection.agency:wrapper":{"1":{"line":12,"col":2}},"schemaParamInjection.agency:main":{"1":{"line":18,"col":2},"2":{"line":19,"col":2},"3":{"line":23,"col":2},"4":{"line":24,"col":2},"5":{"line":30,"col":2},"6":{"line":31,"col":2},"7":{"line":34,"col":2},"8":{"line":35,"col":2},"9":{"line":41,"col":2}}};


### PR DESCRIPTION
## Summary

Adds a compile-time feature: when a function declares a `Schema<...>` parameter and the caller does not pass it explicitly, the compiler synthesizes a Zod schema from the call's expected type (an LHS annotation or enclosing return type) and injects it as the missing argument.

This generalizes the magic that today lives as a special case inside `processLlmCall` — instead of being tied to the `llm()` builtin, any user function can declare a `Schema<...>` parameter and benefit from automatic schema generation at call sites.

## Why

The longer-term goal is to move `llm()` out of the compiler and into Agency code (see `docs/superpowers/specs/2026-05-20-llm-as-agency-function-design.md`). A prerequisite is a general mechanism for "compile-time schema injection from a type hint." This PR adds that mechanism without yet touching `llm()` itself — `processLlmCall` is unchanged.

The feature is independently useful for user-defined structured-output wrappers (custom `llm`-style functions, typed JSON parsers, etc.). It is not expected to see heavy day-to-day use; it lives in the `appendix/` section of the docs.

## How it works

The injection lives in a new preprocessor pass, `injectSchemaArgs`. It walks the AST, looks for assignments and `return` statements whose RHS is a function call to a known function with a `Schema<...>` parameter, and — when the parameter is not supplied explicitly — appends a synthetic `schemaExpression` AST node as a named argument. Codegen for `schemaExpression` already exists; no builder changes were needed.

The type checker treats `Schema<...>` parameters as optional for arity purposes so that calls without the argument do not error before the preprocessor fills them in.

Pipeline: `parse → type check (Schema params optional) → preprocess (injection happens here) → builder → emit`.

## Constraints / known v1 limitations

These are documented in the appendix and can be relaxed in future iterations:

- **At most one Schema parameter per function.** There is only one expected-type slot at any call site, so multiple Schema params have no sensible meaning. Compile-time error if declared.
- **LHS / return-position injection only.** Argument-position injection (`foo(parseValue("hi"))` where `foo`'s param type drives the hint), pipe-chain injection, partial-application injection, and type-alias-named-Schema injection are all out of scope for this PR.
- **No special compile error for "missing arg, no hint."** A bare `parseValue("hi")` with no LHS just doesn't inject; the function receives `undefined` and fails at runtime when it tries to use the schema.

## Precedence rules

When all three sources of a schema arg could apply:

1. **Explicit argument wins.** Whether positional or named.
2. **LHS hint wins over a default.** If the caller omits the arg and the LHS / return-position is annotated, the synthesized schema is used.
3. **Default wins last.** Only fires when there's no explicit arg and no hint.

## Tests

- Unit tests for the `schemaParam` helpers (`isSchemaTypeHint`, `findSchemaParam` — including the multi-Schema-param error).
- Unit tests for `injectSchemaArgsInProgram` covering LHS injection, return-position injection, explicit positional and named overrides, no-hint no-op, multi-Schema-param error, and unknown-function no-op.
- Generator fixture (`tests/typescriptGenerator/schemaParamInjection.agency` ↔ `.mjs`) covering LHS injection, return-position injection, `any` LHS (`z.any()`), `!` validation interaction, explicit override, and bare-expression no-op.
- Runtime test (`tests/agency/schema-param-injection.test.json`) exercising the feature end-to-end via the deterministic test runner.

## Files

- `lib/utils/schemaParam.ts` (new) — shared helpers.
- `lib/preprocessors/injectSchemaArgs.ts` (new) — the injection pass.
- `lib/preprocessors/typescriptPreprocessor.ts` — wire the pass in.
- `lib/typeChecker/checker.ts` — relax arity rule for Schema params.
- `docs/site/appendix/schema-parameter-injection.md` (new) — user-facing docs.
- `docs/site/.vitepress/config.mts` — sidebar entries.
- Tests as listed above.

## Out of scope (future work)

- Moving `llm()`'s body into Agency code (the bigger refactor in `2026-05-20-llm-as-agency-function-design.md`).
- True generic functions (`def foo<T>(...)`).
- Removing `processLlmCall` from the builder.
