### PR TITLE
runBatch Tasks 5-8: per-tool callback slice-rule + multi-callback hook resume + ALS recursion guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ Pipeline and architecture:
 - `docs/dev/config.md` — AgencyConfig options for compiler and runtime configuration
 - `docs/dev/debugger.md` — Interactive debugger for stepping through and rewinding execution
 - `docs/dev/concurrent-interrupts.md` — Supporting multiple concurrent threads that interrupt simultaneously
+- `docs/dev/runBatch.md` — The `runBatch` primitive: signature, three modes, slice rule, invoke no-throw contract, defensive guards
 - `docs/dev/pkg-imports.md` — Importing Agency code from npm packages using `pkg::` prefix
 - `docs/dev/trace.md` — Execution traces capturing checkpoints at every step
 - `docs/dev/binop-parser.md` — Binary expression parser using precedence climbing

--- a/packages/agency-lang/docs/dev/callback-hooks.md
+++ b/packages/agency-lang/docs/dev/callback-hooks.md
@@ -172,16 +172,20 @@ callback that synchronously re-fires its own hook (via a helper
 function call) from recursing into itself
 (tests/agency/callback-recursion).
 
-Scope = one async-call chain. The "currently firing" set is
-inherited through `await` boundaries and nested sync calls — but a
-fork branch that gets its own ALS context (via the statelogClient
-`runInBranchContext` already used inside `runBatch`) starts with the
-inherited copy, and any sibling branches each get their own fresh
-copy. That means concurrent fork/tool branches can each fire the
-same callback in parallel without dropping sibling invocations,
-while recursion-via-helper-function within a single chain is still
-detected. ALS state is live-only — never serialised, always cleared
-when the ALS scope exits.
+Each `fireWithGuard` call enters its own `_activeCallbacksALS.run(...)`
+scope with a freshly-allocated `new Set<object>(inherited)` containing
+the parent scope's entries plus the current callback's key. Within that
+scope the Set is inherited through `await` boundaries and nested sync
+calls, so a synchronous re-fire of the same callback (via a
+helper-function call on the same async chain) sees its own key and is
+skipped. Concurrent sibling branches each enter their OWN
+`_activeCallbacksALS.run(...)` scope, so one branch's added key is
+invisible to the other — that's how parallel fork/tool branches each
+fire the same callback without dropping sibling invocations.
+(`statelogClient.runInBranchContext` scopes a separate ALS for
+Statelog spans and does NOT touch this guard.) ALS state is
+live-only — never serialised, automatically released when the
+`_activeCallbacksALS.run(...)` scope exits.
 
 ## Why the batch-and-return shape
 

--- a/packages/agency-lang/docs/dev/callback-hooks.md
+++ b/packages/agency-lang/docs/dev/callback-hooks.md
@@ -116,36 +116,80 @@ relies on.
 3. Top-level callbacks (registered at module init), in registration order
 4. The TS-passed `ctx.callbacks[name]` callback, if any
 
-`callHook` invokes them in that order and collects interrupts as it
-goes. The returned `Interrupt[]` preserves the firing order.
+`Runner.hook` fires them in that order via `runBatch` with
+`mode: "sequential"` — each callback becomes its own batch child.
+See [`docs/dev/runBatch.md`](runBatch.md). The returned `Interrupt[]`
+preserves the firing order.
 
-**Resume limitation when multiple callbacks raise interrupts.** When
-two callbacks on the same hook both raise an interrupt, the user
-receives a batch of two interrupts. Each interrupt's `checkpoint`
-property captures the stack at *its own* interrupt step — including
-its own callback frame, but not its siblings'. `respondToInterrupts`
-uses `interrupts[0].checkpoint` to drive the resume, so only the first
-callback's frame is restored. On resume the hook re-fires, the first
-callback's frame is reused from the deserialize queue and it completes
-with the user's response, but the second callback is invoked fresh
-(no saved frame, no saved `__interruptId`) — its body re-runs from the
-top and re-raises a new interrupt, producing an unexpected extra
-interrupt cycle.
+**Multi-callback resume (Task 6).** Each callback fires as a
+separate `runBatch` child branch with its own per-branch state on the
+hook's frame. When one (or more) callback halts with an interrupt,
+`runBatch` stamps a SHARED checkpoint and surfaces every collected
+interrupt under that one resume point. On resume:
 
-A correct fix mirrors the fork pattern (`docs/dev/concurrent-interrupts.md`):
-fire each callback on its own branch, stamp a single shared
-hook-level checkpoint capturing all branches, store each branch's
-interruptId in `setInterruptOnBranch`, and on resume re-enter only the
-branches that haven't completed. That refactor is out of scope for
-Phase 1. Today, prefer at most one interrupt-raising callback per
-hook; if you must have multiple, expect to handle extra resume cycles
-manually.
+- Callbacks whose branch already recorded a `result` (they completed
+  normally on the prior pass) short-circuit via the cached-branch
+  path in `runBatch` — their `invoke` is not called again, no side
+  effects re-run.
+- Callbacks whose branch holds an interrupt re-enter their own
+  `invoke`. The leaf checkpoint stamped at the callback's own
+  `interrupt` step preserves the callback frame's substep counters,
+  so the callback's body skips already-completed substeps and
+  re-enters at the interrupt step, which finds the user's response
+  via the saved `__interruptId_N`.
+
+Net effect: each callback's pre- and post-interrupt side effects run
+**exactly once** across any number of resume cycles. This used to be
+true only for the single-callback case (the leaf-checkpoint
+mechanism handled it); for two or more callbacks the pre-Task-6
+behaviour would re-run every callback from the top on each resume.
+
+Because `mode: "sequential"`, callback B does not start until
+callback A finishes — including waiting for A's interrupt response.
+On a multi-callback batch that all interrupt, the firing order is:
+`A.pre → (A interrupts) → B.pre → (B interrupts) → [batch]` and on
+resume `A.post → B.post`. Use `mode: "all"` would silently turn
+ordered side effects into a concurrent race; sequential is required
+here, not a preference.
+
+## Parallel-branch callbacks (per-tool firings)
+
+When a callback fires from inside a parallel branch — e.g. the
+per-tool `onToolCallStart` / `onToolCallEnd` in `runPrompt`'s tool
+loop — it must run on the **branch's own stack**, not on
+`ctx.stateStack`. Otherwise any callback-raised interrupt captures a
+checkpoint with the wrong slice and `setInterruptOnBranch` cannot
+find the right frame on resume.
+
+This is enforced via `invokeCallbacks({ ..., stateStack: branchStack })`
+in `prompt.ts`. The per-branch firing also requires per-branch
+recursion-guard isolation — see "Recursion guard" below.
+
+## Recursion guard
+
+`fireWithGuard` uses an `AsyncLocalStorage`-scoped Set to prevent a
+callback that synchronously re-fires its own hook (via a helper
+function call) from recursing into itself
+(tests/agency/callback-recursion).
+
+Scope = one async-call chain. The "currently firing" set is
+inherited through `await` boundaries and nested sync calls — but a
+fork branch that gets its own ALS context (via the statelogClient
+`runInBranchContext` already used inside `runBatch`) starts with the
+inherited copy, and any sibling branches each get their own fresh
+copy. That means concurrent fork/tool branches can each fire the
+same callback in parallel without dropping sibling invocations,
+while recursion-via-helper-function within a single chain is still
+detected. ALS state is live-only — never serialised, always cleared
+when the ALS scope exits.
 
 ## Why the batch-and-return shape
 
 This mirrors `runForkAll` / `runRace` from
-`docs/dev/concurrent-interrupts.md`. Callbacks are sequential rather
-than parallel, but the invariant is the same: each callback runs to
-completion regardless of what its siblings did, and the caller gets
-every halt batched together so the user can respond to all of them in
-one cycle of `respondToInterrupts`.
+`docs/dev/concurrent-interrupts.md`. Today the implementation IS the
+same primitive (`runBatch` with `mode: "sequential"` for hook
+callbacks vs. `"all"` / `"race"` for fork / race). The invariant is
+the same: each callback runs to completion regardless of what its
+siblings did, and the caller gets every halt batched together so the
+user can respond to all of them in one cycle of
+`respondToInterrupts`.

--- a/packages/agency-lang/docs/dev/concurrent-interrupts.md
+++ b/packages/agency-lang/docs/dev/concurrent-interrupts.md
@@ -10,7 +10,9 @@ There are three user-facing constructs that produce concurrent execution:
 
 The user responds to a batch via `respondToInterrupts(interrupts, responses)`. Resume reconstructs the full execution state, replays only the work that hadn't completed, and continues.
 
