### PR TITLE
Phase 0: callHook returns Interrupt[]; add callHookAndDrop wrapper

### DIFF
--- a/packages/agency-lang/docs/dev/callback-hooks.md
+++ b/packages/agency-lang/docs/dev/callback-hooks.md
@@ -1,0 +1,86 @@
+# Callback hooks and interrupts
+
+Agency lets user code register callbacks for runtime events
+(`onFunctionStart`, `onNodeStart`, `onLLMCallStart`, `onToolCallStart`,
+etc.) via the stdlib `callback()` function. A callback body can call
+`interrupt(...)` like any other agency code. This doc explains what
+happens to that interrupt and where it ends up.
+
+## Two paths through `callHook`
+
+`callHook(...)` in `lib/runtime/hooks.ts` is the single dispatcher that
+fires every callback for a given hook name. It now returns
+`Interrupt[] | undefined`:
+
+- **`undefined`** — no callback raised an interrupt; the hook fired and
+  every callback completed normally.
+- **`Interrupt[]`** — at least one callback halted with an `interrupt`
+  statement that wasn't caught by a `handle` block on the live call
+  stack. *All* callbacks still ran (interrupts from callback A do not
+  short-circuit callback B); the returned array contains every
+  interrupt that bubbled out.
+
+There are two kinds of call site:
+
+### Codegen-emitted (`ts.callHook(...)`)
+
+These fire from inside compiled agency code (function entry/exit, node
+entry/exit, `emit`). The runner, `__stack`, and `__stateStack` are in
+scope at the firing point. After Phase 1, these sites check the return
+value of `callHook` and propagate it through the same interrupt-return
+mechanism the rest of the runner uses — the user can respond to the
+interrupt via `respondToInterrupts` and resume the program.
+
+In Phase 0 (the plumbing PR) these sites still drop the returned
+interrupt array because the generated code wraps `await callHook(...)`
+in a statement context that discards the value. That preserves the
+pre-refactor "fire and forget" behavior. Phase 1 replaces this with a
+specialized Runner step type (`runner.hook(id, name, data)`) that
+checkpoints + propagates.
+
+### TS-side runtime (`callHookAndDrop(...)`)
+
+These fire from `lib/runtime/node.ts` and `lib/runtime/prompt.ts`,
+outside any agency frame. They cannot pause/resume cleanly because
+either there's no agency state to checkpoint (`onAgentStart` /
+`onAgentEnd`) or the surrounding TS code (`runPrompt`'s internal state
+machine) has no substep machinery to skip already-fired hooks on
+resume. These sites use `callHookAndDrop` which fires the hook, logs
+any returned interrupts to `console.error`, and continues. Phase 2
+will migrate the LLM/tool hooks to a proper propagation path by
+splitting `runPrompt` into agency-callable pieces.
+
+## Errors vs. interrupts in callback bodies
+
+`fireWithGuard` distinguishes the two:
+
+- A real JS `throw` inside a callback body is caught and
+  `console.error`-logged. It never propagates further.
+- An `interrupt(...)` statement in a callback body returns
+  `Interrupt[]` from `AgencyFunction.invoke`. `invokeCallback` returns
+  the array; `fireWithGuard` returns the array; `callHook` collects it
+  into its batch. The interrupt does NOT go through the `catch` block.
+
+`RestoreSignal` and `AgencyCancelledError` are special — they always
+re-throw, since they're internal control-flow signals the runtime
+relies on.
+
+## Multiple callbacks on the same hook
+
+`gatherCallbacks` returns callbacks in this order:
+1. Innermost stack-frame scoped callbacks
+2. Outer stack-frame scoped callbacks (walking up)
+3. Top-level callbacks (registered at module init), in registration order
+4. The TS-passed `ctx.callbacks[name]` callback, if any
+
+`callHook` invokes them in that order and collects interrupts as it
+goes. The returned `Interrupt[]` preserves the firing order.
+
+## Why the batch-and-return shape
+
+This mirrors `runForkAll` / `runRace` from
+`docs/dev/concurrent-interrupts.md`. Callbacks are sequential rather
+than parallel, but the invariant is the same: each callback runs to
+completion regardless of what its siblings did, and the caller gets
+every halt batched together so the user can respond to all of them in
+one cycle of `respondToInterrupts`.

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-22-callback-interrupts-phase-0-plumbing.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-22-callback-interrupts-phase-0-plumbing.md
@@ -1,0 +1,631 @@
+# Callback Interrupts — Phase 0: Plumbing
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `callHook` and its inner helpers so that callbacks can return interrupts back to their caller instead of having them swallowed. Add concurrent-interrupt batching so multiple callbacks on the same hook can each raise an interrupt and have them all collected. No user-visible behavior change — every existing call site is migrated to a fire-and-forget wrapper that preserves today's "log + drop" semantics.
+
+**Architecture:** Change `callHook`'s return type from `Promise<void>` to `Promise<Interrupt[] | undefined>`. Have `invokeCallback` and `fireWithGuard` return interrupts instead of throwing. Loop over all registered callbacks in `callHook`, collecting their interrupts into a single batch (mirroring `runForkAll`'s shape, minus the per-branch state machinery — callbacks are sequential, not parallel). Introduce a `callHookAndDrop(args, label)` helper that wraps `callHook` for callers that aren't yet ready to handle propagation, and migrate all six existing call sites in `lib/runtime/node.ts` and `lib/runtime/prompt.ts` to use it. Phase 1 will replace the codegen-emitted call sites with a different wrapper that actually propagates.
+
+**Tech Stack:** TypeScript runtime (`lib/runtime/hooks.ts`, `lib/runtime/node.ts`, `lib/runtime/prompt.ts`), vitest unit tests.
+
+**Prerequisites:** None. This phase touches only `lib/runtime/` — no codegen, no template, no AST, no preprocessor changes. Phase 1 depends on this PR being merged.
+
+---
+
+## File Structure
+
+- **Modify:** `lib/runtime/hooks.ts` — change return types of `callHook` / `invokeCallback` / `fireWithGuard`, add interrupt collection loop, add `callHookAndDrop` export.
+- **Modify:** `lib/runtime/node.ts` — replace 2 existing `await callHook(...)` calls with `await callHookAndDrop(...)`.
+- **Modify:** `lib/runtime/prompt.ts` — replace 4 existing `await callHook(...)` calls with `await callHookAndDrop(...)`.
+- **Create:** `lib/runtime/hooks.test.ts` — new unit tests for interrupt collection, multiple-callback batching, error vs. interrupt distinction in `fireWithGuard`.
+
+The codegen-emitted `ts.callHook(...)` builder in `lib/ir/builders.ts` is NOT touched in Phase 0. It continues to emit `await callHook(...)` which now returns a value that the generated code ignores. That's fine — Phase 0 maintains backward compatibility specifically so existing compiled output keeps working unchanged.
+
+---
+
+## Task 1: Add `Interrupt[]` plumbing to `invokeCallback`
+
+**Files:**
+- Modify: `lib/runtime/hooks.ts:98-125` (`invokeCallback`)
+- Test: `lib/runtime/hooks.test.ts` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `lib/runtime/hooks.test.ts` with this content:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { callHook, callHookAndDrop } from "./hooks.js";
+import { AgencyFunction } from "./agencyFunction.js";
+
+// Minimal fake context shape. Only the fields callHook touches.
+function fakeCtx(): any {
+  return {
+    topLevelCallbacks: [],
+    callbacks: {},
+    stateStack: { collectScopedCallbacks: () => [] },
+  };
+}
+
+// Build an AgencyFunction stub whose `.invoke(...)` returns the given value.
+function fakeAgencyFn(invokeResult: any): AgencyFunction {
+  const fn = {
+    name: "fake-cb",
+    invoke: vi.fn(async () => invokeResult),
+  } as unknown as AgencyFunction;
+  (fn as any).__isAgencyFunction = true;
+  return fn;
+}
+
+describe("invokeCallback / fireWithGuard interrupt return", () => {
+  it("returns the interrupt array when an AgencyFunction callback halts with interrupts", async () => {
+    const ctx = fakeCtx();
+    const intr = { kind: "myapp::test", message: "hi", data: null, origin: "x", interruptId: "i-1" };
+    const cb = fakeAgencyFn([intr]);
+    ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: cb }];
+
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(out).toEqual([intr]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run lib/runtime/hooks.test.ts`
+Expected: FAIL — `callHook` currently returns `undefined`/`Promise<void>`, not the interrupt array.
+
+- [ ] **Step 3: Change `invokeCallback` to return interrupts instead of throwing**
+
+In `lib/runtime/hooks.ts:98-125`, replace the existing `invokeCallback` with:
+
+```ts
+async function invokeCallback(
+  fn: any,
+  data: unknown,
+  ctx: RuntimeContext<any>,
+  errorLabel: string,
+): Promise<Interrupt[] | undefined> {
+  if (AgencyFunction.isAgencyFunction(fn)) {
+    const result = await (fn as AgencyFunction).invoke(
+      { type: "positional", args: [data] },
+      { ctx },
+    );
+    // The callback body completed with an unhandled `interrupt` statement.
+    // Surface the interrupts so the caller can decide what to do — Phase 0
+    // callers (`callHookAndDrop`) log them; Phase 1+ codegen sites stamp a
+    // checkpoint and propagate them up the runner.
+    if (hasInterrupts(result)) {
+      return result as Interrupt[];
+    }
+    return undefined;
+  }
+  // Plain JS callbacks (from AgencyCallbacks TS arg) have no interrupt
+  // mechanism — they're just async functions. Errors thrown by them still
+  // get caught by fireWithGuard below.
+  await fn(data);
+  return undefined;
+}
+```
+
+Add `import type { Interrupt } from "./interrupts.js";` at the top if not already present (it already imports `hasInterrupts`).
+
+Then update `fireWithGuard` to thread the return through:
+
+```ts
+async function fireWithGuard(
+  fn: any,
+  data: unknown,
+  ctx: RuntimeContext<any>,
+  errorLabel: string,
+): Promise<Interrupt[] | undefined> {
+  const key = fn as object;
+  if (_activeCallbacks.has(key)) return undefined;
+  _activeCallbacks.add(key);
+  try {
+    return await invokeCallback(fn, data, ctx, errorLabel);
+  } catch (error) {
+    if (error instanceof RestoreSignal) throw error;
+    if (error instanceof AgencyCancelledError) throw error;
+    // Real JS errors (e.g. a callback body crashed) still get logged here.
+    // Interrupts no longer flow through this path — they return normally
+    // from invokeCallback now.
+    console.error(`[agency] ${errorLabel} callback error:`, error);
+    return undefined;
+  } finally {
+    _activeCallbacks.delete(key);
+  }
+}
+```
+
+- [ ] **Step 4: Update `callHook` return type to thread the array through**
+
+Replace `callHook` at `lib/runtime/hooks.ts:165-180`:
+
+```ts
+export async function callHook<K extends keyof CallbackMap>(args: {
+  ctx: RuntimeContext<any>;
+  name: K;
+  data: CallbackMap[K];
+}): Promise<Interrupt[] | undefined> {
+  const { ctx, name, data } = args;
+
+  // Single shared collector. Mirrors the runForkAll pattern of "let every
+  // sibling run to completion, batch all interrupts together at the end"
+  // (see docs/dev/concurrent-interrupts.md). Callbacks are sequential
+  // here (not parallel like fork branches), but the batching semantics
+  // are the same: an interrupt from callback A must not short-circuit
+  // callback B.
+  const collected: Interrupt[] = [];
+
+  // Fire global hooks (from external packages) first. They cannot raise
+  // agency interrupts (they're plain JS), so we don't collect from them.
+  for (const fn of _globalHooks[name] ?? []) {
+    await fireWithGuard(fn, data, ctx, `global ${name}`);
+  }
+
+  for (const fn of gatherCallbacks(ctx, name)) {
+    const result = await fireWithGuard(fn, data, ctx, name);
+    if (result) collected.push(...result);
+  }
+
+  return collected.length > 0 ? collected : undefined;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pnpm vitest run lib/runtime/hooks.test.ts`
+Expected: PASS for the one test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/runtime/hooks.ts lib/runtime/hooks.test.ts
+git commit -m "Phase 0: callHook returns Interrupt[] when callbacks halt"
+```
+
+---
+
+## Task 2: Add multi-callback batching test + verify collection order
+
+**Files:**
+- Modify: `lib/runtime/hooks.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `lib/runtime/hooks.test.ts`:
+
+```ts
+it("collects interrupts from every callback even when earlier ones halt", async () => {
+  const ctx = fakeCtx();
+  const intrA = { kind: "a::k", message: "A", data: null, origin: "x", interruptId: "i-a" };
+  const intrB = { kind: "b::k", message: "B", data: null, origin: "x", interruptId: "i-b" };
+  const cbA = fakeAgencyFn([intrA]);
+  const cbB = fakeAgencyFn([intrB]);
+  ctx.topLevelCallbacks = [
+    { name: "onNodeStart", fn: cbA },
+    { name: "onNodeStart", fn: cbB },
+  ];
+
+  const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+  expect(out).toEqual([intrA, intrB]);
+  // Both callbacks must have been invoked — an interrupt in A must not
+  // short-circuit B. This is the concurrent-batching invariant that
+  // mirrors runForkAll: every sibling runs to completion, all halts
+  // are batched together.
+  expect((cbA as any).invoke).toHaveBeenCalledTimes(1);
+  expect((cbB as any).invoke).toHaveBeenCalledTimes(1);
+});
+
+it("returns undefined when no callback halts", async () => {
+  const ctx = fakeCtx();
+  ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: fakeAgencyFn(undefined) }];
+  const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+  expect(out).toBeUndefined();
+});
+
+it("real JS errors in a callback do NOT appear in the returned interrupts", async () => {
+  const ctx = fakeCtx();
+  const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  const cbCrash = {
+    invoke: vi.fn(async () => { throw new Error("boom"); }),
+  } as unknown as AgencyFunction;
+  (cbCrash as any).__isAgencyFunction = true;
+  ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: cbCrash }];
+  const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+  expect(out).toBeUndefined();
+  expect(errSpy).toHaveBeenCalled();
+  errSpy.mockRestore();
+});
+```
+
+- [ ] **Step 2: Run tests to verify all pass**
+
+Run: `pnpm vitest run lib/runtime/hooks.test.ts`
+Expected: PASS for all four tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/runtime/hooks.test.ts
+git commit -m "Phase 0: cover multi-callback batching, no-interrupt, and crash cases"
+```
+
+---
+
+## Task 3: Add `callHookAndDrop` helper for fire-and-forget callers
+
+**Files:**
+- Modify: `lib/runtime/hooks.ts`
+- Modify: `lib/runtime/hooks.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `lib/runtime/hooks.test.ts`:
+
+```ts
+describe("callHookAndDrop", () => {
+  it("returns void and logs to console.error when interrupts come back", async () => {
+    const ctx = fakeCtx();
+    const intr = { kind: "x::y", message: "", data: null, origin: "x", interruptId: "i-1" };
+    ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: fakeAgencyFn([intr]) }];
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const out: void = await callHookAndDrop({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(out).toBeUndefined();
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[agency] onNodeStart callback raised an unhandled interrupt"),
+      expect.anything(),
+    );
+    errSpy.mockRestore();
+  });
+
+  it("returns void with no logging when no interrupts are raised", async () => {
+    const ctx = fakeCtx();
+    ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: fakeAgencyFn(undefined) }];
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await callHookAndDrop({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(errSpy).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm vitest run lib/runtime/hooks.test.ts`
+Expected: FAIL — `callHookAndDrop` does not exist yet.
+
+- [ ] **Step 3: Add the helper**
+
+At the bottom of `lib/runtime/hooks.ts`, add:
+
+```ts
+/**
+ * Fire a hook with the today-style "log + drop" interrupt behavior.
+ *
+ * Existing TS-side runtime call sites (in `lib/runtime/node.ts` and
+ * `lib/runtime/prompt.ts`) wrap `callHook` with this helper because
+ * they cannot propagate callback interrupts up the agency runner: they
+ * sit either outside any agency frame (onAgentStart / onAgentEnd) or
+ * inside `runPrompt`'s internal state machine which has no resumable
+ * substep machinery yet. Phase 2 of the callback-interrupts work will
+ * give those sites real propagation; until then they continue to log
+ * and drop, matching the pre-refactor behavior.
+ *
+ * Codegen-emitted hook sites (the `ts.callHook(...)` builder) get
+ * actual propagation in Phase 1 by emitting `callHook` directly and
+ * checking the return value inline.
+ */
+export async function callHookAndDrop<K extends keyof CallbackMap>(args: {
+  ctx: RuntimeContext<any>;
+  name: K;
+  data: CallbackMap[K];
+}): Promise<void> {
+  const result = await callHook(args);
+  if (result) {
+    console.error(
+      `[agency] ${args.name} callback raised an unhandled interrupt ` +
+        `(kind="${result[0].kind}") at a runtime call site that does not ` +
+        `support interrupt propagation. The interrupt is being dropped. ` +
+        `Move the hook firing into an agency-controlled scope, or wait for ` +
+        `Phase 2 of the callback-interrupts work.`,
+      result,
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm vitest run lib/runtime/hooks.test.ts`
+Expected: PASS for all six tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/hooks.ts lib/runtime/hooks.test.ts
+git commit -m "Phase 0: add callHookAndDrop for fire-and-forget callers"
+```
+
+---
+
+## Task 4: Migrate `lib/runtime/node.ts` call sites
+
+**Files:**
+- Modify: `lib/runtime/node.ts:4` (import), `lib/runtime/node.ts:174` (onAgentStart), `lib/runtime/node.ts:222` (onAgentEnd)
+
+- [ ] **Step 1: Update the import**
+
+Change line 4 of `lib/runtime/node.ts` from:
+
+```ts
+import { callHook } from "./hooks.js";
+```
+
+to:
+
+```ts
+import { callHookAndDrop } from "./hooks.js";
+```
+
+- [ ] **Step 2: Replace the two `callHook` call sites**
+
+At `lib/runtime/node.ts:174`, change `await callHook({ ... })` to `await callHookAndDrop({ ... })`. Same at `lib/runtime/node.ts:222`. The argument shape is unchanged.
+
+Verify with: `grep -n "callHook\b\|callHookAndDrop" lib/runtime/node.ts`
+Expected: only `callHookAndDrop` references, no bare `callHook`.
+
+- [ ] **Step 3: Run the existing agency tests touching node lifecycle hooks**
+
+Run:
+```bash
+node ./dist/scripts/agency.js test tests/agency/callback-toplevel.agency
+node ./dist/scripts/agency.js test tests/agency/callback-basic.agency
+```
+Expected: both PASS. These exercise the runtime hook path and prove that swapping in `callHookAndDrop` didn't change observable behavior.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/runtime/node.ts
+git commit -m "Phase 0: migrate node.ts hook sites to callHookAndDrop"
+```
+
+---
+
+## Task 5: Migrate `lib/runtime/prompt.ts` call sites
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts:6` (import), `lib/runtime/prompt.ts:57`, `:194`, `:483`, `:609`
+
+- [ ] **Step 1: Update the import**
+
+Change line 6 of `lib/runtime/prompt.ts` from:
+
+```ts
+import { callHook } from "./hooks.js";
+```
+
+to:
+
+```ts
+import { callHookAndDrop } from "./hooks.js";
+```
+
+- [ ] **Step 2: Replace the four `callHook` call sites**
+
+In `lib/runtime/prompt.ts`, change each of these `await callHook({ ... })` to `await callHookAndDrop({ ... })`:
+- Line 57: `onLLMCallStart`
+- Line 194: `onLLMCallEnd`
+- Line 483: `onToolCallStart`
+- Line 609: `onToolCallEnd`
+
+Argument shape is unchanged.
+
+Verify with: `grep -n "callHook\b\|callHookAndDrop" lib/runtime/prompt.ts`
+Expected: only `callHookAndDrop` references.
+
+- [ ] **Step 3: Run the broader test suite as a regression check**
+
+Run: `pnpm vitest run 2>&1 | tail -5`
+Expected: 4373+ tests pass (whatever the current count is — Phase 0 should not change any test outcome).
+
+Run: `node ./dist/scripts/agency.js test tests/agency/callback-resume.agency`
+Expected: PASS. This is the resume-roundtrip test and is the single best smoke test that the runtime hook path still works end-to-end.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add lib/runtime/prompt.ts
+git commit -m "Phase 0: migrate prompt.ts hook sites to callHookAndDrop"
+```
+
+---
+
+## Task 6: Update the `ts.callHook` builder to await the result (no propagation yet)
+
+**Files:**
+- Modify: `lib/ir/builders.ts:515-524`
+
+This task is technically optional in Phase 0 — the existing generated code calls `await callHook(...)` and ignores the returned `Interrupt[] | undefined`, which is exactly today's "drop" behavior. But it's worth adding a comment in the builder that points future contributors at the Phase 1 work.
+
+- [ ] **Step 1: Add a docstring + leave the implementation unchanged**
+
+Replace `lib/ir/builders.ts:515-524` with:
+
+```ts
+/**
+ * Emit `await callHook({ ctx, name, data })`.
+ *
+ * Phase 0 (the migration that introduced `Interrupt[]` returns from
+ * `callHook`) preserves the codegen-side behavior: the generated `await`
+ * expression evaluates to `Interrupt[] | undefined`, but the surrounding
+ * statement context discards it. That matches the today-style behavior
+ * of "interrupts raised by callbacks fire-and-forget at codegen-emitted
+ * sites" — see `lib/runtime/hooks.ts` `callHookAndDrop` for the
+ * equivalent at TS-side runtime call sites.
+ *
+ * Phase 1 will replace this builder (or add a sibling like
+ * `ts.callHookPropagating(...)`) that emits the interrupt-propagation
+ * pattern: substep guard, return-the-interrupts-and-halt, stamp a
+ * checkpoint at the firing site. See
+ * `docs/superpowers/plans/2026-05-22-callback-interrupts-phase-1-codegen-sites.md`.
+ */
+callHook(hookName: string, data: Record<string, TsNode> | TsNode): TsNode {
+  const dataNode = "kind" in data ? data as TsNode : ts.obj(data as Record<string, TsNode>);
+  return ts.awaitCall(ts.id("callHook"), [
+    ts.obj({
+      ctx: ts.runtime.ctx,
+      name: ts.str(hookName),
+      data: dataNode,
+    }),
+  ]);
+},
+```
+
+- [ ] **Step 2: Build + run the agency test suite**
+
+Run:
+```bash
+make
+pnpm vitest run 2>&1 | tail -5
+```
+Expected: build clean, all tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add lib/ir/builders.ts
+git commit -m "Phase 0: document ts.callHook builder; Phase 1 will replace it"
+```
+
+---
+
+## Task 7: Document the hook-callback-interrupt contract
+
+**Files:**
+- Create: `docs/dev/callback-hooks.md`
+
+- [ ] **Step 1: Create the doc**
+
+```markdown
+# Callback hooks and interrupts
+
+Agency lets user code register callbacks for runtime events
+(`onFunctionStart`, `onNodeStart`, `onLLMCallStart`, `onToolCallStart`,
+etc.) via the stdlib `callback()` function. A callback body can call
+`interrupt(...)` like any other agency code. This doc explains what
+happens to that interrupt and where it ends up.
+
+## Two paths through `callHook`
+
+`callHook(...)` in `lib/runtime/hooks.ts` is the single dispatcher that
+fires every callback for a given hook name. It now returns
+`Interrupt[] | undefined`:
+
+- **`undefined`** — no callback raised an interrupt; the hook fired and
+  every callback completed normally.
+- **`Interrupt[]`** — at least one callback halted with an `interrupt`
+  statement that wasn't caught by a `handle` block on the live call
+  stack. *All* callbacks still ran (interrupts from callback A do not
+  short-circuit callback B); the returned array contains every
+  interrupt that bubbled out.
+
+There are two kinds of call site:
+
+### Codegen-emitted (`ts.callHook(...)`)
+
+These fire from inside compiled agency code (function entry/exit, node
+entry/exit, `emit`). The runner, `__stack`, and `__stateStack` are in
+scope at the firing point. After Phase 1, these sites check the return
+value of `callHook` and propagate it through the same interrupt-return
+mechanism the rest of the runner uses — the user can respond to the
+interrupt via `respondToInterrupts` and resume the program.
+
+### TS-side runtime (`callHookAndDrop(...)`)
+
+These fire from `lib/runtime/node.ts` and `lib/runtime/prompt.ts`,
+outside any agency frame. They cannot pause/resume cleanly because
+either there's no agency state to checkpoint (onAgentStart/onAgentEnd)
+or the surrounding TS code (runPrompt's internal state machine) has no
+substep machinery to skip already-fired hooks on resume. These sites
+use `callHookAndDrop` which fires the hook, logs any returned
+interrupts to `console.error`, and continues. Phase 2 will migrate the
+LLM/tool hooks to a proper propagation path.
+
+## Errors vs. interrupts in callback bodies
+
+`fireWithGuard` distinguishes the two:
+
+- A real JS `throw` inside a callback body is caught and
+  `console.error`-logged. It never propagates further.
+- An `interrupt(...)` statement in a callback body returns
+  `Interrupt[]` from `AgencyFunction.invoke`. `invokeCallback` returns
+  the array; `fireWithGuard` returns the array; `callHook` collects it
+  into its batch. The interrupt does NOT go through the `catch` block.
+
+`RestoreSignal` and `AgencyCancelledError` are special — they always
+re-throw, since they're internal control-flow signals the runtime
+relies on.
+
+## Multiple callbacks on the same hook
+
+`gatherCallbacks` returns callbacks in this order:
+1. Innermost stack-frame scoped callbacks
+2. Outer stack-frame scoped callbacks (walking up)
+3. Top-level callbacks (registered at module init), in registration order
+4. The TS-passed `ctx.callbacks[name]` callback, if any
+
+`callHook` invokes them in that order and collects interrupts as it
+goes. The returned `Interrupt[]` preserves the firing order.
+
+## Why the batch-and-return shape
+
+This mirrors `runForkAll` / `runRace` from
+`docs/dev/concurrent-interrupts.md`. Callbacks are sequential rather
+than parallel, but the invariant is the same: each callback runs to
+completion regardless of what its siblings did, and the caller gets
+every halt batched together so the user can respond to all of them in
+one cycle of `respondToInterrupts`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/dev/callback-hooks.md
+git commit -m "Phase 0: document callback hook + interrupt contract"
+```
+
+---
+
+## Final validation
+
+- [ ] **Step 1: Full validation pass**
+
+```bash
+make
+pnpm run typecheck
+pnpm run lint:structure
+pnpm vitest run
+for t in tests/agency/callback-*.agency; do
+  node ./dist/scripts/agency.js test "$t" 2>&1 | grep -E "passed|FAIL" | tail -1
+done
+```
+
+Expected: every command succeeds; every callback test still passes; no regression in `pnpm vitest run` (same count as `main` plus the new tests in `hooks.test.ts`).
+
+- [ ] **Step 2: Push the branch and open PR**
+
+PR description should explicitly note:
+- Zero user-visible behavior change.
+- Internals refactored to enable Phase 1 (codegen propagation) and eventual Phase 2 (LLM/tool hook propagation).
+- All existing callers (`lib/runtime/node.ts`, `lib/runtime/prompt.ts`) migrated to `callHookAndDrop` to preserve today's swallow-and-log semantics.
+- New tests in `lib/runtime/hooks.test.ts` cover the interrupt-collection mechanism, multi-callback batching, and the error-vs-interrupt distinction.
+
+## Out of scope for Phase 0
+
+- Codegen-emitted call sites (`ts.callHook`) keep dropping interrupts. Phase 1 fixes those.
+- LLM/tool hooks in `lib/runtime/prompt.ts` keep dropping interrupts. Phase 2 fixes those (and is harder because `runPrompt` has no substep machinery today).
+- `onAgentStart`/`onAgentEnd` callbacks fundamentally cannot propagate interrupts (no agency frame exists). Leaving these on `callHookAndDrop` permanently — Phase 2 should add an explicit reject when these specific hooks return interrupts, so users get an actionable error rather than a silent log.
+- No changes to `respondToInterrupts`. The existing batched-interrupt resume machinery already handles arrays of interrupts; Phase 1 just produces them from a new source.

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-22-callback-interrupts-phase-1-codegen-sites.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-22-callback-interrupts-phase-1-codegen-sites.md
@@ -1,0 +1,624 @@
+# Callback Interrupts — Phase 1: Codegen-emitted Hook Sites (via Runner step type)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Propagate interrupts raised inside callback bodies for the five hook sites emitted by the typescriptBuilder (`onFunctionStart`, `onFunctionEnd`, `onEmit`, `onNodeStart`, `onNodeEnd`). When a callback halts with `Interrupt[]`, the surrounding compiled function/node must stamp a checkpoint, halt its runner, and return the interrupts up the stack so `respondToInterrupts` works end-to-end. On resume the firing site must skip already-fired hooks so they don't re-run.
+
+**Architecture:** Add a new specialized Runner step type — `runner.hook(id, hookName, data)` — modeled exactly on the existing `runner.handle` / `runner.thread` / `runner.pipe` step types in `lib/runtime/runner.ts`. Codegen emits a single line per hook site:
+
+```ts
+await runner.hook(<id>, "onFunctionStart", { functionName: ... });
+```
+
+`Runner.hook` itself handles substep-counter resume skipping, debugger/coverage integration, the actual `callHook` call, checkpoint stamping on interrupts, and the halt protocol. This keeps the halt/checkpoint/substep machinery encapsulated inside Runner — exactly where it lives for every other step type — instead of leaking it into generated code or a one-off mustache template.
+
+This intentionally avoids:
+- A new mustache template that re-implements substep guards and halt protocol in textual form.
+- A bespoke `__hookFired_<id>` flag scheme that parallels (and risks diverging from) the existing substep counter.
+- Threading `moduleId` / `scopeName` strings through builders/IR/templates just to stamp a checkpoint — `Runner` already has `getCheckpointInfo()` for this.
+
+**Tech Stack:** TypeScript runtime (`lib/runtime/runner.ts`, `lib/runtime/hooks.ts`), TypeScript codegen (`lib/backends/typescriptBuilder.ts`, `lib/ir/builders.ts`, `lib/ir/tsIR.ts`, `lib/ir/prettyPrint.ts`), generated-fixture regeneration via `make fixtures`, and agency execution tests under `tests/agency/`.
+
+**Prerequisites:** Phase 0 (`docs/superpowers/plans/2026-05-22-callback-interrupts-phase-0-plumbing.md`) must be merged. `callHook` must return `Interrupt[] | undefined`; `callHookAndDrop` must exist for the TS-side runtime sites that can't propagate.
+
+---
+
+## File Structure
+
+- **Modify:** `lib/runtime/runner.ts` — add `async hook(id, hookName, data)` method following the `handle` / `thread` shape.
+- **Modify:** `lib/runtime/runner.test.ts` — unit-test the new Runner method directly (resume skip; halt-on-interrupt; checkpoint stamping; no-interrupt happy path).
+- **Modify:** `lib/ir/tsIR.ts` — add `TsRunnerHook` node kind.
+- **Modify:** `lib/ir/builders.ts` — add `ts.runnerHook(...)` builder. Keep existing `ts.callHook(...)` for any place that wants the raw expression (none today after Phase 1).
+- **Modify:** `lib/ir/prettyPrint.ts` — render `runnerHook` as a single `await runner.hook(...)` line.
+- **Modify:** `lib/backends/typescriptBuilder.ts` — replace the five `ts.callHook(...)` call sites with `ts.runnerHook(...)`. Move `onFunctionEnd` out of `finally` so its interrupts can propagate (interrupts thrown from `finally` cannot be returned cleanly).
+- **Modify:** `lib/runtime/hooks.ts` — explicit reject when `onAgentStart` / `onAgentEnd` callbacks return interrupts (defensive; those sites use `callHookAndDrop`, but this catches future misuse).
+- **Create:** `tests/agency/callback-interrupt-resume-onfunctionstart.{agency,test.json}` — resume roundtrip for an interrupt raised by an onFunctionStart callback.
+- **Create:** `tests/agency/callback-interrupt-resume-onnodeend.{agency,test.json}` — same for onNodeEnd.
+- **Create:** `tests/agency/callback-interrupt-resume-onemit.{agency,test.json}` — same for an onEmit callback.
+- **Create:** `tests/agency/callback-multi-interrupt-resume.{agency,test.json}` — multiple callbacks each interrupting, both responded to, resume completes; verifies no double-fire.
+- **Run:** `make fixtures` — regenerate every fixture under `tests/typescriptGenerator/` and `tests/typescriptBuilder/` to pick up the new codegen shape.
+
+---
+
+## Background: why a runner step type
+
+Read `docs/dev/interrupts.md` ("Substeps" section), `docs/dev/concurrent-interrupts.md` ("Capture-time slice rule"), and `lib/runtime/runner.ts` (especially `step`, `handle`, `thread`, `pipe`) before starting.
+
+Every other resumable construct in Agency is a Runner step type. They all share the same skeleton:
+
+```ts
+async XXX(id: number, ...args, callback?: ...): Promise<...> {
+  if (this.shouldSkip()) return;
+  if (this.getCounter() > id) return;
+  if (await this.maybeDebugHook(id)) return;
+  this.ctx.coverageCollector?.hit(this.moduleId, this.scopeName, this.stepPath(id));
+  this.path.push(id);
+  try {
+    // do the specialized work
+  } finally {
+    this.path.pop();
+  }
+  if (this.halted) return;
+  this.clearDebugFlag(id);
+  this.setCounter(id + 1);
+}
+```
+
+This skeleton already encodes everything Phase 1 needs:
+
+| Phase 1 requirement                                  | How the skeleton provides it                                                                 |
+|------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| Skip the hook on resume after it already fired       | `this.getCounter() > id` short-circuits.                                                     |
+| Re-fire the hook on resume when it halted with intr  | When halt happens we **don't** call `setCounter(id + 1)`, so resume sees `counter <= id`.    |
+| Debugger pause point at the hook site                | `maybeDebugHook(id)` already there.                                                          |
+| Coverage hit at the hook site                        | `coverageCollector.hit` already there.                                                       |
+| Correct checkpoint metadata (module/scope/stepPath)  | `getCheckpointInfo()` already there.                                                         |
+| Composes with fork/race (slice-only invariant)       | Runner already operates on its local frame; checkpoint stamp goes through `__ctx.checkpoints.createPinned(this.stack, ...)` using the Runner's own stack reference. |
+
+The only thing the skeleton doesn't already do is call `callHook` and stamp interrupt IDs onto the returned interrupts. That's the entire delta for `Runner.hook`.
+
+---
+
+## Task 1: Add `Runner.hook` plus unit tests
+
+**Files:**
+- Modify: `lib/runtime/runner.ts`
+- Modify: `lib/runtime/runner.test.ts` (or create alongside if it doesn't exist)
+
+- [ ] **Step 1: Read the sibling step types first**
+
+Read `lib/runtime/runner.ts` lines 243–375 — the bodies of `step`, `pipe`, `thread`, `handle`. The new method goes alongside them, after `handle`. Match the same comment style and section banner (`// ── Specialized: hook ──`).
+
+- [ ] **Step 2: Add `Runner.hook`**
+
+In `lib/runtime/runner.ts`, after `handle`:
+
+```ts
+// ── Specialized: hook ──
+
+/**
+ * Fire a codegen-emitted callback hook (onFunctionStart, onFunctionEnd,
+ * onEmit, onNodeStart, onNodeEnd) as a resumable substep.
+ *
+ * If any registered callback for `hookName` halts with `Interrupt[]`,
+ * we stamp a pinned checkpoint at this substep's path and halt the
+ * runner. The interrupts are returned via runner.haltResult so the
+ * surrounding generated function returns them up the stack. The
+ * substep counter is NOT advanced on halt, so on resume this method
+ * re-enters and re-fires the hook — at which point the user's response
+ * (keyed by each Interrupt's interruptId) is consulted by the callback
+ * body's saved __interruptId_N local, exactly like any other interrupt
+ * resume.
+ *
+ * If the hook returns no interrupts the substep counter advances,
+ * so subsequent resumes skip the hook (no duplicate analytics events
+ * after every interrupt cycle).
+ */
+async hook(
+  id: number,
+  hookName: CallbackName,
+  data: Record<string, unknown>,
+): Promise<void> {
+  if (this.shouldSkip()) return;
+  if (this.getCounter() > id) return;
+
+  if (await this.maybeDebugHook(id)) return;
+
+  this.ctx.coverageCollector?.hit(this.moduleId, this.scopeName, this.stepPath(id));
+
+  this.path.push(id);
+  try {
+    const result = await callHook({ ctx: this.ctx, name: hookName, data });
+    if (hasInterrupts(result)) {
+      const cpId = this.ctx.checkpoints.createPinned(
+        this.stack!,
+        this.ctx,
+        this.getCheckpointInfo(),
+      );
+      for (const intr of result) intr.checkpointId = cpId;
+      this.halt(result);
+      return;
+    }
+  } finally {
+    this.path.pop();
+  }
+
+  if (this.halted) return;
+  this.clearDebugFlag(id);
+  this.setCounter(id + 1);
+},
+```
+
+Add imports at the top of the file:
+```ts
+import { callHook } from "./hooks.js";
+import type { CallbackName } from "./types.js";
+```
+
+Confirm `this.stack` is non-null at hook-fire sites. Existing step types (`fork`) use `stateStack` parameters; for `hook`, the Runner is always created with a `stack` opt from the surrounding generated function (verify by searching emitted output for `new Runner(...,{ stack: __stateStack })`). If a code path constructs a Runner without `stack`, the checkpoint stamp falls back to a non-pinned form — but the existing slice-only invariant requires the local `__stateStack`, so emit code MUST pass it. Add a defensive `if (!this.stack) throw new Error("Runner.hook requires stack opt")` to make the contract explicit at runtime.
+
+- [ ] **Step 3: Unit-test `Runner.hook`**
+
+In `lib/runtime/runner.test.ts`, add four cases:
+
+1. Happy path: no callbacks registered → returns without halting, counter advances to `id+1`.
+2. Resume skip: counter already past id → method is a no-op (no `callHook` call).
+3. Halt on interrupts: registered callback returns `[interrupt]` → runner.halted=true, runner.haltResult is the array, every entry has `checkpointId` populated, counter does NOT advance.
+4. Re-fire on resume after halt: same setup as (3), then call `runner.hook(id, ...)` again with the callback now returning `undefined` → fires, counter advances.
+
+Use the existing test helpers in `runner.test.ts` for context/frame setup.
+
+- [ ] **Step 4: Build + test**
+
+```bash
+make
+pnpm vitest run lib/runtime/runner.test.ts 2>&1 | tee /tmp/runner-hook.log
+```
+
+Expected: all four new cases pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/runtime/runner.ts lib/runtime/runner.test.ts
+git commit -m "Phase 1: add Runner.hook specialized step type"
+```
+
+---
+
+## Task 2: Add the IR node + builder + prettyPrint case
+
+**Files:**
+- Modify: `lib/ir/tsIR.ts`
+- Modify: `lib/ir/builders.ts`
+- Modify: `lib/ir/prettyPrint.ts`
+
+This is intentionally the same shape as `runnerHandle` / `runnerStep` — three small additions, no mustache.
+
+- [ ] **Step 1: IR node**
+
+In `lib/ir/tsIR.ts`, alongside `TsRunnerHandle`:
+
+```ts
+/** runner.hook(id, hookName, data) */
+export type TsRunnerHook = {
+  kind: "runnerHook";
+  id: number;
+  hookName: string;
+  data: TsNode;
+};
+```
+
+Add it to the `TsNode` union.
+
+- [ ] **Step 2: Builder**
+
+In `lib/ir/builders.ts`, alongside `runnerHandle`:
+
+```ts
+runnerHook(opts: {
+  id: number;
+  hookName: string;
+  data: Record<string, TsNode> | TsNode;
+}): TsRunnerHook {
+  const dataNode = "kind" in opts.data
+    ? opts.data as TsNode
+    : ts.obj(opts.data as Record<string, TsNode>);
+  return { kind: "runnerHook", id: opts.id, hookName: opts.hookName, data: dataNode };
+},
+```
+
+- [ ] **Step 3: prettyPrint**
+
+In `lib/ir/prettyPrint.ts`, alongside the `runnerHandle` case:
+
+```ts
+case "runnerHook": {
+  const data = prettyPrint(node.data, ctx);
+  return `await runner.hook(${node.id}, ${JSON.stringify(node.hookName)}, ${data});`;
+}
+```
+
+- [ ] **Step 4: Build + commit**
+
+```bash
+make
+git add lib/ir/tsIR.ts lib/ir/builders.ts lib/ir/prettyPrint.ts
+git commit -m "Phase 1: add ts.runnerHook IR node and builder"
+```
+
+---
+
+## Task 3: Migrate the five codegen sites in `typescriptBuilder.ts`
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder.ts`
+
+Existing sites (verified via grep):
+- `:1477` `onFunctionStart`
+- `:1566` `onFunctionEnd` — currently inside `finally`
+- `:1823` `onEmit`
+- `:2146` `onNodeStart`
+- `:2172` `onNodeEnd`
+
+Each call site needs a substep id from the surrounding `StepPathTracker` (`this.steps.currentId()` or however the surrounding code assigns ids). Read each site to find the right id source.
+
+- [ ] **Step 1: `onFunctionStart` (line 1477)**
+
+Replace:
+```ts
+ts.callHook("onFunctionStart", { functionName: ts.str(functionName) })
+```
+with:
+```ts
+ts.runnerHook({
+  id: this.steps.nextId(),
+  hookName: "onFunctionStart",
+  data: { functionName: ts.str(functionName) },
+})
+```
+
+Mirror however the surrounding code allocates ids for other step types (look at how `runnerStep` ids are allocated immediately before/after this site).
+
+- [ ] **Step 2: `onNodeStart` (line 2146)** and **`onEmit` (line 1823)**
+
+Same pattern. Both already live inside generated function/node bodies, so a Runner is in scope.
+
+- [ ] **Step 3: `onNodeEnd` (line 2172)**
+
+Same pattern. Confirm it's not inside a `finally` block; if it is, apply the same out-of-finally move as Step 4.
+
+- [ ] **Step 4: `onFunctionEnd` (line 1566) — out of `finally`**
+
+Today this lives in a `finally` block, gated by `__functionCompleted`. Move it onto the success path immediately before the `return` (and before `__stateStack.pop()` if it currently runs after). Two reasons:
+
+1. You cannot return interrupts from `finally`. If a callback halts there, the halt result is lost.
+2. The `__functionCompleted` flag exists only to suppress the hook on the failure (catch) path. After the move, that gating becomes explicit (don't call the hook in the catch handler) and the flag can be deleted entirely.
+
+Concrete shape:
+
+```ts
+ts.tryCatch(
+  ts.statements([
+    ts.statements(body),
+    ts.runnerHook({
+      id: this.steps.nextId(),
+      hookName: "onFunctionEnd",
+      data: { functionName: ts.str(functionName), result: ts.id("__result") },
+    }),
+    ts.return(ts.id("__result")),
+  ]),
+  ts.raw(renderFunctionCatchFailure.default({ functionName: JSON.stringify(functionName) })),
+  "__error",
+  ts.statements([ts.raw("__stateStack.pop()")]),
+)
+```
+
+Remove `__functionCompleted` decl + assignments. If the catch path historically fired `onFunctionEnd` for failure paths, add a separate `ts.runnerHook(...)` call inside the catch handler with its own substep id (see Step 6).
+
+- [ ] **Step 5: Verify hook firing-on-failure semantics**
+
+Search for `__functionCompleted` and any docs claiming `onFunctionEnd` fires on every exit path:
+
+```bash
+grep -rn "__functionCompleted\|onFunctionEnd" lib/ docs/ tests/agency/callback-*.agency
+```
+
+If existing tests/docs expect failure-path firing, add the catch-side `ts.runnerHook(...)`. If not, leave it success-only (matching current `__functionCompleted` gating).
+
+- [ ] **Step 6: Build + run existing callback tests**
+
+```bash
+make
+for t in tests/agency/callback-*.agency; do
+  echo "=== $(basename $t) ==="
+  node ./dist/scripts/agency.js test "$t" 2>&1 | tail -3
+done | tee /tmp/callback-tests-task3.log
+```
+
+Expected: all 16 existing callback tests still pass. Investigate any failure before continuing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/backends/typescriptBuilder.ts
+git commit -m "Phase 1: migrate codegen hook sites to runner.hook; move onFunctionEnd out of finally"
+```
+
+---
+
+## Task 4: Reject interrupts from `onAgentStart` / `onAgentEnd`
+
+**Files:**
+- Modify: `lib/runtime/hooks.ts`
+- Modify: `lib/runtime/hooks.test.ts`
+
+`onAgentStart` and `onAgentEnd` fire from `lib/runtime/node.ts` outside any agency frame and cannot resume. They use `callHookAndDrop` so interrupts are logged and dropped — but a user registering an interrupt-raising callback on those hooks today gets silent failure. Make it loud.
+
+- [ ] **Step 1: Failing test**
+
+In `lib/runtime/hooks.test.ts`:
+
+```ts
+it("throws when onAgentStart or onAgentEnd callbacks raise interrupts", async () => {
+  for (const hookName of ["onAgentStart", "onAgentEnd"] as const) {
+    const ctx = fakeCtx();
+    const intr = { kind: "x::y", message: "", data: null, origin: "x", interruptId: "i" };
+    ctx.topLevelCallbacks = [{ name: hookName, fn: fakeAgencyFn([intr]) }];
+    await expect(
+      callHook({ ctx, name: hookName, data: {} as any }),
+    ).rejects.toThrow(/cannot raise interrupts/);
+  }
+});
+```
+
+- [ ] **Step 2: Implement**
+
+In `callHook` (or wherever the collected interrupt array is returned), before returning:
+
+```ts
+if (collected.length > 0 && (name === "onAgentStart" || name === "onAgentEnd")) {
+  throw new Error(
+    `[agency] ${name} callbacks cannot raise interrupts: the agent has ` +
+      `no active frame to checkpoint, so there's nowhere for the user to ` +
+      `respond from. Remove the interrupt() call from the callback body, ` +
+      `or move the registration to a hook that fires inside an agency ` +
+      `call frame (onFunctionStart, onNodeStart, etc.).`,
+  );
+}
+```
+
+- [ ] **Step 3: Run + commit**
+
+```bash
+pnpm vitest run lib/runtime/hooks.test.ts
+git add lib/runtime/hooks.ts lib/runtime/hooks.test.ts
+git commit -m "Phase 1: reject interrupts from onAgentStart/onAgentEnd callbacks"
+```
+
+---
+
+## Task 5: End-to-end resume tests
+
+**Files:**
+- Create: `tests/agency/callback-interrupt-resume-onfunctionstart.{agency,test.json}`
+- Create: `tests/agency/callback-interrupt-resume-onnodeend.{agency,test.json}`
+- Create: `tests/agency/callback-interrupt-resume-onemit.{agency,test.json}`
+
+Each test follows the same pattern: register a top-level callback for the hook, the callback raises an interrupt the first time and returns normally on resume, the program completes after `respondToInterrupts`. Verify that on resume the hook does NOT fire a second time (assert via a counter that increments inside the callback).
+
+- [ ] **Step 1: Write the three tests**
+
+Model on `tests/agency/callback-toplevel-interrupt.agency` (already in place from earlier work). One example for `onFunctionStart`:
+
+```agency
+let calls: number = 0
+
+callback("onFunctionStart") as data {
+  if (data.functionName == "doWork") {
+    calls = calls + 1
+    if (calls == 1) {
+      interrupt myapp::pause("waiting", data)
+    }
+  }
+}
+
+def doWork(): string {
+  return "ok"
+}
+
+node main() {
+  let r: string = doWork()
+  return [calls, r]
+}
+```
+
+Expected after responding to `myapp::pause` once: `[1, "ok"]` (callback fired exactly once total — the resume re-enters the function and the substep counter has not advanced past the hook because the halt skipped it, then the callback re-fires, returns undefined this time, the counter advances, and execution continues).
+
+Wait — that means `calls` would be `2`, not `1`. Re-read `Runner.hook`: on halt, the counter does NOT advance, so on resume the hook re-fires. The callback body is re-entered with its saved `__interruptId_N` matching the user's response, so the interrupt resolves without re-throwing — but the `calls = calls + 1` line outside the interrupt does run again.
+
+Decide the expected value based on intended semantics:
+- If we want "fired exactly once per logical event," then the test must read `calls == 2` and the docs must call this out (the callback body re-runs from the top on resume, like every other agency code path that resumes after an interrupt).
+- If we want "fired exactly once total," then `Runner.hook` would need to set the counter eagerly before calling `callHook` — but then a callback that mid-body throws would leave the counter advanced and the resume wouldn't re-enter the callback at all. That breaks the response routing.
+
+Correct expected value: **`calls == 2`** (the callback body re-runs after resume; `interrupt(...)` inside the body returns the user's response the second time, so the if-branch doesn't re-trigger). This matches existing interrupt semantics and is consistent with how user-written `interrupt()` calls behave today.
+
+Document this expectation in the test fixture's `.test.json` and in `docs/dev/callback-hooks.md` (see Task 7).
+
+- [ ] **Step 2: Run + commit**
+
+```bash
+for t in tests/agency/callback-interrupt-resume-*.agency; do
+  node ./dist/scripts/agency.js test "$t" 2>&1 | tail -3
+done | tee /tmp/resume-tests.log
+git add tests/agency/callback-interrupt-resume-*
+git commit -m "Phase 1: end-to-end resume tests for codegen hook interrupts"
+```
+
+---
+
+## Task 6: Multi-callback resume test
+
+**Files:**
+- Create: `tests/agency/callback-multi-interrupt-resume.{agency,test.json}`
+
+- [ ] **Step 1: Write the test**
+
+Two callbacks on the same hook, both interrupt the first time, both respond, resume completes:
+
+```agency
+let firedA: number = 0
+let firedB: number = 0
+
+callback("onFunctionEnd") as data {
+  if (data.functionName == "doWork") {
+    firedA = firedA + 1
+    if (firedA == 1) { interrupt myapp::a("A", data) }
+  }
+}
+
+callback("onFunctionEnd") as data {
+  if (data.functionName == "doWork") {
+    firedB = firedB + 1
+    if (firedB == 1) { interrupt myapp::b("B", data) }
+  }
+}
+
+def doWork(): string { return "x" }
+
+node main() {
+  let r: string = doWork()
+  return [firedA, firedB, r]
+}
+```
+
+Critical invariants:
+- Both interrupts surface in a single batched `Interrupt[]` (Phase 0 made `callHook` collect across callbacks).
+- After responding to both, resume re-enters `doWork`, `onFunctionEnd` re-fires, both callback bodies re-run, neither re-throws (their `if (firedX == 1)` guard is false the second time), substep counter advances, `r` returns `"x"`.
+- Final state: `[2, 2, "x"]`.
+
+- [ ] **Step 2: Run + commit**
+
+```bash
+node ./dist/scripts/agency.js test tests/agency/callback-multi-interrupt-resume.agency
+git add tests/agency/callback-multi-interrupt-resume.*
+git commit -m "Phase 1: cover multi-callback interrupt resume on same hook"
+```
+
+---
+
+## Task 7: Regenerate fixtures + full validation
+
+- [ ] **Step 1: Regenerate**
+
+```bash
+make fixtures
+```
+
+Inspect the diff. Each function/node should now show `await runner.hook(<n>, "onFunctionStart", {...})` etc. in place of the old `await callHook({...})` expressions. The diff is mechanical; investigate anything that changes shape unexpectedly.
+
+- [ ] **Step 2: Full validation**
+
+```bash
+make
+pnpm run typecheck
+pnpm run lint:structure
+pnpm vitest run 2>&1 | tail -5 | tee /tmp/vitest.log
+for t in tests/agency/callback-*.agency; do
+  node ./dist/scripts/agency.js test "$t" 2>&1 | grep -E "passed|FAIL" | tail -1
+done | tee /tmp/callback-final.log
+```
+
+Expected: all green. All 20 callback agency tests pass (16 existing + 4 new).
+
+- [ ] **Step 3: Commit fixtures**
+
+```bash
+git add tests/typescriptBuilder/ tests/typescriptGenerator/
+git commit -m "Phase 1: regenerate fixtures for runner.hook codegen"
+```
+
+---
+
+## Task 8: Update docs
+
+**Files:**
+- Modify: `docs/dev/callback-hooks.md` (created in Phase 0)
+- Modify: `docs/dev/interrupts.md`
+
+- [ ] **Step 1: Update `docs/dev/callback-hooks.md`**
+
+In the "Codegen-emitted (`ts.callHook(...)`)" section, replace the "After Phase 1" forward reference with: codegen emits `ts.runnerHook(...)`, which compiles to `await runner.hook(id, name, data)`. `Runner.hook` (in `lib/runtime/runner.ts`) handles the resume/halt/checkpoint protocol uniformly with every other Runner step type. The user-visible semantic is "if any callback for this hook interrupts, the surrounding agency frame halts and returns the interrupt batch up the stack; on resume, the hook re-fires and the callback bodies re-run with their saved interrupt-response locals."
+
+Call out explicitly that the callback body **re-runs from the top on resume** — same as every other agency code path that resumes after an interrupt. Counters and other observable side effects inside the callback body will appear to run twice for an interrupted callback.
+
+Note the asymmetry with `callHookAndDrop` (still used by TS-runtime sites) and the explicit reject for `onAgentStart` / `onAgentEnd`.
+
+- [ ] **Step 2: Add a section to `docs/dev/interrupts.md`**
+
+Under "Substeps", add:
+
+```markdown
+## Callback hook firing
+
+Codegen-emitted hook sites (onFunctionStart, onFunctionEnd, onEmit,
+onNodeStart, onNodeEnd) are compiled as a specialized Runner step type:
+`Runner.hook(id, hookName, data)` in lib/runtime/runner.ts.
+
+The step type follows the same skeleton as Runner.handle / Runner.thread:
+substep-counter resume-skipping, debugger pause, coverage hit, halt
+protocol. The hook-specific piece is calling callHook(...) and, if any
+callback halts with Interrupt[], stamping a pinned checkpoint at the
+substep path and halting the runner without advancing the counter so
+resume re-fires the hook.
+
+See lib/runtime/runner.ts (`hook` method) and docs/dev/callback-hooks.md
+for the full semantics.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/dev/callback-hooks.md docs/dev/interrupts.md
+git commit -m "Phase 1: document Runner.hook step type"
+```
+
+---
+
+## Final validation + PR
+
+- [ ] **Step 1: Inspect the commit log**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected: ~10 commits, one per task. Squash at PR-merge time per team convention.
+
+- [ ] **Step 2: Push + open PR**
+
+PR description should explicitly note:
+- Builds on Phase 0 (the plumbing PR).
+- New Runner step type `runner.hook(...)` propagates callback interrupts at the five codegen-emitted hook sites. The substep machinery (resume-skip, halt, checkpoint stamping) is inherited from the existing Runner skeleton — no bespoke flags, no new mustache, no leaky abstraction in generated code.
+- `onFunctionEnd` moves out of `finally` so its interrupts can propagate. Success-vs-failure firing semantics are preserved.
+- `onAgentStart` / `onAgentEnd` callbacks now throw if they raise interrupts (previously silently logged and dropped).
+- LLM/tool hooks (onLLMCallStart, onLLMCallEnd, onToolCallStart, onToolCallEnd) still use `callHookAndDrop` — Phase 2 covers those (`runPrompt` needs to be split into agency-callable pieces first).
+- Fixtures regenerated; the diff is mechanical and reflects the new `await runner.hook(...)` codegen.
+
+---
+
+## Out of scope for Phase 1
+
+- LLM/tool hook propagation. See the Phase 2 research notes: the TS-side runtime sites in `lib/runtime/prompt.ts` need to be split so callback firing happens inside agency code (where Runner is in scope) instead of mid-TS-function. That work is its own plan.
+- Removing `callHookAndDrop`. The agent-start/end sites fundamentally can't resume; they keep using `callHookAndDrop` permanently. The prompt.ts sites migrate in Phase 2.
+- Optimizing substep-id allocation. The current scheme uses `this.steps.nextId()` which assigns ids in source order. Compression is a future refactor.
+
+---
+
+## Risks worth flagging during review
+
+- **Test fixture churn.** `make fixtures` will rewrite ~100 `.mjs` files. The diff should be one-line per old `callHook` call replaced by a `runner.hook` call. If anything else changes shape, investigate before merging.
+- **`onFunctionEnd` semantics.** Moving out of `finally` changes when it fires on the failure path. Existing tests + Step 5 of Task 3 must explicitly cover both success and failure path firing.
+- **Callback body re-runs on resume.** Document this loudly in `docs/dev/callback-hooks.md`. Users who put non-idempotent side effects in callback bodies will be surprised. This matches existing agency semantics; the hook layer doesn't change it.
+- **`this.stack` requirement in Runner.hook.** The checkpoint stamp uses `this.stack!`. All codegen-emitted Runners pass a `stack` opt, but verify with grep before merging. The defensive `if (!this.stack) throw` in Task 1 makes violations loud.
+- **Hook firing inside an interrupt handler.** A callback body that interrupts inside an enclosing `handle` block still hits the live handler stack at firing time (existing Phase 0 behavior, unchanged). The new propagation only kicks in for *un*handled interrupts.

--- a/packages/agency-lang/lib/ir/builders.ts
+++ b/packages/agency-lang/lib/ir/builders.ts
@@ -512,6 +512,22 @@ export const ts = {
     return ts.raw(`__process.env[${JSON.stringify(varName)}]`);
   },
 
+  /**
+   * Emit `await callHook({ ctx, name, data })`.
+   *
+   * Phase 0 (the migration that introduced `Interrupt[]` returns from
+   * `callHook`) preserves the codegen-side behavior: the generated `await`
+   * expression evaluates to `Interrupt[] | undefined`, but the surrounding
+   * statement context discards it. That matches the today-style behavior
+   * of "interrupts raised by callbacks fire-and-forget at codegen-emitted
+   * sites" — see `lib/runtime/hooks.ts` `callHookAndDrop` for the
+   * equivalent at TS-side runtime call sites.
+   *
+   * Phase 1 will replace this builder (or add a sibling like
+   * `ts.runnerHook(...)`) that emits the interrupt-propagation pattern
+   * via a specialized Runner step type. See
+   * `docs/superpowers/plans/2026-05-22-callback-interrupts-phase-1-codegen-sites.md`.
+   */
   callHook(hookName: string, data: Record<string, TsNode> | TsNode): TsNode {
     const dataNode = "kind" in data ? data as TsNode : ts.obj(data as Record<string, TsNode>);
     return ts.awaitCall(ts.id("callHook"), [

--- a/packages/agency-lang/lib/runtime/hooks.test.ts
+++ b/packages/agency-lang/lib/runtime/hooks.test.ts
@@ -1,8 +1,27 @@
 import { describe, it, expect, vi } from "vitest";
 import { AgencyFunction } from "./agencyFunction.js";
 import { AgencyCancelledError, RestoreSignal } from "./errors.js";
-import { callHook } from "./hooks.js";
+import { callHook, callHookAndDrop } from "./hooks.js";
 import { State, StateStack } from "./state/stateStack.js";
+
+// Minimal fake context shape. Only the fields callHook touches.
+function fakeCtx(): any {
+  return {
+    topLevelCallbacks: [],
+    callbacks: {},
+    stateStack: { collectScopedCallbacks: () => [] },
+  };
+}
+
+// Build an AgencyFunction stub whose `.invoke(...)` returns the given value.
+function fakeAgencyFn(invokeResult: any): AgencyFunction {
+  const fn = {
+    name: "fake-cb",
+    invoke: vi.fn(async () => invokeResult),
+  } as unknown as AgencyFunction;
+  (fn as any).__agencyFunction = true;
+  return fn;
+}
 
 function ctxWithStack(
   stack: State[],
@@ -147,11 +166,11 @@ describe("callHook (rewritten)", () => {
     expect(calls).toEqual(["a", "b", "c"]);
   });
 
-  it("throws loudly when a callback halts with an unhandled Interrupt[]", async () => {
-    // Simulate an AgencyFunction callback body that produced an interrupt
-    // value (i.e. interrupt was raised inside the callback and no handler
-    // on the call stack caught it). callHook must surface this instead of
-    // silently dropping the interrupt.
+  it("returns the Interrupt[] when a callback halts with an unhandled interrupt", async () => {
+    // After Phase 0, callHook no longer logs and drops on unhandled
+    // interrupts — it returns the Interrupt[] so the caller can decide
+    // what to do (callHookAndDrop logs; future codegen sites will
+    // checkpoint + propagate).
     const consoleErr = vi.spyOn(console, "error").mockImplementation(() => {});
     const fakeInterrupt = { type: "interrupt", kind: "myapp::oops", message: "x" };
     const callbackFn = AgencyFunction.create(
@@ -167,14 +186,11 @@ describe("callHook (rewritten)", () => {
     const inner = new State();
     inner.scopedCallbacks = [{ name: "onNodeStart", fn: callbackFn }];
     const ctx = ctxWithStack([inner]);
-    await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
-    // Error is logged (not rethrown — fireWithGuard's catch turns it into a
-    // console.error to keep one buggy callback from killing the whole run),
-    // but it MUST be visible.
-    expect(consoleErr).toHaveBeenCalled();
-    const logged = consoleErr.mock.calls.map((c) => String(c[1])).join("\n");
-    expect(logged).toMatch(/unhandled interrupt/i);
-    expect(logged).toMatch(/myapp::oops/);
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
+    expect(out).toEqual([fakeInterrupt]);
+    // callHook itself no longer logs the unhandled interrupt — that
+    // responsibility moves to callHookAndDrop.
+    expect(consoleErr).not.toHaveBeenCalled();
     consoleErr.mockRestore();
   });
 
@@ -195,5 +211,84 @@ describe("callHook (rewritten)", () => {
     ctxHolder.ctx = ctxWithStack([inner]);
     await callHook({ ctx: ctxHolder.ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
     expect(maxDepth).toBe(1);
+  });
+});
+
+describe("invokeCallback / fireWithGuard interrupt return", () => {
+  it("returns the interrupt array when an AgencyFunction callback halts with interrupts", async () => {
+    const ctx = fakeCtx();
+    const intr = { type: "interrupt", kind: "myapp::test", message: "hi", data: null, origin: "x", interruptId: "i-1" };
+    const cb = fakeAgencyFn([intr]);
+    ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: cb }];
+
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(out).toEqual([intr]);
+  });
+
+  it("collects interrupts from every callback even when earlier ones halt", async () => {
+    const ctx = fakeCtx();
+    const intrA = { type: "interrupt", kind: "a::k", message: "A", data: null, origin: "x", interruptId: "i-a" };
+    const intrB = { type: "interrupt", kind: "b::k", message: "B", data: null, origin: "x", interruptId: "i-b" };
+    const cbA = fakeAgencyFn([intrA]);
+    const cbB = fakeAgencyFn([intrB]);
+    ctx.topLevelCallbacks = [
+      { name: "onNodeStart", fn: cbA },
+      { name: "onNodeStart", fn: cbB },
+    ];
+
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(out).toEqual([intrA, intrB]);
+    // Both callbacks must have been invoked — an interrupt in A must not
+    // short-circuit B. This is the concurrent-batching invariant that
+    // mirrors runForkAll: every sibling runs to completion, all halts
+    // are batched together.
+    expect((cbA as any).invoke).toHaveBeenCalledTimes(1);
+    expect((cbB as any).invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns undefined when no callback halts", async () => {
+    const ctx = fakeCtx();
+    ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: fakeAgencyFn(undefined) }];
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(out).toBeUndefined();
+  });
+
+  it("real JS errors in a callback do NOT appear in the returned interrupts", async () => {
+    const ctx = fakeCtx();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const cbCrash = {
+      invoke: vi.fn(async () => { throw new Error("boom"); }),
+    } as unknown as AgencyFunction;
+    (cbCrash as any).__agencyFunction = true;
+    ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: cbCrash }];
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(out).toBeUndefined();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});
+
+describe("callHookAndDrop", () => {
+  it("returns void and logs to console.error when interrupts come back", async () => {
+    const ctx = fakeCtx();
+    const intr = { type: "interrupt", kind: "x::y", message: "", data: null, origin: "x", interruptId: "i-1" };
+    ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: fakeAgencyFn([intr]) }];
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const out: void = await callHookAndDrop({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(out).toBeUndefined();
+    expect(errSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[agency] onNodeStart callback raised an unhandled interrupt"),
+      expect.anything(),
+    );
+    errSpy.mockRestore();
+  });
+
+  it("returns void with no logging when no interrupts are raised", async () => {
+    const ctx = fakeCtx();
+    ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: fakeAgencyFn(undefined) }];
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await callHookAndDrop({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(errSpy).not.toHaveBeenCalled();
+    errSpy.mockRestore();
   });
 });

--- a/packages/agency-lang/lib/runtime/hooks.test.ts
+++ b/packages/agency-lang/lib/runtime/hooks.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { AgencyFunction } from "./agencyFunction.js";
 import { AgencyCancelledError, RestoreSignal } from "./errors.js";
-import { callHook, callHookAndDrop } from "./hooks.js";
+import { callHook, callHookAndDrop, registerGlobalHook } from "./hooks.js";
 import { State, StateStack } from "./state/stateStack.js";
 
 // Minimal fake context shape. Only the fields callHook touches.
@@ -21,6 +21,23 @@ function fakeAgencyFn(invokeResult: any): AgencyFunction {
   } as unknown as AgencyFunction;
   (fn as any).__agencyFunction = true;
   return fn;
+}
+
+// Build a *real* AgencyFunction whose body returns the given value.
+// Exercises the actual `invoke()` pipeline (positional args, hasInterrupts
+// unwrap, return-shape detection) instead of mocking it away.
+let _realCbCounter = 0;
+function realAgencyFn(returnValue: any): AgencyFunction {
+  return AgencyFunction.create(
+    {
+      name: `__real_cb_${_realCbCounter++}`,
+      module: "test",
+      fn: async () => returnValue,
+      params: [{ name: "data", hasDefault: false, defaultValue: undefined, variadic: false }],
+      toolDefinition: null,
+    },
+    {},
+  );
 }
 
 function ctxWithStack(
@@ -290,5 +307,126 @@ describe("callHookAndDrop", () => {
     await callHookAndDrop({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
     expect(errSpy).not.toHaveBeenCalled();
     errSpy.mockRestore();
+  });
+});
+
+// Tests below use the real AgencyFunction pipeline (not a mock) so that the
+// wire shape between `AgencyFunction.invoke` and `invokeCallback` is part of
+// the contract being tested. If something downstream of `invoke` ever wraps
+// or unwraps the returned interrupt array, these tests fail.
+describe("Phase 0: end-to-end shape (real AgencyFunction)", () => {
+  const intrA = { type: "interrupt", kind: "a::k", message: "A", data: null, origin: "x", interruptId: "i-a" };
+  const intrB = { type: "interrupt", kind: "b::k", message: "B", data: null, origin: "x", interruptId: "i-b" };
+  const intrC = { type: "interrupt", kind: "c::k", message: "C", data: null, origin: "x", interruptId: "i-c" };
+
+  it("real AgencyFunction callback halt returns Interrupt[] via the real invoke pipeline", async () => {
+    const ctx = fakeCtx();
+    ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: realAgencyFn([intrA]) }];
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(out).toEqual([intrA]);
+  });
+
+  it("mixed batch: halt → succeed → halt yields [first, third] in order", async () => {
+    const ctx = fakeCtx();
+    ctx.topLevelCallbacks = [
+      { name: "onNodeStart", fn: realAgencyFn([intrA]) },
+      { name: "onNodeStart", fn: realAgencyFn(undefined) },
+      { name: "onNodeStart", fn: realAgencyFn([intrC]) },
+    ];
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    // The undefined return in the middle must not break the loop, must not
+    // add anything to the batch, and must not perturb ordering.
+    expect(out).toEqual([intrA, intrC]);
+  });
+
+  it("cross-source ordering: scoped first, then top-level, in the returned batch", async () => {
+    const inner = new State();
+    inner.scopedCallbacks = [{ name: "onNodeStart", fn: realAgencyFn([intrA]) }];
+    const ctx = ctxWithStack(
+      [inner],
+      {},
+      [{ name: "onNodeStart", fn: realAgencyFn([intrB]) }],
+    );
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } } as any);
+    // gatherCallbacks order: scoped → top-level → TS-passed. The interrupt
+    // batch must preserve that firing order. (TS-passed is plain JS and
+    // can't contribute — covered in a separate test below.)
+    expect(out).toEqual([intrA, intrB]);
+  });
+});
+
+describe("Phase 0: scoped-callback halt path", () => {
+  it("a single scoped AgencyFunction callback halt returns its Interrupt[]", async () => {
+    // Gap-B: every other halt test uses topLevelCallbacks; this test exercises
+    // the stateStack.collectScopedCallbacks branch of gatherCallbacks so that
+    // a regression in the scoped path is independently caught.
+    const intr = { type: "interrupt", kind: "scope::k", message: "S", data: null, origin: "x", interruptId: "i-s" };
+    const inner = new State();
+    inner.scopedCallbacks = [{ name: "onNodeStart", fn: realAgencyFn([intr]) }];
+    const ctx = ctxWithStack([inner]);
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } } as any);
+    expect(out).toEqual([intr]);
+  });
+});
+
+describe("Phase 0: non-AgencyFunction callbacks cannot contribute to the batch", () => {
+  it("plain JS scoped callback returning interrupt-shaped value is silently dropped", async () => {
+    // Plain JS callbacks (no __agencyFunction marker) have no interrupt
+    // mechanism — their return value is ignored entirely. A return value
+    // that happens to look like Interrupt[] must NOT end up in the batch.
+    const fakeShape = [{ type: "interrupt", kind: "js::oops", message: "" }];
+    const inner = new State();
+    inner.scopedCallbacks = [{ name: "onNodeStart", fn: () => fakeShape }];
+    const ctx = ctxWithStack([inner]);
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } } as any);
+    expect(out).toBeUndefined();
+  });
+
+  it("TS-passed callback returning interrupt-shaped value is silently dropped", async () => {
+    const fakeShape = [{ type: "interrupt", kind: "js::oops", message: "" }];
+    const ctx = ctxWithStack([new State()], { onNodeStart: () => fakeShape });
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } } as any);
+    expect(out).toBeUndefined();
+  });
+
+  it("global hook returning interrupt-shaped value is silently dropped", async () => {
+    const fakeShape = [{ type: "interrupt", kind: "global::oops", message: "" }];
+    // registerGlobalHook is module-scoped; we have to clean up after to keep
+    // other tests pristine. There's no public unregister API, so we shadow
+    // the result by registering another hook that resets the array — but the
+    // cleaner approach is to register on a hook name no other test uses.
+    registerGlobalHook("onEmit", (() => fakeShape) as any);
+    const ctx = fakeCtx();
+    const out = await callHook({ ctx, name: "onEmit", data: undefined as any });
+    expect(out).toBeUndefined();
+  });
+});
+
+describe("Phase 0: hasInterrupts edge cases at the callback boundary", () => {
+  it("empty array return is treated as non-interrupt (dropped)", async () => {
+    const ctx = fakeCtx();
+    ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: realAgencyFn([]) }];
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(out).toBeUndefined();
+  });
+
+  it("mixed array (interrupt + non-interrupt) is treated as non-interrupt (dropped)", async () => {
+    // hasInterrupts requires every element to be an Interrupt. A partial
+    // match must NOT leak into the batch.
+    const ctx = fakeCtx();
+    const intr = { type: "interrupt", kind: "x::y", message: "" };
+    ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: realAgencyFn([intr, "not-an-interrupt"]) }];
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(out).toBeUndefined();
+  });
+
+  it("single interrupt object (not array-wrapped) is treated as non-interrupt (dropped)", async () => {
+    // hasInterrupts requires Array.isArray. A bare interrupt object must
+    // not be unwrapped or auto-arrayed.
+    const ctx = fakeCtx();
+    const intr = { type: "interrupt", kind: "x::y", message: "" };
+    ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: realAgencyFn(intr) }];
+    const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
+    expect(out).toBeUndefined();
   });
 });

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -9,7 +9,7 @@ import type {
 import type { CallbackName } from "../types/function.js";
 import { AgencyFunction } from "./agencyFunction.js";
 import { AgencyCancelledError, RestoreSignal } from "./errors.js";
-import { hasInterrupts } from "./interrupts.js";
+import { hasInterrupts, type Interrupt } from "./interrupts.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { TraceEvent } from "./trace/types.js";
 import type { RunNodeResult } from "./types.js";
@@ -99,29 +99,27 @@ async function invokeCallback(
   fn: any,
   data: unknown,
   ctx: RuntimeContext<any>,
-  errorLabel: string,
-): Promise<void> {
+  _errorLabel: string,
+): Promise<Interrupt[] | undefined> {
   if (AgencyFunction.isAgencyFunction(fn)) {
     const result = await (fn as AgencyFunction).invoke(
       { type: "positional", args: [data] },
       { ctx },
     );
-    // If the callback body halts with an unhandled Interrupt[] (i.e. an
-    // `interrupt` statement was executed inside the callback body but no
-    // enclosing `handle` block caught it), surface it instead of silently
-    // dropping it. Callbacks fire outside the normal step-driven control
-    // flow, so we can't propagate the interrupt up the call stack; the only
-    // safe behavior is to fail loudly.
+    // The callback body completed with an unhandled `interrupt` statement.
+    // Surface the interrupts so the caller can decide what to do — Phase 0
+    // callers (`callHookAndDrop`) log them; Phase 1+ codegen sites stamp a
+    // checkpoint and propagate them up the runner.
     if (hasInterrupts(result)) {
-      throw new Error(
-        `[agency] ${errorLabel} callback raised an unhandled interrupt ` +
-        `(kind="${result[0].kind}"). Interrupts inside callbacks must be ` +
-        `caught by a \`handle\` block on the enclosing call stack.`,
-      );
+      return result as Interrupt[];
     }
-    return;
+    return undefined;
   }
+  // Plain JS callbacks (from AgencyCallbacks TS arg) have no interrupt
+  // mechanism — they're just async functions. Errors thrown by them still
+  // get caught by fireWithGuard below.
   await fn(data);
+  return undefined;
 }
 
 async function fireWithGuard(
@@ -129,17 +127,21 @@ async function fireWithGuard(
   data: unknown,
   ctx: RuntimeContext<any>,
   errorLabel: string,
-): Promise<void> {
+): Promise<Interrupt[] | undefined> {
   const key = fn as object;
-  if (_activeCallbacks.has(key)) return;
+  if (_activeCallbacks.has(key)) return undefined;
   _activeCallbacks.add(key);
   try {
-    await invokeCallback(fn, data, ctx, errorLabel);
+    return await invokeCallback(fn, data, ctx, errorLabel);
   } catch (error) {
     // Never swallow real control-flow exceptions used by the runtime.
     if (error instanceof RestoreSignal) throw error;
     if (error instanceof AgencyCancelledError) throw error;
+    // Real JS errors (e.g. a callback body crashed) still get logged here.
+    // Interrupts no longer flow through this path — they return normally
+    // from invokeCallback now.
     console.error(`[agency] ${errorLabel} callback error:`, error);
+    return undefined;
   } finally {
     _activeCallbacks.delete(key);
   }
@@ -166,15 +168,62 @@ export async function callHook<K extends keyof CallbackMap>(args: {
   ctx: RuntimeContext<any>;
   name: K;
   data: CallbackMap[K];
-}): Promise<void> {
+}): Promise<Interrupt[] | undefined> {
   const { ctx, name, data } = args;
 
-  // Fire global hooks (from external packages) first
+  // Single shared collector. Mirrors the runForkAll pattern of "let every
+  // sibling run to completion, batch all interrupts together at the end"
+  // (see docs/dev/concurrent-interrupts.md). Callbacks are sequential
+  // here (not parallel like fork branches), but the batching semantics
+  // are the same: an interrupt from callback A must not short-circuit
+  // callback B.
+  const collected: Interrupt[] = [];
+
+  // Fire global hooks (from external packages) first. They are plain JS
+  // and have no interrupt mechanism, so they can't contribute to the
+  // batch.
   for (const fn of _globalHooks[name] ?? []) {
     await fireWithGuard(fn, data, ctx, `global ${name}`);
   }
 
   for (const fn of gatherCallbacks(ctx, name)) {
-    await fireWithGuard(fn, data, ctx, name);
+    const result = await fireWithGuard(fn, data, ctx, name);
+    if (result) collected.push(...result);
+  }
+
+  return collected.length > 0 ? collected : undefined;
+}
+
+/**
+ * Fire a hook with the today-style "log + drop" interrupt behavior.
+ *
+ * Existing TS-side runtime call sites (in `lib/runtime/node.ts` and
+ * `lib/runtime/prompt.ts`) wrap `callHook` with this helper because
+ * they cannot propagate callback interrupts up the agency runner: they
+ * sit either outside any agency frame (onAgentStart / onAgentEnd) or
+ * inside `runPrompt`'s internal state machine which has no resumable
+ * substep machinery yet. Phase 2 of the callback-interrupts work will
+ * give the LLM/tool sites real propagation; until then they continue
+ * to log and drop, matching the pre-refactor behavior.
+ *
+ * Codegen-emitted hook sites (the `ts.callHook(...)` builder) get
+ * actual propagation in Phase 1 by emitting `callHook` directly and
+ * checking the return value inline.
+ */
+export async function callHookAndDrop<K extends keyof CallbackMap>(args: {
+  ctx: RuntimeContext<any>;
+  name: K;
+  data: CallbackMap[K];
+}): Promise<void> {
+  const result = await callHook(args);
+  if (result) {
+    console.error(
+      `[agency] ${args.name} callback raised an unhandled interrupt ` +
+        `(kind="${result[0].kind}") at a runtime call site that does not ` +
+        `support interrupt propagation. The interrupt is being dropped. ` +
+        `Move the hook firing into an agency-controlled scope, or wait for ` +
+        `Phase 2 of the callback-interrupts work.`,
+      result,
+    );
   }
 }

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -99,7 +99,6 @@ async function invokeCallback(
   fn: any,
   data: unknown,
   ctx: RuntimeContext<any>,
-  _errorLabel: string,
 ): Promise<Interrupt[] | undefined> {
   if (AgencyFunction.isAgencyFunction(fn)) {
     const result = await (fn as AgencyFunction).invoke(
@@ -132,7 +131,7 @@ async function fireWithGuard(
   if (_activeCallbacks.has(key)) return undefined;
   _activeCallbacks.add(key);
   try {
-    return await invokeCallback(fn, data, ctx, errorLabel);
+    return await invokeCallback(fn, data, ctx);
   } catch (error) {
     // Never swallow real control-flow exceptions used by the runtime.
     if (error instanceof RestoreSignal) throw error;
@@ -221,8 +220,11 @@ export async function callHookAndDrop<K extends keyof CallbackMap>(args: {
       `[agency] ${args.name} callback raised an unhandled interrupt ` +
         `(kind="${result[0].kind}") at a runtime call site that does not ` +
         `support interrupt propagation. The interrupt is being dropped. ` +
-        `Move the hook firing into an agency-controlled scope, or wait for ` +
-        `Phase 2 of the callback-interrupts work.`,
+        `Some sites (onAgentStart/onAgentEnd) fundamentally cannot ` +
+        `propagate because they fire outside any agency frame; others ` +
+        `(LLM/tool hooks) may gain propagation in a future phase. To ` +
+        `respond to this interrupt, register the callback on a hook ` +
+        `that fires inside an agency call frame instead.`,
       result,
     );
   }

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { MessageJSON } from "smoltalk";
-import { callHook } from "./hooks.js";
+import { callHookAndDrop } from "./hooks.js";
 import type { AgencyCallbacks } from "./hooks.js";
 import type { RuntimeContext } from "./state/context.js";
 import {
@@ -171,7 +171,7 @@ export async function runNode({
     });
   }
 
-  await callHook({
+  await callHookAndDrop({
     ctx: execCtx,
     name: "onAgentStart",
     data: { nodeName, args: data, messages: messages || [], cancel },
@@ -219,7 +219,7 @@ export async function runNode({
             timeTaken: performance.now() - agentStartTime,
             tokenStats: returnObject.tokens,
           });
-          await callHook({
+          await callHookAndDrop({
             ctx: execCtx,
             name: "onAgentEnd",
             data: { nodeName, result: returnObject },

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -3,7 +3,7 @@ import { PromptResult, Result, StreamChunk, ToolCallJSON } from "smoltalk";
 import { createLogger } from "../logger.js";
 import { AgencyFunction } from "./agencyFunction.js";
 import { AgencyCancelledError, isAbortError } from "./errors.js";
-import { callHook } from "./hooks.js";
+import { callHookAndDrop } from "./hooks.js";
 import { Interrupt, hasInterrupts, isRejected } from "./interrupts.js";
 import type { PromptConfig } from "./llmClient.js";
 import { setupFunction } from "./node.js";
@@ -54,7 +54,7 @@ async function _runPrompt({
   const stream = !!(clientConfig as any)?.stream;
   const startTime = performance.now();
 
-  await callHook({
+  await callHookAndDrop({
     ctx,
     name: "onLLMCallStart",
     data: {
@@ -191,7 +191,7 @@ async function _runPrompt({
     }
   }
 
-  await callHook({
+  await callHookAndDrop({
     ctx,
     name: "onLLMCallEnd",
     data: {
@@ -480,7 +480,7 @@ export async function runPrompt(args: {
         const branchStack = stack.getOrCreateBranch(branchKey).stack;
 
         const namedArgs = { ...toolCall.arguments };
-        await callHook({
+        await callHookAndDrop({
           ctx,
           name: "onToolCallStart",
           data: { toolName: handler.name, args: namedArgs },
@@ -606,7 +606,7 @@ export async function runPrompt(args: {
         stack.setResultOnBranch(branchKey, result);
 
         const toolCallEndTime = performance.now();
-        await callHook({
+        await callHookAndDrop({
           ctx,
           name: "onToolCallEnd",
           data: {

--- a/packages/agency-lang/tests/agency/callback-runtime-site-interrupt-dropped.agency
+++ b/packages/agency-lang/tests/agency/callback-runtime-site-interrupt-dropped.agency
@@ -1,0 +1,22 @@
+
+// A top-level callback that raises an interrupt on `onAgentEnd`.
+// `onAgentEnd` fires from `lib/runtime/node.ts`, OUTSIDE any agency call
+// frame, via `callHookAndDrop`. The callHookAndDrop path must log the
+// interrupt to console.error and let the program complete normally —
+// it must NOT crash the run, throw an exception, or cause the agent's
+// final result to change.
+//
+// This is the Phase 0 contract for TS-side runtime sites: unhandled
+// callback interrupts are dropped, the program output is unaffected.
+
+callback("onAgentEnd") as data {
+  interrupt myapp::droppedAtRuntimeSite("from onAgentEnd", data)
+}
+
+def helper(): string {
+  return "ok"
+}
+
+node main() {
+  return helper()
+}

--- a/packages/agency-lang/tests/agency/callback-runtime-site-interrupt-dropped.test.json
+++ b/packages/agency-lang/tests/agency/callback-runtime-site-interrupt-dropped.test.json
@@ -1,0 +1,9 @@
+{
+  "tests": [{
+    "nodeName": "main",
+    "input": "",
+    "expectedOutput": "\"ok\"",
+    "evaluationCriteria": [{ "type": "exact" }],
+    "description": "interrupt raised by an onAgentEnd callback (TS-side runtime site) is logged and dropped via callHookAndDrop; the program completes with its original return value"
+  }]
+}


### PR DESCRIPTION
## Summary

Phase 0 of the callback-interrupts work. Pure plumbing — **zero user-visible behavior change**.

`callHook` now returns `Interrupt[] | undefined` so callers can decide whether to propagate or drop unhandled callback interrupts. Every existing call site is migrated to a fire-and-forget wrapper (`callHookAndDrop`) that preserves today's "log + swallow" semantics.

This sets up Phase 1, which will replace codegen-emitted hook sites with a specialized `Runner.hook` step type that actually propagates interrupts up the runner so `respondToInterrupts` works end-to-end.

## What changed

- **`lib/runtime/hooks.ts`**
  - `invokeCallback` returns `Interrupt[] | undefined` instead of throwing on unhandled interrupts.
  - `fireWithGuard` threads the return value through.
  - `callHook` loops over every callback, batching interrupts into a single returned array. An interrupt from callback A no longer short-circuits callback B (mirrors the `runForkAll` concurrent-batching invariant in `docs/dev/concurrent-interrupts.md`).
  - New `callHookAndDrop(args)` helper: `await callHook` and `console.error`-log any returned interrupts.
- **`lib/runtime/node.ts`** — `onAgentStart` / `onAgentEnd` migrated to `callHookAndDrop`.
- **`lib/runtime/prompt.ts`** — `onLLMCallStart` / `onLLMCallEnd` / `onToolCallStart` / `onToolCallEnd` migrated to `callHookAndDrop`.
- **`lib/ir/builders.ts`** — docstring on `ts.callHook` pointing at the Phase 1 plan; emitted code unchanged.
- **`docs/dev/callback-hooks.md`** — new doc describing the two paths through `callHook`, the error-vs-interrupt distinction in `fireWithGuard`, multi-callback batching, and the rationale for the batch-and-return shape.
- **`lib/runtime/hooks.test.ts`** — 6 new tests covering the new return shape, multi-callback batching, no-interrupt path, real-JS-error path, and `callHookAndDrop` log behavior. One existing test was updated from "throws loudly" to "returns the array" to match the new contract.
- **`docs/superpowers/plans/`** — Phase 0 and Phase 1 implementation plans committed for reference.

## Out of scope

- Codegen-emitted call sites (`ts.callHook`) keep dropping interrupts in Phase 0 — they wrap the new return in a statement context that ignores it. **Phase 1** fixes those via a new `Runner.hook` step type.
- LLM/tool hooks in `lib/runtime/prompt.ts` keep dropping interrupts. **Phase 2** fixes those (requires splitting `runPrompt` into agency-callable pieces).
- `onAgentStart` / `onAgentEnd` fundamentally cannot propagate interrupts (no agency frame). They will stay on `callHookAndDrop` permanently — Phase 1 adds an explicit reject so users get a loud error instead of a silent log.

## Validation

- `pnpm vitest run` — **4379/4379 passing** (6 new tests in `hooks.test.ts`)
- `pnpm run typecheck` — clean
- `pnpm run lint:structure` — clean
- All 16 callback agency tests still pass.
