### PR TITLE
Replace callback keyword with scoped callback() stdlib function

### DIFF
--- a/packages/agency-lang/docs/misc/lifecycleHooks.md
+++ b/packages/agency-lang/docs/misc/lifecycleHooks.md
@@ -72,41 +72,6 @@ await approveInterrupt(response, { callbacks });
 await rejectInterrupt(response, { callbacks });
 ```
 
-## Modifying Messages in LLM Hooks
-
-The `onLLMCallStart` and `onLLMCallEnd` hooks receive the current `messages` array (as serialized `MessageJSON[]`) and can optionally return a new messages array to replace it.
-
-### Modifying messages before the LLM call
-
-Return a new array from `onLLMCallStart` to change what gets sent to the model:
-
-```ts
-const callbacks: AgencyCallbacks = {
-  onLLMCallStart: ({ messages, prompt, model }) => {
-    // Add a system message before every LLM call
-    return [
-      { role: "system", content: "Always respond in JSON." },
-      ...messages,
-    ];
-  },
-};
-```
-
-### Modifying messages after the LLM response
-
-Return a new array from `onLLMCallEnd` to change the conversation history going forward:
-
-```ts
-const callbacks: AgencyCallbacks = {
-  onLLMCallEnd: ({ messages, result }) => {
-    // Remove the first message (e.g. a one-shot system prompt)
-    return messages.slice(1);
-  },
-};
-```
-
-If the callback does not return a value (or returns `undefined`), the messages are left unchanged. You can also mutate the `messages` array in-place; since it is passed by reference, changes will be reflected without needing to return a new array.
-
 ## Hook Data Reference
 
 ### `onAgentStart`
@@ -166,7 +131,7 @@ Fires when a `def` function finishes executing.
 
 ### `onLLMCallStart`
 
-Fires before an LLM call is made. Can return a `MessageJSON[]` to replace the messages sent to the model.
+Fires before an LLM call is made.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -177,7 +142,7 @@ Fires before an LLM call is made. Can return a `MessageJSON[]` to replace the me
 
 ### `onLLMCallEnd`
 
-Fires after an LLM response is received. Can return a `MessageJSON[]` to replace the message history going forward.
+Fires after an LLM response is received.
 
 | Field | Type | Description |
 |-------|------|-------------|

--- a/packages/agency-lang/docs/site/appendix/callbacks.md
+++ b/packages/agency-lang/docs/site/appendix/callbacks.md
@@ -5,10 +5,18 @@ Agency exposes a number of hooks. It's possible to write callbacks for these hoo
 ## Callbacks in Agency files
 
 ```ts