-**As of the runBatch refactor (PR #186):** all three of those call sites delegate to a single runtime primitive, [`runBatch`](../../lib/runtime/runBatch.ts), that owns the concurrent-interrupt orchestration. Previously every site hand-rolled the same `Promise.allSettled` / `Promise.race` boilerplate, made the same subtle mistakes, and was hard to keep in lock-step. After the refactor there is **one** place where branch lifecycle, abort composition, checkpoint stamping, and `intr.checkpoint` overwrite live, and three thin adapter functions that wire it up.
+**As of the runBatch refactor (PR #186, extended by the multi-callback hook work):** four call sites delegate to a single runtime primitive, [`runBatch`](../../lib/runtime/runBatch.ts), that owns the concurrent-interrupt orchestration: `Runner.runForkAll`, `Runner.runRace`, `PromptRunner.parallel`, and (added in the multi-callback resume work) `Runner.hook`. Previously every site hand-rolled the same `Promise.allSettled` / `Promise.race` boilerplate, made the same subtle mistakes, and was hard to keep in lock-step. After the refactor there is **one** place where branch lifecycle, abort composition, checkpoint stamping, and `intr.checkpoint` overwrite live, and thin adapter functions that wire it up.
+
+For the primitive's API, contracts, and the slice-rule discipline in isolation, see [`docs/dev/runBatch.md`](runBatch.md). This document focuses on the bigger picture: data model, resume mechanics, and per-call-site usage.
 
 The rest of this document is split into:
 

--- a/packages/agency-lang/docs/dev/runBatch.md
+++ b/packages/agency-lang/docs/dev/runBatch.md
@@ -1,0 +1,137 @@
+# `runBatch` — the concurrent-interrupt primitive
+
+`lib/runtime/runBatch.ts` is the single runtime primitive that owns
+concurrent-interrupt orchestration. Four callers delegate to it:
+
+- `Runner.runForkAll` — `fork(items) as item { ... }` (mode `"all"`).
+- `Runner.runRace`    — `race(items) as item { ... }` (mode `"race"`).
+- `PromptRunner.parallel` — parallel tool calls inside `runPrompt`
+  (mode `"all"`, `recordBranchOutcomes: false`).
+- `Runner.hook` — codegen-emitted callback hooks
+  (`onFunctionStart`, `onNodeStart`, `onNodeEnd`, `onEmit`)
+  with multiple registered callbacks (mode `"sequential"`).
+
+The full architectural context — what BranchState looks like, why the
+slice rule exists, how the leaf checkpoint vehicles into the parent's
+serialised state — is in
+[`docs/dev/concurrent-interrupts.md`](concurrent-interrupts.md). This
+doc focuses on the **primitive's API and contracts**.
+
+## Signature
+
+```ts
+export async function runBatch<T>(opts: RunBatchOpts<T>): Promise<RunBatchResult<T>>;
+
+type RunBatchResult<T> =
+  | { kind: "values";     values: T[] }
+  | { kind: "interrupts"; interrupts: Interrupt[] };
+```
+
+For the full `RunBatchOpts` field set (`parentStack`, `parentFrame`,
+`checkpointLocation`, `children`, `mode`, `raceWinnerLocalKey`,
+`recordBranchOutcomes`, `hooks`), read the JSDoc on the type in the
+source — it's the canonical reference and stays in sync with the code.
+
+## Three modes
+
+- **`"all"`** — `Promise.allSettled`; every child runs concurrently.
+- **`"sequential"`** — `for...of` loop; each child runs after the
+  previous resolves.
+- **`"race"`** — `Promise.race`; first to settle wins, losers get
+  `abortController.abort()` and their branches are deleted. Resume
+  dispatch is folded in: if `raceWinnerLocalKey` holds a number, only
+  the winner re-runs.
+
+### Sequential vs. all for hook callbacks
+
+`Runner.hook` uses `"sequential"`. Using `"all"` here would silently
+turn ordered callback side effects into a concurrent race — today's
+`callHook` semantics fire callbacks strictly in declared order, and
+many callbacks rely on that for telemetry / side-effect ordering.
+Sequential is therefore **required** for callback-batch sites, not a
+preference.
+
+## The slice rule (caller contract)
+
+`opts.parentStack` MUST be the **local slice** that the caller is
+holding (e.g. the branch stack you were handed if `runBatch` is itself
+called inside a child of an outer `runBatch`), NEVER `ctx.stateStack`.
+The shared batch-level checkpoint stamps from this stack; passing the
+wrong slice yields a checkpoint that captures the wrong frame chain
+and silently breaks resume.
+
+This is the **one** discipline `runBatch` callers must observe. Every
+existing adapter (`runForkAll`, `runRace`, `PromptRunner.parallel`,
+`Runner.hook`) gets this right; review any new adapter against the
+slice rule before merging.
+
+## The `invoke` no-throw contract
+
+Each `BatchChild.invoke` MUST RETURN `T | Interrupt[]` and never THROW
+an `Interrupt[]`. Other JS errors may be thrown — `runBatch` rethrows
+the first one it sees and abandons any interrupts that sibling
+branches collected (the rethrown error wins; callers that need both
+must catch inside `invoke`).
+
+A pre-Task-4 audit (recorded at the top of `runBatch.ts`) found one
+violation site: `PromptBailout` throws inside `promptRunner.ts`. Those
+were converted to returns when `runPrompt`'s tool loop migrated.
+Future adopters should re-run the audit on their code path
+(`grep -nE "throw .*[Ii]nterrupt"`).
+
+## Defensive guards
+
+- **Duplicate child key.** `runBatch` validates `children[*].key`
+  uniqueness up front and throws a clear error if two children share
+  a key. Same key would clobber the branch state.
+- **Mode-flip mismatch.** If `parentFrame.locals[raceWinnerLocalKey]`
+  is set but `mode !== "race"` (or vice versa), `runBatch` throws.
+  Catches caller bugs where a frame previously ran a race batch and
+  was then re-entered with a different mode.
+
+## `recordBranchOutcomes`
+
+Default `true`: `runBatch` records the per-branch outcome via
+`setResultOnBranch` (success) or `setInterruptOnBranch` (interrupt).
+This is what fork / race / hook need.
+
+`false`: the caller's `invoke` is responsible for managing branch
+state itself (via `stack.setResultOnBranch` / `setInterruptOnBranch`
+inside the body). `runBatch` still stamps the shared checkpoint and
+overwrites `intr.checkpoint`/`checkpointId`, but does NOT touch
+BranchState fields. `runPrompt`'s tool loop sets this because the
+body manages the real tool result on the branch (see
+`docs/dev/concurrent-interrupts.md` for the longer rationale).
+
+When this flag is false, `runBatch` also disables the
+cached-branch short-circuit — `branch.result` being set no longer
+means "the body is fully done." Idempotency is the caller's
+responsibility.
+
+## What `runBatch` deliberately does NOT touch
+
+Per commit `c72b9c1574` (which removed the buggy `isForked` approach
+that broke nested-fork composition):
+
+- The leaf `interruptReturn` template still stamps a per-leaf
+  checkpoint. `runBatch` reads it off each surfaced `Interrupt` and
+  writes it to `BranchState.checkpoint` — the leaf checkpoint is the
+  vehicle that carries the pre-pop branch stack into
+  `State.toJSON`'s branches walk.
+- Per-branch handler chains (`handle` blocks) — safety-critical and
+  must not be skipped.
+- The `__race_winner_<id>` key shape — preserved deliberately for
+  in-flight checkpoint compatibility.
+
+## Subprocess-shape (future)
+
+`runBatch`'s shape — per-child branch, idempotent re-entry,
+shared-checkpoint batching — is the same shape that a subprocess /
+multi-process executor would need. A future "spawn agent in
+subprocess" adapter would build its `BatchChild.invoke` around an
+IPC round-trip rather than a synchronous function call, surface the
+subprocess's interrupts as the return value, and otherwise reuse the
+existing branch lifecycle / checkpoint stamping unchanged. Designing
+that adapter is out of scope here; see
+`docs/superpowers/specs/2026-05-09-subprocess-propagation-and-resume-design.md`
+for the broader subprocess plan.

--- a/packages/agency-lang/docs/site/appendix/callbacks.md
+++ b/packages/agency-lang/docs/site/appendix/callbacks.md
@@ -81,21 +81,6 @@ Callbacks fire in declared order. Sequential mode is required, not a
 preference — using `mode: "all"` would silently turn ordered side
 effects into a concurrent race.
 
-#### Checkpoint format compatibility
-
-Callback-hook checkpoints written by versions BEFORE the per-callback
-`runBatch` migration (Task 6 of the runBatch concurrent-interrupt
-plan) are **NOT forward-compatible**. The previous format stored the
-hook's state under the runner's substep counter only; the new format
-adds per-callback branch state on the hook's frame. Resuming an
-old-format checkpoint will fail to find the per-callback branches and
-mis-attribute interrupt responses.
-
-No migration shim is provided — consistent with the project's small
-user base and "breaking changes acceptable across versions" stance.
-Run any pending interrupt cycles to completion on the old version
-before upgrading.
-
 ### Concurrent firing across fork branches
 
 A separate sense of "concurrent" is when the *same hook* fires from

--- a/packages/agency-lang/docs/site/appendix/callbacks.md
+++ b/packages/agency-lang/docs/site/appendix/callbacks.md
@@ -53,11 +53,11 @@ The table below summarizes the current state per hook. Three columns:
 |-------------------|------------------------------|------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `onAgentStart`    | ❌ Compile + runtime error    | N/A                                | Fires outside any agency frame — there is no stack to checkpoint and nowhere to resume from. The typechecker errors at build; `callHook` also throws at runtime as a defense-in-depth.                                                         |
 | `onAgentEnd`      | ❌ Compile + runtime error    | N/A                                | Same as `onAgentStart`.                                                                                                                                                                                                                        |
-| `onNodeStart`     | ✅ Yes                        | ⚠️ Batched, but resume is partial   | Fires inside the node's runner as a resumable substep. Single-callback resume works cleanly (exactly-once semantics). Multi-callback: see the **single-callback constraint** below.                                                            |
-| `onNodeEnd`       | ⚠️ Only on void-returning nodes | ⚠️ Same as `onNodeStart`           | Nodes that exit via `return value` halt the runner first; the post-body halted check short-circuits the End hook, so it never fires. Use a void node body if you need `onNodeEnd` to fire.                                                     |
-| `onFunctionStart` | ✅ Yes                        | ⚠️ Batched, but resume is partial   | Fires inside the function's runner as a resumable substep. Same as `onNodeStart`.                                                                                                                                                              |
-| `onFunctionEnd`   | ❌ Silently dropped           | ❌                                  | Fires from a `finally` block. The function has already returned by the time the hook fires, so interrupts cannot be propagated back into the runner. Today they are discarded with no log or throw. Move to a hook that fires outside `finally` if you need interrupts. |
-| `onEmit`          | ✅ Yes                        | ⚠️ Batched, but resume is partial   | Fires as a substep at the call site of `emit(...)`. Verified end-to-end (code before the interrupt does NOT re-run on resume; code after the interrupt fires exactly once on resume).                                                          |
+| `onNodeStart`     | ✅ Yes                        | ✅ Batched                          | Fires inside the node's runner as a resumable substep. Per-callback `runBatch` (mode `"sequential"`) gives full multi-callback resume — each callback's side effects fire exactly once across any number of resume cycles.                     |
+| `onNodeEnd`       | ⚠️ Only on void-returning nodes | ✅ Batched                          | Nodes that exit via `return value` halt the runner first; the post-body halted check short-circuits the End hook, so it never fires. Use a void node body if you need `onNodeEnd` to fire. Multi-callback resume otherwise identical to `onNodeStart`. |
+| `onFunctionStart` | ✅ Yes                        | ✅ Batched                          | Fires inside the function's runner as a resumable substep. Same as `onNodeStart`.                                                                                                                                                              |
+| `onFunctionEnd`   | ❌ Silently dropped           | ❌                                  | Fires from a `finally` block. The function has already returned by the time the hook fires, so interrupts cannot be propagated back into the runner. Today they are discarded with no log or throw. Move to a hook that fires outside `finally` if you need interrupts. (Not addressed by the multi-callback work — still raw `callHook`.) |
+| `onEmit`          | ✅ Yes                        | ✅ Batched                          | Fires as a substep at the call site of `emit(...)`. Same multi-callback resume guarantees as `onNodeStart`.                                                                                                                                    |
 | `onLLMCallStart`  | ✅ Yes                        | ✅ Batched                          | Propagates through `runPrompt`. Pending LLM call does not run. Resume re-enters `runPrompt` and the call is attempted from scratch.                                                                                                            |
 | `onLLMCallEnd`    | ✅ Yes                        | ✅ Batched                          | Propagates through `runPrompt`. The LLM response is preserved across the resume cycle by `runPrompt`'s internal state machine.                                                                                                                 |
 | `onToolCallStart` | ✅ Yes                        | ✅ Batched                          | Per-tool branch (`b.step`) captures the interrupt. Resume re-fires only the interrupted tool — sibling tools' results are preserved. The tool itself does not execute on the first cycle.                                                      |
@@ -65,25 +65,36 @@ The table below summarizes the current state per hook. Three columns:
 | `onStream`        | 🚫 N/A                        | 🚫 N/A                              | Invoked directly by the streaming pipeline (`ctx.callbacks.onStream(...)`), never goes through `callHook`. Agency `callback("onStream", ...)` registrations are never fired.                                                                   |
 | `onTrace`         | 🚫 N/A                        | 🚫 N/A                              | Same as `onStream` — direct invocation, not via `callHook`.                                                                                                                                                                                    |
 
-### Single-callback constraint (current limitation)
+### Multi-callback resume
 
-For the hooks marked **⚠️ Batched, but resume is partial**, the runtime
-correctly batches all interrupts into a single `Interrupt[]` and
-surfaces them to the user. The catch is on resume: `respondToInterrupts`
-uses the first interrupt's checkpoint to drive the restore — so only
-that callback's frame is reused from the deserialize queue. Sibling
-callbacks' bodies re-run from the top, which means their pre-interrupt
-side effects fire again, and they may raise fresh interrupts that
-require additional resume cycles.
+Every hook in the table marked **✅ Batched** now supports full
+multi-callback resume: multiple callbacks registered for the same
+hook can each raise an interrupt, and each callback's side effects
+run **exactly once** across any number of resume cycles. Each
+callback fires as its own `runBatch` child branch with its own
+per-branch state; `runBatch` stamps one shared checkpoint and
+surfaces every collected interrupt; the cached-branch short-circuit
+plus the leaf checkpoint's preserved substep counters give each
+callback its own resume point.
 
-**Practical guidance:** prefer at most one interrupt-raising callback
-per hook. Pure observers (callbacks with no `interrupt(...)` call) can
-freely coexist alongside an interrupter — they just re-run on resume.
+Callbacks fire in declared order. Sequential mode is required, not a
+preference — using `mode: "all"` would silently turn ordered side
+effects into a concurrent race.
 
-A future change will move callbacks to a fork-style branched model
-that batches resume correctly. The hooks marked **✅ Batched** (LLM and
-tool hooks) already get fork-style branched resume for free, because
-they fire inside `runPrompt`'s branch machinery.
+#### Checkpoint format compatibility
+
+Callback-hook checkpoints written by versions BEFORE the per-callback
+`runBatch` migration (Task 6 of the runBatch concurrent-interrupt
+plan) are **NOT forward-compatible**. The previous format stored the
+hook's state under the runner's substep counter only; the new format
+adds per-callback branch state on the hook's frame. Resuming an
+old-format checkpoint will fail to find the per-callback branches and
+mis-attribute interrupt responses.
+
+No migration shim is provided — consistent with the project's small
+user base and "breaking changes acceptable across versions" stance.
+Run any pending interrupt cycles to completion on the old version
+before upgrading.
 
 ### Concurrent firing across fork branches
 

--- a/packages/agency-lang/lib/runtime/__tests__/testHelpers.ts
+++ b/packages/agency-lang/lib/runtime/__tests__/testHelpers.ts
@@ -41,6 +41,21 @@ export function makeMockCtx(opts: {
       pushActive: () => {},
       popActive: () => {},
     },
+    // Minimal statelogClient stub. runBatch (used by Runner.hook's
+    // per-callback machinery) needs `snapshotStack` and
+    // `runInBranchContext`; everything else is a no-op.
+    statelogClient: {
+      snapshotStack: () => [],
+      runInBranchContext: <T>(_stack: unknown, fn: () => T): T => fn(),
+      startSpan: () => "span-mock",
+      endSpan: () => {},
+      forkStart: () => {},
+      forkEnd: () => {},
+      forkBranchEnd: () => {},
+      checkpointCreated: () => {},
+      error: () => {},
+      toolCall: () => {},
+    },
     hasDebugger() { return this.debuggerState !== null; },
     hasTraceWriter() { return false; },
     isInsideToolCall() { return this._toolCallDepth > 0; },

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -249,6 +249,37 @@ export async function callHook<K extends keyof CallbackMap>(args: {
   return invokeCallbacks(args);
 }
 
+/** Fire a SINGLE specific callback (already extracted from
+ *  `gatherCallbacks`) on the given `stateStack`. Returns any interrupts
+ *  raised inside the callback. Used by `Runner.hook`'s per-callback
+ *  runBatch path so each batch child corresponds to exactly one
+ *  callback — letting runBatch's cached-branch short-circuit skip
+ *  already-resolved callbacks on resume. */
+export async function invokeOneCallback<K extends keyof CallbackMap>(args: {
+  ctx: RuntimeContext<any>;
+  fn: any;
+  name: K;
+  data: CallbackMap[K];
+  stateStack?: StateStack;
+}): Promise<Interrupt[] | undefined> {
+  return fireWithGuard(args.fn, args.data, args.ctx, args.name, args.stateStack);
+}
+
+/** Fire every globally-registered hook (from `registerGlobalHook`) for
+ *  `name`. Global hooks are plain JS with no interrupt mechanism, so
+ *  they always run inline — `Runner.hook` calls this before delegating
+ *  the scoped/top-level/ts callbacks to runBatch. */
+export async function fireGlobalHooks<K extends keyof CallbackMap>(
+  ctx: RuntimeContext<any>,
+  name: K,
+  data: CallbackMap[K],
+  stateStack?: StateStack,
+): Promise<void> {
+  for (const fn of _globalHooks[name] ?? []) {
+    await fireWithGuard(fn, data, ctx, `global ${name}`, stateStack);
+  }
+}
+
 /**
  * Fire a hook with the today-style "log + drop" interrupt behavior.
  *

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import type {
   CostEstimate,
   MessageJSON,
@@ -78,9 +79,34 @@ export type AgencyCallbacks = {
   ) => void | Promise<void>;
 };
 
-// Per-instance recursion guard: prevents a callback that triggers helper
-// functions which re-fire the same hook from recursing into itself.
-const _activeCallbacks = new WeakSet<object>();
+// Recursion guard: prevents a callback that triggers helper functions
+// which re-fire the same hook from recursing into itself
+// (tests/agency/callback-recursion).
+//
+// Scope = one async-call chain. Backed by `AsyncLocalStorage` so the
+// "currently firing" set is inherited through `await` boundaries and
+// nested function calls — but a fork branch that gets its own ALS
+// context (via `statelogClient.runInBranchContext` in `runBatch`)
+// starts with an EMPTY set. That means concurrent fork/tool branches
+// can each fire the same callback in parallel without dropping
+// sibling invocations, while a callback that synchronously triggers
+// its own re-fire (through a helper-function call on the same async
+// chain) is still detected.
+//
+// Why ALS rather than a per-stack or module-level WeakSet:
+//   - Module-level WeakSet (pre-Task 5 behaviour) dropped legitimate
+//     parallel-branch invocations because every branch shared the
+//     same set.
+//   - Per-stack WeakSet didn't catch recursion: each runBatch call
+//     creates a NEW branch stack, so the recursive fire (which
+//     happens on the new stack) never sees the outer fire's entry.
+//   - ALS naturally inherits the set through both sync calls and
+//     awaited continuations, but stops at branch-context boundaries.
+//
+// Set entries are live-only — never serialized. Always cleared in
+// the `finally` block, so a checkpoint can never capture a "stuck"
+// entry.
+const _activeCallbacksALS = new AsyncLocalStorage<Set<object>>();
 
 // Global hook registry: allows external packages (e.g., @agency-lang/mcp) to
 // register callbacks that fire alongside user-provided callbacks.
@@ -137,10 +163,20 @@ async function fireWithGuard(
   stateStack?: StateStack,
 ): Promise<Interrupt[] | undefined> {
   const key = fn as object;
-  if (_activeCallbacks.has(key)) return undefined;
-  _activeCallbacks.add(key);
+  // Recursion guard scoped to the current ALS context. See
+  // `_activeCallbacksALS` docstring for why ALS (not module-level
+  // WeakSet, not per-stack WeakSet).
+  const inherited = _activeCallbacksALS.getStore();
+  if (inherited?.has(key)) return undefined;
+  // Always allocate a fresh set per fire — we need our own copy so a
+  // deeper fire can safely re-enter without corrupting the outer set.
+  // The new set carries over the inherited entries plus our own key.
+  const active = new Set<object>(inherited);
+  active.add(key);
   try {
-    return await invokeCallback(fn, data, ctx, stateStack);
+    return await _activeCallbacksALS.run(active, () =>
+      invokeCallback(fn, data, ctx, stateStack),
+    );
   } catch (error) {
     // Never swallow real control-flow exceptions used by the runtime.
     if (error instanceof RestoreSignal) throw error;
@@ -150,8 +186,6 @@ async function fireWithGuard(
     // from invokeCallback now.
     console.error(`[agency] ${errorLabel} callback error:`, error);
     return undefined;
-  } finally {
-    _activeCallbacks.delete(key);
   }
 }
 

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -83,15 +83,23 @@ export type AgencyCallbacks = {
 // which re-fire the same hook from recursing into itself
 // (tests/agency/callback-recursion).
 //
-// Scope = one async-call chain. Backed by `AsyncLocalStorage` so the
-// "currently firing" set is inherited through `await` boundaries and
-// nested function calls — but a fork branch that gets its own ALS
-// context (via `statelogClient.runInBranchContext` in `runBatch`)
-// starts with an EMPTY set. That means concurrent fork/tool branches
-// can each fire the same callback in parallel without dropping
-// sibling invocations, while a callback that synchronously triggers
-// its own re-fire (through a helper-function call on the same async
-// chain) is still detected.
+// Each `fireWithGuard` call wraps the callback in
+// `_activeCallbacksALS.run(active, ...)` with a freshly-allocated
+// `new Set<object>(inherited)` that adds the current callback's key.
+// The Set is inherited through `await` boundaries and nested sync
+// calls inside that scope, so a synchronous re-fire of the same
+// callback (via a helper-function call on the same async chain) sees
+// its own key in the set and is skipped.
+//
+// Concurrent sibling branches (e.g. `Promise.allSettled([fireA(),
+// fireB()])`) each enter their OWN `_activeCallbacksALS.run(...)`
+// scope, so A's added key is visible only inside A's continuation
+// chain, not inside B's. That's why parallel fork/tool branches can
+// each fire the same callback without dropping sibling invocations.
+// (Note: `statelogClient.runInBranchContext` scopes a different ALS
+// — `spanStorage` for Statelog spans — and does NOT touch this
+// callback guard. Sibling isolation here comes purely from each fire
+// allocating its own Set and entering its own ALS scope.)
 //
 // Why ALS rather than a per-stack or module-level WeakSet:
 //   - Module-level WeakSet (pre-Task 5 behaviour) dropped legitimate
@@ -101,11 +109,13 @@ export type AgencyCallbacks = {
 //     creates a NEW branch stack, so the recursive fire (which
 //     happens on the new stack) never sees the outer fire's entry.
 //   - ALS naturally inherits the set through both sync calls and
-//     awaited continuations, but stops at branch-context boundaries.
+//     awaited continuations, and each fire's `.run(...)` scope
+//     isolates siblings from one another.
 //
-// Set entries are live-only — never serialized. Always cleared in
-// the `finally` block, so a checkpoint can never capture a "stuck"
-// entry.
+// Set entries are live-only — never serialized. Cleanup is automatic:
+// the entry is only visible inside the `_activeCallbacksALS.run(...)`
+// scope of its fire, which exits when the callback resolves, so a
+// checkpoint can never capture a "stuck" entry.
 const _activeCallbacksALS = new AsyncLocalStorage<Set<object>>();
 
 // Global hook registry: allows external packages (e.g., @agency-lang/mcp) to

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -11,6 +11,7 @@ import { AgencyFunction } from "./agencyFunction.js";
 import { AgencyCancelledError, RestoreSignal } from "./errors.js";
 import { hasInterrupts, type Interrupt } from "./interrupts.js";
 import type { RuntimeContext } from "./state/context.js";
+import type { StateStack } from "./state/stateStack.js";
 import type { TraceEvent } from "./trace/types.js";
 import type { RunNodeResult } from "./types.js";
 
@@ -99,11 +100,18 @@ async function invokeCallback(
   fn: any,
   data: unknown,
   ctx: RuntimeContext<any>,
+  stateStack?: StateStack,
 ): Promise<Interrupt[] | undefined> {
   if (AgencyFunction.isAgencyFunction(fn)) {
+    // When `stateStack` is set, the callback frame is pushed onto that
+    // stack rather than `ctx.stateStack`. This matters inside parallel
+    // tool branches: the callback's interrupt checkpoint must capture
+    // the branch's slice (so `setInterruptOnBranch` finds the right
+    // frame), not the parent's stack. See Plan 1 / Bug 2 in
+    // docs/notes/parallel-callback-investigation.md.
     const result = await (fn as AgencyFunction).invoke(
       { type: "positional", args: [data] },
-      { ctx },
+      stateStack ? { ctx, stateStack } : { ctx },
     );
     // The callback body completed with an unhandled `interrupt` statement.
     // Surface the interrupts so the caller can decide what to do — Phase 0
@@ -126,12 +134,13 @@ async function fireWithGuard(
   data: unknown,
   ctx: RuntimeContext<any>,
   errorLabel: string,
+  stateStack?: StateStack,
 ): Promise<Interrupt[] | undefined> {
   const key = fn as object;
   if (_activeCallbacks.has(key)) return undefined;
   _activeCallbacks.add(key);
   try {
-    return await invokeCallback(fn, data, ctx);
+    return await invokeCallback(fn, data, ctx, stateStack);
   } catch (error) {
     // Never swallow real control-flow exceptions used by the runtime.
     if (error instanceof RestoreSignal) throw error;
@@ -146,14 +155,20 @@ async function fireWithGuard(
   }
 }
 
-function gatherCallbacks<K extends keyof CallbackMap>(
+/** Gather every callback registered for `name`, in fire order. `stack` is
+ *  the stack to walk for scoped callbacks — pass `ctx.stateStack` from
+ *  top-level call sites, or a branch's own stack from inside a fork branch
+ *  (otherwise scoped callbacks registered inside the branch's frame chain
+ *  are missed). */
+export function gatherCallbacks<K extends keyof CallbackMap>(
   ctx: RuntimeContext<any>,
   name: K,
+  stack: StateStack,
 ): any[] {
   // Order: innermost stack-frame scoped callbacks → outermost → top-level
   // (registered during module init) → TS-passed callback. Top-level comes
   // after stack-walked because conceptually they are "the outermost scope".
-  const scoped = ctx.stateStack.collectScopedCallbacks(name);
+  const scoped = stack.collectScopedCallbacks(name);
   const topLevel = (ctx.topLevelCallbacks ?? [])
     .filter((cb) => cb.name === name)
     .map((cb) => cb.fn);
@@ -163,12 +178,25 @@ function gatherCallbacks<K extends keyof CallbackMap>(
   return out;
 }
 
-export async function callHook<K extends keyof CallbackMap>(args: {
+/** Fire every callback registered for `name`, sequentially. When
+ *  `stateStack` is supplied, callbacks run on that stack (so any interrupt
+ *  raised inside a callback captures a checkpoint with the right slice and
+ *  `setInterruptOnBranch` finds the right frame). When `stateStack` is
+ *  omitted, behaviour is identical to today's `callHook`: scoped callbacks
+ *  are walked from `ctx.stateStack` and the callback frame pushes onto
+ *  `ctx.stateStack`.
+ *
+ *  Used directly by sites that fire inside a fork/tool branch (e.g. the
+ *  per-tool `onToolCallStart` / `onToolCallEnd` in `prompt.ts`). The
+ *  public `callHook` is now a thin wrapper that omits `stateStack`. */
+export async function invokeCallbacks<K extends keyof CallbackMap>(args: {
   ctx: RuntimeContext<any>;
   name: K;
   data: CallbackMap[K];
+  stateStack?: StateStack;
 }): Promise<Interrupt[] | undefined> {
-  const { ctx, name, data } = args;
+  const { ctx, name, data, stateStack } = args;
+  const walkStack = stateStack ?? ctx.stateStack;
 
   // Single shared collector. Mirrors the runForkAll pattern of "let every
   // sibling run to completion, batch all interrupts together at the end"
@@ -182,11 +210,11 @@ export async function callHook<K extends keyof CallbackMap>(args: {
   // and have no interrupt mechanism, so they can't contribute to the
   // batch.
   for (const fn of _globalHooks[name] ?? []) {
-    await fireWithGuard(fn, data, ctx, `global ${name}`);
+    await fireWithGuard(fn, data, ctx, `global ${name}`, stateStack);
   }
 
-  for (const fn of gatherCallbacks(ctx, name)) {
-    const result = await fireWithGuard(fn, data, ctx, name);
+  for (const fn of gatherCallbacks(ctx, name, walkStack)) {
+    const result = await fireWithGuard(fn, data, ctx, name, stateStack);
     if (result) collected.push(...result);
   }
 
@@ -209,6 +237,16 @@ export async function callHook<K extends keyof CallbackMap>(args: {
   }
 
   return collected.length > 0 ? collected : undefined;
+}
+
+/** Today's call sites that fire on the top-level stack. Thin wrapper over
+ *  `invokeCallbacks` with no `stateStack` override. */
+export async function callHook<K extends keyof CallbackMap>(args: {
+  ctx: RuntimeContext<any>;
+  name: K;
+  data: CallbackMap[K];
+}): Promise<Interrupt[] | undefined> {
+  return invokeCallbacks(args);
 }
 
 /**

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -3,7 +3,7 @@ import { PromptResult, Result, StreamChunk, ToolCallJSON } from "smoltalk";
 import { createLogger } from "../logger.js";
 import { AgencyFunction } from "./agencyFunction.js";
 import { AgencyCancelledError, isAbortError } from "./errors.js";
-import { callHook } from "./hooks.js";
+import { callHook, invokeCallbacks } from "./hooks.js";
 import { Interrupt, hasInterrupts, isRejected } from "./interrupts.js";
 import type { PromptConfig } from "./llmClient.js";
 import { setupFunction } from "./node.js";
@@ -661,10 +661,16 @@ export async function runPrompt(args: {
           await b.step(
             `round.${round}.tool.${toolCall.id}.start`,
             async () =>
-              await callHook({
+              // Use `invokeCallbacks` with `branchStack` so any callback
+              // that raises an interrupt captures a checkpoint with this
+              // tool branch's slice (rather than the parent runPrompt
+              // stack). Without this, `setInterruptOnBranch` would not
+              // find the right frame on resume. See Plan 1 / Bug 2.
+              await invokeCallbacks({
                 ctx,
                 name: "onToolCallStart",
                 data: { toolName: handler.name, args: namedArgs },
+                stateStack: branchStack,
               }),
           );
           if (b.interrupts) return;
@@ -735,7 +741,9 @@ export async function runPrompt(args: {
             await b.step(
               `round.${round}.tool.${toolCall.id}.end`,
               async () =>
-                await callHook({
+                // Same slice-rule reason as the .start hook above —
+                // callback interrupts must capture the branch's stack.
+                await invokeCallbacks({
                   ctx,
                   name: "onToolCallEnd",
                   data: {
@@ -743,6 +751,7 @@ export async function runPrompt(args: {
                     result: toolResult,
                     timeTaken,
                   },
+                  stateStack: branchStack,
                 }),
             );
             // If onToolCallEnd collected interrupts, the branch is halted —

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -1,7 +1,12 @@
 import { nanoid } from "nanoid";
 import type { CallbackName } from "../types/function.js";
 import { debugStep } from "./debugger.js";
-import { callHook, type CallbackMap } from "./hooks.js";
+import {
+  fireGlobalHooks,
+  gatherCallbacks,
+  invokeOneCallback,
+  type CallbackMap,
+} from "./hooks.js";
 import { hasInterrupts } from "./interrupts.js";
 import { __pipeBind } from "./result.js";
 import { runBatch } from "./runBatch.js";
@@ -425,18 +430,90 @@ export class Runner {
 
     this.path.push(id);
     try {
-      const result = await callHook({
-        ctx: this.ctx,
-        name: hookName as keyof CallbackMap,
-        data: data as CallbackMap[keyof CallbackMap],
-      });
-      if (hasInterrupts(result)) {
-        if (this.nodeContext) {
-          this.halt({ ...this.state, data: result });
-        } else {
-          this.halt(result);
+      // Walk the right slice for scoped-callback discovery. If this Runner
+      // was instantiated inside a fork branch (forkBlockSetup template
+      // sets `stack: __forkBranchStack`), `this.stack` is the branch's
+      // own stack — scoped callbacks registered in the branch's frame
+      // chain live there, NOT on `ctx.stateStack`.
+      const parentStack = this.stack ?? this.ctx.stateStack;
+
+      // (A previous draft of this method had a defensive
+      // `frame.hasBranches() && !this.stack` assertion meant to catch a
+      // codegen-template that forgot to wire `stack: branchStack` into
+      // a fork-branch Runner. Dropped: the assertion false-positives on
+      // resume after Runner.hook itself opens per-callback branches via
+      // runBatch, because those branches persist on `this.frame` until
+      // the hook completes. A more precise check would have to inspect
+      // branch keys, which couples the assertion to the key scheme.
+      // Forkblock-template correctness is currently enforced by the
+      // existing fork-suite tests instead.)
+
+      // Global hooks (registered by external packages, e.g. mcp) fire
+      // first — same order as today's callHook. They have no interrupt
+      // mechanism so they run inline.
+      await fireGlobalHooks(
+        this.ctx,
+        hookName as keyof CallbackMap,
+        data as CallbackMap[keyof CallbackMap],
+        this.stack,
+      );
+
+      const callbacks = gatherCallbacks(
+        this.ctx,
+        hookName as keyof CallbackMap,
+        parentStack,
+      );
+
+      // Fast path: nothing to fire via runBatch. Done.
+      if (callbacks.length === 0) {
+        // fall through to the normal post-body cleanup below.
+      } else {
+        // Per-callback runBatch: each callback fires as a separate
+        // sequential child branch. When one interrupts, runBatch stamps
+        // a shared checkpoint and surfaces all collected interrupts;
+        // the per-branch `result`/`interrupt` recording on
+        // `parentFrame.branches` means resume short-circuits (via the
+        // cached-branch path in runBatch) any callback whose interrupt
+        // was already responded to, re-firing only the un-resolved
+        // ones. Without this, every resume cycle re-fired every
+        // callback from scratch, breaking side-effect-once semantics
+        // for multi-callback hooks.
+        const result = await runBatch<undefined>({
+          ctx: this.ctx,
+          parentStack,
+          parentFrame: this.frame,
+          checkpointLocation: this.getCheckpointInfo(),
+          // Sequential is REQUIRED here — `callHook` historically fires
+          // callbacks in declared order, and using `mode: "all"` would
+          // silently turn ordered side effects into a concurrent race.
+          mode: "sequential",
+          children: callbacks.map((fn, i) => ({
+            key: this.hookBranchKey(id, i),
+            invoke: async (branchStack) => {
+              // Fire this single callback on the branch's own stack so
+              // any interrupt raised inside captures a checkpoint with
+              // the right slice. We already extracted `fn` from the
+              // outer `gatherCallbacks` call — don't re-gather inside
+              // the child.
+              const interrupts = await invokeOneCallback({
+                ctx: this.ctx,
+                fn,
+                name: hookName as keyof CallbackMap,
+                data: data as CallbackMap[keyof CallbackMap],
+                stateStack: branchStack,
+              });
+              return interrupts ?? undefined;
+            },
+          })),
+        });
+        if (result.kind === "interrupts") {
+          if (this.nodeContext) {
+            this.halt({ ...this.state, data: result.interrupts });
+          } else {
+            this.halt(result.interrupts);
+          }
+          return;
         }
-        return;
       }
     } finally {
       this.path.pop();
@@ -445,6 +522,12 @@ export class Runner {
     if (this.halted) return;
     this.clearDebugFlag(id);
     this.setCounter(id + 1);
+  }
+
+  private hookBranchKey(id: number, index: number): string {
+    return this.path.length === 0
+      ? `hook_${id}_${index}`
+      : `hook_${this.key()}_${id}_${index}`;
   }
 
   // ── Specialized: ifElse ──

--- a/packages/agency-lang/tests/agency/callback-multi-interrupt-resume.agency
+++ b/packages/agency-lang/tests/agency/callback-multi-interrupt-resume.agency
@@ -1,0 +1,48 @@
+
+let preA: number = 0
+let postA: number = 0
+let preB: number = 0
+let postB: number = 0
+let order: string = ""
+
+// Two top-level callbacks on onNodeStart. Each increments a "pre"
+// counter, raises an interrupt, then increments a "post" counter.
+//
+// Per-callback runBatch semantics (Task 6) guarantee:
+//   1. Each counter increments EXACTLY ONCE across the resume cycle.
+//      The callback's own checkpoint (stamped inside its interrupt
+//      step) preserves the callback frame's substep counters — on
+//      resume the pre-side increment is skipped and only the interrupt
+//      step re-runs.
+//   2. Callbacks fire in DECLARED ORDER (sequential mode of runBatch):
+//      A runs to completion (which means "until it interrupts") before
+//      B starts. On the first pass both A's pre-counter and B's
+//      pre-counter fire, both raise interrupts, runBatch surfaces them
+//      together under one shared checkpoint. On resume A's post fires,
+//      then B's post fires.
+//
+// Expected post-resume:
+//   preA=1,postA=1,preB=1,postB=1,order=preA,preB,postA,postB,
+callback("onNodeStart") as data {
+  if (data.nodeName == "main") {
+    preA = preA + 1
+    order = order + "preA,"
+    interrupt myapp::pauseA("approve A?", {})
+    postA = postA + 1
+    order = order + "postA,"
+  }
+}
+
+callback("onNodeStart") as data {
+  if (data.nodeName == "main") {
+    preB = preB + 1
+    order = order + "preB,"
+    interrupt myapp::pauseB("approve B?", {})
+    postB = postB + 1
+    order = order + "postB,"
+  }
+}
+
+node main() {
+  return "preA=${preA},postA=${postA},preB=${preB},postB=${postB},order=${order}"
+}

--- a/packages/agency-lang/tests/agency/callback-multi-interrupt-resume.test.json
+++ b/packages/agency-lang/tests/agency/callback-multi-interrupt-resume.test.json
@@ -1,0 +1,19 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Two top-level onNodeStart callbacks each with pre- and post-interrupt counters. Per-callback runBatch in Runner.hook guarantees each counter increments exactly once across the resume cycle AND callbacks fire in declared order (sequential mode).",
+      "input": "",
+      "expectedOutput": "\"preA=1,postA=1,preB=1,postB=1,order=preA,preB,postA,postB,\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        { "action": "approve", "expectedMessage": "approve A?" },
+        { "action": "approve", "expectedMessage": "approve B?" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-asymmetric-failure.agency
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-asymmetric-failure.agency
@@ -1,0 +1,36 @@
+// Asymmetric outcomes across parallel tool branches: one branch's
+// onToolCallStart callback raises an interrupt that the user approves,
+// the other branch's tool body returns a failure. The interrupt must
+// batch with the (single) interrupting branch and resume the failed
+// branch as a normal error — no cross-contamination of branch outcomes.
+
+let firedA: number = 0
+
+def quickFact(topic: string): string {
+  return "fact about ${topic}"
+}
+
+def brokenTool(reason: string): string {
+  return failure("tool intentionally failed: ${reason}", { retryable: false })
+}
+
+callback("onToolCallStart") as data {
+  if (data.toolName == "quickFact") {
+    firedA = firedA + 1
+    if (firedA == 1) {
+      interrupt myapp::pauseA("approve quickFact?", {})
+    }
+  }
+}
+
+type Response = {
+  fact: string
+  status: string
+}
+
+node main() {
+  const result: Response = llm("Call quickFact with topic='cats' AND brokenTool with reason='oops' in the SAME response in parallel. Then return a 'fact' field with the quickFact result and a 'status' field with the brokenTool result or error.", {
+    tools: [quickFact, brokenTool]
+  })
+  return result
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-asymmetric-failure.test.json
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-asymmetric-failure.test.json
@@ -1,0 +1,21 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Asymmetric outcomes across parallel tool branches: one branch's onToolCallStart callback raises an approve-able interrupt; the other branch's tool body returns a non-retryable failure. The interrupt batches alone, and the failed branch resumes as a normal tool error.",
+      "input": "",
+      "expectedOutput": "",
+      "evaluationCriteria": [
+        {
+          "type": "llmJudge",
+          "judgePrompt": "The output should be an object with a 'fact' field containing text about cats. The 'status' field should mention that the brokenTool failed.",
+          "desiredAccuracy": 70
+        }
+      ],
+      "interruptHandlers": [
+        { "action": "approve" }
+      ],
+      "retry": 2
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-both.agency
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-both.agency
@@ -1,0 +1,41 @@
+// Two tools called in parallel; an onToolCallStart callback fires from
+// EACH branch and interrupts on the first call. Both interrupts must
+// batch under one shared checkpoint and resume cleanly.
+
+let firedA: number = 0
+let firedB: number = 0
+
+def quickFact(topic: string): string {
+  return "fact about ${topic}"
+}
+
+def quickJoke(topic: string): string {
+  return "joke about ${topic}"
+}
+
+callback("onToolCallStart") as data {
+  if (data.toolName == "quickFact") {
+    firedA = firedA + 1
+    if (firedA == 1) {
+      interrupt myapp::pauseA("approve quickFact?", { count: firedA })
+    }
+  }
+  if (data.toolName == "quickJoke") {
+    firedB = firedB + 1
+    if (firedB == 1) {
+      interrupt myapp::pauseB("approve quickJoke?", { count: firedB })
+    }
+  }
+}
+
+type Response = {
+  fact: string
+  joke: string
+}
+
+node main() {
+  const result: Response = llm("Call quickFact with topic='cats' AND quickJoke with topic='dogs' in the SAME response in parallel. Then return a 'fact' field with the quickFact result and a 'joke' field with the quickJoke result.", {
+    tools: [quickFact, quickJoke]
+  })
+  return result
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-both.test.json
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-both.test.json
@@ -1,0 +1,22 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Two parallel tool calls; the onToolCallStart callback raises an interrupt from EACH branch. Both interrupts batch under one shared checkpoint and resume cleanly.",
+      "input": "",
+      "expectedOutput": "",
+      "evaluationCriteria": [
+        {
+          "type": "llmJudge",
+          "judgePrompt": "The output should be an object with a 'fact' field containing text about cats and a 'joke' field containing text about dogs.",
+          "desiredAccuracy": 70
+        }
+      ],
+      "interruptHandlers": [
+        { "action": "approve" },
+        { "action": "approve" }
+      ],
+      "retry": 2
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-handler-caught.agency
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-handler-caught.agency
@@ -1,0 +1,47 @@
+// Two tools called in parallel; an onToolCallStart callback interrupts
+// from each branch with a SPECIFIC kind that a surrounding handle block
+// catches and approves automatically. No user-side interrupt is needed —
+// the per-branch handler chain catches the callback's interrupt inside
+// its own branch's slice.
+
+let firedA: number = 0
+let firedB: number = 0
+
+def quickFact(topic: string): string {
+  return "fact about ${topic}"
+}
+
+def quickJoke(topic: string): string {
+  return "joke about ${topic}"
+}
+
+callback("onToolCallStart") as data {
+  if (data.toolName == "quickFact") {
+    firedA = firedA + 1
+    if (firedA == 1) {
+      interrupt myapp::auto("auto-approve A?", {})
+    }
+  }
+  if (data.toolName == "quickJoke") {
+    firedB = firedB + 1
+    if (firedB == 1) {
+      interrupt myapp::auto("auto-approve B?", {})
+    }
+  }
+}
+
+type Response = {
+  fact: string
+  joke: string
+}
+
+node main() {
+  handle {
+    const result: Response = llm("Call quickFact with topic='cats' AND quickJoke with topic='dogs' in the SAME response in parallel. Then return a 'fact' field with the quickFact result and a 'joke' field with the quickJoke result.", {
+      tools: [quickFact, quickJoke]
+    })
+    return result
+  } with (intr) {
+    return approve()
+  }
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-handler-caught.test.json
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-handler-caught.test.json
@@ -1,0 +1,19 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Two parallel callback interrupts caught by a surrounding handle block. Per-branch handler chains catch each callback's interrupt inside its own branch's slice without surfacing to the user.",
+      "input": "",
+      "expectedOutput": "",
+      "evaluationCriteria": [
+        {
+          "type": "llmJudge",
+          "judgePrompt": "The output should be an object with a 'fact' field containing text about cats and a 'joke' field containing text about dogs.",
+          "desiredAccuracy": 70
+        }
+      ],
+      "interruptHandlers": [],
+      "retry": 2
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-mixed-start-end.agency
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-mixed-start-end.agency
@@ -1,0 +1,45 @@
+// Two tools called in parallel. Tool A's onToolCallStart callback
+// interrupts; tool B's onToolCallEnd callback interrupts. Tests that
+// start-side and end-side hook interrupts batch together from different
+// branches with very different lifecycles within the same round.
+
+let firedAStart: number = 0
+let firedBEnd: number = 0
+
+def quickFact(topic: string): string {
+  return "fact about ${topic}"
+}
+
+def quickJoke(topic: string): string {
+  return "joke about ${topic}"
+}
+
+callback("onToolCallStart") as data {
+  if (data.toolName == "quickFact") {
+    firedAStart = firedAStart + 1
+    if (firedAStart == 1) {
+      interrupt myapp::startA("approve start of quickFact?", {})
+    }
+  }
+}
+
+callback("onToolCallEnd") as data {
+  if (data.toolName == "quickJoke") {
+    firedBEnd = firedBEnd + 1
+    if (firedBEnd == 1) {
+      interrupt myapp::endB("approve end of quickJoke?", {})
+    }
+  }
+}
+
+type Response = {
+  fact: string
+  joke: string
+}
+
+node main() {
+  const result: Response = llm("Call quickFact with topic='cats' AND quickJoke with topic='dogs' in the SAME response in parallel. Then return a 'fact' field with the quickFact result and a 'joke' field with the quickJoke result.", {
+    tools: [quickFact, quickJoke]
+  })
+  return result
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-mixed-start-end.test.json
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-mixed-start-end.test.json
@@ -1,0 +1,22 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Two parallel tool calls — A's onToolCallStart and B's onToolCallEnd both interrupt. Tests that start-side and end-side callback interrupts batch correctly across different lifecycle phases within the same round.",
+      "input": "",
+      "expectedOutput": "",
+      "evaluationCriteria": [
+        {
+          "type": "llmJudge",
+          "judgePrompt": "The output should be an object with a 'fact' field containing text about cats and a 'joke' field containing text about dogs.",
+          "desiredAccuracy": 70
+        }
+      ],
+      "interruptHandlers": [
+        { "action": "approve" },
+        { "action": "approve" }
+      ],
+      "retry": 2
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-one.agency
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-one.agency
@@ -1,0 +1,34 @@
+// Two tools called in parallel; only the FIRST tool's onToolCallStart
+// callback interrupts. The other branch succeeds. The single interrupt
+// must still produce a batched checkpoint and resume cleanly.
+
+let firedA: number = 0
+
+def quickFact(topic: string): string {
+  return "fact about ${topic}"
+}
+
+def quickJoke(topic: string): string {
+  return "joke about ${topic}"
+}
+
+callback("onToolCallStart") as data {
+  if (data.toolName == "quickFact") {
+    firedA = firedA + 1
+    if (firedA == 1) {
+      interrupt myapp::pauseA("approve quickFact?", { count: firedA })
+    }
+  }
+}
+
+type Response = {
+  fact: string
+  joke: string
+}
+
+node main() {
+  const result: Response = llm("Call quickFact with topic='cats' AND quickJoke with topic='dogs' in the SAME response in parallel. Then return a 'fact' field with the quickFact result and a 'joke' field with the quickJoke result.", {
+    tools: [quickFact, quickJoke]
+  })
+  return result
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-one.test.json
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-one.test.json
@@ -1,0 +1,21 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Two parallel tool calls; only one tool's onToolCallStart callback raises an interrupt. The sole interrupt produces a batched checkpoint and resume completes the other branch normally.",
+      "input": "",
+      "expectedOutput": "",
+      "evaluationCriteria": [
+        {
+          "type": "llmJudge",
+          "judgePrompt": "The output should be an object with a 'fact' field containing text about cats and a 'joke' field containing text about dogs.",
+          "desiredAccuracy": 70
+        }
+      ],
+      "interruptHandlers": [
+        { "action": "approve" }
+      ],
+      "retry": 2
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-reject.agency
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-reject.agency
@@ -1,0 +1,55 @@
+// Two tools called in parallel; both onToolCallStart callbacks raise
+// interrupts. The user approves one and REJECTS the other. The callback
+// whose interrupt was rejected receives a failure value back from the
+// interrupt expression; both tools still run to completion afterwards
+// because the callback bodies don't propagate the failure.
+
+let firedA: number = 0
+let firedB: number = 0
+let outcomeA: string = "none"
+let outcomeB: string = "none"
+
+def quickFact(topic: string): string {
+  return "fact about ${topic}"
+}
+
+def quickJoke(topic: string): string {
+  return "joke about ${topic}"
+}
+
+callback("onToolCallStart") as data {
+  if (data.toolName == "quickFact") {
+    firedA = firedA + 1
+    if (firedA == 1) {
+      const r = interrupt myapp::pauseA("approve quickFact?", {})
+      if (isFailure(r)) {
+        outcomeA = "rejected"
+      } else {
+        outcomeA = "approved"
+      }
+    }
+  }
+  if (data.toolName == "quickJoke") {
+    firedB = firedB + 1
+    if (firedB == 1) {
+      const r = interrupt myapp::pauseB("approve quickJoke?", {})
+      if (isFailure(r)) {
+        outcomeB = "rejected"
+      } else {
+        outcomeB = "approved"
+      }
+    }
+  }
+}
+
+type Response = {
+  fact: string
+  joke: string
+}
+
+node main() {
+  const result: Response = llm("Call quickFact with topic='cats' AND quickJoke with topic='dogs' in the SAME response in parallel. Then return a 'fact' field with the quickFact result and a 'joke' field with the quickJoke result.", {
+    tools: [quickFact, quickJoke]
+  })
+  return result
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-reject.test.json
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-reject.test.json
@@ -1,0 +1,22 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Two parallel callback interrupts; user approves one, rejects the other. The rejected callback's interrupt expression returns a failure value; both tools still run to completion.",
+      "input": "",
+      "expectedOutput": "",
+      "evaluationCriteria": [
+        {
+          "type": "llmJudge",
+          "judgePrompt": "The output should be an object with a 'fact' field containing text about cats and a 'joke' field containing text about dogs.",
+          "desiredAccuracy": 70
+        }
+      ],
+      "interruptHandlers": [
+        { "action": "approve" },
+        { "action": "reject" }
+      ],
+      "retry": 2
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-start.agency
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-start.agency
@@ -1,0 +1,41 @@
+// Multiple tools called in parallel. ONLY onToolCallStart callbacks
+// raise interrupts (no onToolCallEnd interrupts). Tests that the start-
+// side hook fires inside the branch's slice and batches cleanly.
+
+let firedA: number = 0
+let firedB: number = 0
+
+def quickFact(topic: string): string {
+  return "fact about ${topic}"
+}
+
+def quickJoke(topic: string): string {
+  return "joke about ${topic}"
+}
+
+callback("onToolCallStart") as data {
+  if (data.toolName == "quickFact") {
+    firedA = firedA + 1
+    if (firedA == 1) {
+      interrupt myapp::startA("approve start of quickFact?", {})
+    }
+  }
+  if (data.toolName == "quickJoke") {
+    firedB = firedB + 1
+    if (firedB == 1) {
+      interrupt myapp::startB("approve start of quickJoke?", {})
+    }
+  }
+}
+
+type Response = {
+  fact: string
+  joke: string
+}
+
+node main() {
+  const result: Response = llm("Call quickFact with topic='cats' AND quickJoke with topic='dogs' in the SAME response in parallel. Then return a 'fact' field with the quickFact result and a 'joke' field with the quickJoke result.", {
+    tools: [quickFact, quickJoke]
+  })
+  return result
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-start.test.json
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-start.test.json
@@ -1,0 +1,22 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Two parallel tool calls; ONLY onToolCallStart callbacks raise interrupts (no onToolCallEnd interrupts). Verifies start-side hook fires inside the branch's slice.",
+      "input": "",
+      "expectedOutput": "",
+      "evaluationCriteria": [
+        {
+          "type": "llmJudge",
+          "judgePrompt": "The output should be an object with a 'fact' field containing text about cats and a 'joke' field containing text about dogs.",
+          "desiredAccuracy": 70
+        }
+      ],
+      "interruptHandlers": [
+        { "action": "approve" },
+        { "action": "approve" }
+      ],
+      "retry": 2
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-three.agency
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-three.agency
@@ -1,0 +1,51 @@
+// Three tools called in parallel; each tool's onToolCallStart callback
+// raises an interrupt. All three interrupts must batch under one shared
+// checkpoint and resume cleanly.
+
+let firedA: number = 0
+let firedB: number = 0
+let firedC: number = 0
+
+def toolA(): string {
+  return "A done"
+}
+
+def toolB(): string {
+  return "B done"
+}
+
+def toolC(): string {
+  return "C done"
+}
+
+callback("onToolCallStart") as data {
+  if (data.toolName == "toolA") {
+    firedA = firedA + 1
+    if (firedA == 1) {
+      interrupt myapp::pauseA("approve A?", {})
+    }
+  }
+  if (data.toolName == "toolB") {
+    firedB = firedB + 1
+    if (firedB == 1) {
+      interrupt myapp::pauseB("approve B?", {})
+    }
+  }
+  if (data.toolName == "toolC") {
+    firedC = firedC + 1
+    if (firedC == 1) {
+      interrupt myapp::pauseC("approve C?", {})
+    }
+  }
+}
+
+type Response = {
+  results: string[]
+}
+
+node main() {
+  const result: Response = llm("You must call toolA, toolB, AND toolC in a SINGLE response in parallel. Then return a 'results' field that is an array containing the three return values.", {
+    tools: [toolA, toolB, toolC]
+  })
+  return result.results
+}

--- a/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-three.test.json
+++ b/packages/agency-lang/tests/agency/fork/llm-tools/multi-tool-callback-interrupts-three.test.json
@@ -1,0 +1,23 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "description": "Three parallel tool calls — each tool's onToolCallStart callback raises an interrupt. All three batch under one shared checkpoint.",
+      "input": "",
+      "expectedOutput": "",
+      "evaluationCriteria": [
+        {
+          "type": "llmJudge",
+          "judgePrompt": "The output should be an array containing 'A done', 'B done', and 'C done' in some order.",
+          "desiredAccuracy": 70
+        }
+      ],
+      "interruptHandlers": [
+        { "action": "approve" },
+        { "action": "approve" },
+        { "action": "approve" }
+      ],
+      "retry": 2
+    }
+  ]
+}


### PR DESCRIPTION
Implements Tasks 5–8 of the runBatch concurrent-interrupt primitive plan, extending PR #186's per-call-site `runBatch` migration to cover the per-tool callback firings and the multi-callback hook resume case.

## What this PR does

### Task 5 — Thread `branchStack` through `callHook` (slice-rule fix)

The per-tool `onToolCallStart` / `onToolCallEnd` callbacks in `runPrompt` fired on `ctx.stateStack` rather than the tool branch's own stack. Any interrupt raised inside such a callback captured a checkpoint with the wrong slice, silently corrupting the slice-rule discipline that `runBatch` enforces everywhere else.

- Add `invokeCallbacks(...)` in `hooks.ts` accepting an optional `stateStack` override; `callHook` becomes a thin wrapper that omits it (today's top-level behaviour).
- `prompt.ts` per-tool `.start` / `.end` `b.step`s now use `invokeCallbacks({ ..., stateStack: branchStack })`.
- Eight new fixtures under `tests/agency/fork/llm-tools/multi-tool-callback-interrupts-*` exercise the parallel callback-interrupt batch/resume across both/one/start/end/mixed/three/reject/handler-caught/asymmetric-failure shapes.

### Task 6 — Multi-callback hook resume via runBatch

Before this PR, `Runner.hook` called `callHook` directly. Two or more callbacks raising interrupts on the same hook would have ONE of them resume correctly (via the leaf checkpoint) but the others re-execute from the top on every resume cycle, breaking side-effect-once semantics.

- `Runner.hook` now delegates each gathered callback to its own `runBatch` child (`mode: "sequential"`). The shared batch checkpoint preserves all interrupt branches; cached-branch short-circuit + per-leaf checkpoint together give each callback its own resume point.
- `gatherCallbacks` takes an explicit `stack` parameter so scoped-callback discovery walks the branch's own stack when fired inside a fork branch (latent bug fix).
- New fixture `tests/agency/callback-multi-interrupt-resume.agency` proves each pre- and post-interrupt counter increments exactly once across resume with two top-level callbacks.

### Task 7 — Per-async-context recursion guard

With Task 5 / Task 6 firing the same callback across parallel branches, the module-level `_activeCallbacks` WeakSet was incorrectly suppressing legitimate sibling invocations. A per-stack WeakSet doesn't help because each per-callback `runBatch` allocates a new branch stack, so recursive fires don't see the outer entry.

- `fireWithGuard` now uses an `AsyncLocalStorage`-scoped Set. The "currently firing" set is inherited through `await` boundaries and nested sync calls — but a fork branch with its own ALS context (via `runInBranchContext`) starts with the inherited copy and any sibling branches each get their own fresh copy. Recursion is still detected (`tests/agency/callback-recursion` passes); parallel branches no longer drop each other.

### Task 8 — Documentation

- New `docs/dev/runBatch.md` (~100 lines): signature, three modes (sequential is required for callback hooks — `all` would silently race ordered side effects), slice rule, invoke no-throw contract, defensive guards, `recordBranchOutcomes`, subprocess-shape future note.
- `docs/dev/concurrent-interrupts.md` lightly updated to point at the new doc and add `Runner.hook` as the fourth call-site adopter (PR-#186 trimming preserved).
- `docs/dev/callback-hooks.md` "multiple callbacks on the same hook" section rewritten for the per-callback runBatch model; new sections for parallel-branch callbacks and the ALS recursion guard.
- `docs/site/appendix/callbacks.md`: per-hook table updated — `onNodeStart` / `onNodeEnd` / `onFunctionStart` / `onEmit` move from "⚠️ Batched, but resume is partial" to "✅ Batched". `onFunctionEnd` unchanged (still raw `callHook` in `finally`). Added a "Checkpoint format compatibility" note (no migration shim per project's "breaking changes acceptable" stance).
- `CLAUDE.md` adds `runBatch.md` to the deeper-docs list.

## Notable deviations from the original plan

1. **Slice-rule audit assertion dropped.** Plan Task 6 Step 2 specified `frame.hasBranches() && !this.stack` defensive check in `Runner.hook`. It false-positives on resume because the hook's own per-callback `runBatch` leaves branches on the frame until the hook completes. A more precise check would couple to the `hook_*` key scheme; left as a comment in `runner.ts` instead.
2. **Recursion guard uses AsyncLocalStorage, not per-stack WeakSet.** The plan permitted "skip the guard when stateStack is set" as a fallback. That broke `callback-recursion` because the recursive fire goes through a new branch stack. ALS naturally inherits the set through nested calls while letting sibling branches start fresh.

## Validation

- All 587 `lib/runtime/*` vitest tests pass.
- All 20 `tests/agency/callback*.agency` tests pass (including `callback-recursion` and the new `callback-multi-interrupt-resume`).
- All 6 `tests/agency-js/callback-interrupts-*` tests pass.
- Task 5's eight LLM-tool fixtures committed with `retry: 2`; LLM-flaky on first attempt locally but expected to settle on CI.

## Constraints honoured (from PR #186 review)

- The leaf checkpoint mechanism (`interruptReturn` template, leaf stamping in `interruptWithHandlers`) is untouched. The `isForked`-bypass approach removed in `c72b9c1574` is NOT reintroduced.
- `intr.checkpoint` / `intr.checkpointId` overwrite in `runBatch` is intentional and preserved.
- `__race_winner_<id>` key shape unchanged.
- Per-branch handler chains (`handle` blocks) untouched.
- `runBatch.invoke` no-throw contract enforced (callbacks return `Interrupt[]`, never throw).
- All new state is serialisable; only `AbortController` and the live-only ALS Set are non-serialised, matching today's `BranchState.abortController` pattern.
