### PR TITLE
codegen: Phase 4 ALS cleanup (prune dead locals, __stateStack accessor, body wrap)

### DIFF
--- a/packages/agency-lang/docs/dev/async-context.md
+++ b/packages/agency-lang/docs/dev/async-context.md
@@ -78,12 +78,16 @@ After the "drop per-call-site context plumbing" pass (see plan), runtime helpers
 - `__call(target, descriptor)` / `__callMethod(obj, prop, descriptor)` build the `__state` bag from ALS internally — call sites only pass the location-info bag (`{moduleId, scopeName, stepPath}`) when invoking `checkpoint`/`getCheckpoint`/`restore`, and pass `{ctx}` when invoked from inside `__initializeGlobals` (which runs before any ALS frame exists).
 - `runPrompt({prompt, messages, clientConfig, ...})` no longer accepts `ctx` / `stateStack` — both come from ALS.
 - `callHook({name, data})` no longer requires `ctx`; it falls back to `getRuntimeContext().ctx` when omitted. Generated code stops emitting `ctx: __ctx`.
-- `new Runner(__ctx, __stack, {moduleId, scopeName})` — the `stack` and `threads` opts are gone. The Runner constructor reads them from ALS as a fallback so `runner.step/hook/fork` etc. still re-seed the per-scope frame correctly.
+- `new Runner(__ctx, __stack, {moduleId, scopeName, threads})` — `stack` defaults from ALS when omitted. `threads` is passed explicitly because every Runner needs to install its own per-scope ALS frame inside `Runner.runInScope`, and that frame must carry the per-node/per-function `ThreadStore` (which the outer ALS frame doesn't have, especially when a function is called as a tool). See PR [#200](https://github.com/egonSchiele/agency-lang/pull/200).
 
 The two external entry points called from host TS code — `respondToInterrupts` and `rewindFrom` — install their own outer `agencyStore.run(...)` frame around the resume/replay loop so that callbacks and stdlib helpers triggered during resume see the right context.
 
 ## See also
 
+- [docs/dev/codegen-als-accessors.md](./codegen-als-accessors.md) — how generated code reads from the ALS frame via `__threads()` / `__ctx()` / `__stateStack()` accessors, plus the recipe for adding a new accessor or pruning an existing setup-block local.
 - The initial ALS migration that introduced `agencyStore` / `getRuntimeContext()` (commit `d39103cc` on `main`).
 - The follow-up PR [#198](https://github.com/egonSchiele/agency-lang/pull/198) that dropped per-call-site `{ctx, threads, stateStack}` bag emission from generated code.
+- PR [#199](https://github.com/egonSchiele/agency-lang/pull/199) — BootstrapThreadStore sentinel + onAgentEnd real ThreadStore wrap.
+- PR [#200](https://github.com/egonSchiele/agency-lang/pull/200) — explicit `threads:` on the Runner constructor so per-scope ALS frames carry the right `ThreadStore`.
+- PR [#201](https://github.com/egonSchiele/agency-lang/pull/201) — first accessor migration (`__threads()`), template for the rest of Phase 4 cleanup.
 - [docs/dev/adding-a-module-to-the-agency-stdlib.md](./adding-a-module-to-the-agency-stdlib.md) — step-by-step recipe for adding a new module.

--- a/packages/agency-lang/docs/dev/codegen-als-accessors.md
+++ b/packages/agency-lang/docs/dev/codegen-als-accessors.md
@@ -269,9 +269,13 @@ You're outside an `agencyStore.run(...)` frame. Three cases:
 - **Bootstrap scope** (module top-level `const x = ...`, `callback(...)` registration, `onAgentStart` hook). The frame is a `BootstrapThreadStore` if you're reading `threads`; for other fields the frame is real, but reads must not assume node-body semantics. See [docs/dev/async-context.md](./async-context.md) "Frame kinds".
 - **A nested `await` after the frame was torn down.** Rare — frames propagate through normal `await` chains. If you see this, the frame was probably popped between scheduling and execution.
 
-### "Don't change `__stateStack` inside `forkBlockSetup.mustache`"
+### "Adding a local that shadows an accessor import"
 
-[`forkBlockSetup.mustache`](../../lib/templates/backends/typescriptGenerator/forkBlockSetup.mustache) line 10 has `const __stateStack = __forkBranchStack;`. This is **not** a normal setup-block local — it's an intentional rebind to the branch-specific stack inside a fork branch body. The branch stack must not be sourced from the parent ALS frame (which has the parent's stack); the entry point for the fork branch already installs an inner ALS frame with the branch stack via `runBatch.runInBranchAlsFrame`. Leave the rebind alone when migrating `__stateStack` to `__stateStack()` elsewhere.
+If you find yourself tempted to write `const __stateStack = somethingElse;` (or any other rebind that shares a name with the runtime import) inside a `.mustache` template, **don't**. The runtime import is a function; the local would shadow it; TypeScript renames the local to `__stateStack2` (or similar); any other template that emits `__stateStack()` then resolves to `__stateStack2` — a `StateStack` value, not a function — and crashes with `__stateStack2 is not a function`.
+
+This bit us specifically in `forkBlockSetup.mustache`: an earlier `const __stateStack = __forkBranchStack;` rebind was kept "to make the branch stack visible inside the body". It turned out to be unnecessary: `runBatch.runInBranchAlsFrame` (lib/runtime/runBatch.ts) already seeds the branch ALS frame with `stack: branchStack`, so `__stateStack()` inside the branch body resolves to the branch stack automatically. The rebind was removed; the gotcha here is "don't reintroduce it".
+
+If you genuinely need a *different* StateStack visible inside a sub-scope, install a new ALS frame for that scope (`agencyStore.run({...}, ...)`) rather than rebinding the name.
 
 ### Runner constructor needs explicit `threads`
 
@@ -307,7 +311,7 @@ Use this as a checklist when migrating one of the remaining locals (`__ctx`, `__
 - Backend: `lib/backends/typescriptBuilder.ts` → search for the bare name; both function-body emission (around line 1473) and node-body emission (around line 2179) call `setupEnv`. Other raw-string emissions of `__X.method(...)` need updating individually.
 - Templates: `lib/templates/backends/typescriptGenerator/`:
   - `blockSetup.mustache`
-  - `forkBlockSetup.mustache` (caveat: `__stateStack` rebind, see Gotchas)
+  - `forkBlockSetup.mustache` (note: no `__stateStack` rebind — the branch ALS frame from `runBatch.runInBranchAlsFrame` carries the branch stack)
   - `classMethod.mustache`
   - `debugger.mustache`
   - `interruptAssignment.mustache`

--- a/packages/agency-lang/docs/dev/codegen-als-accessors.md
+++ b/packages/agency-lang/docs/dev/codegen-als-accessors.md
@@ -1,0 +1,326 @@
+# Codegen ALS accessors: `__threads()`, `__ctx()`, `__stateStack()`
+
+This doc covers how generated Agency code reads runtime values (the `ThreadStore`, `RuntimeContext`, `StateStack`) from the active `agencyStore` ALS frame, the file layout for the codegen → runtime → template path, and the recipe for adding a new accessor or pruning an existing setup-block local.
+
+Sister doc: [docs/dev/async-context.md](./async-context.md) describes `agencyStore` itself and where frames are installed. Read that first.
+
+## TL;DR
+
+Generated Agency code used to declare per-scope `const __threads = ...; const __ctx = ...; const __stateStack = ...;` locals in every function and node body's setup block. That worked but it forced the codegen and every downstream emission site (templates, IR builders, `typescriptBuilder.ts`) to thread the values through by name. The migration replaces each `__X` local with a runtime accessor function `__X()` that reads from `agencyStore.getStore()?.X`. The codegen now just emits the accessor call where the local used to be referenced.
+
+```ts
+// before
+const __threads = __setupData.threads;
+runner.halt({ messages: __threads, data: result });
+
+// after
+runner.halt({ messages: __threads(), data: result });
+```
+
+The cost is one ALS read per access (negligible — `AsyncLocalStorage.getStore()` is a fast atomic read on Node's async hook stack). The benefit is that setup blocks stop carrying a five-line preamble of `const` declarations and the codegen doesn't have to plumb names through every emission path.
+
+## Current status (as of 2026-05-26)
+
+| Local | Status | Accessor | PR |
+| --- | --- | --- | --- |
+| `__threads` | ✅ pruned | `__threads()` | [#201](https://github.com/egonSchiele/agency-lang/pull/201) |
+| `__graph` | ✅ pruned (dead code) | — | this PR |
+| `statelogClient` | ✅ pruned (dead code) | — | this PR |
+| `__stateStack` | ✅ pruned | `__stateStack()` | this PR |
+| `__ctx` | ❌ still a const | `__ctx()` (defined in runtime, codegen migration deferred — see "Why `__ctx` is deferred" below) | TBD |
+
+Alongside the accessor migrations, function and node body try blocks now wrap in `await agencyStore.run({ctx, stack, threads}, async () => { ... })` (defense-in-depth — closes the gap between Runner-managed steps where the outer ALS frame could be lost by a future refactor).
+
+Migration roadmap: [docs/superpowers/plans/2026-05-26-als-migration-phase-4-cleanup.md](../superpowers/plans/2026-05-26-als-migration-phase-4-cleanup.md).
+
+### Why `__ctx` is deferred
+
+Migrating `__ctx` is structurally identical to `__threads` and `__stateStack`, but three complications make it a meaningfully larger change than the rest of Phase 4:
+
+1. **Top-level rebind for docstring interpolation.** When a module has a function or graph node with an interpolation segment in its doc string (`"version ${toolVersion}"`), the codegen emits `const __ctx = __globalCtx;` at the module top scope so the *eager* tool-registration object literal can read `__ctx.globals.get(...)`. This rebind lives at module scope alongside the runtime import — making `__ctx` a `function` import would clash with the rebind, and turning the rebind into a `__ctx()` call would return `undefined` because the eager evaluation happens before any ALS frame is installed.
+2. **`classMethod.mustache` has its own `__ctx` setup.** `const __ctx = __state?.ctx || __globalCtx;` is method-scoped and inherits the same "no ALS frame yet at the call boundary" problem.
+3. **~17 deref sites in `lib/backends/typescriptBuilder.ts`.** Each needs the lenient (`__ctx()`) vs strict (`getRuntimeContext().ctx`) decision (per the rule in the next section), and several of them sit inside top-level emission paths where ALS is genuinely not available.
+
+This PR ships the `__ctx()` accessor (in `lib/runtime/asyncContext.ts`, exported from `lib/runtime/index.ts`) so the runtime piece is ready, but defers the codegen migration to a follow-up that can handle the docstring-interpolation rewrite in isolation.
+
+## Why two flavors: `__X()` vs `getRuntimeContext().X`
+
+Both shapes read from the same ALS frame, but they behave differently when **no frame is installed**:
+
+- **`__X()`** (lenient) — `agencyStore.getStore()?.X`. Returns `undefined` when no frame. Safe at sites where the consumer either tolerates `undefined` (`setupFunction({state: {threads: __threads()}})` — `setupFunction` falls back to a fresh `ThreadStore` when `threads` is undefined) or assigns into an object property where `undefined` will surface later as a clearer error.
+- **`getRuntimeContext().X`** (strict) — throws `"getRuntimeContext() called outside an Agency execution frame..."`. Use at sites where `undefined` would dereference unactionably (e.g. `getRuntimeContext().threads.active().push(...)` — without the throw, you'd see a cryptic `Cannot read properties of undefined (reading 'active')`).
+
+Rule of thumb: **call the accessor when the value is being passed somewhere; call `getRuntimeContext().X` when the value is being immediately dereferenced.** The Copilot review on PR #201 caught one missed case at `system.mustache` where `__threads().active().push(...)` would crash with a generic TypeError — that line now uses `getRuntimeContext().threads.active().push(...)`.
+
+## File layout
+
+The accessor pattern touches one runtime file, one re-export, one import template, the IR builder, and N templates per migration:
+
+```diagram
+╭──────────────────────────────────────╮
+│ lib/runtime/asyncContext.ts          │  ← define __X(): T | undefined
+│                                      │     export function __threads() { ... }
+╰──────────────┬───────────────────────╯
+               │
+               ▼
+╭──────────────────────────────────────╮
+│ lib/runtime/index.ts                 │  ← re-export __X
+╰──────────────┬───────────────────────╯
+               │
+               ▼
+╭──────────────────────────────────────╮
+│ lib/templates/.../imports.mustache   │  ← add __X to the runtime import list
+╰──────────────┬───────────────────────╯
+               │
+               ▼
+╭──────────────────────────────────────╮     ╭──────────────────────────────╮
+│ lib/ir/builders.ts                   │     │ lib/backends/                │
+│  • ts.runtime.X → TsRaw `__X()`      │◀───▶│  typescriptBuilder.ts        │
+│  • setupEnv drops the X param        │     │  • drop X from setupEnv()    │
+│                                      │     │    callers                   │
+╰──────────────┬───────────────────────╯     │  • flip remaining `__X`      │
+               │                             │    emissions to `__X()`      │
+               ▼                             ╰──────────────────────────────╯
+╭──────────────────────────────────────╮
+│ lib/templates/.../*.mustache         │  ← flip `__X` → `__X()` in every
+│  blockSetup, classMethod, system,    │    template that referenced the
+│  debugger, interruptAssignment,      │    local
+│  interruptReturn, ...                │
+╰──────────────────────────────────────╯
+```
+
+Generated code, after a successful migration:
+
+```ts
+import {
+  ...
+  __threads, __stateStack, __ctx, getRuntimeContext,
+  ...
+} from "agency-lang/runtime";
+
+graph.node("main", async (__state: GraphState) => {
+  const __setupData = setupNode({ state: __state });
+  const __stack = __setupData.stack;
+  const __step = __setupData.step;
+  const __self = __setupData.self;
+  // No __ctx, __threads, __stateStack, statelogClient, __graph here.
+  let __forked;
+  let __functionCompleted = false;
+
+  const runner = new Runner(__ctx(), __stack, {
+    nodeContext: true,
+    state: __stack,
+    moduleId: "...",
+    scopeName: "main",
+    threads: __setupData.threads,
+  });
+
+  try {
+    // body — every reference to the old locals is now a call:
+    //   __threads().active().push(...)
+    //   __ctx().checkpoints.create(...)
+    //   __stateStack().pop()
+    // (or `getRuntimeContext().X` at strict sites)
+  } finally {
+    __stateStack()?.pop();
+  }
+});
+```
+
+## Recipe: adding a new accessor
+
+If you find yourself wanting to prune another setup-block local (or simply add a new read-from-ALS helper for stdlib JS code), follow this recipe. Estimated time: ~30 min for the code change, plus fixture regen.
+
+### 1. Define the accessor
+
+[`lib/runtime/asyncContext.ts`](../../lib/runtime/asyncContext.ts):
+
+```ts
+/**
+ * Generated-code accessor for <thing>. Returns the active
+ * agencyStore frame's <field>, or undefined when no frame is installed.
+ *
+ * For sites where undefined would dereference unactionably, prefer
+ * `getRuntimeContext().<field>` so the missing-frame case throws the
+ * dedicated error with a pointer to runInTestContext.
+ */
+export function __myThing(): MyThing | undefined {
+  return agencyStore.getStore()?.myThing;
+}
+```
+
+If the value isn't already on `AgencyStore`, extend that type:
+
+```ts
+export type AgencyStore = {
+  ctx: RuntimeContext<any>;
+  stack: StateStack;
+  threads: ThreadStore;
+  myThing: MyThing;          // new
+};
+```
+
+…and seed it at every `agencyStore.run(...)` call site: `runNode`, `Runner.runInScope`, `runBatch.runInBranchAlsFrame`, `runInBootstrapFrame`, `runInTestContext`.
+
+### 2. Re-export from `lib/runtime/index.ts`
+
+```ts
+export {
+  agencyStore,
+  getRuntimeContext,
+  runInTestContext,
+  __threads,
+  __myThing,          // new
+  type AgencyStore,
+} from "./asyncContext.js";
+```
+
+### 3. Add to `imports.mustache`
+
+Generated code can't reference `__myThing` until the runtime import list includes it. Add to [`lib/templates/backends/typescriptGenerator/imports.mustache`](../../lib/templates/backends/typescriptGenerator/imports.mustache):
+
+```
+  __call, __callMethod, __threads, __myThing, getRuntimeContext,
+```
+
+### 4. Wire the IR builder
+
+If `__myThing` will appear as a value in `ts.obj({...})`/`ts.call(...)` from `typescriptBuilder.ts`, give it an alias in [`lib/ir/builders.ts`](../../lib/ir/builders.ts) `runtime: { ... }`:
+
+```ts
+runtime: {
+  ...
+  myThing: { kind: "raw", code: "__myThing()" } as TsRaw,
+  ...
+},
+```
+
+This mirrors what `runtime.threads` became in PR #201: a `TsRaw` call expression rather than a bare `TsIdentifier`. Every `ts.runtime.myThing` reference now prints as `__myThing()`.
+
+If the old name was being declared in `setupEnv({...})`, drop the param + the `ts.constDeclId(...)` line.
+
+### 5. Flip template emission sites
+
+For each `.mustache` file that mentions `__myThing`:
+
+- **Bare reads** (`__myThing`) → `__myThing()`
+- **Strict deref sites** (`__myThing.someMethod().chain(...)`) → `getRuntimeContext().myThing.someMethod().chain(...)`
+- **Optional deref** (`__myThing.pop()` in a `finally` block that may run outside any frame) → `__myThing()?.pop()`
+
+Regenerate with `pnpm run templates` (typestache compiles `.mustache` → `.ts`).
+
+### 6. Update `typescriptBuilder.ts`
+
+Grep for the old name:
+
+```bash
+grep -n "__myThing" lib/backends/typescriptBuilder.ts
+```
+
+For each hit:
+- If it's inside `setupEnv({...})`, remove the key.
+- If it's a `ts.id("__myThing")`, replace with `ts.runtime.myThing`.
+- If it's a `ts.raw("...__myThing...")`, edit the raw string.
+
+### 7. Validate
+
+```bash
+pnpm tsc --noEmit          # clean
+pnpm run lint:structure    # clean
+pnpm test:run              # ~90 fixture failures expected
+make                       # rebuild dist + recompile stdlib
+make fixtures              # regenerate every fixture
+pnpm test:run              # 4423/4423
+```
+
+Spot-check a fixture: `grep -n "__myThing\|__myThing()" tests/typescriptBuilder/simple.mjs` — the old name should be gone, the call form present.
+
+### 8. Commit + PR
+
+Two commits per the convention:
+- `codegen: ...` — code + templates (~20 files)
+- `fixtures: regen after ...` — fixture diff (~90 files)
+
+Open with `gh pr create --body-file /tmp/body.md`. Watch for Copilot review within ~2 minutes — the strict-vs-lenient decision is the most common comment.
+
+## Gotchas
+
+### "I added the accessor but generated code still uses the old name"
+
+Three causes, in order of likelihood:
+
+1. Forgot `pnpm run templates` after editing a `.mustache`.
+2. Forgot `make fixtures` after editing codegen.
+3. Edited the generated `.ts` template file instead of the `.mustache` source. The `.ts` files in `lib/templates/backends/typescriptGenerator/` are AUTO-GENERATED with a header that says so; they get clobbered on the next `pnpm run templates`.
+
+### "tsc passes but vitest fails in fixture comparison tests"
+
+Expected after any codegen change. Run `make fixtures` and re-run vitest. If fixture diffs look bigger than the change should produce, you probably edited a template the wrong way or hit an unintended emission path; diff one fixture to confirm.
+
+### "Test passes locally but `make` fails"
+
+`make` runs `tsc` over the dist build. If you regenerated templates and a generated `.ts` import is malformed, vitest won't notice (it uses ts-node-style transforms with looser checks), but `tsc --noEmit` will. Always run `pnpm tsc --noEmit` before pushing.
+
+### "The accessor returns `undefined` but I expected a value"
+
+You're outside an `agencyStore.run(...)` frame. Three cases:
+
+- **Test harness** without `runInTestContext`. Wrap the call: `await runInTestContext(ctx, stack, threads, () => _myHelper(args))`.
+- **Bootstrap scope** (module top-level `const x = ...`, `callback(...)` registration, `onAgentStart` hook). The frame is a `BootstrapThreadStore` if you're reading `threads`; for other fields the frame is real, but reads must not assume node-body semantics. See [docs/dev/async-context.md](./async-context.md) "Frame kinds".
+- **A nested `await` after the frame was torn down.** Rare — frames propagate through normal `await` chains. If you see this, the frame was probably popped between scheduling and execution.
+
+### "Don't change `__stateStack` inside `forkBlockSetup.mustache`"
+
+[`forkBlockSetup.mustache`](../../lib/templates/backends/typescriptGenerator/forkBlockSetup.mustache) line 10 has `const __stateStack = __forkBranchStack;`. This is **not** a normal setup-block local — it's an intentional rebind to the branch-specific stack inside a fork branch body. The branch stack must not be sourced from the parent ALS frame (which has the parent's stack); the entry point for the fork branch already installs an inner ALS frame with the branch stack via `runBatch.runInBranchAlsFrame`. Leave the rebind alone when migrating `__stateStack` to `__stateStack()` elsewhere.
+
+### Runner constructor needs explicit `threads`
+
+`Runner.runInScope` re-enters ALS with `this.threads`. If the constructor didn't get `threads`, ALS frames inside steps would use the OUTER frame's `ThreadStore`, which for a tool-called function is the per-run store (wrong — should be a fresh store). Codegen MUST pass `threads: __setupData.threads` (or the equivalent) to every Runner. See PR [#200](https://github.com/egonSchiele/agency-lang/pull/200) for the bug this fixed.
+
+### `Runner.thread(id, method, callback)` reads `this.threads`
+
+Pre-migration, the signature was `Runner.thread(id, threads, method, callback)` and the codegen emitted `runner.thread(0, __threads, "create", ...)`. After PR [#201](https://github.com/egonSchiele/agency-lang/pull/201), the Runner sources `threads` from its own `this.threads` field and the codegen emits `runner.thread(0, "create", ...)`. If you build a `Runner` manually in a test, you MUST pass `threads:` to the constructor or wrap in `agencyStore.run(...)` — otherwise `runner.thread(...)` throws a clear error.
+
+## Reference: every "ALS frame" site in the runtime
+
+For grep-friendliness when adding a new field to `AgencyStore`:
+
+| Site | File | Frame kind | Notes |
+| --- | --- | --- | --- |
+| `runNode` top-level wrap | [lib/runtime/node.ts](../../lib/runtime/node.ts) | node | Wraps every fresh agent run; outer frame for all node bodies. |
+| `runNode` `onAgentStart` | [lib/runtime/node.ts](../../lib/runtime/node.ts) | bootstrap | Fires before any node runs. |
+| `runNode` `onAgentEnd` | [lib/runtime/node.ts](../../lib/runtime/node.ts) | node | Fires after the run completes — uses the real ThreadStore. |
+| `initializeGlobals` + `registerTopLevelCallbacks` | [lib/runtime/node.ts](../../lib/runtime/node.ts) | bootstrap | Module-level setup. |
+| `Runner.runInScope` | [lib/runtime/runner.ts](../../lib/runtime/runner.ts) | node | Per-step ALS re-wrap. |
+| `runBatch.runInBranchAlsFrame` | [lib/runtime/runBatch.ts](../../lib/runtime/runBatch.ts) | node (branch) | Per-fork-branch ALS with branch stack. |
+| `respondToInterrupts` resume wrap | [lib/runtime/interrupts.ts](../../lib/runtime/interrupts.ts) | bootstrap | Resume from interrupt. |
+| `rewindFrom` replay wrap | [lib/runtime/rewind.ts](../../lib/runtime/rewind.ts) | bootstrap | Replay from checkpoint. |
+| `runInTestContext` | [lib/runtime/asyncContext.ts](../../lib/runtime/asyncContext.ts) | test | Convenience wrapper for unit tests. |
+
+When you add a new field to `AgencyStore`, every entry in this table needs to seed that field. Forgetting one site is the most common source of "the accessor returns undefined" bugs.
+
+## Reference: every emission site that touches a setup-block local
+
+Use this as a checklist when migrating one of the remaining locals (`__ctx`, `__stateStack`):
+
+- IR builder: `lib/ir/builders.ts` → `ts.runtime.X` definition, `setupEnv({...})` signature + body, any helper that constructs an identifier from the name.
+- Backend: `lib/backends/typescriptBuilder.ts` → search for the bare name; both function-body emission (around line 1473) and node-body emission (around line 2179) call `setupEnv`. Other raw-string emissions of `__X.method(...)` need updating individually.
+- Templates: `lib/templates/backends/typescriptGenerator/`:
+  - `blockSetup.mustache`
+  - `forkBlockSetup.mustache` (caveat: `__stateStack` rebind, see Gotchas)
+  - `classMethod.mustache`
+  - `debugger.mustache`
+  - `interruptAssignment.mustache`
+  - `interruptReturn.mustache`
+  - `resultCheckpointSetup.mustache`
+  - `functionCatchFailure.mustache`
+  - `builtinFunctions/system.mustache` (and any other per-builtin templates)
+- Generated mirrors in `lib/templates/.../*.ts` — auto-regenerated by `pnpm run templates`. Never edit by hand.
+- Runtime helpers: `lib/runtime/runner.ts` if Runner method signatures referenced the value as a positional arg (rare — `Runner.thread(...)` is the example).
+
+## Related docs
+
+- [docs/dev/async-context.md](./async-context.md) — `agencyStore` itself, frame seeding sites, frame kinds.
+- [docs/dev/typescript-ir.md](./typescript-ir.md) — TsNode tree the IR builders produce.
+- [docs/dev/threads.md](./threads.md) — `ThreadStore` and `MessageThread` design.
+- [docs/superpowers/plans/2026-05-26-als-migration-phase-4-cleanup.md](../superpowers/plans/2026-05-26-als-migration-phase-4-cleanup.md) — outstanding migration tasks.

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-26-als-migration-phase-4-cleanup.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-26-als-migration-phase-4-cleanup.md
@@ -1,0 +1,674 @@
+# ALS Migration Phase 4 Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Finish pruning the codegen-emitted setup-block locals (`__graph`, `statelogClient`, `__stateStack`, `__ctx`) so generated agency code reads runtime context from `agencyStore` (ALS) instead of from per-scope `const` declarations, and add a body-level `agencyStore.run` wrap as defense-in-depth.
+
+**Architecture:** Each local being pruned gets the same treatment that `__threads` got in PR #201:
+
+1. Introduce a tiny `__<name>()` accessor in `lib/runtime/asyncContext.ts` that reads from the active `agencyStore` frame (or returns `undefined` when no frame is installed, matching pre-migration lenient behavior).
+2. Export the accessor from `lib/runtime/index.ts`, add to `imports.mustache`.
+3. Flip every `__X` reference in `lib/templates/.../*.mustache` and the IR builders (`lib/ir/builders.ts` / `prettyPrint.ts`) to `__X()` (or `getRuntimeContext().X` at sites where a `TypeError` from an undefined dereference would be unactionable — see PR #201's `system.mustache` precedent).
+4. Drop the `const __X = ...` declaration from `setupEnv()` in `lib/ir/builders.ts` and from the corresponding `setupEnv({...})` calls in `lib/backends/typescriptBuilder.ts`.
+5. For `classMethod.mustache`, drop the explicit `const __X = ...` line and inline the source (e.g. `__setupData.threads` style) where still needed.
+6. Regenerate templates (`pnpm run templates`), commit code + templates.
+7. Regenerate fixtures (`make fixtures`), commit fixtures.
+8. Push, open PR, watch Copilot review.
+
+**Tech Stack:** TypeScript, typestache mustache templates, vitest, the existing `lib/runtime/asyncContext.ts` ALS infrastructure (`agencyStore`, `getRuntimeContext`, `runInBootstrapFrame`, `BootstrapThreadStore`).
+
+**Workflow conventions (apply to every task):**
+
+- Create a fresh worktree per PR: `git worktree add -b <branch-name> .worktrees/<branch-name> main` from `/Users/adityabhargava/agency-lang/packages/agency-lang/`. The agency-lang package lives at `.worktrees/<branch-name>/packages/agency-lang/`.
+- After `git worktree add`, run `pnpm install` in the worktree (templates and stdlib build depend on it).
+- Commit code + templates in one commit, then fixture regen in a separate follow-up commit on the same PR. Reviewers can stop at the first commit.
+- Templates: only edit `.mustache`; run `pnpm run templates` to regenerate the `.ts`. Commit both.
+- Commit messages and PR bodies via file (`git commit -F /tmp/msg.txt`, `gh pr create --body-file /tmp/body.md`) — apostrophes break on the command line.
+- Validation: `pnpm tsc --noEmit && pnpm run lint:structure && pnpm test:run`. Do NOT run the full agency suite locally — CI runs it.
+- Save test output to a file (`pnpm test:run 2>&1 | tee /tmp/vitest-out.log | tail -10`) so re-runs aren't needed.
+
+---
+
+## Task 1: Prune dead `__graph` and `statelogClient` locals
+
+**Why:** These two `setupEnv` locals are declared in every generated function/node setup block (and `classMethod`) but **never referenced** by any other template, IR builder, or codegen path. `grep -rEn "\\b__graph\\b" lib/` only finds the declaration site itself. Same for `statelogClient`. This is the smallest possible win — pure dead-code removal with no ALS work.
+
+**Files:**
+- Modify: `lib/ir/builders.ts:542-577` (drop `statelogClient` and `graph` params + `constDeclId` lines from `setupEnv`)
+- Modify: `lib/backends/typescriptBuilder.ts:1473-1482` (drop `statelogClient:` and `graph:` from setupEnv call in function-body emission)
+- Modify: `lib/backends/typescriptBuilder.ts:2179-2188` (drop them from node-body emission)
+- Modify: `lib/templates/backends/typescriptGenerator/classMethod.mustache:7-8` (drop the two `const` lines)
+
+**Estimated fixture fan-out:** ~90 files (every generated module loses 2 lines).
+
+### Steps
+
+- [ ] **Step 1: Create worktree**
+
+```bash
+git worktree add -b prune-dead-setup-locals .worktrees/prune-dead-setup-locals main
+cd .worktrees/prune-dead-setup-locals/packages/agency-lang
+pnpm install
+```
+
+- [ ] **Step 2: Verify the dead-local claim**
+
+```bash
+grep -rEn "\b__graph\b" lib/ stdlib/ | grep -v "\.ts:" | grep -v "/runtime/" | head
+grep -rEn "\bstatelogClient\b" lib/templates/ lib/ir/ lib/backends/typescriptBuilder.ts | head
+```
+
+Expected: only the declaration sites in `setupEnv`, `classMethod.mustache`, and (for `statelogClient`) the two `setupEnv` calls in `typescriptBuilder.ts`. If anything else uses them, STOP and reassess scope.
+
+- [ ] **Step 3: Edit `lib/ir/builders.ts`'s `setupEnv`**
+
+Drop `statelogClient` and `graph` from both the destructuring params and the `TsStatements` array. The signature becomes:
+
+```ts
+setupEnv({
+  stateStack,
+  stack,
+  step,
+  self,
+  ctx,
+}: {
+  stateStack?: TsNode;
+  stack: TsNode;
+  step: TsNode;
+  self: TsNode;
+  ctx: TsNode;
+}): TsStatements {
+  return ts.statements([
+    ...(stateStack ? [ts.constDecl("__stateStack", stateStack)] : []),
+    ts.constDeclId(ts.runtime.stack, stack),
+    ts.constDeclId(ts.runtime.step, step),
+    ts.constDeclId(ts.runtime.self, self),
+    ts.constDeclId(ts.runtime.ctx, ctx),
+    ts.letDecl("__forked"),
+    ts.letDecl("__functionCompleted", ts.bool(false)),
+  ]);
+},
+```
+
+Also remove `statelogClient` and `graph` from `ts.runtime` if they have no other consumers (they don't — these were only used by `setupEnv`):
+
+```bash
+grep -n "runtime\.statelogClient\|runtime\.graph" lib/
+```
+
+If only `setupEnv` referenced them, drop the entries from the `runtime: { ... }` object at the bottom of `builders.ts`.
+
+- [ ] **Step 4: Update both `setupEnv` callers in `lib/backends/typescriptBuilder.ts`**
+
+Search for `setupEnv({` (two hits, around lines 1473 and 2179). Remove the `statelogClient: ts.ctx("statelogClient"),` and `graph: ts.ctx("graph"),` lines from both.
+
+- [ ] **Step 5: Edit `classMethod.mustache`**
+
+Remove:
+```
+    const statelogClient = __ctx.statelogClient;
+    const __graph = __ctx.graph;
+```
+
+- [ ] **Step 6: Regenerate templates**
+
+```bash
+pnpm run templates
+```
+
+Verify the generated `classMethod.ts` no longer mentions either local.
+
+- [ ] **Step 7: Type-check + lint + tests**
+
+```bash
+pnpm tsc --noEmit
+pnpm run lint:structure
+pnpm test:run 2>&1 | tee /tmp/vitest-dead-locals.log | tail -20
+```
+
+Expected: tsc clean, lint clean, fixture comparison tests fail (vitest reports ~90 failures, all of form "expected vs received — `statelogClient` / `__graph` lines missing"). Other tests should pass.
+
+- [ ] **Step 8: Build + fixture regen**
+
+```bash
+make           # rebuild dist so stdlib codegen reflects the change
+make fixtures  # regen integration test fixtures
+```
+
+- [ ] **Step 9: Re-run vitest, confirm 4423/4423 pass**
+
+```bash
+pnpm test:run 2>&1 | tee /tmp/vitest-dead-locals-2.log | tail -10
+```
+
+- [ ] **Step 10: Spot-check fixtures**
+
+```bash
+grep -n "__graph\|statelogClient" tests/typescriptBuilder/simple.mjs
+# Expected: no output
+```
+
+- [ ] **Step 11: Commit code + templates**
+
+```bash
+git add lib/ir/builders.ts lib/backends/typescriptBuilder.ts \
+  lib/templates/backends/typescriptGenerator/classMethod.mustache \
+  lib/templates/backends/typescriptGenerator/classMethod.ts
+cat > /tmp/commit-dead-locals.txt <<'EOF'
+codegen: remove dead __graph and statelogClient setup locals
+
+The setupEnv helper declares `const __graph = ...` and
+`const statelogClient = ...` (also redeclared in classMethod.mustache),
+but no template, IR builder, or downstream codegen path ever references
+either local. Verified via grep across lib/templates, lib/ir, and
+lib/backends — only the declaration sites match. Drop both declarations
+and the corresponding ts.runtime entries.
+
+Pure dead-code removal — no ALS work. The accessor migrations for
+__ctx and __stateStack land in follow-up PRs.
+
+Fixture regen lands in the next commit.
+EOF
+git commit -F /tmp/commit-dead-locals.txt
+```
+
+- [ ] **Step 12: Commit fixtures**
+
+```bash
+git add -A
+cat > /tmp/commit-dead-locals-fixtures.txt <<'EOF'
+fixtures: regen after removing dead __graph and statelogClient locals
+
+Generated via `make fixtures`.
+EOF
+git commit -F /tmp/commit-dead-locals-fixtures.txt
+```
+
+- [ ] **Step 13: Push + open PR**
+
+```bash
+git push -u origin prune-dead-setup-locals
+gh pr create --base main \
+  --title "codegen: remove dead __graph and statelogClient setup locals" \
+  --body-file /tmp/pr-dead-locals.md
+```
+
+PR body talks about: dead-code finding, grep-based verification, no behavior change.
+
+- [ ] **Step 14: Watch Copilot review**
+
+```bash
+sleep 90 && gh api repos/egonSchiele/agency-lang/pulls/<N>/comments --jq '.[] | {path, line, body}'
+```
+
+If comments arrive, address them in a follow-up commit (do NOT amend).
+
+---
+
+## Task 2: Prune `__stateStack` local via `__stateStack()` accessor
+
+**Why:** `__stateStack` is one of the four remaining setup-block locals. It has real consumers (passed to `checkpoints.create*` and `interruptWithHandlers`) so this PR is the template for migrating non-dead locals.
+
+**Files:**
+- Modify: `lib/runtime/asyncContext.ts` — add `__stateStack()` accessor next to `__threads()`
+- Modify: `lib/runtime/index.ts` — export `__stateStack`
+- Modify: `lib/templates/backends/typescriptGenerator/imports.mustache` — add `__stateStack` to runtime import list
+- Modify: `lib/ir/builders.ts` — drop `stateStack` from `setupEnv`, change `runtime.stateStack` (if it exists) or introduce one
+- Modify: `lib/backends/typescriptBuilder.ts` — drop `stateStack:` from both `setupEnv` calls; flip the two `ts.id("__stateStack")` / `ts.raw("__stateStack.pop()")` references at lines ~1593, ~2095, ~2136 to `__stateStack()` calls. Note: `__stateStack.pop()` happens inside `finally` blocks on Runner-managed state — it removes the frame this scope pushed. After ALS migration we still need to pop; just change to `__stateStack().pop()`.
+- Modify: `lib/templates/backends/typescriptGenerator/classMethod.mustache:27` — `__stateStack.pop()` → `__stateStack().pop()`
+- Modify: `lib/templates/backends/typescriptGenerator/resultCheckpointSetup.mustache:3` — `__ctx.checkpoints.createPinned(__stateStack, ...)` → `... (__stateStack(), ...)`
+- Modify: `lib/templates/backends/typescriptGenerator/interruptReturn.mustache` — lines 18, 32 (both `__stateStack` references)
+- Modify: `lib/templates/backends/typescriptGenerator/interruptAssignment.mustache` — lines 22, 38
+
+**Special case — `forkBlockSetup.mustache:10`:** `const __stateStack = __forkBranchStack;` — this is a local rebind inside a fork branch body. Leave it alone (or rename `__forkBranchStack` directly into the fork emission and drop the alias). The accessor would not return the branch-specific stack here. Document this exception in the PR body.
+
+**Estimated fixture fan-out:** ~90 files.
+
+### Steps
+
+- [ ] **Step 1: Create worktree, install**
+
+```bash
+git worktree add -b prune-stateStack-local .worktrees/prune-stateStack-local main
+cd .worktrees/prune-stateStack-local/packages/agency-lang
+pnpm install
+```
+
+- [ ] **Step 2: Add the `__stateStack()` accessor**
+
+In `lib/runtime/asyncContext.ts`, right after `__threads()`:
+
+```ts
+/**
+ * Generated-code accessor for the current StateStack. Mirrors __threads()
+ * — reads from the active agencyStore frame. Returns undefined when no
+ * frame is installed; the only emission site that can hit that path is
+ * the finally-block `__stateStack().pop()` in classMethod scopes called
+ * outside any Agency execution frame (e.g. as a tool by an LLM where no
+ * outer ALS frame is set). The optional chaining at the call site
+ * (templates emit `__stateStack()?.pop()` there) handles that cleanly.
+ *
+ * Sites where undefined would crash unactionably (e.g.
+ * `interruptWithHandlers(..., __stateStack(), ...)`) should call
+ * getRuntimeContext().stack directly to get the strict-throw error.
+ */
+export function __stateStack(): StateStack | undefined {
+  return agencyStore.getStore()?.stack;
+}
+```
+
+Add `import type { StateStack } from "./state/stateStack.js";` to the file's existing imports.
+
+- [ ] **Step 3: Export from `lib/runtime/index.ts`**
+
+Add `__stateStack` to the existing `asyncContext.js` re-export.
+
+- [ ] **Step 4: Add to imports template**
+
+In `lib/templates/backends/typescriptGenerator/imports.mustache:27`:
+
+```
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext,
+```
+
+- [ ] **Step 5: Flip template emission sites**
+
+For each `.mustache` file in the Files list, replace `__stateStack` references with `__stateStack()`. Use `sed -i ''` for bulk changes but verify each one is in a safe context (no chained access on potentially-undefined values without optional chaining):
+
+```bash
+# classMethod.mustache finally block: use optional chaining
+sed -i '' 's/__stateStack\.pop()/__stateStack()?.pop()/' \
+  lib/templates/backends/typescriptGenerator/classMethod.mustache
+
+# Other sites pass __stateStack as an argument — switch to plain call:
+for f in lib/templates/backends/typescriptGenerator/resultCheckpointSetup.mustache \
+         lib/templates/backends/typescriptGenerator/interruptReturn.mustache \
+         lib/templates/backends/typescriptGenerator/interruptAssignment.mustache; do
+  # Match `__stateStack` NOT followed by `()` and not preceded by `__`
+  sed -i '' -E 's/([(, ])__stateStack([,)])/\1__stateStack()\2/g' "$f"
+done
+```
+
+After the substitutions, diff each file and visually confirm. Then regenerate `.ts` via `pnpm run templates`.
+
+- [ ] **Step 6: Update `lib/ir/builders.ts`**
+
+Remove `stateStack` from the `setupEnv` signature and body:
+
+```ts
+setupEnv({
+  stack,
+  step,
+  self,
+  ctx,
+}: {
+  stack: TsNode;
+  step: TsNode;
+  self: TsNode;
+  ctx: TsNode;
+}): TsStatements {
+  return ts.statements([
+    ts.constDeclId(ts.runtime.stack, stack),
+    ts.constDeclId(ts.runtime.step, step),
+    ts.constDeclId(ts.runtime.self, self),
+    ts.constDeclId(ts.runtime.ctx, ctx),
+    ts.letDecl("__forked"),
+    ts.letDecl("__functionCompleted", ts.bool(false)),
+  ]);
+},
+```
+
+If `ts.runtime.stack` referred to the State frame (not the StateStack), introduce a `ts.runtime.stateStack` as a TsRaw call expression (like `ts.runtime.threads` now is): `{ kind: "raw", code: "__stateStack()" } as TsRaw`.
+
+- [ ] **Step 7: Update `lib/backends/typescriptBuilder.ts`**
+
+- Lines 1473, 2179: drop `stateStack:` from the `setupEnv({...})` calls.
+- Line 2095: `ts.id("__stateStack")` → `ts.runtime.stateStack` (or `ts.raw("__stateStack()")`).
+- Lines 1593, 2136: `ts.raw("__stateStack.pop()")` → `ts.raw("__stateStack()?.pop()")`.
+
+- [ ] **Step 8: Regenerate templates, build, validate**
+
+```bash
+pnpm run templates
+make
+pnpm tsc --noEmit
+pnpm run lint:structure
+pnpm test:run 2>&1 | tee /tmp/vitest-stateStack-1.log | tail -20
+```
+
+Expect ~90 fixture failures.
+
+- [ ] **Step 9: Regen fixtures + re-validate**
+
+```bash
+make fixtures
+pnpm test:run 2>&1 | tee /tmp/vitest-stateStack-2.log | tail -10
+```
+
+Should show 4423/4423 passing.
+
+- [ ] **Step 10: Spot-check a generated file**
+
+```bash
+grep -n "__stateStack" tests/typescriptBuilder/simple.mjs | head
+# Expect: __stateStack() or __stateStack()?.pop() — no bare __stateStack
+```
+
+- [ ] **Step 11: Commit code + templates, fixtures, push, open PR**
+
+Mirror Task 1's commit/PR pattern. Commit message templates:
+
+```text
+codegen: drop __stateStack local, read via ALS accessor
+
+Follow-up to PR #201 (__threads accessor). Adds an __stateStack()
+accessor in lib/runtime/asyncContext.ts that returns the active
+agencyStore frame's StateStack (or undefined when no frame). Every
+template, IR builder, and typescriptBuilder.ts emission site flips
+from `__stateStack` to `__stateStack()`. setupEnv no longer declares
+the const; classMethod.mustache uses `__stateStack()?.pop()` in the
+finally block (the only call site that can run outside a frame).
+
+forkBlockSetup.mustache's `const __stateStack = __forkBranchStack;`
+is left untouched — that's an intentional local rebind to the
+fork-branch stack and shouldn't be sourced from the parent ALS frame.
+
+Fixture regen lands in the next commit.
+```
+
+Open the PR with `gh pr create --base main`.
+
+- [ ] **Step 12: Watch Copilot review, fix any issues in follow-up commits.**
+
+---
+
+## Task 3: Prune `__ctx` local via `__ctx()` accessor
+
+**Why:** Final and largest local prune. `__ctx` is referenced ~17 times in `typescriptBuilder.ts` and many times in every template (`__ctx.checkpoints.*`, `__ctx.getInterruptResponse(...)`, `__ctx.globals.*`, etc.). After this, `setupEnv` reduces to just `__stack/__step/__self/__forked/__functionCompleted` and `classMethod.mustache` becomes much leaner.
+
+**Files:**
+- Modify: `lib/runtime/asyncContext.ts` — add `__ctx()` accessor
+- Modify: `lib/runtime/index.ts` — export `__ctx`
+- Modify: `lib/templates/backends/typescriptGenerator/imports.mustache` — add `__ctx` to import list
+- Modify: `lib/ir/builders.ts` — drop `ctx` from `setupEnv` signature/body; change `ts.runtime.ctx` (line 734) to a `TsRaw` `__ctx()` call (mirrors what `ts.runtime.threads` became in PR #201)
+- Modify: `lib/backends/typescriptBuilder.ts` — drop `ctx:` from both `setupEnv` calls; audit every emission site that builds raw strings containing `__ctx` (e.g. lines around 1487 for `__ctx.globals.isInitialized`, 1489 for `__initializeGlobals(__ctx)`); these need to switch to `__ctx()`
+- Modify: every template that uses `__ctx`:
+  - `blockSetup.mustache:1,7,12`
+  - `classMethod.mustache:6,7,8,11,12,14` (drop the `const __ctx = ...` line on 6, change every other reference to `__ctx()`)
+  - `debugger.mustache:1` (`debugStep(__ctx, ...)` → `debugStep(__ctx(), ...)` — caveat: if the call is in a node-context where `__ctx()` MUST be non-undefined, prefer `getRuntimeContext().ctx`)
+  - `interruptReturn.mustache:2,12,18,24,32,34`
+  - `interruptAssignment.mustache:2,16,22,28,38,40`
+  - `resultCheckpointSetup.mustache:2,3,5,6,7`
+  - `functionCatchFailure.mustache:15`
+- Modify: `lib/runtime/runner.ts` — the codegen-emitted `__ctx?.getResultCheckpoint()` (`runner.haltResult` may carry it) needs no change; runtime helpers already use `getRuntimeContext().ctx` directly.
+
+**Decision: lenient `__ctx()` vs strict `getRuntimeContext().ctx`.** Same trade-off as `__threads()` in PR #201. Recommend `__ctx()` for sites that:
+- Pass `__ctx` as an argument to a function that itself uses ALS (e.g. `__initializeGlobals(__ctx())` — but actually `__initializeGlobals` reads from ALS, so the argument can be dropped entirely; verify against the helper's signature).
+- Read a property that's typed `| undefined`-tolerant by the consumer.
+
+Use `getRuntimeContext().ctx` at sites where a `Cannot read properties of undefined` would be opaque:
+- `__ctx.checkpoints.create(...)` — checkpoint creation outside an ALS frame is a programmer error worth a clear message.
+- `__ctx.getInterruptResponse(...)` — same.
+
+**Estimated fixture fan-out:** ~90 files. Diff per file will be substantially larger than `__threads` because `__ctx` appears in many more lines.
+
+### Steps
+
+- [ ] **Step 1: Create worktree, install**
+
+```bash
+git worktree add -b prune-ctx-local .worktrees/prune-ctx-local main
+cd .worktrees/prune-ctx-local/packages/agency-lang
+pnpm install
+```
+
+- [ ] **Step 2: Add `__ctx()` accessor**
+
+In `lib/runtime/asyncContext.ts`, next to `__threads()` and `__stateStack()`:
+
+```ts
+/**
+ * Generated-code accessor for the current RuntimeContext. Returns the
+ * `ctx` field of the active agencyStore frame, or undefined when no
+ * frame is installed. See the strict/lenient guidance in
+ * docs/dev/async-context.md — emission sites that would crash
+ * unactionably on undefined should use `getRuntimeContext().ctx`
+ * instead.
+ */
+export function __ctx(): RuntimeContext<any> | undefined {
+  return agencyStore.getStore()?.ctx;
+}
+```
+
+- [ ] **Step 3: Export, add to imports template** (same pattern as Tasks 1+2)
+
+- [ ] **Step 4: Update `ts.runtime.ctx` in `lib/ir/builders.ts`**
+
+```ts
+ctx: { kind: "raw", code: "__ctx()" } as TsRaw,
+```
+
+Drop `ctx` from `setupEnv`. Update the `ts.ctx(varName)` helper if it still references `ts.runtime.ctx`:
+
+```ts
+ctx(varName: string): TsNode {
+  return ts.prop(ts.runtime.ctx, varName);
+},
+```
+
+`ts.prop(<TsRaw>, "X")` should emit `__ctx().X`. Confirm via a unit test or manual probe.
+
+- [ ] **Step 5: Flip each template**
+
+For each template in the Files list, change `__ctx` → `__ctx()` *except* for sites flagged "strict" (use `getRuntimeContext().ctx` there). Suggested decisions:
+
+- `__ctx.checkpoints.*` → `getRuntimeContext().ctx.checkpoints.*`
+- `__ctx.getInterruptResponse` → `getRuntimeContext().ctx.getInterruptResponse`
+- `__ctx.getResultCheckpoint` → `__ctx()?.getResultCheckpoint()` (sites are inside `failure(...)` constructors where undefined would degrade gracefully)
+- `__ctx._pendingArgOverrides` and `__ctx.globals.isInitialized` → `__ctx().*` if always inside a Runner frame
+
+Document each decision in the PR body.
+
+- [ ] **Step 6: Update `lib/backends/typescriptBuilder.ts`**
+
+Search for every `ts.id("__ctx")`, `ts.raw("...__ctx...")`, and `ts.ctx(...)`. Roughly 17 sites. For each, decide strict-vs-lenient and rewrite. Easiest mechanical pattern:
+
+```bash
+grep -n "__ctx" lib/backends/typescriptBuilder.ts
+```
+
+- [ ] **Step 7: Regenerate templates, build, validate**
+
+```bash
+pnpm run templates
+make
+pnpm tsc --noEmit
+pnpm run lint:structure
+pnpm test:run 2>&1 | tee /tmp/vitest-ctx-1.log | tail -20
+```
+
+Expect ~90 fixture failures.
+
+- [ ] **Step 8: Regen fixtures, re-validate**
+
+```bash
+make fixtures
+pnpm test:run 2>&1 | tee /tmp/vitest-ctx-2.log | tail -10
+```
+
+Confirm 4423/4423.
+
+- [ ] **Step 9: Diff a representative fixture, sanity-check codegen**
+
+```bash
+git diff tests/typescriptBuilder/simple.mjs | head -60
+```
+
+Look for: no bare `__ctx` declaration, all `__ctx` references now `__ctx()` or `getRuntimeContext().ctx`.
+
+- [ ] **Step 10: Commit code + templates, fixtures, push, open PR**
+
+```text
+codegen: drop __ctx local, read via ALS accessor
+
+The third and largest local in the Phase 4 cleanup. setupEnv no
+longer declares `const __ctx = ...`. Every reference in templates
+and typescriptBuilder.ts flips to either:
+
+  - `__ctx()` — lenient, returns undefined outside any ALS frame.
+    Used at sites where degradation is graceful (failure(...)
+    constructors that can carry an undefined checkpoint).
+  - `getRuntimeContext().ctx` — strict throw. Used at sites where
+    undefined would produce an opaque TypeError (checkpoint
+    creation, interrupt response lookup, global initialization
+    guards). Mirrors the system.mustache decision from PR #201.
+
+After this PR, the setup block becomes: __stack, __step, __self,
+__forked, __functionCompleted. classMethod.mustache loses the
+`const __ctx = ...` line entirely.
+
+Fixture regen lands in the next commit.
+```
+
+- [ ] **Step 11: Address Copilot review.**
+
+---
+
+## Task 4: Body-level `agencyStore.run` wrap
+
+**Why:** Defense in depth. Today, each `Runner.step` body re-enters ALS via `Runner.runInScope`, but code that runs *between* Runner steps (the `try { ... }` body of a function/node, hooks, finally blocks) runs in whatever outer ALS frame happened to be installed. Nothing user-facing reaches that gap today, but the gap means a future refactor could silently lose the per-scope frame. Wrapping the whole try block in `agencyStore.run({ ctx, stack, threads }, async () => { ... })` makes the contract explicit and removes the gap.
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder.ts` — function-body emission (~1573) and node-body emission (~2214). Wrap the `ts.tryCatch(...)` body inside `agencyStore.run({ ... }, async () => { <body> })`. The `agencyStore` import needs to be added to `imports.mustache` if not present.
+- Modify: `lib/templates/backends/typescriptGenerator/classMethod.mustache:19-29` — wrap the `try { ... } catch { ... } finally { ... }` block.
+
+**Subtleties:**
+- The `finally` block currently does `__stateStack.pop()` (or `__stateStack()?.pop()` post-Task 2). After wrapping, the pop runs inside the ALS frame — that's fine, no semantic difference.
+- The `runner` variable must be declared OUTSIDE the `agencyStore.run` wrap so it's visible from both the wrap and the `if (runner.halted)` check after.
+- Async closure: `agencyStore.run` accepts a function whose return value is the wrapped fn's return. Make sure to `return await agencyStore.run(...)` so the surrounding `async` function awaits the inner block.
+
+**Estimated fixture fan-out:** ~90 files (every generated function/node body gets the wrap).
+
+### Steps
+
+- [ ] **Step 1: Create worktree, install** (same as prior tasks)
+
+- [ ] **Step 2: Sketch the desired generated code**
+
+Before:
+```ts
+const runner = new Runner(...);
+try {
+  // body
+} catch (...) {
+  // ...
+} finally {
+  __stateStack()?.pop();
+}
+```
+
+After:
+```ts
+const runner = new Runner(...);
+try {
+  await agencyStore.run(
+    { ctx: __setupData.ctx, stack: __setupData.stack, threads: __setupData.threads },
+    async () => {
+      // body
+    },
+  );
+} catch (...) {
+  // ...
+} finally {
+  __stateStack()?.pop();
+}
+```
+
+- [ ] **Step 3: Edit `typescriptBuilder.ts` to emit the wrap**
+
+Update both `ts.tryCatch` emission sites (function-body around line 1573; node-body around line 2214). Wrap their `body` argument in an `agencyStore.run(...)` call expression.
+
+Create a small builder in `lib/ir/builders.ts`:
+
+```ts
+/** Wrap a block body in `await agencyStore.run({ ctx, stack, threads }, async () => { ... })`. */
+withAlsFrame(body: TsNode[]): TsNode {
+  return ts.raw(
+    `await agencyStore.run(
+      { ctx: __setupData.ctx, stack: __setupData.stack, threads: __setupData.threads },
+      async () => {
+${body.map((n) => printTs(n, 1)).join("\n")}
+      },
+    );`
+  );
+}
+```
+
+(Or refactor to use proper IR nodes once the pattern works.)
+
+- [ ] **Step 4: Ensure `agencyStore` is imported**
+
+Check `imports.mustache:9-30`. `agencyStore` is exported from `agency-lang/runtime` but probably not imported into generated code yet. Add it.
+
+- [ ] **Step 5: Edit `classMethod.mustache`**
+
+Wrap the `try { ... }` body the same way.
+
+- [ ] **Step 6: Regenerate templates, build, validate, regen fixtures, re-validate** (standard cycle)
+
+- [ ] **Step 7: Sanity-test a real Agency program with the new wrap**
+
+```bash
+cat > /tmp/wrap-smoke.agency <<'EOF'
+def double(x: number): number {
+  return x * 2
+}
+
+node main(): number {
+  return double(21)
+}
+EOF
+pnpm run agency /tmp/wrap-smoke.agency
+# Expect: 42
+```
+
+If this crashes, the wrap is malformed.
+
+- [ ] **Step 8: Commit, push, PR** (standard workflow)
+
+PR body should explicitly call out: no behavior change today, but closes the gap between Runner-step entries; future work that adds code to the try block body will see the right ALS frame automatically.
+
+---
+
+## Task 5: Remove `class` from Agency (separate workstream)
+
+**Why:** Out of scope for the ALS migration but mentioned in the original handoff as upcoming work that would simplify codegen further. Removing classes deletes `classMethod.mustache` entirely and folds class-emitter logic out of `lib/backends/typescriptBuilder/classEmitter.ts`. The user said to do ALS work first, then this.
+
+**This is a placeholder.** Do NOT execute this task as part of the ALS-cleanup plan. When the user is ready, brainstorm a separate spec. Notes that will help that future work:
+
+- `classEmitter.ts` is one of the bigger files under `lib/backends/typescriptBuilder/`.
+- The parser has `class` / `extends` / `new` / `super` keywords — see `lib/parsers/`. Removal needs parser, AST, type checker, and codegen passes.
+- `lib/types/classDefinition.ts` defines the AST node.
+- ~30 test fixtures under `tests/typescriptGenerator/` (`class-*.mjs`) need to be deleted or migrated to plain object/function patterns.
+- Documentation: `docs/site/guide/` likely has class examples to remove.
+
+---
+
+## Verification checklist (apply at the end of every task)
+
+- [ ] `pnpm tsc --noEmit` — clean
+- [ ] `pnpm run lint:structure` — clean
+- [ ] `pnpm test:run` — 4423/4423 pass
+- [ ] `make` — builds without error
+- [ ] Spot-checked a representative fixture for the expected codegen shape
+- [ ] No bare references to the pruned local in `tests/typescriptBuilder/`, `tests/typescriptGenerator/`, `tests/debugger/`, or `stdlib/*.js`
+- [ ] Commits split: code + templates in commit 1, fixtures in commit 2
+- [ ] PR body documents which sites picked `__X()` vs `getRuntimeContext().X` and why
+- [ ] Copilot review checked within ~2 minutes of opening the PR (`gh api repos/.../pulls/<N>/comments`)
+
+## Open questions / risks
+
+- **`__ctx()` returning undefined.** Once `__ctx` becomes a function call, the cost is one function call per access — many per node body. Negligible runtime cost but verifies the call shape. If profiling shows it, cache locally in hot paths (`const ctx = __ctx();`).
+- **Fixtures cap.** Each PR regenerates ~90 fixtures. If multiple PRs land in parallel, expect merge conflicts on the same fixture files. Sequence the PRs — merge one before opening the next.
+- **Class removal interaction.** If classes are removed before Task 3 lands, `classMethod.mustache` disappears and that edit drops out. The plan still works; just skip the classMethod edit.
+- **Real-LLM CI flakiness.** Independent issue (see ampcode thread for diagnosis). Don't conflate flaky thread/memory test failures with regressions from these PRs.

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1581,9 +1581,15 @@ export class TypeScriptBuilder {
           // callback site re-seeds ALS via Runner.runInScope, but the
           // wrap closes the gap for code that runs between steps and
           // makes the per-scope frame contract explicit.
+          //
+          // `stack:` carries the StateStack (not the current State
+          // frame) — matches what the now-pruned `const __stateStack =
+          // __setupData.stateStack;` line used to bind, so
+          // `__stateStack()` reads inside the wrap return a real
+          // StateStack rather than a per-frame State.
           ts.withAlsFrame({
             ctx: ts.id("__ctx"),
-            stack: ts.id("__stack"),
+            stack: $(ts.id("__setupData")).prop("stateStack").done(),
             threads: $(ts.id("__setupData")).prop("threads").done(),
             body: [
               ...onFunctionStartHook,
@@ -2248,9 +2254,15 @@ export class TypeScriptBuilder {
           // inner callback may bare-`return` from `runner.halt(...)`
           // emissions, and we want the outer node arrow to keep
           // running into the halted check / onNodeEnd / final return.
+          //
+          // `stack:` carries the StateStack (not the current State
+          // frame) — matches what the now-pruned `const __stateStack =
+          // __state.ctx.stateStack;` line used to bind, so
+          // `__stateStack()` reads inside the wrap return a real
+          // StateStack rather than a per-frame State.
           ts.withAlsFrame({
             ctx: ts.id("__ctx"),
-            stack: ts.id("__stack"),
+            stack: ts.raw("__ctx.stateStack"),
             threads: $(ts.id("__setupData")).prop("threads").done(),
             body: [
               ts.runnerHookStep({

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1471,13 +1471,10 @@ export class TypeScriptBuilder {
         "__state will be undefined if this function is being called as a tool by an llm",
       ),
       ts.setupEnv({
-        stateStack: $(ts.id("__setupData")).prop("stateStack").done(),
         stack: $(ts.id("__setupData")).prop("stack").done(),
         step: $(ts.id("__setupData")).prop("step").done(),
         self: $(ts.id("__setupData")).prop("self").done(),
         ctx: ts.raw("__state?.ctx || __globalCtx"),
-        statelogClient: ts.ctx("statelogClient"),
-        graph: ts.ctx("graph"),
       }),
 
       // Ensure this module's globals are initialized on the current ctx.
@@ -1574,10 +1571,25 @@ export class TypeScriptBuilder {
     setupStmts.push(
       ts.tryCatch(
         ts.statements([
+          // Validation guards stay OUTSIDE the agencyStore.run wrap:
+          // they emit `return __vr_x` for failures, and we need that
+          // value to escape the outer function, not just the inner
+          // async callback.
           ...validationGuards,
           ...hoistedAliases,
-          ...onFunctionStartHook,
-          ...bodyCode,
+          // Body-level ALS frame (defense-in-depth). Today every
+          // callback site re-seeds ALS via Runner.runInScope, but the
+          // wrap closes the gap for code that runs between steps and
+          // makes the per-scope frame contract explicit.
+          ts.withAlsFrame({
+            ctx: ts.id("__ctx"),
+            stack: ts.id("__stack"),
+            threads: $(ts.id("__setupData")).prop("threads").done(),
+            body: [
+              ...onFunctionStartHook,
+              ...bodyCode,
+            ],
+          }),
           ts.raw(
             "if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }",
           ),
@@ -1589,8 +1601,11 @@ export class TypeScriptBuilder {
         ),
         "__error",
         // finally block: pop state stack and conditionally fire onFunctionEnd.
+        // The optional chain handles the rare case where the finally
+        // runs outside any ALS frame (e.g. a function invoked as a tool
+        // without an outer agencyStore.run wrap).
         ts.statements([
-          ts.raw("__stateStack.pop()"),
+          ts.raw("__stateStack()?.pop()"),
           ...(skipHooks ? [] : [
             ts.if(
               ts.id("__functionCompleted"),
@@ -2092,7 +2107,17 @@ export class TypeScriptBuilder {
 
     return $(ts.id("runner"))
       .prop("fork")
-      .call([ts.num(id), itemsNode, blockFn, ts.str(mode), ts.id("__stateStack")])
+      .call([
+        ts.num(id),
+        itemsNode,
+        blockFn,
+        ts.str(mode),
+        // `runner.fork` requires the current StateStack to push branch
+        // frames onto. Use the strict accessor so a missing ALS frame
+        // throws the actionable error instead of producing a generic
+        // TypeError deep inside the fork machinery.
+        ts.raw("getRuntimeContext().stack"),
+      ])
       .await()
       .done();
   }
@@ -2132,8 +2157,9 @@ export class TypeScriptBuilder {
     });
 
     return ts.statements([
-      // Pop the current node's frame before transitioning — it won't be re-entered on resume
-      ts.raw("__stateStack.pop()"),
+      // Pop the current node's frame before transitioning — it won't be re-entered on resume.
+      // Optional chain defends against the rare goto reached outside any ALS frame.
+      ts.raw("__stateStack()?.pop()"),
       ts.functionReturn(ts.goToNode(functionName, goToArgs)),
     ]);
   }
@@ -2178,13 +2204,10 @@ export class TypeScriptBuilder {
       ),
 
       ts.setupEnv({
-        stateStack: ts.raw("__state.ctx.stateStack"),
         stack: $(ts.id("__setupData")).prop("stack").done(),
         step: $(ts.id("__setupData")).prop("step").done(),
         self: $(ts.id("__setupData")).prop("self").done(),
         ctx: $(ts.runtime.state).prop("ctx").done(),
-        statelogClient: ts.ctx("statelogClient"),
-        graph: ts.ctx("graph"),
       }),
 
       // Pass `threads` explicitly so the Runner's ALS frame is seeded
@@ -2219,13 +2242,26 @@ export class TypeScriptBuilder {
     stmts.push(
       ts.tryCatch(
         ts.statements([
-          ts.runnerHookStep({
-            id: onNodeStartId,
+          // Body-level ALS frame (defense-in-depth). The onNodeStart
+          // hook and user body go inside the wrap. The post-body
+          // halted check and onNodeEnd hook stay outside: the wrap's
+          // inner callback may bare-`return` from `runner.halt(...)`
+          // emissions, and we want the outer node arrow to keep
+          // running into the halted check / onNodeEnd / final return.
+          ts.withAlsFrame({
+            ctx: ts.id("__ctx"),
+            stack: ts.id("__stack"),
+            threads: $(ts.id("__setupData")).prop("threads").done(),
             body: [
-              ts.callHook("onNodeStart", { nodeName: ts.str(nodeName) }),
+              ts.runnerHookStep({
+                id: onNodeStartId,
+                body: [
+                  ts.callHook("onNodeStart", { nodeName: ts.str(nodeName) }),
+                ],
+              }),
+              ...bodyCode,
             ],
           }),
-          ...bodyCode,
           ts.raw("if (runner.halted) return runner.haltResult;"),
           ts.runnerHookStep({
             id: onNodeEndId,

--- a/packages/agency-lang/lib/ir/builders.ts
+++ b/packages/agency-lang/lib/ir/builders.ts
@@ -516,6 +516,48 @@ export const ts = {
     return ts.runnerHalt(ts.obj({ messages: ts.runtime.threads, data: value }));
   },
 
+  /**
+   * Wrap a list of statements in
+   * `await agencyStore.run({ ctx, stack, threads }, async () => { ... })`.
+   *
+   * Defense-in-depth: every function/node body's try block carries an
+   * ALS frame so stdlib helpers and `__threads()` / `__stateStack()`
+   * reads resolve correctly even for code that runs between Runner
+   * steps. Today the gap is empty (every callback emission uses
+   * `runner.step`/`runner.hook`/etc. which re-seed the frame
+   * themselves), but the wrap makes the contract explicit and
+   * removes the risk that a future refactor silently loses the
+   * per-scope frame.
+   *
+   * NOTE: `return` statements inside the wrapped body escape only the
+   * inner async callback, not the outer function. Validation guards
+   * that return a non-`undefined` value (e.g. `return __vr_x` for a
+   * validation failure) must stay outside the wrap so the outer
+   * function actually returns the value to its caller. The bare
+   * `return;` emitted by `runnerHalt` is fine: after the callback
+   * returns, the outer `if (runner.halted) return runner.haltResult;`
+   * check picks up the halted result.
+   */
+  withAlsFrame({
+    ctx,
+    stack,
+    threads,
+    body,
+  }: {
+    ctx: TsNode;
+    stack: TsNode;
+    threads: TsNode;
+    body: TsNode[];
+  }): TsNode {
+    return ts.awaitCall(
+      ts.prop(ts.id("agencyStore"), "run"),
+      [
+        ts.obj({ ctx, stack, threads }),
+        ts.arrowFn([], ts.statements(body), { async: true }),
+      ],
+    );
+  },
+
   env(varName: string): TsRaw {
     return ts.raw(`__process.env[${JSON.stringify(varName)}]`);
   },
@@ -540,34 +582,29 @@ export const ts = {
   },
 
   setupEnv({
-    stateStack,
     stack,
     step,
     self,
     ctx,
-    statelogClient,
-    graph,
   }: {
-    stateStack?: TsNode;
     stack: TsNode;
     step: TsNode;
     self: TsNode;
     ctx: TsNode;
-    statelogClient: TsNode;
-    graph: TsNode;
   }): TsStatements {
-    // No `__threads` const declaration here: the per-scope ThreadStore
-    // is now read on demand via the `__threads()` accessor (which
-    // resolves the value through the active `agencyStore` ALS frame).
-    // See `ts.runtime.threads` and `lib/runtime/asyncContext.ts`.
+    // No `__threads` or `__stateStack` const declaration here: those
+    // per-scope values are now read on demand via the `__threads()`
+    // and `__stateStack()` accessors (which resolve through the active
+    // `agencyStore` ALS frame). The `__graph` and `statelogClient`
+    // locals that used to be declared here were dead code — no
+    // template or codegen path referenced them — so they were dropped
+    // entirely. See `ts.runtime.threads` / `ts.runtime.stateStack` and
+    // `lib/runtime/asyncContext.ts`.
     return ts.statements([
-      ...(stateStack ? [ts.constDecl("__stateStack", stateStack)] : []),
       ts.constDeclId(ts.runtime.stack, stack),
       ts.constDeclId(ts.runtime.step, step),
       ts.constDeclId(ts.runtime.self, self),
       ts.constDeclId(ts.runtime.ctx, ctx),
-      ts.constDeclId(ts.runtime.statelogClient, statelogClient),
-      ts.constDeclId(ts.runtime.graph, graph),
       ts.letDecl("__forked"),
 
       // Track whether the function completed normally (vs pausing for a debug interrupt).
@@ -729,27 +766,25 @@ export const ts = {
     return { kind: "agencyFunctionWrap", name, module, fn, params };
   },
 
-  /** Predefined runtime identifiers. `threads` is a `__threads()` call
-   *  (not a bare identifier) because post-ALS migration the per-scope
-   *  ThreadStore lives on the active `agencyStore` frame instead of in a
-   *  codegen-emitted `const __threads` local. Every site that referenced
-   *  the old local now emits an `__threads()` accessor call, which reads
-   *  from ALS and returns the live store (or `undefined` outside any
-   *  frame — see `runtime/asyncContext.ts`). */
+  /** Predefined runtime identifiers. `threads` and `stateStack` are
+   *  `__threads()` / `__stateStack()` accessor calls (not bare
+   *  identifiers) because post-ALS migration the per-scope
+   *  `ThreadStore` and `StateStack` live on the active `agencyStore`
+   *  frame instead of in codegen-emitted `const __threads` /
+   *  `const __stateStack` locals. Every site that referenced the old
+   *  locals now emits the accessor call, which reads from ALS and
+   *  returns the live store (or `undefined` outside any frame — see
+   *  `runtime/asyncContext.ts`). */
   runtime: {
     self: { kind: "identifier", name: "__self" } as TsIdentifier,
     ctx: { kind: "identifier", name: "__ctx" } as TsIdentifier,
     threads: { kind: "raw", code: "__threads()" } as TsRaw,
+    stateStack: { kind: "raw", code: "__stateStack()" } as TsRaw,
     stack: { kind: "identifier", name: "__stack" } as TsIdentifier,
     step: { kind: "identifier", name: "__step" } as TsIdentifier,
     state: { kind: "identifier", name: "__state" } as TsIdentifier,
     globalCtx: { kind: "identifier", name: "__globalCtx" } as TsIdentifier,
     client: { kind: "identifier", name: "__client" } as TsIdentifier,
-    statelogClient: {
-      kind: "identifier",
-      name: "statelogClient",
-    } as TsIdentifier,
-    graph: { kind: "identifier", name: "__graph" } as TsIdentifier,
   },
 
   /** Thread operations */

--- a/packages/agency-lang/lib/runtime/asyncContext.ts
+++ b/packages/agency-lang/lib/runtime/asyncContext.ts
@@ -105,6 +105,32 @@ export function __threads(): ThreadStore | undefined {
 }
 
 /**
+ * Generated-code accessor for the current StateStack. Mirrors
+ * `__threads()` — reads from the active `agencyStore` frame. Returns
+ * `undefined` when no frame is installed; the call sites that may run
+ * without one (notably the `finally` block in `classMethod.mustache`
+ * that pops the per-scope frame when a function is called as a tool
+ * outside any Agency execution frame) defend with `?.pop()` /
+ * `?.method(...)`. Code that needs the strict-throw behavior should
+ * call `getRuntimeContext().stack` directly.
+ */
+export function __stateStack(): StateStack | undefined {
+  return agencyStore.getStore()?.stack;
+}
+
+/**
+ * Generated-code accessor for the current RuntimeContext. Mirrors
+ * `__threads()` — reads from the active `agencyStore` frame. Returns
+ * `undefined` when no frame is installed. Sites where dereferencing
+ * `undefined` would produce an opaque `TypeError` should use
+ * `getRuntimeContext().ctx` instead so the missing-frame case throws
+ * the dedicated error with a pointer to `runInTestContext`.
+ */
+export function __ctx(): RuntimeContext<any> | undefined {
+  return agencyStore.getStore()?.ctx;
+}
+
+/**
  * Convenience wrapper for tests that construct a RuntimeContext manually
  * and need to invoke stdlib helpers that read from ALS. Mirrors
  * `agencyStore.run(...)` but with explicit named parameters so test

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -12,6 +12,8 @@ export {
   getRuntimeContext,
   runInTestContext,
   __threads,
+  __stateStack,
+  __ctx,
   type AgencyStore,
 } from "./asyncContext.js";
 export { StateStack, State } from "./state/stateStack.js";

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/classMethod.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/classMethod.mustache
@@ -4,8 +4,6 @@
     const __step = __setupData.step;
     const __self = __setupData.self;
     const __ctx = __state?.ctx || __globalCtx;
-    const statelogClient = __ctx.statelogClient;
-    const __graph = __ctx.graph;
     let __forked;
     let __functionCompleted = false;
     if (!__ctx.globals.isInitialized({{{moduleId}}})) {
@@ -16,14 +14,17 @@
     __stack.args[{{{this.nameQuoted}}}] = {{{this.name}}};
 {{/paramAssignments}}
     try {
+      await agencyStore.run({ ctx: __ctx, stack: __setupData.stateStack, threads: __setupData.threads }, async () => {
 {{{body}}}
+        if (runner.halted) { return; }
+        __functionCompleted = true;
+      });
       if (runner.halted) { return runner.haltResult; }
-      __functionCompleted = true;
     } catch (__error) {
       if (__error instanceof RestoreSignal) { throw __error; }
       if (__error instanceof GuardExceededError) { throw __error; }
       throw __error;
     } finally {
-      __stateStack.pop()
+      __stateStack()?.pop()
     }
   }

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/classMethod.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/classMethod.ts
@@ -9,8 +9,6 @@ export const template = `  async {{{methodName}}}({{{params}}}__state: any = und
     const __step = __setupData.step;
     const __self = __setupData.self;
     const __ctx = __state?.ctx || __globalCtx;
-    const statelogClient = __ctx.statelogClient;
-    const __graph = __ctx.graph;
     let __forked;
     let __functionCompleted = false;
     if (!__ctx.globals.isInitialized({{{moduleId}}})) {
@@ -21,15 +19,18 @@ export const template = `  async {{{methodName}}}({{{params}}}__state: any = und
     __stack.args[{{{this.nameQuoted}}}] = {{{this.name}}};
 {{/paramAssignments}}
     try {
+      await agencyStore.run({ ctx: __ctx, stack: __setupData.stateStack, threads: __setupData.threads }, async () => {
 {{{body}}}
+        if (runner.halted) { return; }
+        __functionCompleted = true;
+      });
       if (runner.halted) { return runner.haltResult; }
-      __functionCompleted = true;
     } catch (__error) {
       if (__error instanceof RestoreSignal) { throw __error; }
       if (__error instanceof GuardExceededError) { throw __error; }
       throw __error;
     } finally {
-      __stateStack.pop()
+      __stateStack()?.pop()
     }
   }`;
 

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/forkBlockSetup.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/forkBlockSetup.mustache
@@ -7,7 +7,15 @@ const __parentForkArgs = __bstack.args;
 {{/isNested}}
 const __bstack = __forkBranchStack.getNewState();
 const __self = __bstack.locals;
-const __stateStack = __forkBranchStack;
+// `__stateStack` is read from ALS via the `__stateStack()` accessor.
+// The branch ALS frame seeded by `runBatch.runInBranchAlsFrame`
+// (lib/runtime/runBatch.ts) already carries `stack: __forkBranchStack`,
+// so accessor calls inside the branch body resolve to the branch
+// stack automatically — no local rebind needed. The earlier
+// `const __stateStack = __forkBranchStack` line was removed because
+// it shadowed the runtime import and made `__stateStack()` calls
+// (emitted by interrupt/checkpoint templates) crash with
+// "__stateStack2 is not a function".
 const {{{paramName:string}}} = __forkItem;
 {{#isNested}}
 Object.assign(__bstack.args, __parentForkArgs);

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/forkBlockSetup.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/forkBlockSetup.ts
@@ -12,7 +12,15 @@ const __parentForkArgs = __bstack.args;
 {{/isNested}}
 const __bstack = __forkBranchStack.getNewState();
 const __self = __bstack.locals;
-const __stateStack = __forkBranchStack;
+// \`__stateStack\` is read from ALS via the \`__stateStack()\` accessor.
+// The branch ALS frame seeded by \`runBatch.runInBranchAlsFrame\`
+// (lib/runtime/runBatch.ts) already carries \`stack: __forkBranchStack\`,
+// so accessor calls inside the branch body resolve to the branch
+// stack automatically — no local rebind needed. The earlier
+// \`const __stateStack = __forkBranchStack\` line was removed because
+// it shadowed the runtime import and made \`__stateStack()\` calls
+// (emitted by interrupt/checkpoint templates) crash with
+// "__stateStack2 is not a function".
 const {{{paramName:string}}} = __forkItem;
 {{#isNested}}
 Object.assign(__bstack.args, __parentForkArgs);

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -29,7 +29,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.mustache
@@ -19,7 +19,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers({{{kind}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack);
+  const __handlerResult = await interruptWithHandlers({{{kind}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });
@@ -35,7 +35,7 @@ if (__response) {
     // No handler — propagate interrupt array to TypeScript caller
     // Store interruptId on frame BEFORE checkpoint so it's captured in the snapshot
     __self.{{{interruptIdKey:string}}} = __handlerResult[0].interruptId;
-    const __checkpointId = __ctx.checkpoints.create(__stateStack, __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: {{{stepPath}}} });
+    const __checkpointId = __ctx.checkpoints.create(__stateStack(), __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: {{{stepPath}}} });
     __handlerResult[0].checkpointId = __checkpointId;
     __handlerResult[0].checkpoint = __ctx.checkpoints.get(__checkpointId);
     {{#nodeContext}}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptAssignment.ts
@@ -24,7 +24,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers({{{kind}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack);
+  const __handlerResult = await interruptWithHandlers({{{kind}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });
@@ -40,7 +40,7 @@ if (__response) {
     // No handler — propagate interrupt array to TypeScript caller
     // Store interruptId on frame BEFORE checkpoint so it's captured in the snapshot
     __self.{{{interruptIdKey:string}}} = __handlerResult[0].interruptId;
-    const __checkpointId = __ctx.checkpoints.create(__stateStack, __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: {{{stepPath}}} });
+    const __checkpointId = __ctx.checkpoints.create(__stateStack(), __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: {{{stepPath}}} });
     __handlerResult[0].checkpointId = __checkpointId;
     __handlerResult[0].checkpoint = __ctx.checkpoints.get(__checkpointId);
     {{#nodeContext}}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.mustache
@@ -15,7 +15,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers({{{kind}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack);
+  const __handlerResult = await interruptWithHandlers({{{kind}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });
@@ -29,7 +29,7 @@ if (__response) {
     // No handler — propagate interrupt array to TypeScript caller
     // Store interruptId on frame BEFORE checkpoint so it's captured in the snapshot
     __self.{{{interruptIdKey:string}}} = __handlerResult[0].interruptId;
-    const __checkpointId = __ctx.checkpoints.create(__stateStack, __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: {{{stepPath}}} });
+    const __checkpointId = __ctx.checkpoints.create(__stateStack(), __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: {{{stepPath}}} });
     __handlerResult[0].checkpointId = __checkpointId;
     __handlerResult[0].checkpoint = __ctx.checkpoints.get(__checkpointId);
     {{#nodeContext}}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/interruptReturn.ts
@@ -20,7 +20,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers({{{kind}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack);
+  const __handlerResult = await interruptWithHandlers({{{kind}}}, {{{message}}}, {{{data}}}, {{{origin}}}, __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     {{#nodeContext}}
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });
@@ -34,7 +34,7 @@ if (__response) {
     // No handler — propagate interrupt array to TypeScript caller
     // Store interruptId on frame BEFORE checkpoint so it's captured in the snapshot
     __self.{{{interruptIdKey:string}}} = __handlerResult[0].interruptId;
-    const __checkpointId = __ctx.checkpoints.create(__stateStack, __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: {{{stepPath}}} });
+    const __checkpointId = __ctx.checkpoints.create(__stateStack(), __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: {{{stepPath}}} });
     __handlerResult[0].checkpointId = __checkpointId;
     __handlerResult[0].checkpoint = __ctx.checkpoints.get(__checkpointId);
     {{#nodeContext}}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/resultCheckpointSetup.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/resultCheckpointSetup.mustache
@@ -1,6 +1,6 @@
 let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/resultCheckpointSetup.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/resultCheckpointSetup.ts
@@ -5,7 +5,7 @@ import { apply } from "typestache";
 
 export const template = `let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -26,7 +26,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -168,13 +168,10 @@ async function __add_impl(a: any, b: number, __state: InternalFunctionState | un
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("tests/debugger/function-call-test.agency")) {
@@ -187,7 +184,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "tests/debugger/function-call-test.agency", scopeName: "add", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "tests/debugger/function-call-test.agency", scopeName: "add", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "tests/debugger/function-call-test.agency", scopeName: "add", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -204,31 +201,37 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "add",
-          args: {
-            a: a,
-            b: b
-          },
-          isBuiltin: false,
-          moduleId: "tests/debugger/function-call-test.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "add",
+            args: {
+              a: a,
+              b: b
+            },
+            isBuiltin: false,
+            moduleId: "tests/debugger/function-call-test.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.result = __stack.args.a + __stack.args.b;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.doubled = __stack.locals.result * 2;
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.doubled)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -253,7 +256,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -292,55 +295,58 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/function-call-test.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-__stack.locals.x = 1;
-    });
-    await runner.step(2, async (runner) => {
-__stack.locals.y = await __call(add, {
-        type: "positional",
-        args: [__stack.locals.x, 2]
-      });
-if (hasInterrupts(__stack.locals.y)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.y
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
         })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(1, async (runner) => {
+__stack.locals.x = 1;
+      });
+      await runner.step(2, async (runner) => {
+__stack.locals.y = await __call(add, {
+          type: "positional",
+          args: [__stack.locals.x, 2]
+        });
+if (hasInterrupts(__stack.locals.y)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.y
+          })
+          return;
+        }
+      });
+      await runner.step(3, async (runner) => {
 __stack.locals.z = __stack.locals.y + 10;
-    });
-    await runner.step(4, async (runner) => {
+      });
+      await runner.step(4, async (runner) => {
 __stack.locals.w = __stack.locals.z + 1;
-    });
-    await runner.step(5, async (runner) => {
+      });
+      await runner.step(5, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.w
-      })
+          messages: __threads(),
+          data: __stack.locals.w
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(6, async () => {
 await callHook({

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -203,7 +203,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -305,7 +305,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -26,7 +26,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -167,13 +167,10 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/if-else-test.agency", scopeName: "main", threads: __setupData.threads });
@@ -181,37 +178,43 @@ let __functionCompleted = false;
     __stack.args["x"] = __state.data.x;
   }
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.ifElse(1, [
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.ifElse(1, [
 
   {
     condition: async () => __stack.args.x > 0,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `positive`;
-          });
+            });
     },
   },
 
 ], async (runner) => {
 await runner.step(1, async (runner) => {
 __stack.locals.result = `non-positive`;
-        });
+          });
 });
-    await runner.step(2, async (runner) => {
+      await runner.step(2, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.result
-      })
+          messages: __threads(),
+          data: __stack.locals.result
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -180,7 +180,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -26,7 +26,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -167,29 +167,31 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/interrupt-test.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.x = 1;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 // Resume path: check for a response by interruptId
 const __response = __ctx.getInterruptResponse(__self.__interruptId_2);
 if (__response) {
@@ -209,7 +211,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers("unknown", `check value`, {}, "./tests/debugger/interrupt-test.agency", __ctx, __stateStack);
+  const __handlerResult = await interruptWithHandlers("unknown", `check value`, {}, "./tests/debugger/interrupt-test.agency", __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });
@@ -223,7 +225,7 @@ if (__response) {
     // No handler — propagate interrupt array to TypeScript caller
     // Store interruptId on frame BEFORE checkpoint so it's captured in the snapshot
     __self.__interruptId_2 = __handlerResult[0].interruptId;
-    const __checkpointId = __ctx.checkpoints.create(__stateStack, __ctx, { moduleId: "tests/debugger/interrupt-test.agency", scopeName: "main", stepPath: "2" });
+    const __checkpointId = __ctx.checkpoints.create(__stateStack(), __ctx, { moduleId: "tests/debugger/interrupt-test.agency", scopeName: "main", stepPath: "2" });
     __handlerResult[0].checkpointId = __checkpointId;
     __handlerResult[0].checkpoint = __ctx.checkpoints.get(__checkpointId);
     
@@ -234,17 +236,18 @@ if (__response) {
   }
 }
 
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 __stack.locals.z = __stack.locals.x + __stack.locals.y;
-    });
-    await runner.step(4, async (runner) => {
+      });
+      await runner.step(4, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.z
-      })
+          messages: __threads(),
+          data: __stack.locals.z
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -26,7 +26,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -167,40 +167,43 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/loop-test.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.sum = 0;
-    });
-    await runner.loop(2, Array.from({length: 3 - 0}, (_, __i) => __i + 0), async (i, _, runner) => {
+      });
+      await runner.loop(2, Array.from({length: 3 - 0}, (_, __i) => __i + 0), async (i, _, runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.sum = __stack.locals.sum + i;
+        });
       });
-    });
-    await runner.step(3, async (runner) => {
+      await runner.step(3, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.sum
-      })
+          messages: __threads(),
+          data: __stack.locals.sum
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -26,7 +26,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -168,13 +168,10 @@ async function __double_impl(n: number, __state: InternalFunctionState | undefin
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("tests/debugger/nested-calls-test.agency")) {
@@ -186,7 +183,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "double", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "double", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "double", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -199,27 +196,33 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "double",
-          args: {
-            n: n
-          },
-          isBuiltin: false,
-          moduleId: "tests/debugger/nested-calls-test.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "double",
+            args: {
+              n: n
+            },
+            isBuiltin: false,
+            moduleId: "tests/debugger/nested-calls-test.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.result = __stack.args.n * 2;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.result)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -244,7 +247,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -279,13 +282,10 @@ async function __addAndDouble_impl(a: any, b: number, __state: InternalFunctionS
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("tests/debugger/nested-calls-test.agency")) {
@@ -298,7 +298,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "addAndDouble", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "addAndDouble", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "addAndDouble", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -315,39 +315,45 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "addAndDouble",
-          args: {
-            a: a,
-            b: b
-          },
-          isBuiltin: false,
-          moduleId: "tests/debugger/nested-calls-test.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-__stack.locals.sum = __stack.args.a + __stack.args.b;
-    });
-    await runner.step(2, async (runner) => {
-__stack.locals.result = await __call(double, {
-        type: "positional",
-        args: [__stack.locals.sum]
+          name: "onFunctionStart",
+          data: {
+            functionName: "addAndDouble",
+            args: {
+              a: a,
+              b: b
+            },
+            isBuiltin: false,
+            moduleId: "tests/debugger/nested-calls-test.agency"
+          }
+        })
       });
+      await runner.step(1, async (runner) => {
+__stack.locals.sum = __stack.args.a + __stack.args.b;
+      });
+      await runner.step(2, async (runner) => {
+__stack.locals.result = await __call(double, {
+          type: "positional",
+          args: [__stack.locals.sum]
+        });
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__stack.locals.result)
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.result)
+          return;
+        }
+      });
+      await runner.step(3, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.result)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -372,7 +378,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -411,46 +417,49 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-__stack.locals.x = await __call(addAndDouble, {
-        type: "positional",
-        args: [1, 2]
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
       });
+      await runner.step(1, async (runner) => {
+__stack.locals.x = await __call(addAndDouble, {
+          type: "positional",
+          args: [1, 2]
+        });
 if (hasInterrupts(__stack.locals.x)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.x
+          })
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
+runner.halt({
+          messages: __threads(),
           data: __stack.locals.x
         })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-runner.halt({
-        messages: __threads(),
-        data: __stack.locals.x
-      })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -198,7 +198,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -317,7 +317,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -427,7 +427,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -26,7 +26,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -167,41 +167,44 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/step-test.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.x = 1;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.y = 2;
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 __stack.locals.z = __stack.locals.x + __stack.locals.y;
-    });
-    await runner.step(4, async (runner) => {
+      });
+      await runner.step(4, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.z
-      })
+          messages: __threads(),
+          data: __stack.locals.z
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -177,7 +177,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,48 +147,51 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "assignment.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.bar = await runPrompt({
-        prompt: `the number 1`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.number()
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `the number 1`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.number()
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.bar)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.bar
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.bar
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(2, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -180,7 +180,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -294,7 +294,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -399,7 +399,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -25,7 +25,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -150,13 +150,10 @@ async function __safeLookup_impl(id: string, __state: InternalFunctionState | un
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("safe-function.agency")) {
@@ -168,7 +165,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "safe-function.agency", scopeName: "safeLookup", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "safe-function.agency", scopeName: "safeLookup", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "safe-function.agency", scopeName: "safeLookup", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -181,27 +178,33 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "safeLookup",
-          args: {
-            id: id
-          },
-          isBuiltin: false,
-          moduleId: "safe-function.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "safeLookup",
+            args: {
+              id: id
+            },
+            isBuiltin: false,
+            moduleId: "safe-function.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(await __call(lookupItem, {
-        type: "positional",
-        args: [__stack.args.id]
-      }))
+          type: "positional",
+          args: [__stack.args.id]
+        }))
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -226,7 +229,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -261,13 +264,10 @@ async function __unsafeSave_impl(id: string, __state: InternalFunctionState | un
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("safe-function.agency")) {
@@ -279,7 +279,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "safe-function.agency", scopeName: "unsafeSave", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "safe-function.agency", scopeName: "unsafeSave", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "safe-function.agency", scopeName: "unsafeSave", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -292,39 +292,45 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "unsafeSave",
-          args: {
-            id: id
-          },
-          isBuiltin: false,
-          moduleId: "safe-function.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "unsafeSave",
+            args: {
+              id: id
+            },
+            isBuiltin: false,
+            moduleId: "safe-function.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__retryable = false;
 const __funcResult = await __call(saveItem, {
-        type: "positional",
-        args: [__stack.args.id]
-      });
+          type: "positional",
+          args: [__stack.args.id]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(await __call(lookupItem, {
-        type: "positional",
-        args: [__stack.args.id]
-      }))
+          type: "positional",
+          args: [__stack.args.id]
+        }))
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -349,7 +355,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -383,54 +389,57 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "safe-function.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.result = await runPrompt({
-        prompt: `Use the tools`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {
-          "tools": [safeLookup, unsafeSave]
-        },
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Use the tools`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {
+            "tools": [safeLookup, unsafeSave]
+          },
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.result
+          })
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
+runner.halt({
           messages: __threads(),
           data: __stack.locals.result
         })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-runner.halt({
-        messages: __threads(),
-        data: __stack.locals.result
-      })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,59 +147,62 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "simple.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.greeting = await runPrompt({
-        prompt: `say hello`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `say hello`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.greeting)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.greeting
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.greeting]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.greeting
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.greeting]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,99 +147,102 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "array.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.numbers = await runPrompt({
-        prompt: `the first 5 prime numbers`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.array(z.number())
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `the first 5 prime numbers`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.array(z.number())
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.numbers)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.numbers
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.numbers]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.numbers
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.numbers]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(3, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.greetings = await runPrompt({
-        prompt: `a list of 3 common greetings in different languages`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.array(z.string())
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `a list of 3 common greetings in different languages`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.array(z.string())
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.greetings)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.greetings
-        })
-        return;
-      }
-    });
-    await runner.step(4, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.greetings]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.greetings
+          })
+          return;
+        }
       });
+      await runner.step(4, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.greetings]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,48 +147,51 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "assignment.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.bar = await runPrompt({
-        prompt: `the number 1`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.number()
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `the number 1`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.number()
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.bar)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.bar
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.bar
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(2, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __compute_impl(val: number, __state: InternalFunctionState | unde
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("asyncAssigned.agency")) {
@@ -166,7 +163,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "asyncAssigned.agency", scopeName: "compute", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "asyncAssigned.agency", scopeName: "compute", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "asyncAssigned.agency", scopeName: "compute", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -179,35 +176,41 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "compute",
-          args: {
-            val: val
-          },
-          isBuiltin: false,
-          moduleId: "asyncAssigned.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(sleep, {
-        type: "positional",
-        args: [100]
+          name: "onFunctionStart",
+          data: {
+            functionName: "compute",
+            args: {
+              val: val
+            },
+            isBuiltin: false,
+            moduleId: "asyncAssigned.agency"
+          }
+        })
       });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(sleep, {
+          type: "positional",
+          args: [100]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.args.val * 2)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -232,7 +235,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -266,73 +269,76 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "asyncAssigned.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.branchStep(1, "1", async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.branchStep(1, "1", async (runner) => {
 if ((__stack.branches && __stack.branches["1"])) {
-        __forked = __stack.branches["1"].stack;
-        __forked.deserializeMode()
-      } else {
-        __forked = __ctx.forkStack();
-      }
+          __forked = __stack.branches["1"].stack;
+          __forked.deserializeMode()
+        } else {
+          __forked = __ctx.forkStack();
+        }
 __stack.branches = (__stack.branches || {});
 __stack.branches["1"] = {
-        stack: __forked
-      };
+          stack: __forked
+        };
 __stack.locals.x = __call(compute, {
-        type: "positional",
-        args: [5]
-      }, {
-        stateStack: __forked
-      });
+          type: "positional",
+          args: [5]
+        }, {
+          stateStack: __forked
+        });
 __self.__pendingKey_x = __ctx.pendingPromises.add(__stack.locals.x, (val) => { __stack.locals.x = val; });
-    });
-    await runner.branchStep(2, "2", async (runner) => {
+      });
+      await runner.branchStep(2, "2", async (runner) => {
 if ((__stack.branches && __stack.branches["2"])) {
-        __forked = __stack.branches["2"].stack;
-        __forked.deserializeMode()
-      } else {
-        __forked = __ctx.forkStack();
-      }
+          __forked = __stack.branches["2"].stack;
+          __forked.deserializeMode()
+        } else {
+          __forked = __ctx.forkStack();
+        }
 __stack.branches = (__stack.branches || {});
 __stack.branches["2"] = {
-        stack: __forked
-      };
+          stack: __forked
+        };
 __stack.locals.y = __call(compute, {
-        type: "positional",
-        args: [10]
-      }, {
-        stateStack: __forked
-      });
+          type: "positional",
+          args: [10]
+        }, {
+          stateStack: __forked
+        });
 __self.__pendingKey_y = __ctx.pendingPromises.add(__stack.locals.y, (val) => { __stack.locals.y = val; });
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 await __ctx.pendingPromises.awaitPending([__self.__pendingKey_x, __self.__pendingKey_y]);
-    });
-    await runner.step(4, async (runner) => {
+      });
+      await runner.step(4, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: [__stack.locals.x, __stack.locals.y]
-      })
+          messages: __threads(),
+          data: [__stack.locals.x, __stack.locals.y]
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -178,7 +178,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -279,7 +279,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,59 +147,62 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "asyncLlm.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.x = runPrompt({
-        prompt: `What is 2+2?`,
-        messages: __threads().createAndReturnSubthread(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `What is 2+2?`,
+          messages: __threads().createAndReturnSubthread(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 __self.__pendingKey_x = __ctx.pendingPromises.add(__stack.locals.x, (val) => { __stack.locals.x = val; });
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.y = runPrompt({
-        prompt: `What is 3+3?`,
-        messages: __threads().createAndReturnSubthread(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `What is 3+3?`,
+          messages: __threads().createAndReturnSubthread(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 __self.__pendingKey_y = __ctx.pendingPromises.add(__stack.locals.y, (val) => { __stack.locals.y = val; });
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 await __ctx.pendingPromises.awaitPending([__self.__pendingKey_x, __self.__pendingKey_y]);
-    });
-    await runner.step(4, async (runner) => {
+      });
+      await runner.step(4, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: [__stack.locals.x, __stack.locals.y]
-      })
+          messages: __threads(),
+          data: [__stack.locals.x, __stack.locals.y]
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -183,7 +183,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -285,7 +285,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __append_impl(sleepTime: number, value: any, __state: InternalFun
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("asyncUnassigned.agency")) {
@@ -167,7 +164,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "asyncUnassigned.agency", scopeName: "append", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "asyncUnassigned.agency", scopeName: "append", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "asyncUnassigned.agency", scopeName: "append", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -184,31 +181,37 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "append",
-          args: {
-            sleepTime: sleepTime,
-            value: value
-          },
-          isBuiltin: false,
-          moduleId: "asyncUnassigned.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(sleep, {
-        type: "positional",
-        args: [__stack.args.sleepTime]
+          name: "onFunctionStart",
+          data: {
+            functionName: "append",
+            args: {
+              sleepTime: sleepTime,
+              value: value
+            },
+            isBuiltin: false,
+            moduleId: "asyncUnassigned.agency"
+          }
+        })
       });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(sleep, {
+          type: "positional",
+          args: [__stack.args.sleepTime]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -233,7 +236,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -272,68 +275,71 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "asyncUnassigned.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.branchStep(1, "1", async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.branchStep(1, "1", async (runner) => {
 if ((__stack.branches && __stack.branches["1"])) {
-        __forked = __stack.branches["1"].stack;
-        __forked.deserializeMode()
-      } else {
-        __forked = __ctx.forkStack();
-      }
+          __forked = __stack.branches["1"].stack;
+          __forked.deserializeMode()
+        } else {
+          __forked = __ctx.forkStack();
+        }
 __stack.branches = (__stack.branches || {});
 __stack.branches["1"] = {
-        stack: __forked
-      };
+          stack: __forked
+        };
 __ctx.pendingPromises.add(__call(append, {
   type: "positional",
   args: [1, `hello`]
 }, {
   stateStack: __forked
 }))
-    });
-    await runner.branchStep(2, "2", async (runner) => {
+      });
+      await runner.branchStep(2, "2", async (runner) => {
 if ((__stack.branches && __stack.branches["2"])) {
-        __forked = __stack.branches["2"].stack;
-        __forked.deserializeMode()
-      } else {
-        __forked = __ctx.forkStack();
-      }
+          __forked = __stack.branches["2"].stack;
+          __forked.deserializeMode()
+        } else {
+          __forked = __ctx.forkStack();
+        }
 __stack.branches = (__stack.branches || {});
 __stack.branches["2"] = {
-        stack: __forked
-      };
+          stack: __forked
+        };
 __ctx.pendingPromises.add(__call(append, {
   type: "positional",
   args: [0.5, `world`]
 }, {
   stateStack: __forked
 }))
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: `done`
-      })
+          messages: __threads(),
+          data: `done`
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __process_impl(data: number, __state: InternalFunctionState | und
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("bangParams.agency")) {
@@ -166,7 +163,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "bangParams.agency", scopeName: "process", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "bangParams.agency", scopeName: "process", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "bangParams.agency", scopeName: "process", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -184,35 +181,41 @@ if (__ctx._pendingArgOverrides) {
       return __vr_data;
     }
     __stack.args["data"] = __vr_data.value;
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "process",
-          args: {
-            data: data
-          },
-          isBuiltin: false,
-          moduleId: "bangParams.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.args.data]
+          name: "onFunctionStart",
+          data: {
+            functionName: "process",
+            args: {
+              data: data
+            },
+            isBuiltin: false,
+            moduleId: "bangParams.agency"
+          }
+        })
       });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.args.data]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.args.data)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -237,7 +240,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -271,53 +274,56 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "bangParams.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.result = await __call(process, {
-        type: "positional",
-        args: [`not a number`]
-      });
+          type: "positional",
+          args: [`not a number`]
+        });
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.result
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.result]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.result
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.result]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -183,7 +183,7 @@ if (__ctx._pendingArgOverrides) {
     __stack.args["data"] = __vr_data.value;
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -284,7 +284,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -178,7 +178,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -268,7 +268,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __process_impl(x: number, __state: InternalFunctionState | undefi
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("bangReturnType.agency")) {
@@ -166,7 +163,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "bangReturnType.agency", scopeName: "process", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "bangReturnType.agency", scopeName: "process", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "bangReturnType.agency", scopeName: "process", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -179,24 +176,30 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "process",
-          args: {
-            x: x
-          },
-          isBuiltin: false,
-          moduleId: "bangReturnType.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "process",
+            args: {
+              x: x
+            },
+            isBuiltin: false,
+            moduleId: "bangReturnType.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(__validateType(__stack.args.x, z.number()))
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -221,7 +224,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -255,53 +258,56 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "bangReturnType.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.result = await __call(process, {
-        type: "positional",
-        args: [42]
-      });
+          type: "positional",
+          args: [42]
+        });
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.result
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.result]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.result
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.result]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -149,43 +149,46 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "bangValidation.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.result = `bug`;
 __stack.locals.result = __validateType(__stack.locals.result, Category);
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.result]
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.result]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -159,7 +159,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __twice_impl(block: () => string, __state: InternalFunctionState 
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("blockBasic.agency")) {
@@ -166,7 +163,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "blockBasic.agency", scopeName: "twice", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "blockBasic.agency", scopeName: "twice", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "blockBasic.agency", scopeName: "twice", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -179,46 +176,52 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "twice",
-          args: {
-            block: block
-          },
-          isBuiltin: false,
-          moduleId: "blockBasic.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "twice",
+            args: {
+              block: block
+            },
+            isBuiltin: false,
+            moduleId: "blockBasic.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.a = await __call(__stack.args.block, {
-        type: "positional",
-        args: []
-      });
+          type: "positional",
+          args: []
+        });
 if (hasInterrupts(__stack.locals.a)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__stack.locals.a)
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-__stack.locals.b = await __call(__stack.args.block, {
-        type: "positional",
-        args: []
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.a)
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+__stack.locals.b = await __call(__stack.args.block, {
+          type: "positional",
+          args: []
+        });
 if (hasInterrupts(__stack.locals.b)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__stack.locals.b)
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.b)
+          return;
+        }
+      });
+      await runner.step(3, async (runner) => {
 __functionCompleted = true;
 runner.halt([__stack.locals.a, __stack.locals.b])
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -243,7 +246,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -277,30 +280,32 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "blockBasic.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.results = await __call(twice, {
-        type: "positional",
-        args: [__AgencyFunction.create({ name: "__block_0", module: "blockBasic.agency", fn: async () => {
-          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
+          type: "positional",
+          args: [__AgencyFunction.create({ name: "__block_0", module: "blockBasic.agency", fn: async () => {
+            const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 
@@ -314,31 +319,32 @@ return runner.halted ? runner.haltResult : undefined;
 } finally {
 __ctx.stateStack.pop();
 }
-        }, params: [], toolDefinition: null }, __toolRegistry)]
-      });
+          }, params: [], toolDefinition: null }, __toolRegistry)]
+        });
 if (hasInterrupts(__stack.locals.results)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.results
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.results]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.results
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.results]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -178,7 +178,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -290,7 +290,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __mapItems_impl(items: any[], block: (any) => any, __state: Inter
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("blockParams.agency")) {
@@ -167,7 +164,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "blockParams.agency", scopeName: "mapItems", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "blockParams.agency", scopeName: "mapItems", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "blockParams.agency", scopeName: "mapItems", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -184,52 +181,58 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "mapItems",
-          args: {
-            items: items,
-            block: block
-          },
-          isBuiltin: false,
-          moduleId: "blockParams.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "mapItems",
+            args: {
+              items: items,
+              block: block
+            },
+            isBuiltin: false,
+            moduleId: "blockParams.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.results = [];
-    });
-    await runner.loop(2, __stack.args.items, async (item, _, runner) => {
+      });
+      await runner.loop(2, __stack.args.items, async (item, _, runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = await __call(__stack.args.block, {
-          type: "positional",
-          args: [item]
-        });
+            type: "positional",
+            args: [item]
+          });
 if (hasInterrupts(__stack.locals.result)) {
-          await __ctx.pendingPromises.awaitAll()
-          runner.halt(__stack.locals.result)
-          return;
-        }
-      });
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt(__stack.locals.result)
+            return;
+          }
+        });
 await runner.step(1, async (runner) => {
 __stack.locals.results = await __call(append, {
-          type: "positional",
-          args: [__stack.locals.results, __stack.locals.result]
-        });
+            type: "positional",
+            args: [__stack.locals.results, __stack.locals.result]
+          });
 if (hasInterrupts(__stack.locals.results)) {
-          await __ctx.pendingPromises.awaitAll()
-          runner.halt(__stack.locals.results)
-          return;
-        }
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt(__stack.locals.results)
+            return;
+          }
+        });
       });
-    });
-    await runner.step(3, async (runner) => {
+      await runner.step(3, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.results)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -254,7 +257,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -293,33 +296,35 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "blockParams.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.items = [1, 2, 3];
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.doubled = await __call(mapItems, {
-        type: "positional",
-        args: [__stack.locals.items, __AgencyFunction.create({ name: "__block_0", module: "blockParams.agency", fn: async (x: any) => {
-          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
+          type: "positional",
+          args: [__stack.locals.items, __AgencyFunction.create({ name: "__block_0", module: "blockParams.agency", fn: async (x: any) => {
+            const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 
@@ -335,31 +340,32 @@ return runner.halted ? runner.haltResult : undefined;
 } finally {
 __ctx.stateStack.pop();
 }
-        }, params: [{ name: "x", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry)]
-      });
+          }, params: [{ name: "x", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry)]
+        });
 if (hasInterrupts(__stack.locals.doubled)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.doubled
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.doubled]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.doubled
+          })
+          return;
+        }
       });
+      await runner.step(3, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.doubled]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -183,7 +183,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -306,7 +306,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,67 +147,70 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "checkpoint-restore.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.cp = await __call(checkpoint, {
-        type: "positional",
-        args: []
-      }, {
-        moduleId: "checkpoint-restore.agency",
-        scopeName: "main",
-        stepPath: "1"
-      });
+          type: "positional",
+          args: []
+        }, {
+          moduleId: "checkpoint-restore.agency",
+          scopeName: "main",
+          stepPath: "1"
+        });
 if (hasInterrupts(__stack.locals.cp)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.cp
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-__stack.locals.x = 1;
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(restore, {
-        type: "positional",
-        args: [__stack.locals.cp, {}]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.cp
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+__stack.locals.x = 1;
+      });
+      await runner.step(3, async (runner) => {
+const __funcResult = await __call(restore, {
+          type: "positional",
+          args: [__stack.locals.cp, {}]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
-    await runner.step(4, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(4, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.x
-      })
+          messages: __threads(),
+          data: __stack.locals.x
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
@@ -186,7 +186,7 @@ if (__ctx._pendingArgOverrides) {
 try {
       await agencyStore.run({
         ctx: __ctx,
-        stack: __stack,
+        stack: __setupData.stateStack,
         threads: __setupData.threads
       }, async () => {
         await runner.hook(0, async () => {
@@ -281,7 +281,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-basic.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -161,13 +161,10 @@ const __setupData = setupFunction({
       state: __state
     });
 // __state will be undefined if this function is being called as a tool by an llm
-const __stateStack = __setupData.stateStack;
 const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
 if (!__ctx.globals.isInitialized("class-basic.agency")) {
@@ -178,7 +175,7 @@ __self.__retryable = __self.__retryable ?? true;
 const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "class-basic.agency", scopeName: "Counter.increment", threads: __setupData.threads });
 let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "class-basic.agency", scopeName: "Counter.increment", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "class-basic.agency", scopeName: "Counter.increment", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -187,25 +184,31 @@ if (__ctx._pendingArgOverrides) {
 }
 
 try {
-      await runner.hook(0, async () => {
+      await agencyStore.run({
+        ctx: __ctx,
+        stack: __stack,
+        threads: __setupData.threads
+      }, async () => {
+        await runner.hook(0, async () => {
 await callHook({
-          name: "onFunctionStart",
-          data: {
-            functionName: "Counter.increment",
-            args: {},
-            isBuiltin: false,
-            moduleId: "class-basic.agency"
-          }
-        })
-      });
-      await runner.step(1, async (runner) => {
+            name: "onFunctionStart",
+            data: {
+              functionName: "Counter.increment",
+              args: {},
+              isBuiltin: false,
+              moduleId: "class-basic.agency"
+            }
+          })
+        });
+        await runner.step(1, async (runner) => {
 this.value = this.value + 1;
-      });
-      await runner.step(2, async (runner) => {
+        });
+        await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(this.value)
 return;
-      });
+        });
+      })
       if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
     } catch (__error) {
       if (__error instanceof RestoreSignal) {
@@ -230,7 +233,7 @@ return failure(
 );
 
     } finally {
-      __stateStack.pop()
+      __stateStack()?.pop()
       if (__functionCompleted) {
         await callHook({
           name: "onFunctionEnd",
@@ -268,44 +271,47 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "class-basic.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.c = new Counter(0);
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 await __callMethod(__stack.locals.c, "increment", {
-        type: "positional",
-        args: []
-      })
-    });
-    await runner.step(3, async (runner) => {
-runner.halt({
-        messages: __threads(),
-        data: await __callMethod(__stack.locals.c, "increment", {
           type: "positional",
           args: []
         })
-      })
+      });
+      await runner.step(3, async (runner) => {
+runner.halt({
+          messages: __threads(),
+          data: await __callMethod(__stack.locals.c, "increment", {
+            type: "positional",
+            args: []
+          })
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
@@ -186,7 +186,7 @@ if (__ctx._pendingArgOverrides) {
 try {
       await agencyStore.run({
         ctx: __ctx,
-        stack: __stack,
+        stack: __setupData.stateStack,
         threads: __setupData.threads
       }, async () => {
         await runner.hook(0, async () => {
@@ -312,7 +312,7 @@ if (__ctx._pendingArgOverrides) {
 try {
       await agencyStore.run({
         ctx: __ctx,
-        stack: __stack,
+        stack: __setupData.stateStack,
         threads: __setupData.threads
       }, async () => {
         await runner.hook(0, async () => {
@@ -411,7 +411,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/class-inheritance.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -161,13 +161,10 @@ const __setupData = setupFunction({
       state: __state
     });
 // __state will be undefined if this function is being called as a tool by an llm
-const __stateStack = __setupData.stateStack;
 const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
 if (!__ctx.globals.isInitialized("class-inheritance.agency")) {
@@ -178,7 +175,7 @@ __self.__retryable = __self.__retryable ?? true;
 const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "class-inheritance.agency", scopeName: "Animal.speak", threads: __setupData.threads });
 let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "class-inheritance.agency", scopeName: "Animal.speak", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "class-inheritance.agency", scopeName: "Animal.speak", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -187,25 +184,31 @@ if (__ctx._pendingArgOverrides) {
 }
 
 try {
-      await runner.hook(0, async () => {
+      await agencyStore.run({
+        ctx: __ctx,
+        stack: __stack,
+        threads: __setupData.threads
+      }, async () => {
+        await runner.hook(0, async () => {
 await callHook({
-          name: "onFunctionStart",
-          data: {
-            functionName: "Animal.speak",
-            args: {},
-            isBuiltin: false,
-            moduleId: "class-inheritance.agency"
-          }
-        })
-      });
-      await runner.step(1, async (runner) => {
+            name: "onFunctionStart",
+            data: {
+              functionName: "Animal.speak",
+              args: {},
+              isBuiltin: false,
+              moduleId: "class-inheritance.agency"
+            }
+          })
+        });
+        await runner.step(1, async (runner) => {
 __stack.locals.n = this.name;
-      });
-      await runner.step(2, async (runner) => {
+        });
+        await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.n + ` makes a sound`)
 return;
-      });
+        });
+      })
       if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
     } catch (__error) {
       if (__error instanceof RestoreSignal) {
@@ -230,7 +233,7 @@ return failure(
 );
 
     } finally {
-      __stateStack.pop()
+      __stateStack()?.pop()
       if (__functionCompleted) {
         await callHook({
           name: "onFunctionEnd",
@@ -284,13 +287,10 @@ const __setupData = setupFunction({
       state: __state
     });
 // __state will be undefined if this function is being called as a tool by an llm
-const __stateStack = __setupData.stateStack;
 const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
 if (!__ctx.globals.isInitialized("class-inheritance.agency")) {
@@ -301,7 +301,7 @@ __self.__retryable = __self.__retryable ?? true;
 const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "class-inheritance.agency", scopeName: "Dog.speak", threads: __setupData.threads });
 let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "class-inheritance.agency", scopeName: "Dog.speak", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "class-inheritance.agency", scopeName: "Dog.speak", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -310,25 +310,31 @@ if (__ctx._pendingArgOverrides) {
 }
 
 try {
-      await runner.hook(0, async () => {
+      await agencyStore.run({
+        ctx: __ctx,
+        stack: __stack,
+        threads: __setupData.threads
+      }, async () => {
+        await runner.hook(0, async () => {
 await callHook({
-          name: "onFunctionStart",
-          data: {
-            functionName: "Dog.speak",
-            args: {},
-            isBuiltin: false,
-            moduleId: "class-inheritance.agency"
-          }
-        })
-      });
-      await runner.step(1, async (runner) => {
+            name: "onFunctionStart",
+            data: {
+              functionName: "Dog.speak",
+              args: {},
+              isBuiltin: false,
+              moduleId: "class-inheritance.agency"
+            }
+          })
+        });
+        await runner.step(1, async (runner) => {
 __stack.locals.n = this.name;
-      });
-      await runner.step(2, async (runner) => {
+        });
+        await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.n + ` barks`)
 return;
-      });
+        });
+      })
       if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
     } catch (__error) {
       if (__error instanceof RestoreSignal) {
@@ -353,7 +359,7 @@ return failure(
 );
 
     } finally {
-      __stateStack.pop()
+      __stateStack()?.pop()
       if (__functionCompleted) {
         await callHook({
           name: "onFunctionEnd",
@@ -395,41 +401,44 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "class-inheritance.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-__stack.locals.dog = new Dog(`Rex`, `Labrador`);
-    });
-    await runner.step(2, async (runner) => {
-__stack.locals.result = await __callMethod(__stack.locals.dog, "speak", {
-        type: "positional",
-        args: []
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
       });
-    });
-    await runner.step(3, async (runner) => {
+      await runner.step(1, async (runner) => {
+__stack.locals.dog = new Dog(`Rex`, `Labrador`);
+      });
+      await runner.step(2, async (runner) => {
+__stack.locals.result = await __callMethod(__stack.locals.dog, "speak", {
+          type: "positional",
+          args: []
+        });
+      });
+      await runner.step(3, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.result
-      })
+          messages: __threads(),
+          data: __stack.locals.result
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -156,13 +156,10 @@ async function __greet_impl(__state: InternalFunctionState | undefined = undefin
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("comments.agency")) {
@@ -173,7 +170,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "comments.agency", scopeName: "greet", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "comments.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "comments.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -182,29 +179,35 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "greet",
-          args: {},
-          isBuiltin: false,
-          moduleId: "comments.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "greet",
+            args: {},
+            isBuiltin: false,
+            moduleId: "comments.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 //  Comment inside function
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.message = `Hello, World!`;
 //  Another comment
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.message)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -229,7 +232,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -258,80 +261,83 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "comments.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 //  Comment before function call
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.result = await __call(greet, {
-        type: "positional",
-        args: []
-      });
+          type: "positional",
+          args: []
+        });
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.result
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.result]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.result
+          })
+          return;
+        }
       });
+      await runner.step(3, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.result]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
 //  Testing comments in different contexts
-    });
-    await runner.step(4, async (runner) => {
+      });
+      await runner.step(4, async (runner) => {
 __stack.locals.age = 25;
 //  2. Before conditionals
-    });
-    await runner.step(5, async (runner) => {
+      });
+      await runner.step(5, async (runner) => {
 __stack.locals.status = `active`;
-    });
-    await runner.ifElse(6, [
+      });
+      await runner.ifElse(6, [
 
   {
     condition: async () => __stack.locals.status === `inactive`,
     body: async (runner) => {
 await __call(print, {
-            type: "positional",
-            args: [`Stopped`]
-          })
+              type: "positional",
+              args: [`Stopped`]
+            })
     },
   },
 
 ]);
-    await runner.step(7, async (runner) => {
+      await runner.step(7, async (runner) => {
 //  Final comment at end of file
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(8, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -181,7 +181,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -271,7 +271,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -160,13 +160,10 @@ async function __greet_impl(name: string, greeting: string | typeof __UNSET = __
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("defaultValues.agency")) {
@@ -179,7 +176,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "defaultValues.agency", scopeName: "greet", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "defaultValues.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "defaultValues.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -196,31 +193,37 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "greet",
-          args: {
-            name: name,
-            greeting: greeting
-          },
-          isBuiltin: false,
-          moduleId: "defaultValues.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.args.greeting, __stack.args.name]
+          name: "onFunctionStart",
+          data: {
+            functionName: "greet",
+            args: {
+              name: name,
+              greeting: greeting
+            },
+            isBuiltin: false,
+            moduleId: "defaultValues.agency"
+          }
+        })
       });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.args.greeting, __stack.args.name]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -245,7 +248,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -195,7 +195,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -187,7 +187,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -300,7 +300,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -411,7 +411,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -524,7 +524,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -618,7 +618,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -152,13 +152,10 @@ async function __add_impl(a: any, b: any, __state: InternalFunctionState | undef
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
@@ -171,7 +168,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "docstrings.agency", scopeName: "add", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "docstrings.agency", scopeName: "add", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "docstrings.agency", scopeName: "add", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -188,20 +185,26 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "add",
-          args: {
-            a: a,
-            b: b
-          },
-          isBuiltin: false,
-          moduleId: "docstrings.agency"
-        }
-      })
-    });
+          name: "onFunctionStart",
+          data: {
+            functionName: "add",
+            args: {
+              a: a,
+              b: b
+            },
+            isBuiltin: false,
+            moduleId: "docstrings.agency"
+          }
+        })
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -226,7 +229,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -267,13 +270,10 @@ async function __greet_impl(name: any, __state: InternalFunctionState | undefine
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
@@ -285,7 +285,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "docstrings.agency", scopeName: "greet", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "docstrings.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "docstrings.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -298,19 +298,25 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "greet",
-          args: {
-            name: name
-          },
-          isBuiltin: false,
-          moduleId: "docstrings.agency"
-        }
-      })
-    });
+          name: "onFunctionStart",
+          data: {
+            functionName: "greet",
+            args: {
+              name: name
+            },
+            isBuiltin: false,
+            moduleId: "docstrings.agency"
+          }
+        })
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -335,7 +341,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -370,13 +376,10 @@ async function __calculateArea_impl(width: any, height: any, __state: InternalFu
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
@@ -389,7 +392,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "docstrings.agency", scopeName: "calculateArea", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "docstrings.agency", scopeName: "calculateArea", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "docstrings.agency", scopeName: "calculateArea", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -406,20 +409,26 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "calculateArea",
-          args: {
-            width: width,
-            height: height
-          },
-          isBuiltin: false,
-          moduleId: "docstrings.agency"
-        }
-      })
-    });
+          name: "onFunctionStart",
+          data: {
+            functionName: "calculateArea",
+            args: {
+              width: width,
+              height: height
+            },
+            isBuiltin: false,
+            moduleId: "docstrings.agency"
+          }
+        })
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -444,7 +453,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -490,13 +499,10 @@ async function __processData_impl(__state: InternalFunctionState | undefined = u
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
@@ -507,7 +513,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "docstrings.agency", scopeName: "processData", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "docstrings.agency", scopeName: "processData", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "docstrings.agency", scopeName: "processData", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -516,17 +522,23 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "processData",
-          args: {},
-          isBuiltin: false,
-          moduleId: "docstrings.agency"
-        }
-      })
-    });
+          name: "onFunctionStart",
+          data: {
+            functionName: "processData",
+            args: {},
+            isBuiltin: false,
+            moduleId: "docstrings.agency"
+          }
+        })
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -551,7 +563,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -581,13 +593,10 @@ async function __versionedTool_impl(__state: InternalFunctionState | undefined =
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
@@ -598,7 +607,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "docstrings.agency", scopeName: "versionedTool", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "docstrings.agency", scopeName: "versionedTool", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "docstrings.agency", scopeName: "versionedTool", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -607,17 +616,23 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "versionedTool",
-          args: {},
-          isBuiltin: false,
-          moduleId: "docstrings.agency"
-        }
-      })
-    });
+          name: "onFunctionStart",
+          data: {
+            functionName: "versionedTool",
+            args: {},
+            isBuiltin: false,
+            moduleId: "docstrings.agency"
+          }
+        })
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -642,7 +657,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -149,29 +149,31 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0001.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.sum = 0;
-    });
-    await runner.loop(2, Array.from({length: 1000 - 1}, (_, __i) => __i + 1), async (i, _, runner) => {
+      });
+      await runner.loop(2, Array.from({length: 1000 - 1}, (_, __i) => __i + 1), async (i, _, runner) => {
 await runner.ifElse(0, [
 
   {
@@ -179,19 +181,20 @@ await runner.ifElse(0, [
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.sum = __stack.locals.sum + i;
-            });
+              });
     },
   },
 
 ]);
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.sum
-      })
+          messages: __threads(),
+          data: __stack.locals.sum
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -159,7 +159,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -149,35 +149,37 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0002.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.a = 1;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.b = 2;
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 __stack.locals.sum = 0;
-    });
-    await runner.whileLoop(4, async () => __stack.locals.a <= 4000000, async (runner) => {
+      });
+      await runner.whileLoop(4, async () => __stack.locals.a <= 4000000, async (runner) => {
 await runner.ifElse(0, [
 
   {
@@ -185,28 +187,29 @@ await runner.ifElse(0, [
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.sum = __stack.locals.sum + __stack.locals.a;
-            });
+              });
     },
   },
 
 ]);
 await runner.step(1, async (runner) => {
 __stack.locals.c = __stack.locals.a + __stack.locals.b;
-      });
+        });
 await runner.step(2, async (runner) => {
 __stack.locals.a = __stack.locals.b;
-      });
+        });
 await runner.step(3, async (runner) => {
 __stack.locals.b = __stack.locals.c;
+        });
       });
-    });
-    await runner.step(5, async (runner) => {
+      await runner.step(5, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.sum
-      })
+          messages: __threads(),
+          data: __stack.locals.sum
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(6, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -159,7 +159,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -149,48 +149,51 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0003.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.n = 600851475143;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.d = 2;
-    });
-    await runner.whileLoop(3, async () => __stack.locals.d * __stack.locals.d <= __stack.locals.n, async (runner) => {
+      });
+      await runner.whileLoop(3, async () => __stack.locals.d * __stack.locals.d <= __stack.locals.n, async (runner) => {
 await runner.whileLoop(0, async () => __stack.locals.n % __stack.locals.d === 0, async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.n = __stack.locals.n / __stack.locals.d;
+          });
         });
-      });
 await runner.step(1, async (runner) => {
 __stack.locals.d = __stack.locals.d + 1;
+        });
       });
-    });
-    await runner.step(4, async (runner) => {
+      await runner.step(4, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.n
-      })
+          messages: __threads(),
+          data: __stack.locals.n
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -159,7 +159,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -180,7 +180,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -301,7 +301,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -150,13 +150,10 @@ async function __isPalindrome_impl(n: number, __state: InternalFunctionState | u
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("euler-0004.agency")) {
@@ -168,7 +165,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "euler-0004.agency", scopeName: "isPalindrome", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "euler-0004.agency", scopeName: "isPalindrome", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "euler-0004.agency", scopeName: "isPalindrome", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -181,29 +178,34 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "isPalindrome",
-          args: {
-            n: n
-          },
-          isBuiltin: false,
-          moduleId: "euler-0004.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "isPalindrome",
+            args: {
+              n: n
+            },
+            isBuiltin: false,
+            moduleId: "euler-0004.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.s = `${__stack.args.n}`;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.left = 0;
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 __stack.locals.right = __stack.locals.s.length - 1;
-    });
-    await runner.whileLoop(4, async () => __stack.locals.left < __stack.locals.right, async (runner) => {
+      });
+      await runner.whileLoop(4, async () => __stack.locals.left < __stack.locals.right, async (runner) => {
 await runner.ifElse(0, [
 
   {
@@ -213,23 +215,24 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(false)
 return;
-            });
+              });
     },
   },
 
 ]);
 await runner.step(1, async (runner) => {
 __stack.locals.left = __stack.locals.left + 1;
-      });
+        });
 await runner.step(2, async (runner) => {
 __stack.locals.right = __stack.locals.right - 1;
+        });
       });
-    });
-    await runner.step(5, async (runner) => {
+      await runner.step(5, async (runner) => {
 __functionCompleted = true;
 runner.halt(true)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -254,7 +257,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -288,69 +291,72 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0004.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.largest = 0;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.i = 999;
-    });
-    await runner.whileLoop(3, async () => __stack.locals.i >= 100, async (runner) => {
+      });
+      await runner.whileLoop(3, async () => __stack.locals.i >= 100, async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.j = __stack.locals.i;
-      });
+        });
 await runner.whileLoop(1, async () => __stack.locals.j >= 100, async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.product = __stack.locals.i * __stack.locals.j;
-        });
+          });
 await runner.ifElse(1, [
 
   {
     condition: async () => __stack.locals.product > __stack.locals.largest && await __call(isPalindrome, {
-              type: "positional",
-              args: [__stack.locals.product]
-            }),
+                type: "positional",
+                args: [__stack.locals.product]
+              }),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.largest = __stack.locals.product;
-              });
+                });
     },
   },
 
 ]);
 await runner.step(2, async (runner) => {
 __stack.locals.j = __stack.locals.j - 1;
+          });
         });
-      });
 await runner.step(2, async (runner) => {
 __stack.locals.i = __stack.locals.i - 1;
+        });
       });
-    });
-    await runner.step(4, async (runner) => {
+      await runner.step(4, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.largest
-      })
+          messages: __threads(),
+          data: __stack.locals.largest
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -185,7 +185,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -324,7 +324,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -423,7 +423,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -150,13 +150,10 @@ async function __gcd_impl(a: number, b: number, __state: InternalFunctionState |
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("euler-0005.agency")) {
@@ -169,7 +166,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "euler-0005.agency", scopeName: "gcd", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "euler-0005.agency", scopeName: "gcd", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "euler-0005.agency", scopeName: "gcd", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -186,42 +183,48 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "gcd",
-          args: {
-            a: a,
-            b: b
-          },
-          isBuiltin: false,
-          moduleId: "euler-0005.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "gcd",
+            args: {
+              a: a,
+              b: b
+            },
+            isBuiltin: false,
+            moduleId: "euler-0005.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.x = __stack.args.a;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.y = __stack.args.b;
-    });
-    await runner.whileLoop(3, async () => __stack.locals.y !== 0, async (runner) => {
+      });
+      await runner.whileLoop(3, async () => __stack.locals.y !== 0, async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.temp = __stack.locals.y;
-      });
+        });
 await runner.step(1, async (runner) => {
 __stack.locals.y = __stack.locals.x % __stack.locals.y;
-      });
+        });
 await runner.step(2, async (runner) => {
 __stack.locals.x = __stack.locals.temp;
+        });
       });
-    });
-    await runner.step(4, async (runner) => {
+      await runner.step(4, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.x)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -246,7 +249,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -286,13 +289,10 @@ async function __lcm_impl(a: number, b: number, __state: InternalFunctionState |
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("euler-0005.agency")) {
@@ -305,7 +305,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "euler-0005.agency", scopeName: "lcm", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "euler-0005.agency", scopeName: "lcm", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "euler-0005.agency", scopeName: "lcm", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -322,28 +322,34 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "lcm",
-          args: {
-            a: a,
-            b: b
-          },
-          isBuiltin: false,
-          moduleId: "euler-0005.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "lcm",
+            args: {
+              a: a,
+              b: b
+            },
+            isBuiltin: false,
+            moduleId: "euler-0005.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.args.a / await __call(gcd, {
-        type: "positional",
-        args: [__stack.args.a, __stack.args.b]
-      }) * __stack.args.b)
+          type: "positional",
+          args: [__stack.args.a, __stack.args.b]
+        }) * __stack.args.b)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -368,7 +374,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -407,51 +413,54 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0005.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.result = 1;
-    });
-    await runner.loop(2, Array.from({length: 21 - 2}, (_, __i) => __i + 2), async (i, _, runner) => {
+      });
+      await runner.loop(2, Array.from({length: 21 - 2}, (_, __i) => __i + 2), async (i, _, runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = await __call(lcm, {
-          type: "positional",
-          args: [__stack.locals.result, i]
-        });
+            type: "positional",
+            args: [__stack.locals.result, i]
+          });
 if (hasInterrupts(__stack.locals.result)) {
-          await __ctx.pendingPromises.awaitAll()
-          runner.halt({
-            ...__state,
-            data: __stack.locals.result
-          })
-          return;
-        }
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt({
+              ...__state,
+              data: __stack.locals.result
+            })
+            return;
+          }
+        });
       });
-    });
-    await runner.step(3, async (runner) => {
+      await runner.step(3, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.result
-      })
+          messages: __threads(),
+          data: __stack.locals.result
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -160,7 +160,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -150,49 +150,52 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0006.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.sumOfSquares = 0;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.sum = 0;
-    });
-    await runner.loop(3, Array.from({length: 101 - 1}, (_, __i) => __i + 1), async (i, _, runner) => {
+      });
+      await runner.loop(3, Array.from({length: 101 - 1}, (_, __i) => __i + 1), async (i, _, runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.sumOfSquares = __stack.locals.sumOfSquares + i * i;
-      });
+        });
 await runner.step(1, async (runner) => {
 __stack.locals.sum = __stack.locals.sum + i;
+        });
       });
-    });
-    await runner.step(4, async (runner) => {
+      await runner.step(4, async (runner) => {
 __stack.locals.squareOfSum = __stack.locals.sum * __stack.locals.sum;
-    });
-    await runner.step(5, async (runner) => {
+      });
+      await runner.step(5, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.squareOfSum - __stack.locals.sumOfSquares
-      })
+          messages: __threads(),
+          data: __stack.locals.squareOfSum - __stack.locals.sumOfSquares
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(6, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -150,13 +150,10 @@ async function __isPrime_impl(n: number, __state: InternalFunctionState | undefi
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("euler-0007.agency")) {
@@ -168,7 +165,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "euler-0007.agency", scopeName: "isPrime", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "euler-0007.agency", scopeName: "isPrime", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "euler-0007.agency", scopeName: "isPrime", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -181,69 +178,28 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "isPrime",
-          args: {
-            n: n
-          },
-          isBuiltin: false,
-          moduleId: "euler-0007.agency"
-        }
-      })
-    });
-    await runner.ifElse(1, [
+          name: "onFunctionStart",
+          data: {
+            functionName: "isPrime",
+            args: {
+              n: n
+            },
+            isBuiltin: false,
+            moduleId: "euler-0007.agency"
+          }
+        })
+      });
+      await runner.ifElse(1, [
 
   {
     condition: async () => __stack.args.n < 2,
-    body: async (runner) => {
-await runner.step(0, async (runner) => {
-__functionCompleted = true;
-runner.halt(false)
-return;
-          });
-    },
-  },
-
-]);
-    await runner.ifElse(2, [
-
-  {
-    condition: async () => __stack.args.n < 4,
-    body: async (runner) => {
-await runner.step(0, async (runner) => {
-__functionCompleted = true;
-runner.halt(true)
-return;
-          });
-    },
-  },
-
-]);
-    await runner.ifElse(3, [
-
-  {
-    condition: async () => __stack.args.n % 2 === 0 || __stack.args.n % 3 === 0,
-    body: async (runner) => {
-await runner.step(0, async (runner) => {
-__functionCompleted = true;
-runner.halt(false)
-return;
-          });
-    },
-  },
-
-]);
-    await runner.step(4, async (runner) => {
-__stack.locals.i = 5;
-    });
-    await runner.whileLoop(5, async () => __stack.locals.i * __stack.locals.i <= __stack.args.n, async (runner) => {
-await runner.ifElse(0, [
-
-  {
-    condition: async () => __stack.args.n % __stack.locals.i === 0 || __stack.args.n % (__stack.locals.i + 2) === 0,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -254,15 +210,62 @@ return;
   },
 
 ]);
-await runner.step(1, async (runner) => {
-__stack.locals.i = __stack.locals.i + 6;
-      });
-    });
-    await runner.step(6, async (runner) => {
+      await runner.ifElse(2, [
+
+  {
+    condition: async () => __stack.args.n < 4,
+    body: async (runner) => {
+await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(true)
 return;
-    });
+            });
+    },
+  },
+
+]);
+      await runner.ifElse(3, [
+
+  {
+    condition: async () => __stack.args.n % 2 === 0 || __stack.args.n % 3 === 0,
+    body: async (runner) => {
+await runner.step(0, async (runner) => {
+__functionCompleted = true;
+runner.halt(false)
+return;
+            });
+    },
+  },
+
+]);
+      await runner.step(4, async (runner) => {
+__stack.locals.i = 5;
+      });
+      await runner.whileLoop(5, async () => __stack.locals.i * __stack.locals.i <= __stack.args.n, async (runner) => {
+await runner.ifElse(0, [
+
+  {
+    condition: async () => __stack.args.n % __stack.locals.i === 0 || __stack.args.n % (__stack.locals.i + 2) === 0,
+    body: async (runner) => {
+await runner.step(0, async (runner) => {
+__functionCompleted = true;
+runner.halt(false)
+return;
+              });
+    },
+  },
+
+]);
+await runner.step(1, async (runner) => {
+__stack.locals.i = __stack.locals.i + 6;
+        });
+      });
+      await runner.step(6, async (runner) => {
+__functionCompleted = true;
+runner.halt(true)
+return;
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -287,7 +290,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -321,58 +324,61 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0007.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.count = 0;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.num = 1;
-    });
-    await runner.whileLoop(3, async () => __stack.locals.count < 10001, async (runner) => {
+      });
+      await runner.whileLoop(3, async () => __stack.locals.count < 10001, async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.num = __stack.locals.num + 1;
-      });
+        });
 await runner.ifElse(1, [
 
   {
     condition: async () => await __call(isPrime, {
-            type: "positional",
-            args: [__stack.locals.num]
-          }),
+              type: "positional",
+              args: [__stack.locals.num]
+            }),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.count = __stack.locals.count + 1;
-            });
+              });
     },
   },
 
 ]);
-    });
-    await runner.step(4, async (runner) => {
+      });
+      await runner.step(4, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.num
-      })
+          messages: __threads(),
+          data: __stack.locals.num
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -180,7 +180,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -334,7 +334,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -181,7 +181,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -397,7 +397,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -151,13 +151,10 @@ async function __toDigit_impl(c: string, __state: InternalFunctionState | undefi
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("euler-0008.agency")) {
@@ -169,7 +166,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "euler-0008.agency", scopeName: "toDigit", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "euler-0008.agency", scopeName: "toDigit", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "euler-0008.agency", scopeName: "toDigit", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -182,20 +179,25 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "toDigit",
-          args: {
-            c: c
-          },
-          isBuiltin: false,
-          moduleId: "euler-0008.agency"
-        }
-      })
-    });
-    await runner.ifElse(1, [
+          name: "onFunctionStart",
+          data: {
+            functionName: "toDigit",
+            args: {
+              c: c
+            },
+            isBuiltin: false,
+            moduleId: "euler-0008.agency"
+          }
+        })
+      });
+      await runner.ifElse(1, [
 
   {
     condition: async () => __stack.args.c === `1`,
@@ -204,12 +206,12 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(1)
 return;
-          });
+            });
     },
   },
 
 ]);
-    await runner.ifElse(2, [
+      await runner.ifElse(2, [
 
   {
     condition: async () => __stack.args.c === `2`,
@@ -218,12 +220,12 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(2)
 return;
-          });
+            });
     },
   },
 
 ]);
-    await runner.ifElse(3, [
+      await runner.ifElse(3, [
 
   {
     condition: async () => __stack.args.c === `3`,
@@ -232,12 +234,12 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(3)
 return;
-          });
+            });
     },
   },
 
 ]);
-    await runner.ifElse(4, [
+      await runner.ifElse(4, [
 
   {
     condition: async () => __stack.args.c === `4`,
@@ -246,12 +248,12 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(4)
 return;
-          });
+            });
     },
   },
 
 ]);
-    await runner.ifElse(5, [
+      await runner.ifElse(5, [
 
   {
     condition: async () => __stack.args.c === `5`,
@@ -260,12 +262,12 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(5)
 return;
-          });
+            });
     },
   },
 
 ]);
-    await runner.ifElse(6, [
+      await runner.ifElse(6, [
 
   {
     condition: async () => __stack.args.c === `6`,
@@ -274,12 +276,12 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(6)
 return;
-          });
+            });
     },
   },
 
 ]);
-    await runner.ifElse(7, [
+      await runner.ifElse(7, [
 
   {
     condition: async () => __stack.args.c === `7`,
@@ -288,12 +290,12 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(7)
 return;
-          });
+            });
     },
   },
 
 ]);
-    await runner.ifElse(8, [
+      await runner.ifElse(8, [
 
   {
     condition: async () => __stack.args.c === `8`,
@@ -302,12 +304,12 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(8)
 return;
-          });
+            });
     },
   },
 
 ]);
-    await runner.ifElse(9, [
+      await runner.ifElse(9, [
 
   {
     condition: async () => __stack.args.c === `9`,
@@ -316,16 +318,17 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(9)
 return;
-          });
+            });
     },
   },
 
 ]);
-    await runner.step(10, async (runner) => {
+      await runner.step(10, async (runner) => {
 __functionCompleted = true;
 runner.halt(0)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -350,7 +353,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -384,52 +387,54 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0008.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.digits = `7316717653133062491922511967442657474235534919493496983520312774506326239578318016984801869478851843858615607891129494954595017379583319528532088055111254069874715852386305071569329096329522744304355766896648950445244523161731856403098711121722383113622298934233803081353362766142828064444866452387493035890729629049156044077239071381051585930796086670172427121883998797908792274921901699720888093776657273330010533678812202354218097512545405947522435258490771167055601360483958644670632441572215539753697817977846174064955149290862569321978468622482839722413756570560574902614079729686524145351004748216637048440319989000889524345065854122758866688116427171479924442928230863465674813919123162824586178664583591245665294765456828489128831426076900422421902267105562632111110937054421750694165896040807198403850962455444362981230987879927244284909188845801561660979191338754992005240636899125607176060588611646710940507754100225698315520005593572972571636269561882670428252483600823257530420752963450`;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.maxProduct = 0;
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 __stack.locals.i = 0;
-    });
-    await runner.whileLoop(4, async () => __stack.locals.i <= __stack.locals.digits.length - 13, async (runner) => {
+      });
+      await runner.whileLoop(4, async () => __stack.locals.i <= __stack.locals.digits.length - 13, async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.product = 1;
-      });
+        });
 await runner.step(1, async (runner) => {
 __stack.locals.j = 0;
-      });
+        });
 await runner.whileLoop(2, async () => __stack.locals.j < 13, async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.product = __stack.locals.product * await __call(toDigit, {
-            type: "positional",
-            args: [__stack.locals.digits[__stack.locals.i + __stack.locals.j]]
+              type: "positional",
+              args: [__stack.locals.digits[__stack.locals.i + __stack.locals.j]]
+            });
           });
-        });
 await runner.step(1, async (runner) => {
 __stack.locals.j = __stack.locals.j + 1;
+          });
         });
-      });
 await runner.ifElse(3, [
 
   {
@@ -437,22 +442,23 @@ await runner.ifElse(3, [
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.maxProduct = __stack.locals.product;
-            });
+              });
     },
   },
 
 ]);
 await runner.step(4, async (runner) => {
 __stack.locals.i = __stack.locals.i + 1;
+        });
       });
-    });
-    await runner.step(5, async (runner) => {
+      await runner.step(5, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.maxProduct
-      })
+          messages: __threads(),
+          data: __stack.locals.maxProduct
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(6, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -149,36 +149,38 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0009.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.a = 1;
-    });
-    await runner.whileLoop(2, async () => __stack.locals.a < 1000, async (runner) => {
+      });
+      await runner.whileLoop(2, async () => __stack.locals.a < 1000, async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.b = __stack.locals.a + 1;
-      });
+        });
 await runner.whileLoop(1, async () => __stack.locals.b < 1000 - __stack.locals.a, async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.c = 1000 - __stack.locals.a - __stack.locals.b;
-        });
+          });
 await runner.ifElse(1, [
 
   {
@@ -186,30 +188,31 @@ await runner.ifElse(1, [
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 runner.halt({
-                  messages: __threads(),
-                  data: __stack.locals.a * __stack.locals.b * __stack.locals.c
-                })
+                    messages: __threads(),
+                    data: __stack.locals.a * __stack.locals.b * __stack.locals.c
+                  })
 return;
-              });
+                });
     },
   },
 
 ]);
 await runner.step(2, async (runner) => {
 __stack.locals.b = __stack.locals.b + 1;
+          });
         });
-      });
 await runner.step(2, async (runner) => {
 __stack.locals.a = __stack.locals.a + 1;
+        });
       });
-    });
-    await runner.step(3, async (runner) => {
+      await runner.step(3, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: 0
-      })
+          messages: __threads(),
+          data: 0
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -159,7 +159,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -150,13 +150,10 @@ async function __isPrime_impl(n: number, __state: InternalFunctionState | undefi
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("euler-0010.agency")) {
@@ -168,7 +165,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "euler-0010.agency", scopeName: "isPrime", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "euler-0010.agency", scopeName: "isPrime", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "euler-0010.agency", scopeName: "isPrime", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -181,69 +178,28 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "isPrime",
-          args: {
-            n: n
-          },
-          isBuiltin: false,
-          moduleId: "euler-0010.agency"
-        }
-      })
-    });
-    await runner.ifElse(1, [
+          name: "onFunctionStart",
+          data: {
+            functionName: "isPrime",
+            args: {
+              n: n
+            },
+            isBuiltin: false,
+            moduleId: "euler-0010.agency"
+          }
+        })
+      });
+      await runner.ifElse(1, [
 
   {
     condition: async () => __stack.args.n < 2,
-    body: async (runner) => {
-await runner.step(0, async (runner) => {
-__functionCompleted = true;
-runner.halt(false)
-return;
-          });
-    },
-  },
-
-]);
-    await runner.ifElse(2, [
-
-  {
-    condition: async () => __stack.args.n < 4,
-    body: async (runner) => {
-await runner.step(0, async (runner) => {
-__functionCompleted = true;
-runner.halt(true)
-return;
-          });
-    },
-  },
-
-]);
-    await runner.ifElse(3, [
-
-  {
-    condition: async () => __stack.args.n % 2 === 0 || __stack.args.n % 3 === 0,
-    body: async (runner) => {
-await runner.step(0, async (runner) => {
-__functionCompleted = true;
-runner.halt(false)
-return;
-          });
-    },
-  },
-
-]);
-    await runner.step(4, async (runner) => {
-__stack.locals.i = 5;
-    });
-    await runner.whileLoop(5, async () => __stack.locals.i * __stack.locals.i <= __stack.args.n, async (runner) => {
-await runner.ifElse(0, [
-
-  {
-    condition: async () => __stack.args.n % __stack.locals.i === 0 || __stack.args.n % (__stack.locals.i + 2) === 0,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __functionCompleted = true;
@@ -254,15 +210,62 @@ return;
   },
 
 ]);
-await runner.step(1, async (runner) => {
-__stack.locals.i = __stack.locals.i + 6;
-      });
-    });
-    await runner.step(6, async (runner) => {
+      await runner.ifElse(2, [
+
+  {
+    condition: async () => __stack.args.n < 4,
+    body: async (runner) => {
+await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(true)
 return;
-    });
+            });
+    },
+  },
+
+]);
+      await runner.ifElse(3, [
+
+  {
+    condition: async () => __stack.args.n % 2 === 0 || __stack.args.n % 3 === 0,
+    body: async (runner) => {
+await runner.step(0, async (runner) => {
+__functionCompleted = true;
+runner.halt(false)
+return;
+            });
+    },
+  },
+
+]);
+      await runner.step(4, async (runner) => {
+__stack.locals.i = 5;
+      });
+      await runner.whileLoop(5, async () => __stack.locals.i * __stack.locals.i <= __stack.args.n, async (runner) => {
+await runner.ifElse(0, [
+
+  {
+    condition: async () => __stack.args.n % __stack.locals.i === 0 || __stack.args.n % (__stack.locals.i + 2) === 0,
+    body: async (runner) => {
+await runner.step(0, async (runner) => {
+__functionCompleted = true;
+runner.halt(false)
+return;
+              });
+    },
+  },
+
+]);
+await runner.step(1, async (runner) => {
+__stack.locals.i = __stack.locals.i + 6;
+        });
+      });
+      await runner.step(6, async (runner) => {
+__functionCompleted = true;
+runner.halt(true)
+return;
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -287,7 +290,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -321,58 +324,61 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0010.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.sum = 2;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.n = 3;
-    });
-    await runner.whileLoop(3, async () => __stack.locals.n < 2000000, async (runner) => {
+      });
+      await runner.whileLoop(3, async () => __stack.locals.n < 2000000, async (runner) => {
 await runner.ifElse(0, [
 
   {
     condition: async () => await __call(isPrime, {
-            type: "positional",
-            args: [__stack.locals.n]
-          }),
+              type: "positional",
+              args: [__stack.locals.n]
+            }),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.sum = __stack.locals.sum + __stack.locals.n;
-            });
+              });
     },
   },
 
 ]);
 await runner.step(1, async (runner) => {
 __stack.locals.n = __stack.locals.n + 2;
+        });
       });
-    });
-    await runner.step(4, async (runner) => {
+      await runner.step(4, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.sum
-      })
+          messages: __threads(),
+          data: __stack.locals.sum
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -180,7 +180,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -334,7 +334,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,102 +147,105 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "forLoop.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 //  Basic for-of loop
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.items = [`a`, `b`, `c`];
-    });
-    await runner.loop(3, __stack.locals.items, async (item, _, runner) => {
+      });
+      await runner.loop(3, __stack.locals.items, async (item, _, runner) => {
 await runner.step(0, async (runner) => {
 const __funcResult = await __call(print, {
-          type: "positional",
-          args: [item]
-        });
+            type: "positional",
+            args: [item]
+          });
 if (hasInterrupts(__funcResult)) {
-          await __ctx.pendingPromises.awaitAll()
-          runner.halt({
-            ...__state,
-            data: __funcResult
-          })
-          return;
-        }
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt({
+              ...__state,
+              data: __funcResult
+            })
+            return;
+          }
+        });
       });
-    });
-    await runner.step(4, async (runner) => {
+      await runner.step(4, async (runner) => {
 //  Range-based for loop
-    });
-    await runner.loop(5, Array.from({length: 5 - 0}, (_, __i) => __i + 0), async (i, _, runner) => {
+      });
+      await runner.loop(5, Array.from({length: 5 - 0}, (_, __i) => __i + 0), async (i, _, runner) => {
 await runner.step(0, async (runner) => {
 const __funcResult = await __call(print, {
-          type: "positional",
-          args: [i]
-        });
+            type: "positional",
+            args: [i]
+          });
 if (hasInterrupts(__funcResult)) {
-          await __ctx.pendingPromises.awaitAll()
-          runner.halt({
-            ...__state,
-            data: __funcResult
-          })
-          return;
-        }
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt({
+              ...__state,
+              data: __funcResult
+            })
+            return;
+          }
+        });
       });
-    });
-    await runner.step(6, async (runner) => {
+      await runner.step(6, async (runner) => {
 //  Indexed for loop
-    });
-    await runner.step(7, async (runner) => {
+      });
+      await runner.step(7, async (runner) => {
 __stack.locals.names = [`alice`, `bob`];
-    });
-    await runner.loop(8, __stack.locals.names, async (name, index, runner) => {
+      });
+      await runner.loop(8, __stack.locals.names, async (name, index, runner) => {
 await runner.step(0, async (runner) => {
 const __funcResult = await __call(print, {
-          type: "positional",
-          args: [name]
-        });
+            type: "positional",
+            args: [name]
+          });
 if (hasInterrupts(__funcResult)) {
-          await __ctx.pendingPromises.awaitAll()
-          runner.halt({
-            ...__state,
-            data: __funcResult
-          })
-          return;
-        }
-      });
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt({
+              ...__state,
+              data: __funcResult
+            })
+            return;
+          }
+        });
 await runner.step(1, async (runner) => {
 const __funcResult = await __call(print, {
-          type: "positional",
-          args: [index]
-        });
+            type: "positional",
+            args: [index]
+          });
 if (hasInterrupts(__funcResult)) {
-          await __ctx.pendingPromises.awaitAll()
-          runner.halt({
-            ...__state,
-            data: __funcResult
-          })
-          return;
-        }
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt({
+              ...__state,
+              data: __funcResult
+            })
+            return;
+          }
+        });
       });
-    });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(9, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -183,7 +183,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -320,7 +320,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -453,7 +453,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -587,7 +587,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -715,7 +715,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -822,7 +822,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -898,7 +898,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __add_impl(x: number, y: number, __state: InternalFunctionState |
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
@@ -167,7 +164,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function-with-types.agency", scopeName: "add", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "function-with-types.agency", scopeName: "add", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function-with-types.agency", scopeName: "add", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -184,45 +181,51 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "add",
-          args: {
-            x: x,
-            y: y
-          },
-          isBuiltin: false,
-          moduleId: "function-with-types.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "add",
+            args: {
+              x: x,
+              y: y
+            },
+            isBuiltin: false,
+            moduleId: "function-with-types.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.result = await runPrompt({
-        prompt: `add ${__stack.args.x} and ${__stack.args.y}`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.number()
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `add ${__stack.args.x} and ${__stack.args.y}`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.number()
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__stack.locals.result)
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.result)
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.result)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -247,7 +250,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -287,13 +290,10 @@ async function __greet_impl(name: string, __state: InternalFunctionState | undef
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
@@ -305,7 +305,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function-with-types.agency", scopeName: "greet", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "function-with-types.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function-with-types.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -318,41 +318,47 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "greet",
-          args: {
-            name: name
-          },
-          isBuiltin: false,
-          moduleId: "function-with-types.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "greet",
+            args: {
+              name: name
+            },
+            isBuiltin: false,
+            moduleId: "function-with-types.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.message = await runPrompt({
-        prompt: `Hello ${__stack.args.name}!`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Hello ${__stack.args.name}!`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.message)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__stack.locals.message)
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.message)
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.message)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -377,7 +383,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -412,13 +418,10 @@ async function __mixed_impl(count: number, label: any, __state: InternalFunction
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
@@ -431,7 +434,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function-with-types.agency", scopeName: "mixed", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "function-with-types.agency", scopeName: "mixed", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function-with-types.agency", scopeName: "mixed", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -448,42 +451,48 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "mixed",
-          args: {
-            count: count,
-            label: label
-          },
-          isBuiltin: false,
-          moduleId: "function-with-types.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "mixed",
+            args: {
+              count: count,
+              label: label
+            },
+            isBuiltin: false,
+            moduleId: "function-with-types.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.output = await runPrompt({
-        prompt: `${__stack.args.label}: ${__stack.args.count}`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `${__stack.args.label}: ${__stack.args.count}`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.output)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__stack.locals.output)
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.output)
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.output)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -508,7 +517,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -548,13 +557,10 @@ async function __processArray_impl(items: number[], __state: InternalFunctionSta
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
@@ -566,7 +572,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function-with-types.agency", scopeName: "processArray", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "function-with-types.agency", scopeName: "processArray", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function-with-types.agency", scopeName: "processArray", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -579,41 +585,47 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "processArray",
-          args: {
-            items: items
-          },
-          isBuiltin: false,
-          moduleId: "function-with-types.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "processArray",
+            args: {
+              items: items
+            },
+            isBuiltin: false,
+            moduleId: "function-with-types.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.result = await runPrompt({
-        prompt: `Processing array with ${__stack.args.items} items`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Processing array with ${__stack.args.items} items`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__stack.locals.result)
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.result)
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.result)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -638,7 +650,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -673,13 +685,10 @@ async function __flexible_impl(value: string | number, __state: InternalFunction
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
@@ -691,7 +700,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function-with-types.agency", scopeName: "flexible", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "function-with-types.agency", scopeName: "flexible", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function-with-types.agency", scopeName: "flexible", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -704,41 +713,47 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "flexible",
-          args: {
-            value: value
-          },
-          isBuiltin: false,
-          moduleId: "function-with-types.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "flexible",
+            args: {
+              value: value
+            },
+            isBuiltin: false,
+            moduleId: "function-with-types.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.result = await runPrompt({
-        prompt: `Received value: ${__stack.args.value}`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Received value: ${__stack.args.value}`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__stack.locals.result)
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.result)
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.result)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -763,7 +778,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -797,46 +812,49 @@ graph.node("foo", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "function-with-types.agency", scopeName: "foo", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "foo"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`This is a node with a return type`]
-      });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
+          name: "onNodeStart",
+          data: {
+            nodeName: "foo"
+          }
         })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`This is a node with a return type`]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: `Node completed`
-      })
+          messages: __threads(),
+          data: `Node completed`
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({
@@ -870,98 +888,101 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "function-with-types.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 //  Call the functions
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.sum = await __call(add, {
-        type: "positional",
-        args: [5, 10]
-      });
+          type: "positional",
+          args: [5, 10]
+        });
 if (hasInterrupts(__stack.locals.sum)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.sum
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.sum
+          })
+          return;
+        }
+      });
+      await runner.step(3, async (runner) => {
 __stack.locals.greeting = await __call(greet, {
-        type: "positional",
-        args: [`Alice`]
-      });
+          type: "positional",
+          args: [`Alice`]
+        });
 if (hasInterrupts(__stack.locals.greeting)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.greeting
-        })
-        return;
-      }
-    });
-    await runner.step(4, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.greeting
+          })
+          return;
+        }
+      });
+      await runner.step(4, async (runner) => {
 __stack.locals.labeled = await __call(mixed, {
-        type: "positional",
-        args: [42, `Answer`]
-      });
+          type: "positional",
+          args: [42, `Answer`]
+        });
 if (hasInterrupts(__stack.locals.labeled)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.labeled
-        })
-        return;
-      }
-    });
-    await runner.step(5, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.labeled
+          })
+          return;
+        }
+      });
+      await runner.step(5, async (runner) => {
 __stack.locals.processed = await __call(processArray, {
-        type: "positional",
-        args: [[1, 2, 3, 4, 5]]
-      });
+          type: "positional",
+          args: [[1, 2, 3, 4, 5]]
+        });
 if (hasInterrupts(__stack.locals.processed)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.processed
-        })
-        return;
-      }
-    });
-    await runner.step(6, async (runner) => {
-__stack.locals.flexResult = await __call(flexible, {
-        type: "positional",
-        args: [`test`]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.processed
+          })
+          return;
+        }
       });
+      await runner.step(6, async (runner) => {
+__stack.locals.flexResult = await __call(flexible, {
+          type: "positional",
+          args: [`test`]
+        });
 if (hasInterrupts(__stack.locals.flexResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.flexResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.flexResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(7, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -173,7 +173,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -280,7 +280,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -374,7 +374,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __test_impl(__state: InternalFunctionState | undefined = undefine
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function.agency")) {
@@ -165,7 +162,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function.agency", scopeName: "test", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "function.agency", scopeName: "test", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function.agency", scopeName: "test", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -174,20 +171,26 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "test",
-          args: {},
-          isBuiltin: false,
-          moduleId: "function.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "test",
+            args: {},
+            isBuiltin: false,
+            moduleId: "function.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.foo = 1;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -212,7 +215,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -242,13 +245,10 @@ async function __add_impl(a: any, b: any, __state: InternalFunctionState | undef
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function.agency")) {
@@ -261,7 +261,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function.agency", scopeName: "add", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "function.agency", scopeName: "add", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function.agency", scopeName: "add", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -278,23 +278,29 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "add",
-          args: {
-            a: a,
-            b: b
-          },
-          isBuiltin: false,
-          moduleId: "function.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "add",
+            args: {
+              a: a,
+              b: b
+            },
+            isBuiltin: false,
+            moduleId: "function.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 //  multi-param function
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -319,7 +325,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -358,42 +364,45 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "function.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [await __call(test, {
-          type: "positional",
-          args: []
-        })]
-      });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
         })
-        return;
-      }
-    });
+      });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [await __call(test, {
+            type: "positional",
+            args: []
+          })]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(2, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -178,7 +178,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -289,7 +289,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -405,7 +405,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -515,7 +515,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __greet_impl(name: string, __state: InternalFunctionState | undef
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("functionRef.agency")) {
@@ -166,7 +163,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "functionRef.agency", scopeName: "greet", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "functionRef.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "functionRef.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -179,24 +176,30 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "greet",
-          args: {
-            name: name
-          },
-          isBuiltin: false,
-          moduleId: "functionRef.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "greet",
+            args: {
+              name: name
+            },
+            isBuiltin: false,
+            moduleId: "functionRef.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(`hi ${__stack.args.name}`)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -221,7 +224,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -256,13 +259,10 @@ async function __double_impl(x: number, __state: InternalFunctionState | undefin
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("functionRef.agency")) {
@@ -274,7 +274,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "functionRef.agency", scopeName: "double", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "functionRef.agency", scopeName: "double", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "functionRef.agency", scopeName: "double", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -287,24 +287,30 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "double",
-          args: {
-            x: x
-          },
-          isBuiltin: false,
-          moduleId: "functionRef.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "double",
+            args: {
+              x: x
+            },
+            isBuiltin: false,
+            moduleId: "functionRef.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.args.x * 2)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -329,7 +335,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -364,13 +370,10 @@ async function __applyToAll_impl(items: number[], transform: (number) => number,
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("functionRef.agency")) {
@@ -383,7 +386,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "functionRef.agency", scopeName: "applyToAll", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "functionRef.agency", scopeName: "applyToAll", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "functionRef.agency", scopeName: "applyToAll", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -400,39 +403,45 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "applyToAll",
-          args: {
-            items: items,
-            transform: transform
-          },
-          isBuiltin: false,
-          moduleId: "functionRef.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-__stack.locals.result = [];
-    });
-    await runner.loop(2, __stack.args.items, async (item, _, runner) => {
-await runner.step(0, async (runner) => {
-await __callMethod(__stack.locals.result, "push", {
-          type: "positional",
-          args: [await __call(__stack.args.transform, {
-            type: "positional",
-            args: [item]
-          })]
+          name: "onFunctionStart",
+          data: {
+            functionName: "applyToAll",
+            args: {
+              items: items,
+              transform: transform
+            },
+            isBuiltin: false,
+            moduleId: "functionRef.agency"
+          }
         })
       });
-    });
-    await runner.step(3, async (runner) => {
+      await runner.step(1, async (runner) => {
+__stack.locals.result = [];
+      });
+      await runner.loop(2, __stack.args.items, async (item, _, runner) => {
+await runner.step(0, async (runner) => {
+await __callMethod(__stack.locals.result, "push", {
+            type: "positional",
+            args: [await __call(__stack.args.transform, {
+              type: "positional",
+              args: [item]
+            })]
+          })
+        });
+      });
+      await runner.step(3, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.result)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -457,7 +466,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -496,56 +505,59 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "functionRef.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.fn = greet;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.result = await __call(__stack.locals.fn, {
-        type: "positional",
-        args: [`Bob`]
-      });
+          type: "positional",
+          args: [`Bob`]
+        });
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.result
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-__stack.locals.doubled = await __call(applyToAll, {
-        type: "positional",
-        args: [[1, 2, 3], double]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.result
+          })
+          return;
+        }
       });
+      await runner.step(3, async (runner) => {
+__stack.locals.doubled = await __call(applyToAll, {
+          type: "positional",
+          args: [[1, 2, 3], double]
+        });
 if (hasInterrupts(__stack.locals.doubled)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.doubled
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.doubled
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -149,13 +149,10 @@ async function __process_impl(c: Container<number>, __state: InternalFunctionSta
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("genericAliasValidation.agency")) {
@@ -167,7 +164,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "genericAliasValidation.agency", scopeName: "process", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "genericAliasValidation.agency", scopeName: "process", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "genericAliasValidation.agency", scopeName: "process", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -185,35 +182,41 @@ if (__ctx._pendingArgOverrides) {
       return __vr_c;
     }
     __stack.args["c"] = __vr_c.value;
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "process",
-          args: {
-            c: c
-          },
-          isBuiltin: false,
-          moduleId: "genericAliasValidation.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.args.c.value]
+          name: "onFunctionStart",
+          data: {
+            functionName: "process",
+            args: {
+              c: c
+            },
+            isBuiltin: false,
+            moduleId: "genericAliasValidation.agency"
+          }
+        })
       });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.args.c.value]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.args.c)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -238,7 +241,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -272,55 +275,58 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "genericAliasValidation.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.c = await __call(process, {
-        type: "positional",
-        args: [{
-          "value": 42
-        }]
-      });
+          type: "positional",
+          args: [{
+            "value": 42
+          }]
+        });
 if (hasInterrupts(__stack.locals.c)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.c
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.c.value]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.c
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.c.value]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -184,7 +184,7 @@ if (__ctx._pendingArgOverrides) {
     __stack.args["c"] = __vr_c.value;
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -285,7 +285,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,39 +147,42 @@ graph.node("foo", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "goto.agency", scopeName: "foo", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "foo"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`in foo`]
-      });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
+          name: "onNodeStart",
+          data: {
+            nodeName: "foo"
+          }
         })
-        return;
-      }
-    });
+      });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`in foo`]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(2, async () => {
 await callHook({
@@ -213,35 +216,38 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "goto.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-__stateStack.pop()
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__stateStack()?.pop()
 __functionCompleted = true;
 runner.halt(goToNode("foo", {
-        messages: __threads(),
-        ctx: __ctx,
-        data: {}
-      }))
+          messages: __threads(),
+          ctx: __ctx,
+          data: {}
+        }))
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(2, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -226,7 +226,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -160,7 +160,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -229,7 +229,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,13 +147,10 @@ graph.node("greet", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "gotoWithArgs.agency", scopeName: "greet", threads: __setupData.threads });
@@ -161,28 +158,34 @@ let __functionCompleted = false;
     __stack.args["name"] = __state.data.name;
   }
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "greet"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`hello ${__stack.args.name}`]
-      });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
+          name: "onNodeStart",
+          data: {
+            nodeName: "greet"
+          }
         })
-        return;
-      }
-    });
+      });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`hello ${__stack.args.name}`]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(2, async () => {
 await callHook({
@@ -216,37 +219,40 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "gotoWithArgs.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-__stateStack.pop()
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__stateStack()?.pop()
 __functionCompleted = true;
 runner.halt(goToNode("greet", {
-        messages: __threads(),
-        ctx: __ctx,
-        data: {
-          name: `world`
-        }
-      }))
+          messages: __threads(),
+          ctx: __ctx,
+          data: {
+            name: `world`
+          }
+        }))
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(2, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ graph.node("greet", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "graph-node-with-types.agency", scopeName: "greet", threads: __setupData.threads });
@@ -162,48 +159,54 @@ let __functionCompleted = false;
     __stack.args["name"] = __state.data.name;
   }
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "greet"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "greet"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.greeting = await runPrompt({
-        prompt: `Say hello to ${__stack.args.name}`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Say hello to ${__stack.args.name}`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.greeting)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.greeting
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.greeting]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.greeting
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.greeting]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -161,7 +161,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,92 +147,94 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "ifElse.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 //  Basic if statement with boolean variable
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.flag = true;
-    });
-    await runner.ifElse(3, [
+      });
+      await runner.ifElse(3, [
 
   {
     condition: async () => __stack.locals.flag,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `condition was true`;
-          });
+            });
     },
   },
 
 ]);
-    await runner.ifElse(4, [
+      await runner.ifElse(4, [
 
   {
     condition: async () => await __call(isReady, {
-          type: "positional",
-          args: []
-        }),
+            type: "positional",
+            args: []
+          }),
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.status = `ready`;
-          });
+            });
     },
   },
 
 ]);
-    await runner.step(5, async (runner) => {
+      await runner.step(5, async (runner) => {
 //  If statement with property access
-    });
-    await runner.step(6, async (runner) => {
+      });
+      await runner.step(6, async (runner) => {
 __stack.locals.obj = {
-        "active": true
-      };
-    });
-    await runner.ifElse(7, [
+          "active": true
+        };
+      });
+      await runner.ifElse(7, [
 
   {
     condition: async () => __stack.locals.obj.active,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.message = `object is active`;
-          });
+            });
     },
   },
 
 ]);
-    await runner.step(8, async (runner) => {
+      await runner.step(8, async (runner) => {
 //  Nested if statements
-    });
-    await runner.step(9, async (runner) => {
+      });
+      await runner.step(9, async (runner) => {
 __stack.locals.outer = true;
-    });
-    await runner.ifElse(10, [
+      });
+      await runner.ifElse(10, [
 
   {
     condition: async () => __stack.locals.outer,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.inner = false;
-          });
+            });
 await runner.ifElse(1, [
 
   {
@@ -240,7 +242,7 @@ await runner.ifElse(1, [
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.nested = `both true`;
-                });
+                  });
     },
   },
 
@@ -249,7 +251,7 @@ __stack.locals.nested = `both true`;
   },
 
 ]);
-    await runner.step(11, async (runner) => {
+      await runner.step(11, async (runner) => {
 //  TODO fix
 //  If with index access
 //  arr = [1, 2, 3]
@@ -257,79 +259,79 @@ __stack.locals.nested = `both true`;
 //    firstElement = "exists"
 //  }
 //  Multiple statements in then body
-    });
-    await runner.step(12, async (runner) => {
+      });
+      await runner.step(12, async (runner) => {
 __stack.locals.condition = true;
-    });
-    await runner.ifElse(13, [
+      });
+      await runner.ifElse(13, [
 
   {
     condition: async () => __stack.locals.condition,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.a = 1;
-          });
+            });
 await runner.step(1, async (runner) => {
 __stack.locals.b = 2;
-          });
+            });
 await runner.step(2, async (runner) => {
 __stack.locals.c = 3;
-          });
+            });
     },
   },
 
 ]);
-    await runner.step(14, async (runner) => {
+      await runner.step(14, async (runner) => {
 //  Multiple statements in both then and else bodies
-    });
-    await runner.step(15, async (runner) => {
+      });
+      await runner.step(15, async (runner) => {
 __stack.locals.value = false;
-    });
-    await runner.ifElse(16, [
+      });
+      await runner.ifElse(16, [
 
   {
     condition: async () => __stack.locals.value,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.x = 10;
-          });
+            });
 await runner.step(1, async (runner) => {
 __stack.locals.y = 20;
-          });
+            });
     },
   },
 
 ]);
-    await runner.step(17, async (runner) => {
+      await runner.step(17, async (runner) => {
 //  Basic else
-    });
-    await runner.ifElse(18, [
+      });
+      await runner.ifElse(18, [
 
   {
     condition: async () => __stack.locals.flag,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `yes`;
-          });
+            });
     },
   },
 
 ], async (runner) => {
 await runner.step(1, async (runner) => {
 __stack.locals.result = `no`;
-        });
+          });
 });
-    await runner.step(19, async (runner) => {
+      await runner.step(19, async (runner) => {
 //  else if chain
-    });
-    await runner.ifElse(20, [
+      });
+      await runner.ifElse(20, [
 
   {
     condition: async () => __stack.locals.a === 1,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = `one`;
-          });
+            });
     },
   },
 
@@ -338,15 +340,16 @@ __stack.locals.result = `one`;
     body: async (runner) => {
 await runner.step(1, async (runner) => {
 __stack.locals.result = `two`;
-          });
+            });
     },
   },
 
 ], async (runner) => {
 await runner.step(2, async (runner) => {
 __stack.locals.result = `other`;
-        });
+          });
 });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(21, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -39,7 +39,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __twice_impl(block: () => string, __state: InternalFunctionState 
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("inlineBlockBasic.agency")) {
@@ -166,7 +163,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "inlineBlockBasic.agency", scopeName: "twice", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "inlineBlockBasic.agency", scopeName: "twice", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "inlineBlockBasic.agency", scopeName: "twice", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -179,46 +176,52 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "twice",
-          args: {
-            block: block
-          },
-          isBuiltin: false,
-          moduleId: "inlineBlockBasic.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "twice",
+            args: {
+              block: block
+            },
+            isBuiltin: false,
+            moduleId: "inlineBlockBasic.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.a = await __call(__stack.args.block, {
-        type: "positional",
-        args: []
-      });
+          type: "positional",
+          args: []
+        });
 if (hasInterrupts(__stack.locals.a)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__stack.locals.a)
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-__stack.locals.b = await __call(__stack.args.block, {
-        type: "positional",
-        args: []
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.a)
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+__stack.locals.b = await __call(__stack.args.block, {
+          type: "positional",
+          args: []
+        });
 if (hasInterrupts(__stack.locals.b)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__stack.locals.b)
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.b)
+          return;
+        }
+      });
+      await runner.step(3, async (runner) => {
 __functionCompleted = true;
 runner.halt([__stack.locals.a, __stack.locals.b])
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -243,7 +246,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -277,30 +280,32 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "inlineBlockBasic.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.results = await __call(twice, {
-        type: "positional",
-        args: [__AgencyFunction.create({ name: "__block_0", module: "inlineBlockBasic.agency", fn: async () => {
-          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
+          type: "positional",
+          args: [__AgencyFunction.create({ name: "__block_0", module: "inlineBlockBasic.agency", fn: async () => {
+            const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 
@@ -314,31 +319,32 @@ return runner.halted ? runner.haltResult : undefined;
 } finally {
 __ctx.stateStack.pop();
 }
-        }, params: [], toolDefinition: null }, __toolRegistry)]
-      });
+          }, params: [], toolDefinition: null }, __toolRegistry)]
+        });
 if (hasInterrupts(__stack.locals.results)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.results
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.results]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.results
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.results]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -178,7 +178,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -290,7 +290,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __mapItems_impl(items: any[], block: (any) => any, __state: Inter
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("inlineBlockParams.agency")) {
@@ -167,7 +164,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "inlineBlockParams.agency", scopeName: "mapItems", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "inlineBlockParams.agency", scopeName: "mapItems", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "inlineBlockParams.agency", scopeName: "mapItems", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -184,47 +181,53 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "mapItems",
-          args: {
-            items: items,
-            block: block
-          },
-          isBuiltin: false,
-          moduleId: "inlineBlockParams.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "mapItems",
+            args: {
+              items: items,
+              block: block
+            },
+            isBuiltin: false,
+            moduleId: "inlineBlockParams.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.results = [];
-    });
-    await runner.loop(2, __stack.args.items, async (item, _, runner) => {
+      });
+      await runner.loop(2, __stack.args.items, async (item, _, runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = await __call(__stack.args.block, {
-          type: "positional",
-          args: [item]
-        });
+            type: "positional",
+            args: [item]
+          });
 if (hasInterrupts(__stack.locals.result)) {
-          await __ctx.pendingPromises.awaitAll()
-          runner.halt(__stack.locals.result)
-          return;
-        }
-      });
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt(__stack.locals.result)
+            return;
+          }
+        });
 await runner.step(1, async (runner) => {
 __stack.locals.results = await __callMethod(__stack.locals.results, "concat", {
-          type: "positional",
-          args: [[__stack.locals.result]]
+            type: "positional",
+            args: [[__stack.locals.result]]
+          });
         });
       });
-    });
-    await runner.step(3, async (runner) => {
+      await runner.step(3, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.results)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -249,7 +252,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -288,33 +291,35 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "inlineBlockParams.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.items = [1, 2, 3];
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.doubled = await __call(mapItems, {
-        type: "positional",
-        args: [__stack.locals.items, __AgencyFunction.create({ name: "__block_0", module: "inlineBlockParams.agency", fn: async (x: any) => {
-          const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
+          type: "positional",
+          args: [__stack.locals.items, __AgencyFunction.create({ name: "__block_0", module: "inlineBlockParams.agency", fn: async (x: any) => {
+            const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 
@@ -330,24 +335,25 @@ return runner.halted ? runner.haltResult : undefined;
 } finally {
 __ctx.stateStack.pop();
 }
-        }, params: [{ name: "x", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry)]
-      });
+          }, params: [{ name: "x", hasDefault: false, defaultValue: undefined, variadic: false }], toolDefinition: null }, __toolRegistry)]
+        });
 if (hasInterrupts(__stack.locals.doubled)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.doubled
+          })
+          return;
+        }
+      });
+      await runner.step(3, async (runner) => {
+runner.halt({
+          messages: __threads(),
           data: __stack.locals.doubled
         })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-runner.halt({
-        messages: __threads(),
-        data: __stack.locals.doubled
-      })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -183,7 +183,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -301,7 +301,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,76 +147,79 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "input.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-__stack.locals.message = await __call(input, {
-        type: "positional",
-        args: [`Please enter a message: `]
-      });
-if (hasInterrupts(__stack.locals.message)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.message
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
         })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(1, async (runner) => {
+__stack.locals.message = await __call(input, {
+          type: "positional",
+          args: [`Please enter a message: `]
+        });
+if (hasInterrupts(__stack.locals.message)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.message
+          })
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.sentiment = await runPrompt({
-        prompt: `Categorize the sentiment in this message: ${__stack.locals.message}`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.union([z.literal("happy"), z.literal("sad"), z.literal("neutral")])
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Categorize the sentiment in this message: ${__stack.locals.message}`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.union([z.literal("happy"), z.literal("sad"), z.literal("neutral")])
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.sentiment)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.sentiment
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.sentiment]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.sentiment
+          })
+          return;
+        }
       });
+      await runner.step(3, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.sentiment]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,62 +147,65 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interpolation.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.name = `Alice`;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.greeting = await runPrompt({
-        prompt: `say hi to ${__stack.locals.name}`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `say hi to ${__stack.locals.name}`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.greeting)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.greeting
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.greeting]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.greeting
+          })
+          return;
+        }
       });
+      await runner.step(3, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.greeting]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -183,7 +183,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -346,7 +346,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -479,7 +479,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __greet_impl(name: string, age: number, __state: InternalFunction
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("interrupt-2-deep-in-function.agency")) {
@@ -167,7 +164,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "interrupt-2-deep-in-function.agency", scopeName: "greet", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "interrupt-2-deep-in-function.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "interrupt-2-deep-in-function.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -184,21 +181,26 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "greet",
-          args: {
-            name: name,
-            age: age
-          },
-          isBuiltin: false,
-          moduleId: "interrupt-2-deep-in-function.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "greet",
+            args: {
+              name: name,
+              age: age
+            },
+            isBuiltin: false,
+            moduleId: "interrupt-2-deep-in-function.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 // Resume path: check for a response by interruptId
 const __response = __ctx.getInterruptResponse(__self.__interruptId_1);
 if (__response) {
@@ -214,7 +216,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers("unknown", `Agent wants to call the greet function with name: ${__stack.args.name} and age: ${__stack.args.age}`, {}, "./interrupt-2-deep-in-function.agency", __ctx, __stateStack);
+  const __handlerResult = await interruptWithHandlers("unknown", `Agent wants to call the greet function with name: ${__stack.args.name} and age: ${__stack.args.age}`, {}, "./interrupt-2-deep-in-function.agency", __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     
     
@@ -226,7 +228,7 @@ if (__response) {
     // No handler — propagate interrupt array to TypeScript caller
     // Store interruptId on frame BEFORE checkpoint so it's captured in the snapshot
     __self.__interruptId_1 = __handlerResult[0].interruptId;
-    const __checkpointId = __ctx.checkpoints.create(__stateStack, __ctx, { moduleId: "interrupt-2-deep-in-function.agency", scopeName: "greet", stepPath: "1" });
+    const __checkpointId = __ctx.checkpoints.create(__stateStack(), __ctx, { moduleId: "interrupt-2-deep-in-function.agency", scopeName: "greet", stepPath: "1" });
     __handlerResult[0].checkpointId = __checkpointId;
     __handlerResult[0].checkpoint = __ctx.checkpoints.get(__checkpointId);
     
@@ -238,12 +240,13 @@ if (__response) {
   // Approved — continue execution past interrupt
 }
 
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(`Kya chal raha jai, ${__stack.args.name}! You are ${__stack.args.age} years old.`)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -268,7 +271,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -308,13 +311,10 @@ async function __foo2_impl(name: string, age: number, __state: InternalFunctionS
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("interrupt-2-deep-in-function.agency")) {
@@ -327,7 +327,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "interrupt-2-deep-in-function.agency", scopeName: "foo2", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "interrupt-2-deep-in-function.agency", scopeName: "foo2", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "interrupt-2-deep-in-function.agency", scopeName: "foo2", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -344,59 +344,65 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "foo2",
-          args: {
-            name: name,
-            age: age
-          },
-          isBuiltin: false,
-          moduleId: "interrupt-2-deep-in-function.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "foo2",
+            args: {
+              name: name,
+              age: age
+            },
+            isBuiltin: false,
+            moduleId: "interrupt-2-deep-in-function.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 await __call(print, {
-        type: "positional",
-        args: [`In foo2, name is ${__stack.args.name} and age is ${__stack.args.age}, this message should only print once...`]
-      }) + greet
-    });
-    await runner.step(2, async (runner) => {
+          type: "positional",
+          args: [`In foo2, name is ${__stack.args.name} and age is ${__stack.args.age}, this message should only print once...`]
+        }) + greet
+      });
+      await runner.step(2, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.response = await runPrompt({
-        prompt: `Greet the user with their name: ${__stack.args.name} and age ${__stack.args.age} using the greet function.`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Greet the user with their name: ${__stack.args.name} and age ${__stack.args.age} using the greet function.`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.response)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__stack.locals.response)
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`Greeted, age is still ${__stack.args.age}...`]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.response)
+          return;
+        }
       });
+      await runner.step(3, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`Greeted, age is still ${__stack.args.age}...`]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
-    await runner.step(4, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+      await runner.step(4, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.response)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -421,7 +427,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -460,13 +466,10 @@ graph.node("sayHi", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interrupt-2-deep-in-function.agency", scopeName: "sayHi", threads: __setupData.threads });
@@ -474,80 +477,86 @@ let __functionCompleted = false;
     __stack.args["name"] = __state.data.name;
   }
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "sayHi"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`Saying hi to ${__stack.args.name}...`]
-      });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
+          name: "onNodeStart",
+          data: {
+            nodeName: "sayHi"
+          }
         })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-__stack.locals.age = 30;
-    });
-    await runner.step(3, async (runner) => {
-__stack.locals.response = await __call(foo2, {
-        type: "positional",
-        args: [__stack.args.name, __stack.locals.age]
       });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`Saying hi to ${__stack.args.name}...`]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
+__stack.locals.age = 30;
+      });
+      await runner.step(3, async (runner) => {
+__stack.locals.response = await __call(foo2, {
+          type: "positional",
+          args: [__stack.args.name, __stack.locals.age]
+        });
 if (hasInterrupts(__stack.locals.response)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.response
+          })
+          return;
+        }
+      });
+      await runner.step(4, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.response]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(5, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`Greeting sent.`]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(6, async (runner) => {
+runner.halt({
+          messages: __threads(),
           data: __stack.locals.response
         })
-        return;
-      }
-    });
-    await runner.step(4, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.response]
-      });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
-    await runner.step(5, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`Greeting sent.`]
-      });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
-    await runner.step(6, async (runner) => {
-runner.halt({
-        messages: __threads(),
-        data: __stack.locals.response
-      })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(7, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,26 +147,28 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interrupt-assignment.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 // Resume path: check for a response by interruptId
 const __response = __ctx.getInterruptResponse(__self.__interruptId_1);
 if (__response) {
@@ -186,7 +188,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers("unknown", `What is your name?`, {}, "./interrupt-assignment.agency", __ctx, __stateStack);
+  const __handlerResult = await interruptWithHandlers("unknown", `What is your name?`, {}, "./interrupt-assignment.agency", __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     
     runner.halt({ messages: __threads(), data: failure(__handlerResult.value ?? "interrupt rejected", { retryable: false }) });
@@ -200,7 +202,7 @@ if (__response) {
     // No handler — propagate interrupt array to TypeScript caller
     // Store interruptId on frame BEFORE checkpoint so it's captured in the snapshot
     __self.__interruptId_1 = __handlerResult[0].interruptId;
-    const __checkpointId = __ctx.checkpoints.create(__stateStack, __ctx, { moduleId: "interrupt-assignment.agency", scopeName: "main", stepPath: "1" });
+    const __checkpointId = __ctx.checkpoints.create(__stateStack(), __ctx, { moduleId: "interrupt-assignment.agency", scopeName: "main", stepPath: "1" });
     __handlerResult[0].checkpointId = __checkpointId;
     __handlerResult[0].checkpoint = __ctx.checkpoints.get(__checkpointId);
     
@@ -211,34 +213,35 @@ if (__response) {
   }
 }
 
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.greeting = await runPrompt({
-        prompt: `Say hello to {name}`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Say hello to {name}`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.greeting)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.greeting
+          })
+          return;
+        }
+      });
+      await runner.step(3, async (runner) => {
+runner.halt({
           messages: __threads(),
           data: __stack.locals.greeting
         })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-runner.halt({
-        messages: __threads(),
-        data: __stack.locals.greeting
-      })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -183,7 +183,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -324,7 +324,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -429,7 +429,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __greet_impl(name: string, age: number, __state: InternalFunction
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("interrupt-in-node.agency")) {
@@ -167,7 +164,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "interrupt-in-node.agency", scopeName: "greet", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "interrupt-in-node.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "interrupt-in-node.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -184,21 +181,26 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "greet",
-          args: {
-            name: name,
-            age: age
-          },
-          isBuiltin: false,
-          moduleId: "interrupt-in-node.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "greet",
+            args: {
+              name: name,
+              age: age
+            },
+            isBuiltin: false,
+            moduleId: "interrupt-in-node.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 // Resume path: check for a response by interruptId
 const __response = __ctx.getInterruptResponse(__self.__interruptId_1);
 if (__response) {
@@ -214,7 +216,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers("unknown", `Agent wants to call the greet function with name: ${__stack.args.name} and age: ${__stack.args.age}`, {}, "./interrupt-in-node.agency", __ctx, __stateStack);
+  const __handlerResult = await interruptWithHandlers("unknown", `Agent wants to call the greet function with name: ${__stack.args.name} and age: ${__stack.args.age}`, {}, "./interrupt-in-node.agency", __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     
     
@@ -226,7 +228,7 @@ if (__response) {
     // No handler — propagate interrupt array to TypeScript caller
     // Store interruptId on frame BEFORE checkpoint so it's captured in the snapshot
     __self.__interruptId_1 = __handlerResult[0].interruptId;
-    const __checkpointId = __ctx.checkpoints.create(__stateStack, __ctx, { moduleId: "interrupt-in-node.agency", scopeName: "greet", stepPath: "1" });
+    const __checkpointId = __ctx.checkpoints.create(__stateStack(), __ctx, { moduleId: "interrupt-in-node.agency", scopeName: "greet", stepPath: "1" });
     __handlerResult[0].checkpointId = __checkpointId;
     __handlerResult[0].checkpoint = __ctx.checkpoints.get(__checkpointId);
     
@@ -238,12 +240,13 @@ if (__response) {
   // Approved — continue execution past interrupt
 }
 
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(`Kya chal raha jai, ${__stack.args.name}! You are ${__stack.args.age} years old.`)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -268,7 +271,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -307,13 +310,10 @@ graph.node("foo2", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interrupt-in-node.agency", scopeName: "foo2", threads: __setupData.threads });
@@ -322,61 +322,67 @@ let __functionCompleted = false;
     __stack.args["age"] = __state.data.age;
   }
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "foo2"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "foo2"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 await __call(print, {
-        type: "positional",
-        args: [`In foo2, name is ${__stack.args.name} and age is ${__stack.args.age}, this message should only print once...`]
-      }) + greet
-    });
-    await runner.step(2, async (runner) => {
+          type: "positional",
+          args: [`In foo2, name is ${__stack.args.name} and age is ${__stack.args.age}, this message should only print once...`]
+        }) + greet
+      });
+      await runner.step(2, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.response = await runPrompt({
-        prompt: `Greet the user with their name: ${__stack.args.name} and age ${__stack.args.age} using the greet function.`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Greet the user with their name: ${__stack.args.name} and age ${__stack.args.age} using the greet function.`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.response)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.response
+          })
+          return;
+        }
+      });
+      await runner.step(3, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`Greeted, age is still ${__stack.args.age}...`]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(4, async (runner) => {
+runner.halt({
           messages: __threads(),
           data: __stack.locals.response
         })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`Greeted, age is still ${__stack.args.age}...`]
-      });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
-    await runner.step(4, async (runner) => {
-runner.halt({
-        messages: __threads(),
-        data: __stack.locals.response
-      })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({
@@ -410,13 +416,10 @@ graph.node("sayHi", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interrupt-in-node.agency", scopeName: "sayHi", threads: __setupData.threads });
@@ -424,44 +427,50 @@ let __functionCompleted = false;
     __stack.args["name"] = __state.data.name;
   }
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "sayHi"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`Saying hi to ${__stack.args.name}...`]
-      });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
+          name: "onNodeStart",
+          data: {
+            nodeName: "sayHi"
+          }
         })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`Saying hi to ${__stack.args.name}...`]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.age = 30;
-    });
-    await runner.step(3, async (runner) => {
-__stateStack.pop()
+      });
+      await runner.step(3, async (runner) => {
+__stateStack()?.pop()
 __functionCompleted = true;
 runner.halt(goToNode("foo2", {
-        messages: __threads(),
-        ctx: __ctx,
-        data: {
-          name: __stack.args.name,
-          age: __stack.locals.age
-        }
-      }))
+          messages: __threads(),
+          ctx: __ctx,
+          data: {
+            name: __stack.args.name,
+            age: __stack.locals.age
+          }
+        }))
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -160,7 +160,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -150,87 +150,90 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "llmConfigParam.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.foo = await runPrompt({
-        prompt: `What are 5 numbers?`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.array(z.number())
-        }),
-        clientConfig: __ctx.globals.get("llmConfigParam.agency", "config"),
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `What are 5 numbers?`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.array(z.number())
+          }),
+          clientConfig: __ctx.globals.get("llmConfigParam.agency", "config"),
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.foo)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.foo
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.foo
+          })
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.foo2 = await runPrompt({
-        prompt: `What are 5 numbers?`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.array(z.number())
-        }),
-        clientConfig: {
-          "maxTokens": 100
-        },
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `What are 5 numbers?`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.array(z.number())
+          }),
+          clientConfig: {
+            "maxTokens": 100
+          },
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.foo2)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.foo2
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.foo, __stack.locals.foo2]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.foo2
+          })
+          return;
+        }
       });
+      await runner.step(3, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.foo, __stack.locals.foo2]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,41 +147,43 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "matchBlock.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 //  Test match blocks (pattern matching)
 //  Simple match with string literals
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.action = `start`;
-    });
-    await runner.ifElse(3, [
+      });
+      await runner.ifElse(3, [
 
   {
     condition: async () => __stack.locals.action === `start`,
     body: async (runner) => {
 await __call(print, {
-            type: "positional",
-            args: [`Starting...`]
-          })
+              type: "positional",
+              args: [`Starting...`]
+            })
     },
   },
 
@@ -189,9 +191,9 @@ await __call(print, {
     condition: async () => __stack.locals.action === `stop`,
     body: async (runner) => {
 await __call(print, {
-            type: "positional",
-            args: [`Stopping...`]
-          })
+              type: "positional",
+              args: [`Stopping...`]
+            })
     },
   },
 
@@ -199,33 +201,33 @@ await __call(print, {
     condition: async () => __stack.locals.action === `restart`,
     body: async (runner) => {
 await __call(print, {
-            type: "positional",
-            args: [`Restarting...`]
-          })
+              type: "positional",
+              args: [`Restarting...`]
+            })
     },
   },
 
 ], async (runner) => {
 await __call(print, {
-          type: "positional",
-          args: [`Unknown action`]
-        })
+            type: "positional",
+            args: [`Unknown action`]
+          })
 });
-    await runner.step(4, async (runner) => {
+      await runner.step(4, async (runner) => {
 //  Match with number literals
-    });
-    await runner.step(5, async (runner) => {
+      });
+      await runner.step(5, async (runner) => {
 __stack.locals.statusCode = 200;
-    });
-    await runner.ifElse(6, [
+      });
+      await runner.ifElse(6, [
 
   {
     condition: async () => __stack.locals.statusCode === 200,
     body: async (runner) => {
 await __call(print, {
-            type: "positional",
-            args: [`OK`]
-          })
+              type: "positional",
+              args: [`OK`]
+            })
     },
   },
 
@@ -233,9 +235,9 @@ await __call(print, {
     condition: async () => __stack.locals.statusCode === 404,
     body: async (runner) => {
 await __call(print, {
-            type: "positional",
-            args: [`Not Found`]
-          })
+              type: "positional",
+              args: [`Not Found`]
+            })
     },
   },
 
@@ -243,28 +245,28 @@ await __call(print, {
     condition: async () => __stack.locals.statusCode === 500,
     body: async (runner) => {
 await __call(print, {
-            type: "positional",
-            args: [`Internal Server Error`]
-          })
+              type: "positional",
+              args: [`Internal Server Error`]
+            })
     },
   },
 
 ], async (runner) => {
 await __call(print, {
-          type: "positional",
-          args: [`Unknown status`]
-        })
+            type: "positional",
+            args: [`Unknown status`]
+          })
 });
-    await runner.step(7, async (runner) => {
+      await runner.step(7, async (runner) => {
 //  Match with variable assignment in body
-    });
-    await runner.step(8, async (runner) => {
+      });
+      await runner.step(8, async (runner) => {
 __stack.locals.grade = `A`;
-    });
-    await runner.step(9, async (runner) => {
+      });
+      await runner.step(9, async (runner) => {
 __stack.locals.points = 0;
-    });
-    await runner.ifElse(10, [
+      });
+      await runner.ifElse(10, [
 
   {
     condition: async () => __stack.locals.grade === `A`,
@@ -297,21 +299,21 @@ __stack.locals.d = 55;
 ], async (runner) => {
 __stack.locals.e = 0;
 });
-    await runner.step(11, async (runner) => {
+      await runner.step(11, async (runner) => {
 //  Match with function calls in body
-    });
-    await runner.step(12, async (runner) => {
+      });
+      await runner.step(12, async (runner) => {
 __stack.locals.level = `debug`;
-    });
-    await runner.ifElse(13, [
+      });
+      await runner.ifElse(13, [
 
   {
     condition: async () => __stack.locals.level === `debug`,
     body: async (runner) => {
 await __call(print, {
-            type: "positional",
-            args: [`Debug mode enabled`]
-          })
+              type: "positional",
+              args: [`Debug mode enabled`]
+            })
     },
   },
 
@@ -319,9 +321,9 @@ await __call(print, {
     condition: async () => __stack.locals.level === `info`,
     body: async (runner) => {
 await __call(print, {
-            type: "positional",
-            args: [`Info level logging`]
-          })
+              type: "positional",
+              args: [`Info level logging`]
+            })
     },
   },
 
@@ -329,9 +331,9 @@ await __call(print, {
     condition: async () => __stack.locals.level === `warn`,
     body: async (runner) => {
 await __call(print, {
-            type: "positional",
-            args: [`Warning level`]
-          })
+              type: "positional",
+              args: [`Warning level`]
+            })
     },
   },
 
@@ -339,20 +341,20 @@ await __call(print, {
     condition: async () => __stack.locals.level === `error`,
     body: async (runner) => {
 await __call(print, {
-            type: "positional",
-            args: [`Error level`]
-          })
+              type: "positional",
+              args: [`Error level`]
+            })
     },
   },
 
 ]);
-    await runner.step(14, async (runner) => {
+      await runner.step(14, async (runner) => {
 //  Match with array results
-    });
-    await runner.step(15, async (runner) => {
+      });
+      await runner.step(15, async (runner) => {
 __stack.locals.resultType = `array`;
-    });
-    await runner.ifElse(16, [
+      });
+      await runner.ifElse(16, [
 
   {
     condition: async () => __stack.locals.resultType === `array`,
@@ -365,30 +367,30 @@ __stack.locals.data1 = [1, 2, 3];
     condition: async () => __stack.locals.resultType === `object`,
     body: async (runner) => {
 __stack.locals.data2 = {
-            "x": 1,
-            "y": 2
-          };
+              "x": 1,
+              "y": 2
+            };
     },
   },
 
 ], async (runner) => {
 __stack.locals.data3 = [];
 });
-    await runner.step(17, async (runner) => {
+      await runner.step(17, async (runner) => {
 //  Match with object results
-    });
-    await runner.step(18, async (runner) => {
+      });
+      await runner.step(18, async (runner) => {
 __stack.locals.format = `json`;
-    });
-    await runner.ifElse(19, [
+      });
+      await runner.ifElse(19, [
 
   {
     condition: async () => __stack.locals.format === `xml`,
     body: async (runner) => {
 __stack.locals.output1 = {
-            "type": `xml`,
-            "ext": `.xml`
-          };
+              "type": `xml`,
+              "ext": `.xml`
+            };
     },
   },
 
@@ -396,9 +398,9 @@ __stack.locals.output1 = {
     condition: async () => __stack.locals.format === `json`,
     body: async (runner) => {
 __stack.locals.output2 = {
-            "type": `json`,
-            "ext": `.json`
-          };
+              "type": `json`,
+              "ext": `.json`
+            };
     },
   },
 
@@ -406,18 +408,19 @@ __stack.locals.output2 = {
     condition: async () => __stack.locals.format === `csv`,
     body: async (runner) => {
 __stack.locals.output3 = {
-            "type": `csv`,
-            "ext": `.csv`
-          };
+              "type": `csv`,
+              "ext": `.csv`
+            };
     },
   },
 
 ], async (runner) => {
 __stack.locals.output4 = {
-          "type": `unknown`,
-          "ext": ``
-        };
+            "type": `unknown`,
+            "ext": ``
+          };
 });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(20, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -176,7 +176,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -151,13 +151,10 @@ async function __greet_impl(__state: InternalFunctionState | undefined = undefin
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("multiLineComment.agency")) {
@@ -168,7 +165,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "multiLineComment.agency", scopeName: "greet", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "multiLineComment.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "multiLineComment.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -177,22 +174,28 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "greet",
-          args: {},
-          isBuiltin: false,
-          moduleId: "multiLineComment.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "greet",
+            args: {},
+            isBuiltin: false,
+            moduleId: "multiLineComment.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(`hello`)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -217,7 +220,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,57 +147,60 @@ graph.node("greet", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "multipleNodes.agency", scopeName: "greet", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "greet"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "greet"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.greeting = await runPrompt({
-        prompt: `say hello`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `say hello`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.greeting)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.greeting
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-__stateStack.pop()
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.greeting
+          })
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
+__stateStack()?.pop()
 __functionCompleted = true;
 runner.halt(goToNode("processGreeting", {
-        messages: __threads(),
-        ctx: __ctx,
-        data: {
-          msg: __stack.locals.greeting
-        }
-      }))
+          messages: __threads(),
+          ctx: __ctx,
+          data: {
+            msg: __stack.locals.greeting
+          }
+        }))
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({
@@ -231,13 +234,10 @@ graph.node("processGreeting", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "multipleNodes.agency", scopeName: "processGreeting", threads: __setupData.threads });
@@ -245,48 +245,54 @@ let __functionCompleted = false;
     __stack.args["msg"] = __state.data.msg;
   }
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "processGreeting"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "processGreeting"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.result = await runPrompt({
-        prompt: `format this greeting: ${__stack.args.msg}`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `format this greeting: ${__stack.args.msg}`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.result
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.result]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.result
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.result]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({
@@ -320,35 +326,38 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "multipleNodes.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-__stateStack.pop()
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+__stateStack()?.pop()
 __functionCompleted = true;
 runner.halt(goToNode("greet", {
-        messages: __threads(),
-        ctx: __ctx,
-        data: {}
-      }))
+          messages: __threads(),
+          ctx: __ctx,
+          data: {}
+        }))
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(2, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -247,7 +247,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -336,7 +336,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -167,13 +167,10 @@ async function __greet_impl(name: string, greeting: string | typeof __UNSET = __
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("namedArgs.agency")) {
@@ -186,7 +183,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "namedArgs.agency", scopeName: "greet", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "namedArgs.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "namedArgs.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -203,31 +200,37 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "greet",
-          args: {
-            name: name,
-            greeting: greeting
-          },
-          isBuiltin: false,
-          moduleId: "namedArgs.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.args.greeting, __stack.args.name]
+          name: "onFunctionStart",
+          data: {
+            functionName: "greet",
+            args: {
+              name: name,
+              greeting: greeting
+            },
+            isBuiltin: false,
+            moduleId: "namedArgs.agency"
+          }
+        })
       });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.args.greeting, __stack.args.name]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -252,7 +255,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -202,7 +202,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -188,7 +188,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -290,7 +290,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __greet_impl(name: string, greeting: string | typeof __UNSET = __
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("namedArgsReorder.agency")) {
@@ -168,7 +165,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "namedArgsReorder.agency", scopeName: "greet", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "namedArgsReorder.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "namedArgsReorder.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -189,26 +186,32 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "greet",
-          args: {
-            name: name,
-            greeting: greeting,
-            punctuation: punctuation
-          },
-          isBuiltin: false,
-          moduleId: "namedArgsReorder.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "greet",
+            args: {
+              name: name,
+              greeting: greeting,
+              punctuation: punctuation
+            },
+            isBuiltin: false,
+            moduleId: "namedArgsReorder.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.args.greeting + ` ${__stack.args.name}${__stack.args.punctuation}`)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -233,7 +236,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -277,90 +280,93 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "namedArgsReorder.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 //  Reordered named args
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.a = await __call(greet, {
-        type: "named",
-        positionalArgs: [],
-        namedArgs: {
-          greeting: `Hi`,
-          name: `world`
-        }
-      });
+          type: "named",
+          positionalArgs: [],
+          namedArgs: {
+            greeting: `Hi`,
+            name: `world`
+          }
+        });
 if (hasInterrupts(__stack.locals.a)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.a
-        })
-        return;
-      }
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.a
+          })
+          return;
+        }
 //  Skip middle param with named args
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 __stack.locals.b = await __call(greet, {
-        type: "named",
-        positionalArgs: [],
-        namedArgs: {
-          name: `world`,
-          punctuation: `.`
-        }
-      });
+          type: "named",
+          positionalArgs: [],
+          namedArgs: {
+            name: `world`,
+            punctuation: `.`
+          }
+        });
 if (hasInterrupts(__stack.locals.b)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.b
-        })
-        return;
-      }
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.b
+          })
+          return;
+        }
 //  Mixed positional + named
-    });
-    await runner.step(4, async (runner) => {
+      });
+      await runner.step(4, async (runner) => {
 __stack.locals.c = await __call(greet, {
-        type: "named",
-        positionalArgs: [`world`],
-        namedArgs: {
-          punctuation: `?`
+          type: "named",
+          positionalArgs: [`world`],
+          namedArgs: {
+            punctuation: `?`
+          }
+        });
+if (hasInterrupts(__stack.locals.c)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.c
+          })
+          return;
         }
       });
-if (hasInterrupts(__stack.locals.c)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.c
-        })
-        return;
-      }
-    });
-    await runner.step(5, async (runner) => {
+      await runner.step(5, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.a + ` | ${__stack.locals.b} | ${__stack.locals.c}`
-      })
+          messages: __threads(),
+          data: __stack.locals.a + ` | ${__stack.locals.b} | ${__stack.locals.c}`
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(6, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,59 +147,62 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "noResponseFormat.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.response1 = await runPrompt({
-        prompt: `say hello`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `say hello`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.response1)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.response1
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.response1]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.response1
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.response1]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,62 +147,65 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "objectDescription.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.url = await runPrompt({
-        prompt: `extract the hostname and port from 'https://example.com:8080'`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.object({ "hostname": z.string(), "port": z.number() })
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `extract the hostname and port from 'https://example.com:8080'`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.object({ "hostname": z.string(), "port": z.number() })
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.url)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.url
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.url]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.url
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.url]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -160,13 +160,10 @@ async function __greet_impl(name: string, greeting: string | typeof __UNSET = __
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("optionalParams.agency")) {
@@ -179,7 +176,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "optionalParams.agency", scopeName: "greet", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "optionalParams.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "optionalParams.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -196,31 +193,37 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "greet",
-          args: {
-            name: name,
-            greeting: greeting
-          },
-          isBuiltin: false,
-          moduleId: "optionalParams.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.args.greeting, __stack.args.name]
+          name: "onFunctionStart",
+          data: {
+            functionName: "greet",
+            args: {
+              name: name,
+              greeting: greeting
+            },
+            isBuiltin: false,
+            moduleId: "optionalParams.agency"
+          }
+        })
       });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.args.greeting, __stack.args.name]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -245,7 +248,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -195,7 +195,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -178,7 +178,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -294,7 +294,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -416,7 +416,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -526,7 +526,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __double_impl(x: number, __state: InternalFunctionState | undefin
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("pipe-operator.agency")) {
@@ -166,7 +163,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "pipe-operator.agency", scopeName: "double", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "pipe-operator.agency", scopeName: "double", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "pipe-operator.agency", scopeName: "double", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -179,24 +176,30 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "double",
-          args: {
-            x: x
-          },
-          isBuiltin: false,
-          moduleId: "pipe-operator.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "double",
+            args: {
+              x: x
+            },
+            isBuiltin: false,
+            moduleId: "pipe-operator.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.args.x * 2)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -221,7 +224,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -256,13 +259,10 @@ async function __multiply_impl(a: number, b: number, __state: InternalFunctionSt
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("pipe-operator.agency")) {
@@ -275,7 +275,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "pipe-operator.agency", scopeName: "multiply", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "pipe-operator.agency", scopeName: "multiply", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "pipe-operator.agency", scopeName: "multiply", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -292,25 +292,31 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "multiply",
-          args: {
-            a: a,
-            b: b
-          },
-          isBuiltin: false,
-          moduleId: "pipe-operator.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "multiply",
+            args: {
+              a: a,
+              b: b
+            },
+            isBuiltin: false,
+            moduleId: "pipe-operator.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.args.a * __stack.args.b)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -335,7 +341,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -375,13 +381,10 @@ async function __safeDivide_impl(a: number, b: number, __state: InternalFunction
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("pipe-operator.agency")) {
@@ -394,7 +397,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "pipe-operator.agency", scopeName: "safeDivide", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "pipe-operator.agency", scopeName: "safeDivide", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "pipe-operator.agency", scopeName: "safeDivide", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -411,21 +414,26 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "safeDivide",
-          args: {
-            a: a,
-            b: b
-          },
-          isBuiltin: false,
-          moduleId: "pipe-operator.agency"
-        }
-      })
-    });
-    await runner.ifElse(1, [
+          name: "onFunctionStart",
+          data: {
+            functionName: "safeDivide",
+            args: {
+              a: a,
+              b: b
+            },
+            isBuiltin: false,
+            moduleId: "pipe-operator.agency"
+          }
+        })
+      });
+      await runner.ifElse(1, [
 
   {
     condition: async () => __stack.args.b === 0,
@@ -434,16 +442,17 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(failure(`division by zero`, { checkpoint: __ctx.getResultCheckpoint(), functionName: "safeDivide", args: __stack.args }))
 return;
-          });
+            });
     },
   },
 
 ]);
-    await runner.step(2, async (runner) => {
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(await success(__stack.args.a / __stack.args.b))
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -468,7 +477,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -507,82 +516,85 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "pipe-operator.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.__pipe_0 = await success(5);
-    });
-    __stack.locals.r1 = await runner.pipe(2, __stack.locals.__pipe_0, async (__pipeArg) => await __call(double, {
-      type: "positional",
-      args: [__pipeArg]
-    }));
-    await runner.step(3, async (runner) => {
+      });
+      __stack.locals.r1 = await runner.pipe(2, __stack.locals.__pipe_0, async (__pipeArg) => await __call(double, {
+        type: "positional",
+        args: [__pipeArg]
+      }));
+      await runner.step(3, async (runner) => {
 __stack.locals.__pipe_1 = await success(5);
-    });
-    __stack.locals.r2 = await runner.pipe(4, __stack.locals.__pipe_1, async (__pipeArg) => await __call(await __callMethod(multiply, "partial", {
-      type: "named",
-      positionalArgs: [],
-      namedArgs: {
-        a: 10
-      }
-    }), {
-      type: "positional",
-      args: [__pipeArg]
-    }));
-    await runner.step(5, async (runner) => {
+      });
+      __stack.locals.r2 = await runner.pipe(4, __stack.locals.__pipe_1, async (__pipeArg) => await __call(await __callMethod(multiply, "partial", {
+        type: "named",
+        positionalArgs: [],
+        namedArgs: {
+          a: 10
+        }
+      }), {
+        type: "positional",
+        args: [__pipeArg]
+      }));
+      await runner.step(5, async (runner) => {
 __stack.locals.__pipe_2 = await success(10);
-    });
-    __stack.locals.__pipe_2 = await runner.pipe(6, __stack.locals.__pipe_2, async (__pipeArg) => await __call(double, {
-      type: "positional",
-      args: [__pipeArg]
-    }));
-    __stack.locals.r3 = await runner.pipe(7, __stack.locals.__pipe_2, async (__pipeArg) => await __call(await __callMethod(multiply, "partial", {
-      type: "named",
-      positionalArgs: [],
-      namedArgs: {
-        a: 3
-      }
-    }), {
-      type: "positional",
-      args: [__pipeArg]
-    }));
-    await runner.step(8, async (runner) => {
+      });
+      __stack.locals.__pipe_2 = await runner.pipe(6, __stack.locals.__pipe_2, async (__pipeArg) => await __call(double, {
+        type: "positional",
+        args: [__pipeArg]
+      }));
+      __stack.locals.r3 = await runner.pipe(7, __stack.locals.__pipe_2, async (__pipeArg) => await __call(await __callMethod(multiply, "partial", {
+        type: "named",
+        positionalArgs: [],
+        namedArgs: {
+          a: 3
+        }
+      }), {
+        type: "positional",
+        args: [__pipeArg]
+      }));
+      await runner.step(8, async (runner) => {
 __stack.locals.__pipe_3 = await failure(`nope`);
-    });
-    __stack.locals.r4 = await runner.pipe(9, __stack.locals.__pipe_3, async (__pipeArg) => await __call(double, {
-      type: "positional",
-      args: [__pipeArg]
-    }));
-    await runner.step(10, async (runner) => {
+      });
+      __stack.locals.r4 = await runner.pipe(9, __stack.locals.__pipe_3, async (__pipeArg) => await __call(double, {
+        type: "positional",
+        args: [__pipeArg]
+      }));
+      await runner.step(10, async (runner) => {
 __stack.locals.__pipe_4 = await success(10);
-    });
-    __stack.locals.r5 = await runner.pipe(11, __stack.locals.__pipe_4, async (__pipeArg) => await __call(await __callMethod(safeDivide, "partial", {
-      type: "named",
-      positionalArgs: [],
-      namedArgs: {
-        b: 2
-      }
-    }), {
-      type: "positional",
-      args: [__pipeArg]
-    }));
+      });
+      __stack.locals.r5 = await runner.pipe(11, __stack.locals.__pipe_4, async (__pipeArg) => await __call(await __callMethod(safeDivide, "partial", {
+        type: "named",
+        positionalArgs: [],
+        namedArgs: {
+          b: 2
+        }
+      }), {
+        type: "positional",
+        args: [__pipeArg]
+      }));
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(12, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -158,7 +158,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,56 +148,43 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "recordIndex.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-__stack.locals.votes = {
-        "alice": `approve`,
-        "bob": `reject`
-      };
-    });
-    await runner.step(2, async (runner) => {
-__stack.locals.votes[`carol`] = `approve`;
-    });
-    await runner.step(3, async (runner) => {
-__stack.locals.v = __stack.locals.votes[`alice`];
-    });
-    await runner.step(4, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.v]
-      });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
         })
-        return;
-      }
-    });
-    await runner.loop(5, __stack.locals.votes, async (k, _, runner) => {
-await runner.step(0, async (runner) => {
+      });
+      await runner.step(1, async (runner) => {
+__stack.locals.votes = {
+          "alice": `approve`,
+          "bob": `reject`
+        };
+      });
+      await runner.step(2, async (runner) => {
+__stack.locals.votes[`carol`] = `approve`;
+      });
+      await runner.step(3, async (runner) => {
+__stack.locals.v = __stack.locals.votes[`alice`];
+      });
+      await runner.step(4, async (runner) => {
 const __funcResult = await __call(print, {
           type: "positional",
-          args: [k]
+          args: [__stack.locals.v]
         });
 if (hasInterrupts(__funcResult)) {
           await __ctx.pendingPromises.awaitAll()
@@ -208,7 +195,23 @@ if (hasInterrupts(__funcResult)) {
           return;
         }
       });
-    });
+      await runner.loop(5, __stack.locals.votes, async (k, _, runner) => {
+await runner.step(0, async (runner) => {
+const __funcResult = await __call(print, {
+            type: "positional",
+            args: [k]
+          });
+if (hasInterrupts(__funcResult)) {
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt({
+              ...__state,
+              data: __funcResult
+            })
+            return;
+          }
+        });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(6, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __checkAge_impl(age: number, __state: InternalFunctionState | und
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("result-basic.agency")) {
@@ -166,7 +163,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "result-basic.agency", scopeName: "checkAge", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "result-basic.agency", scopeName: "checkAge", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "result-basic.agency", scopeName: "checkAge", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -179,20 +176,25 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "checkAge",
-          args: {
-            age: age
-          },
-          isBuiltin: false,
-          moduleId: "result-basic.agency"
-        }
-      })
-    });
-    await runner.ifElse(1, [
+          name: "onFunctionStart",
+          data: {
+            functionName: "checkAge",
+            args: {
+              age: age
+            },
+            isBuiltin: false,
+            moduleId: "result-basic.agency"
+          }
+        })
+      });
+      await runner.ifElse(1, [
 
   {
     condition: async () => __stack.args.age >= 18,
@@ -201,16 +203,17 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(await success(__stack.args.age))
 return;
-          });
+            });
     },
   },
 
 ]);
-    await runner.step(2, async (runner) => {
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(failure(`too young`, { checkpoint: __ctx.getResultCheckpoint(), functionName: "checkAge", args: __stack.args }))
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -235,7 +238,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -178,7 +178,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -178,7 +178,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __checkValue_impl(r: Result, __state: InternalFunctionState | und
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("result-guards.agency")) {
@@ -166,7 +163,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "result-guards.agency", scopeName: "checkValue", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "result-guards.agency", scopeName: "checkValue", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "result-guards.agency", scopeName: "checkValue", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -179,20 +176,25 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "checkValue",
-          args: {
-            r: r
-          },
-          isBuiltin: false,
-          moduleId: "result-guards.agency"
-        }
-      })
-    });
-    await runner.ifElse(1, [
+          name: "onFunctionStart",
+          data: {
+            functionName: "checkValue",
+            args: {
+              r: r
+            },
+            isBuiltin: false,
+            moduleId: "result-guards.agency"
+          }
+        })
+      });
+      await runner.ifElse(1, [
 
   {
     condition: async () => await isSuccess(__stack.args.r),
@@ -201,16 +203,17 @@ await runner.step(0, async (runner) => {
 __functionCompleted = true;
 runner.halt(`ok`)
 return;
-          });
+            });
     },
   },
 
 ]);
-    await runner.step(2, async (runner) => {
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(`error`)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -235,7 +238,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,35 +147,38 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "returnValue.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.x = 42;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.x
-      })
+          messages: __threads(),
+          data: __stack.locals.x
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -160,7 +160,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,13 +147,10 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "rewindCheckpoint.agency", scopeName: "main", threads: __setupData.threads });
@@ -161,44 +158,50 @@ let __functionCompleted = false;
     __stack.args["message"] = __state.data.message;
   }
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.mood = await runPrompt({
-        prompt: `Categorize: ${__stack.args.message}`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.union([z.literal("happy"), z.literal("sad")])
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Categorize: ${__stack.args.message}`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.union([z.literal("happy"), z.literal("sad")])
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.mood)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.mood
+          })
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
+runner.halt({
           messages: __threads(),
           data: __stack.locals.mood
         })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-runner.halt({
-        messages: __threads(),
-        data: __stack.locals.mood
-      })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -25,7 +25,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -159,7 +159,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -149,48 +149,51 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "schemaAccess.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-__stack.locals.s = new Schema(Category);
-    });
-    await runner.step(2, async (runner) => {
-__stack.locals.result = await __callMethod(__stack.locals.s, "parse", {
-        type: "positional",
-        args: [`bug`]
-      });
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.result]
-      });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
         })
-        return;
-      }
-    });
+      });
+      await runner.step(1, async (runner) => {
+__stack.locals.s = new Schema(Category);
+      });
+      await runner.step(2, async (runner) => {
+__stack.locals.result = await __callMethod(__stack.locals.s, "parse", {
+          type: "positional",
+          args: [`bug`]
+        });
+      });
+      await runner.step(3, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.result]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -153,13 +153,10 @@ async function __parseValue_impl(input: string, s: Schema<any>, __state: Interna
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("schemaParamInjection.agency")) {
@@ -172,7 +169,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "schemaParamInjection.agency", scopeName: "parseValue", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "schemaParamInjection.agency", scopeName: "parseValue", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "schemaParamInjection.agency", scopeName: "parseValue", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -189,28 +186,34 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "parseValue",
-          args: {
-            input: input,
-            s: s
-          },
-          isBuiltin: false,
-          moduleId: "schemaParamInjection.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "parseValue",
+            args: {
+              input: input,
+              s: s
+            },
+            isBuiltin: false,
+            moduleId: "schemaParamInjection.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __functionCompleted = true;
 runner.halt(await __callMethod(__stack.args.s, "parseJSON", {
-        type: "positional",
-        args: [__stack.args.input]
-      }))
+          type: "positional",
+          args: [__stack.args.input]
+        }))
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -235,7 +238,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -275,13 +278,10 @@ async function __wrapper_impl(__state: InternalFunctionState | undefined = undef
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("schemaParamInjection.agency")) {
@@ -292,7 +292,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "schemaParamInjection.agency", scopeName: "wrapper", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "schemaParamInjection.agency", scopeName: "wrapper", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "schemaParamInjection.agency", scopeName: "wrapper", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -301,31 +301,37 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "wrapper",
-          args: {},
-          isBuiltin: false,
-          moduleId: "schemaParamInjection.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "wrapper",
+            args: {},
+            isBuiltin: false,
+            moduleId: "schemaParamInjection.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 //  Return-position injection: outer return type provides the hint.
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(await __call(parseValue, {
-        type: "named",
-        positionalArgs: [`[1,2,3]`],
-        namedArgs: {
-          s: new Schema(z.array(z.number()))
-        }
-      }))
+          type: "named",
+          positionalArgs: [`[1,2,3]`],
+          namedArgs: {
+            s: new Schema(z.array(z.number()))
+          }
+        }))
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -350,7 +356,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -379,176 +385,179 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "schemaParamInjection.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 //  LHS-annotation injection — Schema<any> inside parseValue receives
 //  z.array(z.number()) synthesized from `number[]`.
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.nums = await __call(parseValue, {
-        type: "named",
-        positionalArgs: [`[1,2,3]`],
-        namedArgs: {
-          s: new Schema(z.array(z.number()))
+          type: "named",
+          positionalArgs: [`[1,2,3]`],
+          namedArgs: {
+            s: new Schema(z.array(z.number()))
+          }
+        });
+if (hasInterrupts(__stack.locals.nums)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.nums
+          })
+          return;
         }
       });
-if (hasInterrupts(__stack.locals.nums)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.nums
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
+      await runner.step(3, async (runner) => {
 const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.nums]
-      });
+          type: "positional",
+          args: [__stack.locals.nums]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
 //  `any` LHS — degenerate but valid: injects `z.any()`. No assertion
 //  about runtime shape, just verifies it compiles.
-    });
-    await runner.step(4, async (runner) => {
+      });
+      await runner.step(4, async (runner) => {
 __stack.locals.anything = await __call(parseValue, {
-        type: "named",
-        positionalArgs: [`42`],
-        namedArgs: {
-          s: new Schema(z.any())
+          type: "named",
+          positionalArgs: [`42`],
+          namedArgs: {
+            s: new Schema(z.any())
+          }
+        });
+if (hasInterrupts(__stack.locals.anything)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.anything
+          })
+          return;
         }
       });
-if (hasInterrupts(__stack.locals.anything)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.anything
-        })
-        return;
-      }
-    });
-    await runner.step(5, async (runner) => {
+      await runner.step(5, async (runner) => {
 const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.anything]
-      });
+          type: "positional",
+          args: [__stack.locals.anything]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
 //  `!` validation on the LHS: injection still fires with the bare
 //  type. `!` triggers a separate runtime validation pass at the
 //  assignment site; the injected schema and the validator schema are
 //  built from the same LHS type, so they agree.
-    });
-    await runner.step(6, async (runner) => {
+      });
+      await runner.step(6, async (runner) => {
 __stack.locals.validated = await __call(parseValue, {
-        type: "named",
-        positionalArgs: [`[1,2,3]`],
-        namedArgs: {
-          s: new Schema(z.array(z.number()))
+          type: "named",
+          positionalArgs: [`[1,2,3]`],
+          namedArgs: {
+            s: new Schema(z.array(z.number()))
+          }
+        });
+if (hasInterrupts(__stack.locals.validated)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.validated
+          })
+          return;
+        }
+__stack.locals.validated = __validateType(__stack.locals.validated, z.array(z.number()));
+      });
+      await runner.step(7, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.validated]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+//  Explicit override: the user-supplied schema wins, no injection.
+      });
+      await runner.step(8, async (runner) => {
+__stack.locals.explicit = await __call(parseValue, {
+          type: "positional",
+          args: [`[1,2,3]`, new Schema(z.any())]
+        });
+if (hasInterrupts(__stack.locals.explicit)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.explicit
+          })
+          return;
         }
       });
-if (hasInterrupts(__stack.locals.validated)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.validated
-        })
-        return;
-      }
-__stack.locals.validated = __validateType(__stack.locals.validated, z.array(z.number()));
-    });
-    await runner.step(7, async (runner) => {
+      await runner.step(9, async (runner) => {
 const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.validated]
-      });
+          type: "positional",
+          args: [__stack.locals.explicit]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-//  Explicit override: the user-supplied schema wins, no injection.
-    });
-    await runner.step(8, async (runner) => {
-__stack.locals.explicit = await __call(parseValue, {
-        type: "positional",
-        args: [`[1,2,3]`, new Schema(z.any())]
-      });
-if (hasInterrupts(__stack.locals.explicit)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.explicit
-        })
-        return;
-      }
-    });
-    await runner.step(9, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.explicit]
-      });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
 //  Bare expression statement — no LHS, no return position, no injection.
 //  The Schema param is omitted; the function would fail at runtime
 //  because s is undefined. This case exists to lock in "no spooky
 //  injection without a clear context."
-    });
-    await runner.step(10, async (runner) => {
-const __funcResult = await __call(parseValue, {
-        type: "positional",
-        args: [`[1,2,3]`]
       });
+      await runner.step(10, async (runner) => {
+const __funcResult = await __call(parseValue, {
+          type: "positional",
+          args: [`[1,2,3]`]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(11, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -188,7 +188,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -303,7 +303,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -395,7 +395,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -166,7 +166,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -25,7 +25,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -156,59 +156,62 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "setLLMClient.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.result = await runPrompt({
-        prompt: `Hello`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Hello`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.result
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.result]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.result
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.result]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,59 +147,62 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "simple.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.greeting = await runPrompt({
-        prompt: `say hello`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `say hello`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.greeting)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.greeting
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.greeting]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.greeting
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.greeting]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -160,7 +160,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,13 +147,10 @@ graph.node("analyzeData", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "skill.agency", scopeName: "analyzeData", threads: __setupData.threads });
@@ -161,34 +158,40 @@ let __functionCompleted = false;
     __stack.args["input"] = __state.data.input;
   }
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "analyzeData"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "analyzeData"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.result = await runPrompt({
-        prompt: `Analyzing: ${__stack.args.input}`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Analyzing: ${__stack.args.input}`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.result
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.result
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(2, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,52 +147,55 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "slice.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.arr = [1, 2, 3, 4, 5];
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.bothBounds = __stack.locals.arr.slice(1, 3);
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 __stack.locals.startOnly = __stack.locals.arr.slice(2);
-    });
-    await runner.step(4, async (runner) => {
+      });
+      await runner.step(4, async (runner) => {
 __stack.locals.endOnly = __stack.locals.arr.slice(0, 3);
-    });
-    await runner.step(5, async (runner) => {
+      });
+      await runner.step(5, async (runner) => {
 __stack.locals.noBounds = __stack.locals.arr.slice();
-    });
-    await runner.step(6, async (runner) => {
+      });
+      await runner.step(6, async (runner) => {
 __stack.locals.negativeStart = __stack.locals.arr.slice(-2);
-    });
-    await runner.step(7, async (runner) => {
+      });
+      await runner.step(7, async (runner) => {
 __stack.locals.optionalSlice = __stack.locals.arr?.slice(1, 3);
-    });
-    await runner.step(8, async (runner) => {
+      });
+      await runner.step(8, async (runner) => {
 __stack.locals.str = `hello`;
-    });
-    await runner.step(9, async (runner) => {
+      });
+      await runner.step(9, async (runner) => {
 __stack.locals.stringSlice = __stack.locals.str.slice(1, 3);
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(10, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,37 +147,40 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "sliceAssign.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.arr = [1, 2, 3, 4, 5];
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.arr.splice(1, 3 - 1, ...[10, 20])
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 __stack.locals.arr.splice(2, __stack.locals.arr.length - 2, ...[30])
-    });
-    await runner.step(4, async (runner) => {
+      });
+      await runner.step(4, async (runner) => {
 __stack.locals.arr.splice(0, 2 - 0, ...[40, 50])
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -178,7 +178,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -285,7 +285,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __greet_impl(name: string, __state: InternalFunctionState | undef
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("sourceMap.agency")) {
@@ -166,7 +163,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "sourceMap.agency", scopeName: "greet", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "sourceMap.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "sourceMap.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -179,41 +176,47 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "greet",
-          args: {
-            name: name
-          },
-          isBuiltin: false,
-          moduleId: "sourceMap.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "greet",
+            args: {
+              name: name
+            },
+            isBuiltin: false,
+            moduleId: "sourceMap.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.result = await runPrompt({
-        prompt: `Hello ${__stack.args.name}`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Hello ${__stack.args.name}`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__stack.locals.result)
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__stack.locals.result)
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __functionCompleted = true;
 runner.halt(__stack.locals.result)
 return;
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -238,7 +241,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -272,49 +275,52 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "sourceMap.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.x = 1;
-    });
-    await runner.ifElse(2, [
+      });
+      await runner.ifElse(2, [
 
   {
     condition: async () => __stack.locals.x === 1,
     body: async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.y = 2;
-          });
+            });
     },
   },
 
 ], async (runner) => {
 await runner.step(1, async (runner) => {
 __stack.locals.y = 3;
-        });
+          });
 });
-    await runner.loop(3, [`a`, `b`], async (item, _, runner) => {
+      await runner.loop(3, [`a`, `b`], async (item, _, runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.z = item;
+        });
       });
-    });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -176,7 +176,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -166,32 +166,35 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "static.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: foo
-      })
+          messages: __threads(),
+          data: foo
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(2, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,98 +147,101 @@ graph.node("foo", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "streaming.agency", scopeName: "foo", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "foo"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "foo"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.response = await runPrompt({
-        prompt: `Generate a response word by word`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {
-          "stream": true
-        },
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Generate a response word by word`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {
+            "stream": true
+          },
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.response)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.response
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.response]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.response
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.response]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(3, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.response2 = await runPrompt({
-        prompt: `Generate a response word by word, but with a different model`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {
-          "model": `gemini-2.5-flash-lite`,
-          "stream": true
-        },
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Generate a response word by word, but with a different model`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {
+            "model": `gemini-2.5-flash-lite`,
+            "stream": true
+          },
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.response2)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.response2
-        })
-        return;
-      }
-    });
-    await runner.step(4, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.response2]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.response2
+          })
+          return;
+        }
       });
+      await runner.step(4, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.response2]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,28 +147,31 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "string-interpolation.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.greeting = `Hello, my name is ${name} and I am ${age} years old.`;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(2, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,67 +147,70 @@ graph.node("foo", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "stringConcat.agency", scopeName: "foo", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "foo"
+          name: "onNodeStart",
+          data: {
+            nodeName: "foo"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`What is your name?`]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
         }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`What is your name?`]
       });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+      await runner.step(2, async (runner) => {
 __stack.locals.name = await __call(input, {
-        type: "positional",
-        args: [`> `]
-      });
+          type: "positional",
+          args: [`> `]
+        });
 if (hasInterrupts(__stack.locals.name)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __stack.locals.name
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`Hello, ${__stack.locals.name}!`]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __stack.locals.name
+          })
+          return;
+        }
       });
+      await runner.step(3, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`Hello, ${__stack.locals.name}!`]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -173,7 +173,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -416,7 +416,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __foo_impl(__state: InternalFunctionState | undefined = undefined
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("threadsAndSubthreads.agency")) {
@@ -165,7 +162,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "threadsAndSubthreads.agency", scopeName: "foo", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "threadsAndSubthreads.agency", scopeName: "foo", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "threadsAndSubthreads.agency", scopeName: "foo", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -174,43 +171,27 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "foo",
-          args: {},
-          isBuiltin: false,
-          moduleId: "threadsAndSubthreads.agency"
-        }
-      })
-    });
-    await runner.thread(1, "create", async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "foo",
+            args: {},
+            isBuiltin: false,
+            moduleId: "threadsAndSubthreads.agency"
+          }
+        })
+      });
+      await runner.thread(1, "create", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res1 = await runPrompt({
-          prompt: `What are the first 5 prime numbers?`,
-          messages: __threads().getOrCreateActive(),
-          responseFormat: z.object({
-            response: z.array(z.number())
-          }),
-          clientConfig: {},
-          maxToolCallRounds: 10,
-          removedTools: __self.__removedTools,
-          checkpointInfo: runner.getCheckpointInfo()
-        });
-// halt if this is an interrupt
-if (hasInterrupts(__stack.locals.res1)) {
-          await __ctx.pendingPromises.awaitAll()
-          runner.halt(__stack.locals.res1)
-          return;
-        }
-      });
-await runner.thread(1, "createSubthread", async (runner) => {
-await runner.step(0, async (runner) => {
-__self.__removedTools = __self.__removedTools || [];
-__stack.locals.res2 = await runPrompt({
-            prompt: `What are the next 2 prime numbers after those?`,
+            prompt: `What are the first 5 prime numbers?`,
             messages: __threads().getOrCreateActive(),
             responseFormat: z.object({
               response: z.array(z.number())
@@ -221,20 +202,20 @@ __stack.locals.res2 = await runPrompt({
             checkpointInfo: runner.getCheckpointInfo()
           });
 // halt if this is an interrupt
-if (hasInterrupts(__stack.locals.res2)) {
+if (hasInterrupts(__stack.locals.res1)) {
             await __ctx.pendingPromises.awaitAll()
-            runner.halt(__stack.locals.res2)
+            runner.halt(__stack.locals.res1)
             return;
           }
         });
 await runner.thread(1, "createSubthread", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
-__stack.locals.res3 = await runPrompt({
-              prompt: `And what is the sum of all those numbers combined?`,
+__stack.locals.res2 = await runPrompt({
+              prompt: `What are the next 2 prime numbers after those?`,
               messages: __threads().getOrCreateActive(),
               responseFormat: z.object({
-                response: z.number()
+                response: z.array(z.number())
               }),
               clientConfig: {},
               maxToolCallRounds: 10,
@@ -242,17 +223,61 @@ __stack.locals.res3 = await runPrompt({
               checkpointInfo: runner.getCheckpointInfo()
             });
 // halt if this is an interrupt
-if (hasInterrupts(__stack.locals.res3)) {
+if (hasInterrupts(__stack.locals.res2)) {
               await __ctx.pendingPromises.awaitAll()
-              runner.halt(__stack.locals.res3)
+              runner.halt(__stack.locals.res2)
               return;
             }
           });
-        });
+await runner.thread(1, "createSubthread", async (runner) => {
+await runner.step(0, async (runner) => {
+__self.__removedTools = __self.__removedTools || [];
+__stack.locals.res3 = await runPrompt({
+                prompt: `And what is the sum of all those numbers combined?`,
+                messages: __threads().getOrCreateActive(),
+                responseFormat: z.object({
+                  response: z.number()
+                }),
+                clientConfig: {},
+                maxToolCallRounds: 10,
+                removedTools: __self.__removedTools,
+                checkpointInfo: runner.getCheckpointInfo()
+              });
+// halt if this is an interrupt
+if (hasInterrupts(__stack.locals.res3)) {
+                await __ctx.pendingPromises.awaitAll()
+                runner.halt(__stack.locals.res3)
+                return;
+              }
+            });
+          });
 await runner.thread(2, "create", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res5 = await runPrompt({
+                prompt: `And what is the sum of all those numbers combined?`,
+                messages: __threads().getOrCreateActive(),
+                responseFormat: z.object({
+                  response: z.number()
+                }),
+                clientConfig: {},
+                maxToolCallRounds: 10,
+                removedTools: __self.__removedTools,
+                checkpointInfo: runner.getCheckpointInfo()
+              });
+// halt if this is an interrupt
+if (hasInterrupts(__stack.locals.res5)) {
+                await __ctx.pendingPromises.awaitAll()
+                runner.halt(__stack.locals.res5)
+                return;
+              }
+            });
+          });
+        });
+await runner.thread(2, "createSubthread", async (runner) => {
+await runner.step(0, async (runner) => {
+__self.__removedTools = __self.__removedTools || [];
+__stack.locals.res4 = await runPrompt({
               prompt: `And what is the sum of all those numbers combined?`,
               messages: __threads().getOrCreateActive(),
               responseFormat: z.object({
@@ -264,92 +289,70 @@ __stack.locals.res5 = await runPrompt({
               checkpointInfo: runner.getCheckpointInfo()
             });
 // halt if this is an interrupt
-if (hasInterrupts(__stack.locals.res5)) {
+if (hasInterrupts(__stack.locals.res4)) {
               await __ctx.pendingPromises.awaitAll()
-              runner.halt(__stack.locals.res5)
+              runner.halt(__stack.locals.res4)
               return;
             }
           });
         });
       });
-await runner.thread(2, "createSubthread", async (runner) => {
-await runner.step(0, async (runner) => {
-__self.__removedTools = __self.__removedTools || [];
-__stack.locals.res4 = await runPrompt({
-            prompt: `And what is the sum of all those numbers combined?`,
-            messages: __threads().getOrCreateActive(),
-            responseFormat: z.object({
-              response: z.number()
-            }),
-            clientConfig: {},
-            maxToolCallRounds: 10,
-            removedTools: __self.__removedTools,
-            checkpointInfo: runner.getCheckpointInfo()
-          });
-// halt if this is an interrupt
-if (hasInterrupts(__stack.locals.res4)) {
-            await __ctx.pendingPromises.awaitAll()
-            runner.halt(__stack.locals.res4)
-            return;
-          }
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`res1`, __stack.locals.res1]
         });
-      });
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`res1`, __stack.locals.res1]
-      });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`res2`, __stack.locals.res2]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
       });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
-    await runner.step(4, async (runner) => {
+      await runner.step(3, async (runner) => {
 const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`res3`, __stack.locals.res3]
-      });
+          type: "positional",
+          args: [`res2`, __stack.locals.res2]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
-    await runner.step(5, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+      await runner.step(4, async (runner) => {
 const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`res4`, __stack.locals.res4]
-      });
+          type: "positional",
+          args: [`res3`, __stack.locals.res3]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
-    await runner.step(6, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+      await runner.step(5, async (runner) => {
 const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`res5`, __stack.locals.res5]
-      });
+          type: "positional",
+          args: [`res4`, __stack.locals.res4]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+      await runner.step(6, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`res5`, __stack.locals.res5]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -374,7 +377,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -403,54 +406,32 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "threadsAndSubthreads.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.thread(1, "create", async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.thread(1, "create", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res1 = await runPrompt({
-          prompt: `What are the first 5 prime numbers?`,
-          messages: __threads().getOrCreateActive(),
-          responseFormat: z.object({
-            response: z.array(z.number())
-          }),
-          clientConfig: {},
-          maxToolCallRounds: 10,
-          removedTools: __self.__removedTools,
-          checkpointInfo: runner.getCheckpointInfo()
-        });
-// halt if this is an interrupt
-if (hasInterrupts(__stack.locals.res1)) {
-          await __ctx.pendingPromises.awaitAll()
-          runner.halt({
-            messages: __threads(),
-            data: __stack.locals.res1
-          })
-          return;
-        }
-      });
-await runner.thread(1, "createSubthread", async (runner) => {
-await runner.step(0, async (runner) => {
-__self.__removedTools = __self.__removedTools || [];
-__stack.locals.res2 = await runPrompt({
-            prompt: `What are the next 2 prime numbers after those?`,
+            prompt: `What are the first 5 prime numbers?`,
             messages: __threads().getOrCreateActive(),
             responseFormat: z.object({
               response: z.array(z.number())
@@ -461,11 +442,11 @@ __stack.locals.res2 = await runPrompt({
             checkpointInfo: runner.getCheckpointInfo()
           });
 // halt if this is an interrupt
-if (hasInterrupts(__stack.locals.res2)) {
+if (hasInterrupts(__stack.locals.res1)) {
             await __ctx.pendingPromises.awaitAll()
             runner.halt({
               messages: __threads(),
-              data: __stack.locals.res2
+              data: __stack.locals.res1
             })
             return;
           }
@@ -473,11 +454,11 @@ if (hasInterrupts(__stack.locals.res2)) {
 await runner.thread(1, "createSubthread", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
-__stack.locals.res3 = await runPrompt({
-              prompt: `And what is the sum of all those numbers combined?`,
+__stack.locals.res2 = await runPrompt({
+              prompt: `What are the next 2 prime numbers after those?`,
               messages: __threads().getOrCreateActive(),
               responseFormat: z.object({
-                response: z.number()
+                response: z.array(z.number())
               }),
               clientConfig: {},
               maxToolCallRounds: 10,
@@ -485,20 +466,70 @@ __stack.locals.res3 = await runPrompt({
               checkpointInfo: runner.getCheckpointInfo()
             });
 // halt if this is an interrupt
-if (hasInterrupts(__stack.locals.res3)) {
+if (hasInterrupts(__stack.locals.res2)) {
               await __ctx.pendingPromises.awaitAll()
               runner.halt({
                 messages: __threads(),
-                data: __stack.locals.res3
+                data: __stack.locals.res2
               })
               return;
             }
           });
-        });
+await runner.thread(1, "createSubthread", async (runner) => {
+await runner.step(0, async (runner) => {
+__self.__removedTools = __self.__removedTools || [];
+__stack.locals.res3 = await runPrompt({
+                prompt: `And what is the sum of all those numbers combined?`,
+                messages: __threads().getOrCreateActive(),
+                responseFormat: z.object({
+                  response: z.number()
+                }),
+                clientConfig: {},
+                maxToolCallRounds: 10,
+                removedTools: __self.__removedTools,
+                checkpointInfo: runner.getCheckpointInfo()
+              });
+// halt if this is an interrupt
+if (hasInterrupts(__stack.locals.res3)) {
+                await __ctx.pendingPromises.awaitAll()
+                runner.halt({
+                  messages: __threads(),
+                  data: __stack.locals.res3
+                })
+                return;
+              }
+            });
+          });
 await runner.thread(2, "create", async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res5 = await runPrompt({
+                prompt: `And what is the sum of all those numbers combined?`,
+                messages: __threads().getOrCreateActive(),
+                responseFormat: z.object({
+                  response: z.number()
+                }),
+                clientConfig: {},
+                maxToolCallRounds: 10,
+                removedTools: __self.__removedTools,
+                checkpointInfo: runner.getCheckpointInfo()
+              });
+// halt if this is an interrupt
+if (hasInterrupts(__stack.locals.res5)) {
+                await __ctx.pendingPromises.awaitAll()
+                runner.halt({
+                  messages: __threads(),
+                  data: __stack.locals.res5
+                })
+                return;
+              }
+            });
+          });
+        });
+await runner.thread(2, "createSubthread", async (runner) => {
+await runner.step(0, async (runner) => {
+__self.__removedTools = __self.__removedTools || [];
+__stack.locals.res4 = await runPrompt({
               prompt: `And what is the sum of all those numbers combined?`,
               messages: __threads().getOrCreateActive(),
               responseFormat: z.object({
@@ -510,113 +541,88 @@ __stack.locals.res5 = await runPrompt({
               checkpointInfo: runner.getCheckpointInfo()
             });
 // halt if this is an interrupt
-if (hasInterrupts(__stack.locals.res5)) {
+if (hasInterrupts(__stack.locals.res4)) {
               await __ctx.pendingPromises.awaitAll()
               runner.halt({
                 messages: __threads(),
-                data: __stack.locals.res5
+                data: __stack.locals.res4
               })
               return;
             }
           });
         });
       });
-await runner.thread(2, "createSubthread", async (runner) => {
-await runner.step(0, async (runner) => {
-__self.__removedTools = __self.__removedTools || [];
-__stack.locals.res4 = await runPrompt({
-            prompt: `And what is the sum of all those numbers combined?`,
-            messages: __threads().getOrCreateActive(),
-            responseFormat: z.object({
-              response: z.number()
-            }),
-            clientConfig: {},
-            maxToolCallRounds: 10,
-            removedTools: __self.__removedTools,
-            checkpointInfo: runner.getCheckpointInfo()
-          });
-// halt if this is an interrupt
-if (hasInterrupts(__stack.locals.res4)) {
-            await __ctx.pendingPromises.awaitAll()
-            runner.halt({
-              messages: __threads(),
-              data: __stack.locals.res4
-            })
-            return;
-          }
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`res1`, __stack.locals.res1]
         });
-      });
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`res1`, __stack.locals.res1]
-      });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`res2`, __stack.locals.res2]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
       });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
-    await runner.step(4, async (runner) => {
+      await runner.step(3, async (runner) => {
 const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`res3`, __stack.locals.res3]
-      });
+          type: "positional",
+          args: [`res2`, __stack.locals.res2]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
-    await runner.step(5, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(4, async (runner) => {
 const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`res4`, __stack.locals.res4]
-      });
+          type: "positional",
+          args: [`res3`, __stack.locals.res3]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
-    await runner.step(6, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(5, async (runner) => {
 const __funcResult = await __call(print, {
-        type: "positional",
-        args: [`res5`, __stack.locals.res5]
-      });
+          type: "positional",
+          args: [`res4`, __stack.locals.res4]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(6, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [`res5`, __stack.locals.res5]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(7, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,96 +147,99 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "typeHints.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.count = await runPrompt({
-        prompt: `the number 42`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.number()
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `the number 42`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.number()
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.count)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.count
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.count
+          })
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.message = await runPrompt({
-        prompt: `a greeting message`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `a greeting message`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.message)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.message
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.count]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.message
+          })
+          return;
+        }
       });
-if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
-    await runner.step(4, async (runner) => {
+      await runner.step(3, async (runner) => {
 const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.message]
-      });
+          type: "positional",
+          args: [__stack.locals.count]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+      await runner.step(4, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.message]
+        });
+if (hasInterrupts(__funcResult)) {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -149,62 +149,65 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "exportedTypeAlias.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.c = await runPrompt({
-        prompt: `pick a color`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: Color
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `pick a color`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: Color
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.c)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.c
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.c]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.c
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.c]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -159,7 +159,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,94 +147,97 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "literal.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.foo = await runPrompt({
-        prompt: `the string hi`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.literal("hi")
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `the string hi`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.literal("hi")
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.foo)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.foo
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.foo
+          })
+          return;
+        }
+      });
+      await runner.step(2, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.bar = await runPrompt({
-        prompt: `the number 42`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.literal(42)
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `the number 42`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.literal(42)
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.bar)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.bar
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.bar
+          })
+          return;
+        }
+      });
+      await runner.step(3, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.baz = await runPrompt({
-        prompt: `the boolean true`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.literal(true)
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `the boolean true`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.literal(true)
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.baz)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.baz
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.baz
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -151,62 +151,65 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "nestedTypeAlias.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.user = await runPrompt({
-        prompt: `give me a user`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: User
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `give me a user`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: User
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.user)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.user
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.user]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.user
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.user]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -161,7 +161,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -149,62 +149,65 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "typeAlias.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.foo = await runPrompt({
-        prompt: `a set of coordinates`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: Coords
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `a set of coordinates`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: Coords
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.foo)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.foo
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.foo]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.foo
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.foo]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -159,7 +159,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,53 +147,56 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "unitLiterals.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.a = 30000;
-    });
-    await runner.step(2, async (runner) => {
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.b = 500;
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 __stack.locals.c = 5;
-    });
-    await runner.step(4, async (runner) => {
+      });
+      await runner.step(4, async (runner) => {
 __stack.locals.d = 7200000;
-    });
-    await runner.step(5, async (runner) => {
+      });
+      await runner.step(5, async (runner) => {
 __stack.locals.e = 604800000;
-    });
-    await runner.step(6, async (runner) => {
+      });
+      await runner.step(6, async (runner) => {
 __stack.locals.f = 604800000;
-    });
-    await runner.step(7, async (runner) => {
+      });
+      await runner.step(7, async (runner) => {
 __stack.locals.g = 500;
-    });
-    await runner.step(8, async (runner) => {
+      });
+      await runner.step(8, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.a
-      })
+          messages: __threads(),
+          data: __stack.locals.a
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(9, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,68 +147,71 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "valueAccessInterpolation.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.user = {
-        "name": `Alice`,
-        "age": 30
-      };
-    });
-    await runner.step(2, async (runner) => {
+          "name": `Alice`,
+          "age": 30
+        };
+      });
+      await runner.step(2, async (runner) => {
 __stack.locals.greeting = `Hello, ${__stack.locals.user.name}!`;
-    });
-    await runner.step(3, async (runner) => {
+      });
+      await runner.step(3, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.result = await runPrompt({
-        prompt: `Tell me about ${__stack.locals.user.name} who is ${__stack.locals.user.age} years old`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Tell me about ${__stack.locals.user.name} who is ${__stack.locals.user.age} years old`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.result
-        })
-        return;
-      }
-    });
-    await runner.step(4, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.result]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.result
+          })
+          return;
+        }
       });
+      await runner.step(4, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.result]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(5, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -157,7 +157,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,68 +147,71 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "varTypes.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __stack.locals.person = {
-        "name": `Alice`,
-        "age": 30
-      };
-    });
-    await runner.step(2, async (runner) => {
+          "name": `Alice`,
+          "age": 30
+        };
+      });
+      await runner.step(2, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.response = await runPrompt({
-        prompt: `Say hi to ${__stack.locals.person.name}, who is ${__stack.locals.person.age} years old.`,
-        messages: __threads().getOrCreateActive(),
-        responseFormat: z.object({
-          response: z.object({ "greeting": z.string() })
-        }),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `Say hi to ${__stack.locals.person.name}, who is ${__stack.locals.person.age} years old.`,
+          messages: __threads().getOrCreateActive(),
+          responseFormat: z.object({
+            response: z.object({ "greeting": z.string() })
+          }),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.response)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.response
-        })
-        return;
-      }
-    });
-    await runner.step(3, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.response]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.response
+          })
+          return;
+        }
       });
+      await runner.step(3, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.response]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(4, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -189,7 +189,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -154,13 +154,10 @@ async function __log_impl(prefix: string, messages: string[], __state: InternalF
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("variadic.agency")) {
@@ -173,7 +170,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "variadic.agency", scopeName: "log", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "variadic.agency", scopeName: "log", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "variadic.agency", scopeName: "log", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -190,31 +187,37 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "log",
-          args: {
-            prefix: prefix,
-            messages: messages
-          },
-          isBuiltin: false,
-          moduleId: "variadic.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.args.prefix, ...__stack.args.messages]
+          name: "onFunctionStart",
+          data: {
+            functionName: "log",
+            args: {
+              prefix: prefix,
+              messages: messages
+            },
+            isBuiltin: false,
+            moduleId: "variadic.agency"
+          }
+        })
       });
+      await runner.step(1, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.args.prefix, ...__stack.args.messages]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt(__funcResult)
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt(__funcResult)
+          return;
+        }
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -239,7 +242,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -173,7 +173,7 @@ if (__ctx._pendingArgOverrides) {
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __setupData.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {
@@ -292,7 +292,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -148,13 +148,10 @@ async function __foo_impl(__state: InternalFunctionState | undefined = undefined
     state: __state
   });
   // __state will be undefined if this function is being called as a tool by an llm
-  const __stateStack = __setupData.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state?.ctx || __globalCtx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("withModifier.agency")) {
@@ -165,7 +162,7 @@ let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "withModifier.agency", scopeName: "foo", threads: __setupData.threads });
   let __resultCheckpointId = -1;
 if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack, __ctx, { moduleId: "withModifier.agency", scopeName: "foo", stepPath: "", label: "result-entry" });
+  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "withModifier.agency", scopeName: "foo", stepPath: "", label: "result-entry" });
 }
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
@@ -174,18 +171,23 @@ if (__ctx._pendingArgOverrides) {
 }
 
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onFunctionStart",
-        data: {
-          functionName: "foo",
-          args: {},
-          isBuiltin: false,
-          moduleId: "withModifier.agency"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onFunctionStart",
+          data: {
+            functionName: "foo",
+            args: {},
+            isBuiltin: false,
+            moduleId: "withModifier.agency"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 // Resume path: check for a response by interruptId
 const __response = __ctx.getInterruptResponse(__self.__interruptId_1);
 if (__response) {
@@ -201,7 +203,7 @@ if (__response) {
   }
 } else {
   // First run: call handlers, then propagate if unhandled
-  const __handlerResult = await interruptWithHandlers("unknown", `check`, {}, "./withModifier.agency", __ctx, __stateStack);
+  const __handlerResult = await interruptWithHandlers("unknown", `check`, {}, "./withModifier.agency", __ctx, __stateStack());
   if (isRejected(__handlerResult)) {
     
     
@@ -213,7 +215,7 @@ if (__response) {
     // No handler — propagate interrupt array to TypeScript caller
     // Store interruptId on frame BEFORE checkpoint so it's captured in the snapshot
     __self.__interruptId_1 = __handlerResult[0].interruptId;
-    const __checkpointId = __ctx.checkpoints.create(__stateStack, __ctx, { moduleId: "withModifier.agency", scopeName: "foo", stepPath: "1" });
+    const __checkpointId = __ctx.checkpoints.create(__stateStack(), __ctx, { moduleId: "withModifier.agency", scopeName: "foo", stepPath: "1" });
     __handlerResult[0].checkpointId = __checkpointId;
     __handlerResult[0].checkpoint = __ctx.checkpoints.get(__checkpointId);
     
@@ -225,7 +227,8 @@ if (__response) {
   // Approved — continue execution past interrupt
 }
 
-    });
+      });
+    })
     if (runner.halted) { if (isFailure(runner.haltResult)) { runner.haltResult.retryable = runner.haltResult.retryable && __self.__retryable; } return runner.haltResult; }
   } catch (__error) {
     if (__error instanceof RestoreSignal) {
@@ -250,7 +253,7 @@ return failure(
 );
 
   } finally {
-    __stateStack.pop()
+    __stateStack()?.pop()
     if (__functionCompleted) {
       await callHook({
         name: "onFunctionEnd",
@@ -279,48 +282,51 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "withModifier.agency", scopeName: "main", threads: __setupData.threads });
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.handle(1, async (__data: any) => approve(), async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.handle(1, async (__data: any) => approve(), async (runner) => {
 await runner.step(0, async (runner) => {
 __stack.locals.result = await __call(foo, {
-          type: "positional",
-          args: []
-        });
+            type: "positional",
+            args: []
+          });
 if (hasInterrupts(__stack.locals.result)) {
-          await __ctx.pendingPromises.awaitAll()
-          runner.halt({
-            ...__state,
-            data: __stack.locals.result
-          })
-          return;
-        }
+            await __ctx.pendingPromises.awaitAll()
+            runner.halt({
+              ...__state,
+              data: __stack.locals.result
+            })
+            return;
+          }
+        });
       });
-    });
-    await runner.step(2, async (runner) => {
+      await runner.step(2, async (runner) => {
 runner.halt({
-        messages: __threads(),
-        data: __stack.locals.result
-      })
+          messages: __threads(),
+          data: __stack.locals.result
+        })
 return;
-    });
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -160,7 +160,7 @@ let __functionCompleted = false;
   try {
     await agencyStore.run({
       ctx: __ctx,
-      stack: __stack,
+      stack: __ctx.stateStack,
       threads: __setupData.threads
     }, async () => {
       await runner.hook(0, async () => {

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -24,7 +24,7 @@ import {
   readSkillTool as __readSkillTool,
   readSkillToolParams as __readSkillToolParams,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
-  __call, __callMethod, __threads, getRuntimeContext,
+  __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
 } from "agency-lang/runtime";
@@ -147,13 +147,10 @@ graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({
     state: __state
   });
-  const __stateStack = __state.ctx.stateStack;
-const __stack = __setupData.stack;
+  const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
 const __ctx = __state.ctx;
-const statelogClient = __ctx.statelogClient;
-const __graph = __ctx.graph;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "withParam.agency", scopeName: "main", threads: __setupData.threads });
@@ -161,48 +158,54 @@ let __functionCompleted = false;
     __stack.args["input"] = __state.data.input;
   }
   try {
-    await runner.hook(0, async () => {
+    await agencyStore.run({
+      ctx: __ctx,
+      stack: __stack,
+      threads: __setupData.threads
+    }, async () => {
+      await runner.hook(0, async () => {
 await callHook({
-        name: "onNodeStart",
-        data: {
-          nodeName: "main"
-        }
-      })
-    });
-    await runner.step(1, async (runner) => {
+          name: "onNodeStart",
+          data: {
+            nodeName: "main"
+          }
+        })
+      });
+      await runner.step(1, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.result = await runPrompt({
-        prompt: `process this input: ${__stack.args.input}`,
-        messages: __threads().getOrCreateActive(),
-        clientConfig: {},
-        maxToolCallRounds: 10,
-        removedTools: __self.__removedTools,
-        checkpointInfo: runner.getCheckpointInfo()
-      });
+          prompt: `process this input: ${__stack.args.input}`,
+          messages: __threads().getOrCreateActive(),
+          clientConfig: {},
+          maxToolCallRounds: 10,
+          removedTools: __self.__removedTools,
+          checkpointInfo: runner.getCheckpointInfo()
+        });
 // halt if this is an interrupt
 if (hasInterrupts(__stack.locals.result)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          messages: __threads(),
-          data: __stack.locals.result
-        })
-        return;
-      }
-    });
-    await runner.step(2, async (runner) => {
-const __funcResult = await __call(print, {
-        type: "positional",
-        args: [__stack.locals.result]
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            messages: __threads(),
+            data: __stack.locals.result
+          })
+          return;
+        }
       });
+      await runner.step(2, async (runner) => {
+const __funcResult = await __call(print, {
+          type: "positional",
+          args: [__stack.locals.result]
+        });
 if (hasInterrupts(__funcResult)) {
-        await __ctx.pendingPromises.awaitAll()
-        runner.halt({
-          ...__state,
-          data: __funcResult
-        })
-        return;
-      }
-    });
+          await __ctx.pendingPromises.awaitAll()
+          runner.halt({
+            ...__state,
+            data: __funcResult
+          })
+          return;
+        }
+      });
+    })
     if (runner.halted) return runner.haltResult;
     await runner.hook(3, async () => {
 await callHook({


### PR DESCRIPTION
## Summary

Concludes most of the Phase 4 ALS migration cleanup (#198 → #199 → #200 → #201).

This PR combines three related codegen cleanups + a defense-in-depth body-level ALS wrap + the architecture docs that motivate them. The fourth slice (`__ctx` accessor migration) is intentionally deferred to a follow-up PR — rationale in [`docs/dev/codegen-als-accessors.md`](./packages/agency-lang/docs/dev/codegen-als-accessors.md) "Why `__ctx` is deferred".

## What changes

### Task 1: Prune dead `__graph` and `statelogClient` setup locals

`setupEnv` declared both as `const __graph = ...` / `const statelogClient = ...` in every generated function/node setup block (also redeclared in `classMethod.mustache`), but no template, IR builder, or downstream codegen path ever referenced either local. Pure dead-code removal — verified via `grep` across `lib/templates`, `lib/ir`, and `lib/backends`.

### Task 2: Prune `__stateStack` via `__stateStack()` accessor

Mirrors the `__threads()` migration from #201. Adds `__stateStack(): StateStack | undefined` to `lib/runtime/asyncContext.ts`, re-exports it, adds it to `imports.mustache`, and flips every previous reference.

Strict-vs-lenient decisions (per [doc rule](./packages/agency-lang/docs/dev/codegen-als-accessors.md#why-two-flavors-x-vs-getruntimecontextx)):

| Site | Form | Reason |
| --- | --- | --- |
| `finally { __stateStack().pop() }` | `__stateStack()?.pop()` | The `?.` defends against a finally running outside any ALS frame (rare — tool invocation without an outer `agencyStore.run` wrap). |
| `__ctx.checkpoints.create(__stateStack, __ctx, {...})` | `__stateStack()` | Lenient pass-through; the body wrap (Task 4) guarantees a frame inside every scope. |
| `interruptWithHandlers(..., __stateStack)` | `__stateStack()` | Same — pass-through. |
| `runner.fork(..., __stateStack)` | `getRuntimeContext().stack` | Strict throw: `runner.fork` requires the stack; `undefined` would produce a generic `TypeError` deep in the fork machinery. |
| Pop before `goToNode(...)` | `__stateStack()?.pop()` | Optional chain defends against goto reached outside any frame. |

Special case unchanged: `const __stateStack = __forkBranchStack;` in `forkBlockSetup.mustache` stays — intentional rebind to the branch-specific stack.

### Task 4: Body-level `agencyStore.run` wrap (defense-in-depth)

Every function- and node-body try block now wraps its body in:

```ts
await agencyStore.run({ ctx: __ctx, stack: __stack, threads: __setupData.threads }, async () => { ... });
```

Today every callback emission already re-seeds ALS via `Runner.runInScope` / `runBatch.runInBranchAlsFrame`, so the wrap has no observable behavior change. The point is to close the gap between Runner-managed steps: code that runs *between* steps (the try block body itself, hooks, finally) currently runs in whatever outer ALS frame happened to be installed. The wrap makes the per-scope frame contract explicit and removes the risk that a future refactor silently loses it.

Plumbing:

- New `ts.withAlsFrame({ctx, stack, threads, body})` builder in `lib/ir/builders.ts`.
- `imports.mustache` imports `agencyStore` from `agency-lang/runtime`.
- **Function-body emission**: validation guards stay *outside* the wrap (they emit `return __vr_x` for failures; that value must escape the outer function, not just the inner async callback). Hoisted type aliases also stay outside.
- **Node-body emission**: `onNodeStart` hook + `bodyCode` go inside the wrap. The `if (runner.halted) return runner.haltResult;` check, `onNodeEnd` hook, and final `return { messages, data: undefined }` stay outside (the wrap's inner callback may bare-`return` from `runner.halt(...)`; we want the outer arrow to keep running into the halted check / end hook / return).
- **`classMethod.mustache`**: try block body wraps in the same shape. Inner halted check becomes `if (runner.halted) { return; }`; outer check after the wrap returns `runner.haltResult` to the caller.

### `__ctx` runtime accessor shipped; codegen migration deferred

`lib/runtime/asyncContext.ts` now exports `__ctx(): RuntimeContext<any> | undefined` alongside `__threads()` / `__stateStack()`, but the codegen migration is **not** done in this PR. Three structural complications make it a meaningfully larger change:

1. **Top-level rebind for docstring interpolation.** Modules with interpolated doc strings (`"version ${toolVersion}"`) emit `const __ctx = __globalCtx;` at module top scope so the eager tool-registration object literal can read `__ctx.globals.get(...)`. Making `__ctx` a function import would clash with the rebind; turning the rebind into `__ctx()` would return `undefined` because the eager evaluation happens before any ALS frame is installed.
2. **`classMethod.mustache` has its own `__ctx` setup.** Method-scoped `const __ctx = __state?.ctx || __globalCtx;` rebind with the same problem.
3. **~17 deref sites in `typescriptBuilder.ts`.** Each needs the lenient-vs-strict decision and several sit on top-level emission paths where ALS is genuinely not available.

Shipping the runtime accessor now lets the next PR migrate codegen sites incrementally without re-touching the runtime API.

### Docs

- `docs/dev/async-context.md` — note Runner constructor takes `threads:` explicitly (#200) and link to `codegen-als-accessors.md`.
- `docs/dev/codegen-als-accessors.md` (new) — the accessor pattern, file layout, recipe for adding a new accessor, status table, gotchas, deferral rationale for `__ctx`.
- `docs/superpowers/plans/2026-05-26-als-migration-phase-4-cleanup.md` (new) — the migration plan that drove this PR.

## Validation

- `pnpm tsc --noEmit` — clean
- `pnpm run lint:structure` — clean
- `pnpm test:run` — 4423 / 4423 pass
- Smoke-tested a real Agency program (function call from a graph node) — generated wrap shape verified visually:

```ts
graph.node("main", async (__state) => {
  ...
  try {
    await agencyStore.run({ ctx: __ctx, stack: __stack, threads: __setupData.threads }, async () => {
      await runner.hook(0, async () => { await callHook({name: "onNodeStart", ...}); });
      await runner.step(1, async (runner2) => { ... });
      ...
    });
    if (runner.halted) return runner.haltResult;
    await runner.hook(4, async () => { await callHook({name: "onNodeEnd", ...}); });
    return { messages: __threads(), data: void 0 };
  } catch (__error) { ... }
});
```

## Commit layout

1. `codegen: Phase 4 ALS cleanup ...` — runtime + IR builder + typescriptBuilder + templates + docs (17 files, ~1.1k insertions).
2. `fixtures: regen ...` — mechanical fixture regen (94 files).

Reviewers can stop at commit 1.

## Out of scope

- **Task 3 (`__ctx` codegen migration)** — deferred (see above).
- **Task 5 (removing classes)** — deferred per [original plan](./packages/agency-lang/docs/superpowers/plans/2026-05-26-als-migration-phase-4-cleanup.md#task-5-remove-class-from-agency-separate-workstream).
