### PR TITLE
fix: support `return llm(...)` inside any block body

### DIFF
--- a/packages/agency-lang/docs/site/guide/llm.md
+++ b/packages/agency-lang/docs/site/guide/llm.md
@@ -18,6 +18,37 @@ const response: Response = llm("What is the capital of France?")
 print(response)
 ```
 
+### Limitation: structured output inside block bodies
+
+When you write `return llm(...)` as the last statement of a block
+body (a `fork(...) as item { ... }` branch, a `guard(cost: $X) as { ... }`
+body, or any user-defined function that takes a block parameter),
+Agency currently has no way to know the block's declared return type
+at codegen time — so the structured-output schema falls back to
+`string`. The block still runs and returns the LLM's text reply, but
+you cannot get a typed object out of it.
+
+```ts
+type Response = { capital: string }
+
+// ❌ The annotation on `result` is NOT propagated into the block.
+// Each branch returns a plain string from the LLM.
+const result: Response[] = fork(["France", "Spain"]) as country {
+  return llm(`What is the capital of ${country}?`)
+}
+```
+
+The workaround is to assign the LLM call to a typed local first, then
+return it:
+
+```ts
+// ✅ The annotation on `reply` controls the LLM's structured output.
+const result: Response[] = fork(["France", "Spain"]) as country {
+  const reply: Response = llm(`What is the capital of ${country}?`)
+  return reply
+}
+```
+
 Any function defined in Agency can automatically be used as a tool for the LLM. Pass the function in the `tools` option:
 
 ```ts

--- a/packages/agency-lang/docs/site/guide/llm.md
+++ b/packages/agency-lang/docs/site/guide/llm.md
@@ -20,13 +20,14 @@ print(response)
 
 ### Limitation: structured output inside block bodies
 
