### PR TITLE
feat: runBatch concurrent-interrupt primitive + fork/race/runPrompt migrations

### DIFF
--- a/packages/agency-lang/docs/dev/concurrent-interrupts.md
+++ b/packages/agency-lang/docs/dev/concurrent-interrupts.md
@@ -1,34 +1,47 @@
 # Concurrent Interrupts
 
-This doc covers how Agency handles multiple interrupts that arise from concurrent execution paths. There are two user-facing constructs that produce concurrent interrupts:
+This doc covers how Agency handles multiple interrupts that arise from concurrent execution paths.
+
+There are three user-facing constructs that produce concurrent execution:
 
 - **`fork(items) as item { ... }`** — runs the block in parallel for each item. Each item is a separate "branch." If multiple branches interrupt, all interrupts are batched together and returned to the caller in a single `Interrupt[]`.
-- **`llm(prompt, { tools })`** — when the LLM calls multiple tools in a single response, those tool invocations run as parallel branches inside `runPrompt`. If multiple tools interrupt, those interrupts are also batched.
-
-A third construct — **`race(items) as item { ... }`** — also creates parallel branches, but only one wins; interrupts from losers are cancelled rather than batched. See the race section below.
+- **`race(items) as item { ... }`** — same shape as fork, but only one branch wins; interrupts from losers are cancelled.
+- **`llm(prompt, { tools })`** — when the LLM calls multiple tools in a single response, those tool invocations run as parallel branches inside `runPrompt`. If multiple tools interrupt, those interrupts are batched too.
 
 The user responds to a batch via `respondToInterrupts(interrupts, responses)`. Resume reconstructs the full execution state, replays only the work that hadn't completed, and continues.