-callback onNodeStart(data) {
-  print(`Node ${node.id} started.`)
+import { callback } from "std::agency"
+
+callback("onNodeStart") as data {
+  print(`Node ${data.nodeName} started.`)
 }
 ```
+
+Callbacks registered with `callback(name, fn)` are scoped to the dynamic
+extent of the function or node that calls `callback(...)`. When that function
+or node returns, the callback is automatically unregistered. Callbacks
+registered at module top-level (outside any function or node) are active for
+the entire run.
 
 ## Callbacks in TypeScript
 

--- a/packages/agency-lang/docs/site/stdlib/agency.md
+++ b/packages/agency-lang/docs/site/stdlib/agency.md
@@ -60,7 +60,7 @@ type FilterImportsResult = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L122))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L134))
 
 ## Functions
 
@@ -82,6 +82,28 @@ Compile Agency source code. Returns a CompiledProgram on success, or a failure w
 **Returns:** `Result`
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L28))
+
+### callback
+
+```ts
+callback(name: string, fn: any)
+```
+
+Register a scoped callback for the dynamic extent of the calling function or node.
+  When the caller returns, the callback is automatically removed. Top-level callbacks
+  (registered outside any function or node) are active for the whole run.
+
+  @param name - One of the Agency callback hook names (e.g. "onNodeStart", "onFunctionStart", "onLLMCallEnd")
+  @param fn - A function that receives the event data
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| name | `string` |  |
+| fn | `any` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L36))
 
 ### run
 
@@ -117,7 +139,7 @@ Execute a compiled Agency program in a subprocess. The parent's handler chain ex
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L36))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L48))
 
 ### runFile
 
@@ -159,7 +181,7 @@ Compile and execute an Agency file in a subprocess. The file is read from dir/fi
 
 **Throws:** `std::run`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L80))
 
 ### typecheck
 
@@ -181,7 +203,7 @@ Type-check Agency source code without compiling or running it. Returns a TypeChe
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L123))
 
 ### parseAST
 
@@ -203,7 +225,7 @@ Parse Agency source code into an abstract syntax tree. Returns the raw AST as a 
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L139))
 
 ### writeAST
 
@@ -235,7 +257,7 @@ Format an AST as Agency source and write it to dir/filename. The AST is typicall
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L138))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L150))
 
 ### format
 
@@ -257,7 +279,7 @@ Format Agency source code using the standard Agency formatter (the same one used
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L176))
 
 ### formatFile
 
@@ -285,7 +307,7 @@ Format an Agency file in place. Reads dir/filename, formats it with the standard
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L175))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L187))
 
 ### walkAST
 
@@ -311,7 +333,7 @@ Walk every node in a deep-cloned copy of the AST, invoking the visitor with each
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L193))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L205))
 
 ### getNodesOfType
 
@@ -335,7 +357,7 @@ Parse Agency source code and return all AST nodes whose `type` field matches any
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L211))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L223))
 
 ### getImports
 
@@ -355,7 +377,7 @@ Return all import statements in the source (i.e. `import { x } from "..."`).
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L223))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L235))
 
 ### getFunctions
 
@@ -375,7 +397,7 @@ Return all function definitions (`def foo(...) { ... }`) in the source.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L232))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L244))
 
 ### getGraphNodes
 
@@ -395,7 +417,7 @@ Return all graph node definitions (`node main() { ... }`) in the source. Note: "
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L241))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L253))
 
 ### filterImports
 
@@ -438,7 +460,7 @@ Parse Agency source, drop imports that fail the policy, and return the resulting
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L250))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L262))
 
 ### typecheckFile
 
@@ -468,4 +490,4 @@ Type-check an Agency file on disk. The file is read from dir/filename, and relat
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L284))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agency.agency#L296))

--- a/packages/agency-lang/lib/agents/policy/agent.agency
+++ b/packages/agency-lang/lib/agents/policy/agent.agency
@@ -2,16 +2,17 @@ import { writePolicyFile } from "std::policy"
 import { args } from "std::system"
 import { systemMessage } from "std::thread"
 import { map } from "std::array"
+import { callback } from "std::agency"
 
 // crap these comments dont stay in place! So can't ignore a type error
 // in an import
 // @tc-ignore
 
-callback onToolCallStart(data) {
+callback("onToolCallStart") as data {
   print("Calling ${data.toolName}...")
 }
 
-callback onToolCallEnd(data) {
+callback("onToolCallEnd") as data {
   print("Finished calling ${data.toolName}.")
 }
 

--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -275,14 +275,6 @@ describe("AgencyGenerator - Class Definitions", () => {
     expect(output).toContain("new Counter(0)");
   });
 
-  it("should format callback declarations with the callback keyword", () => {
-    const input = `callback onLLMCallEnd(data) {
-  log(data)
-}`;
-    const output = formatAgency(input);
-    expect(output).toContain("callback onLLMCallEnd(data)");
-    expect(output).not.toContain("def onLLMCallEnd");
-  });
 });
 
 describe("AgencyGenerator - Doc Comments", () => {

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -788,7 +788,7 @@ export class AgencyGenerator {
     const prefixes: string[] = [];
     if (node.exported) prefixes.push("export");
     if (node.safe) prefixes.push("safe");
-    prefixes.push(node.callback ? "callback" : "def");
+    prefixes.push("def");
 
     const prefix = `${prefixes.join(" ")} ${functionName}`;
     const renderedParams = this.renderParams(parameters);

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1612,7 +1612,7 @@ export class TypeScriptBuilder {
     });
 
     const implName = `__${functionName}_impl`;
-    const setupStmts = this.buildFunctionBody({ functionName, parameters, bodyCode, skipHooks: node.callback, hoistedAliases });
+    const setupStmts = this.buildFunctionBody({ functionName, parameters, bodyCode, skipHooks: false, hoistedAliases });
 
     const funcDecl = ts.functionDecl(implName, fnParams, ts.statements(setupStmts), {
       async: true,
@@ -1652,14 +1652,6 @@ export class TypeScriptBuilder {
 
     const constDecl = ts.varDecl("const", functionName, createCall);
     const exportedConst = node.exported ? ts.export(constDecl) : constDecl;
-
-    if (node.callback) {
-      return ts.statements([
-        funcDecl,
-        exportedConst,
-        ts.raw(`__globalCtx._registeredCallbacks.${functionName} = ${functionName};`),
-      ]);
-    }
 
     return ts.statements([funcDecl, exportedConst]);
   }

--- a/packages/agency-lang/lib/ir/builders.ts
+++ b/packages/agency-lang/lib/ir/builders.ts
@@ -516,7 +516,7 @@ export const ts = {
     const dataNode = "kind" in data ? data as TsNode : ts.obj(data as Record<string, TsNode>);
     return ts.awaitCall(ts.id("callHook"), [
       ts.obj({
-        callbacks: ts.prop(ts.runtime.ctx, "callbacks"),
+        ctx: ts.runtime.ctx,
         name: ts.str(hookName),
         data: dataNode,
       }),

--- a/packages/agency-lang/lib/parsers/function.test.ts
+++ b/packages/agency-lang/lib/parsers/function.test.ts
@@ -3510,65 +3510,10 @@ describe("classMethodParser with safe keyword", () => {
   });
 });
 
-describe("callback declarations", () => {
-  it("parses a basic callback", () => {
+describe("callback keyword is no longer supported", () => {
+  it("does not parse `callback` as a function declaration", () => {
     const result = functionParser(`callback onLLMCallEnd(data) { log(data) }`);
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.result.type).toBe("function");
-      expect(result.result.callback).toBe(true);
-      expect(result.result.functionName).toBe("onLLMCallEnd");
-      expect(result.result.parameters).toHaveLength(1);
-      expect(result.result.parameters[0].name).toBe("data");
-    }
-  });
-
-  it("throws on unknown callback names", () => {
-    expect(() => functionParser(`callback onFoo(data) { log(data) }`)).toThrow("Unknown callback 'onFoo'");
-  });
-
-  it("throws on exported callbacks", () => {
-    expect(() => functionParser(`export callback onLLMCallEnd(data) { log(data) }`)).toThrow("cannot be exported");
-  });
-
-  it("throws on safe callbacks", () => {
-    expect(() => functionParser(`safe callback onLLMCallEnd(data) { log(data) }`)).toThrow("cannot be marked safe");
-  });
-
-  it("throws when callback has no parameters", () => {
-    expect(() => functionParser(`callback onNodeStart() { log("hi") }`)).toThrow("must declare exactly one parameter");
-  });
-
-  it("throws when callback has multiple parameters", () => {
-    expect(() => functionParser(`callback onNodeStart(a, b) { log(a) }`)).toThrow("must declare exactly one parameter");
-  });
-
-  it("throws when callback parameter is variadic", () => {
-    expect(() => functionParser(`callback onNodeStart(...data) { log(data) }`)).toThrow("cannot be variadic");
-  });
-
-  it("parses all valid callback names", () => {
-    const validNames = [
-      "onAgentStart", "onAgentEnd", "onNodeStart", "onNodeEnd",
-      "onLLMCallStart", "onLLMCallEnd", "onFunctionStart", "onFunctionEnd",
-      "onToolCallStart", "onToolCallEnd", "onStream", "onTrace",
-    ];
-    for (const name of validNames) {
-      const result = functionParser(`callback ${name}(data) { log(data) }`);
-      expect(result.success).toBe(true);
-      if (result.success) {
-        expect(result.result.callback).toBe(true);
-        expect(result.result.functionName).toBe(name);
-      }
-    }
-  });
-
-  it("def functions do not have callback set", () => {
-    const result = functionParser(`def test() { log("hi") }`);
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.result.callback).toBeUndefined();
-    }
+    expect(result.success).toBe(false);
   });
 });
 

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -64,7 +64,6 @@ import {
   Expression,
   FunctionCall,
   FunctionDefinition,
-  VALID_CALLBACK_NAMES,
   FunctionParameter,
   InterpolationSegment,
   Literal,
@@ -3478,7 +3477,7 @@ const _baseFunctionParser: Parser<any> = trace(
   "_baseFunctionParser",
   seqC(
     set("type", "function"),
-    capture(or(str("callback"), str("def")), "keyword"),
+    capture(str("def"), "keyword"),
     many1(space),
     capture(many1Till(char("(")), "functionName"),
     char("("),
@@ -3523,7 +3522,7 @@ const safeKeywordParser: Parser<boolean> = or(
   succeed(false),
 );
 
-// Parse "export" and "safe" in any order before "def"/"callback"
+// Parse "export" and "safe" in any order before "def"
 function parseFunctionModifiers(input: string): { success: true; rest: string; isExported: boolean; isSafe: boolean } | { success: false } {
   let rest = input;
   let isExported = false;
@@ -3561,42 +3560,11 @@ const _functionParserInner: Parser<FunctionDefinition> = (input: string) => {
   const baseResult = _baseFunctionParser(mods.rest);
   if (!baseResult.success) return baseResult;
 
-  const { keyword, returnTypeValidated: _rtv, ...rest } = baseResult.result as any;
+  const { keyword: _keyword, returnTypeValidated: _rtv, ...rest } = baseResult.result as any;
   const result = { ...rest } as FunctionDefinition;
   if (_rtv) result.returnTypeValidated = true;
-  const isCallback = keyword === "callback";
   if (isExported) result.exported = true;
   if (isSafe) result.safe = true;
-  if (isCallback) {
-    result.callback = true;
-    if (isExported) {
-      throw new Error(`Callback '${result.functionName}' cannot be exported`);
-    }
-    if (isSafe) {
-      throw new Error(`Callback '${result.functionName}' cannot be marked safe`);
-    }
-    const validNames: ReadonlySet<string> = new Set(VALID_CALLBACK_NAMES);
-    if (!validNames.has(result.functionName)) {
-      throw new Error(
-        `Unknown callback '${result.functionName}'. Valid callbacks: ${VALID_CALLBACK_NAMES.join(", ")}`,
-      );
-    }
-    if (result.parameters.length !== 1) {
-      throw new Error(
-        `Callback '${result.functionName}' must declare exactly one parameter`,
-      );
-    }
-    if (result.parameters[0].variadic) {
-      throw new Error(
-        `Callback '${result.functionName}' parameter '${result.parameters[0].name}' cannot be variadic`,
-      );
-    }
-    if (result.parameters[0].defaultValue) {
-      throw new Error(
-        `Callback '${result.functionName}' parameter '${result.parameters[0].name}' cannot have a default value`,
-      );
-    }
-  }
 
   // Validate parameter ordering: required → optional (with defaults) → variadic
   const params = result.parameters;

--- a/packages/agency-lang/lib/runtime/hooks.test.ts
+++ b/packages/agency-lang/lib/runtime/hooks.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
+import { AgencyFunction } from "./agencyFunction.js";
+import { AgencyCancelledError, RestoreSignal } from "./errors.js";
 import { callHook } from "./hooks.js";
 import { State, StateStack } from "./state/stateStack.js";
 
@@ -68,18 +70,28 @@ describe("callHook (rewritten)", () => {
     consoleErr.mockRestore();
   });
 
-  it("propagates interrupt errors", async () => {
-    const interrupt = Object.assign(new Error("interrupt"), {
-      __agencyInterrupt: true,
-    });
+  it("rethrows RestoreSignal control-flow errors", async () => {
+    const signal = new RestoreSignal({ id: 1 } as any);
     const inner = new State();
     inner.scopedCallbacks = [
-      { name: "onNodeStart", fn: () => { throw interrupt; } },
+      { name: "onNodeStart", fn: () => { throw signal; } },
     ];
     const ctx = ctxWithStack([inner]);
     await expect(
       callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any),
-    ).rejects.toBe(interrupt);
+    ).rejects.toBe(signal);
+  });
+
+  it("rethrows AgencyCancelledError", async () => {
+    const cancelled = new AgencyCancelledError("user cancelled");
+    const inner = new State();
+    inner.scopedCallbacks = [
+      { name: "onNodeStart", fn: () => { throw cancelled; } },
+    ];
+    const ctx = ctxWithStack([inner]);
+    await expect(
+      callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any),
+    ).rejects.toBe(cancelled);
   });
 
   it("TS-passed onLLMCallStart return value is discarded (message override removed)", async () => {
@@ -133,6 +145,37 @@ describe("callHook (rewritten)", () => {
     const ctx = ctxWithStack([frame]);
     await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
     expect(calls).toEqual(["a", "b", "c"]);
+  });
+
+  it("throws loudly when a callback halts with an unhandled Interrupt[]", async () => {
+    // Simulate an AgencyFunction callback body that produced an interrupt
+    // value (i.e. interrupt was raised inside the callback and no handler
+    // on the call stack caught it). callHook must surface this instead of
+    // silently dropping the interrupt.
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+    const fakeInterrupt = { type: "interrupt", kind: "myapp::oops", message: "x" };
+    const callbackFn = AgencyFunction.create(
+      {
+        name: "__bad_cb",
+        module: "test",
+        fn: async () => [fakeInterrupt],
+        params: [{ name: "data", hasDefault: false, defaultValue: undefined, variadic: false }],
+        toolDefinition: null,
+      },
+      {},
+    );
+    const inner = new State();
+    inner.scopedCallbacks = [{ name: "onNodeStart", fn: callbackFn }];
+    const ctx = ctxWithStack([inner]);
+    await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
+    // Error is logged (not rethrown — fireWithGuard's catch turns it into a
+    // console.error to keep one buggy callback from killing the whole run),
+    // but it MUST be visible.
+    expect(consoleErr).toHaveBeenCalled();
+    const logged = consoleErr.mock.calls.map((c) => String(c[1])).join("\n");
+    expect(logged).toMatch(/unhandled interrupt/i);
+    expect(logged).toMatch(/myapp::oops/);
+    consoleErr.mockRestore();
   });
 
   it("per-instance recursion guard skips re-entry of the same fn", async () => {

--- a/packages/agency-lang/lib/runtime/hooks.test.ts
+++ b/packages/agency-lang/lib/runtime/hooks.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from "vitest";
+import { callHook } from "./hooks.js";
+import { State, StateStack } from "./state/stateStack.js";
+
+function ctxWithStack(
+  stack: State[],
+  tsCallbacks: any = {},
+  topLevelCallbacks: Array<{ name: string; fn: any }> = [],
+): any {
+  const stateStack = new StateStack();
+  stateStack.stack = stack;
+  return { stateStack, callbacks: tsCallbacks, topLevelCallbacks };
+}
+
+describe("callHook (rewritten)", () => {
+  it("fires scoped callbacks innermost → outermost", async () => {
+    const calls: string[] = [];
+    const outer = new State();
+    outer.scopedCallbacks = [
+      { name: "onNodeStart", fn: () => { calls.push("outer"); } },
+    ];
+    const inner = new State();
+    inner.scopedCallbacks = [
+      { name: "onNodeStart", fn: () => { calls.push("inner"); } },
+    ];
+    const ctx = ctxWithStack([outer, inner]);
+    await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
+    expect(calls).toEqual(["inner", "outer"]);
+  });
+
+  it("fires TS-passed callback last", async () => {
+    const calls: string[] = [];
+    const inner = new State();
+    inner.scopedCallbacks = [
+      { name: "onNodeStart", fn: () => { calls.push("scoped"); } },
+    ];
+    const ctx = ctxWithStack([inner], { onNodeStart: () => { calls.push("ts"); } });
+    await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
+    expect(calls).toEqual(["scoped", "ts"]);
+  });
+
+  it("ignores callback return values (no message override)", async () => {
+    const inner = new State();
+    inner.scopedCallbacks = [
+      { name: "onLLMCallEnd", fn: () => ["overridden"] },
+    ];
+    const ctx = ctxWithStack([inner]);
+    const result = await callHook({
+      ctx,
+      name: "onLLMCallEnd",
+      data: {},
+    } as any);
+    expect(result).toBeUndefined();
+  });
+
+  it("catches and logs ordinary errors, continues firing others", async () => {
+    const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
+    const calls: string[] = [];
+    const inner = new State();
+    inner.scopedCallbacks = [
+      { name: "onNodeStart", fn: () => { throw new Error("boom"); } },
+      { name: "onNodeStart", fn: () => { calls.push("after"); } },
+    ];
+    const ctx = ctxWithStack([inner]);
+    await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
+    expect(calls).toEqual(["after"]);
+    expect(consoleErr).toHaveBeenCalled();
+    consoleErr.mockRestore();
+  });
+
+  it("propagates interrupt errors", async () => {
+    const interrupt = Object.assign(new Error("interrupt"), {
+      __agencyInterrupt: true,
+    });
+    const inner = new State();
+    inner.scopedCallbacks = [
+      { name: "onNodeStart", fn: () => { throw interrupt; } },
+    ];
+    const ctx = ctxWithStack([inner]);
+    await expect(
+      callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any),
+    ).rejects.toBe(interrupt);
+  });
+
+  it("TS-passed onLLMCallStart return value is discarded (message override removed)", async () => {
+    const ctx = ctxWithStack(
+      [new State()],
+      { onLLMCallStart: () => [{ role: "system", content: "OVERRIDE" }] as any },
+    );
+    const result = await callHook({
+      ctx,
+      name: "onLLMCallStart",
+      data: { messages: [{ role: "user", content: "original" }] },
+    } as any);
+    expect(result).toBeUndefined();
+  });
+
+  it("fires scoped → top-level → TS-passed (in that order)", async () => {
+    const calls: string[] = [];
+    const inner = new State();
+    inner.scopedCallbacks = [
+      { name: "onNodeStart", fn: () => { calls.push("scoped"); } },
+    ];
+    const ctx = ctxWithStack(
+      [inner],
+      { onNodeStart: () => { calls.push("ts"); } },
+      [{ name: "onNodeStart", fn: () => { calls.push("topLevel"); } }],
+    );
+    await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
+    expect(calls).toEqual(["scoped", "topLevel", "ts"]);
+  });
+
+  it("filters topLevelCallbacks by name", async () => {
+    const calls: string[] = [];
+    const ctx = ctxWithStack(
+      [new State()],
+      {},
+      [
+        { name: "onNodeStart", fn: () => { calls.push("matching"); } },
+        { name: "onNodeEnd", fn: () => { calls.push("other"); } },
+      ],
+    );
+    await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
+    expect(calls).toEqual(["matching"]);
+  });
+
+  it("multiple distinct callbacks for the same event all fire in order", async () => {
+    const calls: string[] = [];
+    const frame = new State();
+    frame.addScopedCallback("onNodeStart", () => { calls.push("a"); });
+    frame.addScopedCallback("onNodeStart", () => { calls.push("b"); });
+    frame.addScopedCallback("onNodeStart", () => { calls.push("c"); });
+    const ctx = ctxWithStack([frame]);
+    await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
+    expect(calls).toEqual(["a", "b", "c"]);
+  });
+
+  it("per-instance recursion guard skips re-entry of the same fn", async () => {
+    let depth = 0;
+    let maxDepth = 0;
+    const ctxHolder: { ctx: any } = { ctx: undefined };
+    const fn = async (data: any) => {
+      depth++;
+      maxDepth = Math.max(maxDepth, depth);
+      if (depth < 5) {
+        await callHook({ ctx: ctxHolder.ctx, name: "onNodeStart", data } as any);
+      }
+      depth--;
+    };
+    const inner = new State();
+    inner.scopedCallbacks = [{ name: "onNodeStart", fn }];
+    ctxHolder.ctx = ctxWithStack([inner]);
+    await callHook({ ctx: ctxHolder.ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
+    expect(maxDepth).toBe(1);
+  });
+});

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -7,6 +7,8 @@ import type {
   ToolCallJSON,
 } from "smoltalk";
 import type { CallbackName } from "../types/function.js";
+import { AgencyFunction } from "./agencyFunction.js";
+import type { RuntimeContext } from "./state/context.js";
 import type { TraceEvent } from "./trace/types.js";
 import type { RunNodeResult } from "./types.js";
 
@@ -62,22 +64,20 @@ export type CallbackMap = {
 type _AssertNamesMatchMap = CallbackName extends keyof CallbackMap ? keyof CallbackMap extends CallbackName ? true : false : false;
 const _callbackNamesInSync: _AssertNamesMatchMap = true;
 
-export type CallbackReturn<K extends keyof CallbackMap> = K extends
-  | "onLLMCallStart"
-  | "onLLMCallEnd"
-  ? MessageJSON[] | void
-  : void;
+/** All callbacks (scoped + top-level + TS-passed) now return `void`. The old
+ *  message-override capability on `onLLMCallStart`/`onLLMCallEnd` has been
+ *  removed — return values are discarded. */
+export type CallbackReturn<K extends keyof CallbackMap> = void;
 
 export type AgencyCallbacks = {
   [K in keyof CallbackMap]?: (
     data: CallbackMap[K],
-  ) => CallbackReturn<K> | Promise<CallbackReturn<K>>;
+  ) => void | Promise<void>;
 };
 
-// Tracks which hooks are currently executing to prevent infinite recursion
-// when a callback calls a helper function that would re-trigger the same hook.
-// Keyed by callbacks object so concurrent executions don't block each other.
-const _activeHooks = new WeakMap<AgencyCallbacks, Set<string>>();
+// Per-instance recursion guard: prevents a callback that triggers helper
+// functions which re-fire the same hook from recursing into itself.
+const _activeCallbacks = new WeakSet<object>();
 
 // Global hook registry: allows external packages (e.g., @agency-lang/mcp) to
 // register callbacks that fire alongside user-provided callbacks.
@@ -93,41 +93,74 @@ export function registerGlobalHook<K extends keyof CallbackMap>(
   _globalHooks[name]!.push(fn);
 }
 
+function isAgencyInterrupt(e: unknown): boolean {
+  return !!(e && typeof e === "object" && (e as any).__agencyInterrupt === true);
+}
+
+async function invokeCallback(
+  fn: any,
+  data: unknown,
+  ctx: RuntimeContext<any>,
+): Promise<void> {
+  if (AgencyFunction.isAgencyFunction(fn)) {
+    await (fn as AgencyFunction).invoke(
+      { type: "positional", args: [data] },
+      { ctx },
+    );
+    return;
+  }
+  await fn(data);
+}
+
+async function fireWithGuard(
+  fn: any,
+  data: unknown,
+  ctx: RuntimeContext<any>,
+  errorLabel: string,
+): Promise<void> {
+  const key = fn as object;
+  if (_activeCallbacks.has(key)) return;
+  _activeCallbacks.add(key);
+  try {
+    await invokeCallback(fn, data, ctx);
+  } catch (error) {
+    if (isAgencyInterrupt(error)) throw error;
+    console.error(`[agency] ${errorLabel} callback error:`, error);
+  } finally {
+    _activeCallbacks.delete(key);
+  }
+}
+
+function gatherCallbacks<K extends keyof CallbackMap>(
+  ctx: RuntimeContext<any>,
+  name: K,
+): any[] {
+  // Order: innermost stack-frame scoped callbacks → outermost → top-level
+  // (registered during module init) → TS-passed callback. Top-level comes
+  // after stack-walked because conceptually they are "the outermost scope".
+  const scoped = ctx.stateStack.collectScopedCallbacks(name);
+  const topLevel = (ctx.topLevelCallbacks ?? [])
+    .filter((cb) => cb.name === name)
+    .map((cb) => cb.fn);
+  const tsCb = ctx.callbacks[name];
+  const out: any[] = [...scoped, ...topLevel];
+  if (tsCb) out.push(tsCb);
+  return out;
+}
+
 export async function callHook<K extends keyof CallbackMap>(args: {
-  callbacks: AgencyCallbacks;
+  ctx: RuntimeContext<any>;
   name: K;
   data: CallbackMap[K];
-}): Promise<CallbackReturn<K> | undefined> {
-  const { callbacks, name, data } = args;
+}): Promise<void> {
+  const { ctx, name, data } = args;
 
-  // Fire global hooks (from external packages)
-  const globalFns = _globalHooks[name];
-  if (globalFns) {
-    for (const fn of globalFns) {
-      try {
-        await fn(data);
-      } catch (error) {
-        console.error(`[agency] global ${name} hook error:`, error);
-      }
-    }
+  // Fire global hooks (from external packages) first
+  for (const fn of _globalHooks[name] ?? []) {
+    await fireWithGuard(fn, data, ctx, `global ${name}`);
   }
 
-  const hook = callbacks[name];
-  if (!hook) return undefined;
-  let active = _activeHooks.get(callbacks);
-  if (!active) {
-    active = new Set();
-    _activeHooks.set(callbacks, active);
+  for (const fn of gatherCallbacks(ctx, name)) {
+    await fireWithGuard(fn, data, ctx, name);
   }
-  if (!active.has(name)) {
-    active.add(name);
-    try {
-      return (await hook(data)) as CallbackReturn<K>;
-    } catch (error) {
-      console.error(`[agency] ${name} callback error:`, error);
-    } finally {
-      active.delete(name);
-    }
-  }
-  return undefined;
 }

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -8,6 +8,8 @@ import type {
 } from "smoltalk";
 import type { CallbackName } from "../types/function.js";
 import { AgencyFunction } from "./agencyFunction.js";
+import { AgencyCancelledError, RestoreSignal } from "./errors.js";
+import { hasInterrupts } from "./interrupts.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { TraceEvent } from "./trace/types.js";
 import type { RunNodeResult } from "./types.js";
@@ -93,20 +95,30 @@ export function registerGlobalHook<K extends keyof CallbackMap>(
   _globalHooks[name]!.push(fn);
 }
 
-function isAgencyInterrupt(e: unknown): boolean {
-  return !!(e && typeof e === "object" && (e as any).__agencyInterrupt === true);
-}
-
 async function invokeCallback(
   fn: any,
   data: unknown,
   ctx: RuntimeContext<any>,
+  errorLabel: string,
 ): Promise<void> {
   if (AgencyFunction.isAgencyFunction(fn)) {
-    await (fn as AgencyFunction).invoke(
+    const result = await (fn as AgencyFunction).invoke(
       { type: "positional", args: [data] },
       { ctx },
     );
+    // If the callback body halts with an unhandled Interrupt[] (i.e. an
+    // `interrupt` statement was executed inside the callback body but no
+    // enclosing `handle` block caught it), surface it instead of silently
+    // dropping it. Callbacks fire outside the normal step-driven control
+    // flow, so we can't propagate the interrupt up the call stack; the only
+    // safe behavior is to fail loudly.
+    if (hasInterrupts(result)) {
+      throw new Error(
+        `[agency] ${errorLabel} callback raised an unhandled interrupt ` +
+        `(kind="${result[0].kind}"). Interrupts inside callbacks must be ` +
+        `caught by a \`handle\` block on the enclosing call stack.`,
+      );
+    }
     return;
   }
   await fn(data);
