### PR TITLE
Builtin cost guards: guard(cost: $X) as { ... } in std::thread

### DIFF
--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+### Added
+- `guard(cost: $X) as { ... }` in `std::thread` — automatic cost-limit
+  enforcement for blocks of LLM-using code. Returns a `Result` so
+  callers can branch on success vs over-budget. See
+  [docs/site/guide/cost-guards.md](./docs/site/guide/cost-guards.md).
+
+### Fixed
+- Trailing block argument is now correctly passed when a function is
+  called with named arguments (`f(name: val) as { ... }`). Previously
+  the block was silently dropped, surfacing as a "Missing required
+  argument" runtime error.
+
 ## May 18 2026 — v0.2
 
 ### Language

--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -1,17 +1,3 @@
-## Unreleased
-
-### Added
-- `guard(cost: $X) as { ... }` in `std::thread` — automatic cost-limit
-  enforcement for blocks of LLM-using code. Returns a `Result` so
-  callers can branch on success vs over-budget. See
-  [docs/site/guide/cost-guards.md](./docs/site/guide/cost-guards.md).
-
-### Fixed
-- Trailing block argument is now correctly passed when a function is
-  called with named arguments (`f(name: val) as { ... }`). Previously
-  the block was silently dropped, surfacing as a "Missing required
-  argument" runtime error.
-
 ## May 18 2026 — v0.2
 
 ### Language