+
+**As of the runBatch refactor (PR #186):** all three of those call sites delegate to a single runtime primitive, [`runBatch`](../../lib/runtime/runBatch.ts), that owns the concurrent-interrupt orchestration. Previously every site hand-rolled the same `Promise.allSettled` / `Promise.race` boilerplate, made the same subtle mistakes, and was hard to keep in lock-step. After the refactor there is **one** place where branch lifecycle, abort composition, checkpoint stamping, and `intr.checkpoint` overwrite live, and three thin adapter functions that wire it up.
+
+The rest of this document is split into:
+
+1. The shared mental model and data types (unchanged by the refactor).
+2. The `runBatch` primitive itself.
+3. **Implementation details**: how each call site uses `runBatch`.
+4. **Usage guide**: how to add a new concurrent-interrupt site without re-introducing the same bugs.
+5. The slice-rule, abort signals, resume mechanics, invariants — preserved from the pre-refactor doc because they are still load-bearing.
+
+---
 
 ## Quick mental model
 
 Think of each parallel branch as having its own miniature state stack. The parent frame holds a map of branches under its `branches` field. The runtime serialises this tree on interrupt, restores it on resume, and tracks which branches have completed (cached result) versus interrupted (saved checkpoint) versus never-finished (just a stack reference).
 
-```
-main_frame
-├─ branches:
-│  ├─ "fork_1_0": BranchState { stack, interruptId?, result?, abortController? }
-│  ├─ "fork_1_1": BranchState { ... }
-│  └─ "fork_1_2": BranchState { ... }
+```diagram
+╭─────────────────────────╮
+│ main_frame              │
+│   branches:             │
+│   ├─ "fork_1_0": ─┐     │      ╭───────────────────────────╮
+│   ├─ "fork_1_1": ─┼────▶│ BranchState                       │
+│   └─ "fork_1_2": ─┘     │ ├ stack          (own StateStack) │
+╰─────────────────────────╯ ├ interruptId?  (set if halted)  │
+                            │ interruptData?                  │
+                            │ checkpoint?    (leaf cp)        │
+                            │ result?        ({ result })     │
+                            │ abortController? (live-only)    │
+                            ╰───────────────────────────────────╯
 ```
 
-Same shape applies to tool-call branches inside `runPrompt`, just keyed differently:
-
-```
-runPrompt_frame
-├─ branches:
-│  ├─ "tool_call_abc123": BranchState { ... }
-│  └─ "tool_call_def456": BranchState { ... }
-```
+Same shape applies to tool-call branches inside `runPrompt`, just keyed differently (`tool_<toolCallId>`).
 
 ## Core data types
 
@@ -39,7 +52,7 @@ export type BranchState = {
   stack: StateStack;            // this branch's own isolated stack
   interruptId?: string;         // set if this branch is paused on an interrupt
   interruptData?: any;
-  checkpoint?: Checkpoint;      // the inner checkpoint this branch produced when it interrupted
+  checkpoint?: Checkpoint;      // the LEAF checkpoint this branch produced when it interrupted
   result?: { result: any };     // set if this branch completed normally
   abortController?: AbortController;  // live, not serialised — used by race
 };
@@ -47,162 +60,387 @@ export type BranchState = {
 
 Two important rules:
 
-- **`result !== undefined`** means "branch finished, here's the value." On resume, `runForkAll`/`runRace` short-circuits past this branch entirely without calling `blockFn` again. The wrapper object distinguishes "no result" from "result was the value `undefined`."
-- **`interruptId` set** means "branch paused at an interrupt." On resume, `blockFn` is re-invoked with the saved `stack`. The inner code finds its saved `__interruptId_N` in frame locals, looks up the user's response via `ctx.getInterruptResponse`, and either continues past the interrupt or halts with rejection.
+- **`result !== undefined`** means "branch finished, here's the value." On resume, `runBatch` short-circuits past this branch entirely without calling `invoke` again — unless `recordBranchOutcomes: false` is set (see below). The wrapper object distinguishes "no result" from "result was the value `undefined`."
+- **`interruptId` set** means "branch paused at an interrupt." On resume, `invoke` is re-called with the saved `stack`. The inner code finds its saved `__interruptId_N` in frame locals, looks up the user's response via `ctx.getInterruptResponse`, and either continues past the interrupt or halts with rejection.
 
-`abortController` and `result` are NOT serialised in `BranchStateJSON`. `abortController` is purely a live execution concept; `result` is reconstructed via `result?: { result }` field which IS serialised.
+`abortController` and live computed fields are NOT serialised in `BranchStateJSON`. `abortController` is purely a live execution concept; `result` is reconstructed via the `result?: { result }` field, which IS serialised.
 
 ### `StateStack.abortSignal`
 
-Each `StateStack` carries an optional `abortSignal?: AbortSignal`. When fork/race creates a branch, it sets the signal on the branch's stack. Anywhere downstream code holds the stack reference (e.g., `runPrompt`'s setupFunction call), it can use `ctx.isCancelled(stack)` and `ctx.getAbortSignal(stack)` to be branch-aware. See "Branch-aware abort signals" below.
+Each `StateStack` carries an optional `abortSignal?: AbortSignal`. When `runBatch` creates a branch, it sets a composed signal on the branch's stack. Anywhere downstream code holds the stack reference (e.g., `runPrompt`'s `setupFunction` call), it can use `ctx.isCancelled(stack)` and `ctx.getAbortSignal(stack)` to be branch-aware. See "Branch-aware abort signals" below.
 
-## Fork: implementation
+---
 
-### Setting up branches
+## The `runBatch` primitive
 
-`Runner.runForkAll` (in `lib/runtime/runner.ts`) handles the `fork` mode. For each item:
+`runBatch` lives in [`lib/runtime/runBatch.ts`](../../lib/runtime/runBatch.ts). Single function, three modes, one tagged-union return type.
 
-1. Build a `branchKey` from the step path and item index, e.g. `fork_1.2_0`.
-2. Call `frame.getOrCreateBranch(branchKey)` — returns the existing branch on resume, or creates a fresh `BranchState` with an empty `StateStack` on first run.
-3. **If `existing.result !== undefined`** → this branch finished in a previous cycle. Resolve immediately with the cached value. Don't call `blockFn`.
-4. **Otherwise** → create an `AbortController` (composed with parent's signal for nested fork support, see below), invoke `blockFn(item, i, existing.stack)`. The block receives the branch's stack so its `setupFunction` pushes frames onto it, isolated from siblings.
+### Signature
 
-`Promise.allSettled` waits for every branch (resolved value or interrupt array). The runner walks the settled list:
+```ts
+export async function runBatch<T>(opts: RunBatchOpts<T>): Promise<RunBatchResult<T>>;
 
-- **Branch returned a value** → `frame.setResultOnBranch(branchKey, value)`. Cached for any future resume cycles.
-- **Branch returned `Interrupt[]`** (via `hasInterrupts`) → `frame.setInterruptOnBranch(branchKey, interruptId, interruptData, checkpoint)`. The branch's saved checkpoint comes from the inner `interruptReturn` template.
+export type RunBatchOpts<T> = {
+  ctx: RuntimeContext<any>;
+  /** The parent's local state stack — used as the capture stack for the
+   *  shared batch-level checkpoint. MUST be the local slice (e.g. the
+   *  branch stack if `runBatch` is itself called inside a child of an
+   *  outer `runBatch`), NOT `ctx.stateStack`. This is the one discipline
+   *  the caller of `runBatch` must observe. */
+  parentStack: StateStack;
+  /** The frame where branch state lives. Usually `parentStack.lastFrame()`. */
+  parentFrame: State;
+  /** Where the shared checkpoint records its location. */
+  checkpointLocation: { moduleId: string; scopeName: string; stepPath: string };
+  /** "all" → Promise.allSettled, concurrent;
+   *  "sequential" → for...of, strict ordering;
+   *  "race" → first to settle wins, others aborted. */
+  mode: "all" | "sequential" | "race";
+  children: BatchChild<T>[];
+  /** Mode "race" only: the `parentFrame.locals` key under which the winner
+   *  index is persisted. */
+  raceWinnerLocalKey?: string;
+  /** Default true. When false, the caller's `invoke` is responsible for
+   *  managing BranchState fields (setResultOnBranch / setInterruptOnBranch
+   *  / deleteBranch) — runBatch only handles abort, settle, checkpoint
+   *  stamp, overwrite. Also disables the cached-branch short-circuit. */
+  recordBranchOutcomes?: boolean;
+  hooks?: BatchHooks;
+};
 
-If any branch produced interrupts, the runner stamps a single shared **fork-level checkpoint** onto every collected interrupt and returns the array. If no branch interrupted, the runner returns the array of values and `popBranches()` clears the entire branches map.
+export type BatchChild<T> = {
+  key: string;
+  /** MUST RETURN T | Interrupt[]; MUST NOT THROW Interrupt[]. */
+  invoke: (childStack: StateStack, abortSignal: AbortSignal) => Promise<T | Interrupt[]>;
+};
 
-### Slice-only checkpoint composition
+export type RunBatchResult<T> =
+  | { kind: "values"; values: T[] }
+  | { kind: "interrupts"; interrupts: Interrupt[] };
+```
 
-This is the most subtle part of the fork implementation, and the source of the most painful bug we've fixed.
+### What `runBatch` owns
 
-When the inner code (`interruptReturn` template at `lib/templates/backends/typescriptGenerator/interruptReturn.mustache`) creates the leaf-level checkpoint for a given interrupt, it captures **only its local `__stateStack`** — the branch's own stack. NOT `ctx.stateStack` (the global root).
+- **Per-child branch lifecycle.** Calls `parentFrame.getOrCreateBranch(child.key)`. On resume, finds the existing branch (idempotent).
+- **AbortController + signal composition.** Each branch gets a fresh `AbortController`. The branch's stack `abortSignal` is composed via `AbortSignal.any([parentSig, child.signal])` so nested aborts cascade down.
+- **ALS-isolated invocation.** Each `invoke` runs inside `ctx.statelogClient.runInBranchContext(parentSpanStack, …)` so concurrent branches don't interleave their span pushes/pops on the parent's stack.
+- **Three modes:**
+  - `"all"` — `Promise.allSettled`; every child runs concurrently.
+  - `"sequential"` — `for...of` loop; each child runs after the previous resolves. Used for hook-callback batching (preserves today's `callHook` strict-ordering semantics).
+  - `"race"` — `Promise.race`; first to settle wins, losers get `abortController.abort()`; loser branches deleted. **Resume dispatch is folded in**: at the top of `runBatch`, if `mode === "race"` and a winner is persisted under `raceWinnerLocalKey`, only the winner's child runs (the equivalent of the old `resumeRaceWinner`).
+- **Outcome collection.** For each settled child:
+  - rejection (non-interrupt error) → rethrow and abandon sibling interrupts (inherited invariant; see "Inherited invariants" below).
+  - returned `Interrupt[]` → batch into the shared collection and (if `recordBranchOutcomes`) call `setInterruptOnBranch(key, id, data, leafCheckpoint)`.
+  - returned value → (if `recordBranchOutcomes`) call `setResultOnBranch(key, value)`.
+- **Shared checkpoint stamp + overwrite.** If any child interrupted, stamp ONE shared checkpoint at `checkpointLocation` and overwrite `intr.checkpoint` + `intr.checkpointId` on every interrupt in the batch. This overwrite is intentional (per commit c72b9c1574): every interrupt in a batch deliberately resumes from the same point.
+- **Cost-propagation hooks.** `seedBranchCost` / `propagateBranchCost` for mode `"all"` / `"sequential"`. For mode `"race"`, the asymmetric pair `propagateLoserCost` / `propagateWinnerCost` (losers eagerly at race time, winner deferred until winner-branch finally completes).
+- **Cleanup on success.** No-interrupt success path: propagate cost, then `parentFrame.popBranches()`.
+- **Defensive guards.** Duplicate-child-key check; mode-flip mismatch assert (if `raceWinnerLocalKey` holds a number but `mode !== "race"`, throw a clear error).
 
-That is critical. If the inner code captured the global root, then when the outer fork serialises a branch's state via `State.toJSON`, it would transplant the global root's snapshot into the branch's slot. The result would be a tree where every branch contains a duplicate of the parent stack from main downward, and on resume `setupFunction` would consume the wrong frames first. Infinite-loop territory.
+### What `runBatch` deliberately does NOT touch
+
+Per commit c72b9c1574 (which removed the buggy `isForked` approach that broke nested-fork composition):
+
+- **The leaf `interruptReturn` template.** It still stamps a per-leaf checkpoint exactly as today. `runBatch` reads that leaf checkpoint off each surfaced `Interrupt` and writes it to `BranchState.checkpoint`. The leaf checkpoint is the vehicle that carries the pre-pop branch stack into `State.toJSON`'s branches walk.
+- **Handler bookkeeping.** Per-branch `handle` chains stay as they were.
+- **In-flight checkpoint key shapes.** The race adapter passes `raceWinnerLocalKey: __race_winner_<id>` — the existing shape, preserved deliberately for checkpoint compatibility.
+
+### `recordBranchOutcomes`: when to set it false
+
+By default `runBatch` records branch outcomes itself via `setResultOnBranch` / `setInterruptOnBranch`. That's what fork and race need.
+
+`runPrompt`'s tool loop sets `recordBranchOutcomes: false` because the per-tool body (`runInvokeStep` in `prompt.ts`) already records branch state — `setResultOnBranch(branchKey, toolResult)` happens inside the body before it returns. If `runBatch` then also called `setResultOnBranch(key, undefined)` (the body returns `void`), it would destroy the meaningful tool result that `runPrompt` reads on resume (around `prompt.ts` line 723).
+
+When this flag is false, `runBatch` also **disables the cached-branch short-circuit**. The reason: `branch.result` being set no longer means "the body is fully done" — for the tool loop it may only mean "the tool's `invoke` step succeeded; the `.end` and `.log` steps still need to fire on resume." Idempotency in that mode is the caller's responsibility (`BranchRunner.step`'s `completedSteps` for the tool loop).
+
+### Inherited invariants
+
+These behaviours come from the pre-refactor code; `runBatch` preserves them exactly.
+
+- **Errors win over interrupts.** If any child rejects (throws a non-interrupt error), `runBatch` rethrows that error and abandons any interrupts that sibling branches successfully halted with. Matches today's `runForkAll` / `runRace`. Callers that need both must catch inside their `invoke`.
+- **Race cost asymmetry.** Losers' cost propagates eagerly at race time (so their partial LLM spend is billed). The winner's cost propagates only when the winner's branch finally completes via a no-interrupt resume.
+- **The leaf stamps its own per-branch checkpoint** at `interruptReturn`. `runBatch` reads it off the surfaced interrupt and stores it on `BranchState.checkpoint`. Do not move leaf stamping anywhere.
+
+---
+
+## Implementation details: how each call site uses `runBatch`
+
+All three call sites are now thin adapters. Their job is to translate domain-specific arguments (items, blockFn, tool calls, …) into `runBatch` options and wire up domain-specific hooks (statelog events, cost helpers).
+
+### `Runner.runForkAll` (`lib/runtime/runner.ts`)
+
+Mode: `"all"`. `recordBranchOutcomes` defaults to true.
+
+The adapter:
+
+- Builds `children` from `items.map((item, i) => ({ key: forkBranchKey(id, i), invoke: (branchStack) => blockFn(item, i, branchStack) }))`.
+- Hooks: `seedBranchCost`, `propagateBranchCost` delegate to `Runner`'s existing helpers. `onBranchEnd → forkBranchEnd` and `onCheckpoint → checkpointCreated` wire up the statelog events. No `propagateLoserCost`/`propagateWinnerCost` (not race).
+- Returns: `result.kind === "interrupts" ? result.interrupts : result.values`.
+
+What that replaces: ~110 lines of hand-rolled `Promise.allSettled` plumbing + per-branch abort setup + per-branch cost seeding + outcome loop + checkpoint stamping + cost propagation + `popBranches`.
+
+### `Runner.runRace` (`lib/runtime/runner.ts`)
+
+Mode: `"race"`. `recordBranchOutcomes` defaults to true. `raceWinnerLocalKey: this.raceWinnerKey(id)` (which evaluates to the existing `__race_winner_<id>` shape — unchanged for in-flight checkpoint compatibility).
+
+The adapter:
+
+- Same `children` construction as fork.
+- Hooks: `seedBranchCost`, **asymmetric** `propagateLoserCost` / `propagateWinnerCost` (both delegating to the same `propagateBranchCost` helper; only the timing differs). `onBranchEnd → forkBranchEnd` (`"aborted"` for losers, `"interrupted"`/`"success"` for winner, `"failure"` for the first rejecting branch). `onCheckpoint → checkpointCreated` with `reason: "race"`.
+- Returns: `result.kind === "interrupts" ? result.interrupts : result.values[0]` (race always has exactly one winner).
+
+What that replaces: ~280 lines (`runRace` + `buildRaceBranchPromise` + `abortLoserBranchesAndEmitEnds` + `resumeRaceWinner`) plus the dispatch in `Runner.fork`. `Runner.fork` no longer needs to distinguish "first run" from "resume winner" — `runBatch`'s mode-`"race"` resume-dispatch path handles both.
+
+### `runPrompt`'s tool loop (`lib/runtime/prompt.ts` + `lib/runtime/promptRunner.ts`)
+
+Mode: `"all"`. **`recordBranchOutcomes: false`** (see above).
+
+`PromptRunner.parallel` becomes a thin wrapper. Its new signature:
+
+```ts
+parallel<T>(
+  keyPrefix: string,
+  items: T[],
+  keyFor: (item: T, index: number) => string,
+  branchFn: (item: T, b: BranchRunner) => Promise<void>,
+): Promise<RunBatchResult<void>>
+```
+
+`keyFor` MUST produce the same branch key that the `branchFn` body uses inside `stack.getOrCreateBranch(...)`. Otherwise `runBatch` allocates a separate branch from the one the body manages, and the leaf-checkpoint vehicle into `State.toJSON`'s branches walk is lost. The real call site in `prompt.ts` passes `(toolCall) => \`tool_${toolCall.id}\``.
+
+The body still uses `BranchRunner.step` for substep idempotency (`.start`, `.invoke`, `.end`, `.log` keyed by `round.X.tool.Y.<phase>` so resume skips already-completed phases). `BranchRunner.step` collects interrupts on `b.interrupts` rather than throwing.
+
+Each child's `invoke` in the adapter is:
+
+```ts
+invoke: async () => {
+  await branchFn(item, branches[i]);
+  return branches[i].interrupts ?? undefined;
+};
+```
+
+If the branch surfaced interrupts (`b.interrupts` set), they bubble up as the invoke's return value; `runBatch` batches them with siblings and stamps the shared checkpoint. Otherwise the invoke returns `undefined` (which `hasInterrupts` reports as not-interrupts, so `runBatch` treats it as success).
+
+The runPrompt outer call site:
+
+```ts
+const parallelResult = await pr.parallel(`round.${round}.tools`, toolCalls, keyFor, branchFn);
+if (parallelResult.kind === "interrupts") {
+  shouldPop = false;
+  return parallelResult.interrupts;
+}
+// continue: parallelResult.kind === "values"
+```
+
+What that replaces: the merged-checkpoint stamping in `PromptRunner.parallel` (was lines 158–188) plus the `PromptBailout` throw / catch dance. `PromptBailout` is still thrown by `PromptRunner.step` (the per-step helper, not parallel); the parallel path's no-throw return preserves the runBatch `invoke` no-throw-`Interrupt[]` contract.
+
+### Audit notes for prompt.ts migration
+
+Task 4 of the runBatch plan included a no-throw-`Interrupt[]` audit before the prompt migration. Findings recorded at the top of [`lib/runtime/runBatch.ts`](../../lib/runtime/runBatch.ts):
+
+- `interrupts.ts`, `agencyFunction.ts`, `prompt.ts` body: NO `Interrupt[]` throws.
+- `promptRunner.ts`: `PromptBailout` was thrown twice. The `parallel` throw was converted to a return; the `step` throw remains (it's caught by runPrompt's outer try, not by `runBatch`).
+
+Any new `runBatch` adopter should re-run that audit (`grep -nE "throw .*[Ii]nterrupt"`) on its code path before migrating.
+
+---
+
+## Usage guide: writing a new concurrent-interrupt site
+
+Before reaching for `runBatch`, ask: is what you're building actually concurrent execution that may produce multiple interrupts that should share a resume point? If you only have a single interrupt path, you don't need this primitive — write a normal step/handler.
+
+If you do need it, follow this checklist.
+
+### 1. Decide which mode
+
+| You need… | Use mode |
+| --- | --- |
+| Run N children concurrently; collect every result; batch any interrupts. | `"all"` |
+| Run N children strictly in order; batch any interrupts at the end. | `"sequential"` |
+| Run N children; first to settle wins; abort losers; recordable resume. | `"race"` |
+
+Examples: fork is `"all"`. Race is `"race"`. Hook-callback batching (Task 6 of the runBatch plan, not yet landed at the time of this doc) is `"sequential"` so the existing `callHook` strict-ordering semantics are preserved — using `"all"` there would silently turn an ordered side-effect chain into a concurrent race.
+
+### 2. Get the parentStack right (this is the only discipline you owe `runBatch`)
+
+`opts.parentStack` MUST be the **local slice** — the branch stack you were handed by the surrounding context, NOT `ctx.stateStack`. This is the discipline that the pre-refactor code got wrong in five different places. `runBatch` enforces everything else (branches, abort, stamping) but it cannot enforce this without knowing your call shape.
+
+If your code is itself running inside a `runBatch` child (i.e., nested), the local slice is the branch stack passed into your `invoke`. If your code is running at the top of a Runner step, the local slice is the `stateStack` arg threaded by the runner.
+
+Pattern (correct):
+
+```ts
+private async runMySite(stateStack: StateStack, id: number) {
+  const result = await runBatch({
+    ctx: this.ctx,
+    parentStack: stateStack,            // ← the local slice
+    parentFrame: this.frame,
+    checkpointLocation: { moduleId: this.moduleId, scopeName: this.scopeName, stepPath: this.stepPath(id) },
+    mode: "all",
+    children: ...,
+  });
+}
+```
+
+Anti-pattern (wrong, will cause the slice-rule duplication bug):
+
+```ts
+parentStack: this.ctx.stateStack,  // ← the global root. DO NOT do this.
+```
+
+### 3. Ensure your `invoke` returns rather than throws `Interrupt[]`
+
+`runBatch`'s `invoke` contract:
+
+> MUST RETURN `T | Interrupt[]`. MUST NOT THROW `Interrupt[]`. May throw other errors.
+
+If your code path can today throw an `Interrupt[]` (or an `Error` subclass wrapping one, like `PromptBailout`), convert it to a return before migrating. Otherwise the interrupts bypass `runBatch`'s shared checkpoint stamp and the resume will be broken.
+
+Run the audit on your code path: `grep -nE "throw .*[Ii]nterrupt"` over every file in your call chain. Document the findings (see the comment at the top of `runBatch.ts`).
+
+### 4. Pick stable branch keys
+
+Each child needs a `key` that:
+
+- Is unique within the parent frame's `branches` map.
+- Stays stable across resume — pick something derivable from input data, not a counter or random.
+- Matches the key your body uses internally (if applicable). The runPrompt tool loop is the cautionary example: `runBatch` allocates a branch under `keyFor(...)`, and `runInvokeStep` in `prompt.ts` separately calls `stack.getOrCreateBranch(branchKey)` — those two MUST produce the same key or you'll get two parallel branches per logical unit and the leaf-checkpoint vehicle will go to the wrong one.
+
+`runBatch` has a defensive `duplicate child key` throw to catch typos, but it can't catch "two different sites used different shapes for the same conceptual branch."
+
+### 5. Decide if you need `recordBranchOutcomes: false`
+
+Almost always **leave it true** (the default). It's what fork and race need.
+
+Set it to `false` only if your `invoke` body manages branch state itself (calls `setResultOnBranch` / `setInterruptOnBranch` / `deleteBranch` inside the body). The runPrompt tool loop is currently the only site that needs this; the comment near that flag's definition in `runBatch.ts` explains why.
+
+If you set it to `false`, you also take on responsibility for body-level idempotency on resume — `branch.result` being set will NOT short-circuit re-invocation. Use a substep-counter machine like `BranchRunner.step`'s `completedSteps` if your body has multiple resumable phases.
+
+### 6. Wire up cost / statelog hooks if you care
+
+The `hooks` field is optional. Don't pass any hooks if your site doesn't track cost or emit statelog events; `runBatch` works fine without them.
+
+If your site does track cost: pass `seedBranchCost` and either `propagateBranchCost` (for mode `"all"`/`"sequential"`) or the pair `propagateLoserCost` + `propagateWinnerCost` (for mode `"race"`). Both branches of the race pair can delegate to the same delta-computing helper; the difference is just the timing (losers eagerly, winner deferred).
+
+If your site emits statelog events: `onBranchStart`, `onBranchEnd(key, idx, outcome, timeMs)`, `onCheckpoint(cpId)` give you the hook points. They fire only for non-cached branches so resume cycles don't re-emit duplicate events.
+
+### 7. Pattern-match the result
+
+```ts
+const result = await runBatch({ ... });
+if (result.kind === "interrupts") {
+  // halt / propagate up; runBatch already stamped the shared checkpoint
+  return result.interrupts;
+}
+// result.kind === "values"
+const values: T[] = result.values;
+```
+
+Use the tagged union. Do not do `if (Array.isArray(result) && result[0]?.type === "interrupt") ...` — that was the pre-refactor pattern and it was easy to get wrong with mixed shapes.
+
+### 8. Test the four cycles, not just the happy path
+
+Any new site needs at least these tests:
+
+1. All children succeed → returns `kind: "values"`.
+2. One child interrupts, others succeed → returns `kind: "interrupts"`; on resume after `respondToInterrupts`, the previously-successful children short-circuit (their `setResultOnBranch` survived), the previously-interrupted child runs once more and succeeds; final result matches the all-succeed case.
+3. Multi-cycle: the previously-interrupted child interrupts AGAIN on its first re-run; one more `respondToInterrupts`; everything completes.
+4. Mode-specific failure case — for race, a loser was aborted mid-flight; for fork, the rejection-wins-over-interrupts invariant.
+
+The existing `tests/agency/fork/*` suite gives you templates for each.
+
+---
+
+## Slice-only checkpoint composition (still load-bearing)
+
+When the leaf code (`interruptReturn` template at `lib/templates/backends/typescriptGenerator/interruptReturn.mustache`) creates the per-branch checkpoint for a given interrupt, it captures **only its local `__stateStack`** — the branch's own stack. NOT `ctx.stateStack`.
+
+That is critical. If the leaf captured the global root, then when the outer concurrent site serialises a branch's state via `State.toJSON`, it would transplant the global root's snapshot into the branch's slot. The result would be a tree where every branch contains a duplicate of the parent stack from main downward, and on resume `setupFunction` would consume the wrong frames first. Infinite-loop territory.
 
 By capturing only the local stack at every layer, the snapshots compose cleanly:
 
 - Innermost interrupt: captures `[block_frame, function_frame_with_locals]`.
-- Fork: stamps that innermost checkpoint onto its sub-branch via `setInterruptOnBranch`. The fork's own checkpoint captures `[search_frame { branches: { fork_X_i: { stack: <innermost slice>, interruptId, ... } } }]`.
-- runPrompt (if fork is inside a tool): stamps fork's checkpoint onto its tool branch. runPrompt's own checkpoint captures `[main_frame, runPrompt_frame { branches: { tool_call_*: { stack: <fork slice>, interruptId, ... } } }]`.
+- Fork/race/parallel: stamps that innermost checkpoint onto its sub-branch via `setInterruptOnBranch`. Its own (batch-level) checkpoint captures `[search_frame { branches: { fork_X_i: { stack: <innermost slice>, interruptId, ... } } }]`.
+- `runPrompt` (if the concurrent site is inside a tool): stamps the inner checkpoint onto its tool branch. Its own checkpoint captures `[main_frame, runPrompt_frame { branches: { tool_call_*: { stack: <inner slice>, interruptId, ... } } }]`.
 
-`State.toJSON` walks `this.branches` and, when a branch has `branch.checkpoint` set, uses `branch.checkpoint.stack` as that branch's serialised stack — meaning the inner slice plugs into the outer slot. The final serialised structure mirrors the execution tree top-to-bottom with no duplication.
+`State.toJSON` walks `this.branches` and, when a branch has `branch.checkpoint` set, uses `branch.checkpoint.stack` as that branch's serialised stack — so the inner slice plugs into the outer slot. The final serialised structure mirrors the execution tree top-to-bottom with no duplication.
 
-The capture sites that must use a local stack (not `ctx.stateStack`):
-- `interruptReturn.mustache:32` and `interruptAssignment.mustache` — innermost.
-- `Runner.runForkAll` and `Runner.runRace` (`runner.ts`) — use the `stateStack` parameter, NOT `this.ctx.stateStack`.
-- `runPrompt` (`prompt.ts`) — uses the `stateStack` returned by its `setupFunction` call.
+**The capture sites that must use a local stack (not `ctx.stateStack`):**
 
-If you ever add a new layer that wraps concurrent execution and stamps checkpoints, follow the same pattern: capture only the local slice.
+- `interruptReturn.mustache` and `interruptAssignment.mustache` — the innermost (leaf).
+- **`runBatch`** — uses the `parentStack` opt the caller passed. As long as the caller does its part (passes the local slice — see "Usage guide" step 2), `runBatch` does the right thing. Pre-refactor this discipline lived in five different hand-rolled sites; today it lives in one.
 
-### Multi-cycle resumes
+If you ever add a new layer that wraps concurrent execution and stamps checkpoints, just use `runBatch`. Do not hand-roll a parallel `Promise.allSettled` again — the whole point of the primitive is to keep this slice-rule discipline in one auditable place.
+
+---
+
+## Multi-cycle resumes
 
 Branches can interrupt across multiple respond/resume cycles. Common pattern: thread A interrupts and gets approved, then later interrupts again. Meanwhile sibling threads B and C may have completed in cycle 1 and shouldn't replay.
 
 The mechanism: `BranchState.result` and `BranchState.interruptId` survive across cycles via `BranchStateJSON`. On any resume:
 
-- Branch with `result` set → short-circuit, no `blockFn` call, no side effects re-run.
-- Branch with `interruptId` only → re-invoke `blockFn` with the saved stack (deserialise mode). The inner code's frame still has its saved `__interruptId_N` in locals; it looks up the response and either continues or interrupts again.
+- Branch with `result` set → `runBatch` marks it `cached: true` and short-circuits (no `invoke` call, no side effects re-run). Hooks (`onBranchStart`, `onBranchEnd`) also skip cached branches so statelog doesn't double-fire.
+- Branch with `interruptId` only → re-invoke `invoke` with the saved stack (deserialise mode). The inner code's frame still has its saved `__interruptId_N` in locals; it looks up the response and either continues or interrupts again.
+
+(When `recordBranchOutcomes: false`, the cached short-circuit is disabled — the body always re-runs and is expected to provide its own substep idempotency. This is the runPrompt tool-loop arrangement.)
 
 This works for arbitrary cycle counts and any mix of completed/interrupted branches.
 
-## Race: implementation
+---
 
-`Runner.runRace` is similar in shape but with different semantics: only one branch wins; the others are cancelled.
+## Race resume (folded into `runBatch`)
 
-### First run
+Pre-refactor: `Runner.fork` checked `frame.locals[__race_winner_<id>]` at entry. If set, it dispatched to `resumeRaceWinner` instead of `runRace`.
 
-1. Build a tagged promise per branch: `blockFn(item, i, existing.stack).then(value => ({ index, value }))`.
-2. `Promise.race(taggedPromises)` resolves with whichever branch settles first.
-3. The losers' promises continue running in the JS event loop (we can't truly cancel synchronous JS) but their resolved values are discarded.
-4. **Abort losers**: walk every non-winner branch and call `branch.abortController?.abort()`. This fires their `stack.abortSignal`, so any cooperative downstream code (LLM HTTP, runPrompt's per-iteration check) tears down. See "Branch-aware abort signals" below.
-5. **Record the winner**: `frame.locals[__race_winner_<id>] = winnerIndex`. This is what makes resume work.
-6. **Save winner state**:
-   - If winner returned `Interrupt[]` → `setInterruptOnBranch` for the winner only. Stamp a fork-level checkpoint. Delete loser branches via `frame.deleteBranch(...)`. Return the interrupt array.
-   - If winner returned a value → `setResultOnBranch` for the winner. Delete loser branches. Return the value.
+Post-refactor: the caller (`Runner.fork`) unconditionally calls the race adapter. At the top of `runBatch`, if `mode === "race"` and a winner is persisted under `raceWinnerLocalKey`, `runBatch` runs only that child via a single-child path (`runRaceResume` inside `runBatch.ts`). The caller doesn't dispatch.
 
-Loser branches are deleted before any serialisation happens, so the saved checkpoint contains only the winner's slice.
+That single-child resume path:
 
-### Resume
-
-`Runner.fork` checks `frame.locals[__race_winner_<id>]` at entry. If set, it dispatches to `resumeRaceWinner` instead of `runRace`:
-
-- Read the saved winner index.
-- Look up `existing = frame.getBranch(winnerBranchKey)`.
-- If `existing.result` is set, return it.
-- Otherwise, re-invoke `blockFn` for that single index with the saved `existing.stack`. No race, no losers — just resume the winner.
-
-This is what guarantees the resume path doesn't re-run loser side effects: the loser branches simply aren't there in the saved state.
+- Looks up the recorded winner branch.
+- If `branch.result !== undefined` → return cached. (Defensive; this path is normally not reached because once a race produces a value, `Runner.fork` advances its step counter and the next call skips the race entirely.)
+- Otherwise sets up a fresh `AbortController` (no losers to compose with on resume) and invokes the body. Outcomes are handled the same way as the first-run path (interrupt → stamp shared checkpoint + overwrite; success → record result + `propagateWinnerCost`).
 
 ### Multi-cycle race
 
-If the winner interrupts a second time after being approved, `resumeRaceWinner` is called again. It still sees the same `winnerIndex`, finds the branch still pending (no `result`), re-invokes the block. The inner code advances past the first interrupt site (cached in frame locals), hits the second interrupt site, mints a new `interruptId`, halts. We stamp another fork-level checkpoint and return.
+If the winner interrupts a second time after being approved, `runBatch`'s race-resume path runs again. The body re-enters, advances past the first interrupt site (cached in frame locals), hits the second interrupt site, mints a new `interruptId`, halts. `runBatch` stamps another batch-level checkpoint, overwrites the new interrupt, and returns.
 
 Each subsequent resume keeps re-entering the same winner until it either produces a value or rejection.
 
-## LLM tool calls: implementation
+---
 
-When `llm(prompt, { tools })` is called, the LLM may emit multiple `toolCalls` in a single round. `runPrompt` processes those tools sequentially in a `for` loop, but each tool's invocation creates its own branch — same machinery as fork.
+## LLM tool calls: implementation today
 
-### Per-tool branches
+When `llm(prompt, { tools })` is called, the LLM may emit multiple `toolCalls` in a single round. `runPrompt` calls `PromptRunner.parallel` (the thin `runBatch` adapter) with `mode: "all"`, `recordBranchOutcomes: false`, and one child per `toolCall`.
 
-In `runPrompt` (`lib/runtime/prompt.ts`):
+The per-tool branchFn body (in `prompt.ts`):
 
-```ts
-for (const toolCall of toolCalls) {
-  const branchKey = `tool_${toolCall.id}`;
-  const existing = stack.getBranch(branchKey);
+1. Checks if the handler exists; if not, marks completion and skips.
+2. Checks `removedTools`; if blacklisted, marks completion and skips.
+3. Allocates the same branch (`stack.getOrCreateBranch("tool_<id>")`) that `runBatch` already created — idempotent.
+4. Runs `b.step("…start")` to fire `onToolCallStart`.
+5. Runs `b.step("…invoke")` which calls `runInvokeStep` — that's where the handler runs and where `stack.setResultOnBranch` / `setInterruptOnBranch` / `deleteBranch` get called depending on outcome.
+6. Runs `b.step("…end")` to fire `onToolCallEnd`.
+7. Runs `b.step("…log")` to emit the `toolCall` statelog event.
 
-  // Cached result (completed in a previous cycle): skip — toolMessage was
-  // already pushed into messagesJSON when it first succeeded.
-  if (existing?.result !== undefined) continue;
+If any of these `b.step` bodies returns interrupts, `BranchRunner.step` collects them on `b.interrupts`, the rest of the body short-circuits via `if (b.interrupts) return`, and the runBatch child's invoke returns the collected array.
 
-  // Previously interrupted, user rejected: emit a "tool call rejected"
-  // toolMessage, remove the tool, move on.
-  if (existing?.interruptId) {
-    const response = ctx.getInterruptResponse(existing.interruptId);
-    if (response?.type === "reject") { ... continue; }
-  }
+Important rule preserved from the pre-refactor code: **don't `deleteBranch` on a tool success during the parallel loop**. A previous version did, and it broke multi-cycle resumes when one tool succeeded and another interrupted: on resume, the deleted branch had no `existing.result`, so the cached short-circuit didn't fire, and runPrompt re-invoked the tool, pushing a duplicate `toolMessage` to the saved `messagesJSON`. OpenAI then rejected the request with `Duplicate value for 'tool_call_id'`. Branches are cleaned up by `popBranches()` (called by `runBatch` on the no-interrupt success path).
 
-  const branchStack = stack.getOrCreateBranch(branchKey).stack;
-  const result = await handler.invoke(args, { ..., stateStack: branchStack, isForked: true });
-
-  if (hasInterrupts(result)) {
-    interrupts.push(...result);
-    stack.setInterruptOnBranch(branchKey, ...);
-    continue;
-  }
-
-  // Tool succeeded: cache and push toolMessage, but do NOT delete the branch.
-  stack.setResultOnBranch(branchKey, result);
-  messages.push(smoltalk.toolMessage(result, ...));
-}
-```
-
-A few things worth knowing:
-
-**Don't `deleteBranch` on success.** A previous version of this code deleted the branch immediately after caching the result. That broke multi-cycle resumes when one tool succeeded and another interrupted: on resume, the deleted branch had no `existing.result`, so the cached short-circuit didn't fire, and runPrompt re-invoked the tool, pushing a duplicate `toolMessage` to the saved `messagesJSON`. OpenAI then rejected the request with `Duplicate value for 'tool_call_id'`. Branches are cleaned up by `popBranches()` after the entire tool-call loop completes without interrupts.
-
-**The cached short-circuit just `continue`s.** It does not re-push the `toolMessage`. The message is already in `messagesJSON` from the original run; on resume `messages` is restored from `messagesJSON`, so the message comes back in place.
-
-**`handler.invoke` runs with `isForked: true`** so the tool's frame stays on its branch stack on interrupt rather than being popped by the function's finally block. This preserves the inner state for resume.
-
-### Tool-call interrupt collection
-
-Same pattern as fork: after the for-loop, if `interrupts.length > 0`, `runPrompt` stamps a single shared checkpoint onto every collected interrupt (capturing its local stack), saves `self.messagesJSON`, returns the array, and skips popping its own frame (`shouldPop = false`).
+`deleteBranch` IS still called on failure/crash/reject paths inside `runInvokeStep` — that's pre-existing behaviour and is fine because the body subsequently returns and `runBatch` doesn't try to touch the deleted branch (it doesn't `setResultOnBranch` when `recordBranchOutcomes` is false).
 
 ### LLM tool calls + fork
 
 When a tool's body contains `fork`, that's the most-nested case the runtime supports. Composition trace:
 
 1. `confirmItem` (innermost function in the fork block) hits `interrupt(...)`. The `interruptReturn` template captures the block-frame stack and stamps it on the interrupt object.
-2. The fork-block returns the interrupt array. `Runner.runForkAll` sees `hasInterrupts`, calls `setInterruptOnBranch` on the matching `fork_*` sub-branch, and stamps its own checkpoint (capturing the search-frame slice with its `branches` populated).
-3. The search function returns the fork's interrupt array. `runPrompt`'s tool loop sees `hasInterrupts(result)`, calls `setInterruptOnBranch` on the `tool_*` branch, and stamps its own checkpoint (capturing the runPrompt-frame slice with its `branches` populated).
-4. `runPrompt` returns the array. The calling node's runner halts; `runNode` returns it as `result.data`.
+2. The fork block returns the interrupt array. `Runner.runForkAll` (via `runBatch`) sees `hasInterrupts`, calls `setInterruptOnBranch` on the matching `fork_*` sub-branch, and stamps its own batch-level checkpoint (capturing the search-frame slice with its `branches` populated).
+3. The search function returns the fork's interrupt array. `runPrompt`'s tool loop (via `PromptRunner.parallel` → `runBatch`) surfaces the interrupts up through the BranchRunner, `runBatch` stamps the tool-level shared checkpoint (capturing the runPrompt-frame slice with its `branches` populated), and the runPrompt body returns the array.
+4. The calling node's runner halts; `runNode` returns the array as `result.data`.
 
-On resume, the user's responses are matched by `interruptId`. Each layer's setupFunction consumes saved frames in order (StateStack `deserializeMode`); each layer's branches map back to the resumed sub-branches; each layer's blockFn re-enters the saved stack; the innermost interrupt site reads its saved `__interruptId_N`, finds the response, continues.
+On resume, the user's responses are matched by `interruptId`. Each layer's `setupFunction` consumes saved frames in order (StateStack `deserializeMode`); each layer's branches map back to the resumed sub-branches; each layer's invoke re-enters the saved stack; the innermost interrupt site reads its saved `__interruptId_N`, finds the response, continues.
+
+---
 
 ## Branch-aware abort signals
 
@@ -210,13 +448,13 @@ Because race needs to actually stop loser work — not just discard the value �
 
 ### Storage
 
-The signal lives on `StateStack.abortSignal`. When `Runner.runRace` (or `runForkAll`, for parity / future use) creates a branch:
+The signal lives on `StateStack.abortSignal`. When `runBatch` creates a branch:
 
 ```ts
 existing.abortController = new AbortController();
-const parentSignal = stateStack.abortSignal;
-existing.stack.abortSignal = parentSignal
-  ? AbortSignal.any([parentSignal, existing.abortController.signal])
+const parentSig = parentStack.abortSignal;
+existing.stack.abortSignal = parentSig
+  ? AbortSignal.any([parentSig, existing.abortController.signal])
   : existing.abortController.signal;
 ```
 
@@ -227,12 +465,12 @@ Composing with the parent stack's signal means a nested fork inside a race-loser
 Three places use the per-branch signal:
 
 - **`Runner.shouldSkip()`** — every step in the runner first checks `this.stack?.abortSignal?.aborted`. If set, the runner halts. The Runner's `stack` opt is set by the `forkBlockSetup.mustache` template to `__forkBranchStack`, so each branch's runner observes its own abort.
-- **`ctx.isCancelled(stack)`** — used in `runPrompt` and `interruptWithHandlers` for cancellation checks. Returns true if the global ctx is aborted OR the given stack's signal is aborted. The 5 sites that previously called `ctx.aborted` now call `ctx.isCancelled(stateStack)` and pass the local stack.
+- **`ctx.isCancelled(stack)`** — used in `runPrompt` and `interruptWithHandlers` for cancellation checks. Returns true if the global ctx is aborted OR the given stack's signal is aborted.
 - **`ctx.getAbortSignal(stack)`** — used in `runPrompt` for the smoltalk HTTP call. Returns a composite `AbortSignal.any([ctx.abortController.signal, stack.abortSignal])`, so when a race loser is mid-LLM-call and the abort fires, the underlying OpenAI SDK cancels the HTTP request and the await throws.
 
 ### What this guarantees
 
-When `Runner.runRace` aborts a loser:
+When `runBatch` aborts a race loser:
 
 - The loser's `stack.abortSignal` fires.
 - The loser's runner halts at the next step (the runner's `shouldSkip()` sees the abort).
@@ -244,7 +482,9 @@ Synchronous code that has already begun executing (e.g., an `interrupt()` call m
 
 ### Why a stack-based signal instead of AsyncLocalStorage
 
-ALS would make `ctx.aborted` magically branch-aware without any call-site changes — but it's Node-only. Agency is meant to run anywhere TS runs. The stack-based approach requires explicit `stack` args at the 5 sites that check cancellation, but it has no platform dependency and aligns with Agency's pattern of threading state through `stateStack`.
+ALS would make `ctx.aborted` magically branch-aware without any call-site changes — but it's Node-only. Agency is meant to run anywhere TS runs. The stack-based approach requires explicit `stack` args at the sites that check cancellation, but it has no platform dependency and aligns with Agency's pattern of threading state through `stateStack`.
+
+---
 
 ## Resume mechanics
 
@@ -252,7 +492,7 @@ ALS would make `ctx.aborted` magically branch-aware without any call-site change
 
 1. Length-check: `interrupts.length === responses.length` or throw.
 2. Build `responseMap: Record<interruptId, response>`.
-3. Pull the shared checkpoint off `interrupts[0].checkpoint`. This is the top-level snapshot (e.g., from `runPrompt`'s capture) — its `.stack` is the full execution tree.
+3. Pull the shared checkpoint off `interrupts[0].checkpoint`. This is the top-level snapshot (e.g., the batch-level cp `runBatch` stamped) — its `.stack` is the full execution tree.
 4. Apply any `overrides` to the checkpoint's `globals`/locals.
 5. Create a fresh `execCtx` via `ctx.createExecutionContext(runId)`. Call `execCtx.restoreState(checkpoint)`. This replaces `execCtx.stateStack` with `StateStack.fromJSON(...)` and calls `stateStack.deserializeMode()` — which recursively flips every nested branch stack into deserialise mode.
 6. Set the response map: `execCtx.setInterruptResponses(responseMap)`.
@@ -263,32 +503,44 @@ During the re-run:
 - Every `setupFunction`/`setupNode` call to `getNewState()` consumes a saved frame from the front of the deserialise queue.
 - Each runner step counter (`frame.step` for top-level, `__substep_X` for nested) skips already-completed steps.
 - Each interrupt site reads its saved `__interruptId_N` from `__self.locals` and consults `ctx.getInterruptResponse(id)`.
-- Fork sites find their `branches` map already populated; cached results short-circuit, interrupted branches re-enter `blockFn`.
-- Race sites find `__race_winner_<id>` and re-enter only that index.
+- Concurrent sites (fork/race/runPrompt tool loop) re-enter `runBatch` which finds the `branches` map already populated: cached results short-circuit, interrupted branches re-run `invoke`.
+- Race sites find `__race_winner_<id>` in locals and `runBatch`'s race-resume path re-enters only that index.
 
 If the re-run produces another batch of interrupts, the cycle repeats.
 
+---
+
 ## Key files
 
-- `lib/runtime/runner.ts` — `Runner.fork`, `runForkAll`, `runRace`, `resumeRaceWinner`, `shouldSkip`. The heart of branch orchestration.
-- `lib/runtime/prompt.ts` — `runPrompt` and `_runPrompt`. The tool-call branch path lives here.
-- `lib/runtime/state/stateStack.ts` — `BranchState`, `BranchStateJSON`, `State.branches`, `setInterruptOnBranch`, `setResultOnBranch`, `deleteBranch`, `popBranches`. Also `StateStack.deserializeMode` and `StateStack.abortSignal`.
-- `lib/runtime/state/context.ts` — `RuntimeContext.isCancelled`, `getAbortSignal`, `restoreState`.
-- `lib/runtime/interrupts.ts` — `interrupt()` factory, `interruptWithHandlers`, `respondToInterrupts`.
-- `lib/templates/backends/typescriptGenerator/interruptReturn.mustache` — innermost interrupt site. Stamps the leaf checkpoint on the interrupt.
-- `lib/templates/backends/typescriptGenerator/interruptAssignment.mustache` — same as above but for `let x = interrupt(...)` form.
-- `lib/templates/backends/typescriptGenerator/forkBlockSetup.mustache` — sets up the per-branch Runner with a `stack: __forkBranchStack` opt so the runner can observe its branch's abort signal.
+- [`lib/runtime/runBatch.ts`](../../lib/runtime/runBatch.ts) — the single concurrent-interrupt primitive. Lives next to the adopters; comment at top documents the no-throw audit findings.
+- [`lib/runtime/runner.ts`](../../lib/runtime/runner.ts) — `Runner.fork`, `runForkAll` (now adapter), `runRace` (now adapter). The remaining branch-orchestration glue.
+- [`lib/runtime/prompt.ts`](../../lib/runtime/prompt.ts) — `runPrompt` and `_runPrompt`. Tool-call branch path.
+- [`lib/runtime/promptRunner.ts`](../../lib/runtime/promptRunner.ts) — `PromptRunner.parallel` (now adapter) + `BranchRunner` (per-branch substep idempotency, unchanged).
+- [`lib/runtime/state/stateStack.ts`](../../lib/runtime/state/stateStack.ts) — `BranchState`, `BranchStateJSON`, `State.branches`, `setInterruptOnBranch`, `setResultOnBranch`, `deleteBranch`, `popBranches`. Also `StateStack.deserializeMode` and `StateStack.abortSignal`.
+- [`lib/runtime/state/context.ts`](../../lib/runtime/state/context.ts) — `RuntimeContext.isCancelled`, `getAbortSignal`, `restoreState`.
+- [`lib/runtime/interrupts.ts`](../../lib/runtime/interrupts.ts) — `interrupt()` factory, `interruptWithHandlers`, `respondToInterrupts`.
+- [`lib/templates/backends/typescriptGenerator/interruptReturn.mustache`](../../lib/templates/backends/typescriptGenerator/interruptReturn.mustache) — leaf interrupt site. Stamps the leaf checkpoint on the interrupt. **Do not modify** without re-reading the slice-only-capture section.
+- [`lib/templates/backends/typescriptGenerator/interruptAssignment.mustache`](../../lib/templates/backends/typescriptGenerator/interruptAssignment.mustache) — same as above but for `let x = interrupt(...)` form.
+- [`lib/templates/backends/typescriptGenerator/forkBlockSetup.mustache`](../../lib/templates/backends/typescriptGenerator/forkBlockSetup.mustache) — sets up the per-branch Runner with a `stack: __forkBranchStack` opt so the runner can observe its branch's abort signal.
+
+---
 
 ## Invariants worth maintaining
 
 If you change anything in this area, make sure these still hold:
 
-1. **Capture-time slice rule.** Any code that creates a checkpoint inside concurrent execution must capture its **local** `stateStack`, not `ctx.stateStack`. Otherwise `State.toJSON`'s branch-checkpoint transplant will duplicate the outer state into a branch slot.
-2. **Don't `deleteBranch` on success during a tool-call loop or fork loop.** Cached `result` must survive across a sibling's interrupt cycle. Cleanup is `popBranches()` after the entire round resolves without interrupts.
-3. **`interruptId` is the single source of truth on resume.** The user's responses are keyed by `interruptId` in `responseMap`. The inner code reads it from `__self.__interruptId_N` (saved in frame locals). If the innermost interrupt template ever mints a new id on resume instead of reading the saved one, you'll see fresh ids each cycle and the resume will infinite-loop.
-4. **Race deletes loser branches before serialisation.** Loser state must not survive into the checkpoint. Otherwise resume will re-execute losers.
-5. **`abortSignal` composes with parent.** Nested branches must inherit ancestor aborts via `AbortSignal.any` so a top-level race abort cascades.
-6. **`ctx.isCancelled` and `ctx.getAbortSignal` get the local stack.** Anywhere new in the runtime that wants cancellation awareness must thread the `stateStack` arg, not just `ctx`.
+1. **Capture-time slice rule.** Any code that creates a checkpoint inside concurrent execution must capture its **local** `stateStack`, not `ctx.stateStack`. After the runBatch refactor this discipline collapses to: when calling `runBatch`, pass your local slice as `parentStack`. Don't reach for `ctx.stateStack`.
+2. **The leaf stamps its own per-branch checkpoint.** Per c72b9c1574, the `isForked`-bypass approach (skipping leaf stamping) was extremely buggy especially for nested forks and nested prompts. Today the leaf always pops + stamps a per-branch checkpoint; `runBatch` reads it and stores it on `BranchState.checkpoint` where `State.toJSON`'s branches walk picks it up. Do not change this.
+3. **Don't `deleteBranch` on success during a tool-call loop or fork loop.** Cached `result` must survive across a sibling's interrupt cycle. Cleanup is `popBranches()` after the entire round resolves without interrupts.
+4. **`interruptId` is the single source of truth on resume.** The user's responses are keyed by `interruptId` in `responseMap`. The inner code reads it from `__self.__interruptId_N` (saved in frame locals). If the innermost interrupt template ever mints a new id on resume instead of reading the saved one, you'll see fresh ids each cycle and the resume will infinite-loop.
+5. **Race deletes loser branches before serialisation.** Loser state must not survive into the checkpoint. Otherwise resume will re-execute losers.
+6. **`abortSignal` composes with parent.** Nested branches must inherit ancestor aborts via `AbortSignal.any` so a top-level race abort cascades.
+7. **`ctx.isCancelled` and `ctx.getAbortSignal` get the local stack.** Anywhere new in the runtime that wants cancellation awareness must thread the `stateStack` arg, not just `ctx`.
+8. **`intr.checkpoint` / `intr.checkpointId` overwrite is intentional.** Every interrupt in a batch deliberately shares one resume point. If you bypass `runBatch` and stamp interrupts yourself, you must also overwrite — otherwise resuming one interrupt won't restore the state needed to resume its siblings.
+9. **`runBatch.invoke` must RETURN `T | Interrupt[]`; must not throw `Interrupt[]`.** Run the `grep -nE "throw .*[Ii]nterrupt"` audit on any new call path before migrating.
+10. **`raceWinnerLocalKey` shape is checkpoint-format-load-bearing.** The race adapter passes `__race_winner_<id>` — keep that shape. Changing it would silently break any in-flight serialised checkpoints.
+
+---
 
 ## Test locations
 
@@ -299,9 +551,15 @@ If you change anything in this area, make sure these still hold:
 - Race + interrupt: `tests/agency/fork/race-interrupt.test.json`, `tests/agency/fork/race/race-{multi-cycle,reject-winner,with-fork-inside,mixed-completion}.test.json`.
 - TypeScript-side API: `tests/agency-js/interrupts/{interrupt-approve,interrupt-reject,interrupt-overrides,interrupt-batched-overrides,interrupt-respond-mismatch,interrupt-respond-by-data}/`.
 - Fork batching: `tests/agency-js/fork/{fork-parallel-interrupts,fork-nested-interrupts,fork-mixed-responses}/`.
+- **`runBatch` unit tests**: `lib/runtime/runBatch.test.ts` — 19 tests covering all three modes, cached short-circuit, abort propagation, race resume dispatch (pending + cached winner), cost-hook asymmetry, empty/duplicate/rejection edge cases, mode-flip defensive assert.
+- **`PromptRunner.parallel` unit tests**: `lib/runtime/promptRunner.test.ts` (the `parallel` block) — uses real `State`/`StateStack` to exercise the runBatch path.
+
+---
 
 ## Known limitations
 
 - **Race loser cancellation is cooperative.** Synchronous JS code in a loser cannot be interrupted — it runs to completion, but its result is discarded. Cancellation only takes effect at await points and at runner step boundaries.
 - **Handler that calls `interrupt()` recursively invokes itself.** See the skipped `tests/agency/fork/handlers/handler-throws-interrupt.test.json`. Whether handler-issued interrupts should bypass the active handler is an open design question.
 - **Race + reject of winner**: rejection becomes the race result (a failure `Result`). There's no automatic re-race against the surviving losers — the user must run `race` again at a higher level if they want that semantics.
+- **The runPrompt tool loop's `recordBranchOutcomes: false` arrangement is the only current site that opts out of `runBatch`'s branch-state recording.** If a future adopter needs the same arrangement, follow the same pattern (and re-read the comment in `runBatch.ts` explaining why the cached-branch short-circuit is also disabled in that mode).
+- **Subprocess interrupts (Plan 3, `docs/superpowers/plans/2026-05-10-subprocess-propagation-and-resume.md`) have the same _logical_ shape as a single-child `runBatch`** but the `invoke` crosses an IPC boundary (JSON serialisation, separate process lifetime, separate checkpoint store). Modeling subprocess as `runBatch({ children: [{ key: "sub", invoke: ipcCall }] })` is correct in shape but the IPC layer still needs to (a) reconstruct serialised checkpoints, (b) translate the subprocess's internal `Interrupt[]` JSON into runtime `Interrupt` objects with `.checkpoint` reconstructed via `Checkpoint.fromJSON`, (c) handle subprocess lifecycle. `runBatch` provides the surrounding shape; the IPC layer is separate work.

--- a/packages/agency-lang/docs/dev/concurrent-interrupts.md
+++ b/packages/agency-lang/docs/dev/concurrent-interrupts.md
@@ -73,51 +73,19 @@ Each `StateStack` carries an optional `abortSignal?: AbortSignal`. When `runBatc
 
 ## The `runBatch` primitive
 
-`runBatch` lives in [`lib/runtime/runBatch.ts`](../../lib/runtime/runBatch.ts). Single function, three modes, one tagged-union return type.
-
-### Signature
+`runBatch` lives in [`lib/runtime/runBatch.ts`](../../lib/runtime/runBatch.ts). Single function, three modes (`"all"`, `"sequential"`, `"race"`), tagged-union return:
 
 ```ts
 export async function runBatch<T>(opts: RunBatchOpts<T>): Promise<RunBatchResult<T>>;
-
-export type RunBatchOpts<T> = {
-  ctx: RuntimeContext<any>;
-  /** The parent's local state stack — used as the capture stack for the
-   *  shared batch-level checkpoint. MUST be the local slice (e.g. the
-   *  branch stack if `runBatch` is itself called inside a child of an
-   *  outer `runBatch`), NOT `ctx.stateStack`. This is the one discipline
-   *  the caller of `runBatch` must observe. */
-  parentStack: StateStack;
-  /** The frame where branch state lives. Usually `parentStack.lastFrame()`. */
-  parentFrame: State;
-  /** Where the shared checkpoint records its location. */
-  checkpointLocation: { moduleId: string; scopeName: string; stepPath: string };
-  /** "all" → Promise.allSettled, concurrent;
-   *  "sequential" → for...of, strict ordering;
-   *  "race" → first to settle wins, others aborted. */
-  mode: "all" | "sequential" | "race";
-  children: BatchChild<T>[];
-  /** Mode "race" only: the `parentFrame.locals` key under which the winner
-   *  index is persisted. */
-  raceWinnerLocalKey?: string;
-  /** Default true. When false, the caller's `invoke` is responsible for
-   *  managing BranchState fields (setResultOnBranch / setInterruptOnBranch
-   *  / deleteBranch) — runBatch only handles abort, settle, checkpoint
-   *  stamp, overwrite. Also disables the cached-branch short-circuit. */
-  recordBranchOutcomes?: boolean;
-  hooks?: BatchHooks;
-};
-
-export type BatchChild<T> = {
-  key: string;
-  /** MUST RETURN T | Interrupt[]; MUST NOT THROW Interrupt[]. */
-  invoke: (childStack: StateStack, abortSignal: AbortSignal) => Promise<T | Interrupt[]>;
-};
-
-export type RunBatchResult<T> =
-  | { kind: "values"; values: T[] }
-  | { kind: "interrupts"; interrupts: Interrupt[] };
+//   RunBatchResult<T> = { kind: "values"; values: T[] } | { kind: "interrupts"; interrupts: Interrupt[] }
 ```
+
+For the full option set (`parentStack`, `parentFrame`, `checkpointLocation`, `children`, `raceWinnerLocalKey`, `recordBranchOutcomes`, `hooks`) and the `BatchChild` contract, read the JSDoc on `RunBatchOpts` in [`lib/runtime/runBatch.ts`](../../lib/runtime/runBatch.ts). Don't re-document those fields here — the source is the canonical reference.
+
+The two callers-must-observe rules are:
+
+- **`parentStack` MUST be the local slice** (the branch stack you were handed), NOT `ctx.stateStack`. See "Slice-only checkpoint composition" below.
+- **`BatchChild.invoke` MUST RETURN `T | Interrupt[]`**, never throw an interrupt array. Other JS errors may be thrown. See "Inherited invariants → Errors win over interrupts" below.
 
 ### What `runBatch` owns
 
@@ -157,8 +125,8 @@ When this flag is false, `runBatch` also **disables the cached-branch short-circ
 
 These behaviours come from the pre-refactor code; `runBatch` preserves them exactly.
 
-- **Errors win over interrupts.** If any child rejects (throws a non-interrupt error), `runBatch` rethrows that error and abandons any interrupts that sibling branches successfully halted with. Matches today's `runForkAll` / `runRace`. Callers that need both must catch inside their `invoke`.
-- **Race cost asymmetry.** Losers' cost propagates eagerly at race time (so their partial LLM spend is billed). The winner's cost propagates only when the winner's branch finally completes via a no-interrupt resume.
+- **Internal runtime errors win over interrupts.** Agency itself uses Result/Failure for user-facing tool errors, not JS exceptions ([guide → error handling](https://agency-lang.com/guide/error-handling.html)). The case this invariant covers is narrower: if a child's promise *rejects* — i.e., a JS error escapes from the runtime layer (a bug in agency itself, or unhandled TypeScript code called from within a branch) — `runBatch` rethrows that error and abandons any interrupts that sibling branches collected. Same behaviour as today's `runForkAll` / `runRace`. A child that needs to surface both a failure and sibling interrupts must catch the JS error inside its own `invoke` and translate it into a Failure value.
+- **Race cost asymmetry.** When the winner settles and `runBatch` aborts the losers, each loser's accumulated cost (any LLM calls it actually made before being aborted) is propagated to the parent right then. The winner's cost is *deferred*: it isn't propagated until the winner's branch finally pops on a no-interrupt resume. This matches the pre-refactor `runRace` semantics.
 - **The leaf stamps its own per-branch checkpoint** at `interruptReturn`. `runBatch` reads it off the surfaced interrupt and stores it on `BranchState.checkpoint`. Do not move leaf stamping anywhere.
 
 ---
@@ -177,8 +145,6 @@ The adapter:
 - Hooks: `seedBranchCost`, `propagateBranchCost` delegate to `Runner`'s existing helpers. `onBranchEnd → forkBranchEnd` and `onCheckpoint → checkpointCreated` wire up the statelog events. No `propagateLoserCost`/`propagateWinnerCost` (not race).
 - Returns: `result.kind === "interrupts" ? result.interrupts : result.values`.
 
-What that replaces: ~110 lines of hand-rolled `Promise.allSettled` plumbing + per-branch abort setup + per-branch cost seeding + outcome loop + checkpoint stamping + cost propagation + `popBranches`.
-
 ### `Runner.runRace` (`lib/runtime/runner.ts`)
 
 Mode: `"race"`. `recordBranchOutcomes` defaults to true. `raceWinnerLocalKey: this.raceWinnerKey(id)` (which evaluates to the existing `__race_winner_<id>` shape — unchanged for in-flight checkpoint compatibility).
@@ -189,7 +155,7 @@ The adapter:
 - Hooks: `seedBranchCost`, **asymmetric** `propagateLoserCost` / `propagateWinnerCost` (both delegating to the same `propagateBranchCost` helper; only the timing differs). `onBranchEnd → forkBranchEnd` (`"aborted"` for losers, `"interrupted"`/`"success"` for winner, `"failure"` for the first rejecting branch). `onCheckpoint → checkpointCreated` with `reason: "race"`.
 - Returns: `result.kind === "interrupts" ? result.interrupts : result.values[0]` (race always has exactly one winner).
 
-What that replaces: ~280 lines (`runRace` + `buildRaceBranchPromise` + `abortLoserBranchesAndEmitEnds` + `resumeRaceWinner`) plus the dispatch in `Runner.fork`. `Runner.fork` no longer needs to distinguish "first run" from "resume winner" — `runBatch`'s mode-`"race"` resume-dispatch path handles both.
+`Runner.fork` doesn't dispatch between "first run" and "resume winner" — it unconditionally calls the race adapter, and `runBatch`'s race-resume path inside the primitive handles the resume case via `raceWinnerLocalKey`.
 
 ### `runPrompt`'s tool loop (`lib/runtime/prompt.ts` + `lib/runtime/promptRunner.ts`)
 
@@ -232,7 +198,7 @@ if (parallelResult.kind === "interrupts") {
 // continue: parallelResult.kind === "values"
 ```
 
-What that replaces: the merged-checkpoint stamping in `PromptRunner.parallel` (was lines 158–188) plus the `PromptBailout` throw / catch dance. `PromptBailout` is still thrown by `PromptRunner.step` (the per-step helper, not parallel); the parallel path's no-throw return preserves the runBatch `invoke` no-throw-`Interrupt[]` contract.
+`PromptBailout` is still thrown by `PromptRunner.step` (the per-step helper, not by `parallel`); the parallel path returns its result instead of throwing so the `runBatch` `invoke` no-throw-`Interrupt[]` contract is preserved.
 
 ### Audit notes for prompt.ts migration
 
@@ -344,8 +310,9 @@ Any new site needs at least these tests:
 
 1. All children succeed → returns `kind: "values"`.
 2. One child interrupts, others succeed → returns `kind: "interrupts"`; on resume after `respondToInterrupts`, the previously-successful children short-circuit (their `setResultOnBranch` survived), the previously-interrupted child runs once more and succeeds; final result matches the all-succeed case.
-3. Multi-cycle: the previously-interrupted child interrupts AGAIN on its first re-run; one more `respondToInterrupts`; everything completes.
-4. Mode-specific failure case — for race, a loser was aborted mid-flight; for fork, the rejection-wins-over-interrupts invariant.
+3. Multiple children interrupt in the same batch → returns `kind: "interrupts"` with every collected interrupt sharing the same `checkpointId`; one `respondToInterrupts` with N responses resumes them all together. This is the case the `intr.checkpoint` overwrite is designed for and the most common source of subtle bugs in concurrent-interrupt code.
+4. Multi-cycle: a previously-interrupted child interrupts AGAIN on its first re-run; another `respondToInterrupts`; everything completes.
+5. Mode-specific failure case — for race, a loser was aborted mid-flight; for fork, the rejection-wins-over-interrupts invariant.
 
 The existing `tests/agency/fork/*` suite gives you templates for each.
 
@@ -562,4 +529,3 @@ If you change anything in this area, make sure these still hold:
 - **Handler that calls `interrupt()` recursively invokes itself.** See the skipped `tests/agency/fork/handlers/handler-throws-interrupt.test.json`. Whether handler-issued interrupts should bypass the active handler is an open design question.
 - **Race + reject of winner**: rejection becomes the race result (a failure `Result`). There's no automatic re-race against the surviving losers — the user must run `race` again at a higher level if they want that semantics.
 - **The runPrompt tool loop's `recordBranchOutcomes: false` arrangement is the only current site that opts out of `runBatch`'s branch-state recording.** If a future adopter needs the same arrangement, follow the same pattern (and re-read the comment in `runBatch.ts` explaining why the cached-branch short-circuit is also disabled in that mode).
-- **Subprocess interrupts (Plan 3, `docs/superpowers/plans/2026-05-10-subprocess-propagation-and-resume.md`) have the same _logical_ shape as a single-child `runBatch`** but the `invoke` crosses an IPC boundary (JSON serialisation, separate process lifetime, separate checkpoint store). Modeling subprocess as `runBatch({ children: [{ key: "sub", invoke: ipcCall }] })` is correct in shape but the IPC layer still needs to (a) reconstruct serialised checkpoints, (b) translate the subprocess's internal `Interrupt[]` JSON into runtime `Interrupt` objects with `.checkpoint` reconstructed via `Checkpoint.fromJSON`, (c) handle subprocess lifecycle. `runBatch` provides the surrounding shape; the IPC layer is separate work.

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -600,9 +600,13 @@ export async function runPrompt(args: {
       // semantics across branches (strategy B in the plan): same-round
       // removal is best-effort and removals always take effect from the
       // NEXT round (the .filter() after this parallel call).
-      await pr.parallel(
+      const parallelResult = await pr.parallel(
         `round.${round}.tools`,
         toolCalls,
+        // keyFor: MUST match the branchKey the body uses below
+        // (`stack.getOrCreateBranch(branchKey)`) so runBatch and the body
+        // operate on the same branch.
+        (toolCall) => `tool_${toolCall.id}`,
         async (toolCall, b) => {
           if (ctx.isCancelled(stateStack)) throw new AgencyCancelledError();
 
@@ -767,7 +771,20 @@ export async function runPrompt(args: {
         },
       );
 
-      // All tool calls complete — clean up branches, next LLM round
+      // pr.parallel returns a RunBatchResult tagged union; if any tool
+      // branch surfaced interrupts, runBatch already stamped the shared
+      // checkpoint. Bail out of runPrompt with the merged batch — the
+      // outer caller checkpoints / propagates as usual. (Replaces the
+      // former PromptBailout throw with an explicit return so runBatch's
+      // no-throw-Interrupt contract is preserved.)
+      if (parallelResult.kind === "interrupts") {
+        shouldPop = false;
+        return parallelResult.interrupts;
+      }
+
+      // All tool calls complete — runBatch already popped branches on the
+      // no-interrupt success path, but call again defensively in case any
+      // branchFn-level cleanup added new branches mid-flight.
       stack.popBranches();
       tools = tools.filter((t) => !removedTools.includes(t.name));
       toolFunctions = toolFunctions.filter(

--- a/packages/agency-lang/lib/runtime/promptRunner.test.ts
+++ b/packages/agency-lang/lib/runtime/promptRunner.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { PromptRunner, PromptBailout } from "./promptRunner.js";
+import { State, StateStack } from "./state/stateStack.js";
 
 /** Stub statelog client. Includes the minimum surface PromptRunner touches:
  *  checkpointCreated for `step()`, snapshotStack / runInBranchContext for
@@ -14,7 +15,9 @@ function stubStatelogClient(extras: Partial<any> = {}) {
   };
 }
 
-/** Build a PromptRunner with stub deps. Override fields as needed. */
+/** Build a PromptRunner with stub deps. Override fields as needed. The
+ *  parallel() path requires a real StateStack/State so runBatch can do
+ *  branch lifecycle; build them by default. */
 function makeRunner(overrides: Partial<any> = {}) {
   const self: any = {};
   const ctx: any = {
@@ -24,15 +27,19 @@ function makeRunner(overrides: Partial<any> = {}) {
     },
     statelogClient: stubStatelogClient(),
   };
+  const stateStack = new StateStack();
+  const parentFrame = new State();
+  stateStack.stack.push(parentFrame);
   const opts = {
     self,
     ctx,
-    stateStack: {} as any,
+    stateStack,
+    parentFrame,
     checkpointInfo: undefined,
     snapshotMessages: () => [],
     ...overrides,
   };
-  return { runner: new PromptRunner(opts), self, ctx };
+  return { runner: new PromptRunner(opts), self, ctx, parentFrame };
 }
 
 /** Build an Interrupt-shaped object (matches `isInterrupt`'s `type === "interrupt"`). */
@@ -230,23 +237,34 @@ describe("PromptRunner.step interrupt handling", () => {
 });
 
 describe("PromptRunner.parallel", () => {
+  // Helper that supplies the per-item branch key. The real call site
+  // passes `(toolCall) => "tool_" + toolCall.id` — for tests we just
+  // use the item itself + index.
+  const keyFor = (item: any, i: number) => `k_${item}_${i}`;
+
   it("runs every branch concurrently", async () => {
     const { runner } = makeRunner();
     const order: string[] = [];
-    await runner.parallel("group", ["a", "b", "c"], async (item, b) => {
-      await b.step(`${item}.s1`, async () => {
-        order.push(`start-${item}`);
-      });
-      await new Promise((r) => setTimeout(r, 5));
-      await b.step(`${item}.s2`, async () => {
-        order.push(`end-${item}`);
-      });
-    });
+    const result = await runner.parallel(
+      "group",
+      ["a", "b", "c"],
+      keyFor,
+      async (item, b) => {
+        await b.step(`${item}.s1`, async () => {
+          order.push(`start-${item}`);
+        });
+        await new Promise((r) => setTimeout(r, 5));
+        await b.step(`${item}.s2`, async () => {
+          order.push(`end-${item}`);
+        });
+      },
+    );
+    expect(result.kind).toBe("values");
     // All three starts happen before any end (concurrent).
     expect(order.indexOf("start-c")).toBeLessThan(order.indexOf("end-a"));
   });
 
-  it("merges interrupts from multiple branches into one bailout with one shared checkpoint", async () => {
+  it("merges interrupts from multiple branches into kind='interrupts' with one shared checkpoint", async () => {
     let cpCount = 0;
     const ctx: any = {
       checkpoints: {
@@ -259,45 +277,54 @@ describe("PromptRunner.parallel", () => {
       statelogClient: stubStatelogClient(),
     };
     const { runner } = makeRunner({ ctx });
-    let caught: PromptBailout | null = null;
-    try {
-      await runner.parallel("group", ["a", "b"], async (item, b) => {
+    const result = await runner.parallel(
+      "group",
+      ["a", "b"],
+      keyFor,
+      async (item, b) => {
         await b.step(`${item}.s1`, async () => [fakeInterrupt(item)] as any);
-      });
-    } catch (e) {
-      if (e instanceof PromptBailout) caught = e;
-    }
-    expect(caught).not.toBeNull();
-    expect(caught!.interrupts.length).toBe(2);
-    expect(cpCount).toBe(1);
-    expect(caught!.interrupts.every((i) => i.checkpointId === 101)).toBe(
-      true,
+      },
     );
+    expect(result.kind).toBe("interrupts");
+    if (result.kind !== "interrupts") return;
+    expect(result.interrupts.length).toBe(2);
+    expect(cpCount).toBe(1);
+    expect(result.interrupts.every((i) => i.checkpointId === 101)).toBe(true);
   });
 
   it("skips a branch step whose key was already completed on a prior pass", async () => {
     const self: any = { runnerState: { completedSteps: ["a.s1"] } };
     const { runner } = makeRunner({ self });
     let ran = 0;
-    await runner.parallel("group", ["a"], async (item, b) => {
-      await b.step(`${item}.s1`, async () => {
-        ran++;
-      });
-    });
+    const result = await runner.parallel(
+      "group",
+      ["a"],
+      keyFor,
+      async (item, b) => {
+        await b.step(`${item}.s1`, async () => {
+          ran++;
+        });
+      },
+    );
+    expect(result.kind).toBe("values");
     expect(ran).toBe(0);
   });
 
   it("once a branch step has collected interrupts, later steps on that branch are no-ops", async () => {
     const { runner } = makeRunner();
     let later = 0;
-    await expect(
-      runner.parallel("group", ["a"], async (item, b) => {
+    const result = await runner.parallel(
+      "group",
+      ["a"],
+      keyFor,
+      async (item, b) => {
         await b.step(`${item}.s1`, async () => [fakeInterrupt(item)] as any);
         await b.step(`${item}.s2`, async () => {
           later++;
         });
-      }),
-    ).rejects.toBeInstanceOf(PromptBailout);
+      },
+    );
+    expect(result.kind).toBe("interrupts");
     expect(later).toBe(0);
   });
 
@@ -314,42 +341,52 @@ describe("PromptRunner.parallel", () => {
       statelogClient: stubStatelogClient(),
     };
     const { runner } = makeRunner({ ctx });
-    await runner.parallel("group", ["a", "b"], async (item, b) => {
-      await b.step(`${item}.s1`, async () => {});
-    });
+    const result = await runner.parallel(
+      "group",
+      ["a", "b"],
+      keyFor,
+      async (item, b) => {
+        await b.step(`${item}.s1`, async () => {});
+      },
+    );
+    expect(result.kind).toBe("values");
     expect(cpCount).toBe(0);
   });
 
   it("mixed branches: A interrupts, B completes — merged batch has only A, B's key is marked", async () => {
     // The real-world parallel-tool case: one tool needs approval, the
-    // others finish. The merged bailout must surface only the bailing
+    // others finish. The merged result must surface only the bailing
     // branch's interrupts, and the completed branch's step must be marked
     // so resume doesn't re-run it.
     const { runner, self } = makeRunner();
-    let caught: PromptBailout | null = null;
-    try {
-      await runner.parallel("group", ["a", "b"], async (item, b) => {
+    const result = await runner.parallel(
+      "group",
+      ["a", "b"],
+      keyFor,
+      async (item, b) => {
         if (item === "a") {
           await b.step(`${item}.s1`, async () => [fakeInterrupt(item)] as any);
         } else {
           await b.step(`${item}.s1`, async () => {});
         }
-      });
-    } catch (e) {
-      if (e instanceof PromptBailout) caught = e;
-    }
-    expect(caught).not.toBeNull();
-    expect(caught!.interrupts.length).toBe(1);
-    expect((caught!.interrupts[0] as any).kind).toBe("a");
+      },
+    );
+    expect(result.kind).toBe("interrupts");
+    if (result.kind !== "interrupts") return;
+    expect(result.interrupts.length).toBe(1);
+    expect((result.interrupts[0] as any).kind).toBe("a");
     expect(self.runnerState.completedSteps.includes("a.s1")).toBe(false);
     expect(self.runnerState.completedSteps.includes("b.s1")).toBe(true);
   });
 
-  it("parallel snapshots messages on merged bailout", async () => {
+  it("parallel snapshots messages on merged interrupts", async () => {
     // `step()` already covers this; `parallel()` runs the same snapshot
     // logic but via a different code path. Verify it actually fires.
     const snapshots: any[] = [];
     const self: any = {};
+    const stateStack = new StateStack();
+    const parentFrame = new State();
+    stateStack.stack.push(parentFrame);
     const runner = new PromptRunner({
       self,
       ctx: {
@@ -359,26 +396,31 @@ describe("PromptRunner.parallel", () => {
         },
         statelogClient: stubStatelogClient(),
       } as any,
-      stateStack: {} as any,
+      stateStack,
+      parentFrame,
       checkpointInfo: undefined,
       snapshotMessages: () => {
         snapshots.push("snap");
         return [{ role: "user", content: "x" }] as any;
       },
     });
-    await expect(
-      runner.parallel("group", ["a"], async (item, b) => {
+    const result = await runner.parallel(
+      "group",
+      ["a"],
+      keyFor,
+      async (item, b) => {
         await b.step(`${item}.s1`, async () => [fakeInterrupt(item)] as any);
-      }),
-    ).rejects.toBeInstanceOf(PromptBailout);
+      },
+    );
+    expect(result.kind).toBe("interrupts");
     expect(snapshots.length).toBe(1);
     expect(self.messagesJSON).toEqual([{ role: "user", content: "x" }]);
   });
 
-  it("parallel with empty items list: no checkpoint, no throw", async () => {
+  it("parallel with empty items list: no checkpoint, returns kind='values'", async () => {
     // Defensive — runPrompt may legitimately have a tool round with zero
     // tool calls, and parallel(...) should be a no-op rather than
-    // bailing or stamping an empty checkpoint.
+    // surfacing interrupts or stamping an empty checkpoint.
     let cpCount = 0;
     const ctx: any = {
       checkpoints: {
@@ -391,27 +433,34 @@ describe("PromptRunner.parallel", () => {
       statelogClient: stubStatelogClient(),
     };
     const { runner } = makeRunner({ ctx });
-    await runner.parallel("group", [], async () => {});
+    const result = await runner.parallel("group", [], keyFor, async () => {});
+    expect(result.kind).toBe("values");
     expect(cpCount).toBe(0);
   });
 
   it("parallel resume: B already complete, A re-runs and now succeeds", async () => {
     // Round 1 (not exercised here): A bailed, B completed → self.runnerState
     // has b.s1 marked. Round 2 (this test): the branchFn for A returns
-    // void this time; the bailout does not fire; A's key is now marked
-    // and B's step body is never re-entered.
+    // void this time; the interrupt path does not fire; A's key is now
+    // marked and B's step body is never re-entered.
     const self: any = {
       runnerState: { completedSteps: ["b.s1"] },
     };
     const { runner } = makeRunner({ self });
     let aRan = 0;
     let bRan = 0;
-    await runner.parallel("group", ["a", "b"], async (item, b) => {
-      await b.step(`${item}.s1`, async () => {
-        if (item === "a") aRan++;
-        else bRan++;
-      });
-    });
+    const result = await runner.parallel(
+      "group",
+      ["a", "b"],
+      keyFor,
+      async (item, b) => {
+        await b.step(`${item}.s1`, async () => {
+          if (item === "a") aRan++;
+          else bRan++;
+        });
+      },
+    );
+    expect(result.kind).toBe("values");
     expect(aRan).toBe(1);
     expect(bRan).toBe(0);
     expect(self.runnerState.completedSteps.includes("a.s1")).toBe(true);

--- a/packages/agency-lang/lib/runtime/promptRunner.ts
+++ b/packages/agency-lang/lib/runtime/promptRunner.ts
@@ -195,6 +195,25 @@ export class PromptRunner {
         },
       })),
       hooks: {
+        // Snapshot the message thread INTO `self.messagesJSON` BEFORE
+        // runBatch calls `ctx.checkpoints.create`. The checkpoint deep-
+        // clones `self.locals` synchronously, so mutating messagesJSON
+        // after `create` would NOT be visible in the captured state.
+        //
+        // This matters because each tool branch's body pushes its
+        // `tool` response onto the shared `MessageThread` via
+        // `messages.push(...)` during the batch — but those pushes
+        // never refresh `self.messagesJSON`. If we let runBatch stamp
+        // the checkpoint with stale messagesJSON, every successful
+        // sibling's tool response is lost on resume (the resumed run
+        // restores from messagesJSON and skips the completed branches,
+        // so their messages.push doesn't re-fire). The next LLM call
+        // then receives an assistant message with N tool_calls but
+        // only M < N matching tool responses, which real APIs reject.
+        // See tests/agency-js/parallel-tools-resume-messages-intact.
+        beforeCheckpoint: () => {
+          this.opts.self.messagesJSON = this.opts.snapshotMessages();
+        },
         onCheckpoint: (cpId) => {
           const cp = this.opts.ctx.checkpoints.get(cpId)!;
           this.opts.ctx.statelogClient.checkpointCreated({
@@ -209,12 +228,6 @@ export class PromptRunner {
         },
       },
     });
-
-    // Snapshot messages so the bailout checkpoint captures the
-    // pre-bailout message state (matches today's parallel behavior).
-    if (result.kind === "interrupts") {
-      this.opts.self.messagesJSON = this.opts.snapshotMessages();
-    }
 
     return result;
   }

--- a/packages/agency-lang/lib/runtime/promptRunner.ts
+++ b/packages/agency-lang/lib/runtime/promptRunner.ts
@@ -1,8 +1,9 @@
 import type { MessageJSON } from "smoltalk";
 import { hasInterrupts, type Interrupt } from "./interrupts.js";
+import { runBatch, type RunBatchResult } from "./runBatch.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
-import type { StateStack } from "./state/stateStack.js";
+import type { State, StateStack } from "./state/stateStack.js";
 
 /**
  * Thrown by {@link PromptRunner.step} when a step body returns interrupts.
@@ -35,6 +36,11 @@ export type PromptRunnerOpts = {
   self: any;
   ctx: RuntimeContext<any>;
   stateStack: StateStack;
+  /** The runPrompt frame (== `stateStack.lastFrame()`). Used by
+   * `parallel()` as `runBatch`'s `parentFrame` for per-tool branch
+   * lifecycle. Defaulted from `stateStack.lastFrame()` for callers that
+   * don't pass it explicitly. */
+  parentFrame?: State;
   /** Source location of the surrounding generated call site. Used as the
    *  base `stepPath` when stamping a checkpoint on bailout — see
    *  `step()` for the per-key suffix.  */
@@ -126,66 +132,91 @@ export class PromptRunner {
    * receives a {@link BranchRunner} which exposes its own `step()` that
    * COLLECTS interrupts rather than throwing — siblings keep running
    * even when one halts so we can batch all interrupts into a single
-   * shared checkpoint (mirrors {@link runForkAll} semantics).
+   * shared checkpoint.
    *
-   * If any branch's `step` collected interrupts, snapshot messages,
-   * stamp ONE checkpoint at `${checkpointInfo.stepPath}/${keyPrefix}`,
-   * attach it to every collected interrupt, and throw `PromptBailout` so
-   * `runPrompt` returns the merged batch up the stack.
+   * Thin adapter over {@link runBatch} with `mode: "all"` and
+   * `recordBranchOutcomes: false` (the caller's `branchFn` body manages
+   * branch state itself via `stack.setResultOnBranch` / `deleteBranch`).
+   * `runBatch` owns: per-branch abort composition, ALS-isolated invoke,
+   * settle, shared checkpoint stamp at
+   * `${checkpointInfo.stepPath}/${keyPrefix}` with
+   * `intr.checkpoint`/`checkpointId` overwrite, and `popBranches` on
+   * the no-interrupt success path. Returns a {@link RunBatchResult}
+   * tagged union — `"interrupts"` if any branch halted (the caller
+   * bails out of runPrompt with `result.interrupts`), `"values"`
+   * otherwise.
    *
-   * IMPORTANT: do NOT call `pr.step(...)` (which throws) from inside a
-   * branch — use `b.step(...)` instead. A throw from `branchFn` is not
-   * caught and will propagate out of `Promise.all`.
+   * `keyFor(item, i)` MUST produce the same branch key the `branchFn`
+   * body uses for its `stack.getOrCreateBranch(...)` — otherwise
+   * `runBatch` would allocate a separate branch from the one the body
+   * manages, and the leaf-checkpoint vehicle into State.toJSON's
+   * branches walk would be lost.
+   *
+   * IMPORTANT: do NOT call `pr.step(...)` (which throws `PromptBailout`)
+   * from inside a branch — use `b.step(...)` instead. A throw from
+   * `branchFn` propagates out of `runBatch` and aborts the whole batch.
    */
   async parallel<T>(
     keyPrefix: string,
     items: T[],
+    keyFor: (item: T, index: number) => string,
     branchFn: (item: T, b: BranchRunner) => Promise<void>,
-  ): Promise<void> {
+  ): Promise<RunBatchResult<void>> {
     const branches = items.map(() => new BranchRunner(this.opts.self));
-    // Snapshot once before scheduling, then run each branch inside its own
-    // ALS-backed span context seeded from that snapshot. Without this,
-    // sibling branches share the root span stack and concurrent
-    // startSpan/endSpan calls interleave (mirrors Runner.runForkAll).
-    const parentStack = this.opts.ctx.statelogClient.snapshotStack();
-    await Promise.all(
-      items.map((item, i) =>
-        this.opts.ctx.statelogClient.runInBranchContext(parentStack, () =>
-          branchFn(item, branches[i]),
-        ),
-      ),
-    );
-    const merged: Interrupt[] = [];
-    for (const b of branches) if (b.interrupts) merged.push(...b.interrupts);
-    if (merged.length === 0) return;
-
-    this.opts.self.messagesJSON = this.opts.snapshotMessages();
+    const parentFrame = this.opts.parentFrame ?? this.opts.stateStack.lastFrame();
     const basePath = this.opts.checkpointInfo?.stepPath ?? "";
     const stepPath = basePath ? `${basePath}/${keyPrefix}` : keyPrefix;
-    const cpId = this.opts.ctx.checkpoints.create(
-      this.opts.stateStack,
-      this.opts.ctx,
-      {
+
+    const result = await runBatch<void>({
+      ctx: this.opts.ctx,
+      parentStack: this.opts.stateStack,
+      parentFrame,
+      checkpointLocation: {
         moduleId: this.opts.checkpointInfo?.moduleId ?? "",
         scopeName: this.opts.checkpointInfo?.scopeName ?? "",
         stepPath,
       },
-    );
-    const cp = this.opts.ctx.checkpoints.get(cpId)!;
-    for (const intr of merged) {
-      intr.checkpoint = cp;
-      intr.checkpointId = cpId;
-    }
-    this.opts.ctx.statelogClient.checkpointCreated({
-      checkpointId: cpId,
-      reason: "interrupt",
-      sourceLocation: {
-        moduleId: cp.moduleId,
-        scopeName: cp.scopeName,
-        stepPath: cp.stepPath,
+      mode: "all",
+      // The branchFn body sets branch.result / interrupt info itself via
+      // `stack.setResultOnBranch` / `setInterruptOnBranch` in
+      // runInvokeStep. runBatch must NOT also call these — letting it
+      // overwrite branch.result with the body's `undefined` return value
+      // would destroy the meaningful tool result that runPrompt needs to
+      // read on resume (e.g. line 723 of prompt.ts).
+      recordBranchOutcomes: false,
+      children: items.map((item, i) => ({
+        key: keyFor(item, i),
+        invoke: async () => {
+          await branchFn(item, branches[i]);
+          // Surface the branch's collected interrupts (if any) as the
+          // invoke's return value. runBatch will batch them with sibling
+          // interrupts and stamp the shared checkpoint.
+          return branches[i].interrupts ?? undefined;
+        },
+      })),
+      hooks: {
+        onCheckpoint: (cpId) => {
+          const cp = this.opts.ctx.checkpoints.get(cpId)!;
+          this.opts.ctx.statelogClient.checkpointCreated({
+            checkpointId: cpId,
+            reason: "interrupt",
+            sourceLocation: {
+              moduleId: cp.moduleId,
+              scopeName: cp.scopeName,
+              stepPath: cp.stepPath,
+            },
+          });
+        },
       },
     });
-    throw new PromptBailout(merged);
+
+    // Snapshot messages so the bailout checkpoint captures the
+    // pre-bailout message state (matches today's parallel behavior).
+    if (result.kind === "interrupts") {
+      this.opts.self.messagesJSON = this.opts.snapshotMessages();
+    }
+
+    return result;
   }
 }
 

--- a/packages/agency-lang/lib/runtime/runBatch.test.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.test.ts
@@ -1,0 +1,578 @@
+import { describe, expect, it } from "vitest";
+import type { Interrupt } from "./interrupts.js";
+import { runBatch } from "./runBatch.js";
+import { State, StateStack } from "./state/stateStack.js";
+
+/** Build a synthetic Checkpoint-ish object (only the fields runBatch reads
+ *  matter for these tests). */
+function fakeLeafCheckpoint(id: number): any {
+  return {
+    id,
+    moduleId: "m",
+    scopeName: "s",
+    stepPath: `leaf.${id}`,
+    stack: { frames: [] },
+  };
+}
+
+function fakeInterrupt(idSuffix = "1", checkpointId = 100): Interrupt {
+  return {
+    type: "interrupt",
+    kind: "test",
+    message: "test",
+    origin: "test",
+    runId: "r-1",
+    interruptId: `i-${idSuffix}`,
+    data: { foo: idSuffix },
+    interruptData: { foo: idSuffix } as any,
+    checkpointId,
+    checkpoint: fakeLeafCheckpoint(checkpointId),
+  };
+}
+
+type StubCtx = {
+  ctx: any;
+  /** Latest checkpoint id handed out by `checkpoints.create`. */
+  lastCheckpointId: () => number | undefined;
+  /** List of `create` invocations (so tests can assert "stamped once"). */
+  createCalls: Array<{ stack: any; opts: any }>;
+};
+
+function makeCtx(): StubCtx {
+  const createCalls: Array<{ stack: any; opts: any }> = [];
+  let nextCpId = 1000;
+  const stored: Record<number, any> = {};
+  const ctx: any = {
+    checkpoints: {
+      create: (stack: any, _ctx: any, opts: any) => {
+        const id = nextCpId++;
+        createCalls.push({ stack, opts });
+        stored[id] = {
+          id,
+          moduleId: opts.moduleId,
+          scopeName: opts.scopeName,
+          stepPath: opts.stepPath,
+          stack: { frames: [] },
+        };
+        return id;
+      },
+      get: (id: number) => stored[id],
+    },
+    statelogClient: {
+      snapshotStack: () => undefined,
+      // Pass-through; AsyncLocalStorage isolation isn't observable here.
+      runInBranchContext: (_s: any, fn: () => any) => fn(),
+    },
+  };
+  return {
+    ctx,
+    lastCheckpointId: () => createCalls.at(-1)?.opts?.cpId,
+    createCalls,
+  };
+}
+
+function makeParent() {
+  const parentStack = new StateStack();
+  const parentFrame = new State();
+  return { parentStack, parentFrame };
+}
+
+const cpLoc = { moduleId: "m", scopeName: "s", stepPath: "0" };
+
+describe("runBatch — mode 'all'", () => {
+  it("single child returning a value → kind=values", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    const result = await runBatch<number>({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "all",
+      children: [{ key: "c0", invoke: async () => 42 }],
+    });
+    expect(result).toEqual({ kind: "values", values: [42] });
+    // popBranches was called → no leftover branch state.
+    expect(parentFrame.getBranch("c0")).toBeUndefined();
+  });
+
+  it("single child returning interrupts → kind=interrupts, leaf checkpoint kept on BranchState", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    const leafIntr = fakeInterrupt("a", 77);
+    const leafCp = leafIntr.checkpoint!;
+    const result = await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "all",
+      children: [{ key: "c0", invoke: async () => [leafIntr] }],
+    });
+    expect(result.kind).toBe("interrupts");
+    // The interrupt's checkpoint was overwritten with the batch-level one
+    // (id != 77 since the stub starts at 1000), but the leaf checkpoint
+    // survives on the BranchState — the vehicle State.toJSON's branches
+    // walk uses.
+    expect(parentFrame.getBranch("c0")?.checkpoint).toBe(leafCp);
+    expect(leafIntr.checkpointId).not.toBe(77);
+    expect(leafIntr.checkpoint).not.toBe(leafCp);
+  });
+
+  it("mixed outcomes: surviving value cached, interrupting branches batched into one shared checkpoint", async () => {
+    const { ctx, createCalls } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    const i1 = fakeInterrupt("x", 10);
+    const i2 = fakeInterrupt("y", 11);
+    const result = await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "all",
+      children: [
+        { key: "c0", invoke: async () => [i1] },
+        { key: "c1", invoke: async () => "ok" },
+        { key: "c2", invoke: async () => [i2] },
+      ],
+    });
+    expect(result.kind).toBe("interrupts");
+    if (result.kind !== "interrupts") return;
+    expect(result.interrupts).toHaveLength(2);
+    // ONE shared checkpoint stamped.
+    expect(createCalls).toHaveLength(1);
+    // Both interrupts now point at it.
+    expect(result.interrupts[0].checkpointId).toBe(result.interrupts[1].checkpointId);
+    // The non-interrupting branch still cached its result.
+    expect(parentFrame.getBranch("c1")?.result).toEqual({ result: "ok" });
+  });
+
+  it("cached branch short-circuits: invoke is not called and onBranchStart/onBranchEnd do not fire", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    // Pre-populate a branch as if a previous resume already completed it.
+    parentFrame.getOrCreateBranch("c0");
+    parentFrame.setResultOnBranch("c0", 42);
+
+    let invokeCalls = 0;
+    let starts = 0;
+    let ends = 0;
+    const result = await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "all",
+      children: [
+        {
+          key: "c0",
+          invoke: async () => {
+            invokeCalls++;
+            return 0;
+          },
+        },
+      ],
+      hooks: {
+        onBranchStart: () => starts++,
+        onBranchEnd: () => ends++,
+      },
+    });
+    expect(invokeCalls).toBe(0);
+    expect(starts).toBe(0);
+    expect(ends).toBe(0);
+    expect(result).toEqual({ kind: "values", values: [42] });
+  });
+
+  it("parent abort signal propagates into child stack", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    const ctrl = new AbortController();
+    parentStack.abortSignal = ctrl.signal;
+    ctrl.abort();
+
+    const seen: boolean[] = [];
+    await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "all",
+      children: [
+        {
+          key: "c0",
+          invoke: async (_s, sig) => {
+            seen.push(sig.aborted);
+            return 1;
+          },
+        },
+      ],
+    });
+    expect(seen).toEqual([true]);
+  });
+
+  it("empty children: returns empty values, no checkpoint stamped, propagate/popBranches still safe", async () => {
+    const { ctx, createCalls } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    let propagateCalls = 0;
+    const result = await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "all",
+      children: [],
+      hooks: {
+        propagateBranchCost: (b) => {
+          propagateCalls++;
+          expect(b).toEqual([]);
+        },
+      },
+    });
+    expect(result).toEqual({ kind: "values", values: [] });
+    expect(createCalls).toHaveLength(0);
+    expect(propagateCalls).toBe(1);
+  });
+
+  it("duplicate child keys throw with a clear message and no side effects", async () => {
+    const { ctx, createCalls } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    await expect(
+      runBatch({
+        ctx,
+        parentStack,
+        parentFrame,
+        checkpointLocation: cpLoc,
+        mode: "all",
+        children: [
+          { key: "dup", invoke: async () => 1 },
+          { key: "dup", invoke: async () => 2 },
+        ],
+      }),
+    ).rejects.toThrow(/duplicate child key/);
+    expect(createCalls).toHaveLength(0);
+    expect(parentFrame.getBranch("dup")).toBeUndefined();
+  });
+
+  it("rejection in a child rethrows and abandons sibling interrupts (documented invariant)", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    const err = new Error("boom");
+    await expect(
+      runBatch({
+        ctx,
+        parentStack,
+        parentFrame,
+        checkpointLocation: cpLoc,
+        mode: "all",
+        children: [
+          { key: "c0", invoke: async () => [fakeInterrupt()] },
+          { key: "c1", invoke: async () => { throw err; } },
+        ],
+      }),
+    ).rejects.toBe(err);
+  });
+
+  it("propagateBranchCost fires once on success with all branches", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    let calls = 0;
+    let lastLen = 0;
+    await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "all",
+      children: [
+        { key: "a", invoke: async () => 1 },
+        { key: "b", invoke: async () => 2 },
+      ],
+      hooks: {
+        propagateBranchCost: (branches) => {
+          calls++;
+          lastLen = branches.length;
+        },
+      },
+    });
+    expect(calls).toBe(1);
+    expect(lastLen).toBe(2);
+  });
+
+  it("onCheckpoint fires once with the stamped id when interrupts are produced", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    const cpIds: number[] = [];
+    await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "all",
+      children: [{ key: "c0", invoke: async () => [fakeInterrupt()] }],
+      hooks: { onCheckpoint: (id) => cpIds.push(id) },
+    });
+    expect(cpIds).toHaveLength(1);
+  });
+});
+
+describe("runBatch — mode 'sequential'", () => {
+  it("invokes children one after the previous, preserving order", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    const log: string[] = [];
+    const make = (k: string) => ({
+      key: k,
+      invoke: async () => {
+        log.push(`start-${k}`);
+        // Yield, then resolve. Sequential mode must wait for this to settle
+        // before starting the next child.
+        await new Promise((r) => setTimeout(r, 1));
+        log.push(`end-${k}`);
+        return k;
+      },
+    });
+    const result = await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "sequential",
+      children: [make("a"), make("b"), make("c")],
+    });
+    expect(result).toEqual({ kind: "values", values: ["a", "b", "c"] });
+    expect(log).toEqual([
+      "start-a",
+      "end-a",
+      "start-b",
+      "end-b",
+      "start-c",
+      "end-c",
+    ]);
+  });
+
+  it("stamps a single shared checkpoint when any child interrupts", async () => {
+    const { ctx, createCalls } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "sequential",
+      children: [
+        { key: "a", invoke: async () => 1 },
+        { key: "b", invoke: async () => [fakeInterrupt("seq-b")] },
+        { key: "c", invoke: async () => [fakeInterrupt("seq-c")] },
+      ],
+    });
+    expect(createCalls).toHaveLength(1);
+  });
+});
+
+describe("runBatch — mode 'race'", () => {
+  const WINNER_KEY = "__race_winner_test";
+
+  it("first to settle wins; losers are aborted and their branches deleted", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    const result = await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "race",
+      raceWinnerLocalKey: WINNER_KEY,
+      children: [
+        {
+          key: "fast",
+          invoke: async () => "fast-value",
+        },
+        {
+          key: "slow",
+          invoke: async (_s, sig) => {
+            // Wait forever unless aborted.
+            return new Promise<string>((_resolve, reject) => {
+              sig.addEventListener("abort", () => reject(new Error("aborted")));
+            });
+          },
+        },
+      ],
+    });
+    expect(result).toEqual({ kind: "values", values: ["fast-value"] });
+    // Winner index persisted.
+    expect(parentFrame.locals[WINNER_KEY]).toBe(0);
+    // Loser branch deleted; winner branch persisted (with cached result).
+    expect(parentFrame.getBranch("fast")?.result).toEqual({
+      result: "fast-value",
+    });
+    expect(() => parentFrame.getBranch("slow")).toThrow(/has been deleted/);
+  });
+
+  it("winner halts with interrupts: loser deleted, shared checkpoint stamped, leaf cp survives on winner branch", async () => {
+    const { ctx, createCalls } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    const intr = fakeInterrupt("race", 50);
+    const leafCp = intr.checkpoint!;
+    const result = await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "race",
+      raceWinnerLocalKey: WINNER_KEY,
+      children: [
+        { key: "fast", invoke: async () => [intr] },
+        {
+          key: "slow",
+          invoke: async (_s, sig) =>
+            new Promise<any>((_r, reject) =>
+              sig.addEventListener("abort", () => reject(new Error("aborted"))),
+            ),
+        },
+      ],
+    });
+    expect(result.kind).toBe("interrupts");
+    expect(parentFrame.locals[WINNER_KEY]).toBe(0);
+    expect(createCalls).toHaveLength(1);
+    expect(parentFrame.getBranch("fast")?.checkpoint).toBe(leafCp);
+    expect(() => parentFrame.getBranch("slow")).toThrow(/has been deleted/);
+    // Winner's interrupt was overwritten with batch checkpoint id.
+    if (result.kind === "interrupts") {
+      expect(result.interrupts[0].checkpointId).not.toBe(50);
+    }
+  });
+
+  it("race resume: with raceWinnerLocalKey persisted, only the winner is invoked", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    // Pre-populate a winner index. Also create the winner branch (as if
+    // it had been created during the first race) but leave .result unset
+    // so the resume must re-run the body.
+    parentFrame.locals[WINNER_KEY] = 1;
+    parentFrame.getOrCreateBranch("c1");
+
+    let aInvoked = false;
+    let bInvoked = false;
+    const result = await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "race",
+      raceWinnerLocalKey: WINNER_KEY,
+      children: [
+        { key: "c0", invoke: async () => { aInvoked = true; return "a"; } },
+        { key: "c1", invoke: async () => { bInvoked = true; return "b"; } },
+      ],
+    });
+    expect(aInvoked).toBe(false);
+    expect(bInvoked).toBe(true);
+    expect(result).toEqual({ kind: "values", values: ["b"] });
+  });
+
+  it("race resume with cached winner result skips invoke entirely", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    parentFrame.locals[WINNER_KEY] = 0;
+    parentFrame.getOrCreateBranch("c0");
+    parentFrame.setResultOnBranch("c0", "cached");
+
+    let invokes = 0;
+    let winnerCostCalls = 0;
+    const result = await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "race",
+      raceWinnerLocalKey: WINNER_KEY,
+      children: [
+        { key: "c0", invoke: async () => { invokes++; return "x"; } },
+        { key: "c1", invoke: async () => { invokes++; return "y"; } },
+      ],
+      hooks: { propagateWinnerCost: () => { winnerCostCalls++; } },
+    });
+    expect(invokes).toBe(0);
+    expect(winnerCostCalls).toBe(1);
+    expect(result).toEqual({ kind: "values", values: ["cached"] });
+  });
+
+  it("race success first-time: propagateLoserCost + propagateWinnerCost both fire", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    let loserCalls = 0;
+    let winnerCalls = 0;
+    await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "race",
+      raceWinnerLocalKey: WINNER_KEY,
+      children: [
+        { key: "c0", invoke: async () => "winner" },
+        {
+          key: "c1",
+          invoke: async (_s, sig) =>
+            new Promise<any>((_r, reject) =>
+              sig.addEventListener("abort", () => reject(new Error("aborted"))),
+            ),
+        },
+      ],
+      hooks: {
+        propagateLoserCost: () => loserCalls++,
+        propagateWinnerCost: () => winnerCalls++,
+      },
+    });
+    expect(loserCalls).toBe(1);
+    expect(winnerCalls).toBe(1);
+  });
+
+  it("race interrupt first-time: propagateLoserCost fires, propagateWinnerCost is deferred", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    let loserCalls = 0;
+    let winnerCalls = 0;
+    await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "race",
+      raceWinnerLocalKey: WINNER_KEY,
+      children: [
+        { key: "c0", invoke: async () => [fakeInterrupt("rinterrupt")] },
+        {
+          key: "c1",
+          invoke: async (_s, sig) =>
+            new Promise<any>((_r, reject) =>
+              sig.addEventListener("abort", () => reject(new Error("aborted"))),
+            ),
+        },
+      ],
+      hooks: {
+        propagateLoserCost: () => loserCalls++,
+        propagateWinnerCost: () => winnerCalls++,
+      },
+    });
+    expect(loserCalls).toBe(1);
+    expect(winnerCalls).toBe(0);
+  });
+
+  it("mode-flip defensive assert: race-winner persisted but mode='all' throws", async () => {
+    const { ctx } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    parentFrame.locals[WINNER_KEY] = 0;
+    await expect(
+      runBatch({
+        ctx,
+        parentStack,
+        parentFrame,
+        checkpointLocation: cpLoc,
+        mode: "all",
+        raceWinnerLocalKey: WINNER_KEY,
+        children: [{ key: "c0", invoke: async () => 1 }],
+      }),
+    ).rejects.toThrow(/checkpoint\/mode mismatch/);
+  });
+});

