### PR TITLE
runtime: BootstrapThreadStore + real threads on onAgentEnd

### DIFF
--- a/packages/agency-lang/docs/dev/async-context.md
+++ b/packages/agency-lang/docs/dev/async-context.md
@@ -30,6 +30,22 @@ There are three seeding points. Everything else inherits them through normal `aw
 
 Subprocess bootstrap deliberately does NOT install its own frame. Each child re-enters `runNode` (which installs the frame) on its own, so threading a frame across the IPC boundary would be redundant.
 
+## Frame kinds: node frames vs bootstrap frames
+
+Not every frame the runtime installs has a real `ThreadStore`. There are two kinds:
+
+- **Node frames** are seeded inside a Runner step, a runBatch branch, or the outer wrap around `graph.run` in `runNode`. The `threads` slot is the actual per-run `ThreadStore` (or, for fork branches, the branch's own store). User code running inside a node frame can freely use `systemMessage`/`userMessage`/`thread { ... }`/etc.
+
+- **Bootstrap frames** are seeded by `runInBootstrapFrame(ctx, fn)` for code that runs *outside* any agent node. The runtime uses them in four places:
+  1. `runNode` — around `initializeGlobals` and `registerTopLevelCallbacks`.
+  2. `runNode` — around the `onAgentStart` callback (no node has executed yet).
+  3. `respondToInterrupts` and `rewindFrom` — around the corresponding `registerTopLevelCallbacks` re-run.
+  4. `respondToInterrupts` and `rewindFrom` — around the resume/replay `graph.run` loop. Generated node bodies re-enter ALS with a real per-node ThreadStore on every step via `Runner.runInScope`, so the bootstrap frame only covers the slice between entering `graph.run` and the first step.
+
+The `threads` slot in a bootstrap frame is a `BootstrapThreadStore` (lib/runtime/state/bootstrapThreadStore.ts). Every user-facing method on it throws with an actionable error. The contract: **message threads do not work in bootstrap scope**. If you reach for them there — at module top-level, inside `callback(...)` registration, or inside `onAgentStart` — you get a loud error instead of a silent write into a placeholder that the runtime is about to discard.
+
+`onAgentEnd` is different: it fires after the run finished, so it runs inside an `agencyStore.run(...)` frame seeded with the *real* per-run ThreadStore. User callbacks can inspect the final conversation through stdlib helpers there.
+
 ## What was wrong with the previous mechanism
 
 Before this, stdlib helpers that needed `ctx`/`stack`/`threads` were named with an `__internal_` prefix and registered in a `CONTEXT_INJECTED_BUILTINS` table. The TypeScript codegen rewrote every call site to prepend the three locals as positional arguments:

--- a/packages/agency-lang/docs/dev/async-context.md
+++ b/packages/agency-lang/docs/dev/async-context.md
@@ -84,6 +84,6 @@ The two external entry points called from host TS code — `respondToInterrupts`
 
 ## See also
 
-- [docs/superpowers/plans/2026-05-25-als-migration.md](../superpowers/plans/2026-05-25-als-migration.md) — the initial ALS migration plan.
-- [docs/superpowers/plans/2026-05-25-drop-per-call-context-plumbing.md](../superpowers/plans/2026-05-25-drop-per-call-context-plumbing.md) — the follow-up that dropped per-call-site bag emission.
+- The initial ALS migration that introduced `agencyStore` / `getRuntimeContext()` (commit `d39103cc` on `main`).
+- The follow-up PR [#198](https://github.com/egonSchiele/agency-lang/pull/198) that dropped per-call-site `{ctx, threads, stateStack}` bag emission from generated code.
 - [docs/dev/adding-a-module-to-the-agency-stdlib.md](./adding-a-module-to-the-agency-stdlib.md) — step-by-step recipe for adding a new module.

--- a/packages/agency-lang/docs/site/guide/llm.md
+++ b/packages/agency-lang/docs/site/guide/llm.md
@@ -166,3 +166,11 @@ def myTool() {
   print("Done!")
 }
 ```
+
+## Where you can call `llm`
+
+`llm(...)` participates in the same message history as the rest of your agent, so it can only be called from places where a message thread exists. That means anywhere inside a `node` or `def` body, and inside callback bodies that fire while a node is running.
+
+It does **not** work at module top level, inside a `callback(...)` registration block, or inside the `onAgentStart` lifecycle hook — those scopes run before any agent has started and have no conversation to append to. If you call `llm` from one of them you'll get a runtime error like *"Message threads are not available in this scope."* Move the call inside a `node` or `def` body to fix it.
+
+See [Message history and threads](./message-history-and-threads.md) for the full picture.