-When you write `return llm(...)` as the last statement of a block
-body (a `fork(...) as item { ... }` branch, a `guard(cost: $X) as { ... }`
-body, or any user-defined function that takes a block parameter),
-Agency currently has no way to know the block's declared return type
-at codegen time — so the structured-output schema falls back to
-`string`. The block still runs and returns the LLM's text reply, but
-you cannot get a typed object out of it.
+Any `return llm(...)` inside a block body — anywhere in the block,
+not just at the end — falls back to a `string` structured-output
+schema. This applies to `fork(...) as item { ... }` branches,
+`guard(cost: $X) as { ... }` bodies, and any user-defined function
+that takes a block parameter. Agency currently has no way to know
+the block's declared return type at codegen time, so the LLM is
+asked for a plain string. The block still runs and returns the
+LLM's text reply, but you cannot get a typed object out of it.
 
 ```ts
 type Response = { capital: string }

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2317,6 +2317,32 @@ export class TypeScriptBuilder {
       if (this.isInterruptExpression(node.value)) {
         return this.processInterruptStatement(node.value as InterruptStatement);
       }
+      // `return llm(...)` from a block: processLlmCall emits multiple
+      // statements (assigning the result to __prompt), so we must hoist
+      // them above the runnerHalt and pass the result var as the halt
+      // value — wrapping the statements list directly in runnerHalt
+      // would produce invalid TS like `runner.halt(stmt; stmt; ...)`.
+      // Scope must be "block" so processLlmCall assigns into
+      // `__bstack.locals.__prompt`, which is what `ts.self(...)`
+      // resolves to inside a block (where `__self = __bstack.locals`).
+      // The block's declared return type is unknown to the builder
+      // (see ScopeManager.returnType comment), so processLlmCall falls
+      // back to a string-typed structured-output schema.
+      if (
+        node.value.type === "functionCall" &&
+        node.value.functionName === "llm"
+      ) {
+        const llmNode = this.processLlmCall(
+          DEFAULT_PROMPT_NAME,
+          this.scopes.returnType(),
+          node.value,
+          "block",
+        );
+        return ts.statements([
+          llmNode,
+          ts.runnerHalt(ts.self(DEFAULT_PROMPT_NAME)),
+        ]);
+      }
       const valueNode = this.processNode(node.value);
       return ts.runnerHalt(valueNode);
     }

--- a/packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/scopeManager.ts
@@ -85,7 +85,24 @@ export class ScopeManager {
 
   /**
    * Declared return type of the currently-executing function or graph node,
-   * or `undefined` for global scope or a function with no annotation.
+   * or `undefined` for global scope, a function with no annotation, or a
+   * block scope.
+   *
+   * Block scopes (`fork(...) as item { ... }`, `guard(cost: $X) as { ... }`,
+   * any `as { ... }` body) currently return `undefined` because we don't
+   * carry the block's declared return type onto `Scope.block`. The only
+   * caller that matters is `processLlmCall` for a `return llm(...)` inside
+   * a block — and `processLlmCall` already defaults `undefined` to
+   * `string` for structured-output inference. So today, a bare
+   * `return llm(...)` from a block is always typed as `string`.
+   *
+   * Propagating the block's declared return type (from the enclosing
+   * function's block-parameter signature) into the builder would require
+   * either threading the parameter type through every `scopes.push({
+   * type: "block", ... })` site or looking it up via the typechecker —
+   * both substantial. Documented in docs/site/guide/llm.md as a known
+   * limitation; users who want a non-string structured type should
+   * assign the call: `const x: Foo = llm(...); return x`.
    */
   returnType(): VariableType | undefined {
     const scope = this.current();
@@ -102,6 +119,8 @@ export class ScopeManager {
         );
         return graphNode?.returnType ?? undefined;
       }
+      case "block":
+        return undefined;
       default:
         throw new Error(`Unknown scope type: ${(scope as any).type}`);
     }

--- a/packages/agency-lang/tests/agency/block-return-llm.agency
+++ b/packages/agency-lang/tests/agency/block-return-llm.agency
@@ -1,0 +1,20 @@
+// Regression test for two related codegen bugs that previously
+// crashed compilation whenever `return llm(...)` appeared inside any
+// block body (fork branches, guard blocks, user-defined block
+// arguments, etc.):
+//
+//   1. ScopeManager.returnType() threw "Unknown scope type: block".
+//   2. processReturnStatement for block scope wrapped the multi-
+//      statement output of processLlmCall in `runner.halt(...)`,
+//      producing invalid TS like `runner.halt(stmt; stmt; ...)`.
+//
+// Both are now fixed. The block's declared return type is not
+// propagated into the builder, so structured-output type defaults
+// to `string` — documented limitation in docs/site/guide/llm.md.
+
+node main() {
+  const replies = fork(["a"]) as item {
+    return llm("echo " + item)
+  }
+  return replies[0]
+}

--- a/packages/agency-lang/tests/agency/block-return-llm.test.json
+++ b/packages/agency-lang/tests/agency/block-return-llm.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"echoA\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "echoA" }
+      ],
+      "description": "`return llm(...)` from inside a fork block compiles cleanly and the block's halt value is the LLM result. Regression for ScopeManager.returnType throwing on block scope and runner.halt wrapping multi-statement codegen."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-fork.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-fork.agency
@@ -6,12 +6,6 @@ import { guard } from "std::thread"
 // by 0.000006. The subsequent LLM call ("after") triggers the cost
 // check in prompt.ts, which sees total guard-scope spend = 0.000008
 // (> 0.000001) and trips.
-//
-// NOTE: there is a separate, pre-existing codegen bug
-// (`Unknown scope type: block` in scopeManager.returnType) that
-// prevents `return llm(...)` inside a fork block. This fixture
-// works around it by assigning the LLM result instead of returning
-// it. Cost propagation behaves identically.
 node main() {
   const result = guard(cost: 0.000001) as {
     fork([1, 2, 3]) as n {


### PR DESCRIPTION
## What

Fixes a codegen bug where `return llm(...)` inside any block body
(fork branch, guard block, any `as { ... }` body) crashed
compilation with `Unknown scope type: block`.

## Why it was broken

Two interacting bugs:

1. `ScopeManager.returnType()` did not handle block scope. It only
   recognised `global`/`function`/`node` and threw on `block`. Any
   path that called `returnType()` from inside a block (e.g.
   `processLlmCall` looking up the type hint for structured output)
   crashed.
2. Even if you got past #1, `processReturnStatement`'s block branch
   ran `processNode(node.value)` and wrapped the result in
   `runner.halt(...)`. For `llm(...)` that produces a statements
   list, so codegen emitted invalid TypeScript like
   `runner.halt(stmt; stmt; ...);`.

## What changed

- `lib/backends/typescriptBuilder/scopeManager.ts` — `returnType()`
  now returns `undefined` for block scope. Documented why:
  propagating the block's declared return type into the builder
  would require threading the block-parameter type through every
  block-scope push site, which is non-trivial.
- `lib/backends/typescriptBuilder.ts` — `processReturnStatement`'s
  block branch now has a dedicated `return llm(...)` path that
  hoists `processLlmCall`'s statements and halts the runner with
  the `__prompt` self-ref. Uses scope `"block"` so the assignment
  lands at `__bstack.locals.__prompt`, which is what `ts.self(...)`
  resolves to inside a block frame.
- `docs/site/guide/llm.md` — documents the limitation that
  `return llm(...)` from a block always uses a string-typed schema,
  with the workaround (assign to a typed local, then return it).
- `tests/agency/block-return-llm.{agency,test.json}` — regression
  fixture.
- `tests/agency/guards/guard-cost-fork.agency` — removes the
  obsolete "pre-existing codegen bug" workaround note.

## Known limitation (documented, not in scope)

A bare `return llm(...)` from a block always uses a `string`
structured-output schema, even when the surrounding block's
declared return type is something else. Users who want a typed
object should assign first:

```ts
const reply: MyType = llm("...")
return reply
```

Propagating the declared block return type into the builder would
require either threading the type through every `scopes.push({
type: "block", ... })` site or looking it up via the typechecker —
substantial enough to be its own PR.

## Validation

- `pnpm test:run -- typeChecker typescriptBuilder typescriptGenerator scopeManager`
  → 4443 / 4443 pass.
- `pnpm run agency test tests/agency/block-return-llm.agency` → pass.
