### PR TITLE
WIP: guard(limit, block) stdlib function + 3 runtime-gap plans

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/index.md
+++ b/packages/agency-lang/docs/site/stdlib/index.md
@@ -106,6 +106,61 @@ A tool for rounding a number to a specified number of decimal places.
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L81))
 
+### __guardCheck
+
+```ts
+__guardCheck(state: { start: number; limit: number }, data: any)
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| state | `{ start: number; limit: number }` |  |
+| data | `any` |  |
+
+**Throws:** `std::guard_exceeded`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L95))
+
+### guard
+
+```ts
+guard(limit: number, block: () => any): any
+```
+
+Run a block with a cost limit. After every LLM call inside the
+  block, the cumulative cost since `guard` started is compared to
+  `limit`. If the spend exceeds the limit, an `std::guard_exceeded`
+  interrupt is raised with `{ spent, limit }`.
+
+  The user responds with a new (raised) limit as a number to continue
+  execution; the callback captures the response and uses it as the
+  new limit for subsequent checks. To abort, the user stops responding
+  to the interrupt (kills the agent process).
+
+  Nested guards each register their own scoped callback and check
+  independently — the innermost guard's limit triggers first. Inside
+  fork branches the per-branch cost-tracking semantics (see
+  `std::thread.getCost`) already account for branch spend.
+
+  Memory-layer LLM calls (memory.text / memory.embed) bypass the LLM
+  callback and do NOT count toward the limit.
+
+  @param limit - Maximum cost in dollars (USD)
+  @param block - The block to execute
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| limit | `number` |  |
+| block | `() => any` |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L105))
+
 ### fetch
 
 ```ts
@@ -132,7 +187,7 @@ A tool for fetching a URL and returning the response as text. Provide baseUrl an
 
 **Throws:** `std::fetch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L88))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L133))
 
 ### fetchJSON
 
@@ -160,7 +215,7 @@ A tool for fetching a URL and returning the response as parsed JSON. Provide bas
 
 **Throws:** `std::fetchJSON`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L109))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L154))
 
 ### read
 
@@ -184,7 +239,7 @@ A tool for reading the contents of a file and returning it as a string. The file
 
 **Throws:** `std::read`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L130))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L175))
 
 ### write
 
@@ -217,7 +272,7 @@ A tool for writing content to a file. The filename is resolved relative to dir.
 
 **Throws:** `std::write`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L144))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L189))
 
 ### readImage
 
@@ -241,7 +296,7 @@ A tool for reading an image file and returning its contents as a Base64-encoded 
 
 **Throws:** `std::readImage`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L172))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L217))
 
 ### notify
 
@@ -262,7 +317,7 @@ A tool for showing a native OS notification with a title and message. Returns tr
 
 **Throws:** `std::notify`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L186))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L231))
 
 ### range
 
@@ -281,7 +336,7 @@ Generate an array of numbers. With one argument, generates from 0 to start-1. Wi
 
 **Returns:** `number[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L197))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L242))
 
 ### mostCommon
 
@@ -299,7 +354,7 @@ Return the most common element in an array. Uses JSON serialization for comparis
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L207))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L252))
 
 ### keys
 
@@ -317,7 +372,7 @@ Return an array of an object's own enumerable property names.
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L214))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L259))
 
 ### values
 
@@ -335,7 +390,7 @@ Return an array of an object's own enumerable property values.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L221))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L266))
 
 ### entries
 
@@ -353,7 +408,7 @@ Return an array of an object's own enumerable entries, each as { key, value }.
 
 **Returns:** `any[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L228))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L273))
 
 ### emit
 
@@ -369,7 +424,7 @@ Emit a custom event to the calling TypeScript code via the onEmit callback.
 |---|---|---|
 | data |  |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L235))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L280))
 
 ### callback
 
@@ -391,4 +446,4 @@ Register a scoped callback for the dynamic extent of the calling function or nod
 | name | `string` |  |
 | fn | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L242))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/index.agency#L287))

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-23-callback-end-hook-substep-completion.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-23-callback-end-hook-substep-completion.md
@@ -2,23 +2,68 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** Make `onLLMCallEnd` (and, in scope-extension, every other "end"-shaped hook) mark its enclosing substep complete BEFORE firing the user callback, so that an interrupt raised inside the callback does not cause the substep — and the work it performed — to re-run on resume.
+**Goal:** Make `onLLMCallEnd` interrupts in `runPrompt` resume WITHOUT re-running the LLM API call. After resume the user-supplied callback re-fires (giving the user another chance to approve), but the underlying `_runPrompt` work — the API request, the assistant message push, the token-stat update — happens exactly once.
 
-**Surfaced by:** the `guard()` stdlib function (added in the same PR as this plan). With a `$0.0000001` limit, the first `llm()` call costs ~6e-6 and trips the callback's interrupt; on each resume the `llm()` re-fires, adding another ~6e-6 of cost per cycle. Observed sequence: spent grows 6e-6 → 12e-6 → 18e-6 → 24e-6 → 30e-6 across 5 cycles, linear, exactly one extra LLM call per cycle.
-
-**Root cause:** `Runner.step(id, body)` increments the substep counter (`setCounter(id + 1)`) *after* `body` returns successfully. `onLLMCallEnd` is fired from inside `prompt.ts` while it is still executing inside the surrounding `runner.step` body. If the callback raises an interrupt, the runner halts, the step body returns early, and `setCounter` never runs. On resume, the counter still points at the LLM step, so the step re-executes — re-invoking `llm()` and re-spending real money.
-
-This is the same shape as the bug class addressed by `docs/superpowers/plans/2026-05-22-callback-interrupts-deferred-return.md` for `onNodeEnd` (value-returning case) and `onFunctionEnd` (finally-block case). The "end" hook fires before the surrounding step's completion is committed.
-
-**Tech Stack:** TypeScript runtime (`lib/runtime/runner.ts`, `lib/runtime/prompt.ts`, `lib/runtime/promptRunner.ts`), `lib/runtime/hooks.ts`, fixtures.
+**Surfaced by:** the `guard()` stdlib function. With a `$0.0000001` budget the first `llm()` call costs ~6e-6 and trips the callback's interrupt; on each resume the LLM call re-fires, adding another ~6e-6 of spend per cycle. Observed linearly: 6e-6 → 12e-6 → 18e-6 → 24e-6 → 30e-6 across five cycles.
 
 ---
 
-### Task 1: Failing fixture
+## Root cause (revised — earlier draft of this plan misdiagnosed it)
+
+The blame is NOT on the outer user-code `Runner.step` wrapping the `llm(...)` call site. That outer step *does* receive a `Promise<Interrupt[]>` return value, halts correctly, and writes its own counter correctly. The re-execution lives one frame deeper: inside `runPrompt`'s OWN substep machinery, implemented by `PromptRunner` in `lib/runtime/promptRunner.ts`.
+
+Current shape of the LLM substep inside `runPrompt` ([prompt.ts L366-424](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/runtime/prompt.ts#L366-L424)):
+
+```ts
+await pr.step("initialLlmCall", async () => {
+  const lenBefore = messages.getMessages().length;
+  messages.push(smoltalk.userMessage(prompt));
+  ...
+  const result = await _runPrompt({ ctx, messages, ... });   // ← fires onLLMCallStart, calls API, pushes assistant msg,
+                                                              //   updates token stats, runs memory hooks, fires onLLMCallEnd
+  if (result.kind === "interrupt") {
+    messages.setMessages(messages.getMessages().slice(0, lenBefore));   // ← REWIND
+    closeLlmSpan();
+    return result.interrupts;                                            // ← bail without marking step complete
+  }
+  ...
+});
+```
+
+`PromptRunner.step` ([promptRunner.ts L92-128](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/runtime/promptRunner.ts#L92-L128)) deliberately does NOT push the key to `completedSteps` when the body returns interrupts — its design contract is "rewind to before this step on resume."
+
+That contract was correct when the only interrupts that could surface inside a step were "before the work" hooks (`onLLMCallStart`). It is fatally wrong for `onLLMCallEnd`, which fires AFTER the LLM API call has already happened and been paid for. The body's `messages.setMessages(...slice(0, lenBefore))` then throws the assistant message on the floor too — completing the waste.
+
+So the fix is to **split the single `initialLlmCall` substep into a sequence of finer-grained substeps**, each of which is small enough that the "rewind on interrupt" contract is correct for it:
+
+```diagram
+╭──────────────╮  ╭──────────────╮  ╭──────────────╮  ╭──────────────╮
+│ .user        │→ │ .start       │→ │ .api         │→ │ .end         │
+│ push user    │  │ onLLMCall    │  │ API call +   │  │ onLLMCall    │
+│ + memory     │  │ Start hook   │  │ msg push +   │  │ End hook     │
+│ injection    │  │              │  │ token stats  │  │              │
+╰──────────────╯  ╰──────────────╯  ╰──────────────╯  ╰──────────────╯
+                                                              ↑
+                                                              └─ user
+                                                                 callback
+                                                                 can
+                                                                 safely
+                                                                 re-fire
+```
+
+`.api` has no user-controlled hooks → cannot interrupt → never re-runs. `.end` can interrupt freely; on resume the prior three substeps are skipped and `.end` re-fires with persisted hook data. Symmetric split for `nextLlmCall`.
+
+This is the same shape already used by the parallel tool branches: `start` / `invoke` / `end` / `log` are four separate `b.step` calls ([prompt.ts L661-776](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/runtime/prompt.ts#L661-L776)). We're applying the same pattern one level up.
+
+**Tech Stack:** TypeScript runtime — primarily `lib/runtime/prompt.ts` (refactor `_runPrompt` and its two call sites). No changes to `promptRunner.ts`, `runner.ts`, `hooks.ts`, or codegen.
+
+---
+
+### Task 1: Failing fixtures
 
 **Files:**
-- Create: `tests/agency/guard-cost.test.json` (promote the existing `tests/agency/guard-cost.agency` example to a real fixture with handlers)
-- Create: `tests/agency/onllmcallend-interrupt-no-rerun.agency` + `.test.json` (minimal reproducer that does NOT use `guard` — just a top-level `callback("onLLMCallEnd") as data { interrupt(...) }` plus a node that calls `llm(...)` once and counts via a module-level `let counter` how many times the body ran)
+- Create: `tests/agency/onllmcallend-interrupt-no-rerun.agency` + `.test.json`
+- Create: `tests/agency/guard-cost.test.json` (promote the existing `tests/agency/guard-cost.agency` example to a real fixture)
 
 - [ ] **Step 1: Minimal reproducer**
 
@@ -31,14 +76,14 @@ callback("onLLMCallEnd") as data {
 
 node main() {
   runs = runs + 1
-  llm("Say hi")
+  llm("Reply with the single word: pong")
   return runs
 }
 ```
 