--- a/packages/agency-lang/docs/site/guide/message-history-and-threads.md
+++ b/packages/agency-lang/docs/site/guide/message-history-and-threads.md
@@ -63,3 +63,17 @@ I don't have access to personal data, so I can't know your favorite ice cream fl
 ```
 
 You can also nest threads and subthreads to create side conversations branching off other side conversations.
+
+## Where threads work
+
+Message threads are scoped to a running agent. They work anywhere inside a `node` or `def` body, and inside callback bodies (`handle`, `pipe`, etc.) that fire while a node is running.
+
+They do **not** work in these "bootstrap" scopes:
+
+- Module top-level code (e.g. a `const x = ...` declaration outside any node/function). This runs once at module load — there is no agent yet, so there is no message thread to attach to.
+- The body of a `callback(...)` registration at the top of a module.
+- The `onAgentStart` lifecycle hook. This fires before the agent runs.
+
+If you call a thread builtin from one of these scopes — `systemMessage`, `userMessage`, `llm`, `thread { ... }`, `subthread { ... }` — you'll get a runtime error like *"Message threads are not available in this scope."* with a pointer to this guide. Move the code inside a `node` or `def` body to fix it.
+
+`onAgentEnd` is the exception: it fires *after* the run completes, so it has access to the final conversation. You can inspect or log the thread state from there.

--- a/packages/agency-lang/lib/runtime/asyncContext.test.ts
+++ b/packages/agency-lang/lib/runtime/asyncContext.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from "vitest";
 import {
   agencyStore,
   getRuntimeContext,
+  runInBootstrapFrame,
   runInTestContext,
 } from "./asyncContext.js";
+import { BootstrapThreadStore } from "./state/bootstrapThreadStore.js";
 import { RuntimeContext } from "./state/context.js";
 import { StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
@@ -112,5 +114,33 @@ describe("agencyStore", () => {
     ]);
     expect(sawA[0]).toBe(a.ctx);
     expect(sawB[0]).toBe(b.ctx);
+  });
+});
+
+describe("runInBootstrapFrame", () => {
+  it("seeds ctx + a BootstrapThreadStore on the frame", async () => {
+    const seed = makeStore();
+    await runInBootstrapFrame(seed.ctx, async () => {
+      const s = getRuntimeContext();
+      expect(s.ctx).toBe(seed.ctx);
+      expect(s.stack).toBe(seed.ctx.stateStack);
+      expect(s.threads).toBeInstanceOf(BootstrapThreadStore);
+    });
+  });
+
+  it("threads slot throws on user-facing ops", async () => {
+    const seed = makeStore();
+    await runInBootstrapFrame(seed.ctx, async () => {
+      const { threads } = getRuntimeContext();
+      expect(() => threads.getOrCreateActive()).toThrow(
+        /Message threads are not available/,
+      );
+    });
+  });
+
+  it("returns the wrapped fn's resolved value", async () => {
+    const seed = makeStore();
+    const out = await runInBootstrapFrame(seed.ctx, async () => 42);
+    expect(out).toBe(42);
   });
 });

--- a/packages/agency-lang/lib/runtime/asyncContext.ts
+++ b/packages/agency-lang/lib/runtime/asyncContext.ts
@@ -22,9 +22,32 @@
  * frame) on its own, so threading a frame across the IPC boundary
  * would be redundant.
  *
- * See docs/superpowers/plans/2026-05-25-als-migration.md.
+ * # Frame kinds
+ *
+ * Frames installed by the runtime fall into two categories:
+ *
+ *  - **Node frames** — installed by `Runner.runInScope` and the wraps
+ *    around `graph.run` inside `runNode`. The `threads` slot is the
+ *    real per-run `ThreadStore` (or the per-fork branch's store) that
+ *    survives across pushes/pops, gets serialized into checkpoints, and
+ *    is what user code sees when it uses `systemMessage`/`userMessage`/
+ *    `thread { ... }`.
+ *
+ *  - **Bootstrap frames** — installed by `runInBootstrapFrame(...)` for
+ *    code that runs *outside* any agent node: module-level global init,
+ *    top-level callback registration, and the small slice of resume/
+ *    rewind logic that runs before `setupNode` reconstitutes the real
+ *    ThreadStore. Bootstrap frames have a `BootstrapThreadStore` in the
+ *    `threads` slot, which throws on every user-facing operation. The
+ *    contract is: thread builtins do not work in bootstrap scope; if a
+ *    user reaches for them there, they get a loud error instead of a
+ *    silent write into a discarded store.
+ *
+ * See docs/superpowers/plans/2026-05-25-als-migration.md and
+ * docs/dev/async-context.md.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
+import { BootstrapThreadStore } from "./state/bootstrapThreadStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { StateStack } from "./state/stateStack.js";
 import type { ThreadStore } from "./state/threadStore.js";
@@ -70,4 +93,30 @@ export function runInTestContext<T>(
   fn: () => T,
 ): T {
   return agencyStore.run({ ctx, stack, threads }, fn);
+}
+
+/**
+ * Wrap `fn` in an ALS frame suitable for code that runs *outside* any
+ * agent node body — module-level global-init, top-level callback
+ * registration, and the resume/rewind prelude. The `threads` slot is a
+ * `BootstrapThreadStore` sentinel: any attempt to use a message-thread
+ * builtin from inside `fn` throws with an actionable error rather than
+ * silently writing into a placeholder that the runtime is about to
+ * discard.
+ *
+ * The `stack` slot is `ctx.stateStack` — the bare execution-context
+ * stack with no node/function frames pushed. This matches what
+ * pre-migration `__initializeGlobals` saw via its explicit `{ ctx }`
+ * arg, and is correct because globals must not push node frames.
+ */
+export function runInBootstrapFrame<T>(
+  ctx: RuntimeContext<any>,
+  fn: () => T | Promise<T>,
+): Promise<T> {
+  return Promise.resolve(
+    agencyStore.run(
+      { ctx, stack: ctx.stateStack, threads: new BootstrapThreadStore() },
+      fn,
+    ),
+  );
 }

--- a/packages/agency-lang/lib/runtime/asyncContext.ts
+++ b/packages/agency-lang/lib/runtime/asyncContext.ts
@@ -43,8 +43,7 @@
  *    user reaches for them there, they get a loud error instead of a
  *    silent write into a discarded store.
  *
- * See docs/superpowers/plans/2026-05-25-als-migration.md and
- * docs/dev/async-context.md.
+ * See docs/dev/async-context.md for the full picture.
  */
 import { AsyncLocalStorage } from "node:async_hooks";
 import { BootstrapThreadStore } from "./state/bootstrapThreadStore.js";
@@ -104,19 +103,26 @@ export function runInTestContext<T>(
  * silently writing into a placeholder that the runtime is about to
  * discard.
  *
- * The `stack` slot is `ctx.stateStack` — the bare execution-context
- * stack with no node/function frames pushed. This matches what
- * pre-migration `__initializeGlobals` saw via its explicit `{ ctx }`
- * arg, and is correct because globals must not push node frames.
+ * The `stack` slot is the caller's current `ctx.stateStack`. At the
+ * `runNode` / `respondToInterrupts` / `rewindFrom` `*registerTopLevel
+ * Callbacks` and `onAgentStart` call sites that's the bare pre-restore
+ * stack (no node frames pushed) — which is the contract
+ * `__initializeGlobals` always expected. At the resume / rewind
+ * `graph.run` call sites it's the restored stack carrying the
+ * checkpoint frames; that's also fine because `Runner.runInScope` on
+ * the first step re-enters ALS with the per-node ThreadStore.
+ *
+ * Declared `async` so synchronous throws inside `fn` (including the
+ * very common case of the `BootstrapThreadStore` sentinel throwing)
+ * surface as rejected promises for `.catch(...)` callers, not as
+ * uncaught sync exceptions.
  */
-export function runInBootstrapFrame<T>(
+export async function runInBootstrapFrame<T>(
   ctx: RuntimeContext<any>,
   fn: () => T | Promise<T>,
 ): Promise<T> {
-  return Promise.resolve(
-    agencyStore.run(
-      { ctx, stack: ctx.stateStack, threads: new BootstrapThreadStore() },
-      fn,
-    ),
+  return agencyStore.run(
+    { ctx, stack: ctx.stateStack, threads: new BootstrapThreadStore() },
+    fn,
   );
 }

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -221,9 +221,20 @@ export function gatherCallbacks<K extends keyof CallbackMap>(
  *  per-tool `onToolCallStart` / `onToolCallEnd` in `prompt.ts`). The
  *  public `callHook` is now a thin wrapper that omits `stateStack`.
  *
- *  `ctx` is optional — when omitted (which is now the case for every
- *  codegen-emitted `callHook(...)` site), it's resolved from the active
- *  ALS frame via `getRuntimeContext()`. */
+ *  `ctx` is optional — when omitted, it's resolved from the active ALS
+ *  frame via `getRuntimeContext()`. Every codegen-emitted `callHook(...)`
+ *  site omits it. Within this repo, the remaining explicit-ctx callers
+ *  are all in runtime code where an ALS frame *is* installed and the
+ *  param is redundant:
+ *    - `node.ts` — `onAgentStart` (inside `runInBootstrapFrame`) and
+ *      `onAgentEnd` (inside `agencyStore.run` with the real threads).
+ *    - `prompt.ts` — `onLLMCallStart`/`End` and the per-tool
+ *      `onToolCallStart`/`End`, all called from inside a
+ *      `Runner.runInScope` frame seeded by the generated node body.
+ *  Those sites pass `ctx` defensively (predating the ALS migration)
+ *  and could be tightened in a follow-up by dropping the param and
+ *  making it required-via-ALS again. The slot stays optional so
+ *  external callers that have a ctx but no ALS frame still work. */
 export async function invokeCallbacks<K extends keyof CallbackMap>(args: {
   ctx?: RuntimeContext<any>;
   name: K;

--- a/packages/agency-lang/lib/runtime/interrupts.ts
+++ b/packages/agency-lang/lib/runtime/interrupts.ts
@@ -1,13 +1,12 @@
 import * as smoltalk from "smoltalk";
 import { nanoid } from "nanoid";
-import { agencyStore } from "./asyncContext.js";
+import { runInBootstrapFrame } from "./asyncContext.js";
 import { AgencyCancelledError, RestoreSignal } from "./errors.js";
 import { applyOverrides } from "./rewind.js";
 import { Checkpoint } from "./state/checkpointStore.js";
 import { RuntimeContext } from "./state/context.js";
 import { GlobalStore, GlobalStoreJSON } from "./state/globalStore.js";
 import { StateStack, StateStackJSON } from "./state/stateStack.js";
-import { ThreadStore } from "./state/threadStore.js";
 import { Approved, GraphState, Rejected } from "./types.js";
 import { createReturnObject, deepClone } from "./utils.js";
 import { reviveWithClasses } from "./classReviver.js";
@@ -288,26 +287,31 @@ async function runResumeLoop(
   agentStartTime: number,
 ): Promise<any> {
   let nodeName = startNodeName;
-  // Seed an ALS frame so stdlib helpers and `callHook` reads (which
-  // post-ALS-migration look up `ctx` / `stack` / `threads` via
-  // `getRuntimeContext()`) see the resumed run's context. The threads
-  // slot is a placeholder — generated node bodies install their own
-  // per-step frames inside `Runner.runInScope` with the actual
-  // ThreadStore reconstituted by `setupNode`.
-  const threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
   while (true) {
     try {
-      const result = await agencyStore.run(
-        { ctx: execCtx, stack: execCtx.stateStack, threads: threadStore },
-        () =>
-          execCtx.graph.run(
-            nodeName,
-            { data: {}, ctx: execCtx, isResume: true },
-            {
-              onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id),
-              statelogClient: execCtx.statelogClient,
-            },
-          ),
+      // Seed an ALS frame so stdlib helpers and `callHook` reads (which
+      // post-ALS-migration look up `ctx` / `stack` / `threads` via
+      // `getRuntimeContext()`) see the resumed run's context.
+      //
+      // This is a bootstrap frame: it only covers the small slice of
+      // execution between entering `graph.run` and the first
+      // `Runner.runInScope` inside the resumed node body — generated
+      // node bodies re-install ALS with the actual per-node
+      // `ThreadStore` (reconstituted by `setupNode` from
+      // `stack.threads` JSON) on every step. So the threads slot here
+      // is intentionally a `BootstrapThreadStore` — if anything inside
+      // graph dispatch / setupNode tries to reach for it, the throw
+      // surfaces the bug instead of letting a write silently land in
+      // a discarded placeholder.
+      const result = await runInBootstrapFrame(execCtx, () =>
+        execCtx.graph.run(
+          nodeName,
+          { data: {}, ctx: execCtx, isResume: true },
+          {
+            onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id),
+            statelogClient: execCtx.statelogClient,
+          },
+        ),
       );
       await execCtx.pendingPromises.awaitAll();
       const returnObject = createReturnObject({ result, globals: execCtx.globals });
@@ -399,15 +403,14 @@ export async function respondToInterrupts(args: {
   // the same registration would instead bind to a caller frame and be
   // popped immediately as the restored frames unwind.
   //
-  // The wrap in `agencyStore.run` mirrors `runNode` — top-level
-  // callback registration runs Agency code that goes through
-  // `__call`, which reads ctx/threads/stack from ALS after the
-  // drop-per-call-context-plumbing migration. See lib/runtime/node.ts.
-  const bootstrapThreads = ThreadStore.withDefaultActive(execCtx.statelogClient);
+  // The bootstrap frame mirrors `runNode` — top-level callback
+  // registration runs Agency code that goes through `__call`, which
+  // reads ctx/threads/stack from ALS after the
+  // drop-per-call-context-plumbing migration. See lib/runtime/node.ts
+  // and lib/runtime/asyncContext.ts (`runInBootstrapFrame`).
   if (args.registerTopLevelCallbacks) {
-    await agencyStore.run(
-      { ctx: execCtx, stack: execCtx.stateStack, threads: bootstrapThreads },
-      () => args.registerTopLevelCallbacks!(execCtx),
+    await runInBootstrapFrame(execCtx, () =>
+      args.registerTopLevelCallbacks!(execCtx),
     );
   }
   execCtx.restoreState(checkpoint);

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { MessageJSON } from "smoltalk";
-import { agencyStore } from "./asyncContext.js";
+import { agencyStore, runInBootstrapFrame } from "./asyncContext.js";
 import { callHook } from "./hooks.js";
 import type { AgencyCallbacks } from "./hooks.js";
 import type { RuntimeContext } from "./state/context.js";
@@ -152,12 +152,24 @@ export async function runNode({
   // `callback(...)` wrapper that the codegen emits inside
   // `__registerTopLevelCallbacks`) would invoke `_callbackImpl(name,
   // fn, undefined)` and crash on `__state.ctx`.
-  const bootstrapThreads = ThreadStore.withDefaultActive(execCtx.statelogClient);
+  //
+  // Consequences worth knowing:
+  //  - `stack` here is `execCtx.stateStack` — the bare global stack
+  //    with no node/function frames pushed. Globals must not push node
+  //    frames, so this is correct.
+  //  - `threads` is a `BootstrapThreadStore` sentinel. Any agency code
+  //    in global-init scope that reaches for a thread/message builtin
+  //    (e.g. `systemMessage("…")` at module top-level) now throws with
+  //    a clear error instead of silently writing into a placeholder
+  //    that this function discards on return.
+  //  - The `insideGlobalInit` codegen branch still emits an explicit
+  //    `{ ctx }` bag on `__call`, and `__call`'s merge prefers extras
+  //    over the ALS-read fields — so `ctx` resolution inside generated
+  //    global-init code does not depend on this frame's `ctx` either.
+  //    The frame is mostly here to satisfy the "every helper must see
+  //    *some* frame" contract.
   if (initializeGlobals) {
-    await agencyStore.run(
-      { ctx: execCtx, stack: execCtx.stateStack, threads: bootstrapThreads },
-      () => initializeGlobals(execCtx),
-    );
+    await runInBootstrapFrame(execCtx, () => initializeGlobals(execCtx));
   }
   // Top-level callbacks are re-registered every fresh run AFTER global
   // init so any module-level vars they reference (via `__ctx.globals`)
@@ -165,10 +177,7 @@ export async function runNode({
   // `respondToInterrupts` does on resume — keep them in sync if you
   // touch either site.
   if (registerTopLevelCallbacks) {
-    await agencyStore.run(
-      { ctx: execCtx, stack: execCtx.stateStack, threads: bootstrapThreads },
-      () => registerTopLevelCallbacks(execCtx),
-    );
+    await runInBootstrapFrame(execCtx, () => registerTopLevelCallbacks(execCtx));
   }
   // Externally-passed callbacks are stored on ctx; hook execution merges them
   // with scoped/top-level callbacks at call time.
@@ -187,11 +196,18 @@ export async function runNode({
     });
   }
 
-  await callHook({
-    ctx: execCtx,
-    name: "onAgentStart",
-    data: { nodeName, args: data, messages: messages || [], cancel },
-  });
+  // onAgentStart fires BEFORE any agent node has executed, so there is
+  // no real per-run ThreadStore yet — use a bootstrap frame so user
+  // callbacks that reach for thread/message builtins get a clear error
+  // instead of writing into a placeholder. `messages` is still
+  // available to the callback via `data.messages`.
+  await runInBootstrapFrame(execCtx, () =>
+    callHook({
+      ctx: execCtx,
+      name: "onAgentStart",
+      data: { nodeName, args: data, messages: messages || [], cancel },
+    }),
+  );
 
   const agentRunSpanId = execCtx.statelogClient.startSpan("agentRun");
   execCtx.statelogClient.agentStart({ entryNode: nodeName, args: data });
@@ -247,11 +263,19 @@ export async function runNode({
             timeTaken: performance.now() - agentStartTime,
             tokenStats: returnObject.tokens,
           });
-          await callHook({
-            ctx: execCtx,
-            name: "onAgentEnd",
-            data: { nodeName, result: returnObject },
-          });
+          // onAgentEnd fires AFTER the run finished, so seed ALS with
+          // the real per-run ThreadStore: user callbacks that inspect
+          // the final conversation through stdlib helpers see the
+          // actual messages, not a sentinel.
+          await agencyStore.run(
+            { ctx: execCtx, stack: execCtx.stateStack, threads: threadStore },
+            () =>
+              callHook({
+                ctx: execCtx,
+                name: "onAgentEnd",
+                data: { nodeName, result: returnObject },
+              }),
+          );
           await execCtx.closeTraceWriter();
         }
         return returnObject;

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -272,13 +272,13 @@ export async function runPrompt(args: {
   // pass them explicitly as `ctx` / `stateStack` keys on `args`, but
   // post-ALS migration every Agency execution path runs inside an
   // `agencyStore.run(...)` frame seeded with the same values.
-  const { ctx: alsCtx, stack: alsStack } = getRuntimeContext();
-  const ctx = alsCtx as RuntimeContext<GraphState>;
+  const runtime = getRuntimeContext();
+  const ctx = runtime.ctx as RuntimeContext<GraphState>;
 
   // Push a frame onto the state stack — runPrompt participates like any other function
   const { stateStack, stack } = setupFunction({
     state: {
-      stateStack: alsStack,
+      stateStack: runtime.stack,
       ctx,
       threads: new ThreadStore(),
     },

--- a/packages/agency-lang/lib/runtime/rewind.ts
+++ b/packages/agency-lang/lib/runtime/rewind.ts
@@ -1,9 +1,8 @@
 import type { Checkpoint } from "./state/checkpointStore.js";
-import { agencyStore } from "./asyncContext.js";
+import { runInBootstrapFrame } from "./asyncContext.js";
 import { RestoreSignal } from "./errors.js";
 import { RuntimeContext } from "./state/context.js";
 import { StateStack } from "./state/stateStack.js";
-import { ThreadStore } from "./state/threadStore.js";
 import type { GraphState } from "./types.js";
 import { createReturnObject, deepClone } from "./utils.js";
 import { color } from "@/utils/termcolors.js";
@@ -45,15 +44,14 @@ export async function rewindFrom(args: {
   const execCtx = await ctx.createExecutionContext(runId);
   // Must run before restoreState so the empty stack routes the
   // registration to `ctx.topLevelCallbacks`. See the matching comment
-  // in `respondToInterrupts`. The `agencyStore.run` wrap is also
-  // mirrored from there — top-level callback registration runs
-  // Agency code (the `callback(...)` wrapper) that needs an ALS
-  // frame for `__call` post-migration.
-  const bootstrapThreads = ThreadStore.withDefaultActive(execCtx.statelogClient);
+  // in `respondToInterrupts`. The bootstrap frame is also mirrored
+  // from there — top-level callback registration runs Agency code
+  // (the `callback(...)` wrapper) that needs an ALS frame for
+  // `__call` post-migration. See `runInBootstrapFrame` in
+  // lib/runtime/asyncContext.ts.
   if (args.registerTopLevelCallbacks) {
-    await agencyStore.run(
-      { ctx: execCtx, stack: execCtx.stateStack, threads: bootstrapThreads },
-      () => args.registerTopLevelCallbacks!(execCtx),
+    await runInBootstrapFrame(execCtx, () =>
+      args.registerTopLevelCallbacks!(execCtx),
     );
   }
   execCtx.restoreState(checkpoint);
@@ -68,31 +66,31 @@ export async function rewindFrom(args: {
   }
 
   let nodeName = checkpoint.nodeId;
-  // See `runResumeLoop` in lib/runtime/interrupts.ts — stdlib helpers
-  // and `callHook` lookups go through `getRuntimeContext()` now, so the
-  // rewind path needs to seed its own ALS frame too. The threads slot is
-  // a placeholder; generated node bodies re-enter ALS inside each
-  // `Runner.runInScope` with the per-scope ThreadStore.
-  const threadStore = ThreadStore.withDefaultActive(execCtx.statelogClient);
 
   try {
     while (true) {
       try {
-        const result = await agencyStore.run(
-          { ctx: execCtx, stack: execCtx.stateStack, threads: threadStore },
-          () =>
-            execCtx.graph.run(
-              nodeName,
-              {
-                data: {},
-                ctx: execCtx,
-                isResume: true,
-              },
-              {
-                onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id),
-                statelogClient: execCtx.statelogClient,
-              },
-            ),
+        // See `runResumeLoop` in lib/runtime/interrupts.ts — stdlib
+        // helpers and `callHook` lookups go through
+        // `getRuntimeContext()` now, so the rewind path needs to
+        // seed its own ALS frame too. This is a bootstrap frame:
+        // generated node bodies re-enter ALS inside each
+        // `Runner.runInScope` with the per-scope ThreadStore
+        // reconstituted by `setupNode` — nothing user-facing should
+        // reach for `threads` in the slice covered by this wrap.
+        const result = await runInBootstrapFrame(execCtx, () =>
+          execCtx.graph.run(
+            nodeName,
+            {
+              data: {},
+              ctx: execCtx,
+              isResume: true,
+            },
+            {
+              onNodeEnter: (id) => execCtx.stateStack.nodesTraversed.push(id),
+              statelogClient: execCtx.statelogClient,
+            },
+          ),
         );
         await execCtx.pendingPromises.awaitAll();
         return createReturnObject({ result, globals: execCtx.globals });

--- a/packages/agency-lang/lib/runtime/state/bootstrapThreadStore.test.ts
+++ b/packages/agency-lang/lib/runtime/state/bootstrapThreadStore.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { BootstrapThreadStore } from "./bootstrapThreadStore.js";
+import { ThreadStore } from "./threadStore.js";
 
 describe("BootstrapThreadStore", () => {
   it("throws on every user-facing operation with an actionable message", () => {
@@ -26,7 +27,9 @@ describe("BootstrapThreadStore", () => {
 
   it("instanceof ThreadStore so it satisfies the ALS store contract", () => {
     const store = new BootstrapThreadStore();
-    expect(store).toBeInstanceOf(BootstrapThreadStore);
+    // ALS frames type their `threads` slot as ThreadStore — the sentinel
+    // must pass that nominal check.
+    expect(store).toBeInstanceOf(ThreadStore);
     // Constructor does not auto-create a default thread, so no throws fire
     // during ALS frame setup. The throw only happens when user code tries
     // to actually use the store.

--- a/packages/agency-lang/lib/runtime/state/bootstrapThreadStore.test.ts
+++ b/packages/agency-lang/lib/runtime/state/bootstrapThreadStore.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { BootstrapThreadStore } from "./bootstrapThreadStore.js";
+
+describe("BootstrapThreadStore", () => {
+  it("throws on every user-facing operation with an actionable message", () => {
+    const store = new BootstrapThreadStore();
+    const expectedFragment = "Message threads are not available in this scope";
+    const calls: { name: string; fn: () => unknown }[] = [
+      { name: "create", fn: () => store.create() },
+      { name: "createAndReturnThread", fn: () => store.createAndReturnThread() },
+      { name: "createSubthread", fn: () => store.createSubthread() },
+      { name: "createAndReturnSubthread", fn: () => store.createAndReturnSubthread() },
+      { name: "get", fn: () => store.get("0") },
+      { name: "pushActive", fn: () => store.pushActive("0") },
+      { name: "popActive", fn: () => store.popActive() },
+      { name: "activeId", fn: () => store.activeId() },
+      { name: "active", fn: () => store.active() },
+      { name: "getOrCreateActive", fn: () => store.getOrCreateActive() },
+    ];
+    for (const call of calls) {
+      expect(call.fn, `BootstrapThreadStore.${call.name} should throw`).toThrow(
+        expectedFragment,
+      );
+    }
+  });
+
+  it("instanceof ThreadStore so it satisfies the ALS store contract", () => {
+    const store = new BootstrapThreadStore();
+    expect(store).toBeInstanceOf(BootstrapThreadStore);
+    // Constructor does not auto-create a default thread, so no throws fire
+    // during ALS frame setup. The throw only happens when user code tries
+    // to actually use the store.
+    expect(store.activeStack).toEqual([]);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/bootstrapThreadStore.ts
+++ b/packages/agency-lang/lib/runtime/state/bootstrapThreadStore.ts
@@ -39,7 +39,7 @@ export class BootstrapThreadStore extends ThreadStore {
         `\n` +
         `Fix: move the code inside a \`node\` or \`def\` body.\n` +
         `\n` +
-        `See docs/dev/async-context.md ("Frame kinds") for details.`,
+        `See https://agency-lang.com/guide/message-history-and-threads.html for details.`,
     );
   }
 

--- a/packages/agency-lang/lib/runtime/state/bootstrapThreadStore.ts
+++ b/packages/agency-lang/lib/runtime/state/bootstrapThreadStore.ts
@@ -1,0 +1,76 @@
+import { ThreadStore } from "./threadStore.js";
+
+/**
+ * A sentinel `ThreadStore` placed on the `agencyStore` ALS frame for code
+ * that runs **outside** any agent node body — specifically:
+ *
+ *  - module-level global-init (`__initializeGlobals`)
+ *  - top-level callback registration (`__registerTopLevelCallbacks`)
+ *  - the resume / rewind bootstrap loops before `setupNode` reconstitutes
+ *    the per-node ThreadStore from `stack.threads` JSON
+ *
+ * After the ALS migration these scopes still need *some* `ThreadStore` on
+ * the ALS frame so `getRuntimeContext()` returns a valid object. Pre-fix,
+ * we put a plain `ThreadStore.withDefaultActive(...)` there — but any
+ * accidental write from those scopes (e.g. someone calling
+ * `systemMessage("…")` at module top-level) would silently disappear when
+ * the bootstrap frame unwound, because that ThreadStore was discarded.
+ *
+ * BootstrapThreadStore replaces the silent-loss failure mode with a loud
+ * one: every user-facing method throws with an actionable message.
+ *
+ * It deliberately does NOT override:
+ *  - `setStatelogClient` — purely additive metadata; harmless to set
+ *  - `toJSON` / `fromJSON` — never reached from bootstrap scope, but if
+ *    something does serialize an empty store, the empty result is correct
+ */
+export class BootstrapThreadStore extends ThreadStore {
+  private throwBootstrap(method: string): never {
+    throw new Error(
+      `Message threads are not available in this scope.\n` +
+        `\n` +
+        `  Called: ThreadStore.${method}()\n` +
+        `\n` +
+        `This usually means agency code at module top-level (a global ` +
+        `\`const x = ...\`), inside a \`callback(...)\` registration, or in ` +
+        `an \`onAgent*\` lifecycle hook tried to use a thread/message ` +
+        `builtin. Those scopes run before any agent node has started, so ` +
+        `there is no message thread to read from or write to.\n` +
+        `\n` +
+        `Fix: move the code inside a \`node\` or \`def\` body.\n` +
+        `\n` +
+        `See docs/dev/async-context.md ("Frame kinds") for details.`,
+    );
+  }
+
+  override create(): never {
+    return this.throwBootstrap("create");
+  }
+  override createAndReturnThread(): never {
+    return this.throwBootstrap("createAndReturnThread");
+  }
+  override createSubthread(): never {
+    return this.throwBootstrap("createSubthread");
+  }
+  override createAndReturnSubthread(): never {
+    return this.throwBootstrap("createAndReturnSubthread");
+  }
+  override get(_id: string): never {
+    return this.throwBootstrap("get");
+  }
+  override pushActive(_id: string): never {
+    return this.throwBootstrap("pushActive");
+  }
+  override popActive(): never {
+    return this.throwBootstrap("popActive");
+  }
+  override activeId(): never {
+    return this.throwBootstrap("activeId");
+  }
+  override active(): never {
+    return this.throwBootstrap("active");
+  }
+  override getOrCreateActive(): never {
+    return this.throwBootstrap("getOrCreateActive");
+  }
+}


### PR DESCRIPTION
Follow-up to PR #198. Addresses the "placeholder ThreadStore" sharp edges that were flagged in the review and tightens a few small ALS-related rough spots.

## What changed

### 1. `BootstrapThreadStore` sentinel

`lib/runtime/state/bootstrapThreadStore.ts`. Subclass of `ThreadStore` whose user-facing methods (`create`, `getOrCreateActive`, `pushActive`, etc.) all throw:

> Message threads are not available in this scope.
>   Called: ThreadStore.X()
> This usually means agency code at module top-level (a global `const x = ...`), inside a `callback(...)` registration, or in an `onAgent*` lifecycle hook tried to use a thread/message builtin ...

Replaces the silent-write-into-discarded-placeholder failure mode with a loud one.

### 2. `runInBootstrapFrame(ctx, fn)` helper

`lib/runtime/asyncContext.ts`. Wraps the five sites where the runtime needs an ALS frame outside any agent node body:

- `runNode`: around `initializeGlobals` and `registerTopLevelCallbacks`.
- `respondToInterrupts`: around `registerTopLevelCallbacks` and the resume `graph.run` loop.
- `rewindFrom`: same two sites for replay.

The frame's `threads` slot is a fresh `BootstrapThreadStore`.

### 3. `onAgentEnd` gets the real threads

`onAgentStart` now runs inside a bootstrap frame (no real threads exist yet — addresses the symmetry concern in the review). `onAgentEnd` now runs inside an `agencyStore.run(...)` frame seeded with the real per-run `ThreadStore`, so user callbacks that inspect the final conversation through stdlib helpers see the actual messages.

### 4. Review-comment cleanup on PR #198

- `hooks.ts` docstring: explain why `ctx?` is still optional and enumerate the remaining explicit-ctx call sites that could be tightened in a follow-up. (Review item #4)
- `interrupts.ts`, `node.ts`: expanded the "ALS wrap on resume / bootstrap" comments to call out consequences (placeholder threads, why `insideGlobalInit` still needs the explicit `ctx` bag, etc.). (Review items #5, #6)
- `prompt.ts`: dropped the `alsCtx` rename — the local was only used once for a cast. (Review item #7)

### 5. Docs

- `docs/dev/async-context.md` gains a "Frame kinds" section describing node vs bootstrap frames and where each kind is installed.
- `docs/site/guide/llm.md` gains a "Where you can call `llm`" section.
- `docs/site/guide/message-history-and-threads.md` gains a "Where threads work" section.

### 6. Tests

- `bootstrapThreadStore.test.ts`: every overridden method throws with the right message.
- `asyncContext.test.ts`: `runInBootstrapFrame` seeds the right ALS frame, the threads slot is the sentinel and throws on use, and the resolved value is propagated.

## Validation

- `pnpm test:run`: **4423 passing** (4418 before + 5 new).
- `pnpm tsc --noEmit`: clean.
- `make fixtures`: no fixture changes — this PR is runtime + docs + tests only.

## Deferred (not in this PR)

- TS-IR builder nits from the PR #198 review (the `buildStateConfig` + push-config-if-present pattern, the `ts.raw("new Runner(...)")` site). Deferred — both are pure refactors and the second will shrink further with Phase 4.
- Tightening the optional `ctx?` on `callHook`/`invokeCallbacks` to a required-via-ALS contract. Documented as a future follow-up; would need to migrate the explicit-ctx call sites in `prompt.ts` first.