--- a/packages/agency-lang/docs/site/guide/cost-guards.md
+++ b/packages/agency-lang/docs/site/guide/cost-guards.md
@@ -1,0 +1,118 @@
+# Cost guards
+
+LLM-driven agents are easy to write, easy to deploy, and easy to set on fire — a runaway loop or a chatty tool can turn a planned $0.20 task into a $20 surprise. Agency's `guard` function caps the LLM cost of a block of work and lets your code decide what to do when the budget is blown.
+
+## The shape
+
+```ts
+import { guard } from "std::thread"
+
+node main() {
+  const result = guard(cost: $2.0) as {
+    const a = llm("classify this email")
+    const b = llm("draft a reply")
+    return a + " — " + b
+  }
+  if (isFailure(result)) {
+    print("Over budget: spent " + result.error.actualCost)
+    return "could not finish"
+  }
+  return result.value
+}
+```
+
+`guard` takes a cost limit (a `number` of dollars — `$2.0` is the same as `2.0` because `$` is a no-op compile-time scale factor) and a trailing block. It runs the block, and:
+
+- If the block completes within budget, `guard` returns `success(blockReturnValue)`.
+- If the cumulative cost of LLM calls inside the block **exceeds** the limit, the block halts immediately and `guard` returns a `Failure` carrying the structured `GuardFailureData`:
+
+  ```ts
+  {
+    type: "guardFailure",
+    maxCost: number,   // the limit you passed
+    actualCost: number, // what was actually spent before the trip
+  }
+  ```
+
+  Access these as `result.error.type`, `result.error.maxCost`, `result.error.actualCost`.
+
+The check fires every time an LLM call's cost is added to the per-branch accumulator. If a single call's cost pushes the total over the limit, the guard trips on that call.
+
+## Nested guards
+
+Guards are scoped — an inner trip does **not** trip an outer guard:
+
+```ts
+const outer = guard(cost: $10.0) as {
+  const inner = guard(cost: $0.001) as {
+    return llm("expensive job")
+  }
+  if (isFailure(inner)) {
+    print("inner blew its $0.001 budget; outer still has plenty")
+  }
+  return "carry on"
+}
+```
+
+The inner guard sees its own baseline (the parent's `localCost` at the moment the inner scope opened) and trips on its own limit. The outer guard sees the *cumulative* spend including the inner's cost — but only against its own (larger) limit.
+
+## Guards inside fork branches (recommended)
+
+If you fan out work across branches and want per-iteration enforcement, put the guard **inside** each branch:
+
+```ts
+const results = fork(jobs) as job {
+  return guard(cost: $0.50) as {
+    return processOneJob(job)
+  }
+}
+// results is an array of Result; each branch may have tripped independently.
+```
+
+Each branch inherits a clone of the parent's guards plus any it pushes itself, so per-branch trips are isolated.
+
+## Limitations (V1)
+
+**Forks don't trip outer guards mid-flight.** Branch costs roll back into the parent stack only at branch completion (via `Runner.propagateBranchCost`). An outer guard wrapping a fork cannot pre-empt branches that are still running:
+
+```ts
+// AVOID this pattern if you want mid-fork enforcement
+guard(cost: $1.0) as {
+  fork(jobs) as job {
+    expensiveCall(job)  // outer guard does NOT see this until the fork completes
+  }
+}
+```
+
+Use per-branch guards (see above) instead. After the fork completes, the next LLM call inside the outer guard will observe the rolled-up spend and trip, so the guard still catches the budget breach — just later than you might expect.
+
+**Memory layer LLM calls bypass the guard.** Calls made internally by the memory layer (e.g. `memory.text`, `memory.embed` extraction prompts) currently don't flow through the guard check. The guard only enforces against LLM calls made via the standard `llm()` and `runPrompt` paths. Tracked as a follow-up.
+
+**No dimensional unit checking.** `$2.0` and `2.0` are the same `number` at the type level — the unit literal is a notation aid, not a type-system distinction. You could pass a non-dollar number; the typechecker won't notice. This will improve when dimensioned types land.
+
+## What about timeouts?
+
+V1 is **cost-only**. The `GuardFailureData.type` field is a `string` rather than a literal `"guardFailure"` exactly so a future `"timeoutFailure"` variant can land without breaking V1 consumers. When timeout guards arrive, the shape will be:
+
+```ts
+type GuardFailureData = {
+  type: "guardFailure" | "timeoutFailure",
+  maxCost?: number,
+  actualCost?: number,
+  maxTime?: number,
+  actualTime?: number,
+}
+```
+
+Existing V1 code that only reads `maxCost` / `actualCost` will continue to work.
+
+## How it works under the hood
+
+1. `guard(cost: X) as { ... }` calls `__internal_pushGuard(X)`, which records `{ costLimit: X, costAtPush: stack.localCost }` on the active `StateStack`.
+2. The block runs. Every LLM call's cost is added to `stack.localCost` inside `prompt.ts`.
+3. After each cost addition, `prompt.ts` walks the active guards innermost-first. If any guard's delta (`stack.localCost - guard.costAtPush`) exceeds its `costLimit`, `prompt.ts` throws a `GuardExceededError`.
+4. The thrown error propagates up through the user's code and the codegen's function-body auto-wrap (which explicitly re-throws `GuardExceededError` rather than converting it to a generic Failure).
+5. The `guard` stdlib function's `try block()` catches the error. The runtime's `__tryCall` detects the `GuardExceededError` and returns a Failure with the structured `GuardFailureData` shape.
+6. `__internal_popGuard()` removes the guard from the stack before `guard` returns. (The guard list is also serialized as part of `StateStack`, so checkpoint/restore cycles keep guards intact.)
+
+See [the design spec](https://github.com/egonSchiele/agency-lang/blob/main/packages/agency-lang/docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md) for the full rationale.

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -1,5 +1,19 @@
 # thread
 
+## Types
+
+### GuardFailureData
+
+```ts
+export type GuardFailureData = {
+  type: string;
+  maxCost: number;
+  actualCost: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/thread.agency#L68))
+
 ## Functions
 
 ### systemMessage
@@ -98,3 +112,52 @@ Get the cumulative token count for the current execution branch.
 **Returns:** `number`
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/thread.agency#L60))
+
+### guard
+
+```ts
+guard(cost: number, block: () => any): any
+```
+
+Run a block with a cost limit. If LLM calls inside the block cause
+  the cumulative cost to exceed the limit, the block halts and `guard`
+  returns a failure carrying the limit and the actual spend.
+
+  On success, returns `success(blockReturnValue)`. The block's local
+  variables are scoped to the block — only the block's return value
+  is observable from the caller. Use isFailure(result) to branch and
+  read result.error.maxCost and result.error.actualCost.
+
+  Nested guards are independent: an inner trip does not trip an outer
+  guard. Fork/race branches inherit the outer guards at branch-creation
+  time, but a branch's cost only rolls up to the outer guard at
+  branch-completion — outer guards cannot pre-empt mid-fork.
+
+  Memory layer LLM calls (memory.text / memory.embed) currently bypass
+  the guard.
+
+  @param cost - Maximum cost in dollars (e.g. $2.00 or 2.00)
+  @param block - The work to run under the guard
+
+  Example:
+    const result = guard(cost: $2.0) as {
+      const a = llm("step 1")
+      const b = llm("step 2")
+      return a + b
+    }
+    if (isFailure(result)) {
+      print("Budget exceeded: spent " + result.error.actualCost)
+    } else {
+      print(result.value)
+    }
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| cost | `number` |  |
+| block | `() => any` |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/thread.agency#L74))

--- a/packages/agency-lang/docs/site/stdlib/thread.md
+++ b/packages/agency-lang/docs/site/stdlib/thread.md
@@ -116,7 +116,7 @@ Get the cumulative token count for the current execution branch.
 ### guard
 
 ```ts
-guard(cost: number, block: () => any): any
+guard(cost: number, block: () => any): Result
 ```
 
 Run a block with a cost limit. If LLM calls inside the block cause
@@ -158,6 +158,6 @@ Run a block with a cost limit. If LLM calls inside the block cause
 | cost | `number` |  |
 | block | `() => any` |  |
 
-**Returns:** `any`
+**Returns:** `Result`
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/thread.agency#L74))

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-23-builtin-cost-guards.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-23-builtin-cost-guards.md
@@ -1,0 +1,648 @@
+# Builtin Cost Guards
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a `guard(cost: $2.0) as { ... }` stdlib function that aborts its block when the cost of LLM calls inside it exceeds the limit, and returns a `Result<T, GuardFailureData>` so the user can decide what to do.
+
+**Reference spec:** [`docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md`](../specs/2026-05-20-cost-and-guard-tracking-design.md) — the canonical design. This plan is the V1 implementation of that spec with the open questions resolved as below.
+
+**Reference prior work:** Per-branch cost accumulation already exists from commit c695d411 (`StateStack.localCost`, `seedCost`, `propagateBranchCost`). This plan piggybacks on the cost-accumulation site at [`prompt.ts:177`](../../lib/runtime/prompt.ts#L177).
+
+**Reference for the runtime mechanism:** Guards throw a JS `GuardExceededError` (not an interrupt). The thrown error propagates up through normal error propagation until the `guard` stdlib function's `try` keyword catches it and returns a `Failure`. This deliberately does NOT use the callback-interrupt mechanism — see the sister plan `2026-05-23-remove-callback-interrupts.md`.
+
+---
+
+## Open questions resolved (V1)
+
+| Question | V1 answer |
+| --- | --- |
+| Surface syntax | `guard(cost: $2.0) as { ... }` — agency's standard trailing-block convention + named params + the existing `$` unit literal that compiles to a plain number. |
+| Cost vs timeout | Cost only. `maxTime`/`actualTime` fields absent in V1; the failure shape's `type` field reserves space for `"timeoutFailure"` in V2 without breaking V1 consumers. |
+| Fork cost merging | Documented limitation. Costs propagate to the outer guard only after the fork completes (existing `propagateBranchCost` semantics). An in-progress outer guard does NOT see in-flight branch spend. |
+| Memory layer costs | Excluded from V1. Memory `text`/`embed` calls bypass the guard. Documented; tracked as a follow-up. |
+| Unit literals | Use the existing `$` literal in examples; `guard(cost: $2.0)` is exactly equivalent to `guard(cost: 2.0)` because `$` is a no-op compile-time scale factor. |
+| Block scoping | Falls out for free: `guard` takes a block, the block has its own scope, only the block's `return` value escapes into `result`. No new scoping rules needed. |
+
+---
+
+## Files to create / modify
+
+### New files
+- `lib/runtime/guard.ts` — `GuardEntry` type, `GuardExceededError` class, type guard helpers.
+- `lib/runtime/guard.test.ts` — unit tests for the error class + entry shape.
+- `tests/agency/guards/guard-cost-trip.agency` + `.test.json`
+- `tests/agency/guards/guard-cost-no-trip.agency` + `.test.json`
+- `tests/agency/guards/guard-nested.agency` + `.test.json`
+- `tests/agency/guards/guard-cost-fork.agency` + `.test.json` (documents the fork-merge limitation)
+- `docs/site/stdlib/guard.md` — stdlib reference page.
+
+### Modified files
+- `lib/runtime/state/stateStack.ts` — add `guards: GuardEntry[]` field + `pushGuard` / `popGuard` methods; serialize in `toJSON`/`fromJSON`.
+- `lib/runtime/prompt.ts` — after `targetStack.localCost += ...` (line 177-ish), walk active guards and throw `GuardExceededError` if any tripped.
+- `lib/codegenBuiltins/contextInjected.ts` — register `__internal_pushGuard` and `__internal_popGuard`.
+- `lib/stdlib/thread.ts` — TS implementations for the two builtins.
+- `stdlib/thread.agency` — agency-side `guard` function + `GuardFailureData` type alias.
+- `lib/typechecker/` — recognize the `guard` symbol with its generic signature, if stdlib pickup is insufficient (Task 7).
+
+---
+
+## Task 1: Add `GuardEntry`, `GuardExceededError`, and `GuardFailureData`
+
+**Files:**
+- Create: `lib/runtime/guard.ts`
+- Create: `lib/runtime/guard.test.ts`
+
+- [ ] **Step 1: `lib/runtime/guard.ts`**
+
+```ts
+/**
+ * Per-guard scope state. Held on `StateStack.guards` as an array;
+ * `pushGuard` appends, `popGuard` removes the last entry. Serialized
+ * with the rest of the stack via `toJSON`/`fromJSON` so guards
+ * survive interrupt + resume cycles.
+ *
+ * V1 only supports cost guards. The shape leaves room for additional
+ * limit types (e.g. `timeoutMs`) without forcing a breaking change to
+ * GuardFailureData consumers.
+ */
+export type GuardEntry = {
+  /** The limit, in dollars. */
+  costLimit: number;
+  /** Stack cost at the moment this guard scope opened. The guard trips
+   *  when `(currentLocalCost - costAtPush) > costLimit`. Storing the
+   *  baseline keeps the check independent of any siblings' cost that
+   *  was already on the stack before the guard scope began. */
+  costAtPush: number;
+};
+
+/**
+ * Thrown by `prompt.ts` immediately after an LLM call's cost is
+ * accumulated into `targetStack.localCost`, when any active guard's
+ * spend has exceeded its limit. Propagates as a normal JS error
+ * through the call stack; the `guard` stdlib function's `try` catches
+ * it and returns a Failure.
+ *
+ * Deliberately not an interrupt — see
+ * `docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md`
+ * sections "Mechanism" and "Layer 2: stdlib function".
+ */
+export class GuardExceededError extends Error {
+  constructor(
+    public readonly type: "cost",
+    public readonly limit: number,
+    public readonly spent: number,
+  ) {
+    super(`guard exceeded: ${type} limit ${limit}, spent ${spent}`);
+    this.name = "GuardExceededError";
+  }
+}
+
+export function isGuardExceededError(e: unknown): e is GuardExceededError {
+  return e instanceof GuardExceededError;
+}
+```
+
+- [ ] **Step 2: Tests**
+
+`lib/runtime/guard.test.ts` — minimal:
+- Constructs a `GuardEntry` with the expected shape.
+- Constructs a `GuardExceededError`; checks `instanceof`, `name`, `type`, `limit`, `spent`.
+- `isGuardExceededError` returns true for the error and false for a plain `Error`.
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm test:run -- guard > /tmp/guard.log 2>&1
+```
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Task 2: Add `guards` to `StateStack` with serialization
+
+**Files:**
+- Modify: `lib/runtime/state/stateStack.ts`
+- Modify: `lib/runtime/state/stateStack.test.ts`
+
+- [ ] **Step 1: Add the field**
+
+```ts
+import type { GuardEntry } from "../guard.js";
+
+export class StateStack {
+  // ...existing fields (localCost, localTokens, seedCost, etc.) ...
+
+  /** Active guard scopes on this stack, innermost last. Walked after
+   *  every LLM cost accumulation in prompt.ts to enforce limits.
+   *  See lib/runtime/guard.ts. */
+  guards: GuardEntry[] = [];
+
+  pushGuard(entry: GuardEntry): void {
+    this.guards.push(entry);
+  }
+
+  popGuard(): GuardEntry | undefined {
+    return this.guards.pop();
+  }
+}
+```
+
+- [ ] **Step 2: Serialize**
+
+In `toJSON`:
+```ts
+return {
+  // ...existing fields...
+  guards: this.guards,  // GuardEntry is plain JSON-safe data
+};
+```
+
+In `fromJSON`:
+```ts
+stateStack.guards = json.guards ?? [];
+```
+
+(The nullish coalesce handles checkpoints written before this field existed.)
+
+- [ ] **Step 3: Update `StateStackJSON` type**
+
+Add `guards?: GuardEntry[]` to the JSON shape declaration.
+
+- [ ] **Step 4: Branch seeding**
+
+When `Runner.seedBranchCost` clones cost state onto a child branch, also clone the guard list — branches inherit their parent's active guards so cost within the branch counts toward an outer guard:
+
+```ts
+private seedBranchCost(branchStack: StateStack, parentStack: StateStack): void {
+  if (branchStack.localCost === 0 && branchStack.localTokens === 0) {
+    branchStack.localCost = parentStack.localCost;
+    branchStack.localTokens = parentStack.localTokens;
+    branchStack.seedCost = parentStack.localCost;
+    branchStack.seedTokens = parentStack.localTokens;
+  }
+  // NEW: clone parent guards so the child's LLM calls are checked
+  // against ancestor limits. Per-entry deep-copy keeps the parent's
+  // entries safe from mutation if the child later pushes its own.
+  branchStack.guards = parentStack.guards.map(g => ({ ...g }));
+}
+```
+
+NOTE: this means a child branch can have guard entries with `costAtPush` that reference the PARENT's baseline at branch-creation time. That's correct: the parent's guard checks "delta from when the guard opened" — including delta produced inside the branch — once costs propagate back via `propagateBranchCost`. **But** because that propagation only fires at branch completion, the outer guard cannot trip mid-fork from a child's spend. Document this limitation in Task 9.
+
+- [ ] **Step 5: Tests**
+
+Extend `stateStack.test.ts`:
+- Push two guards, pop one; verify the array.
+- `toJSON` round-trip preserves `guards`.
+- `seedBranchCost` clones parent guards onto child stack.
+
+- [ ] **Step 6: Run**
+
+```bash
+make
+pnpm test:run -- stateStack guard > /tmp/stack.log 2>&1
+```
+
+- [ ] **Step 7: Commit**
+
+---
+
+## Task 3: Register `__internal_pushGuard` and `__internal_popGuard` as context-injected builtins
+
+**Files:**
+- Modify: `lib/codegenBuiltins/contextInjected.ts`
+
+Follow the existing pattern for `__internal_getCost` / `__internal_getTokens` (lines 148–154 of that file).
+
+- [ ] **Step 1: Add registry entries**
+
+```ts
+__internal_pushGuard: {
+  name: "__internal_pushGuard",
+  // ... follow the shape of __internal_getCost / __internal_getTokens ...
+  // Both functions take a (stack-bearing) prefix and one positional arg.
+},
+__internal_popGuard: {
+  name: "__internal_popGuard",
+  // ... no positional args; just the prefix ...
+},
+```
+
+Match whatever the per-entry shape is in the existing registry — both signature info and the import target (`lib/stdlib/thread.ts`).
+
+- [ ] **Step 2: Tests**
+
+Extend `contextInjected.test.ts` if it tests the registry shape — confirm the two new entries are present and have the right argument arities.
+
+- [ ] **Step 3: Run**
+
+```bash
+pnpm test:run -- contextInjected > /tmp/ctxinj.log 2>&1
+```
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Task 4: TS implementations in `lib/stdlib/thread.ts`
+
+**Files:**
+- Modify: `lib/stdlib/thread.ts`
+
+Follow the existing pattern (`__internal_getCost`, `__internal_getTokens`).
+
+- [ ] **Step 1: Add the two functions**
+
+```ts
+import type { GuardEntry } from "../runtime/guard.js";
+
+export async function __internal_pushGuard(
+  _ctx: RuntimeContext<any>,
+  stack: StateStack,
+  _threads: ThreadStore,
+  costLimit: number,
+): Promise<void> {
+  stack.pushGuard({ costLimit, costAtPush: stack.localCost });
+}
+
+export async function __internal_popGuard(
+  _ctx: RuntimeContext<any>,
+  stack: StateStack,
+  _threads: ThreadStore,
+): Promise<void> {
+  stack.popGuard();
+}
+```
+
+`costAtPush` captures the baseline at push time so the guard's "spent" reading is `stack.localCost - guard.costAtPush`, not the absolute `localCost` (which would include cost spent before the guard scope opened).
+
+- [ ] **Step 2: Type test**
+
+`make` should compile the new TS without error.
+
+- [ ] **Step 3: Commit**
+
+---
+
+## Task 5: Wire the cost check into `prompt.ts`
+
+**Files:**
+- Modify: `lib/runtime/prompt.ts`
+
+The existing cost-accumulation site is around line 177:
+```ts
+targetStack.localCost += completion.cost?.totalCost ?? 0;
+targetStack.localTokens += completion.usage?.totalTokens ?? 0;
+```
+
+Immediately after these two lines, walk the active guards and throw if any tripped.
+
+- [ ] **Step 1: Add the check**
+
+```ts
+import { GuardExceededError } from "./guard.js";
+
+// ... after the existing localCost/localTokens increments ...
+for (const guard of targetStack.guards) {
+  const spent = targetStack.localCost - guard.costAtPush;
+  if (spent > guard.costLimit) {
+    throw new GuardExceededError("cost", guard.costLimit, spent);
+  }
+}
+```
+
+Walk in declaration order (innermost last) — when multiple guards have tripped on the same call, the OUTER guard's entry comes first in the array, so the loop reports the outermost-tripped first. That matches user intuition: "your $10 outer guard tripped" is a stronger signal than "your $1 inner guard tripped" when both fire simultaneously, because the outer trip means the user blew an even bigger budget.
+
+Actually reconsider: innermost-first is the more common intuition (tightest limit fires first). Re-read the spec — it says "all active guards are updated, not just the innermost" but doesn't say which trip is reported. Pick innermost-first (loop in reverse):
+
+```ts
+for (let i = targetStack.guards.length - 1; i >= 0; i--) {
+  const guard = targetStack.guards[i];
+  const spent = targetStack.localCost - guard.costAtPush;
+  if (spent > guard.costLimit) {
+    throw new GuardExceededError("cost", guard.costLimit, spent);
+  }
+}
+```
+
+Document the choice in the loop's comment.
+
+- [ ] **Step 2: Verify the throw is caught only by `guard`'s `try`**
+
+Inspect the surrounding code in `_runPrompt`. The throw should propagate up through:
+- `_runPrompt` (no surrounding try/catch that would swallow it — the `AgencyCancelledError` / `PromptBailout` catches are class-specific).
+- `runPrompt`'s outer try (same — class-specific).
+- The user's `llm()` call site.
+- The user's function body (auto-wrapped in try/catch by codegen — this is the boundary to verify).
+
+Critical: the function-body auto-wrap MUST re-throw `GuardExceededError`. If it converts the error to a Failure return value (the auto-wrap's normal behavior for unexpected JS errors), the guard mechanism breaks.
+
+Two options:
+- (a) Make the auto-wrap class-aware: re-throw `GuardExceededError` (and `AgencyCancelledError`, `RestoreSignal` — already special-cased).
+- (b) Catch in the runner one level out — but the runner is the wrong layer; we want the error to propagate THROUGH the runner up to the `guard` function's body.
+
+Pick (a). Find the codegen template or runtime helper that emits the auto-wrap; add `GuardExceededError` to its class allow-list.
+
+- [ ] **Step 3: Run prompt-related tests**
+
+```bash
+pnpm test:run -- prompt > /tmp/prompt-guard.log 2>&1
+```
+
+Nothing should regress (no guards in flight yet means the loop is a no-op).
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Task 6: Agency-side `guard` function
+
+**Files:**
+- Modify: `stdlib/thread.agency`
+
+- [ ] **Step 1: Add the type alias**
+
+```
+export type GuardFailureData = {
+  type: "guardFailure"
+  maxCost: number
+  actualCost: number
+}
+```
+
+(`maxTime` / `actualTime` are intentionally absent in V1. When timeout lands, add them as optional fields — `maxTime?: number` etc. — and existing V1 consumers continue working.)
+
+- [ ] **Step 2: Add the `guard` function**
+
+```
+/**
+ * Run a block with a cost limit. If LLM calls inside the block
+ * cause the cumulative cost to exceed the limit, the block halts
+ * and `guard` returns a failure carrying the limit and actual spend.
+ *
+ * On success, returns `success(blockReturnValue)`. The block's local
+ * variables are scoped to the block — only the block's return value
+ * is observable from the caller.
+ *
+ * @param cost - Maximum cost in dollars (e.g. $2.00 or 2.00)
+ * @param block - The work to run under the guard
+ *
+ * Example:
+ *   const result = guard(cost: $2.0) as {
+ *     const a = llm("step 1")
+ *     const b = llm("step 2")
+ *     return process(a, b)
+ *   }
+ *   if (isFailure(result)) {
+ *     print("Budget exceeded: spent " + result.data.actualCost)
+ *   } else {
+ *     print(result.value)
+ *   }
+ */
+export def guard<T>(cost: number, block: () => T): Result<T, GuardFailureData> {
+  __internal_pushGuard(cost)
+  const result = try block()
+  __internal_popGuard()
+  return result
+}
+```
+
+Notes:
+- `try block()` converts any thrown error (including `GuardExceededError`) to a `Failure` value. The `data` field will be the error's data — make sure the `try` machinery maps `GuardExceededError` to `failure({ type: "guardFailure", maxCost, actualCost })`. If the existing `try` keyword doesn't apply that mapping by default (i.e. it just wraps the raw error), wrap manually:
+  ```
+  const result = try block()
+  __internal_popGuard()
+  if (isFailure(result)) {
+    // Re-shape if the failure came from a GuardExceededError
+    // (try keyword's default failure shape is {error, retryable, ...})
+    if (result.data.name == "GuardExceededError") {
+      return failure({
+        type: "guardFailure",
+        maxCost: result.data.limit,
+        actualCost: result.data.spent,
+      })
+    }
+    return result  // some other error — propagate as-is
+  }
+  return result
+  ```
+  Verify which behavior `try` has by reading `docs/site/guide/error-handling.md` or grep the codebase.
+- Use the block param directly (`block()`), do NOT copy to a local — see [Blocks guide → limitation](https://agency-lang.com/guide/blocks.html). Resume safety depends on this.
+
+- [ ] **Step 3: Verify the agency code parses and typechecks**
+
+```bash
+pnpm run ast stdlib/thread.agency > /tmp/thread-ast.log
+make
+```
+
+If the typechecker complains about the generic `<T>` or the `() => T` block param type, jump to Task 7 (typechecker registration).
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Task 7: Typechecker support for `guard`
+
+**Files:**
+- Modify: `lib/typechecker/` (whichever file holds the stdlib-function signature registry, if one exists)
+
+Two scenarios:
+
+**Scenario A: stdlib pickup just works.** The typechecker reads `stdlib/thread.agency`, infers `guard`'s signature from the `def`, and propagates the block's return type T through to `Result<T, GuardFailureData>`. The user calls `guard(cost: 2.0) as { return "hello" }` and the typechecker correctly types `result` as `Result<string, GuardFailureData>`. **Do nothing in this task.**
+
+**Scenario B: stdlib pickup fails** (generic inference doesn't propagate, or the typechecker has a special-case registry for builtins that need entries for new ones).
+
+- [ ] **Step 1: Locate the registry**
+
+```bash
+rg "getCost|getTokens" lib/typechecker/
+```
+
+Find where `getCost`/`getTokens` (or the other thread-stdlib functions) are recognized. Either there's a registry, or the typechecker walks `stdlib/*.agency` and inhales signatures.
+
+- [ ] **Step 2: Register `guard` if needed**
+
+If a registry exists, add an entry mapping `guard` to the signature:
+```
+guard: <T>(cost: number, block: () => T) => Result<T, GuardFailureData>
+```
+
+- [ ] **Step 3: Test with a contrived agency snippet**
+
+```bash
+cat > /tmp/guard-test.agency <<EOF
+import { guard } from "std::thread"
+node main() {
+  const r = guard(cost: 2.0) as {
+    return "hello"
+  }
+  return r
+}
+EOF
+pnpm run agency /tmp/guard-test.agency
+```
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Task 8: Integration fixtures
+
+**Files:**
+- Create: `tests/agency/guards/guard-cost-trip.agency` + `.test.json`
+- Create: `tests/agency/guards/guard-cost-no-trip.agency` + `.test.json`
+- Create: `tests/agency/guards/guard-nested.agency` + `.test.json`
+- Create: `tests/agency/guards/guard-cost-fork.agency` + `.test.json`
+
+These use real LLM calls (cheap). Per the testing guide they're acceptable when they're testing something that genuinely needs the LLM path.
+
+- [ ] **Step 1: Trip case**
+
+```
+// tests/agency/guards/guard-cost-trip.agency
+import { guard } from "std::thread"
+
+node main() {
+  const result = guard(cost: 0.00000001) as {  // tiny budget
+    const reply = llm("Reply with the single word: pong")
+    return reply
+  }
+  if (isFailure(result)) {
+    return "tripped: " + result.data.actualCost
+  }
+  return "did not trip"
+}
+```
+
+`.test.json` asserts the output starts with `"tripped: "` and the actual cost is positive.
+
+- [ ] **Step 2: No-trip case**
+
+```
+const result = guard(cost: 10.00) as {
+  const reply = llm("Reply with the single word: pong")
+  return reply
+}
+return result.value  // "pong"
+```
+
+- [ ] **Step 3: Nested guards**
+
+Inner guard tripping doesn't trip outer:
+```
+const outer = guard(cost: 1.00) as {
+  const inner = guard(cost: 0.00000001) as {
+    return llm("Reply with: pong")
+  }
+  // inner is a Failure; outer still has budget
+  if (isFailure(inner)) {
+    return "inner tripped"
+  }
+  return "neither tripped"
+}
+return outer.value  // "inner tripped"
+```
+
+- [ ] **Step 4: Fork case (documents the limitation)**
+
+```
+const result = guard(cost: 0.00000001) as {
+  fork([1, 2, 3]) as n {
+    llm("Reply with: pong")
+  }
+  return "all branches finished"
+}
+```
+
+This SHOULD trip the outer guard after the fork completes (when `propagateBranchCost` rolls up the branch deltas). The fixture confirms that path works. The limitation — that the outer guard doesn't trip MID-fork — is documented in the docs (Task 9), not in this fixture.
+
+- [ ] **Step 5: Build fixtures**
+
+```bash
+make fixtures
+```
+
+- [ ] **Step 6: Run**
+
+```bash
+pnpm test:run -- guards > /tmp/guards-int.log 2>&1
+```
+
+- [ ] **Step 7: Commit**
+
+---
+
+## Task 9: Documentation
+
+**Files:**
+- Create: `docs/site/stdlib/guard.md` — user-facing guide.
+- Modify: `docs/site/stdlib/thread.md` — link to the new guard page.
+
+- [ ] **Step 1: User guide**
+
+`docs/site/stdlib/guard.md` covers:
+- The `guard(cost: $X) as { ... }` syntax (with the unit literal).
+- Return shape: `Result<T, GuardFailureData>`.
+- `GuardFailureData` field-by-field.
+- Nested guards example (each scope independent; inner trip doesn't trip outer).
+- The fork limitation explicitly: "An outer guard wrapping a `fork` block only sees branch costs after the fork completes — it cannot pre-empt branches mid-flight."
+- The memory limitation: "Memory layer LLM calls (memory.text, memory.embed) currently bypass the guard."
+- V2 footnote: "Timeout guards are planned; the `GuardFailureData.type` field will gain a `"timeoutFailure"` variant alongside the current `"guardFailure"`."
+
+- [ ] **Step 2: Cross-link from `docs/site/stdlib/thread.md`**
+
+Add a section pointing at the new page. The existing thread.md already covers `getCost` / `getTokens`; guard is a natural follow-on.
+
+- [ ] **Step 3: CHANGELOG entry**
+
+```
+### Added
+- `guard(cost: $X) as { ... }` in `std::thread` — automatic cost limit enforcement for blocks of LLM-using code. Returns a `Result` so callers can branch on success vs over-budget. See docs/site/stdlib/guard.md.
+```
+
+- [ ] **Step 4: Commit**
+
+---
+
+## Validation checklist
+
+- [ ] `guard(cost: $2.00) as { return llm("...") }` returns a `Success` when under budget, `Failure({ type: "guardFailure", maxCost, actualCost })` when over.
+- [ ] Nested guards work: inner trip doesn't trip outer.
+- [ ] Fork inside a guard: outer trip fires after fork completes (rollup case).
+- [ ] `GuardExceededError` propagates through `_runPrompt` / `runPrompt` / the function-body auto-wrap, caught only by the `try` inside `guard`.
+- [ ] `StateStack` round-trips guards through `toJSON`/`fromJSON`.
+- [ ] Branch seeding clones parent guards onto child stacks.
+- [ ] No regressions in `tests/agency/thread/cost-*` (the existing per-branch-cost fixtures from c695d411).
+- [ ] No regressions in `tests/agency/fork/*`, `tests/agency/handlers/*`, or `tests/agency/substeps/*`.
+- [ ] `make` succeeds. `pnpm run lint:structure` clean.
+
+---
+
+## Risks and known limitations
+
+- **Fork cost is invisible to outer guards mid-flight.** This is documented in the guard.md page and in the test fixture's comment. A user wanting per-iteration enforcement should place the guard INSIDE the fork body (`fork(items) as item { guard(cost: $0.50) as { ... } }`).
+
+- **Memory layer LLM calls bypass the guard.** Same documented limitation. Tracked as a future enhancement — wiring `memory.text` / `memory.embed` through `prompt.ts` (or adding a separate accumulator path) is mechanical but non-trivial.
+
+- **Function-body auto-wrap must re-throw `GuardExceededError`.** Task 5 Step 2 covers this — verify before committing. If the auto-wrap swallows the error, every guard call returns success even when the budget was blown.
+
+- **`__popGuard` cleanup on JS error escape.** If a non-guard JS error escapes both `try block()` and the auto-wrap (i.e., the runtime itself crashes), `__popGuard` is skipped and the guard list is polluted on resume. **Mitigation: guard list is serialized as part of `StateStack`** (Task 2 Step 2), so the deserialized stack on resume carries the right list — the missed pop is a no-op because the snapshot already reflected the right state. Verify this in a test that intentionally throws inside the block.
+
+- **Multiple guards tripping on the same call.** The loop reports the innermost-tripped first (Task 5 Step 1). If multiple guards trip simultaneously, the user sees one failure and the other guards' state still on the stack — but the surrounding `guard` function's body returns immediately, so the outer guard's `try` catches its own failure on the next walk. Test this with the `guard-nested` fixture by setting BOTH limits low enough that both trip.
+
+- **Typechecker generic inference.** Task 7 has a fork: stdlib pickup may or may not handle `<T>`. Be prepared to add a registry entry.
+
+- **Unit literal interactions.** `$2.0` and `2.0` are exactly equivalent at the type level (both `number`). The unit checker doesn't distinguish dollars from arbitrary numbers — so a user could pass a non-dollar number and the typechecker wouldn't catch it. Documented as a known limitation; revisit when dimensioned types land.
+
+---
+
+## Follow-ups (not in V1)
+
+- Timeout guards (`guard(time: 30s) as { ... }`).
+- Depth guards (number of LLM calls, tool-call rounds, etc.).
+- Memory layer integration.
+- Pipe operator interaction.
+- Mid-fork cost propagation (require a shared atomic accumulator OR a checkpoint hook in `runBatch` that rolls deltas to the parent at every cost-emitting site).
+- Richer partial-result return (per the conversation: returning bound locals + message thread at trip time). Deliberately out of scope for V1 in favor of the minimal `{ type, maxCost, actualCost }` shape.

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2241,6 +2241,10 @@ export class TypeScriptBuilder {
             ts.raw("__error instanceof RestoreSignal"),
             ts.statements([ts.throw("__error")]),
           ),
+          ts.if(
+            ts.raw("__error instanceof GuardExceededError"),
+            ts.statements([ts.throw("__error")]),
+          ),
           ts.consoleError(
             ts.template([
               {

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2005,11 +2005,20 @@ export class TypeScriptBuilder {
         }
       }
 
-      return ts.obj({
+      // Pass any trailing block as a dedicated descriptor field so
+      // the runtime can bind it to the last (block) parameter — see
+      // CallType.blockArg in lib/runtime/agencyFunction.ts. Without
+      // this, `f(name: val) as { ... }` would drop the block on the
+      // floor and the runtime would report a missing-arg error.
+      const descriptor: Record<string, TsNode> = {
         type: ts.str("named"),
         positionalArgs: ts.arr(positionalNodes),
         namedArgs: ts.obj(namedEntries),
-      });
+      };
+      if (node.block) {
+        descriptor.blockArg = this.processBlockArgument(node);
+      }
+      return ts.obj(descriptor);
     }
 
     const argNodes: TsNode[] = [];

--- a/packages/agency-lang/lib/codegenBuiltins/contextInjected.ts
+++ b/packages/agency-lang/lib/codegenBuiltins/contextInjected.ts
@@ -157,6 +157,18 @@ export const CONTEXT_INJECTED_BUILTINS: Record<string, ContextInjectedBuiltin> =
     params: [],
     returnType: number,
   },
+  __internal_pushGuard: {
+    name: "__internal_pushGuard",
+    from: THREAD_FROM,
+    params: [number],
+    returnType: voidT,
+  },
+  __internal_popGuard: {
+    name: "__internal_popGuard",
+    from: THREAD_FROM,
+    params: [],
+    returnType: voidT,
+  },
 };
 
 /** True iff `name` is registered as a context-injected builtin. */

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -20,11 +20,17 @@ export type CallType =
       positionalArgs: unknown[];
       namedArgs: Record<string, unknown>;
       /** Trailing-block argument from `f(name: val) as { ... }` syntax.
-       *  Filled into the last unfilled non-variadic parameter (by
-       *  convention the block param) during resolveNamed. Separate
-       *  from positionalArgs because the block always binds to the
-       *  trailing block parameter, regardless of which earlier params
-       *  named args have filled. */
+       *
+       *  In the positional case the block is simply appended to `args`
+       *  (it's always the next positional slot), so no separate field
+       *  is needed. In the named case earlier params may be filled by
+       *  name and intermediate params may need UNSET padding, so the
+       *  block must be bound by NAME to the last non-variadic
+       *  parameter — appending it as positional[N] would mis-fill
+       *  parameter N. resolveNamed synthesizes it into namedArgs under
+       *  the last param's name so the rest of fill logic treats it
+       *  uniformly. Without this, `f(name: val) as { ... }` silently
+       *  dropped the block. */
       blockArg?: unknown;
     };
 

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -15,7 +15,18 @@ export type FuncParam = {
 
 export type CallType =
   | { type: "positional"; args: unknown[] }
-  | { type: "named"; positionalArgs: unknown[]; namedArgs: Record<string, unknown> };
+  | {
+      type: "named";
+      positionalArgs: unknown[];
+      namedArgs: Record<string, unknown>;
+      /** Trailing-block argument from `f(name: val) as { ... }` syntax.
+       *  Filled into the last unfilled non-variadic parameter (by
+       *  convention the block param) during resolveNamed. Separate
+       *  from positionalArgs because the block always binds to the
+       *  trailing block parameter, regardless of which earlier params
+       *  named args have filled. */
+      blockArg?: unknown;
+    };
 
 export type ToolDefinition = {
   name: string;
@@ -212,7 +223,11 @@ export class AgencyFunction {
     if (descriptor.type === "positional") {
       return this.resolvePositional(descriptor.args);
     }
-    return this.resolveNamed(descriptor.positionalArgs, descriptor.namedArgs);
+    return this.resolveNamed(
+      descriptor.positionalArgs,
+      descriptor.namedArgs,
+      descriptor.blockArg,
+    );
   }
 
   private resolvePositional(args: unknown[]): unknown[] {
@@ -243,7 +258,11 @@ export class AgencyFunction {
     return result;
   }
 
-  private resolveNamed(positionalArgs: unknown[], namedArgs: Record<string, unknown>): unknown[] {
+  private resolveNamed(
+    positionalArgs: unknown[],
+    namedArgs: Record<string, unknown>,
+    blockArg?: unknown,
+  ): unknown[] {
     // Validate named args: no unknowns, no conflicts with positional
     for (const name of Object.keys(namedArgs)) {
       const paramIdx = this._nonVariadicUnbound.findIndex(p => p.name === name);
@@ -257,6 +276,26 @@ export class AgencyFunction {
           `Named argument '${name}' conflicts with positional argument at position ${paramIdx + 1} in call to '${this.name}'`,
         );
       }
+    }
+
+    // A trailing block argument (from `f(name: val) as { ... }` syntax)
+    // binds to the LAST non-variadic unbound parameter. By convention
+    // that's the block-typed param. We synthesize it into namedArgs
+    // here so the rest of the fill logic treats it uniformly.
+    const hasBlock = blockArg !== undefined;
+    if (hasBlock) {
+      const lastParam = this._nonVariadicUnbound[this._nonVariadicUnbound.length - 1];
+      if (!lastParam) {
+        throw new Error(
+          `Call to '${this.name}' passed a trailing block but the function takes no parameters`,
+        );
+      }
+      if (Object.hasOwn(namedArgs, lastParam.name)) {
+        throw new Error(
+          `Trailing block conflicts with named argument '${lastParam.name}' in call to '${this.name}'`,
+        );
+      }
+      namedArgs = { ...namedArgs, [lastParam.name]: blockArg };
     }
 
     // Build result: positional args first, then fill from named args in parameter order

--- a/packages/agency-lang/lib/runtime/guard.test.ts
+++ b/packages/agency-lang/lib/runtime/guard.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+  GuardEntry,
+  GuardExceededError,
+  isGuardExceededError,
+} from "./guard.js";
+
+describe("GuardEntry", () => {
+  it("has the expected shape", () => {
+    const entry: GuardEntry = { costLimit: 2.0, costAtPush: 0.0 };
+    expect(entry.costLimit).toBe(2.0);
+    expect(entry.costAtPush).toBe(0.0);
+  });
+});
+
+describe("GuardExceededError", () => {
+  it("is an Error subclass with name, type, limit, spent fields", () => {
+    const err = new GuardExceededError("cost", 2.0, 2.5);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(GuardExceededError);
+    expect(err.name).toBe("GuardExceededError");
+    expect(err.type).toBe("cost");
+    expect(err.limit).toBe(2.0);
+    expect(err.spent).toBe(2.5);
+    expect(err.message).toContain("cost");
+    expect(err.message).toContain("2");
+  });
+});
+
+describe("isGuardExceededError", () => {
+  it("returns true for a GuardExceededError instance", () => {
+    expect(isGuardExceededError(new GuardExceededError("cost", 1, 2))).toBe(
+      true,
+    );
+  });
+
+  it("returns false for a plain Error", () => {
+    expect(isGuardExceededError(new Error("oops"))).toBe(false);
+  });
+
+  it("returns false for non-error values", () => {
+    expect(isGuardExceededError(null)).toBe(false);
+    expect(isGuardExceededError(undefined)).toBe(false);
+    expect(isGuardExceededError("error")).toBe(false);
+    expect(isGuardExceededError({})).toBe(false);
+  });
+});

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-guard scope state. Held on `StateStack.guards` as an array;
+ * `pushGuard` appends, `popGuard` removes the last entry. Serialized
+ * with the rest of the stack via `toJSON`/`fromJSON` so guards
+ * survive interrupt + resume cycles.
+ *
+ * V1 only supports cost guards. The shape leaves room for additional
+ * limit types (e.g. `timeoutMs`) without forcing a breaking change to
+ * GuardFailureData consumers.
+ */
+export type GuardEntry = {
+  /** The limit, in dollars. */
+  costLimit: number;
+  /** Stack cost at the moment this guard scope opened. The guard trips
+   *  when `(currentLocalCost - costAtPush) > costLimit`. Storing the
+   *  baseline keeps the check independent of any siblings' cost that
+   *  was already on the stack before the guard scope began. */
+  costAtPush: number;
+};
+
+/**
+ * Thrown by `prompt.ts` immediately after an LLM call's cost is
+ * accumulated into `targetStack.localCost`, when any active guard's
+ * spend has exceeded its limit. Propagates as a normal JS error
+ * through the call stack; the `guard` stdlib function's `try` catches
+ * it and returns a Failure.
+ *
+ * Deliberately not an interrupt — see
+ * `docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md`
+ * sections "Mechanism" and "Layer 2: stdlib function".
+ */
+export class GuardExceededError extends Error {
+  constructor(
+    public readonly type: "cost",
+    public readonly limit: number,
+    public readonly spent: number,
+  ) {
+    super(`guard exceeded: ${type} limit ${limit}, spent ${spent}`);
+    this.name = "GuardExceededError";
+  }
+}
+
+export function isGuardExceededError(e: unknown): e is GuardExceededError {
+  return e instanceof GuardExceededError;
+}

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -77,6 +77,8 @@ export {
   AgencyCancelledError,
   isAbortError,
 } from "./errors.js";
+export { GuardExceededError, isGuardExceededError } from "./guard.js";
+export type { GuardEntry } from "./guard.js";
 export type { RestoreOptions } from "./errors.js";
 
 export { checkpoint, getCheckpoint, restore } from "./checkpoint.js";

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -3,6 +3,7 @@ import { PromptResult, Result, StreamChunk, ToolCallJSON } from "smoltalk";
 import { createLogger } from "../logger.js";
 import { AgencyFunction } from "./agencyFunction.js";
 import { AgencyCancelledError, isAbortError } from "./errors.js";
+import { GuardExceededError } from "./guard.js";
 import { callHook, invokeCallbacks } from "./hooks.js";
 import { Interrupt, hasInterrupts, isRejected } from "./interrupts.js";
 import type { PromptConfig } from "./llmClient.js";
@@ -170,6 +171,24 @@ async function _runPrompt({
   const targetStack = stateStack ?? ctx.stateStack;
   targetStack.localCost += completion.cost?.totalCost ?? 0;
   targetStack.localTokens += completion.usage?.totalTokens ?? 0;
+
+  // Enforce active cost guards. Walked innermost-first so the
+  // tightest limit fires first when multiple guards have tripped on
+  // the same call — matches the user intuition that the smallest
+  // budget is the most informative trip. The thrown
+  // GuardExceededError propagates up through _runPrompt / runPrompt /
+  // the user's code; the stdlib `guard` function's `try` catches it
+  // and returns a Failure. The function-body auto-wrap re-throws
+  // GuardExceededError so it cannot be silently converted to a
+  // generic failure value. See lib/runtime/guard.ts and
+  // docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md.
+  for (let i = targetStack.guards.length - 1; i >= 0; i--) {
+    const guard = targetStack.guards[i];
+    const spent = targetStack.localCost - guard.costAtPush;
+    if (spent > guard.costLimit) {
+      throw new GuardExceededError("cost", guard.costLimit, spent);
+    }
+  }
 
   // Memory layer: auto-extraction and compaction run unconditionally
   // whenever a MemoryManager is attached (resolved decision #6).

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -173,15 +173,18 @@ async function _runPrompt({
   targetStack.localTokens += completion.usage?.totalTokens ?? 0;
 
   // Enforce active cost guards. Walked innermost-first so the
-  // tightest limit fires first when multiple guards have tripped on
-  // the same call — matches the user intuition that the smallest
-  // budget is the most informative trip. The thrown
-  // GuardExceededError propagates up through _runPrompt / runPrompt /
-  // the user's code; the stdlib `guard` function's `try` catches it
-  // and returns a Failure. The function-body auto-wrap re-throws
-  // GuardExceededError so it cannot be silently converted to a
-  // generic failure value. See lib/runtime/guard.ts and
-  // docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md.
+  // deepest (most recently pushed) guard reports its trip first.
+  // Innermost-first is not the same as "smallest limit first" —
+  // a shallower outer guard with a tighter budget would still trip
+  // on a later LLM call if the inner guard doesn't fail first.
+  // This ordering is a stable, scope-local rule rather than a
+  // global-minimum search. The thrown GuardExceededError propagates
+  // up through _runPrompt / runPrompt / the user's code; the stdlib
+  // `guard` function's `try` catches it and returns a Failure. The
+  // function-body auto-wrap re-throws GuardExceededError so it
+  // cannot be silently converted to a generic failure value. See
+  // lib/runtime/guard.ts and docs/superpowers/specs/2026-05-20-
+  // cost-and-guard-tracking-design.md.
   for (let i = targetStack.guards.length - 1; i >= 0; i--) {
     const guard = targetStack.guards[i];
     const spent = targetStack.localCost - guard.costAtPush;

--- a/packages/agency-lang/lib/runtime/result.ts
+++ b/packages/agency-lang/lib/runtime/result.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { isGuardExceededError } from "./guard.js";
 import { hasInterrupts } from "./interrupts.js";
 
 export type ResultValue = ResultSuccess | ResultFailure;
@@ -63,6 +64,21 @@ export async function __tryCall(fn: () => any, opts?: FailureOpts): Promise<Resu
     if (resultValueSchema.safeParse(value).success) return value;
     return success(value);
   } catch (error) {
+    // Preserve GuardExceededError's structured data so the stdlib
+    // `guard` function can surface { type, maxCost, actualCost }
+    // directly via `result.error`. Without this branch the user
+    // would see only the stringified error message and lose the
+    // numeric limits. See lib/runtime/guard.ts.
+    if (isGuardExceededError(error)) {
+      return failure(
+        {
+          type: "guardFailure",
+          maxCost: error.limit,
+          actualCost: error.spent,
+        },
+        opts,
+      );
+    }
     return failure(
       error instanceof Error ? error.message : String(error),
       opts,

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -221,6 +221,13 @@ export class Runner {
       branchStack.seedCost = parentStack.localCost;
       branchStack.seedTokens = parentStack.localTokens;
     }
+    // Clone parent guards so LLM calls inside the branch are checked
+    // against ancestor limits. Per-entry copy keeps the parent's
+    // entries safe from mutation if the child later pushes its own.
+    // LIMITATION: deltas from a child branch only roll back into the
+    // parent at branch completion (propagateBranchCost), so an outer
+    // guard cannot trip mid-fork — only after the fork completes.
+    branchStack.guards = parentStack.guards.map((g) => ({ ...g }));
   }
 
   /** Propagate cost/token deltas from a set of branches back to the

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -215,12 +215,24 @@ export class Runner {
    *  before the winner resumes. See docs/superpowers/specs/2026-05-20-
    *  thread-builtins-and-stdlib-design.md. */
   private seedBranchCost(branchStack: StateStack, parentStack: StateStack): void {
-    if (branchStack.localCost === 0 && branchStack.localTokens === 0) {
-      branchStack.localCost = parentStack.localCost;
-      branchStack.localTokens = parentStack.localTokens;
-      branchStack.seedCost = parentStack.localCost;
-      branchStack.seedTokens = parentStack.localTokens;
-    }
+    // Fresh-branch detection: seedBranchCost can be called more than
+    // once for the same branch (e.g. a branch interrupts mid-flight
+    // and the parent resumes runBatch on the next response cycle).
+    // We must not clobber state the branch has already accumulated.
+    // A branch is "fresh" iff it has no cost, no tokens, AND no guard
+    // entries — the last check matters when a branch pushes its own
+    // guard before any LLM call and then interrupts.
+    const isFresh =
+      branchStack.localCost === 0 &&
+      branchStack.localTokens === 0 &&
+      branchStack.guards.length === 0;
+    if (!isFresh) return;
+
+    branchStack.localCost = parentStack.localCost;
+    branchStack.localTokens = parentStack.localTokens;
+    branchStack.seedCost = parentStack.localCost;
+    branchStack.seedTokens = parentStack.localTokens;
+
     // Clone parent guards so LLM calls inside the branch are checked
     // against ancestor limits. Per-entry copy keeps the parent's
     // entries safe from mutation if the child later pushes its own.

--- a/packages/agency-lang/lib/runtime/state/stateStack.test.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.test.ts
@@ -493,3 +493,55 @@ describe("_callback", () => {
     ).not.toThrow();
   });
 });
+
+describe("StateStack guards", () => {
+  it("pushGuard appends and popGuard removes from the end", () => {
+    const stack = new StateStack();
+    expect(stack.guards).toEqual([]);
+    stack.pushGuard({ costLimit: 1.0, costAtPush: 0.0 });
+    stack.pushGuard({ costLimit: 2.0, costAtPush: 0.5 });
+    expect(stack.guards).toHaveLength(2);
+    const popped = stack.popGuard();
+    expect(popped).toEqual({ costLimit: 2.0, costAtPush: 0.5 });
+    expect(stack.guards).toHaveLength(1);
+    expect(stack.guards[0]).toEqual({ costLimit: 1.0, costAtPush: 0.0 });
+  });
+
+  it("popGuard on empty stack returns undefined", () => {
+    const stack = new StateStack();
+    expect(stack.popGuard()).toBeUndefined();
+  });
+
+  it("toJSON / fromJSON preserves guards", () => {
+    const stack = new StateStack();
+    stack.pushGuard({ costLimit: 1.5, costAtPush: 0.2 });
+    stack.pushGuard({ costLimit: 0.5, costAtPush: 0.4 });
+    const json = stack.toJSON();
+    expect(json.guards).toEqual([
+      { costLimit: 1.5, costAtPush: 0.2 },
+      { costLimit: 0.5, costAtPush: 0.4 },
+    ]);
+    const restored = StateStack.fromJSON(json);
+    expect(restored.guards).toEqual(stack.guards);
+  });
+
+  it("fromJSON defaults guards to [] when the field is absent (pre-guard checkpoints)", () => {
+    const json: any = {
+      stack: [],
+      mode: "serialize",
+      other: {},
+      deserializeStackLength: 0,
+      nodesTraversed: [],
+    };
+    const restored = StateStack.fromJSON(json);
+    expect(restored.guards).toEqual([]);
+  });
+
+  it("toJSON returns guards as a fresh copy (mutation-safe)", () => {
+    const stack = new StateStack();
+    stack.pushGuard({ costLimit: 1.0, costAtPush: 0.0 });
+    const json = stack.toJSON();
+    json.guards![0].costLimit = 999;
+    expect(stack.guards[0].costLimit).toBe(1.0);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -1,3 +1,4 @@
+import type { GuardEntry } from "../guard.js";
 import { Checkpoint } from "../index.js";
 import { deepClone } from "../utils.js";
 import { ThreadStoreJSON } from "./threadStore.js";
@@ -251,6 +252,7 @@ export type StateStackJSON = {
   localTokens?: number;
   seedCost?: number;
   seedTokens?: number;
+  guards?: GuardEntry[];
 };
 
 export class StateStack {
@@ -289,6 +291,22 @@ export class StateStack {
   // losers propagated at interrupt time, winner propagated later on resume).
   seedCost: number = 0;
   seedTokens: number = 0;
+
+  // Active guard scopes on this stack, innermost last. Walked after
+  // every LLM cost accumulation in prompt.ts to enforce limits.
+  // Serialized so guards survive interrupt/resume cycles. Cloned to
+  // child branches by Runner.seedBranchCost so cost spent inside a
+  // branch counts toward ancestor limits at join time.
+  // See lib/runtime/guard.ts.
+  guards: GuardEntry[] = [];
+
+  pushGuard(entry: GuardEntry): void {
+    this.guards.push(entry);
+  }
+
+  popGuard(): GuardEntry | undefined {
+    return this.guards.pop();
+  }
 
   constructor(
     stack: State[] = [],
@@ -417,6 +435,7 @@ export class StateStack {
       localTokens: this.localTokens,
       seedCost: this.seedCost,
       seedTokens: this.seedTokens,
+      guards: this.guards.map((g) => ({ ...g })),
     };
   }
 
@@ -444,6 +463,9 @@ export class StateStack {
     stateStack.localTokens = json.localTokens ?? 0;
     stateStack.seedCost = json.seedCost ?? 0;
     stateStack.seedTokens = json.seedTokens ?? 0;
+    // Nullish coalesce handles checkpoints written before the
+    // `guards` field existed (back-compat with pre-guard snapshots).
+    stateStack.guards = (json.guards ?? []).map((g) => ({ ...g }));
     return stateStack;
   }
 }

--- a/packages/agency-lang/lib/stdlib/thread.ts
+++ b/packages/agency-lang/lib/stdlib/thread.ts
@@ -67,3 +67,31 @@ export async function __internal_getTokens(
 ): Promise<number> {
   return stack.localTokens;
 }
+
+/**
+ * Open a guard scope on the caller's stack. `costAtPush` captures the
+ * baseline so the guard's "spent" reading is the DELTA since the
+ * guard opened, not the absolute localCost (which would include cost
+ * spent before the guard scope began). See lib/runtime/guard.ts.
+ */
+export async function __internal_pushGuard(
+  _ctx: RuntimeContext<any>,
+  stack: StateStack,
+  _threads: ThreadStore,
+  costLimit: number,
+): Promise<void> {
+  stack.pushGuard({ costLimit, costAtPush: stack.localCost });
+}
+
+/**
+ * Close the innermost guard scope on the caller's stack. A no-op if
+ * the stack has no active guard (defensive — the surrounding `guard`
+ * stdlib function always pairs push/pop).
+ */
+export async function __internal_popGuard(
+  _ctx: RuntimeContext<any>,
+  stack: StateStack,
+  _threads: ThreadStore,
+): Promise<void> {
+  stack.popGuard();
+}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/classMethod.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/classMethod.mustache
@@ -22,6 +22,7 @@
       __functionCompleted = true;
     } catch (__error) {
       if (__error instanceof RestoreSignal) { throw __error; }
+      if (__error instanceof GuardExceededError) { throw __error; }
       throw __error;
     } finally {
       __stateStack.pop()

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/classMethod.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/classMethod.ts
@@ -27,6 +27,7 @@ export const template = `  async {{{methodName}}}({{{params}}}__state: any = und
       __functionCompleted = true;
     } catch (__error) {
       if (__error instanceof RestoreSignal) { throw __error; }
+      if (__error instanceof GuardExceededError) { throw __error; }
       throw __error;
     } finally {
       __stateStack.pop()

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.mustache
@@ -1,6 +1,14 @@
 if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/functionCatchFailure.ts
@@ -6,6 +6,14 @@ import { apply } from "typestache";
 export const template = `if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib \`guard\`
+// function's try/catch (in lib/runtime/result.ts via \`try block()\`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -19,6 +19,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -71,7 +71,7 @@ export type GuardFailureData = {
   actualCost: number,
 }
 
-export def guard(cost: number, block: () => any): any {
+export def guard(cost: number, block: () => any): Result {
   """
   Run a block with a cost limit. If LLM calls inside the block cause
   the cumulative cost to exceed the limit, the block halts and `guard`

--- a/packages/agency-lang/stdlib/thread.agency
+++ b/packages/agency-lang/stdlib/thread.agency
@@ -64,3 +64,49 @@ export safe def getTokens(): number {
   """
   return __internal_getTokens()
 }
+
+export type GuardFailureData = {
+  type: string,
+  maxCost: number,
+  actualCost: number,
+}
+
+export def guard(cost: number, block: () => any): any {
+  """
+  Run a block with a cost limit. If LLM calls inside the block cause
+  the cumulative cost to exceed the limit, the block halts and `guard`
+  returns a failure carrying the limit and the actual spend.
+
+  On success, returns `success(blockReturnValue)`. The block's local
+  variables are scoped to the block — only the block's return value
+  is observable from the caller. Use isFailure(result) to branch and
+  read result.error.maxCost and result.error.actualCost.
+
+  Nested guards are independent: an inner trip does not trip an outer
+  guard. Fork/race branches inherit the outer guards at branch-creation
+  time, but a branch's cost only rolls up to the outer guard at
+  branch-completion — outer guards cannot pre-empt mid-fork.
+
+  Memory layer LLM calls (memory.text / memory.embed) currently bypass
+  the guard.
+
+  @param cost - Maximum cost in dollars (e.g. $2.00 or 2.00)
+  @param block - The work to run under the guard
+
+  Example:
+    const result = guard(cost: $2.0) as {
+      const a = llm("step 1")
+      const b = llm("step 2")
+      return a + b
+    }
+    if (isFailure(result)) {
+      print("Budget exceeded: spent " + result.error.actualCost)
+    } else {
+      print(result.value)
+    }
+  """
+  __internal_pushGuard(cost)
+  const result = try block()
+  __internal_popGuard()
+  return result
+}

--- a/packages/agency-lang/tests/agency/guards/guard-baseline-nonzero.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-baseline-nonzero.agency
@@ -1,0 +1,24 @@
+import { guard } from "std::thread"
+
+// SYNTHETIC_COST per LLM call is 0.000002.
+//
+// Spend one LLM call BEFORE opening the guard so the stack's localCost
+// is 0.000002 at push time (costAtPush = 0.000002). Then the guard's
+// budget of 0.0000025 must accommodate one inside-guard call of
+// 0.000002 (delta = 0.000002, under 0.0000025). The guard must NOT
+// trip.
+//
+// Bug to catch: a cost check that uses `localCost` instead of
+// `localCost - guard.costAtPush` would see total spend
+// 0.000002 + 0.000002 = 0.000004, > 0.0000025 → trip incorrectly.
+node main() {
+  const before = llm("outside")
+  const r = guard(cost: 0.0000025) as {
+    const inside = llm("inside")
+    return inside
+  }
+  if (isFailure(r)) {
+    return "wrong: tripped (delta calc bug — costAtPush not subtracted)"
+  }
+  return r.value
+}

--- a/packages/agency-lang/tests/agency/guards/guard-baseline-nonzero.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-baseline-nonzero.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"inside\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "outside" },
+        { "return": "inside" }
+      ],
+      "description": "Baseline cost > 0 at guard push. The guard's spend tracking must subtract costAtPush; otherwise pre-guard cost gets counted against the guard's limit and it trips spuriously."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-fork.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-fork.agency
@@ -1,0 +1,29 @@
+import { guard } from "std::thread"
+
+// Fork inside a guard. Each of 3 branches spends SYNTHETIC_COST
+// = 0.000002. After the fork completes, Runner.propagateBranchCost
+// rolls the deltas back to the parent stack: parent localCost grows
+// by 0.000006. The subsequent LLM call ("after") triggers the cost
+// check in prompt.ts, which sees total guard-scope spend = 0.000008
+// (> 0.000001) and trips.
+//
+// NOTE: there is a separate, pre-existing codegen bug
+// (`Unknown scope type: block` in scopeManager.returnType) that
+// prevents `return llm(...)` inside a fork block. This fixture
+// works around it by assigning the LLM result instead of returning
+// it. Cost propagation behaves identically.
+node main() {
+  const result = guard(cost: 0.000001) as {
+    fork([1, 2, 3]) as n {
+      const r = llm("branch ${n}")
+    }
+    // Without this trailing call, cost would propagate but no guard
+    // check would fire (the check is only invoked after LLM calls).
+    const after = llm("after")
+    return after
+  }
+  if (isFailure(result)) {
+    return "tripped-after-fork:${result.error.actualCost > 0}"
+  }
+  return "did not trip"
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-fork.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-fork.test.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"tripped-after-fork:true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "b1" },
+        { "return": "b2" },
+        { "return": "b3" },
+        { "return": "after" }
+      ],
+      "description": "Outer guard wraps a fork. Branch costs propagate to the parent stack on fork completion; the next LLM call's cost check sees total spend and trips. Documents the V1 limitation that mid-fork branches do NOT eagerly notify the outer guard."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-no-trip.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-no-trip.agency
@@ -1,0 +1,14 @@
+import { guard } from "std::thread"
+
+// A budget that is well above SYNTHETIC_COST never trips. The guard's
+// block runs to completion and result.value is the block's return.
+node main() {
+  const result = guard(cost: 10.0) as {
+    const reply = llm("Reply with: pong")
+    return reply
+  }
+  if (isFailure(result)) {
+    return "unexpected trip"
+  }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-no-trip.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-no-trip.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pong\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "pong" }
+      ],
+      "description": "A guard with a generous cost limit does not trip; the block runs to completion and the wrapped success value is returned."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-trip.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-trip.agency
@@ -1,0 +1,16 @@
+import { guard } from "std::thread"
+
+// The deterministic LLM provider charges SYNTHETIC_COST = 0.000002 per
+// call. Setting the limit to 0.000001 (just below SYNTHETIC_COST)
+// guarantees the first llm() call inside the guard trips the budget
+// and propagates a GuardExceededError that the stdlib guard catches.
+node main() {
+  const result = guard(cost: 0.000001) as {
+    const reply = llm("Reply with: pong")
+    return reply
+  }
+  if (isFailure(result)) {
+    return "tripped:${result.error.type}:${result.error.maxCost}:${result.error.actualCost > 0}"
+  }
+  return "did not trip"
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-trip.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-trip.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"tripped:guardFailure:0.000001:true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "pong" }
+      ],
+      "description": "A guard with a tiny cost limit trips on the first LLM call. The stdlib guard function catches the GuardExceededError and surfaces a Failure with the structured GuardFailureData ({ type, maxCost, actualCost }). actualCost is positive because the deterministic provider records SYNTHETIC_COST after the call completes."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-generic-return.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-generic-return.agency
@@ -1,0 +1,18 @@
+import { guard } from "std::thread"
+
+// Block returns an array of numbers (not a string). Verifies the
+// typechecker's generic inference: `guard<T>(...)` should pick up
+// T = number[] from the block's return statement and type `r` as
+// `Result<number[], GuardFailureData>`.
+//
+// If generic inference broke, `r.value[0] + r.value[1]` would either
+// fail at typecheck or compile down to NaN arithmetic.
+node main() {
+  const r = guard(cost: 10.0) as {
+    return [10, 20, 30]
+  }
+  if (isFailure(r)) {
+    return -1
+  }
+  return r.value[0] + r.value[1] + r.value[2]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-generic-return.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-generic-return.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "60",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Generic block return type: `guard<T>` should propagate T = number[] from the block's return, so r.value supports number-array indexing and arithmetic."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-in-def.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-in-def.agency
@@ -1,0 +1,21 @@
+import { guard } from "std::thread"
+
+// Guard inside a `def` function (bare failure shape) instead of a
+// `node` (envelope failure shape). The function-body auto-wrap in
+// codegen differs between def and node; both must re-throw
+// GuardExceededError so the surrounding `guard` function's `try`
+// can convert it to a structured GuardFailureData.
+def doGuardedWork(): Result<string, GuardFailureData> {
+  return guard(cost: 0.000001) as {
+    const r = llm("Reply with: pong")
+    return r
+  }
+}
+
+node main() {
+  const result = doGuardedWork()
+  if (isFailure(result)) {
+    return "def-trip:${result.error.maxCost}"
+  }
+  return "did not trip"
+}

--- a/packages/agency-lang/tests/agency/guards/guard-in-def.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-in-def.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"def-trip:0.000001\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "pong" }
+      ],
+      "description": "Guard inside a `def` function must work the same as inside a `node`. Tests the def-flavored function-body auto-wrap allow-list for GuardExceededError."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-nested-iteration-order.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-nested-iteration-order.agency
@@ -1,0 +1,31 @@
+import { guard } from "std::thread"
+
+// Both guards' limits are below SYNTHETIC_COST (0.000002), so the
+// single LLM call inside the inner guard trips BOTH at once. The
+// runtime must scan innermost-first and throw a GuardExceededError
+// whose `limit` is the inner's (0.0000005), not the outer's
+// (0.0000001).
+//
+// The inner `try` catches the error and __tryCall packs it into a
+// Failure whose `maxCost` reflects the thrown error's limit. So:
+//   correct (innermost-first): inner.maxCost = 0.0000005
+//   buggy   (outer-first):     inner.maxCost = 0.0000001
+//
+// The outer guard's body catches the inner Failure and returns a
+// string that exposes inner.maxCost, which the test asserts.
+node main() {
+  const outer = guard(cost: 0.0000001) as {
+    const inner = guard(cost: 0.0000005) as {
+      const r = llm("hi")
+      return r
+    }
+    if (isFailure(inner)) {
+      return "inner.max=${inner.error.maxCost}"
+    }
+    return "no trip"
+  }
+  if (isFailure(outer)) {
+    return "outer also surfaced — unexpected"
+  }
+  return outer.value
+}

--- a/packages/agency-lang/tests/agency/guards/guard-nested-iteration-order.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-nested-iteration-order.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"inner.max=5e-7\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "hi" }
+      ],
+      "description": "When inner and outer guards both trip on the same LLM call, the innermost limit must be reported. JS renders 0.0000005 as \"5e-7\"."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-nested.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-nested.agency
@@ -1,0 +1,22 @@
+import { guard } from "std::thread"
+
+// Inner guard with a tiny limit trips on the LLM call; outer guard
+// with a generous limit catches the inner Failure and proceeds. This
+// proves that guards are scoped — an inner trip does not pollute the
+// outer guard's bookkeeping.
+node main() {
+  const outer = guard(cost: 10.0) as {
+    const inner = guard(cost: 0.000001) as {
+      const r = llm("Reply with: pong")
+      return r
+    }
+    if (isFailure(inner)) {
+      return "inner tripped"
+    }
+    return "inner ok"
+  }
+  if (isFailure(outer)) {
+    return "outer tripped unexpectedly"
+  }
+  return outer.value
+}

--- a/packages/agency-lang/tests/agency/guards/guard-nested.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-nested.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"inner tripped\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "pong" }
+      ],
+      "description": "Nested guards are independent: the inner guard trips on a tiny budget, the outer catches the inner's Failure, and the outer never trips because its own budget is generous."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-sibling-cleanup.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-sibling-cleanup.agency
@@ -1,0 +1,24 @@
+import { guard } from "std::thread"
+
+// Two guards run back-to-back at the same scope. The first trips, the
+// second has a generous budget and must not be polluted by the first.
+// This regression-tests __popGuard cleanup: if the first guard's entry
+// leaked onto the stack, the second guard's LLM call would also trip
+// against the leaked tiny limit and the second test branch would fail.
+node main() {
+  const r1 = guard(cost: 0.000001) as {
+    const a = llm("first")
+    return a
+  }
+  const r2 = guard(cost: 10.0) as {
+    const b = llm("second")
+    return b
+  }
+  if (!isFailure(r1)) {
+    return "r1 did not trip (unexpected)"
+  }
+  if (isFailure(r2)) {
+    return "r2 tripped — popGuard leaked"
+  }
+  return "ok"
+}

--- a/packages/agency-lang/tests/agency/guards/guard-sibling-cleanup.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-sibling-cleanup.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"ok\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "first" },
+        { "return": "second" }
+      ],
+      "description": "Sequential sibling guards: the first trips on a tiny budget, the second has a generous budget. If __popGuard leaks the first entry, the second's LLM call trips against it and r2 is a Failure."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-unit-literal.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-unit-literal.agency
@@ -1,0 +1,16 @@
+import { guard } from "std::thread"
+
+// Verifies the `$X` unit literal is accepted as the cost argument and
+// reaches the runtime as a plain number. Per the unit-literals guide,
+// `$0.000001` compiles to `0.000001`. The fixture mirrors guard-cost-
+// trip but with the unit literal at the call site.
+node main() {
+  const r = guard(cost: $0.000001) as {
+    const reply = llm("Reply with: pong")
+    return reply
+  }
+  if (isFailure(r)) {
+    return "tripped:${r.error.maxCost}"
+  }
+  return "did not trip"
+}

--- a/packages/agency-lang/tests/agency/guards/guard-unit-literal.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-unit-literal.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"tripped:0.000001\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "pong" }
+      ],
+      "description": "`guard(cost: $0.000001)` must compile and trip exactly the same as `guard(cost: 0.000001)`. The `$` unit literal is a compile-time scale (no-op for dollars)."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/named-arg-with-trailing-block.agency
+++ b/packages/agency-lang/tests/agency/named-arg-with-trailing-block.agency
@@ -1,0 +1,37 @@
+// Regression test for the bug fixed alongside builtin guards:
+// `foo(named: x) as { ... }` used to silently drop the trailing
+// `as` block when at least one argument was passed by name. The
+// named-args descriptor path didn't carry blockArg through to
+// resolveNamed.
+//
+// Covered shapes:
+//  - one named arg + trailing block (the original repro)
+//  - mixed positional + named + trailing block
+//  - typed block param + trailing block
+
+def withBlock(label: string, block: () => any): string {
+  return label + ": " + block()
+}
+
+def withMixed(prefix: string, suffix: string, block: () => number): string {
+  return prefix + " " + block() + " " + suffix
+}
+
+node singleNamedArg() {
+  return withBlock(label: "hello") as {
+    return "world"
+  }
+}
+
+node mixedPositionalAndNamed() {
+  return withMixed("start", suffix: "end") as {
+    return 42
+  }
+}
+
+node namedReordered() {
+  // suffix is passed BEFORE prefix by name — common case for named args
+  return withMixed(suffix: "end", prefix: "start") as {
+    return 7
+  }
+}

--- a/packages/agency-lang/tests/agency/named-arg-with-trailing-block.test.json
+++ b/packages/agency-lang/tests/agency/named-arg-with-trailing-block.test.json
@@ -1,0 +1,25 @@
+{
+  "tests": [
+    {
+      "nodeName": "singleNamedArg",
+      "input": "",
+      "expectedOutput": "\"hello: world\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Trailing `as` block is preserved when a single arg is passed by name."
+    },
+    {
+      "nodeName": "mixedPositionalAndNamed",
+      "input": "",
+      "expectedOutput": "\"start 42 end\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Trailing `as` block binds correctly when args are mixed positional + named."
+    },
+    {
+      "nodeName": "namedReordered",
+      "input": "",
+      "expectedOutput": "\"start 7 end\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Trailing `as` block binds correctly when named args appear out of declaration order."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -44,6 +44,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -16,6 +16,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -251,6 +252,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -363,6 +372,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -44,6 +44,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -16,6 +16,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -241,6 +242,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -16,6 +16,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -274,6 +275,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -44,6 +44,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -44,6 +44,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -16,6 +16,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -230,6 +231,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -44,6 +44,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -16,6 +16,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -242,6 +243,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -363,6 +372,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -466,6 +483,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -44,6 +44,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -16,6 +16,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -231,6 +232,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -218,6 +219,9 @@ if (hasInterrupts(__stack.locals.bar)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -15,6 +15,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -226,6 +227,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -346,6 +355,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -450,6 +467,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -43,6 +43,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -233,6 +234,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -279,6 +280,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -218,6 +219,9 @@ if (hasInterrupts(__stack.locals.bar)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -232,6 +233,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -357,6 +366,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -231,6 +232,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -233,6 +234,14 @@ if (hasInterrupts(__funcResult)) {
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -358,6 +367,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -237,6 +238,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -346,6 +355,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -217,6 +218,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -326,6 +335,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -217,6 +218,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -247,6 +248,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -371,6 +380,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -258,6 +259,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -392,6 +401,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -242,6 +243,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -226,6 +227,14 @@ return;
       if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -330,6 +339,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -226,6 +227,14 @@ return;
       if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -338,6 +347,14 @@ return;
       if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -439,6 +456,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -225,6 +226,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -360,6 +369,9 @@ await __call(print, {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -243,6 +244,14 @@ if (hasInterrupts(__funcResult)) {
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -222,6 +223,14 @@ if (__ctx._pendingArgOverrides) {
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -318,6 +327,14 @@ if (__ctx._pendingArgOverrides) {
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(
@@ -418,6 +435,14 @@ if (__ctx._pendingArgOverrides) {
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -514,6 +539,14 @@ if (__ctx._pendingArgOverrides) {
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -592,6 +625,14 @@ if (__ctx._pendingArgOverrides) {
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -219,6 +220,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -234,6 +235,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -218,6 +219,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -250,6 +251,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -371,6 +380,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -242,6 +243,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -357,6 +366,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -465,6 +482,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -220,6 +221,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -283,6 +284,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -393,6 +402,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -346,6 +347,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -473,6 +482,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -237,6 +238,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -283,6 +284,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -393,6 +402,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -286,6 +287,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -245,6 +246,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -364,6 +373,14 @@ return;
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(
@@ -488,6 +505,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -609,6 +634,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -725,6 +758,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -823,6 +864,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)
@@ -957,6 +1001,9 @@ if (hasInterrupts(__stack.locals.flexResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -208,6 +209,14 @@ __stack.locals.foo = 1;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -302,6 +311,14 @@ if (__ctx._pendingArgOverrides) {
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(
@@ -407,6 +424,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -217,6 +218,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -312,6 +321,14 @@ return;
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(
@@ -439,6 +456,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -556,6 +581,9 @@ if (hasInterrupts(__stack.locals.doubled)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -238,6 +239,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -349,6 +358,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -213,6 +214,9 @@ if (hasInterrupts(__funcResult)) {
     if (__error instanceof RestoreSignal) {
       throw __error
     }
+    if (__error instanceof GuardExceededError) {
+      throw __error
+    }
     console.error(`\nAgent crashed: ${__error.message}`)
     console.error(__error.stack)
     return {
@@ -262,6 +266,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -216,6 +217,9 @@ if (hasInterrupts(__funcResult)) {
     if (__error instanceof RestoreSignal) {
       throw __error
     }
+    if (__error instanceof GuardExceededError) {
+      throw __error
+    }
     console.error(`\nAgent crashed: ${__error.message}`)
     console.error(__error.stack)
     return {
@@ -267,6 +271,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -237,6 +238,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -378,6 +379,9 @@ __stack.locals.result = `other`;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -29,6 +29,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -57,6 +57,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -247,6 +248,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -371,6 +380,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -253,6 +254,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -376,6 +385,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -254,6 +255,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -236,6 +237,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -264,6 +265,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -414,6 +423,14 @@ return;
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(
@@ -579,6 +596,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -268,6 +269,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -264,6 +265,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -405,6 +414,9 @@ return;
     if (__error instanceof RestoreSignal) {
       throw __error
     }
+    if (__error instanceof GuardExceededError) {
+      throw __error
+    }
     console.error(`\nAgent crashed: ${__error.message}`)
     console.error(__error.stack)
     return {
@@ -481,6 +493,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -266,6 +267,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -493,6 +494,9 @@ __stack.locals.output4 = {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -211,6 +212,14 @@ return;
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -229,6 +230,9 @@ return;
     if (__error instanceof RestoreSignal) {
       throw __error
     }
+    if (__error instanceof GuardExceededError) {
+      throw __error
+    }
     console.error(`\nAgent crashed: ${__error.message}`)
     console.error(__error.stack)
     return {
@@ -313,6 +317,9 @@ if (hasInterrupts(__funcResult)) {
     if (__error instanceof RestoreSignal) {
       throw __error
     }
+    if (__error instanceof GuardExceededError) {
+      throw __error
+    }
     console.error(`\nAgent crashed: ${__error.message}`)
     console.error(__error.stack)
     return {
@@ -362,6 +369,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -250,6 +251,14 @@ if (hasInterrupts(__funcResult)) {
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -229,6 +230,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -389,6 +398,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -233,6 +234,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -236,6 +237,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -243,6 +244,14 @@ if (hasInterrupts(__funcResult)) {
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -217,6 +218,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -318,6 +327,14 @@ return;
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(
@@ -440,6 +457,14 @@ return;
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(
@@ -613,6 +638,9 @@ __stack.locals.__pipe_4 = await success(10);
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -244,6 +245,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -229,6 +230,14 @@ return;
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -229,6 +230,14 @@ return;
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -203,6 +204,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -228,6 +229,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -15,6 +15,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -43,6 +43,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -226,6 +227,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -235,6 +236,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -341,6 +350,14 @@ return;
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(
@@ -598,6 +615,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -15,6 +15,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -242,6 +243,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -43,6 +43,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -233,6 +234,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -218,6 +219,9 @@ if (hasInterrupts(__stack.locals.result)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -220,6 +221,9 @@ __stack.locals.stringSlice = __stack.locals.str.slice(1, 3);
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -205,6 +206,9 @@ __stack.locals.arr.splice(0, 2 - 0, ...[40, 50])
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -236,6 +237,14 @@ return;
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -333,6 +342,9 @@ __stack.locals.z = item;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -219,6 +220,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -278,6 +279,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -196,6 +197,9 @@ __stack.locals.greeting = `Hello, my name is ${name} and I am ${age} years old.`
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -247,6 +248,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -400,6 +401,14 @@ if (hasInterrupts(__funcResult)) {
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -693,6 +702,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -276,6 +277,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -238,6 +239,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -268,6 +269,9 @@ if (hasInterrupts(__stack.locals.baz)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -240,6 +241,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -238,6 +239,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -221,6 +222,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -242,6 +243,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -242,6 +243,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -237,6 +238,14 @@ if (hasInterrupts(__funcResult)) {
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+  throw __error;
+}
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
   throw __error;
 }
 return failure(

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -246,6 +247,14 @@ if (__response) {
     if (__error instanceof RestoreSignal) {
   throw __error;
 }
+// GuardExceededError must propagate up to the stdlib `guard`
+// function's try/catch (in lib/runtime/result.ts via `try block()`).
+// If we converted it to a Failure here, the guard would never see
+// the trip and every guarded block would appear to succeed even
+// over budget. See lib/runtime/guard.ts.
+if (__error instanceof GuardExceededError) {
+  throw __error;
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -341,6 +350,9 @@ return;
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -14,6 +14,7 @@ import {
   respondToInterrupts as _respondToInterrupts,
   rewindFrom as _rewindFrom,
   RestoreSignal,
+  GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   head, tail, empty,
@@ -236,6 +237,9 @@ if (hasInterrupts(__funcResult)) {
     };
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
+      throw __error
+    }
+    if (__error instanceof GuardExceededError) {
       throw __error
     }
     console.error(`\nAgent crashed: ${__error.message}`)

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -42,6 +42,8 @@ import {
   __internal_assistantMessage,
   __internal_getCost,
   __internal_getTokens,
+  __internal_popGuard,
+  __internal_pushGuard,
   __internal_systemMessage,
   __internal_userMessage,
 } from "agency-lang/stdlib-lib/thread.js";


### PR DESCRIPTION
Adds `guard(cost: $X) as { ... }` to `std::thread` — a stdlib function that aborts its block when the cumulative LLM cost exceeds the limit, returning a `Result` so callers can decide what to do.

## Links

- Plan: [`docs/superpowers/plans/2026-05-23-builtin-cost-guards.md`](./packages/agency-lang/docs/superpowers/plans/2026-05-23-builtin-cost-guards.md)
- Spec: [`docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md`](./packages/agency-lang/docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md)
- User guide: [`docs/site/guide/cost-guards.md`](./packages/agency-lang/docs/site/guide/cost-guards.md)

## Surface syntax

```ts
import { guard } from "std::thread"

node main() {
  const result = guard(cost: $2.0) as {
    const a = llm("classify this email")
    const b = llm("draft a reply")
    return a + " — " + b
  }
  if (isFailure(result)) {
    return "over budget: spent " + result.error.actualCost
  }
  return result.value
}
```

`$2.0` is the existing unit literal that compiles to a plain `number` — `guard(cost: $2.0)` is equivalent to `guard(cost: 2.0)`.

## Failure shape

When a guard trips, `result.error` carries:

```ts
type GuardFailureData = {
  type: "guardFailure",
  maxCost: number,
  actualCost: number,
}
```

The `type` field is a `string` rather than a literal so a future `"timeoutFailure"` variant can be added without breaking V1 consumers.

## How it works

1. The agency `guard` function calls `__internal_pushGuard(cost)` which records `{ costLimit, costAtPush: stack.localCost }` on the `StateStack`.
2. The block runs. Inside `prompt.ts`, after each LLM call's cost is added to `targetStack.localCost`, the active guards are walked innermost-first.
3. If any guard's delta (`localCost - costAtPush`) exceeds its limit, `prompt.ts` throws a `GuardExceededError`.
4. The error propagates through the user's code. The function-body auto-wrap (`functionCatchFailure.mustache` + `typescriptBuilder.ts`) re-throws `GuardExceededError` (alongside `RestoreSignal`) so it cannot be silently converted to a generic Failure.
5. The stdlib `guard` function's `try block()` catches the error. `__tryCall` detects the `GuardExceededError` and emits a Failure with the structured `GuardFailureData` shape.
6. `__internal_popGuard()` removes the guard from the stack.

Guards are serialized as part of `StateStack` so they survive checkpoint/restore. Branch seeding (`Runner.seedBranchCost`) clones the parent's guards onto each child stack.

## Files added

- `lib/runtime/guard.ts` + `guard.test.ts` — `GuardEntry`, `GuardExceededError`, `isGuardExceededError`.
- `tests/agency/guards/guard-cost-trip.{agency,test.json}` — tiny budget trips on the first LLM call.
- `tests/agency/guards/guard-cost-no-trip.{agency,test.json}` — generous budget; block runs to completion.
- `tests/agency/guards/guard-nested.{agency,test.json}` — inner trip doesn't trip outer.
- `docs/site/guide/cost-guards.md` — user-facing guide.

## Files modified

- `lib/runtime/state/stateStack.ts` — `guards: GuardEntry[]` + `pushGuard`/`popGuard`, serialized in `toJSON`/`fromJSON`.
- `lib/runtime/runner.ts` — `seedBranchCost` clones parent guards onto child branch stacks.
- `lib/runtime/prompt.ts` — innermost-first guard check after cost accumulation.
- `lib/runtime/result.ts` — `__tryCall` preserves `GuardExceededError` data as structured failure.
- `lib/runtime/index.ts` — exports `GuardExceededError`, `isGuardExceededError`, `GuardEntry`.
- `lib/codegenBuiltins/contextInjected.ts` — registers `__internal_pushGuard` / `__internal_popGuard`.
- `lib/stdlib/thread.ts` — TS implementations for the two builtins.
- `stdlib/thread.agency` — `guard` function + `GuardFailureData` type.
- `lib/templates/backends/typescriptGenerator/{imports,functionCatchFailure,classMethod}.mustache` (+ regenerated `.ts`) — adds `GuardExceededError` to the auto-wrap allow-list.
- `lib/backends/typescriptBuilder.ts` — programmatic auto-wrap also re-throws `GuardExceededError`.
- Drive-by: fixes the trailing-block-with-named-args bug (`CallType.named` gains `blockArg`; `resolveNamed` binds it to the last parameter).
- Fixture regenerations across `tests/typescriptGenerator/` and `tests/typescriptBuilder/` (import block now includes the two new context-injected builtins).
- `CHANGELOG.md` — Unreleased section.

## V1 limitations (documented)

- **Forks don't trip outer guards mid-flight.** Branch costs only roll up to the parent at branch completion via `propagateBranchCost`. An outer guard wrapping a `fork` cannot pre-empt branches in-flight; the recommended pattern is to put the guard *inside* each branch instead. After the fork completes, the next LLM call inside the outer guard will observe the rolled-up spend and trip.
- **Memory layer LLM calls bypass the guard.** `memory.text` / `memory.embed` extraction prompts currently don't flow through the same accumulator path. Tracked as a follow-up.
- **No dimensional unit checking.** `$2.0` and `2.0` are the same `number` at the type level; the unit literal is a notation aid.

## Test results

- `lib/runtime/guard.test.ts`: 5/5 passed
- `lib/runtime/state/stateStack.test.ts`: 4452/4452 passed (5 new guard cases added)
- `pnpm test:run -- guards thread prompt fork stateStack contextInjected`: 4462/4462 passed
- `node ./dist/scripts/agency.js test tests/agency/guards tests/agency/thread`: 7/7 passed (3 new + 4 existing)
- `make`: clean
- `pnpm run lint:structure`: clean

## Notes for the reviewer

A `guard-cost-fork.agency` fixture was attempted but had to be removed: putting an `llm()` call inside a `fork` branch (with or without a guard) triggers a pre-existing codegen bug — `Error: Unknown scope type: block` from `scopeManager.ts#returnType()`. This is unrelated to guards; the fork-related behavior is covered by the documentation in `cost-guards.md` and by the existing branch-cost-propagation tests in `tests/agency/thread/cost-*`. Flagging in case you want me to file a separate issue for the scope-manager bug.

The trailing-block-with-named-args fix was necessary to make the plan's locked syntax (`guard(cost: $2.0) as { ... }`) work. Without it, named-arg calls silently dropped the trailing block, causing the runtime to report "Missing required argument 'block' in call to 'guard'". The fix adds a `blockArg` field to the named CallType variant, which `resolveNamed` binds to the last non-variadic unbound parameter. This was a small, focused change and made the design intent achievable; let me know if you'd rather split it into its own PR.

The `try` keyword interaction with `GuardExceededError` shook out cleanly: rather than parsing string error messages in agency code, I taught `__tryCall` in `lib/runtime/result.ts` to detect a `GuardExceededError` and emit the structured `GuardFailureData` directly. This keeps the agency-side `guard` function trivial (just `try block()`) and means any future code that uses `try` will also get the structured shape for guard errors.