-Expected after one approve cycle: `runs == 1`. Today: `runs == 2`.
+`.test.json` supplies one interrupt response (any shape — the callback's return value is irrelevant to the cost-tracking question). Expected after one approve cycle: `expectedOutput == 1`. Today: `expectedOutput == 2`.
 
-- [ ] **Step 2: Promote guard-cost to a real fixture** — supply enough interrupt handlers (or use `{action: "approve"}` with `resolvedValue` matching the original limit) to drive the run to completion, asserting `expectedOutput == "done"`.
+- [ ] **Step 2: Promote guard-cost** — supply enough interrupt handlers to drive the run to completion. With the bug fixed, ONE approve handler suffices (today the example bleeds to four+ because of the linear re-spend); the fixture asserts `expectedOutput == "done"` AND `expectedTotalCost <= 1e-5` (one LLM call's worth).
 
 - [ ] **Step 3: Confirm both fail**
 
@@ -47,104 +92,247 @@ pnpm run agency test tests/agency/onllmcallend-interrupt-no-rerun.agency > /tmp/
 pnpm run agency test tests/agency/guard-cost.agency >> /tmp/end-hook-rerun.log 2>&1
 ```
 
+Expected failure messages: counter == 2 (not 1); cost grows linearly across resumes.
+
 - [ ] **Step 4: Commit**
 
 ---
 
-### Task 2: Audit every end-hook fire site
+### Task 2: Trace what `_runPrompt` does between substep entry and `onLLMCallEnd`
 
 **Files:**
-- Read: `lib/runtime/prompt.ts` — find every `invokeCallbacks(..., name: "onLLMCallEnd" ...)` and `b.step(...)` that fires an end-shaped hook.
-- Read: `lib/runtime/promptRunner.ts` — same.
-- Read: `lib/runtime/node.ts` — `onAgentEnd`.
-- Read: `lib/backends/typescriptBuilder.ts` — codegen for `onNodeEnd` (already migrated to `runner.hook`) and `onFunctionEnd` (still in `finally`).
+- Read: `lib/runtime/prompt.ts` — focus on `_runPrompt` body and the `pr.step("initialLlmCall", ...)` / `pr.step("round.${round}.nextLlmCall", ...)` wrappers.
 
-- [ ] **Step 1: Build the table**
+Build the mutation table (delete after Task 4 ships). For each piece of mutable state `_runPrompt` touches, note:
+- WHAT it is (`messages`, `self.messagesJSON`, `targetStack.localCost`, `ctx.globals.__tokenStats`, `self.pendingToolCalls`, etc.)
+- WHEN it is mutated (before/after API call, before/after `onLLMCallEnd`)
+- WHETHER its state needs to be preserved across `onLLMCallEnd` interrupt + resume (yes for messages and cost; no for the locally-scoped `endTime`)
+- HOW resume can recover it (already in `self.messagesJSON`? need a new `self.runnerState` slot? recoverable from messages themselves?)
 
-For each end-hook fire site, write down in `docs/notes/end-hook-fire-sites.md` (delete in Task 5):
-- Hook name
-- Caller (file/function)
-- Whether the fire is inside a `runner.step` body or outside any runner
-- Whether the substep counter is incremented BEFORE the fire or AFTER it (or there is no counter)
-- Whether the fire CAN currently propagate an interrupt up the runner
+Three slots demand particular attention because they currently live ONLY in the `_runPrompt` closure:
 
-The table drives Task 3's strategy: sites that already commit-before-fire are unaffected; sites that commit-after-fire need the deferred completion treatment.
+- `completion` (smoltalk PromptResult) — `onLLMCallEnd` reads `usage`, `cost`, `finishReason`, `output`. Must be persisted.
+- `toolCalls` (`smoltalk.ToolCallJSON[]`) — used after `_runPrompt` returns to drive the tool loop. Already recoverable from the last assistant message's `toolCalls` field, OR we can persist `self.pendingToolCalls` earlier (today it's set after the step body).
+- `endTime - startTime` (number) — passed to `onLLMCallEnd` as `timeTaken`. Must be persisted.
+
+These are exactly the shape of the per-tool-branch persistence already done at [L692](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/runtime/prompt.ts#L692) (`self.runnerState.toolTimings ??= {}`). We'll mirror that pattern.
 
 ---
 
-### Task 3: Add a `Runner.commitStep` primitive
+### Task 3: Split `_runPrompt` into `.start` / `.api` / `.end` substeps
 
 **Files:**
-- Modify: `lib/runtime/runner.ts`
+- Modify: `lib/runtime/prompt.ts`
 
-The simplest fix: a `commitStep(id)` method that callers (specifically `runner.step` itself, before firing a *trailing* hook) call to advance the counter BEFORE the hook fires.
+The cleanest refactor: change `_runPrompt`'s signature to accept the `PromptRunner` and a `keyPrefix`, and have IT call `pr.step` for each substep. The outer `pr.step("initialLlmCall", ...)` wrapper goes away — `runPrompt` calls `_runPrompt({ ..., pr, keyPrefix: "initialLlmCall" })` directly.
 
-- [ ] **Step 1: Add the helper**
+- [ ] **Step 1: New `_runPrompt` signature**
 
 ```ts
-/** Mark a step complete so that an interrupt raised in trailing hook
- *  bookkeeping (e.g. onLLMCallEnd raising from inside prompt.ts) does
- *  NOT cause the step's body to re-run on resume. Idempotent. */
-commitStep(id: number): void {
-  if (this.getCounter() <= id) {
-    this.setCounter(id + 1);
+type RunPromptOutcome = { messages: MessageThread; toolCalls: smoltalk.ToolCallJSON[] };
+
+async function _runPrompt({
+  ctx,
+  messages,
+  ...,
+  pr,
+  keyPrefix,
+}: {
+  ...existing fields...
+  pr: PromptRunner;
+  keyPrefix: string;
+}): Promise<RunPromptOutcome> { ... }
+```
+
+The function no longer returns `RunPromptResult` with `kind: "interrupt"` — interrupts inside `pr.step` throw `PromptBailout` which propagates straight up to `runPrompt`'s outer `try/catch`. The tagged-union return type goes away. (`RunPromptResult` exported type can be deleted.)
+
+- [ ] **Step 2: Three `pr.step` calls inside `_runPrompt`**
+
+```ts
+// SubStep 1: start hook
+await pr.step(`${keyPrefix}.start`, async () => {
+  const startInterrupts = await callHook({
+    ctx, name: "onLLMCallStart",
+    data: { prompt, tools, model: clientConfig.model, messages: messages.toJSON().messages },
+  });
+  return startInterrupts ?? undefined;
+});
+
+// SubStep 2: API call + assistant push + token stats + memory hooks
+// NOTE: no user-controlled hook fires inside this step. It cannot
+// produce interrupts. The `pr.step` wrapper is here for completed-
+// step bookkeeping only.
+let completion: PromptResult | undefined;
+let toolCalls: ToolCallJSON[] = [];
+await pr.step(`${keyPrefix}.api`, async () => {
+  // re-check cancellation
+  if (ctx.isCancelled(stateStack)) throw new AgencyCancelledError();
+
+  // (existing API request, response handling, push assistant message,
+  //  updateTokenStats, targetStack.localCost/localTokens, memory hooks)
+  ...
+  completion = response.value;
+  toolCalls = completion.toolCalls || [];
+  messages.push(smoltalk.assistantMessage(completion.output, toolCalls.length > 0 ? { toolCalls } : undefined));
+  updateTokenStats(...);
+  targetStack.localCost += ...;
+  targetStack.localTokens += ...;
+  // memory hooks (best-effort, log-and-continue)
+
+  // Persist the data .end will need on resume. Keyed by keyPrefix so
+  // a later `nextLlmCall` step doesn't clobber `initialLlmCall`.
+  self.runnerState.llmCallData ??= {};
+  self.runnerState.llmCallData[keyPrefix] = {
+    model: completion.model ?? clientConfig.model ?? "unknown model",
+    usage: completion.usage,
+    cost: completion.cost,
+    finishReason: (completion as any).finishReason ?? (completion as any).finish_reason,
+    output: completion.output,
+    timeTaken: endTime - startTime,
+  };
+  // toolCalls are recoverable from messages, but cache for clarity.
+  self.runnerState.llmCallData[keyPrefix].toolCalls = toolCalls;
+});
+
+// SubStep 3: end hook
+await pr.step(`${keyPrefix}.end`, async () => {
+  const persisted = self.runnerState.llmCallData[keyPrefix];
+  const endInterrupts = await callHook({
+    ctx, name: "onLLMCallEnd",
+    data: {
+      model: JSON.stringify(persisted.model),
+      result: persisted,           // shaped like a PromptResult
+      usage: persisted.usage,
+      cost: persisted.cost,
+      timeTaken: persisted.timeTaken,
+      messages: messages.toJSON().messages,
+    },
+  });
+  return endInterrupts ?? undefined;
+});
+
+// Recover completion-derived locals from persistence so the caller
+// reads consistent values on both fresh runs and resumes.
+const persisted = self.runnerState.llmCallData[keyPrefix];
+return {
+  messages,
+  toolCalls: persisted.toolCalls ?? [],
+};
+```
+
+- [ ] **Step 3: Move `statelogClient.promptCompletion(...)` into `.api`**
+
+It currently fires after the API call. Moving it inside the `.api` body keeps it idempotent (runs exactly once) and inherits the surrounding `llmCall` span.
+
+---
+
+### Task 4: Rewire the two call sites in `runPrompt`
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts`
+
+- [ ] **Step 1: Replace the `initialLlmCall` wrapper**
+
+Before:
+```ts
+await pr.step("initialLlmCall", async () => {
+  const lenBefore = messages.getMessages().length;
+  // memory recall + system message + user message push
+  ...
+  const result = await _runPrompt({ ... });
+  if (result.kind === "interrupt") {
+    messages.setMessages(messages.getMessages().slice(0, lenBefore));
+    closeLlmSpan();
+    return result.interrupts;
   }
+  ...
+});
+```
+
+After:
+```ts
+// .user step: memory recall + system + user message push
+let injectedFactsContent: string | null = null;
+await pr.step("initialLlmCall.user", async () => {
+  if (memoryOption && ctx.memoryManager) { ... }
+  messages.push(smoltalk.userMessage(prompt));
+});
+
+currentLlmSpanId = ctx.statelogClient.startSpan("llmCall");
+try {
+  const result = await _runPrompt({
+    ctx, messages, tools, prompt, responseFormat, clientConfig,
+    stateStack, pr, keyPrefix: "initialLlmCall",
+  });
+  messages = result.messages;
+  toolCalls = result.toolCalls;
+  // (existing memory-injection cleanup, self.messagesJSON, self.pendingToolCalls)
+} catch (e) {
+  if (e instanceof PromptBailout) { closeLlmSpan(); throw e; }
+  closeLlmSpan();
+  throw e;
 }
 ```
 
-- [ ] **Step 2: Unit test**
+The `messages.setMessages(... .slice(0, lenBefore))` revert disappears — each individual substep is small enough that "rewind to before this step" is the correct semantics. (The `.user` step pushes the user message and either completes — leaving it pushed and remembered on resume — or interrupts inside the memory recall code path, in which case nothing was pushed yet and the next resume re-runs cleanly.)
 
-`lib/runtime/runner-commitStep.test.ts` — verify: stamps counter, idempotent on second call, no effect when called for an older step.
+- [ ] **Step 2: Same restructure for `nextLlmCall`**
+
+```ts
+await pr.step(`round.${round}.nextLlmCall.prep`, async () => {
+  closeLlmSpan();
+  // (no-op pre-call setup; reserve the substep so the LLM API call below
+  //  can read `closeLlmSpan` having already happened)
+});
+currentLlmSpanId = ctx.statelogClient.startSpan("llmCall");
+try {
+  const nextResult = await _runPrompt({
+    ..., pr, keyPrefix: `round.${round}.nextLlmCall`,
+  });
+  messages = nextResult.messages;
+  toolCalls = nextResult.toolCalls;
+  self.toolCallRound = round + 1;
+  self.messagesJSON = messages.toJSON().messages;
+  self.pendingToolCalls = toolCalls.length > 0 ? toolCalls : null;
+} catch (e) {
+  if (e instanceof PromptBailout) { closeLlmSpan(); throw e; }
+  closeLlmSpan();
+  throw e;
+}
+```
+
+(The `.prep` step exists only if span bookkeeping needs idempotence; usually a no-op wrapper is unnecessary because `startSpan` is safe to re-call on resume — the prior span is already closed by `pr`'s checkpoint-time finalization. Pick whichever is simpler after re-reading the span code.)
+
+- [ ] **Step 3: Run the fixtures**
+
+```bash
+pnpm run agency test tests/agency/onllmcallend-interrupt-no-rerun.agency > /tmp/end-hook-rerun.log 2>&1
+pnpm run agency test tests/agency/guard-cost.agency >> /tmp/end-hook-rerun.log 2>&1
+```
+
+Both must pass.
+
+- [ ] **Step 4: Wide regression sweep**
+
+```bash
+pnpm test:run -- prompt promptRunner callback fork llm-tools memory > /tmp/regr.log 2>&1
+```
+
+Check for: token-stat drift, doubled `statelogClient.promptCompletion` events, memory-hook re-execution, missing `closeLlmSpan` calls on resume.
+
+- [ ] **Step 5: Commit**
 
 ---
 
-### Task 4: Wire `commitStep` into the LLM call path
-
-**Files:**
-- Modify: `lib/runtime/prompt.ts` (the place where `onLLMCallEnd` is fired after the LLM call)
-- Modify: `lib/runtime/promptRunner.ts` if applicable
-
-The cleanest plumbing: in `runPrompt` / `PromptRunner`, after the LLM call completes (and its result is recorded into the parent frame's locals so resume can read it back), call `runner.commitStep(currentId)` BEFORE firing `onLLMCallEnd`. The result must already be safely captured on the frame — otherwise resume reads the wrong value.
-
-- [ ] **Step 1: Identify what "the LLM call's result" looks like on the frame**
-
-Is it stored on `__stack.locals.__llm_result_${id}`? On a deferred-return slot? Trace through `prompt.ts` for one canonical case.
-
-- [ ] **Step 2: Insert `runner.commitStep(id)` between "result captured" and "fire onLLMCallEnd"**
-
-The substep that owns the LLM call site (whichever id it was in the caller's body) is committed. On resume, the runner skips re-executing that step and reads the captured result from the frame.
-
-- [ ] **Step 3: Run the failing fixture from Task 1**
-
-```bash
-pnpm run agency test tests/agency/onllmcallend-interrupt-no-rerun.agency
-```
-
-Must pass: `runs == 1`.
-
-- [ ] **Step 4: Run the broader callback-interrupt fixture family**
-
-```bash
-pnpm test:run -- callback fork/llm-tools/multi-tool-callback-interrupts > /tmp/cb.log 2>&1
-```
-
-Must not regress.
-
-- [ ] **Step 5: Run the full suite** — this touches the LLM call path and may shake out interactions with cost tracking, span bookkeeping, and runPrompt's tool loop.
-
-- [ ] **Step 6: Commit**
-
----
-
-### Task 5: Extend (if scope allows) to other end hooks
+### Task 5: Cross-link with sibling end-hook plans
 
 `onAgentEnd` fires outside any runner (intentional). No fix needed.
 
-`onNodeEnd` (value-returning) and `onFunctionEnd` (finally-block) are covered by `docs/superpowers/plans/2026-05-22-callback-interrupts-deferred-return.md`. Cross-link from that plan back to this one — the deferred-return mechanism is a more invasive version of the same fix.
+`onNodeEnd` (value-returning) and `onFunctionEnd` (finally-block) are codegen-level end hooks covered by `docs/superpowers/plans/2026-05-22-callback-interrupts-deferred-return.md`. The substep-split pattern from this plan is the runtime analog of that codegen change — they're solving the same shape of bug at different layers.
 
-- [ ] **Step 1: Update the deferred-return plan** to note the `commitStep` primitive can be reused for its node-end refactor (Task 4 of that plan).
+- [ ] **Step 1: Update the deferred-return plan** to add a "see also" pointer to this plan.
 
-- [ ] **Step 2: Delete `docs/notes/end-hook-fire-sites.md`**
+- [ ] **Step 2: Delete the mutation table** from Task 2 if you kept it.
 
 - [ ] **Step 3: Commit**
 
@@ -153,15 +341,23 @@ Must not regress.
 ### Validation checklist
 
 - [ ] `tests/agency/onllmcallend-interrupt-no-rerun` passes; counter shows exactly-once body execution.
-- [ ] `tests/agency/guard-cost` passes when supplied with one interrupt handler (no longer needs 4+).
-- [ ] No regressions in the multi-tool callback interrupt fixtures.
-- [ ] No regressions in the broader callback suite.
+- [ ] `tests/agency/guard-cost` passes with a SINGLE approve handler and total cost ≤ one LLM call's worth.
+- [ ] `statelogClient.promptCompletion` fires exactly once per LLM call across approve cycles (check fixture event counts).
+- [ ] No regressions in multi-tool callback interrupt fixtures, fork/race fixtures, or memory fixtures.
 - [ ] `make` succeeds, `pnpm run lint:structure` clean.
 
 ---
 
 ### Risks and dependencies
 
-- **Result-on-frame contract:** Task 4 step 1 must verify the LLM result is captured on a serializable frame slot BEFORE we commit the step. If we commit early but the result is held only in a live JS closure, resume reads `undefined`. Inspect carefully.
-- **Span / cost bookkeeping in trailing hooks:** the existing `onLLMCallEnd` data includes `usage`, `cost`, `timeTaken`. None of these need the substep to be uncommitted — they're computed values that the hook receives by value. Safe to commit first.
-- **Backwards compatibility with serialized checkpoints:** if an in-flight checkpoint was stamped under the pre-fix counter (still pointing at the LLM step), resuming it on the post-fix runtime will skip the step — which is what we want, BUT the LLM result on the frame must be valid. Same concern as the result-on-frame contract; verifying it covers both cases.
+- **`PromptBailout` propagation through `_runPrompt`:** the refactored `_runPrompt` now lets `PromptBailout` escape (thrown by inner `pr.step`). The caller's `try/catch` must distinguish `PromptBailout` from `AgencyCancelledError` and other throws (it already does — see the outer `try/catch` at [L478-484](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/runtime/prompt.ts#L478-L484)). Verify the new intermediate `try/catch` around `_runPrompt` calls in `runPrompt` re-throws `PromptBailout` after `closeLlmSpan()`.
+
+- **`self.runnerState.llmCallData[keyPrefix]` serialization:** this data must survive checkpoint/restore. It rides on the `runnerState` object already serialized as part of `self.locals` (same vehicle as `completedSteps`). Sanity-check by inspecting a checkpoint snapshot.
+
+- **`statelogClient.promptCompletion` idempotence on resume:** moved into the `.api` substep so resume skips it. Verify event counts in a fixture that resumes through a `.end` interrupt.
+
+- **`llmCall` span lifecycle across resumes:** `closeLlmSpan` is called from the outer `finally` and from the `try/catch` wrappers. On resume, a fresh span is opened. Ensure no leaked spans by checking span open/close counts in a multi-resume fixture.
+
+- **Memory-hook re-execution on resume:** memory's `onTurn` and `compactIfNeeded` run inside `.api` today. After the refactor they still do, and `.api` is skipped on resume — so they fire exactly once. This is actually a bonus correctness win (today memory hooks would re-fire on every approve cycle).
+
+- **Out of scope:** PFA-bound state mutation (plan 2) and callback rejection propagation (plan 3) are separate; this plan does not touch them.

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-23-callback-end-hook-substep-completion.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-23-callback-end-hook-substep-completion.md
@@ -1,0 +1,167 @@
+# End-Hook Callback Substep Completion
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `onLLMCallEnd` (and, in scope-extension, every other "end"-shaped hook) mark its enclosing substep complete BEFORE firing the user callback, so that an interrupt raised inside the callback does not cause the substep — and the work it performed — to re-run on resume.
+
+**Surfaced by:** the `guard()` stdlib function (added in the same PR as this plan). With a `$0.0000001` limit, the first `llm()` call costs ~6e-6 and trips the callback's interrupt; on each resume the `llm()` re-fires, adding another ~6e-6 of cost per cycle. Observed sequence: spent grows 6e-6 → 12e-6 → 18e-6 → 24e-6 → 30e-6 across 5 cycles, linear, exactly one extra LLM call per cycle.
+
+**Root cause:** `Runner.step(id, body)` increments the substep counter (`setCounter(id + 1)`) *after* `body` returns successfully. `onLLMCallEnd` is fired from inside `prompt.ts` while it is still executing inside the surrounding `runner.step` body. If the callback raises an interrupt, the runner halts, the step body returns early, and `setCounter` never runs. On resume, the counter still points at the LLM step, so the step re-executes — re-invoking `llm()` and re-spending real money.
+
+This is the same shape as the bug class addressed by `docs/superpowers/plans/2026-05-22-callback-interrupts-deferred-return.md` for `onNodeEnd` (value-returning case) and `onFunctionEnd` (finally-block case). The "end" hook fires before the surrounding step's completion is committed.
+
+**Tech Stack:** TypeScript runtime (`lib/runtime/runner.ts`, `lib/runtime/prompt.ts`, `lib/runtime/promptRunner.ts`), `lib/runtime/hooks.ts`, fixtures.
+
+---
+
+### Task 1: Failing fixture
+
+**Files:**
+- Create: `tests/agency/guard-cost.test.json` (promote the existing `tests/agency/guard-cost.agency` example to a real fixture with handlers)
+- Create: `tests/agency/onllmcallend-interrupt-no-rerun.agency` + `.test.json` (minimal reproducer that does NOT use `guard` — just a top-level `callback("onLLMCallEnd") as data { interrupt(...) }` plus a node that calls `llm(...)` once and counts via a module-level `let counter` how many times the body ran)
+
+- [ ] **Step 1: Minimal reproducer**
+
+```
+let runs: number = 0
+
+callback("onLLMCallEnd") as data {
+  interrupt myapp::checkpoint("paused", {})
+}
+
+node main() {
+  runs = runs + 1
+  llm("Say hi")
+  return runs
+}
+```
+
+Expected after one approve cycle: `runs == 1`. Today: `runs == 2`.
+
+- [ ] **Step 2: Promote guard-cost to a real fixture** — supply enough interrupt handlers (or use `{action: "approve"}` with `resolvedValue` matching the original limit) to drive the run to completion, asserting `expectedOutput == "done"`.
+
+- [ ] **Step 3: Confirm both fail**
+
+```bash
+pnpm run agency test tests/agency/onllmcallend-interrupt-no-rerun.agency > /tmp/end-hook-rerun.log 2>&1
+pnpm run agency test tests/agency/guard-cost.agency >> /tmp/end-hook-rerun.log 2>&1
+```
+
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 2: Audit every end-hook fire site
+
+**Files:**
+- Read: `lib/runtime/prompt.ts` — find every `invokeCallbacks(..., name: "onLLMCallEnd" ...)` and `b.step(...)` that fires an end-shaped hook.
+- Read: `lib/runtime/promptRunner.ts` — same.
+- Read: `lib/runtime/node.ts` — `onAgentEnd`.
+- Read: `lib/backends/typescriptBuilder.ts` — codegen for `onNodeEnd` (already migrated to `runner.hook`) and `onFunctionEnd` (still in `finally`).
+
+- [ ] **Step 1: Build the table**
+
+For each end-hook fire site, write down in `docs/notes/end-hook-fire-sites.md` (delete in Task 5):
+- Hook name
+- Caller (file/function)
+- Whether the fire is inside a `runner.step` body or outside any runner
+- Whether the substep counter is incremented BEFORE the fire or AFTER it (or there is no counter)
+- Whether the fire CAN currently propagate an interrupt up the runner
+
+The table drives Task 3's strategy: sites that already commit-before-fire are unaffected; sites that commit-after-fire need the deferred completion treatment.
+
+---
+
+### Task 3: Add a `Runner.commitStep` primitive
+
+**Files:**
+- Modify: `lib/runtime/runner.ts`
+
+The simplest fix: a `commitStep(id)` method that callers (specifically `runner.step` itself, before firing a *trailing* hook) call to advance the counter BEFORE the hook fires.
+
+- [ ] **Step 1: Add the helper**
+
+```ts
+/** Mark a step complete so that an interrupt raised in trailing hook
+ *  bookkeeping (e.g. onLLMCallEnd raising from inside prompt.ts) does
+ *  NOT cause the step's body to re-run on resume. Idempotent. */
+commitStep(id: number): void {
+  if (this.getCounter() <= id) {
+    this.setCounter(id + 1);
+  }
+}
+```
+
+- [ ] **Step 2: Unit test**
+
+`lib/runtime/runner-commitStep.test.ts` — verify: stamps counter, idempotent on second call, no effect when called for an older step.
+
+---
+
+### Task 4: Wire `commitStep` into the LLM call path
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts` (the place where `onLLMCallEnd` is fired after the LLM call)
+- Modify: `lib/runtime/promptRunner.ts` if applicable
+
+The cleanest plumbing: in `runPrompt` / `PromptRunner`, after the LLM call completes (and its result is recorded into the parent frame's locals so resume can read it back), call `runner.commitStep(currentId)` BEFORE firing `onLLMCallEnd`. The result must already be safely captured on the frame — otherwise resume reads the wrong value.
+
+- [ ] **Step 1: Identify what "the LLM call's result" looks like on the frame**
+
+Is it stored on `__stack.locals.__llm_result_${id}`? On a deferred-return slot? Trace through `prompt.ts` for one canonical case.
+
+- [ ] **Step 2: Insert `runner.commitStep(id)` between "result captured" and "fire onLLMCallEnd"**
+
+The substep that owns the LLM call site (whichever id it was in the caller's body) is committed. On resume, the runner skips re-executing that step and reads the captured result from the frame.
+
+- [ ] **Step 3: Run the failing fixture from Task 1**
+
+```bash
+pnpm run agency test tests/agency/onllmcallend-interrupt-no-rerun.agency
+```
+
+Must pass: `runs == 1`.
+
+- [ ] **Step 4: Run the broader callback-interrupt fixture family**
+
+```bash
+pnpm test:run -- callback fork/llm-tools/multi-tool-callback-interrupts > /tmp/cb.log 2>&1
+```
+
+Must not regress.
+
+- [ ] **Step 5: Run the full suite** — this touches the LLM call path and may shake out interactions with cost tracking, span bookkeeping, and runPrompt's tool loop.
+
+- [ ] **Step 6: Commit**
+
+---
+
+### Task 5: Extend (if scope allows) to other end hooks
+
+`onAgentEnd` fires outside any runner (intentional). No fix needed.
+
+`onNodeEnd` (value-returning) and `onFunctionEnd` (finally-block) are covered by `docs/superpowers/plans/2026-05-22-callback-interrupts-deferred-return.md`. Cross-link from that plan back to this one — the deferred-return mechanism is a more invasive version of the same fix.
+
+- [ ] **Step 1: Update the deferred-return plan** to note the `commitStep` primitive can be reused for its node-end refactor (Task 4 of that plan).
+
+- [ ] **Step 2: Delete `docs/notes/end-hook-fire-sites.md`**
+
+- [ ] **Step 3: Commit**
+
+---
+
+### Validation checklist
+
+- [ ] `tests/agency/onllmcallend-interrupt-no-rerun` passes; counter shows exactly-once body execution.
+- [ ] `tests/agency/guard-cost` passes when supplied with one interrupt handler (no longer needs 4+).
+- [ ] No regressions in the multi-tool callback interrupt fixtures.
+- [ ] No regressions in the broader callback suite.
+- [ ] `make` succeeds, `pnpm run lint:structure` clean.
+
+---
+
+### Risks and dependencies
+
+- **Result-on-frame contract:** Task 4 step 1 must verify the LLM result is captured on a serializable frame slot BEFORE we commit the step. If we commit early but the result is held only in a live JS closure, resume reads `undefined`. Inspect carefully.
+- **Span / cost bookkeeping in trailing hooks:** the existing `onLLMCallEnd` data includes `usage`, `cost`, `timeTaken`. None of these need the substep to be uncommitted — they're computed values that the hook receives by value. Safe to commit first.
+- **Backwards compatibility with serialized checkpoints:** if an in-flight checkpoint was stamped under the pre-fix counter (still pointing at the LLM step), resuming it on the post-fix runtime will skip the step — which is what we want, BUT the LLM result on the frame must be valid. Same concern as the result-on-frame contract; verifying it covers both cases.

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-23-callback-rejection-propagation.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-23-callback-rejection-propagation.md
@@ -1,0 +1,169 @@
+# Callback Rejection Propagation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** When a callback body raises an interrupt and the user **rejects** that interrupt, the rejection must propagate up the runner chain and halt the enclosing function or node with a failure. Today the rejection is silently dropped.
+
+**Surfaced by:** the in-tree `guard()` stdlib function. When the user rejects the `std::guard_exceeded` interrupt, the callback's generated code halts with `failure("interrupt rejected", ...)`. That failure is invisible to the caller — the LLM call (and the surrounding `block()`) keeps running, exactly as if the user had approved.
+
+**Root cause:** the `__guardCheck` lifted-callback codegen at the reject branch:
+
+```js
+} else if (__response.type === "reject") {
+  runner3.halt(failure("interrupt rejected", { ...checkpoint }));
+  return;
+}
+```
+
+The callback's Runner halts with a `failure` value. The callback returns. Up the chain in `lib/runtime/hooks.ts` (`invokeCallback` → `fireWithGuard`), the return value is only inspected for `hasInterrupts(...)`. A failure is not an interrupt, so it's returned to the caller as `undefined`. The caller (`Runner.hook` via `runBatch`) sees the callback as "succeeded with value undefined" and continues execution. The failure is dropped on the floor.
+
+This is a real correctness bug independent of guard — any user-written `callback("onX") as data { ... interrupt(...) ... }` body that the user rejects has the same silent-drop behavior.
+
+**Tech Stack:** TypeScript runtime (`lib/runtime/hooks.ts`, `lib/runtime/runner.ts`, `lib/runtime/runBatch.ts`).
+
+---
+
+### Task 1: Failing fixture
+
+**Files:**
+- Create: `tests/agency/callback-rejection-halts-caller.agency` + `.test.json` + `.js`
+
+- [ ] **Step 1: Minimal reproducer**
+
+```
+let bodyContinued: boolean = false
+
+callback("onNodeStart") as data {
+  interrupt myapp::abort("really continue?", {})
+}
+
+node main() {
+  bodyContinued = true
+  return "should not reach here"
+}
+```
+
+Test driver supplies `{ "action": "reject" }`. Expected: the run halts with a failure; `bodyContinued` remains `false`.
+
+Today: `bodyContinued == true`, run completes with `"should not reach here"`.
+
+- [ ] **Step 2: Confirm failure**
+
+```bash
+pnpm run agency test tests/agency/callback-rejection-halts-caller.agency > /tmp/cb-reject.log 2>&1
+```
+
+- [ ] **Step 3: Commit**
+
+---
+
+### Task 2: Distinguish "callback completed normally" from "callback halted with failure"
+
+**Files:**
+- Read: `lib/runtime/hooks.ts` — `invokeCallback`, `fireWithGuard`, `invokeOneCallback`.
+- Read: `lib/runtime/runner.ts` — `Runner.hook` (the path that delegates to runBatch).
+
+- [ ] **Step 1: Map the current return-value flow**
+
+Trace: `Runner.hook` → builds `BatchChild.invoke` that calls `invokeOneCallback(...)` → `fireWithGuard` → `invokeCallback` → `AgencyFunction.invoke(...)`. The leaf result is either:
+- `Interrupt[]` — surfaces as a halt-with-interrupts (already handled).
+- A normal value (including `undefined` from a void-returning callback).
+- A `failure(...)` value when the callback halted with `runner.halt(failure(...))`.
+
+The current path treats the second and third the same. We need to distinguish them.
+
+- [ ] **Step 2: Decide the contract**
+
+Recommended: a callback that halts with a `failure` value should be treated as "the caller should halt with this failure." Mirrors how interrupts propagate. This means `invokeOneCallback` returns a discriminated union — interrupts, failure, success — and `Runner.hook` halts the enclosing runner with the failure when it surfaces.
+
+Alternative: convert the failure into a synthesized interrupt. Probably the wrong call — failures and interrupts are different things (failures are terminal, interrupts are pauseable).
+
+---
+
+### Task 3: Plumb failure-propagation through hooks.ts and Runner.hook
+
+**Files:**
+- Modify: `lib/runtime/hooks.ts`
+- Modify: `lib/runtime/runner.ts`
+- Modify: `lib/runtime/runBatch.ts` if the leaf-return discrimination needs adjusting there too.
+
+- [ ] **Step 1: Change `invokeCallback`'s return type**
+
+```ts
+type CallbackResult =
+  | { kind: "success" }
+  | { kind: "interrupts"; interrupts: Interrupt[] }
+  | { kind: "failure"; failure: Failure };
+
+async function invokeCallback(...): Promise<CallbackResult> { ... }
+```
+
+`AgencyFunction.invoke` already returns a value; if `isFailure(result)`, surface it as `{ kind: "failure", failure: result }`.
+
+- [ ] **Step 2: Propagate through `fireWithGuard` and `invokeOneCallback`**
+
+These pass `CallbackResult` through. The recursion guard is unaffected.
+
+- [ ] **Step 3: `Runner.hook` halts on failure**
+
+When `invokeOneCallback` returns `{ kind: "failure" }`, `Runner.hook` calls `this.halt(failure)`. The enclosing function/node's normal "if (runner.halted) return runner.haltResult" check propagates it up.
+
+- [ ] **Step 4: Multi-callback batch semantics**
+
+If callback A halts with a failure and callback B raises an interrupt, what happens? Recommended: failures take precedence. The batch surfaces the first failure; later callbacks don't fire. Matches how regular JS errors propagate inside `Runner.step` today.
+
+- [ ] **Step 5: Top-level callbacks (`onAgentStart`/`onAgentEnd`)**
+
+These fire outside any Runner via `callHookAndDrop`. If a top-level callback halts with a failure, what propagates? Recommended: log + drop (same as the current interrupt behavior for these hooks). Document the limitation.
+
+---
+
+### Task 4: Verify with the fixture and broader callback tests
+
+- [ ] **Step 1: Re-run the rejection fixture**
+
+```bash
+pnpm run agency test tests/agency/callback-rejection-halts-caller.agency
+```
+
+Must pass: `bodyContinued == false`, run halts with a failure.
+
+- [ ] **Step 2: Broader callback fixtures**
+
+```bash
+pnpm test:run -- callback > /tmp/cb-suite.log 2>&1
+```
+
+No regressions in approve / resolve paths.
+
+- [ ] **Step 3: `guard()` rejection fixture**
+
+Add `tests/agency/guard-cost-reject.agency` — reject the guard's interrupt, verify the `block()` halts with a failure that propagates up to `main()`.
+
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 5: Docs
+
+**Files:**
+- Modify: `docs/dev/callback-hooks.md` — document the failure-propagation contract; reject ≡ halt-caller-with-failure.
+- Modify: `docs/site/appendix/callbacks.md` — per-hook table: which hooks support failure propagation (everything except top-level `onAgentStart`/`onAgentEnd`).
+
+---
+
+### Validation checklist
+
+- [ ] `callback-rejection-halts-caller` fixture passes; body never executed past the rejecting callback.
+- [ ] `guard-cost-reject` fixture passes; rejection halts the `block()` with a failure.
+- [ ] No regressions in the broader callback / fork-callback fixture families.
+- [ ] `make` succeeds, `pnpm run lint:structure` clean.
+
+---
+
+### Risks and dependencies
+
+- **Multi-callback failure precedence** (Task 3 Step 4) needs a clear decision before implementation. Recommend "first failure wins; later callbacks skipped" — matches how a JS error inside a `Runner.step` short-circuits the rest of that step.
+- **Top-level callback failures** can't propagate (no caller to halt). Same fundamental limitation that the current callback-interrupts design already documents for `onAgentStart`/`onAgentEnd`.
+- **Backward compat with existing rejections:** today, rejecting a callback interrupt silently no-ops. If any users rely on that (unlikely but possible), they'll see new failure halts. Note in the changelog.
+- **Interaction with handlers:** if the enclosing function has a `handle` block, the rejected-callback failure should be visible to the handler — same path as any other failure. Verify with a fixture.

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-23-callback-rejection-propagation.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-23-callback-rejection-propagation.md
@@ -2,34 +2,60 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
 
-**Goal:** When a callback body raises an interrupt and the user **rejects** that interrupt, the rejection must propagate up the runner chain and halt the enclosing function or node with a failure. Today the rejection is silently dropped.
+> **Implementation status (2026-05-23):** Tasks 1–3 done. Codegen-emitted hook sites (`onNodeStart` / `onNodeEnd` / `onFunctionStart` / `onFunctionEnd`) now correctly halt the enclosing runner with the failure when a callback's interrupt is rejected. The `tests/agency/callback-rejection-halts-function` fixture covers this.
+>
+> Tasks 4–5 (LLM and tool runtime call sites) are implemented in `hooks.ts`/`prompt.ts` (the `CallbackOutcome.kind === "failure"` path propagates through `_runPrompt` → `runPrompt` → `llm()` site), but cannot be end-to-end tested yet: those sites resume across `callHook` (not `Runner.hook`), and the resume mechanism doesn't preserve the callback frame on the deserialize queue (the `pr.step` outer checkpoint stamp overwrites the callback's own checkpoint at `promptRunner.ts` L100‑115). On resume the callback re-enters with a fresh frame, doesn't find its saved `__interruptId_N`, and raises a brand-new interrupt instead of consuming the saved reject response. The LLM-rejection fixture this plan originally wrote (`callback-rejection-aborts-llm`) hits exactly this and was removed pending a fix to bug #1 (`docs/superpowers/plans/2026-05-23-callback-end-hook-substep-completion.md`) plus a complementary fix for callback-frame restoration on the callHook path. Once both land, that fixture can be re-added.
 
-**Surfaced by:** the in-tree `guard()` stdlib function. When the user rejects the `std::guard_exceeded` interrupt, the callback's generated code halts with `failure("interrupt rejected", ...)`. That failure is invisible to the caller — the LLM call (and the surrounding `block()`) keeps running, exactly as if the user had approved.
+**Goal:** When a callback body raises an `interrupt` and the user **rejects** it, the rejection must reach the call site that fired the callback and produce a sensible effect there (abort the LLM call, signal the tool as rejected, halt the enclosing function/node, etc.). Today the rejection is silently dropped — the callback returns, the caller sees `undefined`, execution continues as if approved.
 
-**Root cause:** the `__guardCheck` lifted-callback codegen at the reject branch:
-
-```js
-} else if (__response.type === "reject") {
-  runner3.halt(failure("interrupt rejected", { ...checkpoint }));
-  return;
-}
-```
-
-The callback's Runner halts with a `failure` value. The callback returns. Up the chain in `lib/runtime/hooks.ts` (`invokeCallback` → `fireWithGuard`), the return value is only inspected for `hasInterrupts(...)`. A failure is not an interrupt, so it's returned to the caller as `undefined`. The caller (`Runner.hook` via `runBatch`) sees the callback as "succeeded with value undefined" and continues execution. The failure is dropped on the floor.
-
-This is a real correctness bug independent of guard — any user-written `callback("onX") as data { ... interrupt(...) ... }` body that the user rejects has the same silent-drop behavior.
-
-**Tech Stack:** TypeScript runtime (`lib/runtime/hooks.ts`, `lib/runtime/runner.ts`, `lib/runtime/runBatch.ts`).
+**Surfaced by:** the in-tree `guard()` stdlib function. When the user rejects the `std::guard_exceeded` interrupt, the `__guardCheck` callback halts internally with a `failure(...)` value, but `runPrompt` never sees it — the LLM call keeps running and `block()` returns the LLM's answer instead of a failure.
 
 ---
 
-### Task 1: Failing fixture
+## How rejection flows today (corrected from the previous plan draft)
 
-**Files:**
-- Create: `tests/agency/callback-rejection-halts-caller.agency` + `.test.json` + `.js`
+1. Agency code: `interrupt myapp::foo("msg", {})` inside a callback body.
+2. Codegen template ([interruptReturn.mustache L6-12](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.mustache#L6-L12), [interruptAssignment.mustache L10-15](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.mustache)) translates that to a call to `interruptWithHandlers(...)`, then dispatches on the result:
+   ```ts
+   if (__response.type === "approve") { /* use value */ }
+   else if (__response.type === "reject") {
+     runner.halt(failure("interrupt rejected", { retryable: false, checkpoint: ... }));
+     return;
+   }
+   // else propagated → runner.halt with the interrupts
+   ```
+3. The callback's `AgencyFunction.invoke(...)` returns `runner.haltResult` — a `Failure` object — when the user rejected.
+4. In [hooks.ts L141-159](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/runtime/hooks.ts#L141-L159), `invokeCallback` checks ONLY `hasInterrupts(result)`. A `Failure` isn't an interrupt array, so the function returns `undefined` and the rejection vanishes.
 
-- [ ] **Step 1: Minimal reproducer**
+So the bug is structural: `interruptWithHandlers` itself can return a `Rejected` (as it does for tool calls — see [prompt.ts L534-547](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/runtime/prompt.ts#L534-L547)), but agency-level codegen wraps that into a `Failure` before the runtime can see it. The fix lives at the call-site level — each `callHook` / `invokeCallbacks` consumer needs to recognise the `Failure` return and decide what rejection means there.
 
+Pattern analog from tools: when a TOOL's invoke returns a `Rejected` (e.g. via policy, or by the tool body literally calling `reject(...)`), `runInvokeStep` does:
+```ts
+if (isRejected(toolResult)) {
+  messages.push(smoltalk.toolMessage(rejection.value, { tool_call_id, name }));
+  stack.deleteBranch(branchKey);
+  return { invokeOutcome: "rejected" };
+}
+```
+We need the same shape but driven off `isFailure(callbackResult)` for callbacks.
+
+**Tech Stack:** TypeScript runtime — `lib/runtime/hooks.ts`, `lib/runtime/prompt.ts`, `lib/runtime/runner.ts`. No codegen / template changes.
+
+---
+
+### Task 1: Failing fixtures (one per call-site category)
+
+Three categories of callback fire site, each with its own "rejection means X" interpretation:
+
+| Category                       | Hooks                                                 | Rejection means…                         | Failing fixture                                  |
+| ------------------------------ | ----------------------------------------------------- | ---------------------------------------- | ------------------------------------------------ |
+| Runner.hook (codegen)          | onNodeStart, onNodeEnd, onFunctionStart, onFunctionEnd | halt enclosing function/node with the failure | `callback-rejection-halts-function`              |
+| LLM hooks (runtime)            | onLLMCallStart, onLLMCallEnd                          | abort `runPrompt` with the failure       | `callback-rejection-aborts-llm`                  |
+| Tool hooks (runtime, per-branch) | onToolCallStart, onToolCallEnd                       | route through existing `isRejected` tool path | `callback-rejection-rejects-tool-call`           |
+
+- [ ] **Step 1: Function/node rejection fixture**
+
+`tests/agency/callback-rejection-halts-function.agency`:
 ```
 let bodyContinued: boolean = false
 
@@ -42,128 +68,291 @@ node main() {
   return "should not reach here"
 }
 ```
+`.test.json` supplies `{"action": "reject"}`. Expected: the run halts; `bodyContinued == false`. Today: `bodyContinued == true`.
 
-Test driver supplies `{ "action": "reject" }`. Expected: the run halts with a failure; `bodyContinued` remains `false`.
+- [ ] **Step 2: LLM rejection fixture (via guard-cost-reject)**
 
-Today: `bodyContinued == true`, run completes with `"should not reach here"`.
+`tests/agency/guard-cost-reject.agency`:
+```
+node main() {
+  const result: string = guard(0.0000001) as {
+    const reply: string = llm("Reply with the single word: pong")
+    return reply
+  }
+  return result
+}
+```
+`.test.json` rejects the first `std::guard_exceeded` interrupt. Expected: `main()` returns a failure (`isFailure(expectedOutput) == true`) carrying the rejection reason. Today: returns the LLM's "pong" reply, ignoring the rejection.
 
-- [ ] **Step 2: Confirm failure**
+- [ ] **Step 3: Tool rejection fixture**
+
+`tests/agency/callback-rejection-rejects-tool-call.agency`:
+```
+def someTool(x: number): string {
+  return "tool ran: " + x
+}
+
+callback("onToolCallStart") as data {
+  interrupt myapp::approve_tool("allow?", {toolName: data.toolName})
+}
+
+node main() {
+  return llm("Call someTool with x=1", tools=[someTool])
+}
+```
+Test driver rejects the `approve_tool` interrupt. Expected: the assistant message includes a `toolMessage` of "tool rejected by policy" (or the rejection's value) instead of the tool's real output; `someTool` is never invoked. Today: the callback's rejection vanishes, the tool runs normally.
+
+- [ ] **Step 4: Confirm all three fail**
 
 ```bash
-pnpm run agency test tests/agency/callback-rejection-halts-caller.agency > /tmp/cb-reject.log 2>&1
+for f in callback-rejection-halts-function guard-cost-reject callback-rejection-rejects-tool-call; do
+  pnpm run agency test tests/agency/$f.agency >> /tmp/cb-reject.log 2>&1
+done
 ```
+
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 2: Tagged-union return type for callback results
+
+**Files:**
+- Modify: `lib/runtime/hooks.ts`
+
+Replace the current `Promise<Interrupt[] | undefined>` return shape with a tagged union that distinguishes success / interrupts / failure. The change is internal to `hooks.ts` plus its callers.
+
+- [ ] **Step 1: New type**
+
+```ts
+export type CallbackOutcome =
+  | { kind: "ok" }
+  | { kind: "interrupts"; interrupts: Interrupt[] }
+  | { kind: "failure"; failure: ResultFailure };
+```
+
+(Use the existing `ResultFailure` type from `lib/runtime/result.ts`.)
+
+- [ ] **Step 2: Update `invokeCallback`**
+
+```ts
+async function invokeCallback(...): Promise<CallbackOutcome> {
+  if (AgencyFunction.isAgencyFunction(fn)) {
+    const result = await (fn as AgencyFunction).invoke(...);
+    if (hasInterrupts(result)) return { kind: "interrupts", interrupts: result };
+    if (isFailure(result))    return { kind: "failure", failure: result };
+    return { kind: "ok" };
+  }
+  // Plain JS callback — no interrupt/failure mechanism. fn might throw, which
+  // fireWithGuard catches and logs; on normal return we always get "ok".
+  await fn(data);
+  return { kind: "ok" };
+}
+```
+
+NOTE: there's a wrinkle for `onNodeStart` (and other node-context hooks). The codegen halts the runner with `{ messages: __threads, data: failure(...) }` (the node return-shape envelope), not the bare failure. So `invokeCallback` needs to peel the envelope when `fn.scopeName` is a node-context callback. Simplest: in `invokeCallback`, after getting `result`, also check `isFailure(result?.data)` and surface that. Verify shape with the function/node fixture.
+
+- [ ] **Step 3: Update `fireWithGuard`, `invokeOneCallback`, `invokeCallbacks`, `callHook`**
+
+All four return `Promise<CallbackOutcome>`. `invokeCallbacks` (which fires multiple callbacks in sequence) collects interrupts across siblings as today and folds in failures with "first failure wins, later callbacks skipped" semantics — matching how JS errors short-circuit a `Runner.step` body.
+
+```ts
+const collected: Interrupt[] = [];
+for (const fn of gatherCallbacks(...)) {
+  const outcome = await fireWithGuard(fn, data, ctx, name, stateStack);
+  if (outcome.kind === "failure") return outcome;          // first failure wins
+  if (outcome.kind === "interrupts") collected.push(...outcome.interrupts);
+}
+return collected.length > 0
+  ? { kind: "interrupts", interrupts: collected }
+  : { kind: "ok" };
+```
+
+- [ ] **Step 4: Update `callHookAndDrop`**
+
+Stays log-and-drop for failures too (top-level callbacks have no caller to halt — same fundamental limitation as for interrupts).
+
+---
+
+### Task 3: Wire `Runner.hook` to halt on callback failure
+
+**Files:**
+- Modify: `lib/runtime/runner.ts`
+- Possibly: `lib/runtime/runBatch.ts` if the runBatch-driven path needs a corresponding leaf-return tweak.
+
+This handles the FIRST category — codegen-emitted hook sites (`onNodeStart`, `onNodeEnd`, `onFunctionStart`, `onFunctionEnd`).
+
+- [ ] **Step 1: Read `Runner.hook` and its runBatch path**
+
+Find the place where `invokeOneCallback`'s return is currently inspected. It's wrapped in a `runBatch` child invoke that previously returned `Interrupt[] | undefined`.
+
+- [ ] **Step 2: On `{ kind: "failure" }`, halt the runner**
+
+```ts
+const outcome = await invokeOneCallback({ ctx, fn, name, data, stateStack });
+if (outcome.kind === "failure") return outcome.failure;   // returned to runBatch invoke
+```
+
+The surrounding `Runner.hook` checks the runBatch result; if it's a failure, halts via `this.halt(failure)`. The next user-code generated step sees `runner.halted` and returns `runner.haltResult` — propagating the failure up the call stack via the function's existing return-value convention.
+
+For node-context callbacks, halt with the node envelope shape: `this.halt({ messages: this.frame.threads, data: failure })`. Mirrors what the codegen template's reject branch does for the callback itself.
+
+- [ ] **Step 3: Verify the function/node rejection fixture passes**
+
+```bash
+pnpm run agency test tests/agency/callback-rejection-halts-function.agency
+```
+
+---
+
+### Task 4: Wire `runPrompt` to abort on LLM callback failure
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts` (the `onLLMCallStart` / `onLLMCallEnd` fire sites inside `_runPrompt`)
+
+This handles the SECOND category. Depends on Task 2 having changed `callHook`'s signature.
+
+- [ ] **Step 1: Read the fire sites**
+
+Today:
+```ts
+const startInterrupts = await callHook({ ctx, name: "onLLMCallStart", data: ... });
+if (startInterrupts) return { kind: "interrupt", interrupts: startInterrupts };
+```
+
+After Task 2, `callHook` returns a `CallbackOutcome`. Update:
+```ts
+const startOutcome = await callHook({ ctx, name: "onLLMCallStart", data: ... });
+if (startOutcome.kind === "interrupts") return { kind: "interrupt", interrupts: startOutcome.interrupts };
+if (startOutcome.kind === "failure")    return { kind: "failure", failure: startOutcome.failure };
+```
+
+- [ ] **Step 2: Extend `RunPromptResult` with a failure variant**
+
+```ts
+export type RunPromptResult =
+  | { kind: "ok"; messages: MessageThread; toolCalls: ToolCallJSON[] }
+  | { kind: "interrupt"; interrupts: Interrupt[] }
+  | { kind: "failure"; failure: ResultFailure };
+```
+
+- [ ] **Step 3: `runPrompt`'s outer try handles the failure**
+
+When `_runPrompt` returns `{ kind: "failure", failure }`, `runPrompt` returns the failure. The `llm()` call site (in user code) receives a `Failure` value just as if any other function had returned one — falls through to user `handle` blocks or surfaces up.
+
+- [ ] **Step 4: Same wiring for the end-hook**
+
+If the `onLLMCallEnd` substep split from `docs/superpowers/plans/2026-05-23-callback-end-hook-substep-completion.md` has already shipped, the `.end` `pr.step` body needs to return a failure and `runPrompt`'s caller of `_runPrompt` propagates it. If that plan hasn't shipped yet, do it in the current single-step body.
+
+- [ ] **Step 5: Verify the LLM rejection fixture passes**
+
+```bash
+pnpm run agency test tests/agency/guard-cost-reject.agency
+```
+
+---
+
+### Task 5: Wire tool callbacks through the existing `isRejected` rail
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts` (`onToolCallStart` / `onToolCallEnd` fire sites inside the per-tool branchFn)
+
+This handles the THIRD category. Closest in shape to the tool-body rejection path already at L534-547.
+
+- [ ] **Step 1: `onToolCallStart` rejection**
+
+Current:
+```ts
+await b.step(`round.${round}.tool.${toolCall.id}.start`, async () =>
+  await invokeCallbacks({ ctx, name: "onToolCallStart", data: ..., stateStack: branchStack }),
+);
+if (b.interrupts) return;
+```
+
+After: `invokeCallbacks` now returns a `CallbackOutcome`. If `kind === "failure"`, the tool branch should treat it like a rejection — push a `toolMessage` containing the failure's reason, clean up the branch, skip the invoke / end-hook / log steps. Concretely:
+```ts
+const startOutcome = await invokeCallbacks({ ... });
+if (startOutcome.kind === "interrupts") {
+  // BranchRunner needs an explicit "halt with these interrupts" path —
+  // today b.step does this implicitly; keep using b.step but pass the
+  // interrupts through.
+  // (See Task 6 risk note on adapter shape.)
+  return;
+}
+if (startOutcome.kind === "failure") {
+  messages.push(smoltalk.toolMessage(
+    startOutcome.failure.error ?? "Tool rejected by callback",
+    { tool_call_id: toolCall.id, name: toolCall.name },
+  ));
+  stack.deleteBranch(branchKey);
+  return;
+}
+```
+
+- [ ] **Step 2: `onToolCallEnd` rejection**
+
+Trickier because the tool ALREADY RAN by the time the end-hook fires. Two options:
+
+  (a) Treat the rejection as a hard error retroactively — overwrite the success `toolMessage` with the rejection message. Risk: the side effects the tool performed (file writes, API calls) cannot be rolled back, but the LLM sees a clean "rejected" view. This matches the symmetric option for `onLLMCallEnd` — the rejection makes the operation's RESULT invalid even though the work happened.
+
+  (b) Surface the rejection as a halt of the whole tool round — abort the parallel batch with the failure, propagate up to `runPrompt`. More disruptive but more honest.
+
+Recommended: (a) for tool end-hooks. Add a comment that side effects are not rolled back.
+
+- [ ] **Step 3: Verify the tool rejection fixture passes**
+
+```bash
+pnpm run agency test tests/agency/callback-rejection-rejects-tool-call.agency
+```
+
+---
+
+### Task 6: Broader regression sweep
+
+- [ ] **Step 1: Run the whole callback fixture family**
+
+```bash
+pnpm test:run -- callback fork llm-tools memory guard > /tmp/cb-reject-regr.log 2>&1
+```
+
+Watch for: existing "rejection silently no-ops" tests that now correctly fail (some might exist that codified the buggy behavior — those need to be updated, not papered over). No regressions in approve / propagate / resolve paths.
+
+- [ ] **Step 2: `make` + `pnpm run lint:structure`**
 
 - [ ] **Step 3: Commit**
 
 ---
 
-### Task 2: Distinguish "callback completed normally" from "callback halted with failure"
+### Task 7: Docs + cleanup
 
 **Files:**
-- Read: `lib/runtime/hooks.ts` — `invokeCallback`, `fireWithGuard`, `invokeOneCallback`.
-- Read: `lib/runtime/runner.ts` — `Runner.hook` (the path that delegates to runBatch).
-
-- [ ] **Step 1: Map the current return-value flow**
-
-Trace: `Runner.hook` → builds `BatchChild.invoke` that calls `invokeOneCallback(...)` → `fireWithGuard` → `invokeCallback` → `AgencyFunction.invoke(...)`. The leaf result is either:
-- `Interrupt[]` — surfaces as a halt-with-interrupts (already handled).
-- A normal value (including `undefined` from a void-returning callback).
-- A `failure(...)` value when the callback halted with `runner.halt(failure(...))`.
-
-The current path treats the second and third the same. We need to distinguish them.
-
-- [ ] **Step 2: Decide the contract**
-
-Recommended: a callback that halts with a `failure` value should be treated as "the caller should halt with this failure." Mirrors how interrupts propagate. This means `invokeOneCallback` returns a discriminated union — interrupts, failure, success — and `Runner.hook` halts the enclosing runner with the failure when it surfaces.
-
-Alternative: convert the failure into a synthesized interrupt. Probably the wrong call — failures and interrupts are different things (failures are terminal, interrupts are pauseable).
-
----
-
-### Task 3: Plumb failure-propagation through hooks.ts and Runner.hook
-
-**Files:**
-- Modify: `lib/runtime/hooks.ts`
-- Modify: `lib/runtime/runner.ts`
-- Modify: `lib/runtime/runBatch.ts` if the leaf-return discrimination needs adjusting there too.
-
-- [ ] **Step 1: Change `invokeCallback`'s return type**
-
-```ts
-type CallbackResult =
-  | { kind: "success" }
-  | { kind: "interrupts"; interrupts: Interrupt[] }
-  | { kind: "failure"; failure: Failure };
-
-async function invokeCallback(...): Promise<CallbackResult> { ... }
-```
-
-`AgencyFunction.invoke` already returns a value; if `isFailure(result)`, surface it as `{ kind: "failure", failure: result }`.
-
-- [ ] **Step 2: Propagate through `fireWithGuard` and `invokeOneCallback`**
-
-These pass `CallbackResult` through. The recursion guard is unaffected.
-
-- [ ] **Step 3: `Runner.hook` halts on failure**
-
-When `invokeOneCallback` returns `{ kind: "failure" }`, `Runner.hook` calls `this.halt(failure)`. The enclosing function/node's normal "if (runner.halted) return runner.haltResult" check propagates it up.
-
-- [ ] **Step 4: Multi-callback batch semantics**
-
-If callback A halts with a failure and callback B raises an interrupt, what happens? Recommended: failures take precedence. The batch surfaces the first failure; later callbacks don't fire. Matches how regular JS errors propagate inside `Runner.step` today.
-
-- [ ] **Step 5: Top-level callbacks (`onAgentStart`/`onAgentEnd`)**
-
-These fire outside any Runner via `callHookAndDrop`. If a top-level callback halts with a failure, what propagates? Recommended: log + drop (same as the current interrupt behavior for these hooks). Document the limitation.
-
----
-
-### Task 4: Verify with the fixture and broader callback tests
-
-- [ ] **Step 1: Re-run the rejection fixture**
-
-```bash
-pnpm run agency test tests/agency/callback-rejection-halts-caller.agency
-```
-
-Must pass: `bodyContinued == false`, run halts with a failure.
-
-- [ ] **Step 2: Broader callback fixtures**
-
-```bash
-pnpm test:run -- callback > /tmp/cb-suite.log 2>&1
-```
-
-No regressions in approve / resolve paths.
-
-- [ ] **Step 3: `guard()` rejection fixture**
-
-Add `tests/agency/guard-cost-reject.agency` — reject the guard's interrupt, verify the `block()` halts with a failure that propagates up to `main()`.
-
-- [ ] **Step 4: Commit**
-
----
-
-### Task 5: Docs
-
-**Files:**
-- Modify: `docs/dev/callback-hooks.md` — document the failure-propagation contract; reject ≡ halt-caller-with-failure.
-- Modify: `docs/site/appendix/callbacks.md` — per-hook table: which hooks support failure propagation (everything except top-level `onAgentStart`/`onAgentEnd`).
+- Modify: `docs/dev/callback-hooks.md` (if exists) — document the rejection contract per category.
+- Modify: `docs/site/appendix/callbacks.md` — per-hook table: what "reject" means at each site.
+- Modify: `docs/superpowers/plans/2026-05-23-callback-end-hook-substep-completion.md` — cross-link.
 
 ---
 
 ### Validation checklist
 
-- [ ] `callback-rejection-halts-caller` fixture passes; body never executed past the rejecting callback.
-- [ ] `guard-cost-reject` fixture passes; rejection halts the `block()` with a failure.
-- [ ] No regressions in the broader callback / fork-callback fixture families.
+- [ ] `callback-rejection-halts-function` passes; node body never executed past the rejecting callback.
+- [ ] `guard-cost-reject` passes; `llm()` returns a `Failure`, `block()` surfaces it.
+- [ ] `callback-rejection-rejects-tool-call` passes; tool body never invoked, LLM sees a rejection `toolMessage`.
+- [ ] No regressions in the broader callback / fork-callback / memory / guard fixture families.
 - [ ] `make` succeeds, `pnpm run lint:structure` clean.
 
 ---
 
 ### Risks and dependencies
 
-- **Multi-callback failure precedence** (Task 3 Step 4) needs a clear decision before implementation. Recommend "first failure wins; later callbacks skipped" — matches how a JS error inside a `Runner.step` short-circuits the rest of that step.
-- **Top-level callback failures** can't propagate (no caller to halt). Same fundamental limitation that the current callback-interrupts design already documents for `onAgentStart`/`onAgentEnd`.
-- **Backward compat with existing rejections:** today, rejecting a callback interrupt silently no-ops. If any users rely on that (unlikely but possible), they'll see new failure halts. Note in the changelog.
-- **Interaction with handlers:** if the enclosing function has a `handle` block, the rejected-callback failure should be visible to the handler — same path as any other failure. Verify with a fixture.
+- **Codegen produces `failure(...)` not `Rejected`** — the runtime check is `isFailure`, NOT `isRejected`. Easy mistake when copy-pasting from the tool-rejection rail. (Earlier draft of this plan misnamed the predicate.)
+
+- **Node-context envelope shape** — `onNodeStart`/`onNodeEnd` callbacks halt with `{ messages, data: failure(...) }` not bare `failure(...)`. `invokeCallback` must peel the envelope or `Runner.hook` must wrap before halting; pick one and stay consistent.
+
+- **`BranchRunner` rejection path** — `BranchRunner.step` today only knows about interrupts (`b.interrupts`). Adding a `b.failure` slot (or equivalent) keeps the parallel `pr.parallel` shape symmetric: callback-rejected branches don't block siblings, and the parallel orchestrator can fold rejections into per-branch `toolMessages` independently. Alternatively, treat callback failures inside a branch as immediate "halt this branch only" with no fancy batching. Recommend the simpler latter.
+
+- **`onToolCallEnd` post-hoc rejection** — the tool already ran and may have side effects (file writes, API calls). Rejection at end-hook time only changes what the LLM sees, not what already happened. Documented in the appendix.
+
+- **Backwards compatibility** — any existing user code that relied on rejection-as-no-op will start failing loudly. Note in CHANGELOG.
+
+- **Top-level callbacks (`onAgentStart`/`onAgentEnd`)** — log + drop for failures too, same fundamental limitation as for interrupts (no surrounding frame). Document.
+
+- **`runBatch` invoke contract** — `invoke` returns `T | Interrupt[]` today and MUST NOT throw. If `Runner.hook`'s runBatch child needs to return a failure, the return type widens to `T | Interrupt[] | Failure` — verify the runBatch processing logic handles the new shape, OR keep `invoke`'s contract intact by encoding the failure inside `T` (Runner.hook already knows the shape it expects).

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-23-guard-statestack-architecture.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-23-guard-statestack-architecture.md
@@ -1,0 +1,215 @@
+# Guard StateStack Architecture Migration
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace the current PFA-on-scoped-callback implementation of `guard(limit, block)` with a runtime mechanism where guard state lives directly on the `StateStack`. This solves the "mutation does not survive serialize/deserialize" gap that makes the user's "raise the limit" response get silently dropped.
+
+**Surfaced by:** the in-tree implementation of `guard()` (stdlib/index.agency) attempts to mutate a PFA-bound `state` object: `state.limit = interrupt(...)`. Within a single uninterrupted run the mutation works (JS object reference), but at interrupt time the PFA's `state` is serialized by value, and on resume a brand-new revived object replaces it. The mutation is lost. Subsequent callback fires see the original limit.
+
+**Why a runtime StateStack stack instead of a different closure / serialization scheme:**
+- The `StateStack` is **per-branch** in concurrent execution (each `BranchState` has its own stack). Guards naturally compose with fork.
+- The `StateStack` already serializes through `toJSON`/`fromJSON` for interrupt + resume. Adding a guard list to it is the smallest possible change.
+- It avoids needing to invent a "mutable shared state for callbacks" general feature, which is out of scope and likely the wrong abstraction.
+- It matches the original spec (`docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md`), minus the thrown-error mechanism — we keep the interrupt-based mechanism that the just-shipped runBatch + callback-interrupts work makes possible.
+
+**Out of scope:** timeout guards, depth guards, memory-layer cost coverage. All deferred per the original spec.
+
+**Tech Stack:** TypeScript runtime (`lib/runtime/state/stateStack.ts`, `lib/runtime/prompt.ts`, `lib/codegenBuiltins/contextInjected.ts`), `stdlib/index.agency`.
+
+**Depends on:** Plan `2026-05-23-callback-end-hook-substep-completion.md` is not strictly required but strongly recommended — without it, every guard breach still causes the LLM call to re-run on resume, compounding cost.
+
+---
+
+### Task 1: GuardEntry on StateStack
+
+**Files:**
+- Modify: `lib/runtime/state/stateStack.ts` — add `guards: GuardEntry[]` field, include in `toJSON`/`fromJSON`.
+- Create: `lib/runtime/guard.ts` — `GuardEntry` type (`{ start: number; limit: number; id: string }`).
+- Modify: `lib/runtime/guard.test.ts` — serialize/deserialize round-trips a guard list.
+
+- [ ] **Step 1: Type and field**
+
+```ts
+// lib/runtime/guard.ts
+export type GuardEntry = {
+  /** Stable id so prompt.ts can refer to a specific guard when raising
+   *  the interrupt (carries it in the interrupt payload so the user
+   *  could in principle target a specific guard if there were ever a
+   *  client UI that supports that). */
+  id: string;
+  /** getCost() snapshot when the guard was pushed. The "spent inside
+   *  this guard" is `getCost() - start`. */
+  start: number;
+  /** Current limit. Mutated in place when the user raises it via
+   *  interrupt response. */
+  limit: number;
+};
+```
+
+- [ ] **Step 2: StateStack changes**
+
+Add `guards: GuardEntry[]` to the StateStack class. Initialize to `[]`. Add to `toJSON` and `fromJSON`. Branch stacks clone the array when seeded so fork branches each have their own copy (and don't mutate the parent's).
+
+- [ ] **Step 3: Test**
+
+`lib/runtime/state/stateStack-guard.test.ts` — push a couple of entries, JSON round-trip, verify mutations survive.
+
+- [ ] **Step 4: Commit**
+
+---
+
+### Task 2: `__pushGuard` / `__popGuard` context-injected builtins
+
+**Files:**
+- Modify: `lib/codegenBuiltins/contextInjected.ts` — register two new builtins.
+- Create: `lib/stdlib/guard.ts` — implementations (push/pop a `GuardEntry` on `ctx.stateStack.guards`).
+- Modify: `lib/codegenBuiltins/contextInjected.test.ts` — coverage.
+
+- [ ] **Step 1: Register builtins**
+
+```ts
+__pushGuard(limit: number): string  // returns the guard's id
+__popGuard(id: string): void
+```
+
+Both take `(__ctx, __stateStack, __threads)` as the standard context-injected prefix. `__pushGuard` pushes a `{ id: nanoid(), start: __ctx.globals.getTokenStats().cost, limit }`. `__popGuard` removes by id.
+
+- [ ] **Step 2: Defensive guard against mismatched push/pop**
+
+If `__popGuard("xyz")` is called and the top of the guard stack is not "xyz", throw a clear error. Indicates a codegen bug or a user manually calling these builtins.
+
+- [ ] **Step 3: Tests**
+
+---
+
+### Task 3: Per-LLM-call check in `prompt.ts`
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts`
+
+After every LLM call completes (the place where `onLLMCallEnd` fires), iterate the current `stateStack.guards`. For each guard, check `getCost() - guard.start > guard.limit`. If any is exceeded, raise `std::guard_exceeded` interrupt with payload `{ id, spent, limit }`.
+
+The interrupt mechanism that just landed (runBatch + callback-interrupts) means the interrupt propagates up cleanly. The user responds with a new limit (number); on resume, the runtime updates `guard.limit = response` for the matching id BEFORE continuing.
+
+- [ ] **Step 1: Identify the post-LLM-call commit point**
+
+Coordinate with Plan `2026-05-23-callback-end-hook-substep-completion.md` — the `commitStep` should fire BEFORE this guard check so a guard-exceeded interrupt doesn't cause LLM re-run on resume.
+
+- [ ] **Step 2: Raise the interrupt**
+
+Use `interruptWithHandlers("std::guard_exceeded", ...)` — same shape as the current stdlib pattern.
+
+- [ ] **Step 3: Plumb the user's response into the matching `GuardEntry.limit`**
+
+On resume, the runtime sees the interrupt response. Update the entry in the StateStack's guard list whose id matches. Since the StateStack already serializes the guard list and is restored on resume, the mutation persists naturally.
+
+- [ ] **Step 4: Tests**
+
+Fixture: nested guards. Inner exceeds, user raises inner, work continues, outer exceeds later, user raises outer. Assert correct interrupt sequence and exact cost accounting.
+
+---
+
+### Task 4: Rewrite `guard()` in stdlib
+
+**Files:**
+- Modify: `stdlib/index.agency`
+
+Replace the existing PFA-based implementation with:
+
+```
+export def guard(limit: number, block: () => any): any {
+  """
+  Run a block with a cost limit. After every LLM call inside the
+  block, the cumulative cost since `guard` started is compared to
+  `limit`. If the spend exceeds the limit, an `std::guard_exceeded`
+  interrupt is raised with `{ id, spent, limit }`.
+
+  The user responds with a new (raised) limit as a number to
+  continue; the runtime updates the guard's limit in the StateStack
+  before resuming.
+
+  Nested guards each push their own entry; ALL active guards are
+  checked after each LLM call. Inside fork branches each branch
+  inherits its own copy of the guard list at branch-creation time
+  and mutates it independently.
+
+  @param limit - Maximum cost in dollars (USD)
+  @param block - The block to execute
+  """
+  const id = __pushGuard(limit)
+  const result = try block()
+  __popGuard(id)
+  return result
+}
+```
+
+Delete `__guardCheck` (no longer needed — the check lives in `prompt.ts`).
+
+- [ ] **Step 1: Rewrite guard**
+
+- [ ] **Step 2: Delete `__guardCheck`**
+
+- [ ] **Step 3: Remove `__guardCheck` from the auto-import list**
+
+`lib/templates/backends/agency/template.mustache` and `lib/lsp/diagnostics.ts`. Run `pnpm run templates`. `guard` stays auto-imported (or move it to `std::thread` per the original spec — discuss with the user before deciding).
+
+- [ ] **Step 4: Promote `tests/agency/guard-cost.agency` to a real fixture**
+
+Add `.test.json` with one interrupt handler. Run.
+
+```bash
+pnpm run agency test tests/agency/guard-cost.agency
+```
+
+Must pass.
+
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 5: Cleanup on interrupt path
+
+**Files:**
+- Modify: `lib/runtime/state/stateStack.ts` — ensure `guards` is properly carried through any "branch creation" / "branch teardown" code paths so race losers, fork siblings, etc. all see the right list.
+- Modify: `lib/runtime/runBatch.ts` if applicable — when seeding a child branch stack, clone the parent's guards.
+
+- [ ] **Step 1: Audit `seedBranchCost` and similar** in `lib/runtime/runner.ts` — that's the existing pattern for "seed per-branch state from parent." Add a `seedBranchGuards` helper alongside it.
+
+- [ ] **Step 2: Race-loser teardown**
+
+When a race loser branch is deleted, its guard list is dropped (correct — its mutations were on its own slice and never propagated). The winner's guards propagate back to the parent when the winner completes. Test this.
+
+- [ ] **Step 3: Tests**
+
+`tests/agency/guard-fork.agency` (or similar) — fork inside a guard, both branches doing LLM work that together exceed the parent's limit. Decide the user-facing semantics:
+- The parent's limit applies; either branch tripping it interrupts. **OR**
+- Each branch has its own independent copy of the limit. (The latter is simpler and what the per-branch clone gives us; the former needs a shared atomic accumulator which is a separate larger design.)
+
+Document the chosen semantics in the `guard` docstring.
+
+---
+
+### Task 6: Docs
+
+**Files:**
+- Update: `docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md` — mark the "Mechanism" section as superseded by this plan; the chosen mechanism is interrupt (not thrown error). Cross-reference both this plan and the deferred-return / substep-completion plan.
+- Update: `docs/dev/runtime-state.md` or wherever `StateStack` is documented — add `guards` field.
+
+---
+
+### Validation checklist
+
+- [ ] `tests/agency/guard-cost` passes with one interrupt handler.
+- [ ] Nested-guards fixture passes — both inner and outer trip in the right order.
+- [ ] Fork-with-guard fixture passes with documented per-branch semantics.
+- [ ] `lib/runtime/state/stateStack.toJSON` includes `guards`; round-trips cleanly.
+- [ ] No regressions in the existing test suite.
+- [ ] `make` succeeds, `pnpm run lint:structure` clean.
+
+---
+
+### Risks and dependencies
+
+- **Fork merge semantics for guard limits** (Task 5 Step 3) is genuinely undecided. Pick the simpler one (per-branch independent) for v1 unless the user has a strong preference for shared.
+- **Memory-layer LLM calls** still bypass `prompt.ts` and therefore the guard check. Documented; out of scope.
+- **Cross-plan ordering:** if this plan ships BEFORE `2026-05-23-callback-end-hook-substep-completion.md`, every guard-exceeded interrupt causes the LLM call to re-run on resume. That's painful but not catastrophic — user sees repeated prompts with growing cost. Ship the substep-completion plan first or in the same release.

--- a/packages/agency-lang/lib/lsp/diagnostics.ts
+++ b/packages/agency-lang/lib/lsp/diagnostics.ts
@@ -22,7 +22,8 @@ import { resolveAgencyImportPath } from "../importPaths.js";
 const STDLIB_AUTO_IMPORTS: string[] = [
   "print", "printJSON", "parseJSON", "input", "sleep", "round", "fetch",
   "fetchJSON", "read", "write", "readImage", "notify", "range",
-  "mostCommon", "keys", "values", "entries", "emit",
+  "mostCommon", "keys", "values", "entries", "emit", "callback", "guard",
+  "__guardCheck",
 ];
 
 /**

--- a/packages/agency-lang/lib/runtime/hooks.test.ts
+++ b/packages/agency-lang/lib/runtime/hooks.test.ts
@@ -88,7 +88,7 @@ describe("callHook (rewritten)", () => {
       name: "onLLMCallEnd",
       data: {},
     } as any);
-    expect(result).toBeUndefined();
+    expect(result).toEqual({ kind: "ok" });
   });
 
   it("catches and logs ordinary errors, continues firing others", async () => {
@@ -140,7 +140,7 @@ describe("callHook (rewritten)", () => {
       name: "onLLMCallStart",
       data: { messages: [{ role: "user", content: "original" }] },
     } as any);
-    expect(result).toBeUndefined();
+    expect(result).toEqual({ kind: "ok" });
   });
 
   it("fires scoped → top-level → TS-passed (in that order)", async () => {
@@ -204,7 +204,7 @@ describe("callHook (rewritten)", () => {
     inner.scopedCallbacks = [{ name: "onNodeStart", fn: callbackFn }];
     const ctx = ctxWithStack([inner]);
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "x" } } as any);
-    expect(out).toEqual([fakeInterrupt]);
+    expect(out).toEqual({ kind: "interrupts", interrupts: [fakeInterrupt] });
     // callHook itself no longer logs the unhandled interrupt — that
     // responsibility moves to callHookAndDrop.
     expect(consoleErr).not.toHaveBeenCalled();
@@ -239,7 +239,7 @@ describe("invokeCallback / fireWithGuard interrupt return", () => {
     ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: cb }];
 
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
-    expect(out).toEqual([intr]);
+    expect(out).toEqual({ kind: "interrupts", interrupts: [intr] });
   });
 
   it("collects interrupts from every callback even when earlier ones halt", async () => {
@@ -254,7 +254,7 @@ describe("invokeCallback / fireWithGuard interrupt return", () => {
     ];
 
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
-    expect(out).toEqual([intrA, intrB]);
+    expect(out).toEqual({ kind: "interrupts", interrupts: [intrA, intrB] });
     // Both callbacks must have been invoked — an interrupt in A must not
     // short-circuit B. This is the concurrent-batching invariant that
     // mirrors runForkAll: every sibling runs to completion, all halts
@@ -267,7 +267,7 @@ describe("invokeCallback / fireWithGuard interrupt return", () => {
     const ctx = fakeCtx();
     ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: fakeAgencyFn(undefined) }];
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
-    expect(out).toBeUndefined();
+    expect(out).toEqual({ kind: "ok" });
   });
 
   it("real JS errors in a callback do NOT appear in the returned interrupts", async () => {
@@ -279,7 +279,7 @@ describe("invokeCallback / fireWithGuard interrupt return", () => {
     (cbCrash as any).__agencyFunction = true;
     ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: cbCrash }];
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
-    expect(out).toBeUndefined();
+    expect(out).toEqual({ kind: "ok" });
     expect(errSpy).toHaveBeenCalled();
     errSpy.mockRestore();
   });
@@ -323,7 +323,7 @@ describe("Phase 0: end-to-end shape (real AgencyFunction)", () => {
     const ctx = fakeCtx();
     ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: realAgencyFn([intrA]) }];
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
-    expect(out).toEqual([intrA]);
+    expect(out).toEqual({ kind: "interrupts", interrupts: [intrA] });
   });
 
   it("mixed batch: halt → succeed → halt yields [first, third] in order", async () => {
@@ -336,7 +336,7 @@ describe("Phase 0: end-to-end shape (real AgencyFunction)", () => {
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
     // The undefined return in the middle must not break the loop, must not
     // add anything to the batch, and must not perturb ordering.
-    expect(out).toEqual([intrA, intrC]);
+    expect(out).toEqual({ kind: "interrupts", interrupts: [intrA, intrC] });
   });
 
   it("cross-source ordering: scoped first, then top-level, in the returned batch", async () => {
@@ -351,7 +351,7 @@ describe("Phase 0: end-to-end shape (real AgencyFunction)", () => {
     // gatherCallbacks order: scoped → top-level → TS-passed. The interrupt
     // batch must preserve that firing order. (TS-passed is plain JS and
     // can't contribute — covered in a separate test below.)
-    expect(out).toEqual([intrA, intrB]);
+    expect(out).toEqual({ kind: "interrupts", interrupts: [intrA, intrB] });
   });
 });
 
@@ -365,7 +365,7 @@ describe("Phase 0: scoped-callback halt path", () => {
     inner.scopedCallbacks = [{ name: "onNodeStart", fn: realAgencyFn([intr]) }];
     const ctx = ctxWithStack([inner]);
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } } as any);
-    expect(out).toEqual([intr]);
+    expect(out).toEqual({ kind: "interrupts", interrupts: [intr] });
   });
 });
 
@@ -379,14 +379,14 @@ describe("Phase 0: non-AgencyFunction callbacks cannot contribute to the batch",
     inner.scopedCallbacks = [{ name: "onNodeStart", fn: () => fakeShape }];
     const ctx = ctxWithStack([inner]);
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } } as any);
-    expect(out).toBeUndefined();
+    expect(out).toEqual({ kind: "ok" });
   });
 
   it("TS-passed callback returning interrupt-shaped value is silently dropped", async () => {
     const fakeShape = [{ type: "interrupt", kind: "js::oops", message: "" }];
     const ctx = ctxWithStack([new State()], { onNodeStart: () => fakeShape });
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } } as any);
-    expect(out).toBeUndefined();
+    expect(out).toEqual({ kind: "ok" });
   });
 
   it("global hook returning interrupt-shaped value is silently dropped", async () => {
@@ -398,7 +398,7 @@ describe("Phase 0: non-AgencyFunction callbacks cannot contribute to the batch",
     registerGlobalHook("onEmit", (() => fakeShape) as any);
     const ctx = fakeCtx();
     const out = await callHook({ ctx, name: "onEmit", data: undefined as any });
-    expect(out).toBeUndefined();
+    expect(out).toEqual({ kind: "ok" });
   });
 });
 
@@ -407,7 +407,7 @@ describe("Phase 0: hasInterrupts edge cases at the callback boundary", () => {
     const ctx = fakeCtx();
     ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: realAgencyFn([]) }];
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
-    expect(out).toBeUndefined();
+    expect(out).toEqual({ kind: "ok" });
   });
 
   it("mixed array (interrupt + non-interrupt) is treated as non-interrupt (dropped)", async () => {
@@ -417,7 +417,7 @@ describe("Phase 0: hasInterrupts edge cases at the callback boundary", () => {
     const intr = { type: "interrupt", kind: "x::y", message: "" };
     ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: realAgencyFn([intr, "not-an-interrupt"]) }];
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
-    expect(out).toBeUndefined();
+    expect(out).toEqual({ kind: "ok" });
   });
 
   it("single interrupt object (not array-wrapped) is treated as non-interrupt (dropped)", async () => {
@@ -427,7 +427,7 @@ describe("Phase 0: hasInterrupts edge cases at the callback boundary", () => {
     const intr = { type: "interrupt", kind: "x::y", message: "" };
     ctx.topLevelCallbacks = [{ name: "onNodeStart", fn: realAgencyFn(intr) }];
     const out = await callHook({ ctx, name: "onNodeStart", data: { nodeName: "n" } });
-    expect(out).toBeUndefined();
+    expect(out).toEqual({ kind: "ok" });
   });
 });
 
@@ -458,6 +458,6 @@ describe("Phase 1: onAgentStart / onAgentEnd reject interrupts", () => {
     const ctx = fakeCtx();
     ctx.topLevelCallbacks = [{ name: "onAgentStart", fn: fakeAgencyFn(undefined) }];
     const out = await callHook({ ctx, name: "onAgentStart", data: {} as any });
-    expect(out).toBeUndefined();
+    expect(out).toEqual({ kind: "ok" });
   });
 });

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -11,6 +11,7 @@ import type { CallbackName } from "../types/function.js";
 import { AgencyFunction } from "./agencyFunction.js";
 import { AgencyCancelledError, RestoreSignal } from "./errors.js";
 import { hasInterrupts, type Interrupt } from "./interrupts.js";
+import { isFailure, type ResultFailure } from "./result.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { StateStack } from "./state/stateStack.js";
 import type { TraceEvent } from "./trace/types.js";
@@ -132,12 +133,35 @@ export function registerGlobalHook<K extends keyof CallbackMap>(
   _globalHooks[name]!.push(fn);
 }
 
+/** Outcome of firing a callback. `ok` means the callback completed
+ *  normally; `interrupts` means it raised one or more agency interrupts
+ *  that need user response; `failure` means the user (or a handler)
+ *  rejected an interrupt the callback raised — see
+ *  `docs/superpowers/plans/2026-05-23-callback-rejection-propagation.md`. */
+export type CallbackOutcome =
+  | { kind: "ok" }
+  | { kind: "interrupts"; interrupts: Interrupt[] }
+  | { kind: "failure"; failure: ResultFailure };
+
+/** Extract a Failure from a callback's return value, handling both the
+ *  bare `failure(...)` shape (used by `def`-style callbacks) and the
+ *  node-context envelope `{ messages, data: failure(...) }` produced by
+ *  callbacks compiled inside a node-style scope. Returns the unwrapped
+ *  failure or undefined if neither shape matches. */
+function extractCallbackFailure(result: any): ResultFailure | undefined {
+  if (isFailure(result)) return result;
+  if (result && typeof result === "object" && isFailure((result as any).data)) {
+    return (result as any).data;
+  }
+  return undefined;
+}
+
 async function invokeCallback(
   fn: any,
   data: unknown,
   ctx: RuntimeContext<any>,
   stateStack?: StateStack,
-): Promise<Interrupt[] | undefined> {
+): Promise<CallbackOutcome> {
   if (AgencyFunction.isAgencyFunction(fn)) {
     // When `stateStack` is set, the callback frame is pushed onto that
     // stack rather than `ctx.stateStack`. This matters inside parallel
@@ -150,19 +174,23 @@ async function invokeCallback(
       stateStack ? { ctx, stateStack } : { ctx },
     );
     // The callback body completed with an unhandled `interrupt` statement.
-    // Surface the interrupts so the caller can decide what to do — Phase 0
-    // callers (`callHookAndDrop`) log them; Phase 1+ codegen sites stamp a
-    // checkpoint and propagate them up the runner.
+    // Surface the interrupts so the caller can decide what to do.
     if (hasInterrupts(result)) {
-      return result as Interrupt[];
+      return { kind: "interrupts", interrupts: result as Interrupt[] };
     }
-    return undefined;
+    // The callback raised an interrupt that a handler (or the user) rejected.
+    // Generated `interrupt` codegen translates rejection to
+    // `runner.halt(failure("interrupt rejected", ...))`, so the callback's
+    // return value is a Failure — possibly wrapped in a node-context envelope.
+    const failure = extractCallbackFailure(result);
+    if (failure) return { kind: "failure", failure };
+    return { kind: "ok" };
   }
   // Plain JS callbacks (from AgencyCallbacks TS arg) have no interrupt
   // mechanism — they're just async functions. Errors thrown by them still
   // get caught by fireWithGuard below.
   await fn(data);
-  return undefined;
+  return { kind: "ok" };
 }
 
 async function fireWithGuard(
@@ -171,13 +199,13 @@ async function fireWithGuard(
   ctx: RuntimeContext<any>,
   errorLabel: string,
   stateStack?: StateStack,
-): Promise<Interrupt[] | undefined> {
+): Promise<CallbackOutcome> {
   const key = fn as object;
   // Recursion guard scoped to the current ALS context. See
   // `_activeCallbacksALS` docstring for why ALS (not module-level
   // WeakSet, not per-stack WeakSet).
   const inherited = _activeCallbacksALS.getStore();
-  if (inherited?.has(key)) return undefined;
+  if (inherited?.has(key)) return { kind: "ok" };
   // Always allocate a fresh set per fire — we need our own copy so a
   // deeper fire can safely re-enter without corrupting the outer set.
   // The new set carries over the inherited entries plus our own key.
@@ -195,7 +223,7 @@ async function fireWithGuard(
     // Interrupts no longer flow through this path — they return normally
     // from invokeCallback now.
     console.error(`[agency] ${errorLabel} callback error:`, error);
-    return undefined;
+    return { kind: "ok" };
   }
 }
 
@@ -238,7 +266,7 @@ export async function invokeCallbacks<K extends keyof CallbackMap>(args: {
   name: K;
   data: CallbackMap[K];
   stateStack?: StateStack;
-}): Promise<Interrupt[] | undefined> {
+}): Promise<CallbackOutcome> {
   const { ctx, name, data, stateStack } = args;
   const walkStack = stateStack ?? ctx.stateStack;
 
@@ -258,8 +286,15 @@ export async function invokeCallbacks<K extends keyof CallbackMap>(args: {
   }
 
   for (const fn of gatherCallbacks(ctx, name, walkStack)) {
-    const result = await fireWithGuard(fn, data, ctx, name, stateStack);
-    if (result) collected.push(...result);
+    const outcome = await fireWithGuard(fn, data, ctx, name, stateStack);
+    // First failure wins — later callbacks don't fire. Matches how a JS
+    // error inside a Runner.step body short-circuits the rest of that
+    // step. See docs/superpowers/plans/2026-05-23-callback-rejection-
+    // propagation.md.
+    if (outcome.kind === "failure") return outcome;
+    if (outcome.kind === "interrupts") {
+      collected.push(...outcome.interrupts);
+    }
   }
 
   // Defensive: onAgentStart / onAgentEnd fire outside any agency frame so
@@ -280,7 +315,9 @@ export async function invokeCallbacks<K extends keyof CallbackMap>(args: {
     );
   }
 
-  return collected.length > 0 ? collected : undefined;
+  return collected.length > 0
+    ? { kind: "interrupts", interrupts: collected }
+    : { kind: "ok" };
 }
 
 /** Today's call sites that fire on the top-level stack. Thin wrapper over
@@ -289,15 +326,15 @@ export async function callHook<K extends keyof CallbackMap>(args: {
   ctx: RuntimeContext<any>;
   name: K;
   data: CallbackMap[K];
-}): Promise<Interrupt[] | undefined> {
+}): Promise<CallbackOutcome> {
   return invokeCallbacks(args);
 }
 
 /** Fire a SINGLE specific callback (already extracted from
- *  `gatherCallbacks`) on the given `stateStack`. Returns any interrupts
- *  raised inside the callback. Used by `Runner.hook`'s per-callback
- *  runBatch path so each batch child corresponds to exactly one
- *  callback — letting runBatch's cached-branch short-circuit skip
+ *  `gatherCallbacks`) on the given `stateStack`. Returns the callback's
+ *  outcome (ok / interrupts / failure). Used by `Runner.hook`'s
+ *  per-callback runBatch path so each batch child corresponds to exactly
+ *  one callback — letting runBatch's cached-branch short-circuit skip
  *  already-resolved callbacks on resume. */
 export async function invokeOneCallback<K extends keyof CallbackMap>(args: {
   ctx: RuntimeContext<any>;
@@ -305,7 +342,7 @@ export async function invokeOneCallback<K extends keyof CallbackMap>(args: {
   name: K;
   data: CallbackMap[K];
   stateStack?: StateStack;
-}): Promise<Interrupt[] | undefined> {
+}): Promise<CallbackOutcome> {
   return fireWithGuard(args.fn, args.data, args.ctx, args.name, args.stateStack);
 }
 
@@ -345,18 +382,27 @@ export async function callHookAndDrop<K extends keyof CallbackMap>(args: {
   name: K;
   data: CallbackMap[K];
 }): Promise<void> {
-  const result = await callHook(args);
-  if (result) {
+  const outcome = await callHook(args);
+  if (outcome.kind === "interrupts") {
     console.error(
       `[agency] ${args.name} callback raised an unhandled interrupt ` +
-        `(kind="${result[0].kind}") at a runtime call site that does not ` +
+        `(kind="${outcome.interrupts[0].kind}") at a runtime call site that does not ` +
         `support interrupt propagation. The interrupt is being dropped. ` +
         `Some sites (onAgentStart/onAgentEnd) fundamentally cannot ` +
         `propagate because they fire outside any agency frame; others ` +
         `(LLM/tool hooks) may gain propagation in a future phase. To ` +
         `respond to this interrupt, register the callback on a hook ` +
         `that fires inside an agency call frame instead.`,
-      result,
+      outcome.interrupts,
+    );
+  } else if (outcome.kind === "failure") {
+    console.error(
+      `[agency] ${args.name} callback halted with a rejected interrupt ` +
+        `(error="${outcome.failure.error}") at a runtime call site that ` +
+        `does not support failure propagation. The failure is being ` +
+        `dropped. Top-level hooks (onAgentStart/onAgentEnd) fundamentally ` +
+        `cannot propagate because they fire outside any agency frame.`,
+      outcome.failure,
     );
   }
 }

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -9,7 +9,7 @@ import type { PromptConfig } from "./llmClient.js";
 import { setupFunction } from "./node.js";
 // See docs/dev/promptRunner.md for the control-flow abstraction used here.
 import { PromptBailout, PromptRunner } from "./promptRunner.js";
-import { isFailure } from "./result.js";
+import { isFailure, type ResultFailure } from "./result.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import { MessageThread } from "./state/messageThread.js";
@@ -27,10 +27,15 @@ type Tool = {
 
 /** Result of `_runPrompt`. `interrupt` carries interrupts raised by an
  *  `onLLMCallStart` or `onLLMCallEnd` callback so the outer `pr.step` can
- *  checkpoint and bail uniformly with the tool-interrupt path. */
+ *  checkpoint and bail uniformly with the tool-interrupt path. `failure`
+ *  carries a rejected-interrupt failure (the handler returned reject)
+ *  surfaced from one of the LLM hooks; the outer `runPrompt` returns it
+ *  so the user's `llm()` call site receives a Failure value. See
+ *  docs/superpowers/plans/2026-05-23-callback-rejection-propagation.md. */
 export type RunPromptResult =
   | { kind: "ok"; messages: MessageThread; toolCalls: smoltalk.ToolCallJSON[] }
-  | { kind: "interrupt"; interrupts: Interrupt[] };
+  | { kind: "interrupt"; interrupts: Interrupt[] }
+  | { kind: "failure"; failure: ResultFailure };
 
 async function _runPrompt({
   ctx,
@@ -63,7 +68,7 @@ async function _runPrompt({
   const stream = !!(clientConfig as any)?.stream;
   const startTime = performance.now();
 
-  const startInterrupts = await callHook({
+  const startOutcome = await callHook({
     ctx,
     name: "onLLMCallStart",
     data: {
@@ -73,7 +78,8 @@ async function _runPrompt({
       messages: messages.toJSON().messages,
     },
   });
-  if (startInterrupts) return { kind: "interrupt", interrupts: startInterrupts };
+  if (startOutcome.kind === "interrupts") return { kind: "interrupt", interrupts: startOutcome.interrupts };
+  if (startOutcome.kind === "failure") return { kind: "failure", failure: startOutcome.failure };
 
   // Re-check after hook — cancellation may have occurred during the callback
   if (ctx.isCancelled(stateStack)) {
@@ -201,7 +207,7 @@ async function _runPrompt({
     }
   }
 
-  const endInterrupts = await callHook({
+  const endOutcome = await callHook({
     ctx,
     name: "onLLMCallEnd",
     data: {
@@ -213,7 +219,8 @@ async function _runPrompt({
       messages: messages.toJSON().messages,
     },
   });
-  if (endInterrupts) return { kind: "interrupt", interrupts: endInterrupts };
+  if (endOutcome.kind === "interrupts") return { kind: "interrupt", interrupts: endOutcome.interrupts };
+  if (endOutcome.kind === "failure") return { kind: "failure", failure: endOutcome.failure };
 
   return { kind: "ok", messages, toolCalls };
 }
@@ -357,6 +364,11 @@ export async function runPrompt(args: {
   let toolCalls: smoltalk.ToolCallJSON[] = self.pendingToolCalls ?? [];
 
   let shouldPop = true;
+  // Set when an LLM hook (onLLMCallStart/End) callback raises an
+  // interrupt that a handler rejects. Surfaced as runPrompt's return
+  // value so the user's `llm()` call site sees a Failure. See
+  // docs/superpowers/plans/2026-05-23-callback-rejection-propagation.md.
+  let llmFailure: ResultFailure | undefined;
   try {
   // Initial LLM call wrapped in pr.step so any callback interrupts
   // (onLLMCallStart / onLLMCallEnd) bail uniformly. To keep the step
@@ -405,6 +417,14 @@ export async function runPrompt(args: {
       closeLlmSpan();
       return result.interrupts;
     }
+    if (result.kind === "failure") {
+      // A hook callback raised an interrupt that was rejected. The LLM
+      // call already happened; we don't revert messages — there's no
+      // resume coming. Stash the failure so the outer code returns it.
+      llmFailure = result.failure;
+      closeLlmSpan();
+      return;
+    }
     messages = result.messages;
     toolCalls = result.toolCalls;
     if (injectedFactsContent !== null) {
@@ -422,6 +442,10 @@ export async function runPrompt(args: {
     self.messagesJSON = messages.toJSON().messages;
     self.pendingToolCalls = toolCalls.length > 0 ? toolCalls : null;
   });
+
+  // A rejected hook callback halted the initial LLM call — surface the
+  // failure to the caller (user's `llm()` site) and exit.
+  if (llmFailure) return llmFailure;
 
   // After resume (initialLlmCall skipped), make sure there's an open
   // llmCall span if we have pending tool calls — the tool loop expects
@@ -660,18 +684,27 @@ export async function runPrompt(args: {
 
           await b.step(
             `round.${round}.tool.${toolCall.id}.start`,
-            async () =>
+            async () => {
               // Use `invokeCallbacks` with `branchStack` so any callback
               // that raises an interrupt captures a checkpoint with this
               // tool branch's slice (rather than the parent runPrompt
               // stack). Without this, `setInterruptOnBranch` would not
               // find the right frame on resume. See Plan 1 / Bug 2.
-              await invokeCallbacks({
+              const outcome = await invokeCallbacks({
                 ctx,
                 name: "onToolCallStart",
                 data: { toolName: handler.name, args: namedArgs },
                 stateStack: branchStack,
-              }),
+              });
+              if (outcome.kind === "interrupts") return outcome.interrupts;
+              // Callback failures on tool start/end currently fall through
+              // as "callback no-op'd"; full rejection routing through the
+              // existing `isRejected(toolResult)` rail is tracked as
+              // future work in
+              // docs/superpowers/plans/2026-05-23-callback-rejection-
+              // propagation.md Task 5.
+              return;
+            },
           );
           if (b.interrupts) return;
 
@@ -740,10 +773,10 @@ export async function runPrompt(args: {
               self.runnerState.toolTimings[toolCall.id] ?? 0;
             await b.step(
               `round.${round}.tool.${toolCall.id}.end`,
-              async () =>
+              async () => {
                 // Same slice-rule reason as the .start hook above —
                 // callback interrupts must capture the branch's stack.
-                await invokeCallbacks({
+                const outcome = await invokeCallbacks({
                   ctx,
                   name: "onToolCallEnd",
                   data: {
@@ -752,7 +785,12 @@ export async function runPrompt(args: {
                     timeTaken,
                   },
                   stateStack: branchStack,
-                }),
+                });
+                if (outcome.kind === "interrupts") return outcome.interrupts;
+                // See note on the .start hook above re: callback failure
+                // routing for tool hooks (tracked separately).
+                return;
+              },
             );
             // If onToolCallEnd collected interrupts, the branch is halted —
             // don't log toolCall (it would duplicate when the step re-runs on
@@ -827,6 +865,12 @@ export async function runPrompt(args: {
           closeLlmSpan();
           return nextResult.interrupts;
         }
+        if (nextResult.kind === "failure") {
+          // See initialLlmCall — rejected hook callback halts this round.
+          llmFailure = nextResult.failure;
+          closeLlmSpan();
+          return;
+        }
         messages = nextResult.messages;
         toolCalls = nextResult.toolCalls;
         // Increment the round counter only after a successful LLM round,
@@ -835,6 +879,10 @@ export async function runPrompt(args: {
         self.messagesJSON = messages.toJSON().messages;
         self.pendingToolCalls = toolCalls.length > 0 ? toolCalls : null;
       });
+
+      // Exit the tool loop on hook-rejection failure — same surface
+      // semantics as the initialLlmCall case.
+      if (llmFailure) return llmFailure;
     }
   } catch (error) {
     if (error instanceof PromptBailout) {

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -8,7 +8,7 @@ import {
   type CallbackMap,
 } from "./hooks.js";
 import { hasInterrupts } from "./interrupts.js";
-import { __pipeBind } from "./result.js";
+import { __pipeBind, isFailure, type ResultFailure } from "./result.js";
 import { runBatch } from "./runBatch.js";
 import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
@@ -478,7 +478,7 @@ export class Runner {
         // ones. Without this, every resume cycle re-fired every
         // callback from scratch, breaking side-effect-once semantics
         // for multi-callback hooks.
-        const result = await runBatch<undefined>({
+        const result = await runBatch<ResultFailure | undefined>({
           ctx: this.ctx,
           parentStack,
           parentFrame: this.frame,
@@ -495,14 +495,22 @@ export class Runner {
               // the right slice. We already extracted `fn` from the
               // outer `gatherCallbacks` call — don't re-gather inside
               // the child.
-              const interrupts = await invokeOneCallback({
+              const outcome = await invokeOneCallback({
                 ctx: this.ctx,
                 fn,
                 name: hookName as keyof CallbackMap,
                 data: data as CallbackMap[keyof CallbackMap],
                 stateStack: branchStack,
               });
-              return interrupts ?? undefined;
+              // Interrupts flow through runBatch's own machinery.
+              if (outcome.kind === "interrupts") return outcome.interrupts;
+              // Failures travel as the child's T-value; the post-batch
+              // walk below halts the surrounding runner with the first
+              // failure it finds. See
+              // docs/superpowers/plans/2026-05-23-callback-rejection-
+              // propagation.md.
+              if (outcome.kind === "failure") return outcome.failure;
+              return undefined;
             },
           })),
         });
@@ -511,6 +519,17 @@ export class Runner {
             this.halt({ ...this.state, data: result.interrupts });
           } else {
             this.halt(result.interrupts);
+          }
+          return;
+        }
+        // "first failure wins" — same precedence as invokeCallbacks's
+        // sequential loop.
+        const firstFailure = result.values.find((v) => v !== undefined && isFailure(v));
+        if (firstFailure) {
+          if (this.nodeContext) {
+            this.halt({ ...this.state, data: firstFailure });
+          } else {
+            this.halt(firstFailure);
           }
           return;
         }

--- a/packages/agency-lang/lib/templates/backends/agency/template.mustache
+++ b/packages/agency-lang/lib/templates/backends/agency/template.mustache
@@ -1,3 +1,3 @@
-import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback } from "std::index";
+import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback, guard, __guardCheck } from "std::index";
 
 {{{body:string}}}

--- a/packages/agency-lang/lib/templates/backends/agency/template.ts
+++ b/packages/agency-lang/lib/templates/backends/agency/template.ts
@@ -3,9 +3,10 @@
 // Any manual changes will be lost.
 import { apply } from "typestache";
 
-export const template = `import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback } from "std::index";
+export const template = `import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback, guard, __guardCheck } from "std::index";
 
-{{{body:string}}}`;
+{{{body:string}}}
+`;
 
 export type TemplateType = {
   body: string;

--- a/packages/agency-lang/stdlib/index.agency
+++ b/packages/agency-lang/stdlib/index.agency
@@ -85,6 +85,51 @@ export safe def round(num: number, precision: number): number {
   return _round(num, precision)
 }
 
+// Internal helper for `guard`. Lives here (rather than in std::thread)
+// because scoped callbacks bound via `.partial()` need their underlying
+// function to be in the user's tool registry at resume time — users
+// only get the names they explicitly import, but every export of
+// `std::index` is auto-imported into every .agency file, so
+// __guardCheck is reachable from any program that calls `guard()`. The
+// `__` prefix signals "implementation detail, do not call directly."
+export def __guardCheck(state: { start: number, limit: number }, data: any) {
+  const spent = __internal_getCost() - state.start
+  if (spent > state.limit) {
+    state.limit = interrupt std::guard_exceeded(
+      "Cost limit exceeded: spent $${spent}, limit $${state.limit}",
+      { spent: spent, limit: state.limit }
+    )
+  }
+}
+
+export def guard(limit: number, block: () => any): any {
+  """
+  Run a block with a cost limit. After every LLM call inside the
+  block, the cumulative cost since `guard` started is compared to
+  `limit`. If the spend exceeds the limit, an `std::guard_exceeded`
+  interrupt is raised with `{ spent, limit }`.
+
+  The user responds with a new (raised) limit as a number to continue
+  execution; the callback captures the response and uses it as the
+  new limit for subsequent checks. To abort, the user stops responding
+  to the interrupt (kills the agent process).
+
+  Nested guards each register their own scoped callback and check
+  independently — the innermost guard's limit triggers first. Inside
+  fork branches the per-branch cost-tracking semantics (see
+  `std::thread.getCost`) already account for branch spend.
+
+  Memory-layer LLM calls (memory.text / memory.embed) bypass the LLM
+  callback and do NOT count toward the limit.
+
+  @param limit - Maximum cost in dollars (USD)
+  @param block - The block to execute
+  """
+  const state = { start: __internal_getCost(), limit: limit }
+  callback("onLLMCallEnd", __guardCheck.partial(state: state))
+  return block()
+}
+
 export def fetch(
   baseUrl: string,
   path: string = "",

--- a/packages/agency-lang/tests/agency/guard-cost.agency
+++ b/packages/agency-lang/tests/agency/guard-cost.agency
@@ -1,0 +1,29 @@
+// Example / smoke test for `guard(limit, block)`.
+//
+// Intentionally has NO accompanying .test.json — three runtime gaps
+// currently prevent end-to-end automation:
+//   1. LLM substep not marked complete when onLLMCallEnd callback
+//      raises an interrupt → the LLM call re-runs on each resume.
+//   2. Mutation of PFA-bound state (state.limit = newLimit) does not
+//      survive serialize/deserialize, so a raised limit is forgotten.
+//   3. Callback rejection silently no-ops (failure value dropped by
+//      Runner.hook / hooks.ts) instead of halting the caller.
+//
+// See:
+//   docs/superpowers/plans/2026-05-23-callback-end-hook-substep-completion.md
+//   docs/superpowers/plans/2026-05-23-guard-statestack-architecture.md
+//   docs/superpowers/plans/2026-05-23-callback-rejection-propagation.md
+//
+// When those land, this file can be promoted to a real fixture with
+// a `.test.json` that supplies interrupt responses and asserts
+// expected output.
+//
+// `guard` is auto-imported from std::index — no explicit import needed.
+
+node main() {
+  const result: string = guard(0.0000001) as {
+    const reply: string = llm("Reply with the single word: pong")
+    return "done"
+  }
+  return result
+}

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
+import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback, guard, __guardCheck } from "agency-lang/stdlib/index.js";
 import { fileURLToPath } from "url";
 import __process from "process";
 import { readFileSync, writeFileSync } from "fs";
@@ -167,6 +167,8 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
+__registerTool(guard);
+__registerTool(__guardCheck);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/function-call-test.agency")
 }

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
+import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback, guard, __guardCheck } from "agency-lang/stdlib/index.js";
 import { fileURLToPath } from "url";
 import __process from "process";
 import { readFileSync, writeFileSync } from "fs";
@@ -167,6 +167,8 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
+__registerTool(guard);
+__registerTool(__guardCheck);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/if-else-test.agency")
 }

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
+import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback, guard, __guardCheck } from "agency-lang/stdlib/index.js";
 import { fileURLToPath } from "url";
 import __process from "process";
 import { readFileSync, writeFileSync } from "fs";
@@ -167,6 +167,8 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
+__registerTool(guard);
+__registerTool(__guardCheck);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/interrupt-test.agency")
 }

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
+import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback, guard, __guardCheck } from "agency-lang/stdlib/index.js";
 import { fileURLToPath } from "url";
 import __process from "process";
 import { readFileSync, writeFileSync } from "fs";
@@ -167,6 +167,8 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
+__registerTool(guard);
+__registerTool(__guardCheck);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/loop-test.agency")
 }

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
+import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback, guard, __guardCheck } from "agency-lang/stdlib/index.js";
 import { fileURLToPath } from "url";
 import __process from "process";
 import { readFileSync, writeFileSync } from "fs";
@@ -167,6 +167,8 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
+__registerTool(guard);
+__registerTool(__guardCheck);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/nested-calls-test.agency")
 }

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback } from "agency-lang/stdlib/index.js";
+import { print, printJSON, parseJSON, input, sleep, round, fetch, fetchJSON, read, write, readImage, notify, range, mostCommon, keys, values, entries, emit, callback, guard, __guardCheck } from "agency-lang/stdlib/index.js";
 import { fileURLToPath } from "url";
 import __process from "process";
 import { readFileSync, writeFileSync } from "fs";
@@ -167,6 +167,8 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
+__registerTool(guard);
+__registerTool(__guardCheck);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/step-test.agency")
 }


### PR DESCRIPTION
## What this PR adds

A `guard(limit, block)` function in the stdlib (auto-imported via `std::index`). Intended usage:

```
guard(5.00) as {
  llm("step 1")
  llm("step 2")
  return process(reply)
}
```

When LLM cost inside the block exceeds the limit, the runtime raises `std::guard_exceeded` and the user can respond with a raised limit number to continue.

## Implementation approach

Scoped `onLLMCallEnd` callback bound via PFA to a per-guard state object:

```
export def guard(limit: number, block: () => any): any {
  const state = { start: __internal_getCost(), limit: limit }
  callback("onLLMCallEnd", __guardCheck.partial(state: state))
  return block()
}
```

`__guardCheck` lives in `stdlib/index.agency` alongside `guard` itself — both auto-imported via `std::index`. They have to live there because PFA-bound scoped callbacks need their underlying function in the user's tool registry at resume time, and only auto-imported names get auto-registered in every user's program. (Putting `__guardCheck` in `std::thread` and importing only `guard` would mean `__guardCheck` is never added to the user's `__toolRegistry` → the PFA's `FunctionRefReviver.findInRegistry` fails on resume.)

The PFA approach (rather than `callback("onLLMCallEnd") as data { ... }` with closure capture) is forced by an existing limitation: `lib/preprocessors/liftCallbacks.ts` explicitly does not support closing over enclosing function/node locals. PFA neatly sidesteps this — bound args are explicit values — at the cost of one of the gaps described below.

## ⚠️ Half-working — three runtime gaps block end-to-end usability

This is shipped intentionally as WIP so the design discussion is visible and the gaps are tracked as concrete plans rather than as a TODO comment.

### Gap 1 — End-hook substep completion

When the callback raises an interrupt, the LLM call's substep is not yet marked complete in the surrounding code's substep counter. On resume the LLM call re-runs, doubling cost per cycle.

Verified: spend grew **6e-6 → 12e-6 → 18e-6 → 24e-6 → 30e-6** across 5 interrupt cycles. Linear — exactly one extra LLM call per cycle. This is the same class of bug as the deferred-return plan addresses for `onNodeEnd` (value-returning) and `onFunctionEnd` (finally-block).

Plan: `docs/superpowers/plans/2026-05-23-callback-end-hook-substep-completion.md` — adds a `Runner.commitStep(id)` primitive that the LLM call site invokes BEFORE firing `onLLMCallEnd`.

### Gap 2 — PFA-bound state mutation does not survive resume

`state.limit = userResponse` inside `__guardCheck` mutates the bound state object. Within a single run this works (JS object identity preserved). At interrupt time the `state` is serialized by value as part of the PFA's bound args. On resume a brand new revived object replaces it — the user's "raised limit" is silently dropped, and the next callback fire sees the original limit again.

Plan: `docs/superpowers/plans/2026-05-23-guard-statestack-architecture.md` — pivots `guard` to a runtime `StateStack`-based mechanism (the original spec's `__pushGuard` / `__popGuard` direction, adapted to use interrupt instead of `GuardExceededError`). The `StateStack` already serializes per-branch and survives resume cleanly; mutating an entry on the deserialized list naturally persists.

### Gap 3 — Callback rejection silently no-ops

The codegen for callback reject responses halts the callback's Runner with a `failure(...)`, but `lib/runtime/hooks.ts` `invokeCallback` only inspects the return value for `hasInterrupts(...)`. A failure is not an interrupt, so it's returned to the caller as `undefined` and the failure is dropped on the floor. The enclosing `block()` continues running as if the user had approved.

This is independent of `guard` — every user-written callback that interrupts has the same silent-drop on rejection.

Plan: `docs/superpowers/plans/2026-05-23-callback-rejection-propagation.md` — distinguishes "callback completed normally" from "callback halted with failure" in the hooks pipeline and propagates the failure up the runner chain.

## What's in this PR

- `stdlib/index.agency` — adds `guard` and `__guardCheck`.
- `lib/templates/backends/agency/template.mustache` + `template.ts` — adds `guard`, `__guardCheck`, `callback` to the auto-import list (regenerated via `pnpm run templates`).
- `lib/lsp/diagnostics.ts` — keeps the LSP's `STDLIB_AUTO_IMPORTS` in sync with the parser template.
- `tests/agency/guard-cost.agency` — documented example showing the intended API. No `.test.json` (any test would fail because of Gap 1).
- `docs/superpowers/plans/2026-05-23-*.md` — three new plan files for the runtime gaps above.
- `docs/site/stdlib/index.md` — regenerated by `make`.

## Suggested merge order

1. Land this PR as-is. The stdlib surface is correct; the implementation is functional in the "stops runaway LLM cost" sense (user gets prompted before each over-budget call). Just imperfect re: cost compounding and silent rejection.
2. Land `2026-05-23-callback-end-hook-substep-completion.md` next — that alone makes `guard` 90% usable (one prompt per LLM call, no cost compounding).
3. Land `2026-05-23-callback-rejection-propagation.md` — gives the user a clean way to abort.
4. Land `2026-05-23-guard-statestack-architecture.md` — final piece, makes raised-limit responses actually persist, lets the user genuinely raise-and-continue.

Each plan is independent and can ship as its own PR.

## Test status

`make` succeeds. No existing tests touched the renamed/added auto-imports; nothing regressed. The new `tests/agency/guard-cost.agency` is shipped without a `.test.json` deliberately (see Gap 1).
