### PR TITLE
tests: pin thread/memory tests to deterministic LLM provider

### DIFF
--- a/packages/agency-lang/tests/agency/memory/basic.test.json
+++ b/packages/agency-lang/tests/agency/memory/basic.test.json
@@ -10,6 +10,7 @@
           "type": "exact"
         }
       ],
+      "useTestLLMProvider": true,
       "llmMocks": [
         {
           "return": {

--- a/packages/agency-lang/tests/agency/memory/llm-injection.test.json
+++ b/packages/agency-lang/tests/agency/memory/llm-injection.test.json
@@ -5,6 +5,7 @@
       "input": "",
       "expectedOutput": "true",
       "evaluationCriteria": [{ "type": "exact" }],
+      "useTestLLMProvider": true,
       "llmMocks": [
         {
           "return": {

--- a/packages/agency-lang/tests/agency/threads/default-shared-cross-node.test.json
+++ b/packages/agency-lang/tests/agency/threads/default-shared-cross-node.test.json
@@ -6,6 +6,7 @@
       "expectedOutput": "{\"nums\":[2,3,5,7,11],\"sum\":28}",
       "evaluationCriteria": [{ "type": "exact" }],
       "description": "Message history persists across node transitions — process node sees setup node history",
+      "useTestLLMProvider": true,
       "llmMocks": [
         { "return": [2, 3, 5, 7, 11] },
         { "return": 28 }

--- a/packages/agency-lang/tests/agency/threads/default-shared-thread.test.json
+++ b/packages/agency-lang/tests/agency/threads/default-shared-thread.test.json
@@ -6,6 +6,7 @@
       "expectedOutput": "{\"res1\":[2,3,5,7,11],\"res2\":28}",
       "evaluationCriteria": [{ "type": "exact" }],
       "description": "LLM calls share history by default — res2 should know about res1",
+      "useTestLLMProvider": true,
       "llmMocks": [
         { "return": [2, 3, 5, 7, 11] },
         { "return": 28 }

--- a/packages/agency-lang/tests/agency/threads/messages.test.json
+++ b/packages/agency-lang/tests/agency/threads/messages.test.json
@@ -10,6 +10,7 @@
           "type": "exact"
         }
       ],
+      "useTestLLMProvider": true,
       "llmMocks": [
         { "return": { "response": [2, 3, 5, 7, 11] } },
         { "return": { "response": [13, 17] } },

--- a/packages/agency-lang/tests/agency/threads/no-thread-dependent-call.test.json
+++ b/packages/agency-lang/tests/agency/threads/no-thread-dependent-call.test.json
@@ -9,6 +9,7 @@
           "type": "exact"
         }
       ],
+      "useTestLLMProvider": true,
       "llmMocks": [
         { "return": [101] },
         { "return": [103, 107] }

--- a/packages/agency-lang/tests/agency/threads/pass-messages.test.json
+++ b/packages/agency-lang/tests/agency/threads/pass-messages.test.json
@@ -9,6 +9,7 @@
           "type": "exact"
         }
       ],
+      "useTestLLMProvider": true,
       "llmMocks": [
         { "return": "Got it!" },
         { "return": 3435 }

--- a/packages/agency-lang/tests/agency/threads/simple.test.json
+++ b/packages/agency-lang/tests/agency/threads/simple.test.json
@@ -9,6 +9,7 @@
           "type": "exact"
         }
       ],
+      "useTestLLMProvider": true,
       "llmMocks": [
         { "return": [2, 3, 5, 7, 11] },
         { "return": 28 }

--- a/packages/agency-lang/tests/agency/threads/subthread-inside-function.test.json
+++ b/packages/agency-lang/tests/agency/threads/subthread-inside-function.test.json
@@ -9,6 +9,7 @@
           "type": "exact"
         }
       ],
+      "useTestLLMProvider": true,
       "llmMocks": [
         { "return": { "response": [2, 3, 5, 7, 11] } },
         { "return": { "response": [13, 17] } },

--- a/packages/agency-lang/tests/agency/threads/subthreads.test.json
+++ b/packages/agency-lang/tests/agency/threads/subthreads.test.json
@@ -10,6 +10,7 @@
           "type": "exact"
         }
       ],
+      "useTestLLMProvider": true,
       "llmMocks": [
         { "return": { "response": [2, 3, 5, 7, 11] } },
         { "return": { "response": [13, 17] } },


### PR DESCRIPTION
## Stabilize the post-merge Real-LLM CI: pin thread/memory tests to deterministic provider

Diagnosis of the latest [Real-LLM tests (post-merge) failure on `main`](https://github.com/egonSchiele/agency-lang/actions/runs/26427714834):

The two failing tests both have `llmMocks` defined in their `.test.json` but are missing the `useTestLLMProvider: true` flag. The auto-activation logic in [lib/cli/util.ts](https://github.com/egonSchiele/agency-lang/blob/main/packages/agency-lang/lib/cli/util.ts) only enables the deterministic client when **either** signal is present:

```ts
const useDeterministic =
  !!process.env.AGENCY_USE_TEST_LLM_PROVIDER || !!useTestLLMProvider;
```

- PR CI sets `AGENCY_USE_TEST_LLM_PROVIDER=1` → both tests use mocks → green.
- Push-to-main CI (`Real-LLM tests (post-merge)`) deliberately omits the env var so it can exercise real OpenAI → mocks silently ignored → tests use real LLM → exact-match assertions fail on whatever the model produced.

Captured failures:

- `tests/agency/memory/llm-injection.test.json` — expected `true` (memory injection happened), got `false` (real LLM didn't recall "Mom likes pottery" because the entity wasn't stored deterministically).
- `tests/agency/threads/subthreads.test.json` — expected `[18, 19]` for "next two integers after those", real LLM returned `[14, 15]` even with 2 retries.

8 other tests under `tests/agency/threads/` and `tests/agency/memory/` have the same bug — they currently pass because the LLM happens to be consistent for their prompts, but they're one model-update away from breaking the same way. Fix all 10 in one pass.

### Fix

Add `"useTestLLMProvider": true` next to the `"llmMocks":` field in each test object. Forces the deterministic client on both CI paths, so the mocks are honored and the exact-match assertion is stable.

### Files changed (10)

```
tests/agency/memory/basic.test.json
tests/agency/memory/llm-injection.test.json
tests/agency/threads/default-shared-cross-node.test.json
tests/agency/threads/default-shared-thread.test.json
tests/agency/threads/messages.test.json
tests/agency/threads/no-thread-dependent-call.test.json
tests/agency/threads/pass-messages.test.json
tests/agency/threads/simple.test.json
tests/agency/threads/subthread-inside-function.test.json
tests/agency/threads/subthreads.test.json
```

Mechanical 1-line addition per file.

### Validation

```bash
$ pnpm run agency test tests/agency/threads/subthreads.test.json
  ✓ Exact match passed
$ pnpm run agency test tests/agency/memory/llm-injection.test.json
  ✓ Exact match passed
```

Both previously-failing tests now pass deterministically. The other 8 already passed; they continue to pass under the deterministic client.

### Notes for reviewers

- This is a pure test-config change — no library code, no fixtures.
- Test authors who genuinely want to exercise the real LLM should drop `llmMocks` from their `.test.json` and switch `evaluationCriteria` away from `{ type: "exact" }` (e.g. LLM Judge).
- Consider following up with a structural lint that rejects `.test.json` files that declare `llmMocks` without `useTestLLMProvider: true` (or vice versa) — they're almost always meant to go together.
