### PR TITLE
codegen: drop trailing __state param from generated functions

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1500,23 +1500,23 @@ export class TypeScriptBuilder {
       argsObj[arg] = ts.id(arg);
     }
 
-    // Setup block
+    // Setup block. `setupFunction()` reads `ctx` / `threads` from the
+    // active `agencyStore` ALS frame seeded by the caller (a
+    // `runner.step` body, `runNode`'s top-level frame, or
+    // `runBatch.runInBranchAlsFrame`). Tool dispatch by an LLM also runs
+    // inside the issuing `runner.step` frame, so a frame is always
+    // active here.
     const setupStmts: TsNode[] = [
       ts.constDecl(
         "__setupData",
-        $(ts.id("setupFunction"))
-          .call([ts.obj({ state: ts.runtime.state })])
-          .done(),
+        $(ts.id("setupFunction")).call([]).done(),
       ),
 
-      ts.comment(
-        "__state will be undefined if this function is being called as a tool by an llm",
-      ),
       ts.setupEnv({
         stack: $(ts.id("__setupData")).prop("stack").done(),
         step: $(ts.id("__setupData")).prop("step").done(),
         self: $(ts.id("__setupData")).prop("self").done(),
-        ctx: ts.raw("__state?.ctx || __globalCtx"),
+        ctx: ts.raw("getRuntimeContext().ctx"),
       }),
 
       // Ensure this module's globals are initialized on the current ctx.
@@ -1562,8 +1562,8 @@ export class TypeScriptBuilder {
     );
 
     // Create runner for step execution. `threads` is read directly from
-    // the setup-function result (a fresh ThreadStore when called outside
-    // any node, or the per-node store threaded in via the InternalFunctionState).
+    // the setup-function result, which now resolves it from the active
+    // ALS frame instead of an `__state` positional.
     setupStmts.push(
       ts.raw(
         `const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: ${JSON.stringify(this.moduleId)}, scopeName: ${JSON.stringify(functionName)}, threads: __setupData.threads });`,
@@ -1694,7 +1694,9 @@ export class TypeScriptBuilder {
     this.scopes.inSafeFunction = prevSafe;
     this.scopes.pop();
 
-    // Build function params: typed args + __state
+    // Build function params from the source signature. The legacy
+    // trailing `__state: InternalFunctionState | undefined` positional
+    // is gone — `ctx` / `threads` / `stateStack` flow through ALS.
     const fnParams: TsParam[] = parameters.map((p) => {
       const baseType = p.typeHint ? formatTypeHintTs(p.typeHint) : "any";
       if (p.defaultValue) {
@@ -1705,11 +1707,6 @@ export class TypeScriptBuilder {
         };
       }
       return { name: p.name, typeAnnotation: baseType };
-    });
-    fnParams.push({
-      name: "__state",
-      typeAnnotation: "InternalFunctionState | undefined",
-      defaultValue: ts.id("undefined"),
     });
 
     const implName = `__${functionName}_impl`;
@@ -2270,7 +2267,11 @@ export class TypeScriptBuilder {
         stack: $(ts.id("__setupData")).prop("stack").done(),
         step: $(ts.id("__setupData")).prop("step").done(),
         self: $(ts.id("__setupData")).prop("self").done(),
-        ctx: $(ts.runtime.state).prop("ctx").done(),
+        // `runNode` (and the resume / rewind variants) install the
+        // top-level `agencyStore` frame before `graph.run` invokes
+        // this node body. Read `ctx` from ALS so the local matches
+        // the same per-run context that `setupNode` just used.
+        ctx: ts.raw("getRuntimeContext().ctx"),
       }),
 
       // Pass `threads` explicitly so the Runner's ALS frame is seeded

--- a/packages/agency-lang/lib/runtime/__tests__/node.test.ts
+++ b/packages/agency-lang/lib/runtime/__tests__/node.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from "vitest";
 import { setupNode } from "../node.js";
 import { ThreadStore } from "../state/threadStore.js";
 import { StateStack } from "../state/stateStack.js";
+import { runInTestContext } from "../asyncContext.js";
 
+// Post-ALS migration: setupNode reads `ctx` from `getRuntimeContext()`,
+// not from `state.ctx`. Each test wraps the call in `runInTestContext`
+// so the ALS frame is installed before setupNode dereferences it.
 describe("setupNode", () => {
   it("uses state.messages ThreadStore when stack.threads is null", () => {
     const threadStore = new ThreadStore();
@@ -10,7 +14,9 @@ describe("setupNode", () => {
     const ctx = { stateStack: new StateStack() } as any;
     const state = { messages: threadStore, ctx, data: {} } as any;
 
-    const result = setupNode({ state });
+    const result = runInTestContext(ctx, ctx.stateStack, threadStore, () =>
+      setupNode({ state }),
+    );
 
     expect(result.threads).toBe(threadStore);
     expect(result.threads.activeId()).toBeDefined();
@@ -29,7 +35,9 @@ describe("setupNode", () => {
     const freshThreadStore = new ThreadStore();
     const state = { messages: freshThreadStore, ctx, data: {} } as any;
 
-    const result = setupNode({ state });
+    const result = runInTestContext(ctx, stateStack, freshThreadStore, () =>
+      setupNode({ state }),
+    );
 
     // Should restore from stack.threads, not use state.messages
     expect(result.threads).not.toBe(freshThreadStore);
@@ -39,8 +47,11 @@ describe("setupNode", () => {
   it("falls back to new ThreadStore when neither source is available", () => {
     const ctx = { stateStack: new StateStack() } as any;
     const state = { ctx, data: {} } as any;
+    const seedThreads = new ThreadStore();
 
-    const result = setupNode({ state });
+    const result = runInTestContext(ctx, ctx.stateStack, seedThreads, () =>
+      setupNode({ state }),
+    );
 
     expect(result.threads).toBeInstanceOf(ThreadStore);
     expect(result.threads.activeId()).toBeDefined();

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { stripBoundParams } from "./stripBoundParams.js";
 import { approve } from "./interrupts.js";
+import { agencyStore } from "./asyncContext.js";
 
 export const UNSET: unique symbol = Symbol("UNSET");
 
@@ -120,13 +121,22 @@ export class AgencyFunction {
   }
 
   async invoke(descriptor: CallType, state?: unknown): Promise<unknown> {
-    const ctx = (state as any)?.ctx;
-    if (this._isPreapproved && ctx) {
-      ctx.pushHandler(async () => approve());
-      try {
-        return await this._invokeInner(descriptor, state);
-      } finally {
-        ctx.popHandler();
+    if (this._isPreapproved) {
+      // Post-ALS migration: `ctx` is no longer plumbed in as `state.ctx`
+      // for normal calls — read it from the active `agencyStore` frame
+      // installed by the caller's `runner.step` body (or, for
+      // module-init paths, the bootstrap frame). The preapprove handler
+      // must be pushed onto the same `ctx.handlers` chain that the
+      // invocation will consult, so we MUST read from the live ALS
+      // frame and not from any legacy state-bag fallback.
+      const ctx = agencyStore.getStore()?.ctx;
+      if (ctx) {
+        ctx.pushHandler(async () => approve());
+        try {
+          return await this._invokeInner(descriptor, state);
+        } finally {
+          ctx.popHandler();
+        }
       }
     }
     return this._invokeInner(descriptor, state);

--- a/packages/agency-lang/lib/runtime/call.ts
+++ b/packages/agency-lang/lib/runtime/call.ts
@@ -1,31 +1,47 @@
 import { AgencyFunction } from "./agencyFunction.js";
 import type { CallType } from "./agencyFunction.js";
 import { agencyStore } from "./asyncContext.js";
+import type { StateStack } from "./state/stateStack.js";
 
 /**
- * Construct the `__state` bag that flows into AgencyFunction.invoke() from
- * the active ALS frame, merged with any caller-provided extras (e.g.
- * `moduleId`/`scopeName`/`stepPath` for checkpoint sites, or `{ ctx }`
- * when called from inside `__initializeGlobals` which runs before the
- * ALS frame is installed).
+ * Post-`__state`-drop migration: generated functions read `ctx` /
+ * `threads` / `stateStack` from the active `agencyStore` frame and no
+ * longer accept a trailing `__state` positional. The runtime call
+ * dispatcher therefore no longer constructs a merged state bag for
+ * every call — it just hands the caller-provided `extras` (when
+ * present) to `AgencyFunction.invoke()` as the optional `state` arg.
  *
- * Returning `undefined` here preserves the pre-ALS semantics where some
- * sites called `target.invoke(descriptor)` with no state.
+ * Two narrow special cases survive:
+ *
+ *  1. **`checkpoint()` / `getCheckpoint()` / `restore()` location info.**
+ *     The codegen emits `{ moduleId, scopeName, stepPath }` as `extras`
+ *     so the checkpoint-creation site records the source location.
+ *     These stdlib helpers still accept a trailing `__state` arg, but
+ *     read `ctx` / `stateStack` from ALS — the bag is consulted only
+ *     for the per-call-site location fields.
+ *
+ *  2. **Async-fork `stateStack` override.** Codegen for `async helper()`
+ *     unassigned calls emits `{ stateStack: __forked }` so the branch
+ *     runs on an isolated stack. We install a new ALS frame with the
+ *     forked stack before invoking, so the callee's
+ *     `getRuntimeContext().ctx.stateStack`-equivalent reads see the
+ *     branch stack instead of the parent's. (The async-unassigned
+ *     operator is slated for removal in favor of `fork` / `parallel`,
+ *     which carry their own per-branch ALS frames via
+ *     `runBatch.runInBranchAlsFrame`.)
  */
-function buildStateFromALS(extras?: unknown): unknown {
+function maybeRunWithForkedStack(
+  extras: unknown,
+  fn: () => Promise<unknown>,
+): Promise<unknown> {
+  const e = extras as Record<string, unknown> | undefined;
+  if (!e || !e.stateStack) return fn();
   const store = agencyStore.getStore();
-  if (!store) {
-    // Outside an ALS frame (e.g., global init): rely entirely on
-    // whatever the caller passed.
-    return extras;
-  }
-  const base = {
-    ctx: store.ctx,
-    threads: store.threads,
-    stateStack: store.stack,
-  };
-  if (!extras) return base;
-  return { ...base, ...(extras as Record<string, unknown>) };
+  if (!store) return fn();
+  return agencyStore.run(
+    { ...store, stack: e.stateStack as StateStack },
+    fn,
+  );
 }
 
 export async function __call(
@@ -38,7 +54,9 @@ export async function __call(
     return undefined;
   }
   if (AgencyFunction.isAgencyFunction(target)) {
-    return target.invoke(descriptor, buildStateFromALS(stateExtras));
+    return maybeRunWithForkedStack(stateExtras, () =>
+      target.invoke(descriptor, stateExtras),
+    );
   }
   if (typeof target !== "function") {
     throw new Error(`Cannot call non-function value: ${String(target)}`);
@@ -91,7 +109,9 @@ export async function __callMethod(
 
   const target = (obj as any)[prop];
   if (AgencyFunction.isAgencyFunction(target)) {
-    return target.invoke(descriptor, buildStateFromALS(stateExtras));
+    return maybeRunWithForkedStack(stateExtras, () =>
+      target.invoke(descriptor, stateExtras),
+    );
   }
   if (typeof target !== "function") {
     throw new Error(`Cannot call non-function value at property '${String(prop)}': ${String(target)}`);

--- a/packages/agency-lang/lib/runtime/checkpoint.test.ts
+++ b/packages/agency-lang/lib/runtime/checkpoint.test.ts
@@ -1,11 +1,16 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { checkpoint, getCheckpoint, restore } from "./checkpoint.js";
 import { CheckpointError, RestoreSignal } from "./errors.js";
 import { makeMockCtx } from "./__tests__/testHelpers.js";
 import { CheckpointStore } from "./index.js";
+import { runInTestContext } from "./asyncContext.js";
+import { ThreadStore } from "./state/threadStore.js";
 
-function makeState(ctx: any) {
-  return { ctx } as any;
+// Post-ALS migration: the checkpoint stdlib helpers read `ctx` and
+// `stateStack` from `getRuntimeContext()`. Each test wraps its
+// invocations in an `agencyStore` frame via `runInTestContext`.
+function wrap<T>(ctx: any, fn: () => T): T {
+  return runInTestContext(ctx, ctx.stateStack, new ThreadStore(), fn);
 }
 
 describe("checkpoint()", () => {
@@ -20,7 +25,7 @@ describe("checkpoint()", () => {
     });
     ctx.pendingPromises.add(promise);
 
-    const id = await checkpoint(makeState(ctx));
+    const id = await wrap(ctx, () => checkpoint());
 
     expect(resolved).toBe(true);
     expect(typeof id).toBe("number");
@@ -28,21 +33,20 @@ describe("checkpoint()", () => {
 
   it("should return an id (number)", async () => {
     const ctx = makeMockCtx();
-    const id = await checkpoint(makeState(ctx));
+    const id = await wrap(ctx, () => checkpoint());
     expect(typeof id).toBe("number");
   });
 
   it("should return incrementing ids", async () => {
     const ctx = makeMockCtx();
-    const state = makeState(ctx);
-    const id1 = await checkpoint(state);
-    const id2 = await checkpoint(state);
+    const id1 = await wrap(ctx, () => checkpoint());
+    const id2 = await wrap(ctx, () => checkpoint());
     expect(id2).toBe(id1 + 1);
   });
 
   it("should create a checkpoint that can be retrieved from the store", async () => {
     const ctx = makeMockCtx();
-    const id = await checkpoint(makeState(ctx));
+    const id = await wrap(ctx, () => checkpoint());
     const cp = ctx.checkpoints.get(id);
     expect(cp).toBeDefined();
     expect(cp!.id).toBe(id);
@@ -51,7 +55,7 @@ describe("checkpoint()", () => {
 
   it("should set moduleId, scopeName, stepPath, label, and pinned to default values", async () => {
     const ctx = makeMockCtx();
-    const id = await checkpoint(makeState(ctx));
+    const id = await wrap(ctx, () => checkpoint());
     const cp = ctx.checkpoints.get(id);
     expect(cp).toBeDefined();
     expect(cp!.moduleId).toBe("");
@@ -65,9 +69,8 @@ describe("checkpoint()", () => {
 describe("getCheckpoint()", () => {
   it("should return the checkpoint object", async () => {
     const ctx = makeMockCtx();
-    const state = makeState(ctx);
-    const id = await checkpoint(state);
-    const cp = getCheckpoint(id, state);
+    const id = await wrap(ctx, () => checkpoint());
+    const cp = wrap(ctx, () => getCheckpoint(id));
     expect(cp).toBeDefined();
     expect(cp.id).toBe(id);
     expect(cp.nodeId).toBe("process");
@@ -77,26 +80,25 @@ describe("getCheckpoint()", () => {
 
   it("should throw CheckpointError for missing checkpoint", () => {
     const ctx = makeMockCtx();
-    const state = makeState(ctx);
-    expect(() => getCheckpoint(999, state)).toThrow(CheckpointError);
-    expect(() => getCheckpoint(999, state)).toThrow(/does not exist/);
+    expect(() => wrap(ctx, () => getCheckpoint(999))).toThrow(CheckpointError);
+    expect(() => wrap(ctx, () => getCheckpoint(999))).toThrow(/does not exist/);
   });
 });
 
 describe("restore()", () => {
   it("should throw RestoreSignal", async () => {
     const ctx = makeMockCtx();
-    const id = await checkpoint(makeState(ctx));
+    const id = await wrap(ctx, () => checkpoint());
 
-    expect(() => restore(id, {}, makeState(ctx))).toThrow(RestoreSignal);
+    expect(() => wrap(ctx, () => restore(id, {}))).toThrow(RestoreSignal);
   });
 
   it("should pass checkpoint data in RestoreSignal", async () => {
     const ctx = makeMockCtx();
-    const id = await checkpoint(makeState(ctx));
+    const id = await wrap(ctx, () => checkpoint());
 
     try {
-      restore(id, {}, makeState(ctx));
+      wrap(ctx, () => restore(id, {}));
     } catch (e) {
       expect(e).toBeInstanceOf(RestoreSignal);
       const signal = e as RestoreSignal;
@@ -107,11 +109,11 @@ describe("restore()", () => {
 
   it("should pass options in RestoreSignal", async () => {
     const ctx = makeMockCtx();
-    const id = await checkpoint(makeState(ctx));
+    const id = await wrap(ctx, () => checkpoint());
 
     const options = { messages: [{ role: "user" as const, content: "test" }] };
     try {
-      restore(id, options, makeState(ctx));
+      wrap(ctx, () => restore(id, options));
     } catch (e) {
       expect(e).toBeInstanceOf(RestoreSignal);
       const signal = e as RestoreSignal;
@@ -121,12 +123,11 @@ describe("restore()", () => {
 
   it("should accept a checkpoint object instead of an id", async () => {
     const ctx = makeMockCtx();
-    const state = makeState(ctx);
-    const id = await checkpoint(state);
-    const cp = getCheckpoint(id, state);
+    const id = await wrap(ctx, () => checkpoint());
+    const cp = wrap(ctx, () => getCheckpoint(id));
 
     try {
-      restore(cp, {}, state);
+      wrap(ctx, () => restore(cp, {}));
     } catch (e) {
       expect(e).toBeInstanceOf(RestoreSignal);
       const signal = e as RestoreSignal;
@@ -138,19 +139,19 @@ describe("restore()", () => {
   it("should throw CheckpointError for missing checkpoint", () => {
     const ctx = makeMockCtx();
 
-    expect(() => restore(999, {}, makeState(ctx))).toThrow(CheckpointError);
-    expect(() => restore(999, {}, makeState(ctx))).toThrow(/does not exist/);
+    expect(() => wrap(ctx, () => restore(999, {}))).toThrow(CheckpointError);
+    expect(() => wrap(ctx, () => restore(999, {}))).toThrow(/does not exist/);
   });
 
   it("should clear pending promises", async () => {
     const ctx = makeMockCtx();
-    const id = await checkpoint(makeState(ctx));
+    const id = await wrap(ctx, () => checkpoint());
 
     // Add a pending promise after checkpoint
     ctx.pendingPromises.add(new Promise(() => { })); // never resolves
 
     try {
-      restore(id, {}, makeState(ctx));
+      wrap(ctx, () => restore(id, {}));
     } catch {
       // expected
     }
@@ -162,13 +163,12 @@ describe("restore()", () => {
 
   it("should invalidate later checkpoints", async () => {
     const ctx = makeMockCtx();
-    const state = makeState(ctx);
-    const id0 = await checkpoint(state);
-    const id1 = await checkpoint(state);
-    const id2 = await checkpoint(state);
+    const id0 = await wrap(ctx, () => checkpoint());
+    const id1 = await wrap(ctx, () => checkpoint());
+    const id2 = await wrap(ctx, () => checkpoint());
 
     try {
-      restore(id0, {}, state);
+      wrap(ctx, () => restore(id0, {}));
     } catch {
       // expected
     }
@@ -183,21 +183,20 @@ describe("restore()", () => {
     const ctx = makeMockCtx();
     ctx.checkpoints = new CheckpointStore(2); // max 2 restores
     const id = ctx.checkpoints.create(ctx.stateStack, ctx, { moduleId: "", scopeName: "", stepPath: "" });
-    const state = makeState(ctx);
 
     try {
-      restore(id, {}, state);
+      wrap(ctx, () => restore(id, {}));
     } catch {
       // expected RestoreSignal
     }
     try {
-      restore(id, {}, state);
+      wrap(ctx, () => restore(id, {}));
     } catch {
       // expected RestoreSignal
     }
 
     // Third restore should throw CheckpointError due to max restores exceeded
-    expect(() => restore(id, {}, state)).toThrow(CheckpointError);
-    expect(() => restore(id, {}, state)).toThrow(/Possible infinite loop/);
+    expect(() => wrap(ctx, () => restore(id, {}))).toThrow(CheckpointError);
+    expect(() => wrap(ctx, () => restore(id, {}))).toThrow(/Possible infinite loop/);
   });
 });

--- a/packages/agency-lang/lib/runtime/checkpoint.ts
+++ b/packages/agency-lang/lib/runtime/checkpoint.ts
@@ -1,26 +1,33 @@
 import { CheckpointError, RestoreSignal } from "./errors.js";
 import type { RestoreOptions } from "./errors.js";
-import type { InternalFunctionState } from "./types.js";
+import { getRuntimeContext } from "./asyncContext.js";
 import type { Checkpoint } from "./state/checkpointStore.js";
 
-export async function checkpoint(
-  __state: InternalFunctionState,
-): Promise<number> {
-  const ctx = __state.ctx;
+/**
+ * Per-call-site location info passed by codegen as the `state` extras
+ * to `checkpoint()`. Post-ALS the trailing positional carries ONLY the
+ * location fields (`moduleId` / `scopeName` / `stepPath`) — `ctx` and
+ * `stateStack` are read from the active `agencyStore` frame, not from
+ * this bag.
+ */
+type CheckpointLocation = {
+  moduleId?: string;
+  scopeName?: string;
+  stepPath?: string;
+};
+
+export async function checkpoint(__state?: CheckpointLocation): Promise<number> {
+  const { ctx } = getRuntimeContext();
   await ctx.pendingPromises.awaitAll();
-  const stateStack = __state.stateStack ?? ctx.stateStack;
-  return ctx.checkpoints.create(stateStack, ctx, {
-    moduleId: __state.moduleId ?? "",
-    scopeName: __state.scopeName ?? "",
-    stepPath: __state.stepPath ?? "",
+  return ctx.checkpoints.create(ctx.stateStack, ctx, {
+    moduleId: __state?.moduleId ?? "",
+    scopeName: __state?.scopeName ?? "",
+    stepPath: __state?.stepPath ?? "",
   });
 }
 
-export function getCheckpoint(
-  checkpointId: number,
-  __state?: InternalFunctionState,
-): Checkpoint {
-  const ctx = __state!.ctx;
+export function getCheckpoint(checkpointId: number): Checkpoint {
+  const { ctx } = getRuntimeContext();
   const cp = ctx.checkpoints.get(checkpointId);
   if (!cp)
     throw new CheckpointError(
@@ -32,9 +39,8 @@ export function getCheckpoint(
 export function restore(
   checkpointIdOrCheckpoint: number | Checkpoint,
   options: RestoreOptions,
-  __state?: InternalFunctionState,
 ): void {
-  const ctx = __state!.ctx;
+  const { ctx } = getRuntimeContext();
   let cp: Checkpoint;
   if (typeof checkpointIdOrCheckpoint === "number") {
     const found = ctx.checkpoints.get(checkpointIdOrCheckpoint);

--- a/packages/agency-lang/lib/runtime/debugger.test.ts
+++ b/packages/agency-lang/lib/runtime/debugger.test.ts
@@ -3,10 +3,6 @@ import { debugStep } from "./debugger.js";
 import { DebuggerState } from "../debugger/debuggerState.js";
 import { makeMockCtx } from "./__tests__/testHelpers.js";
 
-function makeState(ctx: any) {
-  return { ctx } as any;
-}
-
 const baseInfo = {
   moduleId: "main.agency",
   scopeName: "main",
@@ -19,7 +15,7 @@ const baseInfo = {
 describe("debugStep()", () => {
   it("returns undefined when ctx.debugger is null", async () => {
     const ctx = makeMockCtx();
-    const result = await debugStep(ctx, makeState(ctx), baseInfo);
+    const result = await debugStep(ctx, baseInfo);
     expect(result).toBeUndefined();
   });
 
@@ -27,7 +23,7 @@ describe("debugStep()", () => {
     const dbg = new DebuggerState(10);
     dbg.stepNext(); // stepping mode, targetDepth === callDepth (both 0)
     const ctx = makeMockCtx({ debuggerState: dbg });
-    const result = await debugStep(ctx, makeState(ctx), baseInfo);
+    const result = await debugStep(ctx, baseInfo);
     expect(result).toBeDefined();
     expect(result![0].type).toBe("interrupt");
   });
@@ -36,7 +32,7 @@ describe("debugStep()", () => {
     const dbg = new DebuggerState(10);
     dbg.running();
     const ctx = makeMockCtx({ debuggerState: dbg });
-    const result = await debugStep(ctx, makeState(ctx), {
+    const result = await debugStep(ctx, {
       ...baseInfo,
       label: null,
     });
@@ -47,7 +43,7 @@ describe("debugStep()", () => {
     const dbg = new DebuggerState(10);
     dbg.running();
     const ctx = makeMockCtx({ debuggerState: dbg });
-    const result = await debugStep(ctx, makeState(ctx), {
+    const result = await debugStep(ctx, {
       ...baseInfo,
       label: "my-breakpoint",
       isUserAdded: true,
@@ -62,12 +58,12 @@ describe("debugStep()", () => {
     const ctx = makeMockCtx({ debuggerState: dbg });
 
     // mode is "running" with no label — will NOT pause, but should still create rolling checkpoint
-    await debugStep(ctx, makeState(ctx), { ...baseInfo, label: null });
+    await debugStep(ctx, { ...baseInfo, label: null });
     expect(dbg.getCheckpoints().length).toBe(1);
 
     // call again with a label — will pause and replace the rolling checkpoint
     // (createRolling deduplicates by location, and both calls share the same stepPath)
-    await debugStep(ctx, makeState(ctx), { ...baseInfo, label: "bp", isUserAdded: true });
+    await debugStep(ctx, { ...baseInfo, label: "bp", isUserAdded: true });
     // Only 1 rolling checkpoint remains (deduplicated); the interrupt checkpoint
     // goes to ctx.checkpoints, not the debugger state
     expect(dbg.getCheckpoints().length).toBe(1);
@@ -82,7 +78,7 @@ describe("debugStep()", () => {
     dbg.enterCall();
     dbg.enterCall();
     const ctx = makeMockCtx({ debuggerState: dbg });
-    const result = await debugStep(ctx, makeState(ctx), baseInfo);
+    const result = await debugStep(ctx, baseInfo);
     expect(result).toBeUndefined();
   });
 
@@ -94,7 +90,7 @@ describe("debugStep()", () => {
     // Now go shallower: callDepth = 2
     dbg.exitCall();
     const ctx = makeMockCtx({ debuggerState: dbg });
-    const result = await debugStep(ctx, makeState(ctx), baseInfo);
+    const result = await debugStep(ctx, baseInfo);
     expect(result).toBeDefined();
     expect(result![0].type).toBe("interrupt");
   });
@@ -104,7 +100,7 @@ describe("debugStep()", () => {
     for (let i = 0; i < 3; i++) dbg.enterCall();
     dbg.stepNext(); // targetDepth = 3, callDepth = 3
     const ctx = makeMockCtx({ debuggerState: dbg });
-    const result = await debugStep(ctx, makeState(ctx), baseInfo);
+    const result = await debugStep(ctx, baseInfo);
     expect(result).toBeDefined();
     expect(result![0].type).toBe("interrupt");
   });
@@ -113,7 +109,7 @@ describe("debugStep()", () => {
     const dbg = new DebuggerState(10);
     dbg.stepNext();
     const ctx = makeMockCtx({ debuggerState: dbg });
-    const result = await debugStep(ctx, makeState(ctx), baseInfo);
+    const result = await debugStep(ctx, baseInfo);
     expect(result).toBeDefined();
     expect(result![0].debugger).toBe(true);
   });
@@ -122,7 +118,7 @@ describe("debugStep()", () => {
     const dbg = new DebuggerState(10);
     dbg.stepNext();
     const ctx = makeMockCtx({ debuggerState: dbg });
-    const result = await debugStep(ctx, makeState(ctx), baseInfo);
+    const result = await debugStep(ctx, baseInfo);
     expect(result).toBeDefined();
     expect(typeof result![0].checkpointId).toBe("number");
     expect(result![0].checkpoint).toBeDefined();
@@ -133,7 +129,7 @@ describe("debugStep()", () => {
     const dbg = new DebuggerState(10);
     dbg.running();
     const ctx = makeMockCtx({ debuggerState: dbg });
-    const result = await debugStep(ctx, makeState(ctx), {
+    const result = await debugStep(ctx, {
       ...baseInfo,
       label: "my-label",
       isUserAdded: true,
@@ -146,7 +142,7 @@ describe("debugStep()", () => {
     const dbg = new DebuggerState(10);
     dbg.stepNext();
     const ctx = makeMockCtx({ debuggerState: dbg });
-    const result = await debugStep(ctx, makeState(ctx), {
+    const result = await debugStep(ctx, {
       ...baseInfo,
       label: null,
     });

--- a/packages/agency-lang/lib/runtime/debugger.ts
+++ b/packages/agency-lang/lib/runtime/debugger.ts
@@ -3,11 +3,9 @@ import { createDebugInterrupt } from "./interrupts.js";
 import { Checkpoint } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { SourceLocation } from "./state/sourceLocation.js";
-import type { InternalFunctionState } from "./types.js";
 
 export async function debugStep(
   ctx: RuntimeContext<any>,
-  state: InternalFunctionState,
   info: Omit<SourceLocation, "nodeId"> & {
     label: string | null;
     nodeContext: boolean;

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -1,6 +1,5 @@
 export type {
   GraphState,
-  InternalFunctionState,
   Rejected,
   Approved,
   HandlerFn,

--- a/packages/agency-lang/lib/runtime/ipc.ts
+++ b/packages/agency-lang/lib/runtime/ipc.ts
@@ -9,7 +9,7 @@ import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { fork } from "child_process";
 import { rmSync } from "fs";
-import type { InternalFunctionState } from "./types.js";
+import { getRuntimeContext } from "./asyncContext.js";
 import { interruptWithHandlers, isApproved, hasInterrupts } from "./interrupts.js";
 import { failure, type ResultFailure } from "./result.js";
 
@@ -433,13 +433,14 @@ export async function _run(
   memory: number,
   ipcPayload: number,
   stdout: number,
-  __state: InternalFunctionState,
 ): Promise<any> {
   if (isIpcMode()) {
     throw new Error("Nested subprocess execution is not supported.");
   }
-  const ctx = __state.ctx;
-  const stateStack = __state.stateStack ?? ctx.stateStack;
+  // Post-ALS: read `ctx` and the per-scope `stateStack` from the active
+  // `agencyStore` frame. The trailing `__state` positional that AgencyFunction
+  // .invoke() still passes is now harmlessly ignored.
+  const { ctx, stack: stateStack } = getRuntimeContext();
   const limits = clampLimits({ wallClock, memory, ipcPayload, stdout });
 
   const memoryMb = Math.max(1, Math.floor(limits.memory / (1024 * 1024)));

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { MessageJSON } from "smoltalk";
-import { agencyStore, runInBootstrapFrame } from "./asyncContext.js";
+import { agencyStore, getRuntimeContext, runInBootstrapFrame } from "./asyncContext.js";
 import { callHook } from "./hooks.js";
 import type { AgencyCallbacks } from "./hooks.js";
 import type { RuntimeContext } from "./state/context.js";
@@ -13,7 +13,7 @@ import {
 import { State, StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { resolveTraceFilePath } from "./trace/traceWriter.js";
-import { GraphState, InternalFunctionState, RunNodeResult } from "./types.js";
+import { GraphState, RunNodeResult } from "./types.js";
 import { createReturnObject } from "./utils.js";
 import { color } from "@/utils/termcolors.js";
 import { nanoid } from "nanoid";
@@ -26,7 +26,12 @@ export function setupNode(args: { state: GraphState }): {
   threads: ThreadStore;
 } {
   const { state } = args;
-  const ctx = state.ctx;
+  // `ctx` flows through the ALS frame installed by `runNode` (or by
+  // `respondToInterrupts` / `rewindFrom`). The `state.ctx` field is still
+  // populated by graph.run for backwards compat, but we no longer rely on
+  // it here — reading from ALS keeps every per-scope helper consistent
+  // with the same source of truth.
+  const ctx = getRuntimeContext().ctx;
 
   const stack = ctx.stateStack.getNewState();
   const step = stack.step;
@@ -52,37 +57,26 @@ export function setupNode(args: { state: GraphState }): {
   return { stack, step, self, threads };
 }
 
-export function setupFunction(args: { state?: InternalFunctionState }): {
+export function setupFunction(): {
   stateStack: StateStack;
   stack: State;
   step: number;
   self: Record<string, any>;
   threads: ThreadStore;
 } {
-  const { state } = args;
-  if (state === undefined) {
-    // this means the function got called as a tool by the llm
-    const stateStack = new StateStack();
-    const stack = stateStack.getNewState();
-    return {
-      stateStack,
-      stack,
-      step: 0,
-      self: stack.locals,
-      threads: new ThreadStore(),
-    };
-  }
-
-  const stateStack = state.stateStack ?? state.ctx.stateStack;
+  // Post-ALS migration: `ctx` / `threads` come from the active
+  // `agencyStore` frame seeded by the caller (a `runner.step` body,
+  // `runNode`'s top-level frame, or `runBatch.runInBranchAlsFrame`).
+  // Tool-dispatch from the LLM also runs inside the issuing
+  // `runner.step` frame, so the previously-needed "called as tool with
+  // no state" fallback (fresh StateStack + empty ThreadStore) cannot
+  // arise here. Direct JS callers of `__foo_impl` from outside an
+  // Agency execution frame must wrap their call in `runInTestContext`
+  // (see lib/runtime/asyncContext.ts).
+  const { ctx, threads } = getRuntimeContext();
+  const stateStack = ctx.stateStack;
   const stack = stateStack.getNewState();
-  const step = stack.step;
-  const self = stack.locals;
-
-  // if being called from a node, we'll pass in threads.
-  // if being called as a tool, we won't have threads, but we'll create an empty ThreadStore here.
-  const threads = state.threads || new ThreadStore();
-
-  return { stateStack, stack, step, self, threads };
+  return { stateStack, stack, step: stack.step, self: stack.locals, threads };
 }
 
 // eslint-disable-next-line max-lines-per-function -- core node-execution loop; refactor tracked separately

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -64,7 +64,7 @@ export function setupFunction(): {
   self: Record<string, any>;
   threads: ThreadStore;
 } {
-  // Post-ALS migration: `ctx` / `threads` come from the active
+  // Post-ALS migration: `ctx` / `stack` / `threads` come from the active
   // `agencyStore` frame seeded by the caller (a `runner.step` body,
   // `runNode`'s top-level frame, or `runBatch.runInBranchAlsFrame`).
   // Tool-dispatch from the LLM also runs inside the issuing
@@ -73,8 +73,15 @@ export function setupFunction(): {
   // arise here. Direct JS callers of `__foo_impl` from outside an
   // Agency execution frame must wrap their call in `runInTestContext`
   // (see lib/runtime/asyncContext.ts).
-  const { ctx, threads } = getRuntimeContext();
-  const stateStack = ctx.stateStack;
+  //
+  // CRITICAL: read `stack` from ALS, not from `ctx.stateStack`. Inside
+  // a fork/parallel/race branch, `runBatch.runInBranchAlsFrame` installs
+  // an ALS frame whose `stack` is the per-branch StateStack — distinct
+  // from `ctx.stateStack`. Pushing a new frame onto `ctx.stateStack`
+  // would corrupt the parent's stack and break per-branch isolation
+  // (interrupts, abort signals, restore on resume). The pre-migration
+  // code preserved this with `state.stateStack ?? state.ctx.stateStack`.
+  const { stack: stateStack, threads } = getRuntimeContext();
   const stack = stateStack.getNewState();
   return { stateStack, stack, step: stack.step, self: stack.locals, threads };
 }

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -276,13 +276,7 @@ export async function runPrompt(args: {
   const ctx = runtime.ctx as RuntimeContext<GraphState>;
 
   // Push a frame onto the state stack — runPrompt participates like any other function
-  const { stateStack, stack } = setupFunction({
-    state: {
-      stateStack: runtime.stack,
-      ctx,
-      threads: new ThreadStore(),
-    },
-  });
+  const { stateStack, stack } = setupFunction();
   const self = stack.locals;
 
   // Frame-backed locals (survive checkpoint/restore)

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -228,7 +228,7 @@ export class Runner {
     // If debugStep doesn't pause, we clear it below.
     this.frame.locals[this.debugFlagKey(id)] = true;
 
-    const dbg = await debugStep(this.ctx, this.state, {
+    const dbg = await debugStep(this.ctx, {
       moduleId: this.moduleId,
       scopeName: this.scopeName,
       stepPath: this.stepPath(id),

--- a/packages/agency-lang/lib/runtime/state/stateStack.test.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.test.ts
@@ -2,6 +2,17 @@ import { describe, it, expect } from "vitest";
 import { StateStack, State, BranchState } from "./stateStack.js";
 import { _callbackImpl } from "../../stdlib/agency.js";
 import { CostGuard, GuardExceededError } from "../guard.js";
+import { runInTestContext } from "../asyncContext.js";
+import { ThreadStore } from "./threadStore.js";
+
+// Post-ALS migration: `_callbackImpl` reads `ctx` from
+// `getRuntimeContext()`, so each call must run inside an ALS frame
+// seeded with the fake ctx. Wrap _callbackImpl invocations here.
+function callCallback(ctx: any, name: string, fn: unknown): void {
+  runInTestContext(ctx, ctx.stateStack, new ThreadStore(), () => {
+    _callbackImpl(name, fn);
+  });
+}
 
 type FrameOpts = {
   args?: Record<string, any>;
@@ -429,7 +440,7 @@ describe("_callback", () => {
   it("registers on the caller frame when stack has >= 2 frames", () => {
     const ctx = ctxWithFrames(2); // [caller, callback's own frame]
     const fn = () => {};
-    _callbackImpl("onNodeStart", fn, { ctx } as any);
+    callCallback(ctx, "onNodeStart", fn);
     expect(ctx.stateStack.stack[0].scopedCallbacks).toEqual([
       { name: "onNodeStart", fn },
     ]);
@@ -440,49 +451,49 @@ describe("_callback", () => {
   it("routes to ctx.topLevelCallbacks when stack length <= 1 (module init)", () => {
     const ctx = ctxWithFrames(1); // only callback's own frame — top level
     const fn = () => {};
-    _callbackImpl("onNodeStart", fn, { ctx } as any);
+    callCallback(ctx, "onNodeStart", fn);
     expect(ctx.topLevelCallbacks).toEqual([{ name: "onNodeStart", fn }]);
     expect(ctx.stateStack.stack[0].scopedCallbacks).toBeUndefined();
   });
 
   it("routes to ctx.topLevelCallbacks when stack is empty (defensive)", () => {
     const ctx = ctxWithFrames(0);
-    _callbackImpl("onNodeStart", () => {}, { ctx } as any);
+    callCallback(ctx, "onNodeStart", () => {});
     expect(ctx.topLevelCallbacks).toHaveLength(1);
   });
 
   it("throws on unknown callback name", () => {
     const ctx = ctxWithFrames(2);
     expect(() =>
-      _callbackImpl("notAHook", () => {}, { ctx } as any),
+      callCallback(ctx, "notAHook", () => {}),
     ).toThrow(/Unknown callback/);
   });
 
   it("throws when fn is a string (non-callable)", () => {
     const ctx = ctxWithFrames(2);
     expect(() =>
-      _callbackImpl("onNodeStart", "not a function" as any, { ctx } as any),
+      callCallback(ctx, "onNodeStart", "not a function" as any),
     ).toThrow(/must be a function/i);
   });
 
   it("throws when fn is a number (non-callable)", () => {
     const ctx = ctxWithFrames(2);
     expect(() =>
-      _callbackImpl("onNodeStart", 42 as any, { ctx } as any),
+      callCallback(ctx, "onNodeStart", 42 as any),
     ).toThrow(/must be a function/i);
   });
 
   it("throws when fn is null", () => {
     const ctx = ctxWithFrames(2);
     expect(() =>
-      _callbackImpl("onNodeStart", null as any, { ctx } as any),
+      callCallback(ctx, "onNodeStart", null as any),
     ).toThrow(/must be a function/i);
   });
 
   it("throws when fn is undefined", () => {
     const ctx = ctxWithFrames(2);
     expect(() =>
-      _callbackImpl("onNodeStart", undefined as any, { ctx } as any),
+      callCallback(ctx, "onNodeStart", undefined as any),
     ).toThrow(/must be a function/i);
   });
 
@@ -490,7 +501,7 @@ describe("_callback", () => {
     const ctx = ctxWithFrames(2);
     const fn = (_data: any) => {};
     expect(() =>
-      _callbackImpl("onNodeStart", fn, { ctx } as any),
+      callCallback(ctx, "onNodeStart", fn),
     ).not.toThrow();
   });
 });

--- a/packages/agency-lang/lib/runtime/types.ts
+++ b/packages/agency-lang/lib/runtime/types.ts
@@ -1,8 +1,6 @@
 import { CostEstimate, TokenUsage } from "smoltalk";
-import { RuntimeContext, StateStack, ThreadStore } from "./index.js";
+import { RuntimeContext, ThreadStore } from "./index.js";
 import { ThreadStoreJSON } from "./state/threadStore.js";
-import { SimpleMachine } from "@/simplemachine/graph.js";
-import { StatelogClient } from "@/statelogClient.js";
 
 
 export type GraphState = {
@@ -16,15 +14,6 @@ export type GraphState = {
 
   // if true, restore the state from the state stack in ctx.
   isResume?: boolean;
-};
-
-export type InternalFunctionState = {
-  threads: ThreadStore;
-  ctx: RuntimeContext<GraphState>;
-  stateStack?: StateStack;  // per-thread stack for async calls
-  moduleId?: string;
-  scopeName?: string;
-  stepPath?: string;
 };
 
 export type NodeReturnValue<T> = {

--- a/packages/agency-lang/lib/stdlib/agency.ts
+++ b/packages/agency-lang/lib/stdlib/agency.ts
@@ -18,7 +18,7 @@ import {
   VALID_CALLBACK_NAMES,
   type CallbackName,
 } from "../types/function.js";
-import type { InternalFunctionState } from "../runtime/types.js";
+import { getRuntimeContext } from "../runtime/asyncContext.js";
 import { AgencyFunction } from "../runtime/agencyFunction.js";
 
 const VALID_CALLBACK_NAME_SET: ReadonlySet<string> = new Set(VALID_CALLBACK_NAMES);
@@ -45,11 +45,9 @@ const VALID_CALLBACK_NAME_SET: ReadonlySet<string> = new Set(VALID_CALLBACK_NAME
  */
 // Exported as `_callbackImpl` so unit tests can call it directly without
 // going through the AgencyFunction wrapper / `invoke()` indirection.
-export function _callbackImpl(
-  name: string,
-  fn: unknown,
-  __state: InternalFunctionState,
-): void {
+// Direct JS callers must wrap their invocation in `runInTestContext` so
+// `getRuntimeContext()` finds an active ALS frame.
+export function _callbackImpl(name: string, fn: unknown): void {
   if (!VALID_CALLBACK_NAME_SET.has(name)) {
     throw new Error(
       `Unknown callback '${name}'. Valid: ${VALID_CALLBACK_NAMES.join(", ")}`,
@@ -60,7 +58,7 @@ export function _callbackImpl(
       `callback('${name}', fn): fn must be a function, got ${fn === null ? "null" : typeof fn}`,
     );
   }
-  const ctx = __state.ctx;
+  const { ctx } = getRuntimeContext();
   // Top-level: we're inside __initializeGlobals. The only frame on the stack
   // is `callback`'s own (or none, defensively). There is no caller frame
   // that survives past init, so route to ctx.topLevelCallbacks.

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.mustache
@@ -1,4 +1,4 @@
-const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
+const __bsetup = setupFunction();
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 {{#params}}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/blockSetup.ts
@@ -3,7 +3,7 @@
 // Any manual changes will be lost.
 import { apply } from "typestache";
 
-export const template = `const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
+export const template = `const __bsetup = setupFunction();
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 {{#params}}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/debugger.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/debugger.mustache
@@ -1,4 +1,4 @@
-const __dbg = await debugStep(__ctx, __state, {
+const __dbg = await debugStep(__ctx, {
   moduleId: {{{moduleId:string}}},
   scopeName: {{{scopeName:string}}},
   stepPath: {{{stepPath:string}}},

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/debugger.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/debugger.ts
@@ -3,7 +3,7 @@
 // Any manual changes will be lost.
 import { apply } from "typestache";
 
-export const template = `const __dbg = await debugStep(__ctx, __state, {
+export const template = `const __dbg = await debugStep(__ctx, {
   moduleId: {{{moduleId:string}}},
   scopeName: {{{scopeName:string}}},
   stepPath: {{{stepPath:string}}},

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -10,7 +10,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -7,7 +7,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -163,15 +163,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
 
-async function __add_impl(a: any, b: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __add_impl(a: any, b: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("tests/debugger/function-call-test.agency")) {
@@ -298,7 +295,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/function-call-test.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -7,7 +7,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -170,7 +170,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/if-else-test.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -7,7 +7,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -170,7 +170,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/interrupt-test.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -7,7 +7,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -170,7 +170,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/loop-test.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -7,7 +7,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -163,15 +163,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
 
-async function __double_impl(n: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __double_impl(n: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("tests/debugger/nested-calls-test.agency")) {
@@ -277,15 +274,12 @@ const double = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __addAndDouble_impl(a: any, b: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __addAndDouble_impl(a: any, b: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("tests/debugger/nested-calls-test.agency")) {
@@ -420,7 +414,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -7,7 +7,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -170,7 +170,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "tests/debugger/step-test.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "assignment.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -6,7 +6,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -145,15 +145,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
 
-async function __safeLookup_impl(id: string, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __safeLookup_impl(id: string) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("safe-function.agency")) {
@@ -259,15 +256,12 @@ const safeLookup = __AgencyFunction.create({
   safe: true,
   exported: false
 }, __toolRegistry);
-async function __unsafeSave_impl(id: string, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __unsafeSave_impl(id: string) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("safe-function.agency")) {
@@ -392,7 +386,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "safe-function.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "simple.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "array.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "assignment.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __compute_impl(val: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __compute_impl(val: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("asyncAssigned.agency")) {
@@ -272,7 +269,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "asyncAssigned.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "asyncLlm.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __append_impl(sleepTime: number, value: any, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __append_impl(sleepTime: number, value: any) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("asyncUnassigned.agency")) {
@@ -278,7 +275,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "asyncUnassigned.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __process_impl(data: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __process_impl(data: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("bangParams.agency")) {
@@ -277,7 +274,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "bangParams.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __process_impl(x: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __process_impl(x: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("bangReturnType.agency")) {
@@ -261,7 +258,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "bangReturnType.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -152,7 +152,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "bangValidation.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __twice_impl(block: () => string, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __twice_impl(block: () => string) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("blockBasic.agency")) {
@@ -283,7 +280,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "blockBasic.agency", scopeName: "main", threads: __setupData.threads });
@@ -305,7 +302,7 @@ await callHook({
 __stack.locals.results = await __call(twice, {
           type: "positional",
           args: [__AgencyFunction.create({ name: "__block_0", module: "blockBasic.agency", fn: async () => {
-            const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
+            const __bsetup = setupFunction();
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __mapItems_impl(items: any[], block: (any) => any, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __mapItems_impl(items: any[], block: (any) => any) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("blockParams.agency")) {
@@ -299,7 +296,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "blockParams.agency", scopeName: "main", threads: __setupData.threads });
@@ -324,7 +321,7 @@ __stack.locals.items = [1, 2, 3];
 __stack.locals.doubled = await __call(mapItems, {
           type: "positional",
           args: [__stack.locals.items, __AgencyFunction.create({ name: "__block_0", module: "blockParams.agency", fn: async (x: any) => {
-            const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
+            const __bsetup = setupFunction();
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "checkpoint-restore.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -151,15 +151,12 @@ __functionRefReviver.registry = __toolRegistry;
 //  can be placed
 //  on consecutive lines
 //  Comment before function definition
-async function __greet_impl(__state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __greet_impl() {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("comments.agency")) {
@@ -264,7 +261,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "comments.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -155,15 +155,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("defaultValues.agency")) {

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -146,15 +146,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
 //  Test docstrings in functions
-async function __add_impl(a: any, b: any, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __add_impl(a: any, b: any) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
@@ -264,15 +261,12 @@ const add = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __greet_impl(name: any, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __greet_impl(name: any) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
@@ -370,15 +364,12 @@ const greet = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __calculateArea_impl(width: any, height: any, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __calculateArea_impl(width: any, height: any) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
@@ -493,15 +484,12 @@ const calculateArea = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __processData_impl(__state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __processData_impl() {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {
@@ -587,15 +575,12 @@ const processData = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __versionedTool_impl(__state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __versionedTool_impl() {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("docstrings.agency")) {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -152,7 +152,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0001.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -152,7 +152,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0002.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -152,7 +152,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0003.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -145,15 +145,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 4: Largest Palindrome Product
 //  Find the largest palindrome made from the product of two 3-digit numbers.
-async function __isPalindrome_impl(n: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __isPalindrome_impl(n: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("euler-0004.agency")) {
@@ -294,7 +291,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0004.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -145,15 +145,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 5: Smallest Multiple
 //  Find the smallest positive number evenly divisible by all numbers from 1 to 20.
-async function __gcd_impl(a: number, b: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __gcd_impl(a: number, b: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("euler-0005.agency")) {
@@ -284,15 +281,12 @@ const gcd = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __lcm_impl(a: number, b: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __lcm_impl(a: number, b: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("euler-0005.agency")) {
@@ -416,7 +410,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0005.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -153,7 +153,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0006.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -145,15 +145,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 7: 10001st Prime
 //  Find the 10001st prime number.
-async function __isPrime_impl(n: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __isPrime_impl(n: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("euler-0007.agency")) {
@@ -327,7 +324,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0007.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -146,15 +146,12 @@ __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 8: Largest Product in a Series
 //  Find the thirteen adjacent digits in the 1000-digit number that have
 //  the greatest product.
-async function __toDigit_impl(c: string, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __toDigit_impl(c: string) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("euler-0008.agency")) {
@@ -390,7 +387,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0008.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -152,7 +152,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0009.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -145,15 +145,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 10: Summation of Primes
 //  Find the sum of all the primes below two million.
-async function __isPrime_impl(n: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __isPrime_impl(n: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("euler-0010.agency")) {
@@ -327,7 +324,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "euler-0010.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "forLoop.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __add_impl(x: number, y: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __add_impl(x: number, y: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
@@ -285,15 +282,12 @@ const add = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __greet_impl(name: string, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __greet_impl(name: string) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
@@ -413,15 +407,12 @@ const greet = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __mixed_impl(count: number, label: any, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __mixed_impl(count: number, label: any) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
@@ -552,15 +543,12 @@ const mixed = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __processArray_impl(items: number[], __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __processArray_impl(items: number[]) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
@@ -680,15 +668,12 @@ const processArray = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __flexible_impl(value: string | number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __flexible_impl(value: string | number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function-with-types.agency")) {
@@ -815,7 +800,7 @@ graph.node("foo", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "function-with-types.agency", scopeName: "foo", threads: __setupData.threads });
@@ -891,7 +876,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "function-with-types.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __test_impl(__state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __test_impl() {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function.agency")) {
@@ -240,15 +237,12 @@ const test = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __add_impl(a: any, b: any, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __add_impl(a: any, b: any) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("function.agency")) {
@@ -367,7 +361,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "function.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __greet_impl(name: string, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __greet_impl(name: string) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("functionRef.agency")) {
@@ -254,15 +251,12 @@ const greet = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __double_impl(x: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __double_impl(x: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("functionRef.agency")) {
@@ -365,15 +359,12 @@ const double = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __applyToAll_impl(items: number[], transform: (number) => number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __applyToAll_impl(items: number[], transform: (number) => number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("functionRef.agency")) {
@@ -508,7 +499,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "functionRef.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -144,15 +144,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
 
-async function __process_impl(c: Container<number>, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __process_impl(c: Container<number>) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("genericAliasValidation.agency")) {
@@ -278,7 +275,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "genericAliasValidation.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("foo", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "goto.agency", scopeName: "foo", threads: __setupData.threads });
@@ -219,7 +219,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "goto.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("greet", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "gotoWithArgs.agency", scopeName: "greet", threads: __setupData.threads });
@@ -222,7 +222,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "gotoWithArgs.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -151,7 +151,7 @@ graph.node("greet", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "graph-node-with-types.agency", scopeName: "greet", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "ifElse.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -20,7 +20,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __twice_impl(block: () => string, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __twice_impl(block: () => string) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("inlineBlockBasic.agency")) {
@@ -283,7 +280,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "inlineBlockBasic.agency", scopeName: "main", threads: __setupData.threads });
@@ -305,7 +302,7 @@ await callHook({
 __stack.locals.results = await __call(twice, {
           type: "positional",
           args: [__AgencyFunction.create({ name: "__block_0", module: "inlineBlockBasic.agency", fn: async () => {
-            const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
+            const __bsetup = setupFunction();
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __mapItems_impl(items: any[], block: (any) => any, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __mapItems_impl(items: any[], block: (any) => any) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("inlineBlockParams.agency")) {
@@ -294,7 +291,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "inlineBlockParams.agency", scopeName: "main", threads: __setupData.threads });
@@ -319,7 +316,7 @@ __stack.locals.items = [1, 2, 3];
 __stack.locals.doubled = await __call(mapItems, {
           type: "positional",
           args: [__stack.locals.items, __AgencyFunction.create({ name: "__block_0", module: "inlineBlockParams.agency", fn: async (x: any) => {
-            const __bsetup = setupFunction({ state: { ctx: __ctx, threads: __threads() } });
+            const __bsetup = setupFunction();
 const __bstack = __bsetup.stack;
 const __self = __bstack.locals;
 

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "input.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interpolation.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __greet_impl(name: string, age: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __greet_impl(name: string, age: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("interrupt-2-deep-in-function.agency")) {
@@ -306,15 +303,12 @@ const greet = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __foo2_impl(name: string, age: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __foo2_impl(name: string, age: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("interrupt-2-deep-in-function.agency")) {
@@ -469,7 +463,7 @@ graph.node("sayHi", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interrupt-2-deep-in-function.agency", scopeName: "sayHi", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interrupt-assignment.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __greet_impl(name: string, age: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __greet_impl(name: string, age: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("interrupt-in-node.agency")) {
@@ -313,7 +310,7 @@ graph.node("foo2", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interrupt-in-node.agency", scopeName: "foo2", threads: __setupData.threads });
@@ -419,7 +416,7 @@ graph.node("sayHi", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "interrupt-in-node.agency", scopeName: "sayHi", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -153,7 +153,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "llmConfigParam.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "matchBlock.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -146,15 +146,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
 __functionRefReviver.registry = __toolRegistry;
 
 
-async function __greet_impl(__state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __greet_impl() {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("multiLineComment.agency")) {

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("greet", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "multipleNodes.agency", scopeName: "greet", threads: __setupData.threads });
@@ -237,7 +237,7 @@ graph.node("processGreeting", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "multipleNodes.agency", scopeName: "processGreeting", threads: __setupData.threads });
@@ -329,7 +329,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "multipleNodes.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -162,15 +162,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("namedArgs.agency")) {

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET, punctuation: string | typeof __UNSET = __UNSET, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET, punctuation: string | typeof __UNSET = __UNSET) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("namedArgsReorder.agency")) {
@@ -283,7 +280,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "namedArgsReorder.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "noResponseFormat.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "objectDescription.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -155,15 +155,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("optionalParams.agency")) {

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __double_impl(x: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __double_impl(x: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("pipe-operator.agency")) {
@@ -254,15 +251,12 @@ const double = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __multiply_impl(a: number, b: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __multiply_impl(a: number, b: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("pipe-operator.agency")) {
@@ -376,15 +370,12 @@ const multiply = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __safeDivide_impl(a: number, b: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __safeDivide_impl(a: number, b: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("pipe-operator.agency")) {
@@ -519,7 +510,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "pipe-operator.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -151,7 +151,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "recordIndex.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __checkAge_impl(age: number, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __checkAge_impl(age: number) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("result-basic.agency")) {

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __checkValue_impl(r: Result, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __checkValue_impl(r: Result) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("result-guards.agency")) {

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "returnValue.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "rewindCheckpoint.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -6,7 +6,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -152,7 +152,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "schemaAccess.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -148,15 +148,12 @@ __functionRefReviver.registry = __toolRegistry;
 //  When a function declares a Schema<...> parameter and the caller does
 //  not pass it explicitly, the compiler injects a Zod schema synthesized
 //  from the LHS type annotation.
-async function __parseValue_impl(input: string, s: Schema<any>, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __parseValue_impl(input: string, s: Schema<any>) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("schemaParamInjection.agency")) {
@@ -273,15 +270,12 @@ const parseValue = __AgencyFunction.create({
   safe: false,
   exported: false
 }, __toolRegistry);
-async function __wrapper_impl(__state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __wrapper_impl() {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("schemaParamInjection.agency")) {
@@ -388,7 +382,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "schemaParamInjection.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -6,7 +6,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -159,7 +159,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "setLLMClient.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "simple.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("analyzeData", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "skill.agency", scopeName: "analyzeData", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "slice.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "sliceAssign.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __greet_impl(name: string, __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __greet_impl(name: string) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("sourceMap.agency")) {
@@ -278,7 +275,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "sourceMap.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -169,7 +169,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "static.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("foo", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "streaming.agency", scopeName: "foo", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "string-interpolation.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("foo", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "stringConcat.agency", scopeName: "foo", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __foo_impl(__state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __foo_impl() {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("threadsAndSubthreads.agency")) {
@@ -409,7 +406,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "threadsAndSubthreads.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "typeHints.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -152,7 +152,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "exportedTypeAlias.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "literal.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -154,7 +154,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "nestedTypeAlias.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -152,7 +152,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "typeAlias.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "unitLiterals.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "valueAccessInterpolation.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "varTypes.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -149,15 +149,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __log_impl(prefix: string, messages: string[], __state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __log_impl(prefix: string, messages: string[]) {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("variadic.agency")) {

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -143,15 +143,12 @@ __toolRegistry["readSkill"] = __AgencyFunction.create({
   toolDefinition: __readSkillTool,
 }, __toolRegistry);
 __functionRefReviver.registry = __toolRegistry;
-async function __foo_impl(__state: InternalFunctionState | undefined = undefined) {
-  const __setupData = setupFunction({
-    state: __state
-  });
-  // __state will be undefined if this function is being called as a tool by an llm
+async function __foo_impl() {
+  const __setupData = setupFunction();
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state?.ctx || __globalCtx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   if (!__ctx.globals.isInitialized("withModifier.agency")) {
@@ -285,7 +282,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "withModifier.agency", scopeName: "main", threads: __setupData.threads });

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -5,7 +5,7 @@ import { z } from "agency-lang/zod";
 import { goToNode, color, nanoid } from "agency-lang";
 import { smoltalk } from "agency-lang";
 import path from "path";
-import type { GraphState, InternalFunctionState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
+import type { GraphState, Interrupt, InterruptResponse, Checkpoint, LLMClient } from "agency-lang/runtime";
 import {
   RuntimeContext, MessageThread, ThreadStore, Runner, McpManager,
   setupNode, setupFunction, runNode, runPrompt, callHook,
@@ -150,7 +150,7 @@ graph.node("main", async (__state: GraphState) => {
   const __stack = __setupData.stack;
 const __step = __setupData.step;
 const __self = __setupData.self;
-const __ctx = __state.ctx;
+const __ctx = getRuntimeContext().ctx;
 let __forked;
 let __functionCompleted = false;
   const runner = new Runner(__ctx, __stack, { nodeContext: true, state: __stack, moduleId: "withParam.agency", scopeName: "main", threads: __setupData.threads });


### PR DESCRIPTION
Eliminates the legacy `__state: InternalFunctionState | undefined` trailing positional from every generated Agency function. After this PR, function signatures are just `async function __foo_impl(a, b)` — `ctx` / `threads` / `stateStack` flow through the active `agencyStore` AsyncLocalStorage frame seeded by the parent scope.

Last PR in the three-part series:
1. `2026-05-26-remove-class-syntax.md` (merged)
2. `2026-05-26-als-migration-ctx-accessor.md` (merged as #205)
3. `2026-05-26-drop-state-param.md` ← this PR

## What changed

### Codegen / templates

- `lib/backends/typescriptBuilder.ts`
  - Function-decl emission drops the trailing `__state: InternalFunctionState | undefined = undefined` param.
  - `setupFunction()` is invoked with **no arguments** — it reads `ctx` / `threads` from `getRuntimeContext()`.
  - The setup-block `ctx:` arg switches from `__state?.ctx || __globalCtx` to `getRuntimeContext().ctx` for both function bodies and graph-node bodies.
  - `setupNode` still receives `__state: GraphState` because the node-arrow signature carries `data` / `isResume` / `messages` from the simplemachine — but `ctx` is read from ALS, not from `state.ctx`.
- `lib/templates/backends/typescriptGenerator/blockSetup.mustache` — no longer plumbs `state: { ctx, threads }` into `setupFunction`.
- `lib/templates/backends/typescriptGenerator/debugger.mustache` — drops the `__state` arg from the `debugStep(__ctx, …)` call.
- `lib/templates/backends/typescriptGenerator/imports.mustache` — drops the now-dead `InternalFunctionState` import.

### Runtime

- `lib/runtime/call.ts` — `__call` / `__callMethod` stop merging an ALS bag into state extras for every call. Caller-passed extras are forwarded to `AgencyFunction.invoke(...)` as-is. **Two narrow special cases remain (Option C):**
  1. **Checkpoint location info** — codegen emits `{ moduleId, scopeName, stepPath }` at every `checkpoint()` site so the created checkpoint records the caller's source location.
  2. **Async-fork `stateStack` override** — `__call` installs a per-branch ALS frame whose `stack` is the forked branch's stack so the callee resolves stack-reads to the branch stack. The async-unassigned operator is slated for removal in favor of `fork` / `parallel`, which carry their own per-branch frames via `runBatch.runInBranchAlsFrame`.
- `lib/runtime/checkpoint.ts` — `checkpoint()` / `getCheckpoint()` / `restore()` read `ctx` / `stateStack` from `getRuntimeContext()`. `checkpoint()` keeps a trailing `__state?` positional that now carries ONLY the location fields. `getCheckpoint` / `restore` drop the trailing state arg entirely (`AgencyFunction.invoke` still silently passes one through; it's ignored).
- `lib/runtime/ipc.ts` — `_run` reads `ctx` and the per-scope `stateStack` from ALS.
- `lib/runtime/debugger.ts` — `debugStep` drops its previously-unused `state` param.
- `lib/stdlib/agency.ts` — `_callbackImpl` reads `ctx` from ALS.
- `lib/runtime/node.ts`
  - `setupFunction()` takes no args. The previous "called as a tool by the LLM with no state" fallback (fresh `StateStack` + empty `ThreadStore`) is no longer reachable because tool dispatch always runs inside the issuing `runner.step` ALS frame.
  - `setupNode` reads `ctx` from ALS instead of `state.ctx`.
- `lib/runtime/prompt.ts`, `lib/runtime/runner.ts` — internal callers updated to the new no-arg signatures.

### Type-system cleanup

- `InternalFunctionState` type deleted from `lib/runtime/types.ts` along with its export from `lib/runtime/index.ts`. Dead `SimpleMachine` / `StatelogClient` imports in `types.ts` removed.

### Tests

Direct-call test sites that exercise runtime helpers without going through `runNode` now wrap their invocations in `runInTestContext(...)` so `getRuntimeContext()` finds an active ALS frame:

- `lib/runtime/__tests__/node.test.ts`
- `lib/runtime/checkpoint.test.ts`
- `lib/runtime/debugger.test.ts`
- `lib/runtime/state/stateStack.test.ts`

### Fixtures

`make fixtures` regenerated every `tests/typescriptGenerator/*.mjs`, `tests/typescriptBuilder/*.mjs`, and `tests/debugger/*.ts` fixture to match the new codegen output.

## End-state shape

```ts
// Before
async function __foo_impl(
  a: number, b: number,
  __state: InternalFunctionState | undefined = undefined,
) {
  const __setupData = setupFunction({ state: __state });
  // ...
  const __ctx = __state?.ctx || __globalCtx;
  // ...
}

// After
async function __foo_impl(a: number, b: number) {
  const __setupData = setupFunction();
  // ...
  const __ctx = getRuntimeContext().ctx;
  // ...
}
```

## Verification

- `pnpm tsc --noEmit` — clean
- `pnpm run lint:structure` — clean
- `pnpm test:run` — **4408 / 4408** vitest tests pass
- Smoke tests (`pnpm run agency test ...`):
  - `tests/agency/fork/fork-interrupt.test.json` — 1/1
  - `tests/agency/interrupts/interrupt.test.json` — 3/3
  - `tests/agency/threads/messages.test.json` — 1/1
- CLI integration: `npm pack` + `node tests/integration/cli/test.mjs ./agency-lang-*.tgz` — all 4 scenarios pass

## Breaking changes for external integrations

- Anyone calling `compiled.__foo_impl(args, customState)` directly from JS gets a runtime "called outside an Agency execution frame…" error unless they wrap in `runInTestContext(ctx, stack, threads, () => compiled.__foo_impl(args))`.
- `setupFunction(...)` and `setupNode(...)` API change — callers outside generated code must install an ALS frame first.
- Anyone importing `InternalFunctionState` from `agency-lang/runtime` will see a missing-symbol error; the type is gone.

## Open caveats

- The legacy `async helper()` unassigned-async operator's branch-stack isolation now relies on `__call`'s per-call ALS-frame install (not on a positional override). Single-helper async-call sites still work. Per the plan, this operator is slated for deletion in favor of `fork` / `parallel`.
