### PR TITLE
Shared cost guards: real-time mid-fork enforcement

### DIFF
--- a/packages/agency-lang/docs/site/guide/guards.md
+++ b/packages/agency-lang/docs/site/guide/guards.md
@@ -94,7 +94,19 @@ const outer = guard(cost: $10.0) as {
 }
 ```
 
-The inner cost guard sees its own baseline (the parent's `localCost` at the moment the inner scope opened) and trips on its own limit. The outer cost guard sees the *cumulative* spend including the inner's cost — but only against its own (larger) limit. Inner time guards similarly track only the compute time spent inside the inner scope; the outer's timer keeps ticking through the inner regardless of whether the inner tripped.
+The inner cost guard owns its own `spent` counter (initialized to `0` at push) and trips on its own limit. The outer cost guard is also charged for every LLM call in scope (including ones made inside the inner) and trips against its own limit. The `prompt.ts` post-call walk goes innermost-first, so when an inner exceeds its limit the inner's trip fires first and the outer's check at the same call site is skipped — that's how the `if (isFailure(inner))` above works. Inner time guards similarly track only the compute time spent inside the inner scope; the outer's timer keeps ticking through the inner regardless of whether the inner tripped.
+
+Inner guards that a branch pushes *after* a `fork` opens stay branch-local — they sit on the child's stack at indices past `inheritedGuardCount` and are never visible to the parent or other sibling branches. This lets you compose an outer "hard cap across all branches" with per-branch sub-budgets:
+
+```ts
+guard(cost: $5.0) as {              // shared across every branch below
+  fork(jobs) as job {
+    guard(cost: $0.50) as {         // per-branch sub-budget, isolated
+      return processOneJob(job)
+    }
+  }
+}
+```
 
 ## Forks, parallel, and message threads
 
@@ -102,8 +114,10 @@ The inner cost guard sees its own baseline (the parent's `localCost` at the mome
 
 Both kinds of guard work, with different mechanics:
 
-- **Cost guards** are *cloned* into each branch. Each branch independently tracks cost-since-push and trips its own clone from inside the branch. The parent's view of cost is updated only at branch completion (see "Limitations" below).
+- **Cost guards** are *shared* across all branches. `CostGuard.cloneForBranch` returns the same in-memory object the parent holds, so every branch's `stack.guards` array contains a live reference to the same `CostGuard` instance. Any LLM call from any branch charges the same counter; the next post-call check (in any branch — whichever runs next) returns the trip when the cumulative shared spend exceeds the limit. Inner cost guards that a branch pushes *after* the fork opens stay branch-local (see [Nested guards](#nested-guards)).
 - **Time guards** are *not* cloned. The parent's `setTimeout` is the single source of truth. When it fires, the parent's `AbortController` propagates through the branches' composed abort signals; each branch halts at its next runner step boundary and control returns to the parent. The parent's next sync point then sees its own time guard's trip and produces the `timeoutFailure`.
+
+A `prompt.ts` **pre-call gate** also walks the guard stack immediately before issuing an LLM request. If a sibling branch's earlier charge has already pushed the shared cost guard over its limit, the gate refuses the request before it hits the wire — you don't pay for a response you'd just throw away.
 
 If you want per-branch enforcement, put the guard **inside** each branch:
 
@@ -139,19 +153,6 @@ If you want per-thread cost or time limits, wrap each thread in its own `guard(.
 
 **JS-bodied tool calls cannot be aborted mid-execution.** Tool functions whose body is written in JavaScript (rather than Agency code) run to completion in the background once started; only the next runner step after they return will see the trip and abandon their result. Agency-bodied tools, in-flight LLM HTTP requests, and the runner itself all observe the abort signal and stop promptly. Long-term plan: opt-in cancellation by reading `state.stateStack.abortSignal` from inside JS tool bodies (currently only internal tools do this).
 
-**Forks don't trip outer cost guards mid-flight.** Branch costs roll back into the parent stack only at branch completion (via `Runner.propagateBranchCost`). An outer cost guard wrapping a fork cannot pre-empt branches that are still running:
-
-```ts
-// AVOID this pattern if you want mid-fork cost enforcement
-guard(cost: $1.0) as {
-  fork(jobs) as job {
-    expensiveCall(job)  // outer cost guard does NOT see this until the fork completes
-  }
-}
-```
-
-Use per-branch guards (see above) instead. After the fork completes, the next LLM call inside the outer guard will observe the rolled-up spend and trip, so the guard still catches the budget breach — just later than you might expect. Time guards do **not** have this limitation: the parent's timer fires on wall clock and aborts every branch directly.
-
 **Memory layer LLM calls bypass cost guards.** Calls made internally by the memory layer (e.g. `memory.text`, `memory.embed` extraction prompts) currently don't flow through the guard check. The guard only enforces against LLM calls made via the standard `llm()` and `runPrompt` paths. Tracked as a follow-up.
 
 **No dimensional unit checking.** `$2.0` and `2.0` are the same `number` at the type level — the unit literal is a notation aid, not a type-system distinction. You could pass a non-dollar number for `cost:` or a non-millisecond number for `time:`; the typechecker won't notice. This will improve when dimensioned types land.
@@ -162,10 +163,10 @@ Both variants share the same `Guard` interface in `lib/runtime/guard.ts`. `State
 
 **Cost guards** (`CostGuard`):
 
-1. `install` captures `stack.localCost` as the baseline.
-2. Every LLM call's cost is added to `stack.localCost` inside `prompt.ts`.
-3. After each cost addition, `prompt.ts` walks the active guards innermost-first. Each guard's `check()` returns a `GuardExceededError` if `stack.localCost - baseline > limit`.
-4. The error propagates through user code; the stdlib `guard`'s `try block()` catches it via `__tryCall`, which produces the structured `Failure`.
+1. Each `CostGuard` instance owns a `spent` counter (initialized to `0`).
+2. Inside `prompt.ts`, every LLM call's cost is dispatched to `guard.charge(cost)` on every guard in `stack.guards` — including any shared parent guards inherited by a child branch.
+3. `prompt.ts` walks the active guards innermost-first **twice** per call: a pre-call gate (refuses to issue the request if any guard's `spent > limit`) and a post-call check after the charge. Either site returns a `GuardExceededError` which propagates through user code; the stdlib `guard`'s `try block()` catches it via `__tryCall` and produces the structured `Failure`.
+4. **Shared across fork branches.** `CostGuard.cloneForBranch` returns `this` — the same JS object — so every branch's `stack.guards` array holds a reference to the parent's CostGuard. Mutations are race-free thanks to single-threaded JS. On serialize, each child stack's `inheritedGuardCount` records how many of its guards were inherited; `toJSON` only serializes branch-owned guards (the inherited parent guard is serialized once on the parent's snapshot). On resume, `runBatch.rehydrateInheritedGuards` re-prepends the parent's live refs onto each child, restoring real-time sharing.
 
 **Time guards** (`TimeGuard`):
 

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-24-shared-cost-guards.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-24-shared-cost-guards.md
@@ -2,6 +2,21 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
 
+> **Divergence from this plan (recorded during implementation):**
+> This plan originally specified that `CostGuard` would also install
+> an `AbortController` (mirroring `TimeGuard`) and fire it on trip to
+> cascade-cancel sibling branches. That was REMOVED during
+> implementation because it caused nested guards to both trip
+> simultaneously — violating the innermost-first reporting contract
+> guaranteed by `guard-nested-iteration-order` (an inner guard's
+> abort signal would also fire the outer's `check()` via the composed
+> signal). The current implementation has `CostGuard.install` /
+> `pause` / `resume` / `uninstall` as no-ops; enforcement happens
+> entirely through the pre-call gate and post-call checks walking
+> `stack.guards` in `prompt.ts`. Wherever this doc says "AbortController",
+> "abort cascade", or "OUTER.resume() rebuilds controllers", treat
+> that as plan-only — it does not describe shipped behavior.
+
 **Goal:** Make `guard(cost: $X)` enforce its budget across all concurrent descendants in real time, not just on fork-join. Today each fork branch gets an isolated clone of the parent's `CostGuard`, so an outer `$2.00` budget can be silently exceeded mid-fork when two branches each reach `$1.25` — neither inner clone trips, and the trip only fires after the fork settles. After this change the parent's guard is a single shared in-memory object referenced by every descendant branch; any LLM call that pushes total spend over the limit trips the outer guard immediately, aborting all siblings via the existing `composeBranchAbortSignal` cascade.
 
 This also adds a **pre-call gate** to `prompt.ts`: before sending an LLM request, check every guard on the stack. If we're already over budget (because of siblings' spend or a prior call), refuse the new call instead of incurring its cost and tripping after the fact.

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-24-shared-cost-guards.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-24-shared-cost-guards.md
@@ -1,0 +1,235 @@
+# Shared Cost Guards (Real-Time Mid-Fork Enforcement)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make `guard(cost: $X)` enforce its budget across all concurrent descendants in real time, not just on fork-join. Today each fork branch gets an isolated clone of the parent's `CostGuard`, so an outer `$2.00` budget can be silently exceeded mid-fork when two branches each reach `$1.25` — neither inner clone trips, and the trip only fires after the fork settles. After this change the parent's guard is a single shared in-memory object referenced by every descendant branch; any LLM call that pushes total spend over the limit trips the outer guard immediately, aborting all siblings via the existing `composeBranchAbortSignal` cascade.
+
+This also adds a **pre-call gate** to `prompt.ts`: before sending an LLM request, check every guard on the stack. If we're already over budget (because of siblings' spend or a prior call), refuse the new call instead of incurring its cost and tripping after the fact.
+
+**Reference prior work:**
+- Cost guards: [`docs/superpowers/plans/2026-05-23-builtin-cost-guards.md`](2026-05-23-builtin-cost-guards.md)
+- Time guards (the `Guard` interface + abort controller pattern this plan extends): [`docs/superpowers/plans/2026-05-24-timeout-guards.md`](2026-05-24-timeout-guards.md)
+- Existing per-branch isolation behavior: [`Runner.seedBranchCost`](../../lib/runtime/runner.ts#L255-L294) and [`CostGuard.cloneForBranch`](../../lib/runtime/guard.ts#L122-L126)
+- Existing join-time rollup: [`Runner.propagateBranchCost`](../../lib/runtime/runner.ts#L304-L316) and the `propagateBranchCost` / `propagateLoserCost` / `propagateWinnerCost` hooks on [`runBatch`](../../lib/runtime/runBatch.ts)
+- The abort cascade we re-use: [`StateStack.abortSignal`](../../lib/runtime/state/stateStack.ts#L275), [`composeBranchAbortSignal`](../../lib/runtime/runBatch.ts#L183-L194)
+- Worked example + design rationale: discussion thread [T-019e5c23-2f65-735c-bebc-2a7b42a40774](https://ampcode.com/threads/T-019e5c23-2f65-735c-bebc-2a7b42a40774)
+
+---
+
+## Design
+
+### The shared-guard model
+
+`CostGuard` becomes a stateful in-memory object that holds its own running `spent` counter (instead of deriving from a single stack's `localCost`). Every LLM-cost site walks `stack.guards` and calls `guard.charge(cost)` on each one; charges accumulate on the guard itself.
+
+`CostGuard.cloneForBranch` returns `this` (a shared reference) instead of a fresh clone. So when a fork begins, every branch's `stack.guards` includes the *same* live `CostGuard` JS object that the parent holds. Any branch charging the shared guard mutates the counter the parent and all siblings see — single-threaded JS makes this race-free.
+
+When the shared counter crosses the limit, `check()` returns a `GuardExceededError` AND the guard's `AbortController` fires (same pattern `TimeGuard` already uses). The signal was composed into the parent's `stack.abortSignal` at install, and each branch's `stack.abortSignal` is composed off the parent's via [`composeBranchAbortSignal`](../../lib/runtime/runBatch.ts#L183-L194). So every running branch wakes, halts at its next step, and surfaces the typed throw via its own `check()` call.
+
+Inner guards pushed *after* a fork opens (e.g. `guard(cost: ...) { inside_branch }`) stay branch-local — they're pushed onto the child's stack, never visible to the parent. So you can mix "outer hard cap shared across siblings" with "inner per-branch sub-budget" naturally.
+
+### Pause/resume — the `inheritedGuardCount` invariant
+
+Each `StateStack` gains a single integer field: `inheritedGuardCount`. Set to `0` on the root stack. When a child branch is seeded, set `child.inheritedGuardCount = parent.guards.length` BEFORE prepending the parent's live guard references into the child's `guards`. Anything at index `≥ inheritedGuardCount` is owned by the child.
+
+```diagram
+Parent stack at fork time:
+  guards = [OUTER]                  parent.inheritedGuardCount = 0
+
+Each child stack immediately after seeding:
+  guards = [OUTER ref]              child.inheritedGuardCount = 1
+
+After child pushes its inner $1.50 guard:
+  guards = [OUTER ref, inner_b1]    child.inheritedGuardCount = 1
+                                    (inner_b1 is child-owned; index ≥ 1)
+```
+
+Serialization:
+- `stack.toJSON()` serializes `guards.slice(stack.inheritedGuardCount)` only — own guards.
+- The shared `OUTER` is serialized exactly once, on the parent's snapshot.
+- `inheritedGuardCount` is serialized so resume knows how many to re-prepend.
+
+Resume:
+- `parentStack` is restored from the batch checkpoint → `OUTER` rehydrates with its `spent` counter intact.
+- When `runBatch` rehydrates a child on resume:
+  ```ts
+  const childStack = StateStack.fromJSON(branchJson.stack);
+  // childStack.guards currently only has branch-owned guards.
+  const inherited = parentStack.guards.slice(0, childStack.inheritedGuardCount);
+  childStack.guards = [...inherited, ...childStack.guards];
+  ```
+- Now child's `guards[0]` is the SAME JS object as `parent.guards[0]`. Real-time sharing fully restored.
+
+`AbortController`s are not serialized; `OUTER.resume(stack)` rebuilds them at the parent's first step after restore, exactly like `TimeGuard` does today.
+
+### Pre-call gate
+
+In [`prompt.ts`](../../lib/runtime/prompt.ts), wrap the LLM dispatch with:
+
+```ts
+// Pre-call: refuse if any active guard is already over budget.
+for (const g of stack.guards) {
+  const trip = g.check(stack);
+  if (trip) throw trip;
+}
+
+// ...send request, await response, compute cost...
+
+stack.localCost += cost;
+for (const g of stack.guards) g.charge(cost);
+for (const g of stack.guards) {
+  const trip = g.check(stack);
+  if (trip) throw trip;
+}
+```
+
+Pre-call reads the live shared `OUTER.spent`, so if siblings have already pushed total past the limit, this call refuses to start. Post-call accounting unchanged.
+
+---
+
+## Out of scope
+
+- **Token-cost pre-call estimation.** A cheap "are we already over?" gate is all this plan adds. Estimating output-token cost upfront is a separate, larger change.
+- **Time guards.** `TimeGuard` already has the shared model (parent's timer is single source of truth; abort cascade enforces). No changes to time enforcement.
+- **General event/observer framework on the runtime.** Discussed in the design thread and explicitly rejected for now — cost is a ledger, not an event stream.
+- **`stack.localCost` / `propagateBranchCost` removal.** Both stay. `localCost` is used by `getCost()` and observability; `propagateBranchCost` still ensures parent's `localCost` is correct after a branch settles, independent of the shared-guard mechanism.
+
+---
+
+## Tasks
+
+### Task 1: Refactor `CostGuard` to track its own `spent` counter
+
+- [ ] **Step 1.** Add to [`lib/runtime/guard.ts`](../../lib/runtime/guard.ts):
+  - `Guard.charge(amount: number): void` — required on the interface. `TimeGuard.charge` is a no-op.
+  - `CostGuard` gains `private spent: number = 0`. `charge` mutates `spent`. `check` becomes `if (this.spent > this.costLimit) return new GuardExceededError("cost", this.costLimit, this.spent)`.
+  - `CostGuard.install` no longer needs `costAtPush`; remove the field. (Its purpose was to compute `branch.localCost - costAtPush` deltas — replaced by the explicit `spent` counter.)
+  - `CostGuard.toJSON` adds `spent`. `CostGuard.fromJSON` restores it.
+  - `CostGuard` gains an `AbortController` field + `install`/`uninstall`/`resume` plumbing copied from `TimeGuard.installAbortPlumbing`. When `check` is about to return a trip, also call `this.controller?.abort()` so the cascade fires.
+- [ ] **Step 2.** Update `Guard.check` invocation sites:
+  - [`prompt.ts`](../../lib/runtime/prompt.ts): change the post-LLM cost block to call `g.charge(cost)` on every guard before calling `g.check(stack)`.
+  - [`StateStack.checkGuards`](../../lib/runtime/state/stateStack.ts) (or wherever the centralized helper landed in the timeout-guards branch): unchanged — it still walks `guards` and calls `check`.
+- [ ] **Step 3.** Unit tests for `CostGuard`:
+  - `charge` mutates `spent`.
+  - `check` returns null below limit, returns `GuardExceededError` above.
+  - `check` is idempotent — after a trip, subsequent `check` calls still return the trip (so the parent's runner observes it on its next step). Or follow `TimeGuard`'s "consumed once" pattern if cleaner.
+  - `toJSON`/`fromJSON` round-trip preserves `spent`.
+
+**Files:** [`lib/runtime/guard.ts`](../../lib/runtime/guard.ts), [`lib/runtime/prompt.ts`](../../lib/runtime/prompt.ts), [`lib/runtime/state/stateStack.ts`](../../lib/runtime/state/stateStack.ts), `lib/runtime/guard.test.ts` (new tests).
+
+### Task 2: Shared-reference `cloneForBranch` + `inheritedGuardCount`
+
+- [ ] **Step 1.** Add `inheritedGuardCount: number = 0` to [`StateStack`](../../lib/runtime/state/stateStack.ts).
+- [ ] **Step 2.** `StateStack.toJSON` change:
+  ```ts
+  guards: this.guards
+    .slice(this.inheritedGuardCount)
+    .map((g) => g.toJSON()),
+  inheritedGuardCount: this.inheritedGuardCount,
+  ```
+- [ ] **Step 3.** `StateStack.fromJSON` change: restore `inheritedGuardCount`. Deserialized `guards` is initially just the own guards (whatever was serialized) — re-prepending happens in `runBatch`, not in `fromJSON` (because `fromJSON` doesn't know about the parent).
+- [ ] **Step 4.** Change `CostGuard.cloneForBranch` to `return this;` (shared reference). Remove the rebased-baseline code.
+- [ ] **Step 5.** Change [`Runner.seedBranchCost`](../../lib/runtime/runner.ts#L255-L294):
+  ```ts
+  // Set inheritedGuardCount BEFORE pushing refs.
+  branchStack.inheritedGuardCount = parentStack.guards.length;
+  // Existing map+filter; CostGuards now return `this`, TimeGuards return undefined.
+  branchStack.guards = parentStack.guards
+    .map((g) => g.cloneForBranch(parentStack, branchStack))
+    .filter((g): g is NonNullable<typeof g> => g !== undefined);
+  ```
+  Note: the existing `localCost`/`seedCost` seeding stays. They're orthogonal — they keep `getCost()` and `propagateBranchCost` correct for the per-stack accounting; guards now use their own counter.
+
+**Files:** [`lib/runtime/state/stateStack.ts`](../../lib/runtime/state/stateStack.ts), [`lib/runtime/guard.ts`](../../lib/runtime/guard.ts), [`lib/runtime/runner.ts`](../../lib/runtime/runner.ts).
+
+### Task 3: Resume-time re-link in `runBatch`
+
+- [ ] **Step 1.** Add a helper in [`lib/runtime/runBatch.ts`](../../lib/runtime/runBatch.ts):
+  ```ts
+  /** Re-link inherited (parent-owned) guard references onto a child
+   * stack that was just rehydrated from JSON. Must run AFTER
+   * StateStack.fromJSON and BEFORE the child's invoke is called. */
+  function rehydrateInheritedGuards(
+    childStack: StateStack,
+    parentStack: StateStack,
+  ): void {
+    const inherited = parentStack.guards.slice(
+      0,
+      childStack.inheritedGuardCount,
+    );
+    childStack.guards = [...inherited, ...childStack.guards];
+  }
+  ```
+- [ ] **Step 2.** Call it on every resume path in `runBatch`:
+  - Top of `runBatch` before iterating tasks: for each existing branch that has interrupt state (was rehydrated from the prior checkpoint), call `rehydrateInheritedGuards(branch.stack, parentStack)`. Should happen before `composeBranchAbortSignal` so the composed signal sees the freshly-installed parent guards' controllers (after `OUTER.resume()` rebuilt them at parent's first step).
+  - `runRaceResume`: same call before `child.invoke(branch.stack, signal)`.
+- [ ] **Step 3.** Idempotency guard: re-running `rehydrateInheritedGuards` on a stack that already has inherited refs would double-prepend. Either:
+  - Track a `rehydrated: boolean` flag on `BranchState`, or
+  - Check `childStack.guards.length < childStack.inheritedGuardCount + ownGuardCount` — if it's already full, skip.
+
+  Prefer the flag; it's local to the live `BranchState` (already not serialized) and survives multiple `runBatch` re-entries in the same execution.
+
+**Files:** [`lib/runtime/runBatch.ts`](../../lib/runtime/runBatch.ts), [`lib/runtime/state/stateStack.ts`](../../lib/runtime/state/stateStack.ts) (the `rehydrated` flag).
+
+### Task 4: Pre-call gate in `prompt.ts`
+
+- [ ] **Step 1.** In [`prompt.ts`](../../lib/runtime/prompt.ts), find the LLM dispatch (the `client.complete(...)` / `client.respond(...)` site). Immediately before it, add:
+  ```ts
+  for (const g of stack.guards) {
+    const trip = g.check(stack);
+    if (trip) throw trip;
+  }
+  ```
+- [ ] **Step 2.** Verify the throw is caught by the existing function-body auto-wrap (the same path that catches the post-call trip today). It should be — `GuardExceededError` is on the allow-list.
+- [ ] **Step 3.** Add a unit test in `tests/agency/guards/`: spend $X via a sibling branch so the shared guard is already tripped, then attempt another LLM call. The pre-call gate must trip without the new call being issued. Assert via call count on the mock provider.
+
+**Files:** [`lib/runtime/prompt.ts`](../../lib/runtime/prompt.ts), `tests/agency/guards/guard-cost-pre-call-gate.agency` (new).
+
+### Task 5: End-to-end regression tests
+
+- [ ] **`tests/agency/guards/guard-cost-shared-outer-trips-mid-fork.agency`** — The motivating example from the design discussion: outer `$0.000008` budget, fork of 3 branches each spending `$0.000003` (over budget in total, under per-branch). Outer must trip mid-fork before all branches finish; assert via the trip's `actualCost` being close to the limit (not 3 × per-branch).
+- [ ] **`tests/agency/guards/guard-cost-shared-survives-interrupt.agency`** — Same setup, but the first branch interrupts before reaching the trip threshold. Harness approves; resume completes the rest. After resume, the outer trip must still fire when total spend crosses the budget. Regression for the `inheritedGuardCount` re-link path.
+- [ ] **`tests/agency/guards/guard-cost-shared-inner-still-isolated.agency`** — Outer `$0.001`, each branch pushes its own inner `$0.000003` guard. One branch spends `$0.000004` (inner trips, branch fails). Other branches' inner guards untouched. Outer never trips (total under outer limit). Asserts the "inner pushed after fork stays branch-local" invariant.
+- [ ] **`tests/agency/guards/guard-cost-pre-call-gate.agency`** — Pre-existing spend exceeds budget; next LLM call must trip without being sent. Mock provider call count = N-1, not N.
+- [ ] **`tests/agency/guards/guard-cost-shared-nested-fork.agency`** — Outer guard at depth 0, inner fork at depth 2. Verifies inheritance walks: depth-2 branches see depth-0 outer guard via the depth-1 branch's `guards` array (which itself contains the depth-0 ref via inheritance). Trip from the deepest leaf must abort everything.
+
+### Task 6: Audit existing tests for behavior changes
+
+- [ ] Re-run the full `tests/agency/guards/` suite. Some existing tests assume the join-time-only behavior — review each failing test and decide whether it should:
+  - Update to assert the new earlier-trip behavior (preferred), or
+  - Migrate to test a per-branch inner guard (which still isolates), if the test was specifically exercising isolation.
+- [ ] Specifically review:
+  - [`guard-cost-fork.agency`](../../tests/agency/guards/guard-cost-fork.agency) — currently documents the "V1 limitation that mid-fork branches do NOT eagerly notify the outer guard." This plan removes that limitation; update the description and assertions.
+  - [`guard-cost-race.agency`](../../tests/agency/guards/guard-cost-race.agency) and [`guard-cost-race-interrupts.agency`](../../tests/agency/guards/guard-cost-race-interrupts.agency) — race-mode propagation tests; the shared-guard mechanism may trip earlier in some scenarios.
+  - [`guard-cost-fork-rejected-rolls-up.agency`](../../tests/agency/guards/guard-cost-fork-rejected-rolls-up.agency) — uses `getCost()` to verify deltas; should still pass since `localCost` + `propagateBranchCost` are unchanged.
+
+### Task 7: Docs
+
+- [ ] Update [`docs/site/guide/cost-guards.md`](../../docs/site/guide/cost-guards.md):
+  - Replace the V1 limitation section with the new behavior: outer guards see real-time cost from all descendants.
+  - Document the inner-guard-stays-local rule.
+  - Add an example with a fork inside a guard showing mid-fork trip.
+- [ ] Update [`docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md`](../../docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md):
+  - New section: "Shared guard references." Explain `cloneForBranch` returning `this`, `inheritedGuardCount`, and the pause/resume re-link.
+
+---
+
+## Success criteria
+
+- [ ] All existing `tests/agency/guards/*` tests pass after the migration (with assertions updated where behavior intentionally changed; see Task 6).
+- [ ] Task 5 new E2E tests pass.
+- [ ] `pnpm test:run` (full unit suite) passes.
+- [ ] Manual smoke: run the motivating example (`guard($2.00) { fork(3 branches) { llm(...) } }`) with synthetic cost and verify trip fires mid-fork, before any branch reaches `propagateBranchCost`.
+
+---
+
+## Risks and how the design mitigates them
+
+| Risk | Mitigation |
+|---|---|
+| Shared guard mutation race | Single-threaded JS event loop — `charge` is a simple `spent += amount`. No locks needed. |
+| Double-charging on resume | Branch's `guards` array is filtered through `inheritedGuardCount` on serialize, so the parent-owned `OUTER` is serialized exactly once (on the parent's snapshot). On resume, re-prepended by reference, not deserialized as a separate copy. |
+| Stale `AbortController` after resume | `CostGuard.resume(stack)` rebuilds the controller and re-composes into `stack.abortSignal`, identical to `TimeGuard`'s existing pattern. |
+| Branch-pushed inner guards leaking to parent | They're pushed onto the branch's own stack AFTER seeding, so they sit at index `≥ inheritedGuardCount`. Serialization keeps them on the branch only. Never visible to the parent. |
+| Double re-link if `runBatch` is re-entered multiple times in one execution | `BranchState.rehydrated` flag (live-only, not serialized) tracks whether we've already prepended. Reset on every new serialize boundary. |
+| Pre-call gate refusing a call that would have succeeded | The pre-call check uses the same `g.check()` as post-call. If `g.check()` returns null, the call proceeds. There's no estimation — just "are we already over?" — so no false positives. |

--- a/packages/agency-lang/lib/runtime/guard.test.ts
+++ b/packages/agency-lang/lib/runtime/guard.test.ts
@@ -102,6 +102,16 @@ describe("CostGuard", () => {
     restored.charge(2);
     expect(restored.check(new StateStack())!.spent).toBeCloseTo(3.5, 5);
   });
+
+  it("fromJSON throws on the legacy {costAtPush} shape", () => {
+    // Clean breaking change: pre-shared-cost-guards checkpoints used
+    // {costLimit, costAtPush} (no `spent`). Restoring them silently
+    // would set spent=undefined → check() compares undefined > limit
+    // → false → guard never trips. Fail loudly instead.
+    expect(() =>
+      CostGuard.fromJSON({ costLimit: 2.0, costAtPush: 0.5 } as any),
+    ).toThrow(/spent/);
+  });
 });
 
 describe("TimeGuard", () => {

--- a/packages/agency-lang/lib/runtime/guard.test.ts
+++ b/packages/agency-lang/lib/runtime/guard.test.ts
@@ -49,15 +49,14 @@ describe("isGuardExceededError", () => {
 });
 
 describe("CostGuard", () => {
-  it("captures costAtPush at install time", () => {
+  it("tracks its own spent counter via charge()", () => {
     const stack = new StateStack();
-    stack.localCost = 0.5;
     const g = new CostGuard(2.0);
     g.install(stack);
     expect(g.check(stack)).toBeNull();
-    stack.localCost = 2.4;
-    expect(g.check(stack)).toBeNull(); // 1.9 spent, within limit
-    stack.localCost = 2.6;
+    g.charge(1.9);
+    expect(g.check(stack)).toBeNull(); // 1.9 ≤ 2.0
+    g.charge(0.2);
     const err = g.check(stack)!;
     expect(err).toBeInstanceOf(GuardExceededError);
     expect(err.type).toBe("cost");
@@ -65,34 +64,43 @@ describe("CostGuard", () => {
     expect(err.spent).toBeCloseTo(2.1, 5);
   });
 
-  it("cloneForBranch rebases costAtPush onto the child's localCost", () => {
+  it("check is independent of stack.localCost", () => {
+    // Cost guard no longer derives spent from stack.localCost — the
+    // counter is its own field. This is what lets the same guard
+    // instance be shared across parent + child branches.
+    const stack = new StateStack();
+    stack.localCost = 999;
+    const g = new CostGuard(1.0);
+    g.install(stack);
+    expect(g.check(stack)).toBeNull(); // localCost ignored
+    g.charge(2);
+    expect(g.check(stack)!.spent).toBeCloseTo(2, 5);
+  });
+
+  it("cloneForBranch returns the same instance (shared reference)", () => {
     const parent = new StateStack();
-    parent.localCost = 10;
     const g = new CostGuard(5);
     g.install(parent);
     const child = new StateStack();
-    child.localCost = 10;
-    const cloned = g.cloneForBranch(parent, child) as CostGuard;
-    expect(cloned).toBeInstanceOf(CostGuard);
-    // Child has accumulated 4 more cost — within limit.
-    child.localCost = 14;
-    expect(cloned.check(child)).toBeNull();
-    // Child accumulates 6 more — trips the clone.
-    child.localCost = 16;
-    expect(cloned.check(child)!.spent).toBeCloseTo(6, 5);
+    const cloned = g.cloneForBranch(parent, child);
+    expect(cloned).toBe(g); // same JS object — not a clone
+    // Charging through either reference mutates the same counter.
+    cloned!.charge(3);
+    expect(g.check(parent)).toBeNull();
+    g.charge(3);
+    expect(cloned!.check(child)!.spent).toBeCloseTo(6, 5); // 3 + 3
   });
 
-  it("round-trips through JSON", () => {
-    const stack = new StateStack();
-    stack.localCost = 1.5;
+  it("round-trips through JSON via spent counter", () => {
     const g = new CostGuard(3.0);
-    g.install(stack);
+    g.install(new StateStack());
+    g.charge(1.5);
     const json = g.toJSON();
-    expect(json).toEqual({ kind: "cost", costLimit: 3.0, costAtPush: 1.5 });
+    expect(json).toEqual({ kind: "cost", costLimit: 3.0, spent: 1.5 });
     const restored = guardFromJSON(json) as CostGuard;
     expect(restored).toBeInstanceOf(CostGuard);
-    stack.localCost = 5;
-    expect(restored.check(stack)!.spent).toBeCloseTo(3.5, 5);
+    restored.charge(2);
+    expect(restored.check(new StateStack())!.spent).toBeCloseTo(3.5, 5);
   });
 });
 
@@ -270,11 +278,10 @@ describe("guardFromJSON", () => {
 describe("CostGuard.isTripped", () => {
   it("always returns false — cost guards don't mutate abortSignal", () => {
     const stack = new StateStack();
-    stack.localCost = 0;
     const g = new CostGuard(1);
     g.install(stack);
     expect(g.isTripped()).toBe(false);
-    stack.localCost = 100; // way over limit
+    g.charge(100); // way over limit
     expect(g.check(stack)).toBeInstanceOf(GuardExceededError);
     // Even with a tripped check, the CostGuard doesn't claim the abort
     // signal — it has none.
@@ -285,15 +292,14 @@ describe("CostGuard.isTripped", () => {
 describe("StateStack guard lifecycle", () => {
   it("pushGuard installs and popGuard uninstalls", () => {
     const stack = new StateStack();
-    stack.localCost = 5;
     const g = new CostGuard(5);
     stack.pushGuard(g);
     expect(stack.guards).toContain(g);
-    // install captured costAtPush=5. spend=10-5=5 is at the limit; check
-    // is strictly > so still null. At 5.01 it trips.
-    stack.localCost = 10;
+    // spend=5 is at the limit; check is strictly > so still null. At
+    // 5.01 it trips.
+    g.charge(5);
     expect(g.check(stack)).toBeNull();
-    stack.localCost = 10.01;
+    g.charge(0.01);
     expect(g.check(stack)!.spent).toBeCloseTo(5.01, 5);
     stack.popGuard();
     expect(stack.guards).not.toContain(g);

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -41,6 +41,12 @@ export type Guard = {
   uninstall(stack: StateStack): void;
   pause(): void;
   resume(stack: StateStack): void;
+  /** Record a per-event delta against this guard. Called from
+   *  prompt.ts immediately after each LLM call's cost is known. Most
+   *  guards (e.g. TimeGuard) ignore charges and derive their state
+   *  from other sources; CostGuard mutates its own `spent` counter
+   *  here. */
+  charge(amount: number): void;
   check(stack: StateStack): GuardExceededError | null;
   /** True iff this guard's limit has been exceeded — even if `check`
    *  has already returned the trip once. Lets `Runner.shouldSkip`
@@ -50,6 +56,12 @@ export type Guard = {
    *  loser. Without this distinction, popping a tripped guard would
    *  re-throw on every sync point. */
   isTripped(): boolean;
+  /** Return a guard reference for the given child branch.
+   *  CostGuard returns `this` (shared in-memory object — child charges
+   *  the same counter the parent sees, enabling real-time mid-fork
+   *  enforcement). TimeGuard returns `undefined` (abort cascades via
+   *  stack.abortSignal — no per-branch guard needed). Future guards
+   *  may return a fresh clone if they want per-branch isolation. */
   cloneForBranch(
     parentStack: StateStack,
     childStack: StateStack,
@@ -59,31 +71,60 @@ export type Guard = {
 
 /** Discriminated-union JSON shape. `guardFromJSON` dispatches on `kind`. */
 export type GuardJSON =
-  | { kind: "cost"; costLimit: number; costAtPush: number }
+  | { kind: "cost"; costLimit: number; spent: number }
   | { kind: "time"; timeLimit: number; elapsedMs: number };
 
 /**
- * Cost guard. Trips when `(stack.localCost - costAtPush) > costLimit`.
+ * Cost guard. Trips when its own `spent` counter exceeds `costLimit`.
  *
- * `install` captures the baseline cost so the trip math is independent
- * of any siblings' spend that was already on the stack before the guard
- * opened. `pause` / `resume` are no-ops — cost is checked at sync
- * points (every LLM call), so there's no in-process timer to freeze.
+ * Unlike the previous design (which derived spent from
+ * `stack.localCost - costAtPush`), the guard now owns its accumulator
+ * directly. Every LLM-cost site walks `stack.guards` and calls
+ * `guard.charge(cost)` on each one — including any shared parent guards
+ * that were inherited by a child branch (see `cloneForBranch` below).
  *
- * `cloneForBranch` creates a fresh guard with `costAtPush` rebased onto
- * the child's `localCost` (which `Runner.seedBranchCost` has already
- * seeded with the parent's `localCost`). The branch then independently
- * tracks cost-since-push and trips its own guard from inside its
- * `Runner.shouldSkip`. The trip math matches what the parent would see
- * for the same delta.
+ * `cloneForBranch` returns `this` — the same in-memory JS object. The
+ * child branch's `stack.guards` then holds a *reference* to the parent's
+ * CostGuard. Any charge from inside a child branch updates the same
+ * counter the parent and all sibling branches see. Single-threaded JS
+ * makes the increment race-free. This is what makes real-time mid-fork
+ * trip detection work: when a charge pushes total spend over the limit,
+ * the next `check()` from any descendant returns the trip — no waiting
+ * for the fork to settle.
+ *
+ * CostGuard does NOT install an `AbortController` (unlike `TimeGuard`).
+ * A sibling branch that's mid-LLM-call won't be cancelled the instant
+ * another branch trips the shared guard — its smoltalk request will
+ * run to completion, then its post-call check will see the over-limit
+ * counter and throw. Mid-flight cancellation could be added by mirroring
+ * `TimeGuard`'s abort plumbing, but that breaks the same-stack nested-
+ * guard semantic ("inner trip should not retroactively trip the outer
+ * via a stale abort signal" — see guard-nested-iteration-order.agency).
+ * The pre-call gate in `prompt.ts` already catches "we're already
+ * over budget" before issuing the next request, which is the more
+ * important optimization.
+ *
+ * `check` is intentionally NOT idempotent across calls: every check
+ * returns the trip if `spent > costLimit`. The trip propagates exactly
+ * once per stack because the user's `try block()` catches it and then
+ * the guard is popped (removed from `stack.guards`), so subsequent
+ * stack-walks don't include it. A sibling stack still holding a
+ * reference to the same shared guard WILL see the trip on its next
+ * check — which is exactly what we want.
+ *
+ * `pause` / `resume` / `uninstall` are no-ops because there's no
+ * in-process timer or signal plumbing to manage. The counter is
+ * durable through serialization via `spent` in `toJSON`.
  */
 export class CostGuard implements Guard {
-  private costAtPush: number = 0;
+  /** Cumulative cost charged since install. Serialized; survives
+   *  interrupt/resume cycles. */
+  private spent: number = 0;
 
   constructor(public readonly costLimit: number) {}
 
-  install(stack: StateStack): void {
-    this.costAtPush = stack.localCost;
+  install(_stack: StateStack): void {
+    /* nothing — no abort controller, no signal composition */
   }
 
   uninstall(_stack: StateStack): void {
@@ -98,37 +139,41 @@ export class CostGuard implements Guard {
     /* nothing */
   }
 
-  check(stack: StateStack): GuardExceededError | null {
-    const spent = stack.localCost - this.costAtPush;
-    if (spent > this.costLimit) {
-      return new GuardExceededError("cost", this.costLimit, spent);
-    }
-    return null;
+  charge(amount: number): void {
+    this.spent += amount;
   }
 
-  /** CostGuards never mutate `stack.abortSignal`, so they can't be
-   *  the cause of a stuck abort. Always returns false. */
+  check(_stack: StateStack): GuardExceededError | null {
+    if (this.spent <= this.costLimit) return null;
+    return new GuardExceededError("cost", this.costLimit, this.spent);
+  }
+
+  /** CostGuards don't compose into `stack.abortSignal`, so they can't
+   *  be the cause of a stuck abort. Always returns false — the
+   *  isTripped check in `Runner.shouldSkip` is for guards (like
+   *  TimeGuard) that own their abort controller. */
   isTripped(): boolean {
     return false;
   }
 
-  cloneForBranch(_parentStack: StateStack, childStack: StateStack): Guard {
-    const g = new CostGuard(this.costLimit);
-    g.costAtPush = childStack.localCost;
-    return g;
+  /** Shared reference, not a clone. The child branch's guards array
+   *  holds this same object; any charge from the child mutates the
+   *  counter the parent and siblings see in real time. */
+  cloneForBranch(_parentStack: StateStack, _childStack: StateStack): Guard {
+    return this;
   }
 
   toJSON(): GuardJSON {
     return {
       kind: "cost",
       costLimit: this.costLimit,
-      costAtPush: this.costAtPush,
+      spent: this.spent,
     };
   }
 
-  static fromJSON(j: { costLimit: number; costAtPush: number }): CostGuard {
+  static fromJSON(j: { costLimit: number; spent: number }): CostGuard {
     const g = new CostGuard(j.costLimit);
-    g.costAtPush = j.costAtPush;
+    g.spent = j.spent;
     return g;
   }
 }
@@ -228,6 +273,10 @@ export class TimeGuard implements Guard {
     // plumbing. (toJSON only serializes elapsedMs + timeLimit.)
     if (!this.controller) this.installAbortPlumbing(stack);
     this.startWindow();
+  }
+
+  charge(_amount: number): void {
+    /* nothing — TimeGuard accumulates wall-clock time, not LLM cost */
   }
 
   check(_stack: StateStack): GuardExceededError | null {

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -24,8 +24,11 @@ import type { StateStack } from "./state/stateStack.js";
  *
  * `cloneForBranch` lets each variant decide whether a fork/race
  * branch needs an independent copy:
- *   - `CostGuard` returns a fresh clone (branch independently
- *     accumulates cost; trip must throw from inside the branch).
+ *   - `CostGuard` returns `this` (a shared in-memory reference). The
+ *     parent's guard appears on every descendant branch's `guards`
+ *     array via `StateStack.rehydrateInheritedGuardsFrom`, so a
+ *     `charge()` from any branch mutates the same counter the parent
+ *     and siblings see — real-time mid-fork enforcement.
  *   - `TimeGuard` returns `undefined` — the parent's timer is the
  *     single source of truth; abort cascade via the composed
  *     `stack.abortSignal` propagates the trip to every branch's

--- a/packages/agency-lang/lib/runtime/guard.ts
+++ b/packages/agency-lang/lib/runtime/guard.ts
@@ -172,6 +172,19 @@ export class CostGuard implements Guard {
   }
 
   static fromJSON(j: { costLimit: number; spent: number }): CostGuard {
+    // Clean break with the prior `{costAtPush}` JSON shape: refuse to
+    // restore a guard whose `spent` is missing rather than silently
+    // initializing it to NaN/undefined and producing nonsense trips.
+    // Older checkpoints from the per-branch-clone era are not
+    // supported by this binary — re-run from scratch.
+    if (typeof j.spent !== "number") {
+      throw new Error(
+        `CostGuard.fromJSON: missing or invalid 'spent' field ` +
+          `(got ${JSON.stringify(j.spent)}). This checkpoint may have ` +
+          `been written by a pre-shared-cost-guards version of the ` +
+          `runtime; that format is no longer supported.`,
+      );
+    }
     const g = new CostGuard(j.costLimit);
     g.spent = j.spent;
     return g;

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -1,5 +1,5 @@
 import * as smoltalk from "smoltalk";
-import { PromptResult, Result, StreamChunk, ToolCallJSON } from "smoltalk";
+import { PromptResult, ToolCallJSON } from "smoltalk";
 import { createLogger } from "../logger.js";
 import { AgencyFunction } from "./agencyFunction.js";
 import { AgencyCancelledError, isAbortError } from "./errors.js";
@@ -34,6 +34,53 @@ export type RunPromptResult = {
   toolCalls: smoltalk.ToolCallJSON[];
 };
 
+/** Dispatch the LLM request and extract `{completion, toolCalls}`,
+ *  branching on the `stream` flag. Streaming uses `handleStreamingResponse`
+ *  to accumulate chunks; non-streaming awaits the single response Promise.
+ *  Throws on transport/protocol errors. */
+async function dispatchLLMRequest({
+  ctx,
+  promptConfig,
+  prompt,
+  stream,
+}: {
+  ctx: RuntimeContext<GraphState>;
+  promptConfig: PromptConfig;
+  prompt: string;
+  stream: boolean;
+}): Promise<{ completion: PromptResult; toolCalls: ToolCallJSON[] }> {
+  if (stream) {
+    const streamGen = ctx.llmClient.textStream(promptConfig);
+    const response = await handleStreamingResponse({
+      ctx,
+      completion: streamGen,
+      prompt,
+    });
+    if (!response) {
+      throw new Error(
+        `No completion returned from streaming LLM call! This shouldn't happen.`,
+      );
+    }
+    if (!response.success) {
+      throw new Error(
+        `Error getting completion from streaming response: ${response.error}`,
+      );
+    }
+    return {
+      completion: response.value.completion,
+      toolCalls: response.value.toolCalls,
+    };
+  }
+  const response = await ctx.llmClient.text(promptConfig);
+  if (!response.success) {
+    throw new Error(`Error getting completion: ${response.error}`);
+  }
+  return {
+    completion: response.value,
+    toolCalls: response.value.toolCalls || [],
+  };
+}
+
 async function _runPrompt({
   ctx,
   messages,
@@ -62,15 +109,11 @@ async function _runPrompt({
   // parent guards inherited by this branch) is already over budget —
   // e.g. because a sibling branch's earlier LLM call pushed the shared
   // CostGuard over its limit, or because a prior call here did — refuse
-  // to issue this call. This catches the "another expensive call would
-  // have been billed but we're already past the cap" case before the
-  // request hits the wire. Walked innermost-first so the deepest guard
-  // reports first, matching the post-call check below.
+  // to issue this call. Catches "another expensive call would have been
+  // billed but we're already past the cap" before the request hits the
+  // wire.
   const targetStack = stateStack ?? ctx.stateStack;
-  for (let i = targetStack.guards.length - 1; i >= 0; i--) {
-    const err = targetStack.guards[i].check(targetStack);
-    if (err) throw err;
-  }
+  targetStack.enforceGuards();
 
   // Note: the llmCall span is opened in the outer `runPrompt`, not here,
   // so that any tool executions triggered by this LLM response nest under
@@ -104,42 +147,12 @@ async function _runPrompt({
     metadata: clientConfig,
   } as any;
 
-  let _completion: AsyncGenerator<StreamChunk> | Promise<Result<PromptResult>>;
-  if (stream) {
-    _completion = ctx.llmClient.textStream(promptConfig);
-  } else {
-    _completion = ctx.llmClient.text(promptConfig);
-  }
-
-  let completion: PromptResult;
-  let toolCalls: ToolCallJSON[] = [];
-
-  if (stream) {
-    const response = await handleStreamingResponse({
-      ctx,
-      completion: _completion as AsyncGenerator<StreamChunk>,
-      prompt,
-    });
-    if (!response) {
-      throw new Error(
-        `No completion returned from streaming LLM call! This shouldn't happen.`,
-      );
-    }
-    if (!response.success) {
-      throw new Error(
-        `Error getting completion from streaming response: ${response.error}`,
-      );
-    }
-    completion = response.value.completion;
-    toolCalls = response.value.toolCalls;
-  } else {
-    const response = await (_completion as Promise<Result<PromptResult>>);
-    if (!response.success) {
-      throw new Error(`Error getting completion: ${response.error}`);
-    }
-    completion = response.value;
-    toolCalls = completion.toolCalls || [];
-  }
+  const { completion, toolCalls } = await dispatchLLMRequest({
+    ctx,
+    promptConfig,
+    prompt,
+    stream,
+  });
 
   // Capture endTime AFTER the response has been fully received. The
   // request Promise is created above but only awaited inside the
@@ -178,40 +191,18 @@ async function _runPrompt({
     cost: completion.cost,
   });
 
-  // Per-branch accumulator: in addition to the global __tokenStats above,
-  // add cost/tokens to the active stack so std::thread's getCost()/getTokens()
-  // can report per-branch totals. `targetStack` was resolved above (so the
-  // pre-call gate could read the same set of guards). See
-  // docs/superpowers/specs/2026-05-20-thread-builtins-and-stdlib-design.md
-  // for the model.
+  // Per-branch accumulator: adds to the active stack so std::thread's
+  // getCost()/getTokens() can report per-branch totals; complementary
+  // to the global __tokenStats above. Then bill every active guard
+  // for this call's cost and enforce limits. Shared parent guards see
+  // descendants' spend in real time; mid-fork trips fire on the next
+  // enforceGuards() call. See docs/superpowers/specs/2026-05-20-thread-
+  // builtins-and-stdlib-design.md.
   const callCost = completion.cost?.totalCost ?? 0;
   targetStack.localCost += callCost;
   targetStack.localTokens += completion.usage?.totalTokens ?? 0;
-
-  // Charge every active guard with this call's cost. Shared parent
-  // guards (CostGuard.cloneForBranch returns `this`) accumulate
-  // descendant spend in real time — this is what makes mid-fork trip
-  // detection work without waiting for the fork to settle.
-  for (const g of targetStack.guards) {
-    g.charge(callCost);
-  }
-
-  // Enforce active guards. Walked innermost-first so the deepest
-  // (most recently pushed) guard reports its trip first. Innermost-
-  // first is not the same as "smallest limit first" — a shallower
-  // outer guard with a tighter budget would still trip on a later LLM
-  // call if the inner guard doesn't fail first. This ordering is a
-  // stable, scope-local rule rather than a global-minimum search.
-  // The thrown GuardExceededError propagates up through _runPrompt /
-  // runPrompt / the user's code; the stdlib `guard` function's `try`
-  // catches it and returns a Failure. The function-body auto-wrap re-
-  // throws GuardExceededError so it cannot be silently converted to a
-  // generic failure value. See lib/runtime/guard.ts and
-  // docs/superpowers/specs/2026-05-20-cost-and-guard-tracking-design.md.
-  for (let i = targetStack.guards.length - 1; i >= 0; i--) {
-    const err = targetStack.guards[i].check(targetStack);
-    if (err) throw err;
-  }
+  targetStack.chargeGuards(callCost);
+  targetStack.enforceGuards();
 
   // Memory layer: auto-extraction and compaction run unconditionally
   // whenever a MemoryManager is attached (resolved decision #6).

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -58,6 +58,20 @@ async function _runPrompt({
     throw new AgencyCancelledError();
   }
 
+  // Pre-call cost-guard gate. If any active guard (including shared
+  // parent guards inherited by this branch) is already over budget —
+  // e.g. because a sibling branch's earlier LLM call pushed the shared
+  // CostGuard over its limit, or because a prior call here did — refuse
+  // to issue this call. This catches the "another expensive call would
+  // have been billed but we're already past the cap" case before the
+  // request hits the wire. Walked innermost-first so the deepest guard
+  // reports first, matching the post-call check below.
+  const targetStack = stateStack ?? ctx.stateStack;
+  for (let i = targetStack.guards.length - 1; i >= 0; i--) {
+    const err = targetStack.guards[i].check(targetStack);
+    if (err) throw err;
+  }
+
   // Note: the llmCall span is opened in the outer `runPrompt`, not here,
   // so that any tool executions triggered by this LLM response nest under
   // the same llmCall span (matching the design spec hierarchy
@@ -166,11 +180,21 @@ async function _runPrompt({
 
   // Per-branch accumulator: in addition to the global __tokenStats above,
   // add cost/tokens to the active stack so std::thread's getCost()/getTokens()
-  // can report per-branch totals. See docs/superpowers/specs/2026-05-20-
-  // thread-builtins-and-stdlib-design.md for the model.
-  const targetStack = stateStack ?? ctx.stateStack;
-  targetStack.localCost += completion.cost?.totalCost ?? 0;
+  // can report per-branch totals. `targetStack` was resolved above (so the
+  // pre-call gate could read the same set of guards). See
+  // docs/superpowers/specs/2026-05-20-thread-builtins-and-stdlib-design.md
+  // for the model.
+  const callCost = completion.cost?.totalCost ?? 0;
+  targetStack.localCost += callCost;
   targetStack.localTokens += completion.usage?.totalTokens ?? 0;
+
+  // Charge every active guard with this call's cost. Shared parent
+  // guards (CostGuard.cloneForBranch returns `this`) accumulate
+  // descendant spend in real time — this is what makes mid-fork trip
+  // detection work without waiting for the fork to settle.
+  for (const g of targetStack.guards) {
+    g.charge(callCost);
+  }
 
   // Enforce active guards. Walked innermost-first so the deepest
   // (most recently pushed) guard reports its trip first. Innermost-

--- a/packages/agency-lang/lib/runtime/runBatch.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.ts
@@ -195,38 +195,19 @@ function composeBranchAbortSignal(
   return composed;
 }
 
-/** Populate a child branch's `stack.guards` with the parent's inherited
- *  guards (via each guard's `cloneForBranch`), and stamp
- *  `inheritedGuardCount` so future serialization slices them off. This
- *  must run before any code reads `branch.stack.guards` or before the
- *  branch is `invoke`d.
- *
- *  Handles both fresh and resumed branches:
- *   - Fresh branch (first run): `branch.stack.guards` is empty;
- *     prepended refs become the entire array.
- *   - Resumed branch (post-deserialize): `branch.stack.guards` holds
- *     only the branch-owned guards (slice from `toJSON`); prepended
- *     refs go in front of them.
- *
- *  Idempotent via `branch.guardsRehydrated` (a live-only flag — reset
- *  to undefined automatically on deserialize, so a fresh execution
- *  always re-runs this once per branch).
- *
- *  `CostGuard.cloneForBranch` returns `this` (shared reference);
- *  `TimeGuard.cloneForBranch` returns `undefined` (parent's timer is
- *  single source of truth via abort cascade). Other future guards
- *  pick their own semantic. */
+/** Thin per-execution idempotency wrapper around
+ *  `StateStack.rehydrateInheritedGuardsFrom`. The inner method handles
+ *  the slice/prepend invariant and the resume validation; this wrapper
+ *  ensures we only do it once per BranchState per execution (the flag
+ *  is live-only — automatically reset on deserialize). Must run before
+ *  any code reads `branch.stack.guards` or before the branch is
+ *  `invoke`d. */
 function rehydrateInheritedGuards(
   branch: BranchState,
   parentStack: StateStack,
 ): void {
   if (branch.guardsRehydrated) return;
-  const child = branch.stack;
-  const inheritedRefs = parentStack.guards
-    .map((g) => g.cloneForBranch(parentStack, child))
-    .filter((g): g is NonNullable<typeof g> => g !== undefined);
-  child.guards = [...inheritedRefs, ...child.guards];
-  child.inheritedGuardCount = inheritedRefs.length;
+  branch.stack.rehydrateInheritedGuardsFrom(parentStack);
   branch.guardsRehydrated = true;
 }
 
@@ -244,12 +225,13 @@ function startInvoke<T>(
   if (t.cached) {
     return Promise.resolve(t.branch.result!.result);
   }
-  // Rehydrate inherited guards BEFORE composing the abort signal —
-  // CostGuard's shared abort controller (composed into parent's
-  // stack.abortSignal at install) becomes visible to the branch's
-  // composed signal via composeBranchAbortSignal. Order doesn't strictly
-  // matter for correctness (both run before invoke), but rehydrating
-  // first matches the order in which a fresh branch was originally set up.
+  // Rehydrate inherited guards BEFORE composing the abort signal.
+  // For TimeGuard, install runs on the parent only — children don't
+  // need separate installs because the parent's abort signal propagates
+  // through composeBranchAbortSignal. For CostGuard, the child's
+  // stack.guards just holds a shared reference to the parent's instance
+  // — no install plumbing involved. Order is informational only; both
+  // run before invoke.
   rehydrateInheritedGuards(t.branch, parentStack);
   const signal = composeBranchAbortSignal(t.branch, parentStack);
   hooks?.seedBranchCost?.(t.branch.stack, parentStack);

--- a/packages/agency-lang/lib/runtime/runBatch.ts
+++ b/packages/agency-lang/lib/runtime/runBatch.ts
@@ -195,6 +195,41 @@ function composeBranchAbortSignal(
   return composed;
 }
 
+/** Populate a child branch's `stack.guards` with the parent's inherited
+ *  guards (via each guard's `cloneForBranch`), and stamp
+ *  `inheritedGuardCount` so future serialization slices them off. This
+ *  must run before any code reads `branch.stack.guards` or before the
+ *  branch is `invoke`d.
+ *
+ *  Handles both fresh and resumed branches:
+ *   - Fresh branch (first run): `branch.stack.guards` is empty;
+ *     prepended refs become the entire array.
+ *   - Resumed branch (post-deserialize): `branch.stack.guards` holds
+ *     only the branch-owned guards (slice from `toJSON`); prepended
+ *     refs go in front of them.
+ *
+ *  Idempotent via `branch.guardsRehydrated` (a live-only flag — reset
+ *  to undefined automatically on deserialize, so a fresh execution
+ *  always re-runs this once per branch).
+ *
+ *  `CostGuard.cloneForBranch` returns `this` (shared reference);
+ *  `TimeGuard.cloneForBranch` returns `undefined` (parent's timer is
+ *  single source of truth via abort cascade). Other future guards
+ *  pick their own semantic. */
+function rehydrateInheritedGuards(
+  branch: BranchState,
+  parentStack: StateStack,
+): void {
+  if (branch.guardsRehydrated) return;
+  const child = branch.stack;
+  const inheritedRefs = parentStack.guards
+    .map((g) => g.cloneForBranch(parentStack, child))
+    .filter((g): g is NonNullable<typeof g> => g !== undefined);
+  child.guards = [...inheritedRefs, ...child.guards];
+  child.inheritedGuardCount = inheritedRefs.length;
+  branch.guardsRehydrated = true;
+}
+
 /** Wire up a branch's AbortController + composed signal, seed cost, and
  * fire `onBranchStart`. Returns the child's `invoke` promise (or a
  * resolved promise for cached branches). Centralized so all three modes
@@ -209,6 +244,13 @@ function startInvoke<T>(
   if (t.cached) {
     return Promise.resolve(t.branch.result!.result);
   }
+  // Rehydrate inherited guards BEFORE composing the abort signal —
+  // CostGuard's shared abort controller (composed into parent's
+  // stack.abortSignal at install) becomes visible to the branch's
+  // composed signal via composeBranchAbortSignal. Order doesn't strictly
+  // matter for correctness (both run before invoke), but rehydrating
+  // first matches the order in which a fresh branch was originally set up.
+  rehydrateInheritedGuards(t.branch, parentStack);
   const signal = composeBranchAbortSignal(t.branch, parentStack);
   hooks?.seedBranchCost?.(t.branch.stack, parentStack);
   hooks?.onBranchStart?.(t.child.key, i);
@@ -537,6 +579,13 @@ async function runRaceResume<T>(
   if (branch.result !== undefined) {
     return { kind: "values", values: [branch.result.result as T] };
   }
+
+  // Rehydrate inherited (parent-owned) guard references onto the
+  // resumed winner's stack before composing the abort signal — same
+  // discipline as startInvoke. Idempotent via branch.guardsRehydrated;
+  // safe to call here even if startInvoke already handled it (e.g.
+  // re-entry without serialize in between).
+  rehydrateInheritedGuards(branch, parentStack);
 
   // Compose the resumed winner's abort signal with the current parent
   // stack's signal so an outer abort (e.g. a surrounding race that

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -253,40 +253,17 @@ export class Runner {
     // once for the same branch (e.g. a branch interrupts mid-flight
     // and the parent resumes runBatch on the next response cycle).
     // We must not clobber state the branch has already accumulated.
-    // A branch is "fresh" iff it has no cost, no tokens, AND no guard
-    // entries — the last check matters when a branch pushes its own
-    // guard before any LLM call and then interrupts.
+    // A branch is "fresh" iff it has no cost AND no tokens. Guards are
+    // handled separately by `rehydrateInheritedGuards` in runBatch.ts —
+    // they have their own idempotency tracking via BranchState.
     const isFresh =
-      branchStack.localCost === 0 &&
-      branchStack.localTokens === 0 &&
-      branchStack.guards.length === 0;
+      branchStack.localCost === 0 && branchStack.localTokens === 0;
     if (!isFresh) return;
 
     branchStack.localCost = parentStack.localCost;
     branchStack.localTokens = parentStack.localTokens;
     branchStack.seedCost = parentStack.localCost;
     branchStack.seedTokens = parentStack.localTokens;
-
-    // Delegate to each guard's cloneForBranch: CostGuard returns a
-    // fresh clone with costAtPush rebased onto the child's localCost
-    // (just set above), so LLM calls inside the branch are checked
-    // against the same delta the parent would see. TimeGuard returns
-    // undefined — the parent's timer is the single source of truth
-    // and abort cascades through composeBranchAbortSignal. The filter
-    // drops the undefineds so branches see a sparser-than-parent
-    // guards list.
-    //
-    // Direct assignment (not stack.pushGuard) so install() isn't
-    // re-invoked on already-running clones.
-    //
-    // LIMITATION: cost deltas from a child branch only roll back into
-    // the parent at branch completion (propagateBranchCost), so an
-    // outer cost guard cannot trip mid-fork — only after the fork
-    // completes. Time guards do not have this limitation since the
-    // parent's timer trips directly on wall-clock.
-    branchStack.guards = parentStack.guards
-      .map((g) => g.cloneForBranch(parentStack, branchStack))
-      .filter((g): g is NonNullable<typeof g> => g !== undefined);
   }
 
   /** Propagate cost/token deltas from a set of branches back to the

--- a/packages/agency-lang/lib/runtime/state/stateStack.test.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.test.ts
@@ -518,14 +518,16 @@ describe("StateStack guards", () => {
 
   it("toJSON / fromJSON preserves guards", () => {
     const stack = new StateStack();
-    stack.localCost = 0.2;
-    stack.pushGuard(new CostGuard(1.5));
-    stack.localCost = 0.4;
-    stack.pushGuard(new CostGuard(0.5));
+    const g1 = new CostGuard(1.5);
+    stack.pushGuard(g1);
+    g1.charge(0.2);
+    const g2 = new CostGuard(0.5);
+    stack.pushGuard(g2);
+    g2.charge(0.4);
     const json = stack.toJSON();
     expect(json.guards).toEqual([
-      { kind: "cost", costLimit: 1.5, costAtPush: 0.2 },
-      { kind: "cost", costLimit: 0.5, costAtPush: 0.4 },
+      { kind: "cost", costLimit: 1.5, spent: 0.2 },
+      { kind: "cost", costLimit: 0.5, spent: 0.4 },
     ]);
     const restored = StateStack.fromJSON(json);
     expect(restored.guards).toHaveLength(2);
@@ -546,16 +548,16 @@ describe("StateStack guards", () => {
     expect(restored.guards).toEqual([]);
   });
 
-  it("pushGuard calls install() (captures costAtPush)", () => {
+  it("pushGuard calls install() and toJSON serializes spent counter", () => {
     const stack = new StateStack();
-    stack.localCost = 1.23;
     const g = new CostGuard(5);
     stack.pushGuard(g);
+    g.charge(1.23);
     const json = stack.toJSON();
     expect(json.guards![0]).toEqual({
       kind: "cost",
       costLimit: 5,
-      costAtPush: 1.23,
+      spent: 1.23,
     });
   });
 });

--- a/packages/agency-lang/lib/runtime/state/stateStack.test.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { StateStack, State, BranchState } from "./stateStack.js";
 import { _callbackImpl } from "../../stdlib/agency.js";
-import { CostGuard } from "../guard.js";
+import { CostGuard, GuardExceededError } from "../guard.js";
 
 type FrameOpts = {
   args?: Record<string, any>;
@@ -559,5 +559,136 @@ describe("StateStack guards", () => {
       costLimit: 5,
       spent: 1.23,
     });
+  });
+});
+
+describe("StateStack.enforceGuards", () => {
+  it("is a no-op when no guards are present", () => {
+    const stack = new StateStack();
+    expect(() => stack.enforceGuards()).not.toThrow();
+  });
+
+  it("is a no-op when every guard is below its limit", () => {
+    const stack = new StateStack();
+    const g = new CostGuard(5);
+    stack.pushGuard(g);
+    g.charge(2);
+    expect(() => stack.enforceGuards()).not.toThrow();
+  });
+
+  it("throws the trip error from the innermost (last-pushed) guard first", () => {
+    // Innermost-first order is the contract — a deeper guard with a
+    // tighter budget should report its trip before a shallower outer.
+    const stack = new StateStack();
+    const outer = new CostGuard(10);
+    stack.pushGuard(outer);
+    const inner = new CostGuard(1);
+    stack.pushGuard(inner);
+    outer.charge(11); // outer is over too
+    inner.charge(2); // inner is over
+    try {
+      stack.enforceGuards();
+      throw new Error("expected enforceGuards to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GuardExceededError);
+      const e = err as GuardExceededError;
+      // Inner's limit is 1, not outer's 10 — proves innermost-first.
+      expect(e.limit).toBe(1);
+    }
+  });
+});
+
+describe("StateStack.chargeGuards", () => {
+  it("calls charge(amount) on every guard", () => {
+    const stack = new StateStack();
+    const g1 = new CostGuard(5);
+    const g2 = new CostGuard(5);
+    stack.pushGuard(g1);
+    stack.pushGuard(g2);
+    stack.chargeGuards(1.5);
+    // Charging makes both guards' spent = 1.5; verify via check() at
+    // the boundary.
+    g1.charge(3.6); // 1.5 + 3.6 = 5.1 > 5
+    expect(g1.check(stack)?.spent).toBeCloseTo(5.1, 5);
+    g2.charge(3.6);
+    expect(g2.check(stack)?.spent).toBeCloseTo(5.1, 5);
+  });
+
+  it("is a no-op when no guards are present", () => {
+    const stack = new StateStack();
+    expect(() => stack.chargeGuards(1)).not.toThrow();
+  });
+});
+
+describe("StateStack.rehydrateInheritedGuardsFrom", () => {
+  it("prepends parent guards via cloneForBranch on a fresh child", () => {
+    const parent = new StateStack();
+    const g = new CostGuard(5);
+    parent.pushGuard(g);
+    const child = new StateStack();
+
+    child.rehydrateInheritedGuardsFrom(parent);
+
+    expect(child.guards).toHaveLength(1);
+    expect(child.guards[0]).toBe(g); // shared reference
+    expect(child.inheritedGuardCount).toBe(1);
+  });
+
+  it("preserves branch-owned guards by prepending parent guards in front", () => {
+    const parent = new StateStack();
+    const outer = new CostGuard(10);
+    parent.pushGuard(outer);
+
+    const child = new StateStack();
+    const inner = new CostGuard(2);
+    // Simulate a resumed child where the inner was deserialized first.
+    child.guards = [inner];
+
+    child.rehydrateInheritedGuardsFrom(parent);
+
+    expect(child.guards).toHaveLength(2);
+    expect(child.guards[0]).toBe(outer); // inherited first
+    expect(child.guards[1]).toBe(inner); // own preserved
+    expect(child.inheritedGuardCount).toBe(1);
+  });
+
+  it("validates persisted inheritedGuardCount on resume; throws on mismatch", () => {
+    // On resume, the child's `inheritedGuardCount` was restored from
+    // JSON. If the parent's guards array has drifted (e.g. the parent
+    // pushed an extra guard between snapshot and resume), the recomputed
+    // inheritedRefs length won't match the persisted count and we throw
+    // — silently inheriting a different set of guards would be a
+    // correctness bug far from its source.
+    const parent = new StateStack();
+    const outer = new CostGuard(10);
+    parent.pushGuard(outer);
+    const newer = new CostGuard(20);
+    parent.pushGuard(newer);
+
+    const child = new StateStack();
+    child.inheritedGuardCount = 1; // snapshot said 1, parent now yields 2
+
+    expect(() => child.rehydrateInheritedGuardsFrom(parent)).toThrow(
+      /inheritedGuardCount/,
+    );
+  });
+
+  it("filters out guards whose cloneForBranch returns undefined", () => {
+    // TimeGuard returns undefined from cloneForBranch — the parent's
+    // timer is the single source of truth, no branch ref needed. The
+    // child's inheritedGuardCount must reflect the number actually
+    // prepended (zero, in the all-TimeGuards case).
+    const parent = new StateStack();
+    // Pretend-time-guard that returns undefined from cloneForBranch.
+    const ignored: any = {
+      cloneForBranch: () => undefined,
+    };
+    parent.guards = [ignored];
+    const child = new StateStack();
+
+    child.rehydrateInheritedGuardsFrom(parent);
+
+    expect(child.guards).toEqual([]);
+    expect(child.inheritedGuardCount).toBe(0);
   });
 });

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -24,6 +24,14 @@ export type BranchState = {
   // abort losing branches when the winner resolves). NOT serialized — only
   // meaningful within a single execution.
   abortController?: AbortController;
+
+  // Live-only flag: true iff this branch's stack has already had its
+  // inherited (parent-owned) guard references prepended in the current
+  // execution. Reset to undefined automatically on deserialize because
+  // it's never serialized. Used by `rehydrateInheritedGuards` in
+  // runBatch.ts to avoid double-prepending on multiple runBatch
+  // re-entries in the same run.
+  guardsRehydrated?: boolean;
 };
 
 export type BranchStateJSON = {
@@ -253,7 +261,13 @@ export type StateStackJSON = {
   localTokens?: number;
   seedCost?: number;
   seedTokens?: number;
+  /** Branch-owned guards only. Inherited (parent-owned) guards are
+   *  serialized on the parent's snapshot and re-prepended at resume by
+   *  `runBatch`. See StateStack.guards. */
   guards?: GuardJSON[];
+  /** Number of leading entries in `guards` that are inherited from the
+   *  parent stack. Always 0 for the root stack. */
+  inheritedGuardCount?: number;
 };
 
 export class StateStack {
@@ -299,7 +313,17 @@ export class StateStack {
   // Serialized so guards survive interrupt/resume cycles. Each guard
   // decides whether it gets cloned into fork/race branches via
   // `cloneForBranch` — see lib/runtime/guard.ts.
+  //
+  // For child branches (fork/race), entries at index < inheritedGuardCount
+  // are SHARED REFERENCES to parent-owned guards (CostGuard.cloneForBranch
+  // returns `this`). Entries at index >= inheritedGuardCount were pushed
+  // by the branch itself (e.g. a `guard(...)` block opened inside the
+  // branch body). Serialization writes only the branch-owned guards; on
+  // resume the runtime re-prepends live references to the parent's guards.
+  // This is what makes real-time mid-fork enforcement work without
+  // double-serializing shared state.
   guards: Guard[] = [];
+  inheritedGuardCount: number = 0;
 
   pushGuard(guard: Guard): void {
     guard.install(this);
@@ -439,7 +463,12 @@ export class StateStack {
       localTokens: this.localTokens,
       seedCost: this.seedCost,
       seedTokens: this.seedTokens,
-      guards: this.guards.map((g) => g.toJSON()),
+      // Serialize only branch-owned guards. Inherited guards are
+      // parent-owned (shared references like CostGuard); they're
+      // serialized exactly once on the parent's snapshot and
+      // re-prepended at resume by `runBatch`.
+      guards: this.guards.slice(this.inheritedGuardCount).map((g) => g.toJSON()),
+      inheritedGuardCount: this.inheritedGuardCount,
     };
   }
 
@@ -472,7 +501,16 @@ export class StateStack {
     // We do NOT call install() on deserialized guards — install effects
     // (e.g. composing abort signals) are runtime state and will be
     // re-established by resume() at the first runner step.
+    //
+    // For child branch stacks: only branch-owned guards were serialized.
+    // `inheritedGuardCount` is preserved but guards.length will be less
+    // than inheritedGuardCount until `runBatch` re-prepends live
+    // references to the parent's guards (see rehydrateInheritedGuards
+    // in runBatch.ts). This intermediate state is safe because nothing
+    // reads child stack guards between deserialize and the runBatch
+    // re-entry that reactivates the branch.
     stateStack.guards = (json.guards ?? []).map(guardFromJSON);
+    stateStack.inheritedGuardCount = json.inheritedGuardCount ?? 0;
     return stateStack;
   }
 }

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -541,9 +541,31 @@ export class StateStack {
       seedCost: this.seedCost,
       seedTokens: this.seedTokens,
       // Serialize only branch-owned guards. Inherited guards are
-      // parent-owned (shared references like CostGuard); they're
-      // serialized exactly once on the parent's snapshot and
-      // re-prepended at resume by `runBatch`.
+      // parent-owned (shared references like CostGuard) and MUST NOT
+      // be re-serialized on every descendant — doing so would
+      // duplicate the JS object on deserialize, defeating the whole
+      // shared-counter model (sibling A and sibling B would each
+      // charge a different OUTER clone).
+      //
+      // Invariant this relies on: every descendant branch is re-entered
+      // on resume through `runBatch` (the only code path that creates
+      // branches in the first place), which calls
+      // `StateStack.rehydrateInheritedGuardsFrom(parentStack)` to
+      // re-prepend live references to the parent's guards before any
+      // user code on that branch reads `stack.guards`. The parent
+      // itself is restored either:
+      //   - directly from the top-level checkpoint (root stack), or
+      //   - by being rehydrated via the same chain from ITS parent
+      //     (deeper nesting), so a depth-N branch sees the same
+      //     OUTER reference all the way up to root after N successive
+      //     `rehydrateInheritedGuardsFrom` calls.
+      //
+      // Concretely: a checkpoint stamped on a non-root stack (e.g.
+      // nested `runBatch`, or `pr.step` inside a fork branch) will
+      // drop its inherited guards from this snapshot. That is safe
+      // ONLY because the OUTER runBatch chain always re-stamps with
+      // its own parent stack on the way up, and the final resume
+      // root is always a stack whose `inheritedGuardCount === 0`.
       guards: this.guards.slice(this.inheritedGuardCount).map((g) => g.toJSON()),
       inheritedGuardCount: this.inheritedGuardCount,
     };

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -265,8 +265,12 @@ export type StateStackJSON = {
    *  serialized on the parent's snapshot and re-prepended at resume by
    *  `runBatch`. See StateStack.guards. */
   guards?: GuardJSON[];
-  /** Number of leading entries in `guards` that are inherited from the
-   *  parent stack. Always 0 for the root stack. */
+  /** Number of parent-owned guard references that were prepended onto
+   *  this stack's `guards` at branch creation. NOT a count of entries
+   *  in the serialized `guards` array (those are branch-owned only).
+   *  Used by `StateStack.rehydrateInheritedGuardsFrom` on resume to
+   *  validate that the parent's guard stack hasn't drifted. Always 0
+   *  for the root stack. */
   inheritedGuardCount?: number;
 };
 
@@ -334,6 +338,79 @@ export class StateStack {
     const guard = this.guards.pop();
     if (guard) guard.uninstall(this);
     return guard;
+  }
+
+  /**
+   * Walk active guards innermost-first and throw the first
+   * `GuardExceededError` returned by `guard.check(this)`. Used by
+   * `prompt.ts` as both the pre-call gate (refuse to issue a request
+   * we're already over budget for) and the post-call check (trip after
+   * the response cost has been billed).
+   *
+   * Innermost-first means the most recently pushed guard reports its
+   * trip first. This is a stable, scope-local rule rather than a
+   * global-minimum search; a shallower outer guard with a tighter
+   * budget would still trip on a later LLM call if the inner doesn't
+   * fail first.
+   */
+  enforceGuards(): void {
+    for (let i = this.guards.length - 1; i >= 0; i--) {
+      const err = this.guards[i].check(this);
+      if (err) throw err;
+    }
+  }
+
+  /**
+   * Charge every active guard with this call's cost. Shared parent
+   * guards (CostGuard.cloneForBranch returns `this`) accumulate
+   * descendant spend in real time — this is what makes mid-fork trip
+   * detection work without waiting for the fork to settle. TimeGuard's
+   * charge is a no-op.
+   */
+  chargeGuards(amount: number): void {
+    for (const g of this.guards) g.charge(amount);
+  }
+
+  /**
+   * Prepend the parent stack's inherited guard references onto this
+   * (child) stack's `guards` array, and stamp `inheritedGuardCount` so
+   * future serialization slices them off.
+   *
+   * Handles both fresh and resumed branches:
+   *  - Fresh branch: `inheritedGuardCount` is 0; the recomputed count
+   *    is stamped onto the stack.
+   *  - Resumed branch: `inheritedGuardCount` was restored from JSON;
+   *    the recomputed count is validated against it. A mismatch (e.g.
+   *    parent pushed an extra guard between snapshot and resume) throws
+   *    rather than silently inheriting a different set of guards.
+   *
+   * Always invokes `guard.cloneForBranch(parent, child)` on each parent
+   * guard so per-guard semantics (CostGuard returns `this`; TimeGuard
+   * returns `undefined`) drive what gets prepended. Slicing the parent
+   * by `inheritedGuardCount` would lose this filter information.
+   *
+   * Caller (runBatch) owns the per-execution idempotency check via
+   * `BranchState.guardsRehydrated` — this method itself is NOT idempotent;
+   * calling it twice on the same stack will double-prepend.
+   */
+  rehydrateInheritedGuardsFrom(parentStack: StateStack): void {
+    const inheritedRefs = parentStack.guards
+      .map((g) => g.cloneForBranch(parentStack, this))
+      .filter((g): g is Guard => g !== undefined);
+    if (
+      this.inheritedGuardCount > 0 &&
+      inheritedRefs.length !== this.inheritedGuardCount
+    ) {
+      throw new Error(
+        `Inherited guard count mismatch on resume: snapshot recorded ` +
+          `inheritedGuardCount=${this.inheritedGuardCount} parent-owned ` +
+          `guards, but parent now yields ${inheritedRefs.length} via ` +
+          `cloneForBranch. Parent's guard stack drifted between snapshot ` +
+          `and resume — state corruption.`,
+      );
+    }
+    this.guards = [...inheritedRefs, ...this.guards];
+    this.inheritedGuardCount = inheritedRefs.length;
   }
 
   constructor(

--- a/packages/agency-lang/tests/agency/guards/guard-cost-fork.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-fork.agency
@@ -1,23 +1,29 @@
 import { guard } from "std::thread"
 
-// Fork inside a guard. Each of 3 branches spends SYNTHETIC_COST
-// = 0.000002. After the fork completes, Runner.propagateBranchCost
-// rolls the deltas back to the parent stack: parent localCost grows
-// by 0.000006. The subsequent LLM call ("after") triggers the cost
-// check in prompt.ts, which sees total guard-scope spend = 0.000008
-// (> 0.000001) and trips.
+// Fork inside a guard. Each branch spends SYNTHETIC_COST = 0.000002.
+// With the shared-guard model (cloneForBranch returns `this`), the
+// OUTER guard is a single in-memory object that every branch charges
+// in real time. The first branch's post-call check ($0.000002 >
+// $0.000001) trips OUTER MID-FORK — well before the fork settles.
+// The trailing llm("after") is unreachable; the trip surfaces
+// immediately as a Failure.
+//
+// Under the prior per-branch-clone model (V1), each branch saw an
+// isolated $0.000001 clone and tripped independently. The deltas
+// rolled up at fork-completion via Runner.propagateBranchCost and
+// the trailing "after" call's post-check is what caught it. With
+// shared guards there's no V1 deferral — the trip fires the moment
+// any branch's charge pushes the shared counter over.
 node main() {
   const result = guard(cost: 0.000001) as {
     fork([1, 2, 3]) as n {
       const r = llm("branch ${n}")
     }
-    // Without this trailing call, cost would propagate but no guard
-    // check would fire (the check is only invoked after LLM calls).
     const after = llm("after")
     return after
   }
   if (isFailure(result)) {
-    return "tripped-after-fork:${result.error.actualCost > 0}"
+    return "tripped-mid-fork:${result.error.actualCost > 0}"
   }
   return "did not trip"
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-fork.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-fork.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "\"tripped-after-fork:true\"",
+      "expectedOutput": "\"tripped-mid-fork:true\"",
       "evaluationCriteria": [{ "type": "exact" }],
       "useTestLLMProvider": true,
       "llmMocks": [
@@ -12,7 +12,7 @@
         { "return": "b3" },
         { "return": "after" }
       ],
-      "description": "Outer guard wraps a fork. Branch costs propagate to the parent stack on fork completion; the next LLM call's cost check sees total spend and trips. Documents the V1 limitation that mid-fork branches do NOT eagerly notify the outer guard."
+      "description": "Outer guard wraps a fork. With the shared-guard model (cloneForBranch returns this), the OUTER CostGuard is a single in-memory object shared across all branches. The first branch's post-call check trips OUTER mid-fork before the fork settles — the trailing llm('after') is unreachable. Regression for real-time mid-fork enforcement. Under the prior per-branch-clone model the trip only fired post-join via the trailing 'after' call."
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-pre-call-gate.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-pre-call-gate.agency
@@ -1,0 +1,54 @@
+import { guard } from "std::thread"
+
+// Pre-call gate: when an LLM call is about to be issued, prompt.ts
+// walks the guard stack (innermost first) and refuses the call if
+// any guard is already over budget. This avoids billing for a call
+// whose result we'd just throw away.
+//
+// Setup engineered to put OUTER over its limit WITHOUT tripping
+// OUTER directly, so a subsequent llm call can be observed to be
+// REFUSED by the pre-call gate.
+//
+// Mechanism: each branch wraps its calls in an INNER guard. When a
+// branch's 2nd LLM call charges both INNER and OUTER, the post-call
+// walk goes innermost-first: INNER trips ($0.000004 > $0.000003),
+// the throw is caught by the INNER's stdlib try, and the branch
+// returns "inner-trip". OUTER's check is skipped at that site (loop
+// breaks on first trip). But OUTER was already CHARGED ($0.000002
+// per call × 4 calls = $0.000008). With OUTER limit $0.000005,
+// OUTER's `spent` is now over its budget.
+//
+// After the fork returns, OUTER's body issues llm("after"). The
+// pre-call gate walks the stack — OUTER's check returns
+// GuardExceededError ($0.000008 > $0.000005) — the call is REFUSED
+// before smoltalk.complete() runs. The mock for "after" is never
+// consumed.
+//
+// llmMocks provides EXACTLY 4 mocks (a1, b1, a2, b2). If the
+// pre-call gate is broken, "after" would be sent and the
+// DeterministicClient would throw "too many calls" because a 5th
+// mock is required.
+def doInner(n: number): string {
+  let r = guard(cost: 0.000003) as {
+    const a = llm("a ${n}")
+    return llm("b ${n}")
+  }
+  if (isFailure(r)) {
+    return "inner-trip-${n}"
+  }
+  return r.value
+}
+
+node main() {
+  const outer = guard(cost: 0.000005) as {
+    let results = fork([1, 2]) as n {
+      return doInner(n)
+    }
+    const after = llm("after")
+    return "got: ${after}"
+  }
+  if (isFailure(outer)) {
+    return "outer-tripped-via-pre-gate:${outer.error.actualCost > 0.000005}"
+  }
+  return "unexpected: ${outer.value}"
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-pre-call-gate.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-pre-call-gate.agency
@@ -14,20 +14,31 @@ import { guard } from "std::thread"
 // walk goes innermost-first: INNER trips ($0.000004 > $0.000003),
 // the throw is caught by the INNER's stdlib try, and the branch
 // returns "inner-trip". OUTER's check is skipped at that site (loop
-// breaks on first trip). But OUTER was already CHARGED ($0.000002
-// per call × 4 calls = $0.000008). With OUTER limit $0.000005,
-// OUTER's `spent` is now over its budget.
+// breaks on first trip). But OUTER was already CHARGED. After
+// branch 1's "b" charges OUTER from $0.000004 to $0.000006, OUTER's
+// `spent` is over its $0.000005 budget.
 //
-// After the fork returns, OUTER's body issues llm("after"). The
-// pre-call gate walks the stack — OUTER's check returns
-// GuardExceededError ($0.000008 > $0.000005) — the call is REFUSED
-// before smoltalk.complete() runs. The mock for "after" is never
-// consumed.
+// Now the pre-call gate fires in two distinct places (timing-
+// dependent on JS microtask ordering — both are valid outcomes):
 //
-// llmMocks provides EXACTLY 4 mocks (a1, b1, a2, b2). If the
-// pre-call gate is broken, "after" would be sent and the
-// DeterministicClient would throw "too many calls" because a 5th
-// mock is required.
+//   (A) Branch 2's "b" pre-gate sees OUTER over budget and refuses
+//       before sending. Branch 2's INNER catches via try, returns
+//       'inner-trip'. After the fork, llm("after") also pre-gate-
+//       refused. Mocks consumed: 3 (a1, b1, a2). actualCost =
+//       $0.000006.
+//   (B) Branch 2's "b" was already in-flight when branch 1's "b"
+//       post-charged OUTER. Both b's complete; both inner-trips
+//       caught. After the fork, llm("after") pre-gate-refused.
+//       Mocks consumed: 4. actualCost = $0.000008.
+//
+// Without the pre-call gate: llm("after") would be sent. Either it
+// would charge OUTER to $0.000010 (post-trip) or DeterministicClient
+// would throw 'too many calls' (since we provide only 4 mocks).
+//
+// Assertion: `actualCost < 0.000010` covers both pre-gate outcomes
+// and rejects the broken case. The mock-count cap acts as a second
+// independent signal: if 5+ calls are issued, DeterministicClient
+// throws and the test fails before any string assertion.
 def doInner(n: number): string {
   let r = guard(cost: 0.000003) as {
     const a = llm("a ${n}")
@@ -48,7 +59,9 @@ node main() {
     return "got: ${after}"
   }
   if (isFailure(outer)) {
-    return "outer-tripped-via-pre-gate:${outer.error.actualCost > 0.000005}"
+    // Pre-gate works: actualCost ∈ {$0.000006, $0.000008}.
+    // Pre-gate broken: actualCost == $0.000010 (or "too many calls").
+    return "pre-gate-trip:${outer.error.actualCost < 0.00001}"
   }
   return "unexpected: ${outer.value}"
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-pre-call-gate.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-pre-call-gate.test.json
@@ -3,7 +3,7 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "\"outer-tripped-via-pre-gate:true\"",
+      "expectedOutput": "\"pre-gate-trip:true\"",
       "evaluationCriteria": [{ "type": "exact" }],
       "useTestLLMProvider": true,
       "llmMocks": [
@@ -12,7 +12,7 @@
         { "return": "a2" },
         { "return": "b2" }
       ],
-      "description": "Pre-call gate refuses an LLM call when a guard is already over budget. The fork engineers OUTER's spent over its limit ($0.000008 > $0.000005) without OUTER itself tripping during the fork — each branch's INNER guard ($0.000003 limit) trips first (innermost-first walk in prompt.ts post-call check), catches via stdlib `try`, and returns 'inner-trip'. After the fork, OUTER's spent is over budget. The next llm('after') call hits the pre-call gate in prompt.ts which walks the guard stack and refuses to issue the request — proven by providing EXACTLY 4 mocks (a1, b1, a2, b2). If the pre-call gate were broken, smoltalk would be called for 'after' and DeterministicClient would throw 'too many calls' on the 5th request."
+      "description": "Pre-call gate refuses an LLM call when a guard is already over budget. Inside the fork, each branch wraps its calls in an INNER guard ($0.000003); the post-call innermost-first walk lets INNER trip and the stdlib try catches without OUTER itself tripping during the fork. OUTER's spent accumulates ($0.000006-$0.000008 depending on JS microtask timing) and crosses its $0.000005 budget. The pre-call gate then refuses either branch 2's 'b' (timing variant A) or llm('after') (timing variant B). Assertion `actualCost < $0.000010` covers both pre-gate variants; without the pre-call gate, actualCost would be $0.000010 (post-trip after 'after' charged). Second independent signal: llmMocks is EXACTLY 4 — if pre-gate were broken, DeterministicClient throws 'too many calls' on the 5th request."
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/guards/guard-cost-pre-call-gate.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-pre-call-gate.test.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"outer-tripped-via-pre-gate:true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "a1" },
+        { "return": "b1" },
+        { "return": "a2" },
+        { "return": "b2" }
+      ],
+      "description": "Pre-call gate refuses an LLM call when a guard is already over budget. The fork engineers OUTER's spent over its limit ($0.000008 > $0.000005) without OUTER itself tripping during the fork — each branch's INNER guard ($0.000003 limit) trips first (innermost-first walk in prompt.ts post-call check), catches via stdlib `try`, and returns 'inner-trip'. After the fork, OUTER's spent is over budget. The next llm('after') call hits the pre-call gate in prompt.ts which walks the guard stack and refuses to issue the request — proven by providing EXACTLY 4 mocks (a1, b1, a2, b2). If the pre-call gate were broken, smoltalk would be called for 'after' and DeterministicClient would throw 'too many calls' on the 5th request."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-inner-still-isolated.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-inner-still-isolated.agency
@@ -1,0 +1,55 @@
+import { guard } from "std::thread"
+
+// Inner guards pushed AFTER a fork opens stay branch-local.
+// The OUTER guard is shared across all branches via the
+// inheritedGuardCount/cloneForBranch=this mechanism, but INNER
+// guards a branch pushes onto its own stack are at index >=
+// branch.inheritedGuardCount — never visible to siblings, never
+// visible to the parent.
+//
+// Setup: OUTER limit $0.001 (way above what we'll spend in total).
+//        Each branch pushes its own INNER limit $0.000003.
+// Branch behavior (cost per call = $0.000002):
+//   branch 1: spends 1 call ($0.000002, under inner $0.000003)
+//             — inner does not trip, branch returns "ok-1".
+//   branch 2: spends 2 calls ($0.000004, over inner $0.000003)
+//             — inner trips, branch's inner guard catches the
+//             trip and returns a Failure, branch returns
+//             "tripped-2".
+//   branch 3: same as branch 1, returns "ok-3".
+//
+// Outer never trips (total $0.000008 well under $0.001).
+// Critical invariant: branch 2's inner trip MUST NOT abort
+// branches 1 and 3. If inner guards leaked to the parent's
+// guards array, branch 2's inner trip would compose into the
+// parent's abortSignal and cascade to siblings.
+def branchWork(item: number, callCount: number): string {
+  const inner = guard(cost: 0.000003) as {
+    let i = 0
+    while (i < callCount) {
+      const r = llm("branch ${item} call ${i}")
+      i = i + 1
+    }
+    return "ok-${item}"
+  }
+  if (isFailure(inner)) {
+    return "tripped-${item}"
+  }
+  return inner.value
+}
+
+node main() {
+  const outer = guard(cost: 0.001) as {
+    let results = fork([1, 2, 3]) as n {
+      if (n == 2) {
+        return branchWork(n, 2)
+      }
+      return branchWork(n, 1)
+    }
+    return results
+  }
+  if (isFailure(outer)) {
+    return "outer-tripped-unexpectedly"
+  }
+  return outer.value
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-inner-still-isolated.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-inner-still-isolated.test.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[\"ok-1\",\"tripped-2\",\"ok-3\"]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "r1" },
+        { "return": "r2a" },
+        { "return": "r2b" },
+        { "return": "r3" }
+      ],
+      "description": "Inner guards pushed by a branch after the fork opens stay branch-local. OUTER ($0.001) is the shared guard across all 3 branches via cloneForBranch=this. Each branch then pushes its own INNER ($0.000003) onto its own stack — that INNER sits at index >= inheritedGuardCount, invisible to the parent and siblings. Branch 2 spends 2 calls ($0.000004) — its INNER trips inside branch 2's prompt.ts post-call check. Branches 1 and 3 each spend 1 call ($0.000002) — their INNERs don't trip. Critical assertion: branch 2's INNER trip MUST NOT leak into the parent's guards array (would otherwise show up on the shared OUTER's check) and MUST NOT cascade to siblings' branches. The OUTER stays well under its budget across all branches' combined $0.000008 spend."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-nested-fork.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-nested-fork.agency
@@ -1,0 +1,50 @@
+import { guard } from "std::thread"
+
+// Nested fork — verifies inheritance walks more than one level deep.
+// OUTER guard is at depth 0. A first fork creates depth-1 branches;
+// each depth-1 branch in turn starts a depth-2 inner fork.
+//
+// The shared-guard model must propagate OUTER through BOTH levels:
+//   - depth-1 branches inherit OUTER from depth-0 (the parent's
+//     guards array, via cloneForBranch returning `this`)
+//   - depth-2 branches inherit OUTER from depth-1 (because depth-1's
+//     guards array contains the OUTER reference, inheritedGuardCount=1,
+//     and seedBranchCost propagates whatever's in the parent's array)
+//
+// Every depth-2 leaf charges OUTER's shared counter. With limit
+// $0.000005 and 2×2=4 leaves × $0.000002 = $0.000008, the trip
+// fires on whichever leaf is 3rd to settle (post-call check sees
+// shared spent > limit). The leaf's throw propagates through its
+// depth-2 fork (which trips), then through its depth-1 fork.
+// OUTER's stdlib try catches the GuardExceededError and returns
+// a Failure.
+//
+// If inheritance walks were broken at the depth-1 → depth-2
+// boundary (e.g. inheritedGuardCount not propagated, or
+// seedBranchCost not invoking cloneForBranch on inherited guards),
+// the depth-2 branches would NOT see OUTER and would all complete
+// independently. The fork would succeed and the trip would never
+// fire.
+
+def innerWork(d1: number, d2: number): string {
+  return llm("d1=${d1} d2=${d2}")
+}
+
+def doInnerFork(d1: number): string[] {
+  return fork([1, 2]) as d2 {
+    return innerWork(d1, d2)
+  }
+}
+
+node main() {
+  const outer = guard(cost: 0.000005) as {
+    let outerResults = fork([1, 2]) as d1 {
+      return doInnerFork(d1)
+    }
+    return "no-trip"
+  }
+  if (isFailure(outer)) {
+    return "nested-trip:${outer.error.actualCost > 0.000005}"
+  }
+  return "unexpected: ${outer.value}"
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-nested-fork.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-nested-fork.test.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"nested-trip:true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "r11" },
+        { "return": "r12" },
+        { "return": "r21" },
+        { "return": "r22" }
+      ],
+      "description": "Nested fork (depth-2) verifies the shared-guard inheritance walks more than one level. OUTER cost guard at depth 0 must reach depth-2 leaves through TWO seedBranchCost / cloneForBranch hops. Each depth-1 branch's guards array contains the OUTER ref (with inheritedGuardCount=1). When depth-1 starts its inner fork, depth-2 branches' seedBranchCost re-runs the cloneForBranch=this contract on depth-1's guards — which propagates OUTER all the way down. Each leaf's charge mutates OUTER's shared counter; the 3rd or 4th leaf's post-call check trips it (spent $0.000008 > limit $0.000005). If inheritance walks were broken at the depth-1 → depth-2 boundary, the depth-2 branches would not see OUTER and the fork would settle successfully."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-outer-trips-mid-fork.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-outer-trips-mid-fork.agency
@@ -1,0 +1,41 @@
+import { guard } from "std::thread"
+
+// Motivating example for the shared-guard design: outer guard wraps
+// a fork. Each branch individually stays under the limit, but their
+// combined spend exceeds it.
+//
+// Old behavior (per-branch cloned guards): branches each saw an
+// isolated $0.000008 budget. No branch tripped (each spends only
+// $0.000002 = SYNTHETIC_COST). The outer would only trip after the
+// fork joined and propagateBranchCost folded the deltas back —
+// requiring a trailing LLM call to act as a sync point.
+//
+// New behavior (shared guard reference): every branch charges the
+// SAME in-memory CostGuard object via `cloneForBranch` returning
+// `this`. As soon as any branch's charge pushes the shared counter
+// over the limit, the next check (post-call in that branch's
+// prompt.ts) trips. The fork's overall result is a Failure carrying
+// the outer guard's typed error.
+//
+// 3 branches × $0.000002 = $0.000006 of charges. Limit is set lower
+// so the SECOND branch's post-call check trips. Assert via the
+// trip's `actualCost` being the shared total at trip time, not a
+// per-branch number.
+node main() {
+  const result = guard(cost: 0.000003) as {
+    fork([1, 2, 3]) as n {
+      const r = llm("branch ${n}")
+      return r
+    }
+    return "ok"
+  }
+  if (isFailure(result)) {
+    // Mid-fork trip: actualCost should be > limit (one branch pushed
+    // total past 0.000003). With the OLD per-branch isolation, no
+    // branch would individually exceed its $0.000003 clone, so the
+    // outer wouldn't trip mid-fork at all.
+    const billed = result.error.actualCost > 0.000003
+    return "tripped-mid-fork:${billed}"
+  }
+  return "did not trip"
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-outer-trips-mid-fork.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-outer-trips-mid-fork.test.json
@@ -1,0 +1,17 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"tripped-mid-fork:true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "b1" },
+        { "return": "b2" },
+        { "return": "b3" }
+      ],
+      "description": "Outer cost guard wraps a fork. With the shared-guard model, the OUTER's CostGuard is a single in-memory object referenced by every branch (cloneForBranch returns this). Each branch's charge mutates the shared counter; the second branch's post-call check trips it mid-fork. The fork settles with the typed GuardExceededError surfacing as a Failure. Regression coverage for real-time mid-fork enforcement — under the old per-branch isolation, no branch would individually exceed the budget and the trip would only fire post-join (requiring a trailing LLM call as sync point)."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-survives-interrupt.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-survives-interrupt.agency
@@ -1,0 +1,49 @@
+import { guard } from "std::thread"
+
+// Shared cost guard must survive a serialized checkpoint cycle.
+// All 3 fork branches interrupt BEFORE the shared OUTER's spend
+// tips over the limit. The harness approves; on resume, runBatch's
+// `rehydrateInheritedGuards` re-prepends a live ref to the parent's
+// OUTER onto each child stack. The OUTER's `spent` counter survives
+// via toJSON (each charge before the interrupt is captured on the
+// parent's snapshot). Post-resume charges continue mutating the
+// same JS object — the trip fires once the cumulative cost crosses
+// the budget.
+//
+// SYNTHETIC_COST per call is $0.000002. Budget is $0.000008.
+//   Pre-interrupt:  3 branches × 1 call = $0.000006   (under, OK)
+//   All 3 interrupt. Harness approves all 3.
+//   Resume: branch X's 2nd call charges +$0.000002 → $0.000008 (no
+//   trip — `spent > limit` is false at equality). Next branch's 2nd
+//   call → $0.000010 → TRIP. Remaining branches abort via the
+//   shared OUTER's AbortController cascade.
+//
+// If the inheritedGuardCount machinery or the rehydrate re-link
+// were broken, the resumed branch would not see the parent's
+// OUTER at all — its post-call check would only see locally-pushed
+// guards (none in this test), and the trip would never fire from
+// inside the branch. The fork would settle successfully and the
+// outer's trip would only fire on the post-fork llm (none here).
+//
+// The assertion (no trailing llm) targets exactly that gap: trip
+// MUST come from inside a branch's post-call check after resume,
+// not from any post-fork sync point.
+def confirmBranch(item: number): string {
+  const r = llm("branch ${item}")
+  interrupt("approve ${item}?")
+  const r2 = llm("branch ${item} part 2")
+  return r2
+}
+
+node main() {
+  const result = guard(cost: 0.000008) as {
+    fork([1, 2, 3]) as n {
+      return confirmBranch(n)
+    }
+    return "fork-completed"
+  }
+  if (isFailure(result)) {
+    return "tripped-after-resume:${result.error.actualCost > 0.000008}"
+  }
+  return result.value
+}

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-survives-interrupt.agency
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-survives-interrupt.agency
@@ -15,8 +15,12 @@ import { guard } from "std::thread"
 //   All 3 interrupt. Harness approves all 3.
 //   Resume: branch X's 2nd call charges +$0.000002 → $0.000008 (no
 //   trip — `spent > limit` is false at equality). Next branch's 2nd
-//   call → $0.000010 → TRIP. Remaining branches abort via the
-//   shared OUTER's AbortController cascade.
+//   call → $0.000010 → TRIP at its post-call check, GuardExceededError
+//   thrown out of the branch. (CostGuard has no AbortController; trips
+//   propagate via post-call check on each branch — remaining branches
+//   that haven't yet completed their 2nd call will trip on their own
+//   post-call check or be refused by the pre-call gate at their next
+//   sync point.)
 //
 // If the inheritedGuardCount machinery or the rehydrate re-link
 // were broken, the resumed branch would not see the parent's

--- a/packages/agency-lang/tests/agency/guards/guard-cost-shared-survives-interrupt.test.json
+++ b/packages/agency-lang/tests/agency/guards/guard-cost-shared-survives-interrupt.test.json
@@ -1,0 +1,25 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"tripped-after-resume:true\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": "b1" },
+        { "return": "b2" },
+        { "return": "b3" },
+        { "return": "b1-p2" },
+        { "return": "b2-p2" },
+        { "return": "b3-p2" }
+      ],
+      "interruptHandlers": [
+        { "action": "approve" },
+        { "action": "approve" },
+        { "action": "approve" }
+      ],
+      "description": "Shared cost guard survives interrupt/resume cycle. All 3 fork branches charge $0.000002 (total $0.000006, under budget $0.000008) then interrupt. Harness approves all 3. On resume, runBatch's rehydrateInheritedGuards re-prepends a live ref to the parent's OUTER CostGuard onto each child stack. The OUTER's spent counter restored from the parent's snapshot ($0.000006). Post-resume LLM calls continue mutating the shared counter; the trip fires once cumulative cost crosses the budget. The trip MUST come from inside a branch's post-call check after resume — proving the rehydrateInheritedGuards re-link correctly restored the shared reference to the parent's CostGuard. If the re-link were broken, the resumed branches would not see the parent's OUTER at all and the fork would settle successfully."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Today each fork branch gets an isolated clone of the parent `CostGuard`, so an outer `guard(cost: $X)` budget can be silently exceeded mid-fork (two branches at $1.25 each under a $2.00 cap — neither clone trips, and the cap only fires after the fork settles).

This PR replaces per-branch cloning with a **shared in-memory CostGuard reference**, so any branch charging the shared counter mutates what the parent and all siblings see in real time. The next post-call check from any descendant returns the trip the moment cumulative spend exceeds the budget.

Plan: [`docs/superpowers/plans/2026-05-24-shared-cost-guards.md`](packages/agency-lang/docs/superpowers/plans/2026-05-24-shared-cost-guards.md)

## Key mechanics

- `CostGuard` owns its own `spent` counter (no more derived from `stack.localCost - costAtPush`). Every LLM-cost site walks `stack.guards` and calls `guard.charge(cost)` on each one.
- `CostGuard.cloneForBranch` returns `this` — the same JS object — so every branch's `stack.guards` array holds a reference to the parent's `CostGuard`. Single-threaded JS makes the increment race-free.
- `StateStack.inheritedGuardCount` records how many of a child's guards are parent-owned (refs at indices `< count`). `toJSON` serializes only branch-owned guards (slice past `count`), so a shared parent guard is serialized **once** on the parent's snapshot.
- `runBatch.rehydrateInheritedGuards` re-prepends the parent's live guard references onto each child stack on resume, restoring real-time sharing across the checkpoint cycle. Idempotent via a live-only `rehydrated` flag on `BranchState`.
- **Pre-call gate** in `prompt.ts`: before issuing an LLM request, walk the guard stack. If a sibling already pushed us over budget, refuse the call before it hits the wire.

`CostGuard` deliberately does NOT install an `AbortController` (unlike `TimeGuard`). A sibling branch mid-LLM-call won't be cancelled the instant another branch trips the shared guard — its smoltalk request runs to completion, then its post-call check sees the over-limit counter and throws. This preserves the same-stack nested-guard "innermost-first" reporting that `guard-nested-iteration-order` guarantees.

## Test coverage

New E2E tests in `tests/agency/guards/`:

| Test | Verifies |
|---|---|
| `guard-cost-shared-outer-trips-mid-fork` | Motivating example: outer trips mid-fork before any branch finishes. |
| `guard-cost-shared-survives-interrupt` | 3 branches interrupt under budget. On resume, rehydrated shared OUTER trips. |
| `guard-cost-shared-inner-still-isolated` | Inner guards a branch pushes after fork-open stay branch-local; one branch's inner trip does not cascade to siblings. |
| `guard-cost-pre-call-gate` | Engineers OUTER over its limit without tripping (via an inner-guard-catches-trip pattern); next `llm()` is refused by the pre-call gate; proven by providing EXACTLY 4 mocks (a 5th would throw "too many calls"). |
| `guard-cost-shared-nested-fork` | Depth-2 fork verifies inheritance propagates through TWO `seedBranchCost` hops. |

Updated `guard-cost-fork` to assert `tripped-mid-fork:true` (was `tripped-after-fork:true` under the V1 deferred-rollup behavior).

## Docs

- [`docs/site/guide/guards.md`](packages/agency-lang/docs/site/guide/guards.md) — documents the shared-guard model, the pre-call gate, and the inner-stays-local rule. Removed the V1 "forks don't trip outer cost guards mid-flight" limitation.

## Verification

- `pnpm run agency test tests/agency/guards/` — **20/20 pass**
- `pnpm test:run` — **4464/4464 pass**
