### PR TITLE
Fix debugger after runner.hook substep changes

### DIFF
--- a/packages/agency-lang/lib/debugger/debuggerState.ts
+++ b/packages/agency-lang/lib/debugger/debuggerState.ts
@@ -45,12 +45,10 @@ export class DebuggerState {
   }
 
   enterCall() {
-    // console.log(color.blue(`[DebuggerState] enterCall at depth ${this.callDepth}, target: ${this.stepTarget ? JSON.stringify(this.stepTarget) : "n/a"}`));
     this.callDepth++;
   }
 
   exitCall() {
-    // console.log(color.blue(`[DebuggerState] exitCall at depth ${this.callDepth}, target: ${this.stepTarget ? JSON.stringify(this.stepTarget) : "n/a"}`));
     if (this.callDepth > 0) {
       this.callDepth--;
     }
@@ -71,7 +69,6 @@ export class DebuggerState {
 
   stepIn() {
     this.stepping();
-    // console.log(color.red(`[DebuggerState] stepIn called at call depth ${this.callDepth}, setting target to ${this.callDepth + 1}`));
     this.stepTarget = {
       type: "stepIn",
       targetDepth: this.callDepth + 1,

--- a/packages/agency-lang/lib/debugger/driver.ts
+++ b/packages/agency-lang/lib/debugger/driver.ts
@@ -504,9 +504,17 @@ export class DebuggerDriver {
 
     this.ui.state.resetOverrides();
 
-    // Reset call depth — it will be rebuilt by hooks during replay
-    this.debuggerState.resetCallDepth();
-    this.ui.state.resetCallStack();
+    // NOTE: we deliberately do NOT reset callDepth here. With the new
+    // runner.hook substep model, onFunctionStart fires once (as a
+    // resumable substep) and its counter advances past it on success,
+    // so the hook does NOT re-fire on resume. enterCall therefore is
+    // not called again during replay. The callDepth tracked at the
+    // moment of the pause is already correct — we preserve it so that
+    // stepOut/next can compare against it accurately.
+    //
+    // exitCall still fires for each function we leave because
+    // onFunctionEnd is emitted from the finally block via callHook
+    // (not via runner.hook), so it runs whenever the function unwinds.
 
     return await this.resumeInterrupt(() =>
       this.mod.respondToInterrupts([interrupt], [{ type: "approve" }], {

--- a/packages/agency-lang/lib/runtime/deterministicClient.test.ts
+++ b/packages/agency-lang/lib/runtime/deterministicClient.test.ts
@@ -69,13 +69,19 @@ describe("DeterministicClient", () => {
     );
   });
 
-  it("throws when tool call mock is missing args", async () => {
+  it("defaults missing tool call args to an empty object", async () => {
+    // Args are optional in the mock so callers don't have to write
+    // `args: {}` for tools that take no arguments. See `deterministicClient.ts`.
     const client = new DeterministicClient([
       { toolCall: { name: "add" } },
     ]);
-    await expect(client.text(baseConfig)).rejects.toThrow(
-      "missing args"
-    );
+    const result = await client.text(baseConfig);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.value.toolCalls).toHaveLength(1);
+      expect(result.value.toolCalls[0].name).toBe("add");
+      expect(result.value.toolCalls[0].arguments).toEqual({});
+    }
   });
 
   it("textStream yields a single done chunk", async () => {

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -414,7 +414,12 @@ export class Runner {
     if (this.shouldSkip()) return;
     if (this.getCounter() > id) return;
 
-    if (await this.maybeDebugHook(id)) return;
+    // NOTE: codegen-emitted hook substeps (onNodeStart/onNodeEnd/onEmit/
+    // onFunctionStart/onFunctionEnd) are invisible to the debugger.
+    // They have no source mapping and aren't user-authored code, so
+    // pausing on them would surprise the user (single-step would land
+    // on an internal hook with no current line). We intentionally do
+    // NOT call maybeDebugHook here.
 
     this.ctx.coverageCollector?.hit(this.moduleId, this.scopeName, this.stepPath(id));
 

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -201,19 +201,6 @@ let __functionCompleted = false;
     await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
-  await callHook({
-    ctx: __ctx,
-    name: "onFunctionStart",
-    data: {
-      functionName: "add",
-      args: {
-        a: a,
-        b: b
-      },
-      isBuiltin: false,
-      moduleId: "tests/debugger/function-call-test.agency"
-    }
-  })
   __stack.args["a"] = a;
   __stack.args["b"] = b;
   __self.__retryable = __self.__retryable ?? true;
@@ -237,13 +224,22 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.step(0, async (runner) => {
-__stack.locals.result = __stack.args.a + __stack.args.b;
+    await runner.hook(0, "onFunctionStart", {
+      functionName: "add",
+      args: {
+        a: a,
+        b: b
+      },
+      isBuiltin: false,
+      moduleId: "tests/debugger/function-call-test.agency"
     });
     await runner.step(1, async (runner) => {
-__stack.locals.doubled = __stack.locals.result * 2;
+__stack.locals.result = __stack.args.a + __stack.args.b;
     });
     await runner.step(2, async (runner) => {
+__stack.locals.doubled = __stack.locals.result * 2;
+    });
+    await runner.step(3, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.doubled)
 return;
@@ -314,19 +310,15 @@ const statelogClient = __ctx.statelogClient;
 const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
-  await callHook({
-    ctx: __ctx,
-    name: "onNodeStart",
-    data: {
-      nodeName: "main"
-    }
-  })
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/function-call-test.agency", scopeName: "main" });
   try {
-    await runner.step(0, async (runner) => {
-__stack.locals.x = 1;
+    await runner.hook(0, "onNodeStart", {
+      nodeName: "main"
     });
     await runner.step(1, async (runner) => {
+__stack.locals.x = 1;
+    });
+    await runner.step(2, async (runner) => {
 __stack.locals.y = await __call(add, {
         type: "positional",
         args: [__stack.locals.x, 2]
@@ -344,13 +336,13 @@ if (hasInterrupts(__stack.locals.y)) {
         return;
       }
     });
-    await runner.step(2, async (runner) => {
+    await runner.step(3, async (runner) => {
 __stack.locals.z = __stack.locals.y + 10;
     });
-    await runner.step(3, async (runner) => {
+    await runner.step(4, async (runner) => {
 __stack.locals.w = __stack.locals.z + 1;
     });
-    await runner.step(4, async (runner) => {
+    await runner.step(5, async (runner) => {
 runner.halt({
         messages: __threads,
         data: __stack.locals.w
@@ -358,14 +350,11 @@ runner.halt({
 return;
     });
     if (runner.halted) return runner.haltResult;
-    await callHook({
-      ctx: __ctx,
-      name: "onNodeEnd",
-      data: {
-        nodeName: "main",
-        data: undefined
-      }
-    })
+    await runner.hook(6, "onNodeEnd", {
+      nodeName: "main",
+      data: undefined
+    });
+    if (runner.halted) return runner.haltResult;
     return {
       messages: __threads,
       data: undefined
@@ -407,4 +396,4 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 }
 export default graph
-export const __sourceMap = {"tests/debugger/function-call-test.agency:add":{"0":{"line":1,"col":2},"1":{"line":2,"col":2},"2":{"line":3,"col":2}},"tests/debugger/function-call-test.agency:main":{"0":{"line":7,"col":2},"1":{"line":8,"col":2},"2":{"line":9,"col":2},"3":{"line":10,"col":2},"4":{"line":11,"col":2}}};
+export const __sourceMap = {"tests/debugger/function-call-test.agency:add":{"1":{"line":1,"col":2},"2":{"line":2,"col":2},"3":{"line":3,"col":2}},"tests/debugger/function-call-test.agency:main":{"1":{"line":7,"col":2},"2":{"line":8,"col":2},"3":{"line":9,"col":2},"4":{"line":10,"col":2},"5":{"line":11,"col":2}}};

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -196,19 +196,15 @@ const statelogClient = __ctx.statelogClient;
 const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
-  await callHook({
-    ctx: __ctx,
-    name: "onNodeStart",
-    data: {
-      nodeName: "main"
-    }
-  })
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/if-else-test.agency", scopeName: "main" });
   if (!__state.isResume) {
     __stack.args["x"] = __state.data.x;
   }
   try {
-    await runner.ifElse(0, [
+    await runner.hook(0, "onNodeStart", {
+      nodeName: "main"
+    });
+    await runner.ifElse(1, [
 
   {
     condition: async () => __stack.args.x > 0,
@@ -224,7 +220,7 @@ await runner.step(1, async (runner) => {
 __stack.locals.result = `non-positive`;
         });
 });
-    await runner.step(1, async (runner) => {
+    await runner.step(2, async (runner) => {
 runner.halt({
         messages: __threads,
         data: __stack.locals.result
@@ -232,14 +228,11 @@ runner.halt({
 return;
     });
     if (runner.halted) return runner.haltResult;
-    await callHook({
-      ctx: __ctx,
-      name: "onNodeEnd",
-      data: {
-        nodeName: "main",
-        data: undefined
-      }
-    })
+    await runner.hook(3, "onNodeEnd", {
+      nodeName: "main",
+      data: undefined
+    });
+    if (runner.halted) return runner.haltResult;
     return {
       messages: __threads,
       data: undefined
@@ -283,4 +276,4 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 }
 export default graph
-export const __sourceMap = {"tests/debugger/if-else-test.agency:main":{"0":{"line":1,"col":2},"1":{"line":6,"col":2},"0.0":{"line":2,"col":4},"0.1":{"line":4,"col":4}}};
+export const __sourceMap = {"tests/debugger/if-else-test.agency:main":{"1":{"line":1,"col":2},"2":{"line":6,"col":2},"1.0":{"line":2,"col":4},"1.1":{"line":4,"col":4}}};

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -196,21 +196,17 @@ const statelogClient = __ctx.statelogClient;
 const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
-  await callHook({
-    ctx: __ctx,
-    name: "onNodeStart",
-    data: {
-      nodeName: "main"
-    }
-  })
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/interrupt-test.agency", scopeName: "main" });
   try {
-    await runner.step(0, async (runner) => {
-__stack.locals.x = 1;
+    await runner.hook(0, "onNodeStart", {
+      nodeName: "main"
     });
     await runner.step(1, async (runner) => {
+__stack.locals.x = 1;
+    });
+    await runner.step(2, async (runner) => {
 // Resume path: check for a response by interruptId
-const __response = __ctx.getInterruptResponse(__self.__interruptId_1);
+const __response = __ctx.getInterruptResponse(__self.__interruptId_2);
 if (__response) {
   if (__response.type === "approve") {
     if (__response.value !== undefined) {
@@ -241,8 +237,8 @@ if (__response) {
   } else {
     // No handler — propagate interrupt array to TypeScript caller
     // Store interruptId on frame BEFORE checkpoint so it's captured in the snapshot
-    __self.__interruptId_1 = __handlerResult[0].interruptId;
-    const __checkpointId = __ctx.checkpoints.create(__stateStack, __ctx, { moduleId: "tests/debugger/interrupt-test.agency", scopeName: "main", stepPath: "1" });
+    __self.__interruptId_2 = __handlerResult[0].interruptId;
+    const __checkpointId = __ctx.checkpoints.create(__stateStack, __ctx, { moduleId: "tests/debugger/interrupt-test.agency", scopeName: "main", stepPath: "2" });
     __handlerResult[0].checkpointId = __checkpointId;
     __handlerResult[0].checkpoint = __ctx.checkpoints.get(__checkpointId);
     
@@ -254,10 +250,10 @@ if (__response) {
 }
 
     });
-    await runner.step(2, async (runner) => {
+    await runner.step(3, async (runner) => {
 __stack.locals.z = __stack.locals.x + __stack.locals.y;
     });
-    await runner.step(3, async (runner) => {
+    await runner.step(4, async (runner) => {
 runner.halt({
         messages: __threads,
         data: __stack.locals.z
@@ -265,14 +261,11 @@ runner.halt({
 return;
     });
     if (runner.halted) return runner.haltResult;
-    await callHook({
-      ctx: __ctx,
-      name: "onNodeEnd",
-      data: {
-        nodeName: "main",
-        data: undefined
-      }
-    })
+    await runner.hook(5, "onNodeEnd", {
+      nodeName: "main",
+      data: undefined
+    });
+    if (runner.halted) return runner.haltResult;
     return {
       messages: __threads,
       data: undefined
@@ -314,4 +307,4 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 }
 export default graph
-export const __sourceMap = {"tests/debugger/interrupt-test.agency:main":{"0":{"line":1,"col":2},"1":{"line":2,"col":2},"2":{"line":3,"col":2},"3":{"line":4,"col":2}}};
+export const __sourceMap = {"tests/debugger/interrupt-test.agency:main":{"1":{"line":1,"col":2},"2":{"line":2,"col":2},"3":{"line":3,"col":2},"4":{"line":4,"col":2}}};

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -196,24 +196,20 @@ const statelogClient = __ctx.statelogClient;
 const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
-  await callHook({
-    ctx: __ctx,
-    name: "onNodeStart",
-    data: {
-      nodeName: "main"
-    }
-  })
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/loop-test.agency", scopeName: "main" });
   try {
-    await runner.step(0, async (runner) => {
+    await runner.hook(0, "onNodeStart", {
+      nodeName: "main"
+    });
+    await runner.step(1, async (runner) => {
 __stack.locals.sum = 0;
     });
-    await runner.loop(1, Array.from({length: 3 - 0}, (_, __i) => __i + 0), async (i, _, runner) => {
+    await runner.loop(2, Array.from({length: 3 - 0}, (_, __i) => __i + 0), async (i, _, runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.sum = __stack.locals.sum + i;
       });
     });
-    await runner.step(2, async (runner) => {
+    await runner.step(3, async (runner) => {
 runner.halt({
         messages: __threads,
         data: __stack.locals.sum
@@ -221,14 +217,11 @@ runner.halt({
 return;
     });
     if (runner.halted) return runner.haltResult;
-    await callHook({
-      ctx: __ctx,
-      name: "onNodeEnd",
-      data: {
-        nodeName: "main",
-        data: undefined
-      }
-    })
+    await runner.hook(4, "onNodeEnd", {
+      nodeName: "main",
+      data: undefined
+    });
+    if (runner.halted) return runner.haltResult;
     return {
       messages: __threads,
       data: undefined
@@ -270,4 +263,4 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 }
 export default graph
-export const __sourceMap = {"tests/debugger/loop-test.agency:main":{"0":{"line":1,"col":2},"1":{"line":2,"col":2},"2":{"line":5,"col":2},"1.0":{"line":3,"col":4}}};
+export const __sourceMap = {"tests/debugger/loop-test.agency:main":{"1":{"line":1,"col":2},"2":{"line":2,"col":2},"3":{"line":5,"col":2},"2.0":{"line":3,"col":4}}};

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -201,18 +201,6 @@ let __functionCompleted = false;
     await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
-  await callHook({
-    ctx: __ctx,
-    name: "onFunctionStart",
-    data: {
-      functionName: "double",
-      args: {
-        n: n
-      },
-      isBuiltin: false,
-      moduleId: "tests/debugger/nested-calls-test.agency"
-    }
-  })
   __stack.args["n"] = n;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "double" });
@@ -231,10 +219,18 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.step(0, async (runner) => {
-__stack.locals.result = __stack.args.n * 2;
+    await runner.hook(0, "onFunctionStart", {
+      functionName: "double",
+      args: {
+        n: n
+      },
+      isBuiltin: false,
+      moduleId: "tests/debugger/nested-calls-test.agency"
     });
     await runner.step(1, async (runner) => {
+__stack.locals.result = __stack.args.n * 2;
+    });
+    await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.result)
 return;
@@ -305,19 +301,6 @@ let __functionCompleted = false;
     await __initializeGlobals(__ctx)
   }
   let __funcStartTime: number = performance.now();
-  await callHook({
-    ctx: __ctx,
-    name: "onFunctionStart",
-    data: {
-      functionName: "addAndDouble",
-      args: {
-        a: a,
-        b: b
-      },
-      isBuiltin: false,
-      moduleId: "tests/debugger/nested-calls-test.agency"
-    }
-  })
   __stack.args["a"] = a;
   __stack.args["b"] = b;
   __self.__retryable = __self.__retryable ?? true;
@@ -341,10 +324,19 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.step(0, async (runner) => {
-__stack.locals.sum = __stack.args.a + __stack.args.b;
+    await runner.hook(0, "onFunctionStart", {
+      functionName: "addAndDouble",
+      args: {
+        a: a,
+        b: b
+      },
+      isBuiltin: false,
+      moduleId: "tests/debugger/nested-calls-test.agency"
     });
     await runner.step(1, async (runner) => {
+__stack.locals.sum = __stack.args.a + __stack.args.b;
+    });
+    await runner.step(2, async (runner) => {
 __stack.locals.result = await __call(double, {
         type: "positional",
         args: [__stack.locals.sum]
@@ -359,7 +351,7 @@ if (hasInterrupts(__stack.locals.result)) {
         return;
       }
     });
-    await runner.step(2, async (runner) => {
+    await runner.step(3, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.result)
 return;
@@ -430,16 +422,12 @@ const statelogClient = __ctx.statelogClient;
 const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
-  await callHook({
-    ctx: __ctx,
-    name: "onNodeStart",
-    data: {
-      nodeName: "main"
-    }
-  })
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "main" });
   try {
-    await runner.step(0, async (runner) => {
+    await runner.hook(0, "onNodeStart", {
+      nodeName: "main"
+    });
+    await runner.step(1, async (runner) => {
 __stack.locals.x = await __call(addAndDouble, {
         type: "positional",
         args: [1, 2]
@@ -457,7 +445,7 @@ if (hasInterrupts(__stack.locals.x)) {
         return;
       }
     });
-    await runner.step(1, async (runner) => {
+    await runner.step(2, async (runner) => {
 runner.halt({
         messages: __threads,
         data: __stack.locals.x
@@ -465,14 +453,11 @@ runner.halt({
 return;
     });
     if (runner.halted) return runner.haltResult;
-    await callHook({
-      ctx: __ctx,
-      name: "onNodeEnd",
-      data: {
-        nodeName: "main",
-        data: undefined
-      }
-    })
+    await runner.hook(3, "onNodeEnd", {
+      nodeName: "main",
+      data: undefined
+    });
+    if (runner.halted) return runner.haltResult;
     return {
       messages: __threads,
       data: undefined
@@ -514,4 +499,4 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 }
 export default graph
-export const __sourceMap = {"tests/debugger/nested-calls-test.agency:double":{"0":{"line":1,"col":2},"1":{"line":2,"col":2}},"tests/debugger/nested-calls-test.agency:addAndDouble":{"0":{"line":6,"col":2},"1":{"line":7,"col":2},"2":{"line":8,"col":2}},"tests/debugger/nested-calls-test.agency:main":{"0":{"line":12,"col":2},"1":{"line":13,"col":2}}};
+export const __sourceMap = {"tests/debugger/nested-calls-test.agency:double":{"1":{"line":1,"col":2},"2":{"line":2,"col":2}},"tests/debugger/nested-calls-test.agency:addAndDouble":{"1":{"line":6,"col":2},"2":{"line":7,"col":2},"3":{"line":8,"col":2}},"tests/debugger/nested-calls-test.agency:main":{"1":{"line":12,"col":2},"2":{"line":13,"col":2}}};

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -196,25 +196,21 @@ const statelogClient = __ctx.statelogClient;
 const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
-  await callHook({
-    ctx: __ctx,
-    name: "onNodeStart",
-    data: {
-      nodeName: "main"
-    }
-  })
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/step-test.agency", scopeName: "main" });
   try {
-    await runner.step(0, async (runner) => {
-__stack.locals.x = 1;
+    await runner.hook(0, "onNodeStart", {
+      nodeName: "main"
     });
     await runner.step(1, async (runner) => {
-__stack.locals.y = 2;
+__stack.locals.x = 1;
     });
     await runner.step(2, async (runner) => {
-__stack.locals.z = __stack.locals.x + __stack.locals.y;
+__stack.locals.y = 2;
     });
     await runner.step(3, async (runner) => {
+__stack.locals.z = __stack.locals.x + __stack.locals.y;
+    });
+    await runner.step(4, async (runner) => {
 runner.halt({
         messages: __threads,
         data: __stack.locals.z
@@ -222,14 +218,11 @@ runner.halt({
 return;
     });
     if (runner.halted) return runner.haltResult;
-    await callHook({
-      ctx: __ctx,
-      name: "onNodeEnd",
-      data: {
-        nodeName: "main",
-        data: undefined
-      }
-    })
+    await runner.hook(5, "onNodeEnd", {
+      nodeName: "main",
+      data: undefined
+    });
+    if (runner.halted) return runner.haltResult;
     return {
       messages: __threads,
       data: undefined
@@ -271,4 +264,4 @@ if (__process.argv[1] === fileURLToPath(import.meta.url)) {
   }
 }
 export default graph
-export const __sourceMap = {"tests/debugger/step-test.agency:main":{"0":{"line":1,"col":2},"1":{"line":2,"col":2},"2":{"line":3,"col":2},"3":{"line":4,"col":2}}};
+export const __sourceMap = {"tests/debugger/step-test.agency:main":{"1":{"line":1,"col":2},"2":{"line":2,"col":2},"3":{"line":3,"col":2},"4":{"line":4,"col":2}}};


### PR DESCRIPTION
## What

Fixes CI: 16 failing debugger / deterministic-client tests on `main`.

## Why

Commit b5865797 moved codegen-emitted callbacks (`onNodeStart`, `onFunctionStart`, etc.) into resumable `runner.hook` substeps. That broke the debugger in two ways:

1. **Hook substeps trapped the debugger.** `runner.hook` called `maybeDebugHook`, so single-step would land on an internal hook step with no source-map entry and empty locals.
2. **`callDepth` was reset on every resume.** The hook now fires only once (its substep counter advances past on success), so `onFunctionStart` no longer re-fires on resume. The old `debugger.resume()` path called `resetCallDepth()` and rebuilt depth from re-fired hooks. With the new substep model that left depth stuck at 0 and broke `stepOut`.

## Changes

- `runner.hook` no longer calls `maybeDebugHook` — hook substeps are invisible to the debugger.
- `driver.resume()` preserves `callDepth` and the UI call stack. `exitCall` still fires for each function unwind because `onFunctionEnd` is still emitted from the `finally` block via `callHook`.
- Updates the `deterministicClient` "missing args" test: the client intentionally defaults missing args to `{}` since commit 6387c8a1, so the old "throws when tool call mock is missing args" assertion is obsolete.
- Regenerates the debugger fixture `.ts` files to match the current codegen.

## Verification

`pnpm test:run`: **257 files / 4422 tests pass** (previously 16 failing).