--- a/packages/agency-lang/lib/runtime/runBatch.test.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.test.ts
@@ -32,8 +32,6 @@ function fakeInterrupt(idSuffix = "1", checkpointId = 100): Interrupt {
 
 type StubCtx = {
   ctx: any;
-  /** Latest checkpoint id handed out by `checkpoints.create`. */
-  lastCheckpointId: () => number | undefined;
   /** List of `create` invocations (so tests can assert "stamped once"). */
   createCalls: Array<{ stack: any; opts: any }>;
 };
@@ -64,11 +62,7 @@ function makeCtx(): StubCtx {
       runInBranchContext: (_s: any, fn: () => any) => fn(),
     },
   };
-  return {
-    ctx,
-    lastCheckpointId: () => createCalls.at(-1)?.opts?.cpId,
-    createCalls,
-  };
+  return { ctx, createCalls };
 }
 
 function makeParent() {
@@ -231,6 +225,56 @@ describe("runBatch — mode 'all'", () => {
     expect(result).toEqual({ kind: "values", values: [] });
     expect(createCalls).toHaveLength(0);
     expect(propagateCalls).toBe(1);
+  });
+
+  it("beforeCheckpoint hook fires immediately before ctx.checkpoints.create and can mutate frame locals visible in the deep-clone", async () => {
+    // Regression test for the messagesJSON-ordering bug surfaced in
+    // PR #186 review (Copilot inline comment). Without this hook
+    // runPrompt's tool loop loses successful sibling tool responses
+    // on resume because `ctx.checkpoints.create` deep-clones
+    // `self.locals` synchronously at create time, so any post-create
+    // mutation isn't reflected in the captured state.
+    const { ctx, createCalls } = makeCtx();
+    const { parentStack, parentFrame } = makeParent();
+    // Seed locals with a stale value the way prompt.ts line 422 does.
+    parentFrame.locals.messagesJSON = ["stale"];
+    const order: string[] = [];
+    const result = await runBatch({
+      ctx,
+      parentStack,
+      parentFrame,
+      checkpointLocation: cpLoc,
+      mode: "all",
+      children: [
+        {
+          key: "c0",
+          invoke: async () => {
+            // Simulate the per-tool body pushing a new entry that
+            // belongs in messagesJSON but isn't reflected there yet.
+            order.push("invoke");
+            return [fakeInterrupt("with-before-cp")];
+          },
+        },
+      ],
+      hooks: {
+        beforeCheckpoint: () => {
+          order.push("beforeCheckpoint");
+          // Caller is expected to flush the up-to-date snapshot here.
+          parentFrame.locals.messagesJSON = ["stale", "fresh"];
+        },
+        onCheckpoint: () => order.push("onCheckpoint"),
+      },
+    });
+    expect(result.kind).toBe("interrupts");
+    // Hook fires after invoke completes and BEFORE checkpoint is stamped.
+    expect(order).toEqual(["invoke", "beforeCheckpoint", "onCheckpoint"]);
+    expect(createCalls).toHaveLength(1);
+    // The mutation done inside beforeCheckpoint is observable to the
+    // checkpoint's deep-clone (proxy: the live frame holds the fresh
+    // value at create time; deep-clone in checkpointStore captures
+    // exactly that — covered end-to-end by the agency-js test
+    // `parallel-tools-resume-messages-intact`).
+    expect(parentFrame.locals.messagesJSON).toEqual(["stale", "fresh"]);
   });
 
   it("duplicate child keys throw with a clear message and no side effects", async () => {

--- a/packages/agency-lang/lib/runtime/runBatch.test.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.test.ts
@@ -470,7 +470,7 @@ describe("runBatch — mode 'race'", () => {
     expect(result).toEqual({ kind: "values", values: ["b"] });
   });
 
-  it("race resume with cached winner result skips invoke entirely", async () => {
+  it("race resume with cached winner result skips invoke entirely and does not double-bill cost", async () => {
     const { ctx } = makeCtx();
     const { parentStack, parentFrame } = makeParent();
     parentFrame.locals[WINNER_KEY] = 0;
@@ -493,7 +493,10 @@ describe("runBatch — mode 'race'", () => {
       hooks: { propagateWinnerCost: () => { winnerCostCalls++; } },
     });
     expect(invokes).toBe(0);
-    expect(winnerCostCalls).toBe(1);
+    // Cost was already propagated when winner first completed; defensive
+    // cached path must NOT propagate again (matches today's
+    // resumeRaceWinner cached-branch behavior).
+    expect(winnerCostCalls).toBe(0);
     expect(result).toEqual({ kind: "values", values: ["cached"] });
   });
 

--- a/packages/agency-lang/lib/runtime/runBatch.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.ts
@@ -108,6 +108,18 @@ export type BatchHooks = {
     outcome: "success" | "interrupted" | "failure" | "aborted",
     timeMs: number,
   ) => void;
+  /** Called once immediately before `ctx.checkpoints.create` deep-clones
+   * the parent frame. Use this to flush state that was mutated by
+   * sibling branches during the batch into frame-backed locals that need
+   * to survive the checkpoint. Concretely: runPrompt's tool loop pushes
+   * `tool` messages onto the shared `MessageThread` from inside each
+   * branch's body, but `self.messagesJSON` (the snapshot the checkpoint
+   * captures) isn't refreshed by those pushes — the adapter uses this
+   * hook to do `self.messagesJSON = snapshotMessages()` so the
+   * deep-clone sees the up-to-date thread. Without this hook the
+   * checkpoint would carry the pre-batch messages and successful
+   * sibling tool responses would be silently lost on resume. */
+  beforeCheckpoint?: () => void;
   /** Called once when the batch stamps its shared checkpoint. */
   onCheckpoint?: (checkpointId: number) => void;
 };
@@ -161,6 +173,28 @@ type Task<T> = {
   cached: boolean;
 };
 
+/** (Re)compose the branch's abort signal from the parent stack's signal
+ * and the branch's own controller. Always overwrites `stack.abortSignal`
+ * so that re-entries (e.g. race resume that reuses a deserialized
+ * branch) don't carry a stale signal. The controller is created on
+ * first use and persists for the life of the branch in this run; the
+ * field is live-only on BranchState and not serialized, so resumes
+ * start from a fresh controller. */
+function composeBranchAbortSignal(
+  branch: BranchState,
+  parentStack: StateStack,
+): AbortSignal {
+  if (!branch.abortController) {
+    branch.abortController = new AbortController();
+  }
+  const parentSig = parentStack.abortSignal;
+  const composed = parentSig
+    ? AbortSignal.any([parentSig, branch.abortController.signal])
+    : branch.abortController.signal;
+  branch.stack.abortSignal = composed;
+  return composed;
+}
+
 /** Wire up a branch's AbortController + composed signal, seed cost, and
  * fire `onBranchStart`. Returns the child's `invoke` promise (or a
  * resolved promise for cached branches). Centralized so all three modes
@@ -175,18 +209,12 @@ function startInvoke<T>(
   if (t.cached) {
     return Promise.resolve(t.branch.result!.result);
   }
-  if (!t.branch.abortController) {
-    t.branch.abortController = new AbortController();
-    const parentSig = parentStack.abortSignal;
-    t.branch.stack.abortSignal = parentSig
-      ? AbortSignal.any([parentSig, t.branch.abortController.signal])
-      : t.branch.abortController.signal;
-  }
+  const signal = composeBranchAbortSignal(t.branch, parentStack);
   hooks?.seedBranchCost?.(t.branch.stack, parentStack);
   hooks?.onBranchStart?.(t.child.key, i);
   t.startedAt = performance.now();
   return ctx.statelogClient.runInBranchContext(parentSpanStack, () =>
-    t.child.invoke(t.branch.stack, t.branch.stack.abortSignal!),
+    t.child.invoke(t.branch.stack, signal),
   );
 }
 
@@ -197,6 +225,12 @@ function stampSharedCheckpoint<T>(
   interrupts: Interrupt[],
 ): void {
   const { ctx, parentStack, checkpointLocation, hooks } = opts;
+  // Give the caller a last chance to mutate frame state that needs to
+  // be visible in the deep-cloned checkpoint (see beforeCheckpoint
+  // hook docstring). runPrompt's parallel-tool adapter uses this to
+  // snapshot the per-tool `messages.push(...)`es that happened during
+  // the batch into `self.messagesJSON` before the deep-clone fires.
+  hooks?.beforeCheckpoint?.();
   const cpId = ctx.checkpoints.create(parentStack, ctx, checkpointLocation);
   const cp = ctx.checkpoints.get(cpId)!;
   for (const intr of interrupts) {
@@ -504,12 +538,12 @@ async function runRaceResume<T>(
     return { kind: "values", values: [branch.result.result as T] };
   }
 
-  // Set up a fresh abort controller for the resumed winner. Unlike the
-  // first-time path there are no losers to compose with.
-  if (!branch.abortController) {
-    branch.abortController = new AbortController();
-    branch.stack.abortSignal = branch.abortController.signal;
-  }
+  // Compose the resumed winner's abort signal with the current parent
+  // stack's signal so an outer abort (e.g. a surrounding race that
+  // cancels this branch) propagates into the resumed work. Uses the
+  // same helper as `startInvoke` so the composition rule lives in one
+  // place.
+  const signal = composeBranchAbortSignal(branch, parentStack);
 
   const parentSpanStack = ctx.statelogClient.snapshotStack();
   const startedAt = performance.now();
@@ -517,7 +551,7 @@ async function runRaceResume<T>(
   let value: T | Interrupt[];
   try {
     value = await ctx.statelogClient.runInBranchContext(parentSpanStack, () =>
-      child.invoke(branch.stack, branch.stack.abortSignal!),
+      child.invoke(branch.stack, signal),
     );
   } catch (err) {
     hooks?.onBranchEnd?.(

--- a/packages/agency-lang/lib/runtime/runBatch.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.ts
@@ -444,9 +444,10 @@ async function runRaceResume<T>(
     );
   }
 
-  // Cached winner — return its value, propagate cost as if it just completed.
+  // Cached winner — return cached result. Cost was already propagated
+  // when the winner first completed; don't double-bill on this defensive
+  // path. (Matches today's resumeRaceWinner cached-branch behavior.)
   if (branch.result !== undefined) {
-    hooks?.propagateWinnerCost?.(branch, parentStack);
     return { kind: "values", values: [branch.result.result as T] };
   }
 

--- a/packages/agency-lang/lib/runtime/runBatch.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.ts
@@ -1,0 +1,504 @@
+/**
+ * `runBatch` — the single concurrent-interrupt primitive.
+ *
+ * Owns the boilerplate that every concurrent-interrupt site in the runtime
+ * (`runForkAll`, `runRace`, `runPrompt`'s tool loop, the multi-callback hook
+ * fire) used to hand-roll: per-child branch creation, abort-signal
+ * composition, settle/collect, batch checkpoint stamping with shared
+ * `intr.checkpoint`/`intr.checkpointId` overwrite, cost seed/propagate
+ * hooks, cleanup on success.
+ *
+ * What `runBatch` does NOT change:
+ *  - The leaf `interruptReturn` template still stamps a per-leaf checkpoint
+ *    exactly as today (commit c72b9c1574 deliberately removed the older
+ *    `isForked`-bypass approach because it broke nested-fork composition).
+ *    `runBatch` reads the leaf's checkpoint off each surfaced `Interrupt`
+ *    and writes it onto the BranchState via `setInterruptOnBranch` — the
+ *    leaf's checkpoint is the vehicle that carries its pre-pop stack into
+ *    `State.toJSON`'s branches walk.
+ *  - Handler bookkeeping. Per-branch handler chains stay as today.
+ *
+ * The `intr.checkpoint` overwrite at the bottom is intentional: per commit
+ * c72b9c1574, every interrupt batched together must share a single resume
+ * point so resuming one resumes the whole batch.
+ *
+ * Invoke no-throw contract (audit when migrating call sites): every
+ * `BatchChild.invoke` MUST RETURN `T | Interrupt[]` and never THROW an
+ * `Interrupt[]`. Other JS errors may be thrown — in that case `runBatch`
+ * rethrows the first one it sees and abandons any interrupts that sibling
+ * branches successfully halted with (this matches today's
+ * `runForkAll` / `runRace` behavior; callers that need both must catch
+ * inside `invoke`). PromptBailout-style throws need to be converted to
+ * returns at their call site before that site migrates to `runBatch`.
+ */
+import { hasInterrupts, type Interrupt } from "./interrupts.js";
+import type { RuntimeContext } from "./state/context.js";
+import type { BranchState, State, StateStack } from "./state/stateStack.js";
+
+export type BatchChild<T> = {
+  /** Stable per-child key. Used for `getOrCreateBranch`. Caller is
+   * responsible for uniqueness within `parentFrame.branches`. */
+  key: string;
+  /** Invoked with the child's own `StateStack` (already seeded with abort
+   * signal composed with parent) and that stack's abort signal. Must
+   * return either a value `T` (success) or an `Interrupt[]` (halted with
+   * interrupts). MUST NOT throw `Interrupt[]`. May throw other errors. */
+  invoke: (
+    childStack: StateStack,
+    abortSignal: AbortSignal,
+  ) => Promise<T | Interrupt[]>;
+};
+
+export type BatchHooks = {
+  seedBranchCost?: (childStack: StateStack, parentStack: StateStack) => void;
+  /** Used by mode "all" / "sequential" only. The race adapter uses the
+   * asymmetric pair below instead. */
+  propagateBranchCost?: (
+    branches: BranchState[],
+    parentStack: StateStack,
+  ) => void;
+  /** Race mode only: propagate loser-branch cost at race-time (before the
+   * losers are deleted). The winner's cost propagates separately on resume
+   * via `propagateWinnerCost`. */
+  propagateLoserCost?: (
+    loserBranches: BranchState[],
+    parentStack: StateStack,
+  ) => void;
+  /** Race mode only: propagate the winner's cost when the winner finally
+   * completes (no-interrupt resume). */
+  propagateWinnerCost?: (
+    winnerBranch: BranchState,
+    parentStack: StateStack,
+  ) => void;
+  /** Called once per branch start (statelog). */
+  onBranchStart?: (key: string, index: number) => void;
+  /** Called once per branch end with its outcome and elapsed time in ms. */
+  onBranchEnd?: (
+    key: string,
+    index: number,
+    outcome: "success" | "interrupted" | "failure" | "aborted",
+    timeMs: number,
+  ) => void;
+  /** Called once when the batch stamps its shared checkpoint. */
+  onCheckpoint?: (checkpointId: number) => void;
+};
+
+export type RunBatchOpts<T> = {
+  ctx: RuntimeContext<any>;
+  /** The parent's local state stack — used as the capture stack for the
+   * shared batch-level checkpoint. MUST be the local slice (e.g. the
+   * branch stack if `runBatch` is itself called inside a child of an
+   * outer `runBatch`), NOT `ctx.stateStack`. This is the one discipline
+   * the caller of `runBatch` must observe. */
+  parentStack: StateStack;
+  /** The frame where branch state lives. Usually `parentStack.lastFrame()`. */
+  parentFrame: State;
+  /** Where the shared checkpoint records its location. Same fields the
+   * existing call sites pass to `ctx.checkpoints.create`. */
+  checkpointLocation: { moduleId: string; scopeName: string; stepPath: string };
+  /** "all" → Promise.allSettled, concurrent; "sequential" → for...of,
+   * each child after the previous (today's callHook semantics); "race"
+   * → first to settle wins, others are aborted.
+   *
+   * IMPORTANT: do not use "all" for hook-callback batching — that would
+   * change today's strictly-sequential `callHook` ordering. Use
+   * "sequential". */
+  mode: "all" | "sequential" | "race";
+  children: BatchChild<T>[];
+  /** Mode "race" only: the `parentFrame.locals` key under which the winner
+   * index is persisted. The caller (race adapter) computes
+   * `__race_winner_${id}` and passes it. */
+  raceWinnerLocalKey?: string;
+  hooks?: BatchHooks;
+};
+
+export type RunBatchResult<T> =
+  | { kind: "values"; values: T[] }
+  | { kind: "interrupts"; interrupts: Interrupt[] };
+
+type Task<T> = {
+  child: BatchChild<T>;
+  branch: BranchState;
+  startedAt: number;
+  cached: boolean;
+};
+
+/** Wire up a branch's AbortController + composed signal, seed cost, and
+ * fire `onBranchStart`. Returns the child's `invoke` promise (or a
+ * resolved promise for cached branches). Centralized so all three modes
+ * use identical setup. */
+function startInvoke<T>(
+  opts: RunBatchOpts<T>,
+  t: Task<T>,
+  i: number,
+  parentSpanStack: ReturnType<RuntimeContext<any>["statelogClient"]["snapshotStack"]>,
+): Promise<T | Interrupt[]> {
+  const { ctx, parentStack, hooks } = opts;
+  if (t.cached) {
+    return Promise.resolve(t.branch.result!.result);
+  }
+  if (!t.branch.abortController) {
+    t.branch.abortController = new AbortController();
+    const parentSig = parentStack.abortSignal;
+    t.branch.stack.abortSignal = parentSig
+      ? AbortSignal.any([parentSig, t.branch.abortController.signal])
+      : t.branch.abortController.signal;
+  }
+  hooks?.seedBranchCost?.(t.branch.stack, parentStack);
+  hooks?.onBranchStart?.(t.child.key, i);
+  t.startedAt = performance.now();
+  return ctx.statelogClient.runInBranchContext(parentSpanStack, () =>
+    t.child.invoke(t.branch.stack, t.branch.stack.abortSignal!),
+  );
+}
+
+/** Stamp the shared batch-level checkpoint and overwrite every interrupt's
+ * checkpoint+id so they all resume from the same point. */
+function stampSharedCheckpoint<T>(
+  opts: RunBatchOpts<T>,
+  interrupts: Interrupt[],
+): void {
+  const { ctx, parentStack, checkpointLocation, hooks } = opts;
+  const cpId = ctx.checkpoints.create(parentStack, ctx, checkpointLocation);
+  const cp = ctx.checkpoints.get(cpId)!;
+  for (const intr of interrupts) {
+    intr.checkpoint = cp;
+    intr.checkpointId = cpId;
+  }
+  hooks?.onCheckpoint?.(cpId);
+}
+
+export async function runBatch<T>(
+  opts: RunBatchOpts<T>,
+): Promise<RunBatchResult<T>> {
+  const { ctx, parentStack, parentFrame, mode, children, hooks } = opts;
+
+  // 0a. Cheap insurance against caller bugs.
+  const seen = new Set<string>();
+  for (const c of children) {
+    if (seen.has(c.key)) {
+      throw new Error(
+        `runBatch: duplicate child key ${JSON.stringify(c.key)}`,
+      );
+    }
+    seen.add(c.key);
+  }
+
+  // 0b. Mode-flip defensive assert. If a previous run recorded a race
+  // winner under `raceWinnerLocalKey` but the caller now passes a
+  // non-race mode (or vice versa), that's a serious checkpoint/code
+  // mismatch — fail loudly rather than produce subtly broken state.
+  const raceKey = opts.raceWinnerLocalKey;
+  const persistedWinner =
+    raceKey !== undefined ? parentFrame.locals[raceKey] : undefined;
+  if (persistedWinner !== undefined && typeof persistedWinner === "number") {
+    if (mode !== "race") {
+      throw new Error(
+        `runBatch: checkpoint/mode mismatch — parentFrame.locals[${JSON.stringify(
+          raceKey,
+        )}] holds a race winner (${persistedWinner}) but mode is ${JSON.stringify(
+          mode,
+        )}.`,
+      );
+    }
+  }
+
+  // 0c. Race resume short-circuit: if a winner is persisted, run only the
+  // winner's child. Subsumes the old `resumeRaceWinner` so the caller
+  // (`Runner.fork`) can unconditionally invoke `runBatch`.
+  if (
+    mode === "race" &&
+    raceKey !== undefined &&
+    typeof persistedWinner === "number"
+  ) {
+    return runRaceResume(opts, persistedWinner);
+  }
+
+  // 1. Set up tasks (branches).
+  const tasks: Task<T>[] = children.map((child) => {
+    const branch = parentFrame.getOrCreateBranch(child.key);
+    return { child, branch, startedAt: 0, cached: branch.result !== undefined };
+  });
+  const parentSpanStack = ctx.statelogClient.snapshotStack();
+
+  if (mode === "race") {
+    return runRaceFirstTime(opts, tasks, parentSpanStack);
+  }
+
+  // 2. mode "all" or "sequential": settle every child.
+  let settled: PromiseSettledResult<T | Interrupt[]>[];
+  if (mode === "sequential") {
+    settled = [];
+    for (let i = 0; i < tasks.length; i++) {
+      try {
+        settled.push({
+          status: "fulfilled",
+          value: await startInvoke(opts, tasks[i], i, parentSpanStack),
+        });
+      } catch (reason) {
+        settled.push({ status: "rejected", reason });
+      }
+    }
+  } else {
+    // mode "all" — parallel.
+    settled = await Promise.allSettled(
+      tasks.map((t, i) => startInvoke(opts, t, i, parentSpanStack)),
+    );
+  }
+
+  // 3. Collect outcomes. Gate hooks on non-cached so cached branches don't
+  // emit duplicate statelog events on resume cycles.
+  const interrupts: Interrupt[] = [];
+  for (let i = 0; i < settled.length; i++) {
+    const s = settled[i];
+    const t = tasks[i];
+    const { child, cached } = t;
+    const timeMs = cached ? 0 : performance.now() - t.startedAt;
+    if (s.status === "rejected") {
+      if (!cached) hooks?.onBranchEnd?.(child.key, i, "failure", timeMs);
+      // Rethrow: any sibling interrupts collected are discarded (matches
+      // today's runForkAll/runRace behavior; documented at top of file).
+      throw s.reason;
+    }
+    const value = s.value;
+    if (hasInterrupts(value)) {
+      if (!cached) hooks?.onBranchEnd?.(child.key, i, "interrupted", timeMs);
+      interrupts.push(...value);
+      parentFrame.setInterruptOnBranch(
+        child.key,
+        value[0].interruptId,
+        value[0].interruptData,
+        // The leaf's per-branch checkpoint goes here — it vehicles the
+        // pre-pop branch stack into State.toJSON's branches walk.
+        value[0].checkpoint,
+      );
+    } else {
+      if (!cached) hooks?.onBranchEnd?.(child.key, i, "success", timeMs);
+      parentFrame.setResultOnBranch(child.key, value as any);
+    }
+  }
+
+  // 4. Stamp shared parent checkpoint + overwrite.
+  if (interrupts.length > 0) {
+    stampSharedCheckpoint(opts, interrupts);
+    return { kind: "interrupts", interrupts };
+  }
+
+  // 5. No interrupts — propagate cost, clear branches, return values.
+  const allBranches = tasks.map((t) => t.branch);
+  hooks?.propagateBranchCost?.(allBranches, parentStack);
+  parentFrame.popBranches();
+  return {
+    kind: "values",
+    values: settled.map((s) => (s as PromiseFulfilledResult<T>).value),
+  };
+}
+
+/** Mode "race" first-time path: launch every child, await the first
+ * settle, abort the rest, delete loser branches, propagate loser cost,
+ * stamp + overwrite if the winner halted. */
+async function runRaceFirstTime<T>(
+  opts: RunBatchOpts<T>,
+  tasks: Task<T>[],
+  parentSpanStack: ReturnType<
+    RuntimeContext<any>["statelogClient"]["snapshotStack"]
+  >,
+): Promise<RunBatchResult<T>> {
+  const { parentFrame, hooks } = opts;
+  const raceKey = opts.raceWinnerLocalKey;
+
+  // Tag promises with their index so we can identify the winner / first
+  // failure regardless of resolution order.
+  const tagged = tasks.map((t, i) =>
+    startInvoke(opts, t, i, parentSpanStack).then(
+      (value) => ({ index: i, value }),
+      (err) => Promise.reject({ index: i, err }),
+    ),
+  );
+
+  let winnerIndex: number;
+  let winnerValue: T | Interrupt[];
+  try {
+    const winner = await Promise.race(tagged);
+    winnerIndex = winner.index;
+    winnerValue = winner.value;
+  } catch (tagged) {
+    const { index: failedIndex, err } = tagged as { index: number; err: any };
+    const failedTask = tasks[failedIndex];
+    const failedTime = failedTask.cached
+      ? 0
+      : performance.now() - failedTask.startedAt;
+    if (!failedTask.cached) {
+      hooks?.onBranchEnd?.(failedTask.child.key, failedIndex, "failure", failedTime);
+    }
+    // Abort still-running siblings so they don't keep doing work whose
+    // results we'll throw away.
+    for (let i = 0; i < tasks.length; i++) {
+      if (i === failedIndex) continue;
+      tasks[i].branch.abortController?.abort();
+    }
+    throw err;
+  }
+
+  // Compute winner timing + abort losers + emit end events.
+  const winnerTask = tasks[winnerIndex];
+  const winnerTime = winnerTask.cached
+    ? 0
+    : performance.now() - winnerTask.startedAt;
+  for (let i = 0; i < tasks.length; i++) {
+    if (i === winnerIndex) continue;
+    const t = tasks[i];
+    t.branch.abortController?.abort();
+    if (!t.cached) {
+      hooks?.onBranchEnd?.(
+        t.child.key,
+        i,
+        "aborted",
+        performance.now() - t.startedAt,
+      );
+    }
+  }
+  if (!winnerTask.cached) {
+    hooks?.onBranchEnd?.(
+      winnerTask.child.key,
+      winnerIndex,
+      hasInterrupts(winnerValue) ? "interrupted" : "success",
+      winnerTime,
+    );
+  }
+
+  // Persist the winner index so resume re-runs only this branch.
+  if (raceKey !== undefined) {
+    parentFrame.locals[raceKey] = winnerIndex;
+  }
+
+  const winnerKey = winnerTask.child.key;
+
+  if (hasInterrupts(winnerValue)) {
+    // Record interrupt info on the winner branch.
+    parentFrame.setInterruptOnBranch(
+      winnerKey,
+      winnerValue[0].interruptId,
+      winnerValue[0].interruptData,
+      winnerValue[0].checkpoint,
+    );
+    // Eagerly propagate LOSER cost — their LLM calls really happened.
+    // Winner's cost is deferred to resume (see `runRaceResume`).
+    const losers: BranchState[] = [];
+    for (let i = 0; i < tasks.length; i++) {
+      if (i === winnerIndex) continue;
+      losers.push(tasks[i].branch);
+    }
+    hooks?.propagateLoserCost?.(losers, opts.parentStack);
+    // Drop loser branches before stamping — losers must not survive into
+    // the serialized checkpoint.
+    for (let i = 0; i < tasks.length; i++) {
+      if (i === winnerIndex) continue;
+      parentFrame.deleteBranch(tasks[i].child.key);
+    }
+    stampSharedCheckpoint(opts, winnerValue);
+    return { kind: "interrupts", interrupts: winnerValue };
+  }
+
+  // Winner produced a value. Cache it, propagate cost from all branches
+  // (winner + losers — their work counted), then drop losers.
+  parentFrame.setResultOnBranch(winnerKey, winnerValue as any);
+  // For race-success-first-time we ALSO bill losers right here (their LLM
+  // calls already happened). The caller's `propagateLoserCost` hook covers
+  // them; the winner's cost is propagated separately via
+  // `propagateWinnerCost`. Today's `runRace` happens to call a single
+  // `propagateBranchCost([winner, ...losers])` for this case; we keep the
+  // asymmetric pair to preserve the resume-time semantics.
+  const losers: BranchState[] = [];
+  for (let i = 0; i < tasks.length; i++) {
+    if (i === winnerIndex) continue;
+    losers.push(tasks[i].branch);
+  }
+  hooks?.propagateLoserCost?.(losers, opts.parentStack);
+  hooks?.propagateWinnerCost?.(winnerTask.branch, opts.parentStack);
+  for (let i = 0; i < tasks.length; i++) {
+    if (i === winnerIndex) continue;
+    parentFrame.deleteBranch(tasks[i].child.key);
+  }
+  return { kind: "values", values: [winnerValue as T] };
+}
+
+/** Mode "race" resume path: only re-run the recorded winner. */
+async function runRaceResume<T>(
+  opts: RunBatchOpts<T>,
+  winnerIndex: number,
+): Promise<RunBatchResult<T>> {
+  const { ctx, parentStack, parentFrame, children, hooks } = opts;
+  const child = children[winnerIndex];
+  if (!child) {
+    throw new Error(
+      `runBatch race resume: persisted winner index ${winnerIndex} is out of range (children.length=${children.length}).`,
+    );
+  }
+  const branch = parentFrame.getBranch(child.key);
+  if (!branch) {
+    throw new Error(
+      `runBatch race resume: winner branch ${JSON.stringify(
+        child.key,
+      )} (index ${winnerIndex}) is missing — state may be corrupted.`,
+    );
+  }
+
+  // Cached winner — return its value, propagate cost as if it just completed.
+  if (branch.result !== undefined) {
+    hooks?.propagateWinnerCost?.(branch, parentStack);
+    return { kind: "values", values: [branch.result.result as T] };
+  }
+
+  // Set up a fresh abort controller for the resumed winner. Unlike the
+  // first-time path there are no losers to compose with.
+  if (!branch.abortController) {
+    branch.abortController = new AbortController();
+    branch.stack.abortSignal = branch.abortController.signal;
+  }
+
+  const parentSpanStack = ctx.statelogClient.snapshotStack();
+  const startedAt = performance.now();
+  hooks?.onBranchStart?.(child.key, winnerIndex);
+  let value: T | Interrupt[];
+  try {
+    value = await ctx.statelogClient.runInBranchContext(parentSpanStack, () =>
+      child.invoke(branch.stack, branch.stack.abortSignal!),
+    );
+  } catch (err) {
+    hooks?.onBranchEnd?.(
+      child.key,
+      winnerIndex,
+      "failure",
+      performance.now() - startedAt,
+    );
+    throw err;
+  }
+
+  if (hasInterrupts(value)) {
+    hooks?.onBranchEnd?.(
+      child.key,
+      winnerIndex,
+      "interrupted",
+      performance.now() - startedAt,
+    );
+    parentFrame.setInterruptOnBranch(
+      child.key,
+      value[0].interruptId,
+      value[0].interruptData,
+      value[0].checkpoint,
+    );
+    stampSharedCheckpoint(opts, value);
+    return { kind: "interrupts", interrupts: value };
+  }
+
+  hooks?.onBranchEnd?.(
+    child.key,
+    winnerIndex,
+    "success",
+    performance.now() - startedAt,
+  );
+  parentFrame.setResultOnBranch(child.key, value as any);
+  hooks?.propagateWinnerCost?.(branch, parentStack);
+  return { kind: "values", values: [value as T] };
+}

--- a/packages/agency-lang/lib/runtime/runBatch.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.ts
@@ -30,6 +30,35 @@
  * `runForkAll` / `runRace` behavior; callers that need both must catch
  * inside `invoke`). PromptBailout-style throws need to be converted to
  * returns at their call site before that site migrates to `runBatch`.
+ *
+ * Audit findings (2026-05-22, recorded at Task 4 step 1):
+ *  - `lib/runtime/interrupts.ts` (`interruptWithHandlers`,
+ *    `respondToInterrupts`, `runHandlerChain`): NO `Interrupt[]` throws.
+ *    Errors thrown are `Error`s on contract violations or other
+ *    bookkeeping bugs, never the interrupt array itself.
+ *  - `lib/runtime/agencyFunction.ts` (`AgencyFunction.invoke`): NO
+ *    `Interrupt[]` throws. Returns interrupts as values.
+ *  - `lib/runtime/prompt.ts` (`runInvokeStep` and the tool loop body):
+ *    NO `Interrupt[]` throws. Returns via `b.step`'s collector pattern.
+ *  - `lib/runtime/promptRunner.ts`: `PromptBailout` IS thrown (twice).
+ *    These are deliberate Error subclasses (not raw `Interrupt[]`) and
+ *    are converted to returns in Task 4 before migration.
+ *
+ * Other adopters considering migration should re-run this audit on their
+ * code path (`grep -nE "throw .*[Ii]nterrupt"`).
+ *
+ * Branch-result recording (see `recordBranchOutcomes`):
+ *  - Default `true`: runBatch records the per-branch outcome via
+ *    `setResultOnBranch` (success) or `setInterruptOnBranch` (interrupt).
+ *    This is what fork/race need.
+ *  - `false`: the caller's `invoke` is responsible for recording branch
+ *    state itself (via `stack.setResultOnBranch` etc. inside the body).
+ *    runBatch still stamps the shared checkpoint and overwrites
+ *    `intr.checkpoint`/`checkpointId`, but does NOT touch BranchState
+ *    fields. This is what runPrompt's tool loop needs because the tool
+ *    body already records the real tool result on the branch before
+ *    returning — letting runBatch then call `setResultOnBranch(key,
+ *    undefined)` would overwrite the meaningful value with undefined.
  */
 import { hasInterrupts, type Interrupt } from "./interrupts.js";
 import type { RuntimeContext } from "./state/context.js";
@@ -109,6 +138,15 @@ export type RunBatchOpts<T> = {
    * index is persisted. The caller (race adapter) computes
    * `__race_winner_${id}` and passes it. */
   raceWinnerLocalKey?: string;
+  /** When `true` (default), runBatch records the per-branch outcome on
+   * `parentFrame.branches` via `setResultOnBranch` (success) or
+   * `setInterruptOnBranch` (interrupt). When `false`, the caller's
+   * `invoke` is responsible for managing branch state itself — runBatch
+   * still stamps the shared checkpoint and overwrites
+   * `intr.checkpoint`/`checkpointId`, but does NOT touch BranchState
+   * fields. Used by runPrompt's tool loop where the body manages the
+   * real tool result on the branch. */
+  recordBranchOutcomes?: boolean;
   hooks?: BatchHooks;
 };
 
@@ -214,10 +252,21 @@ export async function runBatch<T>(
     return runRaceResume(opts, persistedWinner);
   }
 
-  // 1. Set up tasks (branches).
+  // 1. Set up tasks (branches). When `recordBranchOutcomes` is false the
+  //    caller is responsible for setting branch.result, AND for idempotent
+  //    re-execution of the body on resume — branch.result being set does
+  //    NOT mean "the body is fully done" (it may only mean "the tool's
+  //    invoke step succeeded; the .end + .log steps may still need to
+  //    fire"). So skip the cached-branch short-circuit in that mode.
+  const recordOutcomes = opts.recordBranchOutcomes !== false;
   const tasks: Task<T>[] = children.map((child) => {
     const branch = parentFrame.getOrCreateBranch(child.key);
-    return { child, branch, startedAt: 0, cached: branch.result !== undefined };
+    return {
+      child,
+      branch,
+      startedAt: 0,
+      cached: recordOutcomes && branch.result !== undefined,
+    };
   });
   const parentSpanStack = ctx.statelogClient.snapshotStack();
 
@@ -264,17 +313,21 @@ export async function runBatch<T>(
     if (hasInterrupts(value)) {
       if (!cached) hooks?.onBranchEnd?.(child.key, i, "interrupted", timeMs);
       interrupts.push(...value);
-      parentFrame.setInterruptOnBranch(
-        child.key,
-        value[0].interruptId,
-        value[0].interruptData,
-        // The leaf's per-branch checkpoint goes here — it vehicles the
-        // pre-pop branch stack into State.toJSON's branches walk.
-        value[0].checkpoint,
-      );
+      if (recordOutcomes) {
+        parentFrame.setInterruptOnBranch(
+          child.key,
+          value[0].interruptId,
+          value[0].interruptData,
+          // The leaf's per-branch checkpoint goes here — it vehicles the
+          // pre-pop branch stack into State.toJSON's branches walk.
+          value[0].checkpoint,
+        );
+      }
     } else {
       if (!cached) hooks?.onBranchEnd?.(child.key, i, "success", timeMs);
-      parentFrame.setResultOnBranch(child.key, value as any);
+      if (recordOutcomes) {
+        parentFrame.setResultOnBranch(child.key, value as any);
+      }
     }
   }
 

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -1,5 +1,4 @@
 import { nanoid } from "nanoid";
-import type { SpanContext } from "../statelogClient.js";
 import type { CallbackName } from "../types/function.js";
 import { debugStep } from "./debugger.js";
 import { callHook, type CallbackMap } from "./hooks.js";
@@ -723,22 +722,11 @@ export class Runner {
     const readWinner = () =>
       this.frame.locals[this.raceWinnerKey(id)] as number | undefined;
     try {
-      // Race resume: if a winner was already chosen on a previous run,
-      // resume only that branch — skip the race entirely.
-      const raceWinnerKey = this.raceWinnerKey(id);
-      if (mode === "race" && this.frame.locals[raceWinnerKey] !== undefined) {
-        result = await this.resumeRaceWinner(
-          id,
-          items,
-          blockFn,
-          stateStack,
-          this.frame.locals[raceWinnerKey] as number,
-        );
-        if (hasInterrupts(result)) {
-          winnerIndex = readWinner();
-          return result;
-        }
-      } else if (mode === "all") {
+      // Both runForkAll and runRace are now thin adapters over runBatch.
+      // The race adapter internally handles "first run" vs. "resume only
+      // the winner" via the persisted __race_winner_<id> key, so the
+      // caller does NOT need to dispatch between them.
+      if (mode === "all") {
         result = await this.runForkAll(id, items, blockFn, stateStack, forkId);
         if (hasInterrupts(result)) return result;
       } else {
@@ -842,91 +830,16 @@ export class Runner {
   }
 
   /** Run all branches concurrently but return as soon as one settles.
-   * On interrupt: record the winner, abort the losers, clear loser branches,
-   * stamp a checkpoint, and return the interrupt array.
-   * On value: return the value (losers' work is discarded). */
-  /** Build a single race branch's tagged promise. Wires up the
-   * AbortController, records the branch start time, and tags both
-   * resolutions and rejections so the racer can identify the winner /
-   * first-failing branch. */
-  private buildRaceBranchPromise(
-    id: number,
-    i: number,
-    item: any,
-    blockFn: (
-      item: any,
-      index: number,
-      branchStack: StateStack,
-    ) => Promise<any>,
-    stateStack: StateStack,
-    branchStartTimes: number[],
-    parentSpanStack: SpanContext[],
-  ): Promise<{ index: number; value: any }> {
-    const branchKey = this.forkBranchKey(id, i);
-    const existing = this.frame.getOrCreateBranch(branchKey);
-    if (existing.result !== undefined) {
-      return Promise.resolve({ index: i, value: existing.result.result });
-    }
-    if (!existing.abortController) {
-      existing.abortController = new AbortController();
-      // Compose with the parent stack's signal so nested race aborts
-      // propagate down through every level. The branch's signal is
-      // attached to its stack so any code holding the stack (runPrompt,
-      // ctx.isCancelled checks, etc.) observes a branch-only abort.
-      const parentSignal = stateStack.abortSignal;
-      existing.stack.abortSignal = parentSignal
-        ? AbortSignal.any([parentSignal, existing.abortController.signal])
-        : existing.abortController.signal;
-    }
-    // Seed per-branch cost/tokens from the parent (same as runForkAll).
-    this.seedBranchCost(existing.stack, stateStack);
-    branchStartTimes[i] = performance.now();
-    return this.ctx.statelogClient
-      .runInBranchContext(parentSpanStack, () => blockFn(item, i, existing.stack))
-      .then(
-        (value) => ({ index: i, value }),
-        // Tag the rejection so the racer can identify which branch died.
-        (err) => Promise.reject({ index: i, err }),
-      );
-  }
-
-  /** After a race winner is chosen, abort the loser branches and emit
-   * a `forkBranchEnd` event for every branch (winner + losers). The
-   * abort is best-effort: synchronous code that has already reached an
-   * `interrupt()` call before we get here will still resolve its orphan
-   * promise — runRace's caller discards those resolutions. */
-  private abortLoserBranchesAndEmitEnds(
-    id: number,
-    itemCount: number,
-    winnerIndex: number,
-    winnerValue: any,
-    winnerTime: number,
-    branchStartTimes: number[],
-    forkId: string,
-  ): void {
-    for (let i = 0; i < itemCount; i++) {
-      if (i === winnerIndex) continue;
-      const branchKey = this.forkBranchKey(id, i);
-      const branch = this.frame.getBranch(branchKey);
-      branch?.abortController?.abort();
-      this.ctx.statelogClient.forkBranchEnd({
-        forkId,
-        branchIndex: i,
-        outcome: "aborted",
-        // Losers ran at least this long before the winner finished and we
-        // told them to stop. They may continue running briefly after this
-        // until the abort is observed.
-        timeTaken: performance.now() - branchStartTimes[i],
-      });
-    }
-    this.ctx.statelogClient.forkBranchEnd({
-      forkId,
-      branchIndex: winnerIndex,
-      outcome: hasInterrupts(winnerValue) ? "interrupted" : "success",
-      timeTaken: winnerTime,
-    });
-  }
-
+   *
+   * Thin adapter over `runBatch({ mode: "race" })`. The primitive owns
+   * branch lifecycle, abort composition, settle (`Promise.race` with
+   * loser abort), shared checkpoint stamp + intr.checkpoint overwrite,
+   * winner-index persistence under `raceWinnerLocalKey`, loser-branch
+   * deletion, and resume dispatch (re-running only the recorded winner
+   * when a persisted winner is present). The adapter wires up race-
+   * specific statelog events and the asymmetric cost-propagation hooks:
+   * losers propagate eagerly at race time, winner propagates when it
+   * finally completes (no-interrupt resume). */
   private async runRace(
     id: number,
     items: any[],
@@ -938,205 +851,58 @@ export class Runner {
     stateStack: StateStack,
     forkId: string,
   ): Promise<any> {
-    const branchStartTimes: number[] = new Array(items.length).fill(0);
-    // Snapshot the current span stack ONCE — each race branch will run
-    // inside its own ALS context seeded from this snapshot, so concurrent
-    // branches cannot interleave span pushes/pops on the parent stack.
-    const parentSpanStack = this.ctx.statelogClient.snapshotStack();
-    const taggedPromises = items.map((item, i) =>
-      this.buildRaceBranchPromise(
-        id,
-        i,
-        item,
-        blockFn,
-        stateStack,
-        branchStartTimes,
-        parentSpanStack,
-      ),
-    );
-
-    // Promise.race resolves/rejects with whichever settles first.
-    let winnerIndex: number;
-    let winnerValue: any;
-    let winnerTime: number;
-    try {
-      const winner = await Promise.race(taggedPromises);
-      winnerIndex = winner.index;
-      winnerValue = winner.value;
-      winnerTime = performance.now() - branchStartTimes[winnerIndex];
-    } catch (tagged) {
-      // A branch rejected first — we know which one thanks to tagging.
-      const { index: failedIndex, err } = tagged as { index: number; err: any };
-      this.ctx.statelogClient.forkBranchEnd({
-        forkId,
-        branchIndex: failedIndex,
-        outcome: "failure",
-        timeTaken: performance.now() - branchStartTimes[failedIndex],
-      });
-      // Abort the still-running branches. Each branch already runs in
-      // its own ALS-scoped span context, so no parent span bookkeeping
-      // needs balancing here — losers' span stacks simply go away with
-      // their async contexts.
-      for (let i = 0; i < items.length; i++) {
-        if (i === failedIndex) continue;
-        this.frame.getBranch(this.forkBranchKey(id, i))?.abortController?.abort();
-      }
-      throw err;
-    }
-
-    this.abortLoserBranchesAndEmitEnds(
-      id,
-      items.length,
-      winnerIndex,
-      winnerValue,
-      winnerTime,
-      branchStartTimes,
-      forkId,
-    );
-
-    // Record the winner so a resume on the same race step replays only this
-    // branch (not the abandoned losers).
-    this.frame.locals[this.raceWinnerKey(id)] = winnerIndex;
-
-    const winnerBranchKey = this.forkBranchKey(id, winnerIndex);
-
-    if (hasInterrupts(winnerValue)) {
-      // Save the winner's interrupt info on its branch so resume can find it.
-      this.frame.setInterruptOnBranch(
-        winnerBranchKey,
-        winnerValue[0].interruptId,
-        winnerValue[0].interruptData,
-        winnerValue[0].checkpoint,
-      );
-      // Propagate LOSER cost/tokens into the parent before we drop them —
-      // their LLM calls really happened and the user should see that spend.
-      // The winner is still pending; its cost will propagate when it resolves
-      // (in resumeRaceWinner's success path).
-      const losers: BranchState[] = [];
-      for (let i = 0; i < items.length; i++) {
-        if (i === winnerIndex) continue;
-        const loser = this.frame.getBranch(this.forkBranchKey(id, i));
-        if (loser) losers.push(loser);
-      }
-      this.propagateBranchCost(losers, stateStack);
-      // Drop the loser branches before serializing — they hold partial state
-      // we never want to revisit.
-      for (let i = 0; i < items.length; i++) {
-        if (i === winnerIndex) continue;
-        this.frame.deleteBranch(this.forkBranchKey(id, i));
-      }
-      // Stamp a checkpoint capturing only the winner's slice.
-      const cpId = this.ctx.checkpoints.create(stateStack, this.ctx, {
+    const result = await runBatch<any>({
+      ctx: this.ctx,
+      parentStack: stateStack,
+      parentFrame: this.frame,
+      checkpointLocation: {
         moduleId: this.moduleId,
         scopeName: this.scopeName,
         stepPath: this.stepPath(id),
-      });
-      const cp = this.ctx.checkpoints.get(cpId)!;
-      this.ctx.statelogClient.checkpointCreated({
-        checkpointId: cpId,
-        reason: "race",
-        sourceLocation: { moduleId: cp.moduleId, scopeName: cp.scopeName, stepPath: cp.stepPath },
-      });
-      for (const intr of winnerValue) {
-        intr.checkpoint = cp;
-        intr.checkpointId = cpId;
-      }
-      return winnerValue;
-    }
-
-    // Winner produced a value. Cache it on the winner branch and drop losers.
-    this.frame.setResultOnBranch(winnerBranchKey, winnerValue);
-    // Propagate cost/tokens from EVERY branch (winner + losers) into the
-    // parent stack before we delete the loser branches. Loser LLM calls
-    // really happened and the user should see that spend.
-    const allBranches: BranchState[] = [];
-    for (let i = 0; i < items.length; i++) {
-      const branch = this.frame.getBranch(this.forkBranchKey(id, i));
-      if (branch) allBranches.push(branch);
-    }
-    this.propagateBranchCost(allBranches, stateStack);
-    for (let i = 0; i < items.length; i++) {
-      if (i === winnerIndex) continue;
-      this.frame.deleteBranch(this.forkBranchKey(id, i));
-    }
-    return winnerValue;
-  }
-
-  /** Race resume: only the recorded winner is re-executed. */
-  private async resumeRaceWinner(
-    id: number,
-    items: any[],
-    blockFn: (
-      item: any,
-      index: number,
-      branchStack: StateStack,
-    ) => Promise<any>,
-    stateStack: StateStack,
-    winnerIndex: number,
-  ): Promise<any> {
-    const branchKey = this.forkBranchKey(id, winnerIndex);
-    const existing = this.frame.getBranch(branchKey);
-    if (!existing) {
-      throw new Error(
-        `Race resume: winner branch ${branchKey} (index ${winnerIndex}) is missing — state may be corrupted.`,
-      );
-    }
-
-    // Already-completed winner: return cached result.
-    if (existing.result !== undefined) {
-      return existing.result.result;
-    }
-
-    // Pending winner: re-run blockFn with the existing branch stack. We
-    // start a fresh AbortController for the resumed run; the branch stack
-    // hasn't been re-attached to a stack signal yet, but resume only re-runs
-    // the winner so there are no losers to abort. (If the winner itself
-    // contains nested fork/race, those will install their own signals.)
-    if (!existing.abortController) {
-      existing.abortController = new AbortController();
-      existing.stack.abortSignal = existing.abortController.signal;
-    }
-    // Run the resumed winner inside its own branch-local span context
-    // so its spans nest under the (resumed) race span rather than
-    // mutating the outer stack directly.
-    const parentSpanStack = this.ctx.statelogClient.snapshotStack();
-    const value = await this.ctx.statelogClient.runInBranchContext(
-      parentSpanStack,
-      () => blockFn(items[winnerIndex], winnerIndex, existing.stack),
-    );
-
-    if (hasInterrupts(value)) {
-      this.frame.setInterruptOnBranch(
-        branchKey,
-        value[0].interruptId,
-        value[0].interruptData,
-        value[0].checkpoint,
-      );
-      const cpId = this.ctx.checkpoints.create(stateStack, this.ctx, {
-        moduleId: this.moduleId,
-        scopeName: this.scopeName,
-        stepPath: this.stepPath(id),
-      });
-      const cp = this.ctx.checkpoints.get(cpId)!;
-      this.ctx.statelogClient.checkpointCreated({
-        checkpointId: cpId,
-        reason: "race",
-        sourceLocation: { moduleId: cp.moduleId, scopeName: cp.scopeName, stepPath: cp.stepPath },
-      });
-      for (const intr of value) {
-        intr.checkpoint = cp;
-        intr.checkpointId = cpId;
-      }
-      return value;
-    }
-
-    this.frame.setResultOnBranch(branchKey, value);
-    // Propagate the winner's cost/tokens delta into the parent stack now
-    // that the winner has produced a final value. Losers were already
-    // propagated in runRace's interrupt path before they were deleted, so
-    // this single-branch propagation completes the race's total spend.
-    this.propagateBranchCost([existing], stateStack);
-    return value;
+      },
+      mode: "race",
+      // Keep the existing key shape — changing to stepPath would silently
+      // break any in-flight serialized checkpoint stamped before this
+      // migration.
+      raceWinnerLocalKey: this.raceWinnerKey(id),
+      children: items.map((item, i) => ({
+        key: this.forkBranchKey(id, i),
+        invoke: (branchStack) => blockFn(item, i, branchStack),
+      })),
+      hooks: {
+        seedBranchCost: (childStack, parentStack) =>
+          this.seedBranchCost(childStack, parentStack),
+        // Asymmetric cost-propagation: losers eagerly, winner deferred.
+        // Both delegate to the same propagateBranchCost helper — the
+        // delta math (branch.localCost - branch.seedCost) is identical;
+        // only the timing differs.
+        propagateLoserCost: (losers, parentStack) =>
+          this.propagateBranchCost(losers, parentStack),
+        propagateWinnerCost: (winner, parentStack) =>
+          this.propagateBranchCost([winner], parentStack),
+        onBranchEnd: (_key, branchIndex, outcome, timeTaken) => {
+          this.ctx.statelogClient.forkBranchEnd({
+            forkId,
+            branchIndex,
+            outcome,
+            timeTaken,
+          });
+        },
+        onCheckpoint: (cpId) => {
+          const cp = this.ctx.checkpoints.get(cpId)!;
+          this.ctx.statelogClient.checkpointCreated({
+            checkpointId: cpId,
+            reason: "race",
+            sourceLocation: {
+              moduleId: cp.moduleId,
+              scopeName: cp.scopeName,
+              stepPath: cp.stepPath,
+            },
+          });
+        },
+      },
+    });
+    return result.kind === "interrupts" ? result.interrupts : result.values[0];
   }
 
   private raceWinnerKey(id: number): string {

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -5,6 +5,7 @@ import { debugStep } from "./debugger.js";
 import { callHook, type CallbackMap } from "./hooks.js";
 import { hasInterrupts } from "./interrupts.js";
 import { __pipeBind } from "./result.js";
+import { runBatch } from "./runBatch.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { BranchState, State } from "./state/stateStack.js";
@@ -778,7 +779,13 @@ export class Runner {
   }
 
   /** Run all branches in parallel (fork mode). Returns an array of values,
-   * or an Interrupt[] if any branch interrupted. */
+   * or an Interrupt[] if any branch interrupted.
+   *
+   * Thin adapter over `runBatch({ mode: "all" })`. The primitive owns:
+   * branch lifecycle, abort composition, settle, leaf checkpoint capture,
+   * shared checkpoint stamp + intr.checkpoint overwrite, popBranches on
+   * success. This adapter wires up the fork-specific statelog events and
+   * cost propagation. */
   private async runForkAll(
     id: number,
     items: any[],
@@ -790,115 +797,48 @@ export class Runner {
     stateStack: StateStack,
     forkId: string,
   ): Promise<any> {
-    const branchStartTimes: number[] = [];
-    const branchEndTimes: number[] = [];
-    // Snapshot the current span stack ONCE, before branches are scheduled.
-    // Each branch runs inside its own ALS context seeded from this snapshot,
-    // so spans pushed in one branch never leak to siblings or the parent.
-    const parentStack = this.ctx.statelogClient.snapshotStack();
-    const promises = items.map((item, i) => {
-      const branchKey = this.forkBranchKey(id, i);
-      const existing = this.frame.getOrCreateBranch(branchKey);
-      if (existing.result !== undefined) {
-        branchStartTimes[i] = 0;
-        branchEndTimes[i] = 0;
-        return Promise.resolve(existing.result.result);
-      }
-      // Each fork branch gets its own AbortController. For fork-all this is
-      // mainly there for parity with race; we don't currently abort fork-all
-      // branches, but having a signal in place lets generated code use it.
-      if (!existing.abortController) {
-        existing.abortController = new AbortController();
-        // Compose with the parent stack's signal so nested fork/race aborts
-        // propagate down through every level.
-        const parentSignal = stateStack.abortSignal;
-        existing.stack.abortSignal = parentSignal
-          ? AbortSignal.any([parentSignal, existing.abortController.signal])
-          : existing.abortController.signal;
-      }
-      // Seed per-branch cost/tokens from the parent so getCost() inside the
-      // branch sees "parent's total + my own contributions". Idempotent — on
-      // resume, the restored localCost is preserved.
-      this.seedBranchCost(existing.stack, stateStack);
-      branchStartTimes[i] = performance.now();
-      return this.ctx.statelogClient
-        .runInBranchContext(parentStack, () => blockFn(item, i, existing.stack))
-        .finally(() => {
-          branchEndTimes[i] = performance.now();
-        });
-    });
-
-    const settled = await Promise.allSettled(promises);
-    const interrupts: any[] = [];
-
-    for (let i = 0; i < settled.length; i++) {
-      const s = settled[i];
-      const branchKey = this.forkBranchKey(id, i);
-      const branchTime = (branchEndTimes[i] || 0) - (branchStartTimes[i] || 0);
-      if (s.status === "rejected") {
-        this.ctx.statelogClient.forkBranchEnd({
-          forkId,
-          branchIndex: i,
-          outcome: "failure",
-          timeTaken: branchTime,
-        });
-        throw s.reason;
-      }
-      if (hasInterrupts(s.value)) {
-        this.ctx.statelogClient.forkBranchEnd({
-          forkId,
-          branchIndex: i,
-          outcome: "interrupted",
-          timeTaken: branchTime,
-        });
-        interrupts.push(...s.value);
-        this.frame.setInterruptOnBranch(
-          branchKey,
-          s.value[0].interruptId,
-          s.value[0].interruptData,
-          s.value[0].checkpoint,
-        );
-      } else {
-        this.ctx.statelogClient.forkBranchEnd({
-          forkId,
-          branchIndex: i,
-          outcome: "success",
-          timeTaken: branchTime,
-        });
-        this.frame.setResultOnBranch(branchKey, s.value);
-      }
-    }
-
-    if (interrupts.length > 0) {
-      const cpId = this.ctx.checkpoints.create(stateStack, this.ctx, {
+    const result = await runBatch<any>({
+      ctx: this.ctx,
+      parentStack: stateStack,
+      parentFrame: this.frame,
+      checkpointLocation: {
         moduleId: this.moduleId,
         scopeName: this.scopeName,
         stepPath: this.stepPath(id),
-      });
-      const cp = this.ctx.checkpoints.get(cpId)!;
-      this.ctx.statelogClient.checkpointCreated({
-        checkpointId: cpId,
-        reason: "fork",
-        sourceLocation: { moduleId: cp.moduleId, scopeName: cp.scopeName, stepPath: cp.stepPath },
-      });
-      for (const intr of interrupts) {
-        intr.checkpoint = cp;
-        intr.checkpointId = cpId;
-      }
-      return interrupts;
-    }
-
-    // No interrupts — propagate each branch's cost/token delta into the
-    // parent stack BEFORE the caller pops branches. Each branch was seeded
-    // with the parent's totals at creation; delta = branch.localCost - base.
-    const allBranches: BranchState[] = [];
-    for (let i = 0; i < items.length; i++) {
-      const branch = this.frame.getBranch(this.forkBranchKey(id, i));
-      if (branch) allBranches.push(branch);
-    }
-    this.propagateBranchCost(allBranches, stateStack);
-
-    return settled.map((s) => (s as PromiseFulfilledResult<any>).value);
+      },
+      mode: "all",
+      children: items.map((item, i) => ({
+        key: this.forkBranchKey(id, i),
+        invoke: (branchStack) => blockFn(item, i, branchStack),
+      })),
+      hooks: {
+        seedBranchCost: (childStack, parentStack) =>
+          this.seedBranchCost(childStack, parentStack),
+        propagateBranchCost: (branches, parentStack) =>
+          this.propagateBranchCost(branches, parentStack),
+        onBranchEnd: (_key, branchIndex, outcome, timeTaken) => {
+          this.ctx.statelogClient.forkBranchEnd({
+            forkId,
+            branchIndex,
+            outcome,
+            timeTaken,
+          });
+        },
+        onCheckpoint: (cpId) => {
+          const cp = this.ctx.checkpoints.get(cpId)!;
+          this.ctx.statelogClient.checkpointCreated({
+            checkpointId: cpId,
+            reason: "fork",
+            sourceLocation: {
+              moduleId: cp.moduleId,
+              scopeName: cp.scopeName,
+              stepPath: cp.stepPath,
+            },
+          });
+        },
+      },
+    });
+    return result.kind === "interrupts" ? result.interrupts : result.values;
   }
 
   /** Run all branches concurrently but return as soon as one settles.

--- a/packages/agency-lang/tests/agency-js/parallel-tools-resume-messages-intact/agent.agency
+++ b/packages/agency-lang/tests/agency-js/parallel-tools-resume-messages-intact/agent.agency
@@ -1,0 +1,12 @@
+def succeedTool(): string {
+  return "SUCCEED_RESULT"
+}
+
+def interruptTool(): string {
+  interrupt("approve interrupt-tool")
+  return "INTERRUPT_RESULT"
+}
+
+node main() {
+  return llm("call both tools in parallel", { tools: [succeedTool, interruptTool] })
+}

--- a/packages/agency-lang/tests/agency-js/parallel-tools-resume-messages-intact/fixture.json
+++ b/packages/agency-lang/tests/agency-js/parallel-tools-resume-messages-intact/fixture.json
@@ -1,0 +1,6 @@
+{
+  "finalData": "all done",
+  "llmCallCount": 2,
+  "secondCallToolResponseCount": 2,
+  "toolCallIds": ["call-interrupt", "call-succeed"]
+}

--- a/packages/agency-lang/tests/agency-js/parallel-tools-resume-messages-intact/test.js
+++ b/packages/agency-lang/tests/agency-js/parallel-tools-resume-messages-intact/test.js
@@ -1,0 +1,147 @@
+import {
+  main,
+  hasInterrupts,
+  approve,
+  respondToInterrupts,
+  __setLLMClient,
+} from "./agent.js";
+import { writeFileSync } from "fs";
+import { ToolCall } from "smoltalk";
+
+// Regression test for the messagesJSON-snapshot ordering bug surfaced
+// in PR #186 (runBatch primitive migration).
+//
+// Bug: when a parallel-tool round had one tool succeed (pushing its
+// tool_response to the message thread) AND a sibling tool interrupt,
+// PromptRunner.parallel used to snapshot self.messagesJSON BEFORE
+// stamping the bailout checkpoint. The runBatch migration inverted that
+// — runBatch stamps the shared checkpoint internally, then parallel()
+// assigns messagesJSON AFTER runBatch returns. Because
+// `ctx.checkpoints.create` does a synchronous `stateStack.toJSON()`
+// snapshot at call time (see checkpointStore.ts), the captured
+// checkpoint contains the STALE messagesJSON from the previous
+// _runPrompt — i.e. missing every successful sibling tool's
+// tool_response.
+//
+// On resume the messages thread is restored from this stale snapshot
+// (prompt.ts line 314), and because the successful sibling's branch is
+// already marked done in completedSteps, its `messages.push(...)` body
+// is skipped — so the tool_response is never re-added. The next
+// _runPrompt then sees an assistant message with N tool_calls but only
+// M < N matching tool messages. Real OpenAI/Anthropic APIs reject
+// this; the deterministic mock used in unit/agency-js tests silently
+// accepts it, which is why this bug never surfaced.
+//
+// This test wires up a custom LLM client that records every text()
+// call's messages array, then asserts that the SECOND llm call (after
+// resume) contains BOTH tool responses — succeedTool's and
+// interruptTool's. With the bug, the test would observe only 1.
+
+const captured = [];
+let callIndex = 0;
+
+const SYNTHETIC_USAGE = {
+  inputTokens: 1,
+  outputTokens: 1,
+  cachedInputTokens: 0,
+  totalTokens: 2,
+};
+const SYNTHETIC_COST = {
+  inputCost: 0,
+  outputCost: 0,
+  totalCost: 0,
+  currency: "USD",
+};
+
+const captureClient = {
+  async text(config) {
+    // Capture the role + tool_call_id of every message sent to this
+    // call so the assertions below can count tool responses.
+    captured.push({
+      callIndex,
+      messages: config.messages.map((m) => {
+        const json = typeof m.toJSON === "function" ? m.toJSON() : m;
+        return {
+          role: json.role,
+          tool_call_id: json.tool_call_id ?? null,
+          content: json.content ?? null,
+        };
+      }),
+    });
+    const idx = callIndex++;
+    if (idx === 0) {
+      // First call: ask the (mocked) LLM to call BOTH tools in parallel.
+      return {
+        success: true,
+        value: {
+          output: null,
+          toolCalls: [
+            new ToolCall("call-succeed", "succeedTool", {}),
+            new ToolCall("call-interrupt", "interruptTool", {}),
+          ],
+          model: "test",
+          usage: SYNTHETIC_USAGE,
+          cost: SYNTHETIC_COST,
+        },
+      };
+    }
+    // Subsequent calls: return a plain string. The runtime expects this
+    // call to come AFTER both tool responses have been pushed back.
+    return {
+      success: true,
+      value: {
+        output: "all done",
+        toolCalls: [],
+        model: "test",
+        usage: SYNTHETIC_USAGE,
+        cost: SYNTHETIC_COST,
+      },
+    };
+  },
+  async *textStream(config) {
+    const result = await this.text(config);
+    if (result.success) {
+      yield { type: "done", result: result.value };
+    } else {
+      yield { type: "error", error: result.error };
+    }
+  },
+  async embed() {
+    return {
+      success: false,
+      error: "captureClient does not implement embed",
+    };
+  },
+};
+
+__setLLMClient(captureClient);
+
+const initial = await main();
+if (!hasInterrupts(initial.data)) {
+  throw new Error(
+    `Expected interrupts from interruptTool, got: ${JSON.stringify(initial.data)}`,
+  );
+}
+
+const final = await respondToInterrupts(initial.data, [approve()]);
+
+// We expect exactly TWO LLM calls total: the first that produces the
+// parallel tool calls, and the second (after resume) that consumes
+// both tool responses and returns "all done".
+const secondCall = captured[captured.length - 1];
+const toolMsgs = secondCall.messages.filter((m) => m.role === "tool");
+const toolCallIds = toolMsgs.map((m) => m.tool_call_id).sort();
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      finalData: final.data,
+      llmCallCount: captured.length,
+      secondCallToolResponseCount: toolMsgs.length,
+      toolCallIds,
+    },
+    null,
+    2,
+  ),
+);


### PR DESCRIPTION
## Summary

Introduces a single `runBatch` runtime primitive that owns the concurrent-interrupt orchestration that today every site hand-rolls (Promise.allSettled/race, abort composition, shared checkpoint stamping + `intr.checkpoint` overwrite, branch lifecycle). Migrates the three existing call sites — `Runner.runForkAll`, `Runner.runRace` (+ deletes `resumeRaceWinner`), and `runPrompt`'s tool loop — to use the primitive.

This is **Tasks 1–4** of the runBatch plan at [`docs/superpowers/plans/2026-05-22-runbatch-concurrent-interrupt-primitive.md`](docs/superpowers/plans/2026-05-22-runbatch-concurrent-interrupt-primitive.md). Tasks 5–9 (callback slice-rule fixes, multi-callback hook resume, `_activeCallbacks` per-stack guard, docs, supersede markers) are not in this PR.

## What `runBatch` owns

- per-child `getOrCreateBranch` + cached-result short-circuit
- per-child `AbortController` composition with the parent stack's signal
- ALS-isolated `runInBranchContext` invocation
- three modes:
  - `"all"` — `Promise.allSettled`, every child runs concurrently
  - `"sequential"` — `for…of`, strict ordering (today's `callHook` semantics; lets Task 6 preserve them)
  - `"race"` — `Promise.race` + abort losers, with **resume dispatch folded in** (re-runs only the recorded winner when `__race_winner_<id>` is persisted)
- collect/settle, `setInterruptOnBranch` with the leaf-stamped checkpoint, shared batch-level checkpoint stamp, and `intr.checkpoint`/`checkpointId` overwrite (intentional per c72b9c1574 — all interrupts in a batch deliberately share one resume point)
- cost seed/propagate hooks (asymmetric pair for race: `propagateLoserCost` eagerly, `propagateWinnerCost` deferred)
- defensive guards: duplicate-key check, mode-flip mismatch assert

## What `runBatch` deliberately does NOT touch

Per commit c72b9c1574 (which removed the buggy `isForked` approach that broke nested-fork composition):

- the leaf `interruptReturn` template still stamps a per-leaf checkpoint exactly as today; `runBatch` just reads it off each surfaced `Interrupt` and stores it on `BranchState.checkpoint`
- handler (`handle` block) bookkeeping; per-branch handler chains stay as today
- the `__race_winner_<id>` key shape (Task 3 keeps it for in-flight-checkpoint compatibility)

## Commits in this PR

1. **feat: add runBatch primitive** — `lib/runtime/runBatch.ts` + 19 unit tests in `lib/runtime/runBatch.test.ts`. No migrations yet.
2. **refactor: runForkAll uses runBatch primitive** — ~110 lines of hand-rolled `Promise.allSettled` plumbing collapses into a thin adapter.
3. **refactor: runRace uses runBatch primitive (deletes resumeRaceWinner)** — ~280 lines (`runRace` + `buildRaceBranchPromise` + `abortLoserBranchesAndEmitEnds` + `resumeRaceWinner`) collapses into one adapter. `Runner.fork` no longer dispatches between first-run and resume — the adapter handles it internally.
4. **refactor: runPrompt tool loop uses runBatch primitive** — `PromptRunner.parallel` becomes a thin adapter; gains a `keyFor` arg so it and the branchFn body allocate the same branch; returns `RunBatchResult` instead of throwing `PromptBailout`. Adds `recordBranchOutcomes: false` option to `runBatch` so the tool-loop body can keep managing branch state itself (otherwise `runBatch`'s `setResultOnBranch(key, undefined)` would destroy the real tool result).

## Net code change

- `lib/runtime/runner.ts`: **−392 lines** (-110 from fork, −280 from race + helpers, +adapters)
- `lib/runtime/promptRunner.ts`: cleaner, gains tagged-union return
- `lib/runtime/prompt.ts`: minor diff (call-site pattern-match instead of try/catch on `PromptBailout`)
- `lib/runtime/runBatch.ts`: new ~510 lines including doc comments
- `lib/runtime/runBatch.test.ts`: new ~530 lines, 19 unit tests

## Tests

- `lib/runtime/runBatch.test.ts` (19 tests) — pure-JS unit coverage of all three modes, cached short-circuit, abort propagation, race resume dispatch (pending + cached winner), cost-hook asymmetry, empty/duplicate/rejection edge cases, mode-flip defensive assert.
- `lib/runtime/promptRunner.test.ts` (20 tests) — updated to use real `State`/`StateStack` and the new `keyFor` arg, asserts against `RunBatchResult` instead of catching `PromptBailout`.
- `pnpm test:run` — full unit suite (4441 tests, 258 files) passes locally after every commit.
- `pnpm run agency test tests/agency/fork` — all 67 tests pass (covers `fork-multi-interrupt`, `fork-multi-cycle-interrupt`, `fork-nested-interrupt`, `nested/three-levels-deep`, `nested/mixed-completion-nested`, `fork-llm-tool-nested`, `fork-llm-deep-loop`, `fork-stress`, all of `tests/agency/fork/race/*`, all of `tests/agency/fork/llm-tools/*`).
- Full `tests/agency` regression sweep deferred to CI per the project's "don't run the full suite locally — it's slow" guideline.

## Constraints honored

- Everything serializable. The only live-only field on `BranchState` is still `abortController`.
- Handlers (`handle` blocks) — not touched. Per-branch handler chains stay as today.
- Per-branch cost/token propagation preserved (`seedBranchCost` / `propagateBranchCost` hooks).
- Race cost-propagation asymmetry preserved: losers eagerly at race time, winner deferred until winner branch finally pops in a no-interrupt resume.
- `__race_winner_<id>` key shape unchanged — in-flight serialized checkpoints stay compatible.
- `runBatch.invoke` no-throw contract documented at the top of `runBatch.ts`; the only `Interrupt[]`-bearing throw in the runPrompt path (`PromptBailout` from `PromptRunner.parallel`) is converted to a return in Task 4. The audit findings are recorded in the file header.

## Follow-ups (not in this PR)

- Task 5 (thread `branchStack` through `callHook`)
- Task 6 (multi-callback hook resume via `runBatch({ mode: "sequential" })`)
- Task 7 (per-stack `_activeCallbacks` guard)
- Tasks 8 & 9 (docs + supersede plan markers)