@@ -122,9 +134,11 @@ async function fireWithGuard(
   if (_activeCallbacks.has(key)) return;
   _activeCallbacks.add(key);
   try {
-    await invokeCallback(fn, data, ctx);
+    await invokeCallback(fn, data, ctx, errorLabel);
   } catch (error) {
-    if (isAgencyInterrupt(error)) throw error;
+    // Never swallow real control-flow exceptions used by the runtime.
+    if (error instanceof RestoreSignal) throw error;
+    if (error instanceof AgencyCancelledError) throw error;
     console.error(`[agency] ${errorLabel} callback error:`, error);
   } finally {
     _activeCallbacks.delete(key);

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -375,7 +375,6 @@ export async function respondToInterrupts(args: {
   }
   execCtx.restoreState(checkpoint);
   execCtx.setInterruptResponses(responseMap);
-  execCtx.installRegisteredCallbacks(ctx);
   if (metadata.callbacks) Object.assign(execCtx.callbacks, metadata.callbacks);
   if (metadata.debugger) execCtx.debuggerState = metadata.debugger;
 

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -133,8 +133,8 @@ export async function runNode({
   if (initializeGlobals) {
     await initializeGlobals(execCtx);
   }
-  execCtx.installRegisteredCallbacks(ctx);
-  // Externally-passed callbacks override registered ones and receive only data.
+  // Externally-passed callbacks are stored on ctx; hook execution merges them
+  // with scoped/top-level callbacks at call time.
   if (callbacks) {
     Object.assign(execCtx.callbacks, callbacks);
   }
@@ -151,7 +151,7 @@ export async function runNode({
   }
 
   await callHook({
-    callbacks: execCtx.callbacks,
+    ctx: execCtx,
     name: "onAgentStart",
     data: { nodeName, args: data, messages: messages || [], cancel },
   });
@@ -199,7 +199,7 @@ export async function runNode({
             tokenStats: returnObject.tokens,
           });
           await callHook({
-            callbacks: execCtx.callbacks,
+            ctx: execCtx,
             name: "onAgentEnd",
             data: { nodeName, result: returnObject },
           });

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -54,8 +54,8 @@ async function _runPrompt({
   const stream = !!(clientConfig as any)?.stream;
   const startTime = performance.now();
 
-  const startHookResult = await callHook({
-    callbacks: ctx.callbacks,
+  await callHook({
+    ctx,
     name: "onLLMCallStart",
     data: {
       prompt,
@@ -64,9 +64,6 @@ async function _runPrompt({
       messages: messages.toJSON().messages,
     },
   });
-  if (startHookResult) {
-    messages = MessageThread.fromJSON(startHookResult);
-  }
 
   // Re-check after hook — cancellation may have occurred during the callback
   if (ctx.isCancelled(stateStack)) {
@@ -194,8 +191,8 @@ async function _runPrompt({
     }
   }
 
-  const endHookResult = await callHook({
-    callbacks: ctx.callbacks,
+  await callHook({
+    ctx,
     name: "onLLMCallEnd",
     data: {
       model: JSON.stringify(modelName),
@@ -206,9 +203,6 @@ async function _runPrompt({
       messages: messages.toJSON().messages,
     },
   });
-  if (endHookResult) {
-    messages = MessageThread.fromJSON(endHookResult);
-  }
 
   return { messages, toolCalls };
 }
@@ -487,7 +481,7 @@ export async function runPrompt(args: {
 
         const namedArgs = { ...toolCall.arguments };
         await callHook({
-          callbacks: ctx.callbacks,
+          ctx,
           name: "onToolCallStart",
           data: { toolName: handler.name, args: namedArgs },
         });
@@ -613,7 +607,7 @@ export async function runPrompt(args: {
 
         const toolCallEndTime = performance.now();
         await callHook({
-          callbacks: ctx.callbacks,
+          ctx,
           name: "onToolCallEnd",
           data: {
             toolName: handler.name,

--- a/packages/agency-lang/lib/runtime/rewind.ts
+++ b/packages/agency-lang/lib/runtime/rewind.ts
@@ -38,7 +38,6 @@ export async function rewindFrom(args: {
   execCtx.restoreState(checkpoint);
   execCtx._skipNextCheckpoint = true;
 
-  execCtx.installRegisteredCallbacks(ctx);
   if (metadata.callbacks) {
     Object.assign(execCtx.callbacks, metadata.callbacks);
   }

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -4,7 +4,6 @@ import type { DebuggerState } from "../../debugger/debuggerState.js";
 import type { LogLevel } from "../../logger.js";
 import { SimpleMachine } from "../../simplemachine/index.js";
 import { StatelogClient, StatelogConfig } from "../../statelogClient.js";
-import { AgencyFunction } from "../agencyFunction.js";
 import { reviveWithClasses, type ClassRegistry } from "../classReviver.js";
 import { CoverageCollector } from "../coverageCollector.js";
 import { AgencyCancelledError } from "../errors.js";
@@ -106,16 +105,10 @@ export class RuntimeContext<T> {
   // this is the directory that the runtime is running in. We need this to be able to read files relative to the runtime.
   dirname: string;
 
-  // Callback functions registered via the `callback` keyword in Agency code.
-  // Stored separately from `callbacks` so that runNode can wrap them with the
-  // current execution context. We can't register them directly on `callbacks`
-  // because they need access to the per-execution ctx (for globals, state stack,
-  // etc.), but at registration time only __globalCtx exists. External TypeScript
-  // callers pass callbacks via runNode's `callbacks` option and should NOT receive
-  // the execution context — wrapping at execution time keeps that boundary clean.
-  _registeredCallbacks: Partial<
-    Record<keyof AgencyCallbacks, (...args: any[]) => any>
-  > = {};
+  /** Callbacks registered at module top-level (via `_callback` during
+   *  `__initializeGlobals`, when no real caller frame exists yet). Persist for
+   *  the whole run. */
+  topLevelCallbacks: Array<{ name: string; fn: any }> = [];
 
   // class registry for serialization/deserialization of Agency class instances
   classRegistry: ClassRegistry = {};
@@ -241,7 +234,7 @@ export class RuntimeContext<T> {
     execCtx.checkpoints = new CheckpointStore(this.maxRestores);
     execCtx.handlers = [];
     execCtx.callbacks = {};
-    execCtx._registeredCallbacks = {};
+    execCtx.topLevelCallbacks = [];
     execCtx.onStreamLock = false;
     execCtx._skipNextCheckpoint = false;
     execCtx._restoreCount = 0;
@@ -334,23 +327,6 @@ export class RuntimeContext<T> {
   async threads. But we could just replace all calls to `forkStack`
   with `new StateStack()`.
   */
-  /**
-   * Install Agency-defined callbacks (from `callback` declarations) onto this
-   * execution context, wrapping each one to inject ctx so it accesses the
-   * correct per-execution globals/state.
-   */
-  installRegisteredCallbacks(source: RuntimeContext<T>): void {
-    for (const name in source._registeredCallbacks) {
-      const fn = source._registeredCallbacks[name as keyof AgencyCallbacks]!;
-      (this.callbacks as any)[name] = (data: any) => {
-        if (AgencyFunction.isAgencyFunction(fn)) {
-          return fn.invoke({ type: "positional", args: [data] }, { ctx: this });
-        }
-        return (fn as (...args: any[]) => any)(data, { ctx: this });
-      };
-    }
-  }
-
   pushHandler(fn: HandlerFn): void {
     this.handlers.push(fn);
   }

--- a/packages/agency-lang/lib/runtime/state/stateStack.test.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { StateStack, State, BranchState } from "./stateStack.js";
+import { _callbackImpl } from "../../stdlib/agency.js";
 
 type FrameOpts = {
   args?: Record<string, any>;
@@ -295,5 +296,141 @@ describe("StateStack localCost/localTokens/seedCost serialization", () => {
     expect(restored.localTokens).toBe(0);
     expect(restored.seedCost).toBe(0);
     expect(restored.seedTokens).toBe(0);
+  });
+});
+
+describe("State.scopedCallbacks", () => {
+  it("defaults to undefined when no callbacks are registered", () => {
+    expect(new State().scopedCallbacks).toBeUndefined();
+  });
+
+  it("addScopedCallback initializes the array lazily and appends", () => {
+    const state = new State();
+    const fn = () => {};
+    state.addScopedCallback("onNodeStart", fn);
+    state.addScopedCallback("onNodeEnd", fn);
+    expect(state.scopedCallbacks).toEqual([
+      { name: "onNodeStart", fn },
+      { name: "onNodeEnd", fn },
+    ]);
+  });
+
+  it("toJSON/fromJSON round-trip preserves scopedCallbacks (in-memory)", () => {
+    // Verifies State.toJSON/fromJSON pass-through. Full JSON-string round-trip
+    // through nativeTypeReplacer is exercised by the Agency-level resume test
+    // (callback-resume.agency), where fn is a real AgencyFunction.
+    const state = new State();
+    const fn = () => {};
+    state.addScopedCallback("onNodeStart", fn);
+    const restored = State.fromJSON(state.toJSON());
+    expect(restored.scopedCallbacks).toHaveLength(1);
+    expect(restored.scopedCallbacks![0].name).toBe("onNodeStart");
+    expect(restored.scopedCallbacks![0].fn).toBe(fn);
+  });
+
+  it("does not include scopedCallbacks in JSON when empty", () => {
+    expect(new State().toJSON().scopedCallbacks).toBeUndefined();
+  });
+});
+
+describe("StateStack.callerFrame / collectScopedCallbacks", () => {
+  function stackWithFrames(n: number): StateStack {
+    const stack = new StateStack();
+    for (let i = 0; i < n; i++) stack.stack.push(new State());
+    return stack;
+  }
+
+  it("callerFrame returns the second-from-top frame when stack has >= 2 frames", () => {
+    const stack = stackWithFrames(2);
+    expect(stack.callerFrame()).toBe(stack.stack[0]);
+  });
+
+  it("callerFrame falls back to the root frame when stack has 1 frame", () => {
+    const stack = stackWithFrames(1);
+    expect(stack.callerFrame()).toBe(stack.stack[0]);
+  });
+
+  it("callerFrame throws when stack is empty", () => {
+    expect(() => new StateStack().callerFrame()).toThrow();
+  });
+
+  it("collectScopedCallbacks returns innermost → outermost matching the name", () => {
+    const stack = stackWithFrames(3);
+    const a = () => {};
+    const b = () => {};
+    const c = () => {};
+    stack.stack[0].addScopedCallback("onNodeStart", a); // outermost
+    stack.stack[1].addScopedCallback("onNodeStart", b);
+    stack.stack[1].addScopedCallback("onNodeEnd", () => {}); // wrong name, ignored
+    stack.stack[2].addScopedCallback("onNodeStart", c); // innermost
+    expect(stack.collectScopedCallbacks("onNodeStart")).toEqual([c, b, a]);
+  });
+
+  it("collectScopedCallbacks preserves registration order within a single frame", () => {
+    const stack = stackWithFrames(1);
+    const a = () => {};
+    const b = () => {};
+    const c = () => {};
+    stack.stack[0].addScopedCallback("onNodeStart", a);
+    stack.stack[0].addScopedCallback("onNodeStart", b);
+    stack.stack[0].addScopedCallback("onNodeStart", c);
+    expect(stack.collectScopedCallbacks("onNodeStart")).toEqual([a, b, c]);
+  });
+
+  it("collectScopedCallbacks combines same-frame and cross-frame ordering", () => {
+    // Frame layout: outer has two callbacks; inner has one. Result is
+    // inner's callback first, then outer's two in registration order.
+    const stack = stackWithFrames(2);
+    const a = () => {};
+    const b = () => {};
+    const c = () => {};
+    stack.stack[0].addScopedCallback("onNodeStart", a);
+    stack.stack[0].addScopedCallback("onNodeStart", b);
+    stack.stack[1].addScopedCallback("onNodeStart", c);
+    expect(stack.collectScopedCallbacks("onNodeStart")).toEqual([c, a, b]);
+  });
+
+  it("collectScopedCallbacks returns empty when nothing matches", () => {
+    expect(stackWithFrames(2).collectScopedCallbacks("onNodeStart")).toEqual([]);
+  });
+});
+
+describe("_callback", () => {
+  function ctxWithFrames(n: number): any {
+    const stack = new StateStack();
+    for (let i = 0; i < n; i++) stack.stack.push(new State());
+    return { stateStack: stack, topLevelCallbacks: [] };
+  }
+
+  it("registers on the caller frame when stack has >= 2 frames", () => {
+    const ctx = ctxWithFrames(2); // [caller, callback's own frame]
+    const fn = () => {};
+    _callbackImpl("onNodeStart", fn, { ctx } as any);
+    expect(ctx.stateStack.stack[0].scopedCallbacks).toEqual([
+      { name: "onNodeStart", fn },
+    ]);
+    expect(ctx.stateStack.stack[1].scopedCallbacks).toBeUndefined();
+    expect(ctx.topLevelCallbacks).toEqual([]);
+  });
+
+  it("routes to ctx.topLevelCallbacks when stack length <= 1 (module init)", () => {
+    const ctx = ctxWithFrames(1); // only callback's own frame — top level
+    const fn = () => {};
+    _callbackImpl("onNodeStart", fn, { ctx } as any);
+    expect(ctx.topLevelCallbacks).toEqual([{ name: "onNodeStart", fn }]);
+    expect(ctx.stateStack.stack[0].scopedCallbacks).toBeUndefined();
+  });
+
+  it("routes to ctx.topLevelCallbacks when stack is empty (defensive)", () => {
+    const ctx = ctxWithFrames(0);
+    _callbackImpl("onNodeStart", () => {}, { ctx } as any);
+    expect(ctx.topLevelCallbacks).toHaveLength(1);
+  });
+
+  it("throws on unknown callback name", () => {
+    const ctx = ctxWithFrames(2);
+    expect(() =>
+      _callbackImpl("notAHook", () => {}, { ctx } as any),
+    ).toThrow(/Unknown callback/);
   });
 });

--- a/packages/agency-lang/lib/runtime/state/stateStack.test.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.test.ts
@@ -395,6 +395,29 @@ describe("StateStack.callerFrame / collectScopedCallbacks", () => {
   });
 });
 
+describe("StateStack.isGlobalContext", () => {
+  function stackWithFrames(n: number): StateStack {
+    const stack = new StateStack();
+    for (let i = 0; i < n; i++) stack.stack.push(new State());
+    return stack;
+  }
+
+  it("returns true when stack is empty (defensive)", () => {
+    expect(new StateStack().isGlobalContext()).toBe(true);
+  });
+
+  it("returns true when only the callback's own frame is on the stack (top-level)", () => {
+    // When `callback(...)` runs at module top-level (inside __initializeGlobals),
+    // the only frame on the stack is `callback`'s own. There is no real caller.
+    expect(stackWithFrames(1).isGlobalContext()).toBe(true);
+  });
+
+  it("returns false when there is a real caller frame", () => {
+    expect(stackWithFrames(2).isGlobalContext()).toBe(false);
+    expect(stackWithFrames(5).isGlobalContext()).toBe(false);
+  });
+});
+
 describe("_callback", () => {
   function ctxWithFrames(n: number): any {
     const stack = new StateStack();
@@ -432,5 +455,41 @@ describe("_callback", () => {
     expect(() =>
       _callbackImpl("notAHook", () => {}, { ctx } as any),
     ).toThrow(/Unknown callback/);
+  });
+
+  it("throws when fn is a string (non-callable)", () => {
+    const ctx = ctxWithFrames(2);
+    expect(() =>
+      _callbackImpl("onNodeStart", "not a function" as any, { ctx } as any),
+    ).toThrow(/must be a function/i);
+  });
+
+  it("throws when fn is a number (non-callable)", () => {
+    const ctx = ctxWithFrames(2);
+    expect(() =>
+      _callbackImpl("onNodeStart", 42 as any, { ctx } as any),
+    ).toThrow(/must be a function/i);
+  });
+
+  it("throws when fn is null", () => {
+    const ctx = ctxWithFrames(2);
+    expect(() =>
+      _callbackImpl("onNodeStart", null as any, { ctx } as any),
+    ).toThrow(/must be a function/i);
+  });
+
+  it("throws when fn is undefined", () => {
+    const ctx = ctxWithFrames(2);
+    expect(() =>
+      _callbackImpl("onNodeStart", undefined as any, { ctx } as any),
+    ).toThrow(/must be a function/i);
+  });
+
+  it("accepts a plain function", () => {
+    const ctx = ctxWithFrames(2);
+    const fn = (_data: any) => {};
+    expect(() =>
+      _callbackImpl("onNodeStart", fn, { ctx } as any),
+    ).not.toThrow();
   });
 });

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -39,6 +39,7 @@ export class State {
   step: number;
   private branches?: Record<string, BranchState>;
   private deletedBranches?: Set<string>;
+  scopedCallbacks?: Array<{ name: string; fn: any }>;
 
   constructor(
     opts: {
@@ -80,6 +81,13 @@ export class State {
 
   removeDebugFlags(): void {
     this.clearLocalsWithPrefix("__dbg_");
+  }
+
+  /** The sanctioned way to register a scoped callback on this frame. Initializes
+   *  the array on first call so frames with no callbacks pay no overhead. */
+  addScopedCallback(name: string, fn: any): void {
+    if (!this.scopedCallbacks) this.scopedCallbacks = [];
+    this.scopedCallbacks.push({ name, fn });
   }
 
   newBranch(key: string): BranchState {
@@ -163,6 +171,15 @@ export class State {
       threads: this.threads ? deepClone(this.threads) : null,
       step: this.step,
     };
+    if (this.scopedCallbacks && this.scopedCallbacks.length > 0) {
+      // Pass `fn` through as a reference — the outer serializer (with
+      // nativeTypeReplacer) handles AgencyFunctions correctly via the
+      // functionRef registry. deepClone-ing here would lose plain functions.
+      json.scopedCallbacks = this.scopedCallbacks.map((cb) => ({
+        name: cb.name,
+        fn: cb.fn,
+      }));
+    }
     if (this.branches) {
       json.branches = {};
       for (const [key, branch] of Object.entries(this.branches)) {
@@ -192,6 +209,12 @@ export class State {
       threads: json.threads,
       step: json.step,
     });
+    if (json.scopedCallbacks && json.scopedCallbacks.length > 0) {
+      state.scopedCallbacks = json.scopedCallbacks.map((cb) => ({
+        name: cb.name,
+        fn: cb.fn,
+      }));
+    }
     if (json.branches) {
       state.branches = {};
       for (const [key, branch] of Object.entries(json.branches)) {
@@ -215,6 +238,7 @@ export type StateJSON = {
   threads: ThreadStoreJSON | null;
   step: number;
   branches?: Record<string, BranchStateJSON>;
+  scopedCallbacks?: Array<{ name: string; fn: any }>;
 };
 
 export type StateStackJSON = {
@@ -309,6 +333,32 @@ export class StateStack {
 
   lastFrame(): State {
     return this.stack[this.stack.length - 1];
+  }
+
+  /** The frame one below the top. Top is the "current" frame for whatever code
+   *  is running right now; the caller's frame is what owns scoped registrations
+   *  made by the current call. Falls back to the root frame at the top level. */
+  callerFrame(): State {
+    if (this.stack.length === 0) {
+      throw new Error("callerFrame() called on empty stack");
+    }
+    return this.stack.length >= 2
+      ? this.stack[this.stack.length - 2]
+      : this.stack[0];
+  }
+
+  /** All scoped callbacks registered anywhere in the active stack for this hook,
+   *  ordered innermost first (deepest frame's callbacks come first). */
+  collectScopedCallbacks(name: string): any[] {
+    const out: any[] = [];
+    for (let i = this.stack.length - 1; i >= 0; i--) {
+      const cbs = this.stack[i].scopedCallbacks;
+      if (!cbs) continue;
+      for (const cb of cbs) {
+        if (cb.name === name) out.push(cb.fn);
+      }
+    }
+    return out;
   }
 
   static lastFrameJSON(json: StateStackJSON): StateJSON {

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -347,6 +347,14 @@ export class StateStack {
       : this.stack[0];
   }
 
+  /** True when the only frame on the stack is the currently-running call's own
+   *  frame (i.e. there is no caller). This happens during module-level
+   *  initialization (e.g. inside `__initializeGlobals`) where calls like
+   *  `callback(...)` have no real caller frame to register against. */
+  isGlobalContext(): boolean {
+    return this.stack.length <= 1;
+  }
+
   /** All scoped callbacks registered anywhere in the active stack for this hook,
    *  ordered innermost first (deepest frame's callbacks come first). */
   collectScopedCallbacks(name: string): any[] {

--- a/packages/agency-lang/lib/stdlib/agency.ts
+++ b/packages/agency-lang/lib/stdlib/agency.ts
@@ -55,11 +55,16 @@ export function _callbackImpl(
       `Unknown callback '${name}'. Valid: ${VALID_CALLBACK_NAMES.join(", ")}`,
     );
   }
+  if (typeof fn !== "function" && !AgencyFunction.isAgencyFunction(fn)) {
+    throw new Error(
+      `callback('${name}', fn): fn must be a function, got ${fn === null ? "null" : typeof fn}`,
+    );
+  }
   const ctx = __state.ctx;
   // Top-level: we're inside __initializeGlobals. The only frame on the stack
   // is `callback`'s own (or none, defensively). There is no caller frame
   // that survives past init, so route to ctx.topLevelCallbacks.
-  if (ctx.stateStack.stack.length <= 1) {
+  if (ctx.stateStack.isGlobalContext()) {
     ctx.topLevelCallbacks.push({ name, fn });
     return;
   }

--- a/packages/agency-lang/lib/stdlib/agency.ts
+++ b/packages/agency-lang/lib/stdlib/agency.ts
@@ -14,6 +14,68 @@ import {
 import type { AgencyProgram, AgencyNode } from "../types.js";
 import type { ImportStatement } from "../types/importStatement.js";
 import { _write } from "./builtins.js";
+import {
+  VALID_CALLBACK_NAMES,
+  type CallbackName,
+} from "../types/function.js";
+import type { InternalFunctionState } from "../runtime/types.js";
+import { AgencyFunction } from "../runtime/agencyFunction.js";
+
+const VALID_CALLBACK_NAME_SET: ReadonlySet<string> = new Set(VALID_CALLBACK_NAMES);
+
+/**
+ * Register a scoped callback for the dynamic extent of the caller's function
+ * or node. Implementation backing for `callback(name, fn)` in std::agency.
+ *
+ * Frame targeting:
+ *   - At top level (inside `__initializeGlobals`, before any node frame is
+ *     pushed) — route to `ctx.topLevelCallbacks`, which lives on the
+ *     execution context for the whole run.
+ *   - Otherwise — push onto the caller's stack frame, which auto-cleans up
+ *     when the caller's frame pops.
+ *
+ * NOTE on the AgencyFunction wrapping: this function needs access to the
+ * runtime state (to walk the stateStack and find the caller's frame), and
+ * the only way a TS-implemented stdlib export receives that state is by
+ * being wrapped as an AgencyFunction. `__call`'s plain-function branch
+ * silently drops the state argument; the AgencyFunction branch routes
+ * through `invoke()`, which passes state as the last positional arg to the
+ * underlying TS function. See `_run` in `lib/runtime/ipc.ts` for the
+ * established pattern.
+ */
+// Exported as `_callbackImpl` so unit tests can call it directly without
+// going through the AgencyFunction wrapper / `invoke()` indirection.
+export function _callbackImpl(
+  name: string,
+  fn: unknown,
+  __state: InternalFunctionState,
+): void {
+  if (!VALID_CALLBACK_NAME_SET.has(name)) {
+    throw new Error(
+      `Unknown callback '${name}'. Valid: ${VALID_CALLBACK_NAMES.join(", ")}`,
+    );
+  }
+  const ctx = __state.ctx;
+  // Top-level: we're inside __initializeGlobals. The only frame on the stack
+  // is `callback`'s own (or none, defensively). There is no caller frame
+  // that survives past init, so route to ctx.topLevelCallbacks.
+  if (ctx.stateStack.stack.length <= 1) {
+    ctx.topLevelCallbacks.push({ name, fn });
+    return;
+  }
+  ctx.stateStack.callerFrame().addScopedCallback(name as CallbackName, fn);
+}
+
+export const _callback = new AgencyFunction({
+  name: "_callback",
+  module: "agency-lang/stdlib-lib/agency.js",
+  fn: _callbackImpl,
+  params: [
+    { name: "name", hasDefault: false, defaultValue: undefined, variadic: false },
+    { name: "fn", hasDefault: false, defaultValue: undefined, variadic: false },
+  ],
+  toolDefinition: null,
+});
 
 function compileAndPersist(source: string): { moduleId: string; path: string } {
   const result = compileSource(source, {

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache
@@ -1,4 +1,4 @@
-const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads } });
+const __bsetup = setupFunction({ state: { ctx: __ctx, threads: typeof __threads !== "undefined" ? __threads : undefined } });
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 {{#params}}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.ts
@@ -3,7 +3,7 @@
 // Any manual changes will be lost.
 import { apply } from "typestache";
 
-export const template = `const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads } });
+export const template = `const __bsetup = setupFunction({ state: { ctx: __ctx, threads: typeof __threads !== "undefined" ? __threads : undefined } });
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 {{#params}}

--- a/packages/agency-lang/lib/types/function.ts
+++ b/packages/agency-lang/lib/types/function.ts
@@ -52,7 +52,6 @@ export type FunctionDefinition = BaseNode & {
   async?: boolean;
   safe?: boolean;
   exported?: boolean;
-  callback?: boolean;
   tags?: Tag[];
 };
 

--- a/packages/agency-lang/stdlib/agency.agency
+++ b/packages/agency-lang/stdlib/agency.agency
@@ -1,4 +1,4 @@
-import { _compile, _compileFile, _typecheck, _typecheckFile, _parseAST, _writeAST, _format, _formatFile, _walkAST, _getNodesOfType, _filterImports } from "agency-lang/stdlib-lib/agency.js"
+import { _compile, _compileFile, _typecheck, _typecheckFile, _parseAST, _writeAST, _format, _formatFile, _walkAST, _getNodesOfType, _filterImports, _callback } from "agency-lang/stdlib-lib/agency.js"
 
 type CompiledProgram = {
   moduleId: string
@@ -31,6 +31,18 @@ export def compile(source: string): Result {
   @param source - Agency source code as a string
   """
   return try _compile(source)
+}
+
+export def callback(name: string, fn: any) {
+  """
+  Register a scoped callback for the dynamic extent of the calling function or node.
+  When the caller returns, the callback is automatically removed. Top-level callbacks
+  (registered outside any function or node) are active for the whole run.
+
+  @param name - One of the Agency callback hook names (e.g. "onNodeStart", "onFunctionStart", "onLLMCallEnd")
+  @param fn - A function that receives the event data
+  """
+  _callback(name, fn)
 }
 
 export def run(

--- a/packages/agency-lang/tests/agency/builtins/emit.agency
+++ b/packages/agency-lang/tests/agency/builtins/emit.agency
@@ -1,6 +1,8 @@
+import { callback } from "std::agency"
+
 let emittedData = null
 
-callback onEmit(data) {
+callback("onEmit") as data {
   emittedData = data
 }
 

--- a/packages/agency-lang/tests/agency/callback-basic.agency
+++ b/packages/agency-lang/tests/agency/callback-basic.agency
@@ -1,10 +1,12 @@
+import { callback } from "std::agency"
+
 let callbackFired: boolean = false
 
 def helper(): string {
   return "hello"
 }
 
-callback onFunctionStart(data) {
+callback("onFunctionStart") as data {
   callbackFired = true
 }
 

--- a/packages/agency-lang/tests/agency/callback-block-shares-frame.agency
+++ b/packages/agency-lang/tests/agency/callback-block-shares-frame.agency
@@ -1,0 +1,25 @@
+import { callback } from "std::agency"
+
+let fireCount: number = 0
+
+def helper(): string {
+  return "x"
+}
+
+node main() {
+  // Callback is registered inside an if-block, but the block does NOT
+  // push its own frame for callback scoping. The registration must attach
+  // to main()'s frame, so the callback survives past the if-block's end
+  // and fires for helper() calls made after the if-block too.
+  if (true) {
+    callback("onFunctionStart") as data {
+      if (data.functionName == "helper") {
+        fireCount = fireCount + 1
+      }
+    }
+    helper()  // fires → fireCount = 1
+  }
+  helper()    // still inside main → callback should still fire → fireCount = 2
+  helper()    // fireCount = 3
+  return fireCount
+}

--- a/packages/agency-lang/tests/agency/callback-block-shares-frame.test.json
+++ b/packages/agency-lang/tests/agency/callback-block-shares-frame.test.json
@@ -1,0 +1,9 @@
+{
+  "tests": [{
+    "nodeName": "main",
+    "input": "",
+    "expectedOutput": "3",
+    "evaluationCriteria": [{ "type": "exact" }],
+    "description": "callback registered inside a block (if/for/etc.) is scoped to the enclosing function, not the block"
+  }]
+}

--- a/packages/agency-lang/tests/agency/callback-cleanup.agency
+++ b/packages/agency-lang/tests/agency/callback-cleanup.agency
@@ -1,0 +1,25 @@
+import { callback } from "std::agency"
+
+let fireCount: number = 0
+
+def helper(): string {
+  return "x"
+}
+
+def registerAndCall() {
+  callback("onFunctionStart") as data {
+    if (data.functionName == "helper") {
+      fireCount = fireCount + 1
+    }
+  }
+  helper()  // fires the callback → fireCount = 1
+}
+
+node main() {
+  registerAndCall()
+  // After registerAndCall() returns, its frame pops and the scoped callback
+  // is gone. The next helper() call must NOT trigger the callback.
+  helper()
+  helper()
+  return fireCount
+}

--- a/packages/agency-lang/tests/agency/callback-cleanup.test.json
+++ b/packages/agency-lang/tests/agency/callback-cleanup.test.json
@@ -1,0 +1,9 @@
+{
+  "tests": [{
+    "nodeName": "main",
+    "input": "",
+    "expectedOutput": "1",
+    "evaluationCriteria": [{ "type": "exact" }],
+    "description": "scoped callback is cleaned up when the registering function returns"
+  }]
+}

--- a/packages/agency-lang/tests/agency/callback-function-forms.agency
+++ b/packages/agency-lang/tests/agency/callback-function-forms.agency
@@ -1,0 +1,30 @@
+import { callback } from "std::agency"
+
+let blockCount: number = 0
+let namedCount: number = 0
+
+def helper(): string {
+  return "x"
+}
+
+// Named function used as a callback target (no `as data` block syntax).
+def onNamed(data: any) {
+  if (data.functionName == "helper") {
+    namedCount = namedCount + 1
+  }
+}
+
+node main() {
+  // Form 1: trailing as-data block (already covered elsewhere; sanity check)
+  callback("onFunctionStart") as data {
+    if (data.functionName == "helper") {
+      blockCount = blockCount + 1
+    }
+  }
+
+  // Form 2: named function reference
+  callback("onFunctionStart", onNamed)
+
+  helper()
+  return [blockCount, namedCount]
+}

--- a/packages/agency-lang/tests/agency/callback-function-forms.test.json
+++ b/packages/agency-lang/tests/agency/callback-function-forms.test.json
@@ -1,0 +1,9 @@
+{
+  "tests": [{
+    "nodeName": "main",
+    "input": "",
+    "expectedOutput": "[1,1]",
+    "evaluationCriteria": [{ "type": "exact" }],
+    "description": "callback accepts both as-data trailing-block and named-function forms"
+  }]
+}

--- a/packages/agency-lang/tests/agency/callback-interrupt-handled.agency
+++ b/packages/agency-lang/tests/agency/callback-interrupt-handled.agency
@@ -1,0 +1,26 @@
+import { callback } from "std::agency"
+
+let log: string = ""
+
+def guard(block: any) {
+  callback("onFunctionEnd") as data {
+    interrupt myapp::guarded("function ended", data)
+  }
+  block()
+}
+
+def doWork(): string {
+  return "x"
+}
+
+node main() {
+  handle {
+    guard() {
+      doWork()
+    }
+  } with (intr) {
+    log = log + "caught:" + intr.kind + ","
+    return approve()
+  }
+  return log
+}

--- a/packages/agency-lang/tests/agency/callback-interrupt-handled.test.json
+++ b/packages/agency-lang/tests/agency/callback-interrupt-handled.test.json
@@ -1,0 +1,9 @@
+{
+  "tests": [{
+    "nodeName": "main",
+    "input": "",
+    "expectedOutput": "\"caught:myapp::guarded,\"",
+    "evaluationCriteria": [{ "type": "exact" }],
+    "description": "callback interrupt is caught by enclosing handle block"
+  }]
+}

--- a/packages/agency-lang/tests/agency/callback-nested.agency
+++ b/packages/agency-lang/tests/agency/callback-nested.agency
@@ -1,0 +1,35 @@
+import { callback } from "std::agency"
+
+let order: string = ""
+
+def helper(): string {
+  return "x"
+}
+
+def inner() {
+  callback("onFunctionStart") as data {
+    if (data.functionName == "helper") {
+      order = order + "inner,"
+    }
+  }
+  helper()
+}
+
+def outer() {
+  callback("onFunctionStart") as data {
+    if (data.functionName == "helper") {
+      order = order + "outerA,"
+    }
+  }
+  callback("onFunctionStart") as data {
+    if (data.functionName == "helper") {
+      order = order + "outerB,"
+    }
+  }
+  inner()
+}
+
+node main() {
+  outer()
+  return order
+}

--- a/packages/agency-lang/tests/agency/callback-nested.test.json
+++ b/packages/agency-lang/tests/agency/callback-nested.test.json
@@ -1,0 +1,9 @@
+{
+  "tests": [{
+    "nodeName": "main",
+    "input": "",
+    "expectedOutput": "\"inner,outerA,outerB,\"",
+    "evaluationCriteria": [{ "type": "exact" }],
+    "description": "nested callbacks fire innermost-first across frames, registration-order within a frame"
+  }]
+}

--- a/packages/agency-lang/tests/agency/callback-recursion.agency
+++ b/packages/agency-lang/tests/agency/callback-recursion.agency
@@ -1,0 +1,20 @@
+import { callback } from "std::agency"
+
+let fireCount: number = 0
+
+def doWork(): string {
+  return "x"
+}
+
+node main() {
+  callback("onFunctionStart") as data {
+    if (data.functionName == "doWork") {
+      fireCount = fireCount + 1
+      // Calling doWork inside the callback would normally re-fire onFunctionStart.
+      // The recursion guard should skip the re-entry of this same callback.
+      doWork()
+    }
+  }
+  doWork()
+  return fireCount
+}

--- a/packages/agency-lang/tests/agency/callback-recursion.test.json
+++ b/packages/agency-lang/tests/agency/callback-recursion.test.json
@@ -1,0 +1,9 @@
+{
+  "tests": [{
+    "nodeName": "main",
+    "input": "",
+    "expectedOutput": "1",
+    "evaluationCriteria": [{ "type": "exact" }],
+    "description": "per-instance recursion guard prevents self-reentry"
+  }]
+}

--- a/packages/agency-lang/tests/agency/callback-resume.agency
+++ b/packages/agency-lang/tests/agency/callback-resume.agency
@@ -1,0 +1,25 @@
+import { callback } from "std::agency"
+
+let observed: string = ""
+
+// Top-level callback. We expect this to remain active across the
+// interrupt/resume round-trip. (Currently fails — see the topLevelCallbacks
+// architectural issue.)
+callback("onFunctionStart") as data {
+  if (data.functionName == "helper") {
+    observed = observed + "fired,"
+  }
+}
+
+def helper(): string {
+  return "x"
+}
+
+node main() {
+  // Interrupt forces the host to serialize and resume execution. The
+  // helper() call below only runs after deserialize, so if the callback
+  // fires for it, we know the registration survives the round-trip.
+  const _y = interrupt("pause")
+  helper()
+  return observed
+}

--- a/packages/agency-lang/tests/agency/callback-resume.test.json
+++ b/packages/agency-lang/tests/agency/callback-resume.test.json
@@ -1,0 +1,21 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "top-level callback survives interrupt serialization and fires after resume",
+      "input": "",
+      "expectedOutput": "\"fired,\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "expectedMessage": "pause"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/callback-scoped.agency
+++ b/packages/agency-lang/tests/agency/callback-scoped.agency
@@ -1,0 +1,24 @@
+import { callback } from "std::agency"
+
+let fireCount: number = 0
+
+def helper(): string {
+  return "hello"
+}
+
+def withCallback(): boolean {
+  callback("onFunctionStart") as data {
+    fireCount = fireCount + 1
+  }
+  helper()
+  helper()
+  return true
+}
+
+node main() {
+  withCallback()
+  helper()
+  withCallback()
+  helper()
+  return fireCount
+}

--- a/packages/agency-lang/tests/agency/callback-scoped.test.json
+++ b/packages/agency-lang/tests/agency/callback-scoped.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "4",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "description": "scoped callback fires only inside its scope; cleanup makes repeated wrapper calls behave independently"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/callback-toplevel.agency
+++ b/packages/agency-lang/tests/agency/callback-toplevel.agency
@@ -1,0 +1,19 @@
+import { callback } from "std::agency"
+
+let fireCount: number = 0
+
+callback("onFunctionStart") as data {
+  if (data.functionName == "helper") {
+    fireCount = fireCount + 1
+  }
+}
+
+def helper(): string {
+  return "x"
+}
+
+node main() {
+  helper()
+  helper()
+  return fireCount
+}

--- a/packages/agency-lang/tests/agency/callback-toplevel.test.json
+++ b/packages/agency-lang/tests/agency/callback-toplevel.test.json
@@ -1,0 +1,9 @@
+{
+  "tests": [{
+    "nodeName": "main",
+    "input": "",
+    "expectedOutput": "2",
+    "evaluationCriteria": [{ "type": "exact" }],
+    "description": "top-level callback fires for the whole run"
+  }]
+}

--- a/packages/agency-lang/tests/agency/memory/llm-injection.agency
+++ b/packages/agency-lang/tests/agency/memory/llm-injection.agency
@@ -1,4 +1,5 @@
 import { setMemoryId, remember } from "std::memory"
+import { callback } from "std::agency"
 
 // Stores a fact, then makes an llm() call with memory: true. The
 // memory layer should inject a "Relevant context from memory:" system
@@ -9,7 +10,7 @@ import { setMemoryId, remember } from "std::memory"
 // (the deterministic client returns the next mock for any prompt).
 let injected: boolean = false
 
-callback onLLMCallStart(data) {
+callback("onLLMCallStart") as data {
   for (msg in data.messages) {
     if (msg.role == "system" && msg.content != null) {
       const idx = msg.content.indexOf("Relevant context from memory:")

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -198,7 +198,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "add",
@@ -263,7 +263,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "add",
@@ -311,7 +311,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -355,7 +355,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -193,7 +193,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -229,7 +229,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -193,7 +193,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -262,7 +262,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -193,7 +193,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -218,7 +218,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -198,7 +198,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "double",
@@ -254,7 +254,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "double",
@@ -302,7 +302,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "addAndDouble",
@@ -379,7 +379,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "addAndDouble",
@@ -427,7 +427,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -462,7 +462,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -193,7 +193,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -219,7 +219,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -207,7 +207,7 @@ if (hasInterrupts(__stack.locals.bar)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -179,7 +179,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "safeLookup",
@@ -239,7 +239,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "safeLookup",
@@ -287,7 +287,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "unsafeSave",
@@ -363,7 +363,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "unsafeSave",
@@ -406,7 +406,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -447,7 +447,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -222,7 +222,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -268,7 +268,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -207,7 +207,7 @@ if (hasInterrupts(__stack.locals.bar)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "compute",
@@ -245,7 +245,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "compute",
@@ -288,7 +288,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -350,7 +350,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -220,7 +220,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "append",
@@ -246,7 +246,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "append",
@@ -294,7 +294,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -351,7 +351,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "process",
@@ -250,7 +250,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "process",
@@ -293,7 +293,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -339,7 +339,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "process",
@@ -230,7 +230,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "process",
@@ -273,7 +273,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -319,7 +319,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -174,7 +174,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -206,7 +206,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "twice",
@@ -260,7 +260,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "twice",
@@ -303,7 +303,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -315,7 +315,7 @@ let __functionCompleted = false;
 __stack.locals.results = await __call(twice, {
         type: "positional",
         args: [__AgencyFunction.create({ name: "__block_0", module: "blockBasic.agency", fn: async () => {
-          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads } });
+          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: typeof __threads !== "undefined" ? __threads : undefined } });
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 
@@ -364,7 +364,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "mapItems",
@@ -271,7 +271,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "mapItems",
@@ -319,7 +319,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -334,7 +334,7 @@ __stack.locals.items = [1, 2, 3];
 __stack.locals.doubled = await __call(mapItems, {
         type: "positional",
         args: [__stack.locals.items, __AgencyFunction.create({ name: "__block_0", module: "blockParams.agency", fn: async (x: any) => {
-          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads } });
+          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: typeof __threads !== "undefined" ? __threads : undefined } });
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 
@@ -385,7 +385,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -231,7 +231,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
@@ -190,7 +190,7 @@ if (!__ctx.globals.isInitialized("class-basic.agency")) {
     }
 let __funcStartTime: number = performance.now();
 await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onFunctionStart",
       data: {
         functionName: "Counter.increment",
@@ -239,7 +239,7 @@ return failure(
       __stateStack.pop()
       if (__functionCompleted) {
         await callHook({
-          callbacks: __ctx.callbacks,
+          ctx: __ctx,
           name: "onFunctionEnd",
           data: {
             functionName: "Counter.increment",
@@ -286,7 +286,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -323,7 +323,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
@@ -190,7 +190,7 @@ if (!__ctx.globals.isInitialized("class-inheritance.agency")) {
     }
 let __funcStartTime: number = performance.now();
 await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onFunctionStart",
       data: {
         functionName: "Animal.speak",
@@ -239,7 +239,7 @@ return failure(
       __stateStack.pop()
       if (__functionCompleted) {
         await callHook({
-          callbacks: __ctx.callbacks,
+          ctx: __ctx,
           name: "onFunctionEnd",
           data: {
             functionName: "Animal.speak",
@@ -306,7 +306,7 @@ if (!__ctx.globals.isInitialized("class-inheritance.agency")) {
     }
 let __funcStartTime: number = performance.now();
 await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onFunctionStart",
       data: {
         functionName: "Dog.speak",
@@ -355,7 +355,7 @@ return failure(
       __stateStack.pop()
       if (__functionCompleted) {
         await callHook({
-          callbacks: __ctx.callbacks,
+          ctx: __ctx,
           name: "onFunctionEnd",
           data: {
             functionName: "Dog.speak",
@@ -406,7 +406,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -436,7 +436,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -185,7 +185,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "greet",
@@ -238,7 +238,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "greet",
@@ -276,7 +276,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -353,7 +353,7 @@ await __call(print, {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -189,7 +189,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "greet",
@@ -258,7 +258,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "greet",

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -181,7 +181,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "add",
@@ -235,7 +235,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "add",
@@ -289,7 +289,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "greet",
@@ -337,7 +337,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "greet",
@@ -385,7 +385,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "calculateArea",
@@ -439,7 +439,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "calculateArea",
@@ -498,7 +498,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "processData",
@@ -539,7 +539,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "processData",
@@ -582,7 +582,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "versionedTool",
@@ -623,7 +623,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "versionedTool",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -174,7 +174,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -208,7 +208,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -174,7 +174,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -223,7 +223,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -174,7 +174,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -207,7 +207,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -179,7 +179,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "isPalindrome",
@@ -263,7 +263,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "isPalindrome",
@@ -306,7 +306,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -364,7 +364,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -179,7 +179,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "gcd",
@@ -255,7 +255,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "gcd",
@@ -308,7 +308,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "lcm",
@@ -374,7 +374,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "lcm",
@@ -422,7 +422,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -462,7 +462,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -175,7 +175,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -209,7 +209,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -179,7 +179,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "isPrime",
@@ -296,7 +296,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "isPrime",
@@ -339,7 +339,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -386,7 +386,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -180,7 +180,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "toDigit",
@@ -359,7 +359,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "toDigit",
@@ -402,7 +402,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -466,7 +466,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -174,7 +174,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -226,7 +226,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -179,7 +179,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "isPrime",
@@ -296,7 +296,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "isPrime",
@@ -339,7 +339,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -386,7 +386,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -275,7 +275,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "add",
@@ -258,7 +258,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "add",
@@ -311,7 +311,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "greet",
@@ -383,7 +383,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "greet",
@@ -431,7 +431,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "mixed",
@@ -509,7 +509,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "mixed",
@@ -562,7 +562,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "processArray",
@@ -634,7 +634,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "processArray",
@@ -682,7 +682,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "flexible",
@@ -754,7 +754,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "flexible",
@@ -797,7 +797,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "foo"
@@ -832,7 +832,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "foo",
@@ -870,7 +870,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -973,7 +973,7 @@ if (hasInterrupts(__stack.locals.flexResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "test",
@@ -221,7 +221,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "test",
@@ -264,7 +264,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "add",
@@ -321,7 +321,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "add",
@@ -369,7 +369,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -404,7 +404,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "greet",
@@ -230,7 +230,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "greet",
@@ -278,7 +278,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "double",
@@ -331,7 +331,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "double",
@@ -379,7 +379,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "applyToAll",
@@ -460,7 +460,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "applyToAll",
@@ -508,7 +508,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -557,7 +557,7 @@ if (hasInterrupts(__stack.locals.doubled)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -178,7 +178,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "process",
@@ -251,7 +251,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "process",
@@ -294,7 +294,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -342,7 +342,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "foo"
@@ -200,7 +200,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "foo",
@@ -238,7 +238,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -258,7 +258,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "greet"
@@ -203,7 +203,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "greet",
@@ -241,7 +241,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -263,7 +263,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -173,7 +173,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "greet"
@@ -226,7 +226,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "greet",

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -367,7 +367,7 @@ __stack.locals.result = `other`;
 });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "twice",
@@ -260,7 +260,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "twice",
@@ -303,7 +303,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -315,7 +315,7 @@ let __functionCompleted = false;
 __stack.locals.results = await __call(twice, {
         type: "positional",
         args: [__AgencyFunction.create({ name: "__block_0", module: "inlineBlockBasic.agency", fn: async () => {
-          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads } });
+          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: typeof __threads !== "undefined" ? __threads : undefined } });
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 
@@ -364,7 +364,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "mapItems",
@@ -266,7 +266,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "mapItems",
@@ -314,7 +314,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -329,7 +329,7 @@ __stack.locals.items = [1, 2, 3];
 __stack.locals.doubled = await __call(mapItems, {
         type: "positional",
         args: [__stack.locals.items, __AgencyFunction.create({ name: "__block_0", module: "inlineBlockParams.agency", fn: async (x: any) => {
-          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads } });
+          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: typeof __threads !== "undefined" ? __threads : undefined } });
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 
@@ -369,7 +369,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -243,7 +243,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -225,7 +225,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "greet",
@@ -277,7 +277,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "greet",
@@ -330,7 +330,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "foo2",
@@ -433,7 +433,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "foo2",
@@ -481,7 +481,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "sayHi"
@@ -576,7 +576,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "sayHi",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -257,7 +257,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "greet",
@@ -277,7 +277,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "greet",
@@ -325,7 +325,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "foo2"
@@ -396,7 +396,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "foo2",
@@ -434,7 +434,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "sayHi"
@@ -481,7 +481,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "sayHi",

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -175,7 +175,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -255,7 +255,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -482,7 +482,7 @@ __stack.locals.output4 = {
 });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -180,7 +180,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "greet",
@@ -226,7 +226,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "greet",

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "greet"
@@ -216,7 +216,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "greet",
@@ -254,7 +254,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "processGreeting"
@@ -307,7 +307,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "processGreeting",
@@ -345,7 +345,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -365,7 +365,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -196,7 +196,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "greet",
@@ -265,7 +265,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "greet",

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "greet",
@@ -242,7 +242,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "greet",
@@ -295,7 +295,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -382,7 +382,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -222,7 +222,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -225,7 +225,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -189,7 +189,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "greet",
@@ -258,7 +258,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "greet",

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "double",
@@ -230,7 +230,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "double",
@@ -278,7 +278,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "multiply",
@@ -337,7 +337,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "multiply",
@@ -390,7 +390,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "safeDivide",
@@ -463,7 +463,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "safeDivide",
@@ -511,7 +511,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -614,7 +614,7 @@ __stack.locals.__pipe_4 = await success(10);
     }));
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -173,7 +173,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -233,7 +233,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "checkAge",
@@ -244,7 +244,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "checkAge",

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "checkValue",
@@ -244,7 +244,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "checkValue",

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -192,7 +192,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -217,7 +217,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -174,7 +174,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -215,7 +215,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -182,7 +182,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "parseValue",
@@ -248,7 +248,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "parseValue",
@@ -301,7 +301,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "wrapper",
@@ -360,7 +360,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "wrapper",
@@ -398,7 +398,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -595,7 +595,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -181,7 +181,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -231,7 +231,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -222,7 +222,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "analyzeData"
@@ -207,7 +207,7 @@ if (hasInterrupts(__stack.locals.result)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "analyzeData",

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -209,7 +209,7 @@ __stack.locals.stringSlice = __stack.locals.str.slice(1, 3);
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -194,7 +194,7 @@ __stack.locals.arr.splice(0, 2 - 0, ...[40, 50])
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "greet",
@@ -249,7 +249,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "greet",
@@ -292,7 +292,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -326,7 +326,7 @@ __stack.locals.z = item;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -191,7 +191,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -208,7 +208,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "foo"
@@ -267,7 +267,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "foo",

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -185,7 +185,7 @@ __stack.locals.greeting = `Hello, my name is ${name} and I am ${age} years old.`
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "foo"
@@ -236,7 +236,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "foo",

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "foo",
@@ -413,7 +413,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "foo",
@@ -451,7 +451,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -686,7 +686,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -265,7 +265,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -174,7 +174,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -227,7 +227,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -257,7 +257,7 @@ if (hasInterrupts(__stack.locals.baz)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -176,7 +176,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -229,7 +229,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -174,7 +174,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -227,7 +227,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -210,7 +210,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -231,7 +231,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -231,7 +231,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -183,7 +183,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "log",
@@ -252,7 +252,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "log",

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   }
   let __funcStartTime: number = performance.now();
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onFunctionStart",
     data: {
       functionName: "foo",
@@ -259,7 +259,7 @@ return failure(
     __stateStack.pop()
     if (__functionCompleted) {
       await callHook({
-        callbacks: __ctx.callbacks,
+        ctx: __ctx,
         name: "onFunctionEnd",
         data: {
           functionName: "foo",
@@ -297,7 +297,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -334,7 +334,7 @@ return;
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -172,7 +172,7 @@ const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   await callHook({
-    callbacks: __ctx.callbacks,
+    ctx: __ctx,
     name: "onNodeStart",
     data: {
       nodeName: "main"
@@ -225,7 +225,7 @@ if (hasInterrupts(__funcResult)) {
     });
     if (runner.halted) return runner.haltResult;
     await callHook({
-      callbacks: __ctx.callbacks,
+      ctx: __ctx,
       name: "onNodeEnd",
       data: {
         nodeName: "main",


### PR DESCRIPTION
## Summary

Replaces Agency's `callback` keyword with a `callback(name, fn)` stdlib function whose registrations are scoped to the dynamic extent of the calling function/node. Registrations are stored on stack frames, so they clean up automatically on frame pop and survive interrupts via the existing frame serialization.

Implements the plan at `docs/superpowers/plans/2026-05-20-scoped-callbacks.md`.

## What changed

**Runtime / storage**
- `State.scopedCallbacks` field with `addScopedCallback(name, fn)`, serialized through `toJSON` / `fromJSON`
- `StateStack.callerFrame()` and `StateStack.collectScopedCallbacks(name)`
- `RuntimeContext.topLevelCallbacks` for callbacks registered during `__initializeGlobals` (when no real caller frame exists)
- `_callback` runtime function routes registrations to either the caller frame or `topLevelCallbacks`

**Hook execution**
- `callHook` rewritten to gather callbacks from: scoped (innermost → outermost), then top-level, then TS-passed
- Return values from callbacks are discarded — the message-override capability of `onLLMCallStart` / `onLLMCallEnd` is removed
- Per-instance recursion guard prevents a callback from invoking itself
- Errors are caught and logged; interrupts are re-thrown so enclosing `handle` blocks see them

**Language / backends**
- `callback` keyword removed from the parser; `FunctionDefinition.callback` field removed
- `_registeredCallbacks` and `installRegisteredCallbacks` removed from `RuntimeContext` and from call sites in `node.ts`, `interrupts.ts`, `rewind.ts`
- Generated TypeScript now passes `ctx: __ctx` to `callHook`
- `blockSetup.mustache` updated so top-level callback blocks created in `__initializeGlobals` no longer crash trying to reference `__threads`

**stdlib**
- `std::agency` exports a new public `callback(name, fn)` function that wraps `_callback`

**Tests**
- Migrated existing callback-keyword usage to the new function form (`tests/agency/callback-basic.agency`, `tests/agency/memory/llm-injection.agency`, `tests/agency/builtins/emit.agency`, `lib/agents/policy/agent.agency`)
- New Agency execution tests: `callback-scoped`, `callback-nested`, `callback-toplevel`, `callback-recursion`
- New unit tests: `lib/runtime/hooks.test.ts` (10 tests) and additional cases in `lib/runtime/state/stateStack.test.ts`

**Docs**
- `docs/site/appendix/callbacks.md` rewritten to use the new function form and explain scoping
- `docs/misc/lifecycleHooks.md` "Modifying Messages in LLM Hooks" section removed; `onLLMCallStart` / `onLLMCallEnd` descriptions updated

## Verification

- `pnpm run typecheck` ✓
- `pnpm run lint:structure` ✓
- `pnpm test:run` — all 4347 tests pass
- `pnpm run a test` on each new fixture (`callback-scoped`, `callback-nested`, `callback-toplevel`, `callback-recursion`) ✓
- `make` builds cleanly
