### PR TITLE
runtime: move checkpoint location to ALS + drop trailing state arg from invoke/__call

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1993,9 +1993,14 @@ export class TypeScriptBuilder {
     // inline at the call site that overrides `stack`; the callee picks
     // it up via `getRuntimeContext()`.
     if (options?.stateStack) {
-      const wrapped = ts.raw(
-        `agencyStore.run({ ...getRuntimeContext(), stack: ${this.str(options.stateStack)} }, () => ${this.str(callExpr)})`,
-      );
+      const frame = ts.obj([
+        ts.setSpread(ts.call(ts.id("getRuntimeContext"))),
+        ts.set("stack", options.stateStack),
+      ]);
+      const wrapped = ts.call(ts.prop(ts.id("agencyStore"), "run"), [
+        frame,
+        ts.arrowFn([], callExpr),
+      ]);
       return shouldAwait ? ts.await(wrapped) : wrapped;
     }
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -849,27 +849,15 @@ export class TypeScriptBuilder {
         case "methodCall": {
           const fnCall = element.functionCall;
           const descriptor = this.buildCallDescriptor(fnCall);
-          const configObj = this.buildStateConfig();
           const callArgs: TsNode[] = [result, ts.str(fnCall.functionName), descriptor];
-          if (element.optional) {
-            callArgs.push(configObj ?? ts.id("undefined"));
-            callArgs.push(ts.bool(true));
-          } else if (configObj) {
-            callArgs.push(configObj);
-          }
+          if (element.optional) callArgs.push(ts.bool(true));
           result = this.awaitChainCall(ts.call(ts.id("__callMethod"), callArgs), element === node.chain[node.chain.length - 1]);
           break;
         }
         case "call": {
           const descriptor = this.buildCallDescriptor(element);
-          const configObj = this.buildStateConfig();
           const callArgs: TsNode[] = [result, descriptor];
-          if (element.optional) {
-            callArgs.push(configObj ?? ts.id("undefined"));
-            callArgs.push(ts.bool(true));
-          } else if (configObj) {
-            callArgs.push(configObj);
-          }
+          if (element.optional) callArgs.push(ts.bool(true));
           result = this.awaitChainCall(ts.call(ts.id("__call"), callArgs), element === node.chain[node.chain.length - 1]);
           break;
         }

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1004,36 +1004,20 @@ export class TypeScriptBuilder {
   }
 
   /**
-   * Build the state config passed as the third argument to `__call` /
-   * `__callMethod`.
+   * After the ALS migration AND the trailing-`state`-arg drop, every
+   * Agency call site reads `ctx` / `stack` / `threads` / `callsite`
+   * from the active `agencyStore` frame. `__call` / `__callMethod` no
+   * longer accept a state-extras object, and the codegen never emits
+   * one. This helper is kept as a stable seam in case future codegen
+   * needs to attach per-call metadata, but for now it always returns
+   * `undefined` — callers should simply omit the third positional.
    *
-   * After the ALS migration, the runtime helpers read `ctx`/`threads`/
-   * `stateStack` from `agencyStore` (see lib/runtime/call.ts), so call
-   * sites no longer need to thread those locals. This helper returns
-   * `undefined` for the common case — the caller MUST omit the arg
-   * entirely so the emitted code stays minimal.
-   *
-   * It still returns a real object in two situations:
-   *  - `insideGlobalInit`: globals run before the ALS frame is
-   *    installed, so the bag must carry `{ ctx }` explicitly.
-   *  - When `opts.extra` is provided (currently the `checkpoint` /
-   *    `getCheckpoint` / `restore` location info — `moduleId`,
-   *    `scopeName`, `stepPath`): these extras are merged into the
-   *    runtime-built bag by `__call`.
+   * Async-fork sites that need to override the active branch stack
+   * wrap their `__call(...)` invocation in an `agencyStore.run`
+   * frame in codegen (see `emitRuntimeDispatchCall`) — not via this
+   * helper.
    */
-  private buildStateConfig(opts?: {
-    extra?: Record<string, TsNode>;
-  }): TsNode | undefined {
-    if (this.insideGlobalInit) {
-      // `insideGlobalInit` means the call is emitted as part of the
-      // `__initializeGlobals(__ctx)` body, where `__ctx` is a function
-      // parameter (no ALS frame yet). Pass the lexical identifier
-      // instead of the `__ctx()` accessor alias.
-      return ts.functionCallConfig({ ctx: ts.id("__ctx") });
-    }
-    if (opts?.extra && Object.keys(opts.extra).length > 0) {
-      return ts.obj(opts.extra);
-    }
+  private buildStateConfig(): TsNode | undefined {
     return undefined;
   }
 
@@ -2009,28 +1993,24 @@ export class TypeScriptBuilder {
   ): TsNode {
     const descriptor = this.buildCallDescriptor(node);
 
-    const locationOpts = node.functionName === "checkpoint" ? {
-      moduleId: ts.str(this.moduleId),
-      scopeName: ts.str(this.scopes.currentName()),
-      stepPath: ts.str(this.steps.joined()),
-    } : undefined;
-    // Async fork sites pass `stateStack: __forked` so the branch's
-    // isolated stack — not the parent's ALS-frame stack — is used
-    // inside `__call`. Without this, concurrent async Agency calls
-    // would push/pop on the parent stack and break branch isolation.
-    const extra: Record<string, TsNode> = { ...(locationOpts ?? {}) };
-    if (options?.stateStack) extra.stateStack = options.stateStack;
-    const configObj = this.buildStateConfig({
-      extra: Object.keys(extra).length > 0 ? extra : undefined,
-    });
-
     const callee = node.scope
       ? ts.scopedVar(functionName, node.scope, this.moduleId)
       : ts.id(functionName);
 
-    const callArgs: TsNode[] = [callee, descriptor];
-    if (configObj) callArgs.push(configObj);
-    const callExpr = ts.call(ts.id("__call"), callArgs);
+    const callExpr = ts.call(ts.id("__call"), [callee, descriptor]);
+
+    // Async-fork sites need the branch's isolated stack visible to the
+    // callee (so its checkpoints/handlers/etc. push/pop on the branch
+    // stack rather than the parent's). Install a fresh ALS frame
+    // inline at the call site that overrides `stack`; the callee picks
+    // it up via `getRuntimeContext()`.
+    if (options?.stateStack) {
+      const wrapped = ts.raw(
+        `agencyStore.run({ ...getRuntimeContext(), stack: ${this.str(options.stateStack)} }, () => ${this.str(callExpr)})`,
+      );
+      return shouldAwait ? ts.await(wrapped) : wrapped;
+    }
+
     return shouldAwait ? ts.await(callExpr) : callExpr;
   }
 

--- a/packages/agency-lang/lib/ir/builders.ts
+++ b/packages/agency-lang/lib/ir/builders.ts
@@ -407,16 +407,16 @@ export const ts = {
   },
 
   /**
-   * `await __validateChainRecursive(value, <descriptor>, __ctx)` — used at
+   * `await __validateChainRecursive(value, <descriptor>)` — used at
    * `!` sites whose resolved type carries at least one `@validate(...)` tag
    * anywhere in the tree. The descriptor is a TS expression built via
-   * `buildValidationDescriptor(...)`.
+   * `buildValidationDescriptor(...)`. Validators read `ctx` from the
+   * active `agencyStore` ALS frame, so no explicit ctx arg is threaded.
    */
   validateChainRecursive(value: TsNode, descriptor: TsNode): TsAwait {
     return ts.awaitCall(ts.id("__validateChainRecursive"), [
       value,
       descriptor,
-      ts.id("__ctx"),
     ]);
   },
 

--- a/packages/agency-lang/lib/runtime/agencyFunction.test.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { AgencyFunction, UNSET } from "./agencyFunction.js";
+import { runInTestContext } from "./asyncContext.js";
+import { makeMockCtx } from "./__tests__/testHelpers.js";
+import { ThreadStore } from "./state/threadStore.js";
 
 function makeFunction(
   params: { name: string; hasDefault?: boolean; defaultValue?: unknown; variadic?: boolean }[],
@@ -24,7 +27,7 @@ describe("AgencyFunction", () => {
     it("passes exact args through", async () => {
       const fn = makeFunction([{ name: "a" }, { name: "b" }]);
       const result = await fn.invoke({ type: "positional", args: [1, 2] });
-      expect(result).toEqual([1, 2, undefined]); // args + state
+      expect(result).toEqual([1, 2]);
     });
 
     it("pads missing args with UNSET when defaults exist", async () => {
@@ -33,7 +36,7 @@ describe("AgencyFunction", () => {
         { name: "b", hasDefault: true, defaultValue: 10 },
       ]);
       const result = await fn.invoke({ type: "positional", args: [1] });
-      expect(result).toEqual([1, UNSET, undefined]);
+      expect(result).toEqual([1, UNSET]);
     });
 
     it("wraps trailing args into array for variadic param", async () => {
@@ -42,20 +45,31 @@ describe("AgencyFunction", () => {
         { name: "items", variadic: true },
       ]);
       const result = await fn.invoke({ type: "positional", args: [1, 2, 3, 4] });
-      expect(result).toEqual([1, [2, 3, 4], undefined]);
+      expect(result).toEqual([1, [2, 3, 4]]);
     });
 
-    it("passes state through as last argument", async () => {
+    it("does not forward a trailing state arg to _fn", async () => {
+      const seen: unknown[][] = [];
+      const fn = makeFunction([{ name: "a" }], (...args: unknown[]) => {
+        seen.push(args);
+        return "ok";
+      });
+      await fn.invoke({ type: "positional", args: [42] });
+      // Pre-drop, _fn was called as `_fn(42, undefined)` (length 2).
+      // Post-drop, only the resolved args make it through.
+      expect(seen[0]).toEqual([42]);
+    });
+
+    it("rejects unknown second positional via the type system", async () => {
       const fn = makeFunction([{ name: "a" }]);
-      const mockState = { ctx: "mock" } as any;
-      const result = await fn.invoke({ type: "positional", args: [1] }, mockState);
-      expect(result).toEqual([1, mockState]);
+      // @ts-expect-error — invoke no longer accepts a second positional.
+      await fn.invoke({ type: "positional", args: [1] }, { somethingCustom: true });
     });
 
     it("handles zero params", async () => {
       const fn = makeFunction([]);
       const result = await fn.invoke({ type: "positional", args: [] });
-      expect(result).toEqual([undefined]); // just state
+      expect(result).toEqual([]);
     });
   });
 
@@ -67,7 +81,7 @@ describe("AgencyFunction", () => {
         positionalArgs: [],
         namedArgs: { c: 3, a: 1, b: 2 },
       });
-      expect(result).toEqual([1, 2, 3, undefined]);
+      expect(result).toEqual([1, 2, 3]);
     });
 
     it("mixes positional and named args", async () => {
@@ -77,7 +91,7 @@ describe("AgencyFunction", () => {
         positionalArgs: [1],
         namedArgs: { c: 3, b: 2 },
       });
-      expect(result).toEqual([1, 2, 3, undefined]);
+      expect(result).toEqual([1, 2, 3]);
     });
 
     it("fills skipped optional params with UNSET", async () => {
@@ -91,7 +105,7 @@ describe("AgencyFunction", () => {
         positionalArgs: [],
         namedArgs: { a: 1, c: 3 },
       });
-      expect(result).toEqual([1, UNSET, 3, undefined]);
+      expect(result).toEqual([1, UNSET, 3]);
     });
 
     it("pads trailing defaults when named args stop early", async () => {
@@ -105,7 +119,7 @@ describe("AgencyFunction", () => {
         positionalArgs: [],
         namedArgs: { a: 1 },
       });
-      expect(result).toEqual([1, UNSET, UNSET, undefined]);
+      expect(result).toEqual([1, UNSET, UNSET]);
     });
 
     it("throws on unknown named arg", async () => {
@@ -408,5 +422,70 @@ describe("describe()", () => {
     expect(described.params[0].isBound).toBe(true);
     expect(described.getUnboundParams()).toHaveLength(1);
     expect(described.toolDefinition!.description).toBe("Adds 5 to a number");
+  });
+});
+
+describe("preapprove handler wiring", () => {
+  it("invokes via withPushedHandler: handler pushed during call, popped after", async () => {
+    const ctx = makeMockCtx();
+    let lenDuring = -1;
+    const fn = AgencyFunction.create({
+      name: "tool",
+      module: "test",
+      fn: async () => {
+        lenDuring = ctx.handlers.length;
+        return "x";
+      },
+      params: [],
+      toolDefinition: null,
+    }, {}).preapprove();
+
+    const before = ctx.handlers.length;
+    await runInTestContext(ctx, ctx.stateStack, new ThreadStore(), () =>
+      fn.invoke({ type: "positional", args: [] }),
+    );
+    expect(lenDuring).toBe(before + 1);
+    expect(ctx.handlers.length).toBe(before);
+  });
+
+  it("pops the preapprove handler even when the body throws", async () => {
+    const ctx = makeMockCtx();
+    const fn = AgencyFunction.create({
+      name: "tool",
+      module: "test",
+      fn: async () => {
+        throw new Error("boom");
+      },
+      params: [],
+      toolDefinition: null,
+    }, {}).preapprove();
+
+    const before = ctx.handlers.length;
+    await expect(
+      runInTestContext(ctx, ctx.stateStack, new ThreadStore(), () =>
+        fn.invoke({ type: "positional", args: [] }),
+      ),
+    ).rejects.toThrow("boom");
+    expect(ctx.handlers.length).toBe(before);
+  });
+
+  it("does not push a handler for non-preapproved functions", async () => {
+    const ctx = makeMockCtx();
+    let lenDuring = -1;
+    const fn = AgencyFunction.create({
+      name: "tool",
+      module: "test",
+      fn: async () => {
+        lenDuring = ctx.handlers.length;
+      },
+      params: [],
+      toolDefinition: null,
+    }, {});
+
+    const before = ctx.handlers.length;
+    await runInTestContext(ctx, ctx.stateStack, new ThreadStore(), () =>
+      fn.invoke({ type: "positional", args: [] }),
+    );
+    expect(lenDuring).toBe(before);
   });
 });

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { stripBoundParams } from "./stripBoundParams.js";
 import { approve } from "./interrupts.js";
-import { agencyStore } from "./asyncContext.js";
+import { agencyStore, withPushedHandler } from "./asyncContext.js";
 
 export const UNSET: unique symbol = Symbol("UNSET");
 
@@ -120,36 +120,29 @@ export class AgencyFunction {
     return this._unboundParams;
   }
 
-  async invoke(descriptor: CallType, state?: unknown): Promise<unknown> {
-    if (this._isPreapproved) {
-      // Post-ALS migration: `ctx` is no longer plumbed in as `state.ctx`
-      // for normal calls — read it from the active `agencyStore` frame
-      // installed by the caller's `runner.step` body (or, for
-      // module-init paths, the bootstrap frame). The preapprove handler
-      // must be pushed onto the same `ctx.handlers` chain that the
-      // invocation will consult, so we MUST read from the live ALS
-      // frame and not from any legacy state-bag fallback.
-      const ctx = agencyStore.getStore()?.ctx;
-      if (ctx) {
-        ctx.pushHandler(async () => approve());
-        try {
-          return await this._invokeInner(descriptor, state);
-        } finally {
-          ctx.popHandler();
-        }
-      }
-    }
-    return this._invokeInner(descriptor, state);
+  async invoke(descriptor: CallType): Promise<unknown> {
+    // Preapprove tools install a handler that auto-approves any
+    // `request_approval` interrupt raised while the tool body runs.
+    // The handler must be pushed onto the same `ctx.handlers` chain
+    // the invocation consults, so we read `ctx` from the live ALS
+    // frame (seeded by the caller's `runner.step` body — or by the
+    // bootstrap frame for module-init paths). When no frame is
+    // installed (the function was called from a non-Agency context),
+    // skip the push/pop dance — no preapprove machinery to wire up.
+    const ctx = this._isPreapproved ? agencyStore.getStore()?.ctx : undefined;
+    if (!ctx) return this._invokeInner(descriptor);
+    return withPushedHandler(
+      ctx,
+      async () => approve(),
+      () => this._invokeInner(descriptor),
+    );
   }
 
-  private async _invokeInner(descriptor: CallType, state?: unknown): Promise<unknown> {
-    if (this._isBound) {
-      const callArgs = this.resolveArgs(descriptor);
-      const fullArgs = this.mergeWithBound(callArgs);
-      return this._fn(...fullArgs, state);
-    }
-    const resolvedArgs = this.resolveArgs(descriptor);
-    return this._fn(...resolvedArgs, state);
+  private async _invokeInner(descriptor: CallType): Promise<unknown> {
+    const args = this._isBound
+      ? this.mergeWithBound(this.resolveArgs(descriptor))
+      : this.resolveArgs(descriptor);
+    return this._fn(...args);
   }
 
   partial(bindings: Record<string, unknown>): AgencyFunction {

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -121,24 +121,6 @@ export class AgencyFunction {
   }
 
   async invoke(descriptor: CallType): Promise<unknown> {
-    // Preapprove tools install a handler that auto-approves any
-    // `request_approval` interrupt raised while the tool body runs.
-    // The handler must be pushed onto the same `ctx.handlers` chain
-    // the invocation consults, so we read `ctx` from the live ALS
-    // frame (seeded by the caller's `runner.step` body — or by the
-    // bootstrap frame for module-init paths). When no frame is
-    // installed (the function was called from a non-Agency context),
-    // skip the push/pop dance — no preapprove machinery to wire up.
-    const ctx = this._isPreapproved ? agencyStore.getStore()?.ctx : undefined;
-    if (!ctx) return this._invokeInner(descriptor);
-    return withPushedHandler(
-      ctx,
-      async () => approve(),
-      () => this._invokeInner(descriptor),
-    );
-  }
-
-  private async _invokeInner(descriptor: CallType): Promise<unknown> {
     const args = this._isBound
       ? this.mergeWithBound(this.resolveArgs(descriptor))
       : this.resolveArgs(descriptor);
@@ -196,10 +178,24 @@ export class AgencyFunction {
 
   preapprove(): AgencyFunction {
     if (this._isPreapproved) return this;
+    // Wrap `_fn` in a `withPushedHandler` that installs an
+    // auto-approve handler for the duration of every call. The handler
+    // intercepts any `request_approval` interrupt the body raises so
+    // preapproved tools never bubble approval prompts up to the user.
+    // Doing the wrap here — rather than branching inside `invoke()` —
+    // keeps the per-call hot path branch-free.
+    const original = this._fn;
+    const wrapped = (...args: any[]) => {
+      const ctx = agencyStore.getStore()?.ctx;
+      if (!ctx) return original(...args);
+      return withPushedHandler(ctx, async () => approve(), () =>
+        Promise.resolve(original(...args)),
+      );
+    };
     return new AgencyFunction({
       name: this.name,
       module: this.module,
-      fn: this._fn,
+      fn: wrapped,
       params: this.params,
       toolDefinition: this.toolDefinition,
       exported: this.exported,

--- a/packages/agency-lang/lib/runtime/asyncContext.test.ts
+++ b/packages/agency-lang/lib/runtime/asyncContext.test.ts
@@ -4,6 +4,8 @@ import {
   getRuntimeContext,
   runInBootstrapFrame,
   runInTestContext,
+  withCallsite,
+  withPushedHandler,
 } from "./asyncContext.js";
 import { BootstrapThreadStore } from "./state/bootstrapThreadStore.js";
 import { RuntimeContext } from "./state/context.js";
@@ -142,5 +144,108 @@ describe("runInBootstrapFrame", () => {
     const seed = makeStore();
     const out = await runInBootstrapFrame(seed.ctx, async () => 42);
     expect(out).toBe(42);
+  });
+});
+
+describe("withCallsite", () => {
+  it("installs callsite on the active frame", () => {
+    const seed = makeStore();
+    runInTestContext(seed.ctx, seed.stack, seed.threads, () => {
+      expect(agencyStore.getStore()?.callsite).toBeUndefined();
+      withCallsite(
+        { moduleId: "m", scopeName: "s", stepPath: "1.2" },
+        () => {
+          expect(getRuntimeContext().callsite).toEqual({
+            moduleId: "m",
+            scopeName: "s",
+            stepPath: "1.2",
+          });
+        },
+      );
+      expect(agencyStore.getStore()?.callsite).toBeUndefined();
+    });
+  });
+
+  it("nests; inner overrides, outer restored on return", () => {
+    const seed = makeStore();
+    runInTestContext(seed.ctx, seed.stack, seed.threads, () => {
+      withCallsite(
+        { moduleId: "m", scopeName: "outer", stepPath: "" },
+        () => {
+          withCallsite(
+            { moduleId: "m", scopeName: "inner", stepPath: "1" },
+            () => {
+              expect(getRuntimeContext().callsite?.scopeName).toBe("inner");
+            },
+          );
+          expect(getRuntimeContext().callsite?.scopeName).toBe("outer");
+        },
+      );
+    });
+  });
+
+  it("throws outside an agency frame", () => {
+    expect(() =>
+      withCallsite({ moduleId: "", scopeName: "", stepPath: "" }, () => 1),
+    ).toThrow(/outside an Agency execution frame/);
+  });
+
+  it("preserves ctx/stack/threads from the parent frame", () => {
+    const seed = makeStore();
+    runInTestContext(seed.ctx, seed.stack, seed.threads, () => {
+      withCallsite(
+        { moduleId: "m", scopeName: "s", stepPath: "1" },
+        () => {
+          const s = getRuntimeContext();
+          expect(s.ctx).toBe(seed.ctx);
+          expect(s.stack).toBe(seed.stack);
+          expect(s.threads).toBe(seed.threads);
+        },
+      );
+    });
+  });
+});
+
+describe("withPushedHandler", () => {
+  const noopHandler = async () => ({ type: "propagate" as const });
+
+  it("pops on normal return", async () => {
+    const seed = makeStore();
+    await runInTestContext(seed.ctx, seed.stack, seed.threads, async () => {
+      const before = seed.ctx.handlers.length;
+      const result = await withPushedHandler(
+        seed.ctx,
+        noopHandler,
+        async () => "result",
+      );
+      expect(result).toBe("result");
+      expect(seed.ctx.handlers.length).toBe(before);
+    });
+  });
+
+  it("pops on throw", async () => {
+    const seed = makeStore();
+    await runInTestContext(seed.ctx, seed.stack, seed.threads, async () => {
+      const before = seed.ctx.handlers.length;
+      await expect(
+        withPushedHandler(seed.ctx, noopHandler, async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+      expect(seed.ctx.handlers.length).toBe(before);
+    });
+  });
+
+  it("installs the handler for the duration of fn", async () => {
+    const seed = makeStore();
+    await runInTestContext(seed.ctx, seed.stack, seed.threads, async () => {
+      const before = seed.ctx.handlers.length;
+      let lenDuring = -1;
+      await withPushedHandler(seed.ctx, noopHandler, async () => {
+        lenDuring = seed.ctx.handlers.length;
+      });
+      expect(lenDuring).toBe(before + 1);
+      expect(seed.ctx.handlers.length).toBe(before);
+    });
   });
 });

--- a/packages/agency-lang/lib/runtime/asyncContext.ts
+++ b/packages/agency-lang/lib/runtime/asyncContext.ts
@@ -50,14 +50,70 @@ import { BootstrapThreadStore } from "./state/bootstrapThreadStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { StateStack } from "./state/stateStack.js";
 import type { ThreadStore } from "./state/threadStore.js";
+import type { HandlerFn } from "./types.js";
+
+export type CallsiteLocation = {
+  moduleId: string;
+  scopeName: string;
+  stepPath: string;
+};
 
 export type AgencyStore = {
   ctx: RuntimeContext<any>;
   stack: StateStack;
   threads: ThreadStore;
+  /**
+   * Per-call-site source location for the currently-executing step.
+   * Seeded by `Runner.runInScope` for every step body. Stdlib helpers
+   * that need to attribute a checkpoint to its originating step
+   * (`checkpoint()`) read this slot instead of receiving the location
+   * as a trailing positional arg from generated code.
+   *
+   * Optional because not every ALS frame has one: the top-level
+   * `runNode` frame and `runInBootstrapFrame` deliberately omit it
+   * (any checkpoint created in bootstrap scope gets the empty
+   * `""::""::""` fallback, matching pre-ALS behaviour).
+   */
+  callsite?: CallsiteLocation;
 };
 
 export const agencyStore = new AsyncLocalStorage<AgencyStore>();
+
+/**
+ * Push a new ALS frame copying the current ctx/stack/threads but
+ * overriding `callsite`. For TS helpers that want to attach a
+ * per-internal-substep checkpoint location to nested `checkpoint()`
+ * calls. Throws if called outside any agency frame (no inheritable
+ * base).
+ */
+export function withCallsite<T>(loc: CallsiteLocation, fn: () => T): T {
+  const store = agencyStore.getStore();
+  if (!store) {
+    throw new Error("withCallsite() called outside an Agency execution frame.");
+  }
+  return agencyStore.run({ ...store, callsite: loc }, fn);
+}
+
+/**
+ * Run `fn` with `handler` pushed onto `ctx.handlers`; pop in finally.
+ * Two call sites consume this: `AgencyFunction.invoke()`'s preapprove
+ * branch and (in a future PR) `agency.withHandler`. Co-locating the
+ * combinator here means neither call site repeats the push/try/finally
+ * dance and there is no circular import between agencyFunction.ts and
+ * the agency namespace module.
+ */
+export async function withPushedHandler<T>(
+  ctx: RuntimeContext<any>,
+  handler: HandlerFn,
+  fn: () => Promise<T>,
+): Promise<T> {
+  ctx.pushHandler(handler);
+  try {
+    return await fn();
+  } finally {
+    ctx.popHandler();
+  }
+}
 
 /**
  * Read the current Agency runtime context from ALS. Throws if called

--- a/packages/agency-lang/lib/runtime/call.test.ts
+++ b/packages/agency-lang/lib/runtime/call.test.ts
@@ -13,10 +13,25 @@ function makeAgencyFn(fn: (...args: any[]) => any, name = "testFn") {
 }
 
 describe("__call", () => {
-  it("calls AgencyFunction via .invoke() with descriptor and state", async () => {
-    const fn = makeAgencyFn(async (x: number, state: any) => ({ x, state }));
-    const result = await __call(fn, { type: "positional", args: [42] }, "myState");
-    expect(result).toEqual({ x: 42, state: "myState" });
+  it("calls AgencyFunction via .invoke() with descriptor", async () => {
+    const fn = makeAgencyFn(async (x: number) => ({ x }));
+    const result = await __call(fn, { type: "positional", args: [42] });
+    expect(result).toEqual({ x: 42 });
+  });
+
+  it("does not forward any trailing state arg to plain TS callees", async () => {
+    const seen: unknown[][] = [];
+    const target = (...args: unknown[]) => {
+      seen.push(args);
+    };
+    await __call(target, { type: "positional", args: [1, 2] });
+    expect(seen[0]).toEqual([1, 2]);
+  });
+
+  it("rejects unknown third positional via the type system", async () => {
+    const fn = makeAgencyFn(async (x: number) => x);
+    // @ts-expect-error — third positional was stateExtras; removed in this PR.
+    await __call(fn, { type: "positional", args: [1] }, { somethingCustom: true });
   });
 
   it("calls plain TS function by spreading positional args", async () => {
@@ -61,18 +76,18 @@ describe("__callMethod", () => {
   });
 
   it("short-circuits to undefined when optional and obj is null", async () => {
-    const result = await __callMethod(null, "foo", { type: "positional", args: [] }, undefined, true);
+    const result = await __callMethod(null, "foo", { type: "positional", args: [] }, true);
     expect(result).toBeUndefined();
   });
 
   it("short-circuits to undefined when optional and obj is undefined", async () => {
-    const result = await __callMethod(undefined, "foo", { type: "positional", args: [] }, undefined, true);
+    const result = await __callMethod(undefined, "foo", { type: "positional", args: [] }, true);
     expect(result).toBeUndefined();
   });
 
   it("calls normally when optional and obj is non-nullish", async () => {
     const obj = { greet: (name: string) => `hi ${name}` };
-    const result = await __callMethod(obj, "greet", { type: "positional", args: ["Bob"] }, undefined, true);
+    const result = await __callMethod(obj, "greet", { type: "positional", args: ["Bob"] }, true);
     expect(result).toBe("hi Bob");
   });
 

--- a/packages/agency-lang/lib/runtime/call.ts
+++ b/packages/agency-lang/lib/runtime/call.ts
@@ -1,62 +1,29 @@
 import { AgencyFunction } from "./agencyFunction.js";
 import type { CallType } from "./agencyFunction.js";
-import { agencyStore } from "./asyncContext.js";
-import type { StateStack } from "./state/stateStack.js";
 
 /**
- * Post-`__state`-drop migration: generated functions read `ctx` /
- * `threads` / `stateStack` from the active `agencyStore` frame and no
- * longer accept a trailing `__state` positional. The runtime call
- * dispatcher therefore no longer constructs a merged state bag for
- * every call — it just hands the caller-provided `extras` (when
- * present) to `AgencyFunction.invoke()` as the optional `state` arg.
+ * Runtime dispatcher for every Agency call site. Generated code emits
+ * `__call(target, descriptor)` (or `__callMethod(obj, prop, descriptor)`)
+ * and this helper figures out whether `target` is an `AgencyFunction`
+ * (named-arg aware, preapprove handler wiring) or a plain TS callable.
  *
- * Two narrow special cases survive:
- *
- *  1. **`checkpoint()` / `getCheckpoint()` / `restore()` location info.**
- *     The codegen emits `{ moduleId, scopeName, stepPath }` as `extras`
- *     so the checkpoint-creation site records the source location.
- *     These stdlib helpers still accept a trailing `__state` arg, but
- *     read `ctx` / `stateStack` from ALS — the bag is consulted only
- *     for the per-call-site location fields.
- *
- *  2. **Async-fork `stateStack` override.** Codegen for `async helper()`
- *     unassigned calls emits `{ stateStack: __forked }` so the branch
- *     runs on an isolated stack. We install a new ALS frame with the
- *     forked stack before invoking, so the callee's
- *     `getRuntimeContext().ctx.stateStack`-equivalent reads see the
- *     branch stack instead of the parent's. (The async-unassigned
- *     operator is slated for removal in favor of `fork` / `parallel`,
- *     which carry their own per-branch ALS frames via
- *     `runBatch.runInBranchAlsFrame`.)
+ * All execution context (`ctx`, `stack`, `threads`, per-call-site
+ * `callsite`) is read from the active `agencyStore` ALS frame seeded
+ * by `Runner.runInScope`. No state extras pass through this layer —
+ * call sites that need to override the active branch stack (e.g. the
+ * async-fork operator) install their own ALS frame around the
+ * `__call(...)` invocation in codegen.
  */
-function maybeRunWithForkedStack(
-  extras: unknown,
-  fn: () => Promise<unknown>,
-): Promise<unknown> {
-  const e = extras as Record<string, unknown> | undefined;
-  if (!e || !e.stateStack) return fn();
-  const store = agencyStore.getStore();
-  if (!store) return fn();
-  return agencyStore.run(
-    { ...store, stack: e.stateStack as StateStack },
-    fn,
-  );
-}
-
 export async function __call(
   target: unknown,
   descriptor: CallType,
-  stateExtras?: unknown,
   optional?: boolean,
 ): Promise<unknown> {
   if (optional && (target === null || target === undefined)) {
     return undefined;
   }
   if (AgencyFunction.isAgencyFunction(target)) {
-    return maybeRunWithForkedStack(stateExtras, () =>
-      target.invoke(descriptor, stateExtras),
-    );
+    return target.invoke(descriptor);
   }
   if (typeof target !== "function") {
     throw new Error(`Cannot call non-function value: ${String(target)}`);
@@ -73,7 +40,6 @@ export async function __callMethod(
   obj: unknown,
   prop: string | number,
   descriptor: CallType,
-  stateExtras?: unknown,
   optional?: boolean,
 ): Promise<unknown> {
   if (optional && (obj === null || obj === undefined)) {
@@ -109,9 +75,7 @@ export async function __callMethod(
 
   const target = (obj as any)[prop];
   if (AgencyFunction.isAgencyFunction(target)) {
-    return maybeRunWithForkedStack(stateExtras, () =>
-      target.invoke(descriptor, stateExtras),
-    );
+    return target.invoke(descriptor);
   }
   if (typeof target !== "function") {
     throw new Error(`Cannot call non-function value at property '${String(prop)}': ${String(target)}`);

--- a/packages/agency-lang/lib/runtime/checkpoint.test.ts
+++ b/packages/agency-lang/lib/runtime/checkpoint.test.ts
@@ -3,7 +3,7 @@ import { checkpoint, getCheckpoint, restore } from "./checkpoint.js";
 import { CheckpointError, RestoreSignal } from "./errors.js";
 import { makeMockCtx } from "./__tests__/testHelpers.js";
 import { CheckpointStore } from "./index.js";
-import { runInTestContext } from "./asyncContext.js";
+import { runInTestContext, withCallsite } from "./asyncContext.js";
 import { ThreadStore } from "./state/threadStore.js";
 
 // Post-ALS migration: the checkpoint stdlib helpers read `ctx` and
@@ -63,6 +63,33 @@ describe("checkpoint()", () => {
     expect(cp!.stepPath).toBe("");
     expect(cp!.label).toBeNull();
     expect(cp!.pinned).toBe(false);
+  });
+
+  it("records location from the active callsite slot", async () => {
+    const ctx = makeMockCtx();
+    const id = await runInTestContext(
+      ctx,
+      ctx.stateStack,
+      new ThreadStore(),
+      () =>
+        withCallsite(
+          { moduleId: "modA", scopeName: "scopeB", stepPath: "1.2" },
+          () => checkpoint(),
+        ),
+    );
+    const cp = ctx.checkpoints.get(id)!;
+    expect(cp.moduleId).toBe("modA");
+    expect(cp.scopeName).toBe("scopeB");
+    expect(cp.stepPath).toBe("1.2");
+  });
+
+  it("falls back to empty location when no callsite set", async () => {
+    const ctx = makeMockCtx();
+    const id = await wrap(ctx, () => checkpoint());
+    const cp = ctx.checkpoints.get(id)!;
+    expect(cp.moduleId).toBe("");
+    expect(cp.scopeName).toBe("");
+    expect(cp.stepPath).toBe("");
   });
 });
 

--- a/packages/agency-lang/lib/runtime/checkpoint.ts
+++ b/packages/agency-lang/lib/runtime/checkpoint.ts
@@ -4,25 +4,20 @@ import { getRuntimeContext } from "./asyncContext.js";
 import type { Checkpoint } from "./state/checkpointStore.js";
 
 /**
- * Per-call-site location info passed by codegen as the `state` extras
- * to `checkpoint()`. Post-ALS the trailing positional carries ONLY the
- * location fields (`moduleId` / `scopeName` / `stepPath`) — `ctx` and
- * `stateStack` are read from the active `agencyStore` frame, not from
- * this bag.
+ * Capture a checkpoint of the current execution state. The source
+ * location attached to the checkpoint (`moduleId` / `scopeName` /
+ * `stepPath`) is read from the active `agencyStore` frame's
+ * `callsite` slot, which `Runner.runInScope` seeds for every step
+ * body. Calls made outside a runner step (e.g. from bootstrap scope)
+ * fall back to the empty `""::""::""` location.
  */
-type CheckpointLocation = {
-  moduleId?: string;
-  scopeName?: string;
-  stepPath?: string;
-};
-
-export async function checkpoint(__state?: CheckpointLocation): Promise<number> {
-  const { ctx } = getRuntimeContext();
+export async function checkpoint(): Promise<number> {
+  const { ctx, callsite } = getRuntimeContext();
   await ctx.pendingPromises.awaitAll();
   return ctx.checkpoints.create(ctx.stateStack, ctx, {
-    moduleId: __state?.moduleId ?? "",
-    scopeName: __state?.scopeName ?? "",
-    stepPath: __state?.stepPath ?? "",
+    moduleId: callsite?.moduleId ?? "",
+    scopeName: callsite?.scopeName ?? "",
+    stepPath: callsite?.stepPath ?? "",
   });
 }
 

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -9,7 +9,7 @@ import type {
 } from "smoltalk";
 import type { CallbackName } from "../types/function.js";
 import { AgencyFunction } from "./agencyFunction.js";
-import { getRuntimeContext } from "./asyncContext.js";
+import { agencyStore, getRuntimeContext } from "./asyncContext.js";
 import { AgencyCancelledError, RestoreSignal } from "./errors.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { StateStack } from "./state/stateStack.js";
@@ -140,14 +140,21 @@ async function invokeCallback(
   stateStack?: StateStack,
 ): Promise<void> {
   if (AgencyFunction.isAgencyFunction(fn)) {
-    // When `stateStack` is set, the callback frame is pushed onto that
-    // stack rather than `ctx.stateStack`. This matters inside parallel
-    // tool branches: scoped callbacks registered inside a branch's
-    // frame chain must be discovered via the branch's stack.
-    await (fn as AgencyFunction).invoke(
-      { type: "positional", args: [data] },
-      stateStack ? { ctx, stateStack } : { ctx },
-    );
+    // When `stateStack` is set, install an ALS frame overriding the
+    // active stack so the callback body sees the branch's isolated
+    // stack via `getRuntimeContext().stack`. This matters inside
+    // parallel tool branches: scoped callbacks registered inside a
+    // branch's frame chain must be discovered via the branch's stack.
+    const af = fn as AgencyFunction;
+    const desc = { type: "positional" as const, args: [data] };
+    const parent = agencyStore.getStore();
+    if (stateStack && parent) {
+      await agencyStore.run({ ...parent, stack: stateStack }, () =>
+        af.invoke(desc),
+      );
+    } else {
+      await af.invoke(desc);
+    }
     return;
   }
   // Plain JS callbacks (from AgencyCallbacks TS arg) — just async funcs.

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -2,7 +2,7 @@ import * as smoltalk from "smoltalk";
 import { PromptResult, ToolCallJSON } from "smoltalk";
 import { createLogger } from "../logger.js";
 import { AgencyFunction } from "./agencyFunction.js";
-import { getRuntimeContext } from "./asyncContext.js";
+import { agencyStore, getRuntimeContext } from "./asyncContext.js";
 import { AgencyCancelledError, isAbortError } from "./errors.js";
 import { callHook, invokeCallbacks } from "./hooks.js";
 import { hasInterrupts, isRejected } from "./interrupts.js";
@@ -475,9 +475,18 @@ export async function runPrompt(args: {
       try {
         const toolThreads = new ThreadStore();
         toolThreads.setStatelogClient(ctx.statelogClient);
-        toolResult = await handler.invoke(
-          { type: "named", positionalArgs: [], namedArgs },
-          { ctx, threads: toolThreads, stateStack: branchStack },
+        // Install a per-tool ALS frame with the tool's isolated
+        // ThreadStore and the branch's StateStack. The handler body
+        // reads these via `getRuntimeContext()`; without the wrap, it
+        // would see whatever frame the prompt loop is running in.
+        toolResult = await agencyStore.run(
+          { ctx, stack: branchStack, threads: toolThreads },
+          () =>
+            handler.invoke({
+              type: "named",
+              positionalArgs: [],
+              namedArgs,
+            }),
         );
       } catch (error: unknown) {
         const errorMessage =

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -2,7 +2,7 @@ import * as smoltalk from "smoltalk";
 import { PromptResult, ToolCallJSON } from "smoltalk";
 import { createLogger } from "../logger.js";
 import { AgencyFunction } from "./agencyFunction.js";
-import { agencyStore, getRuntimeContext } from "./asyncContext.js";
+import { getRuntimeContext } from "./asyncContext.js";
 import { AgencyCancelledError, isAbortError } from "./errors.js";
 import { callHook, invokeCallbacks } from "./hooks.js";
 import { hasInterrupts, isRejected } from "./interrupts.js";
@@ -15,7 +15,6 @@ import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import { MessageThread } from "./state/messageThread.js";
 import { StateStack } from "./state/stateStack.js";
-import { ThreadStore } from "./state/threadStore.js";
 import { handleStreamingResponse } from "./streaming.js";
 import { GraphState } from "./types.js";
 import { extractResponse, updateTokenStats } from "./utils.js";
@@ -473,21 +472,16 @@ export async function runPrompt(args: {
       let toolResult: any;
       ctx.enterToolCall();
       try {
-        const toolThreads = new ThreadStore();
-        toolThreads.setStatelogClient(ctx.statelogClient);
-        // Install a per-tool ALS frame with the tool's isolated
-        // ThreadStore and the branch's StateStack. The handler body
-        // reads these via `getRuntimeContext()`; without the wrap, it
-        // would see whatever frame the prompt loop is running in.
-        toolResult = await agencyStore.run(
-          { ctx, stack: branchStack, threads: toolThreads },
-          () =>
-            handler.invoke({
-              type: "named",
-              positionalArgs: [],
-              namedArgs,
-            }),
-        );
+        // The tool body runs inside whichever ALS frame the prompt
+        // loop is already in — that frame's `ctx` / `stack` / `threads`
+        // are the correct ones for this tool invocation (the prompt
+        // loop is entered from a `Runner.runInScope` body inside the
+        // branch). No extra wrap needed.
+        toolResult = await handler.invoke({
+          type: "named",
+          positionalArgs: [],
+          namedArgs,
+        });
       } catch (error: unknown) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { Runner } from "./runner.js";
-import { State } from "./state/stateStack.js";
+import { State, StateStack } from "./state/stateStack.js";
+import { ThreadStore } from "./state/threadStore.js";
+import { getRuntimeContext } from "./asyncContext.js";
 import { makeMockCtx } from "./__tests__/testHelpers.js";
 
 function makeFrame(): State {
@@ -635,6 +637,55 @@ describe("Runner", () => {
       expect(frame.locals.__condbranch_1).toBe(0); // ifElse at step 1, branch 0
       expect(frame.locals.__substep_1).toBe(2); // 2 substeps in ifElse
       expect(frame.locals.__iteration_2).toBe(2); // 2 loop iterations
+    });
+  });
+
+  describe("runInScope seeds the ALS callsite slot", () => {
+    it("populates moduleId / scopeName / stepPath for a single step", async () => {
+      const frame = makeFrame();
+      const runner = new Runner(makeMockCtx(), frame, {
+        moduleId: "modX",
+        scopeName: "fooScope",
+        stack: new StateStack(),
+        threads: new ThreadStore(),
+      });
+      let seen: any = null;
+      await runner.step(1, async () => {
+        seen = getRuntimeContext().callsite;
+      });
+      expect(seen).toEqual({
+        moduleId: "modX",
+        scopeName: "fooScope",
+        stepPath: "1",
+      });
+    });
+
+    it("updates stepPath for nested step IDs", async () => {
+      const frame = makeFrame();
+      const runner = new Runner(makeMockCtx(), frame, {
+        moduleId: "modX",
+        scopeName: "fooScope",
+        stack: new StateStack(),
+        threads: new ThreadStore(),
+      });
+      const paths: string[] = [];
+      await runner.step(0, async () => {
+        paths.push(getRuntimeContext().callsite!.stepPath);
+        await runner.ifElse(0, [
+          {
+            condition: () => true,
+            body: async (r) => {
+              await r.step(0, async () => {
+                paths.push(getRuntimeContext().callsite!.stepPath);
+              });
+            },
+          },
+        ]);
+      });
+      // Top-level step 0 (path = ["0"]) and nested step 0.0.0 inside
+      // the ifElse branch (path = ["0", "0", "0", "0"]).
+      expect(paths[0]).toBe("0");
+      expect(paths[paths.length - 1]).toContain("0.0");
     });
   });
 });

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -87,7 +87,16 @@ export class Runner {
   private runInScope<T>(fn: () => Promise<T>): Promise<T> {
     if (this.stack && this.threads) {
       return agencyStore.run(
-        { ctx: this.ctx, stack: this.stack, threads: this.threads },
+        {
+          ctx: this.ctx,
+          stack: this.stack,
+          threads: this.threads,
+          callsite: {
+            moduleId: this.moduleId,
+            scopeName: this.scopeName,
+            stepPath: this.path.join("."),
+          },
+        },
         fn,
       );
     }

--- a/packages/agency-lang/lib/runtime/validateChain.test.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.test.ts
@@ -19,12 +19,12 @@ const doubleIt: AgencyValidator = async (v) =>
 
 describe("__validateChain", () => {
   it("Zod parse passes then validators run in order", async () => {
-    const r = await __validateChain(4, z.number(), [isPos, isEven], ctx);
+    const r = await __validateChain(4, z.number(), [isPos, isEven]);
     expect(isSuccess(r)).toBe(true);
   });
 
   it("returns Zod failure on structural mismatch", async () => {
-    const r = await __validateChain("nope", z.number(), [], ctx);
+    const r = await __validateChain("nope", z.number(), []);
     expect(isFailure(r)).toBe(true);
   });
 
@@ -32,26 +32,26 @@ describe("__validateChain", () => {
     const later = vi.fn(
       async (v: unknown) => success(v),
     ) as unknown as AgencyValidator;
-    const r = await __validateChain(-1, z.number(), [isPos, later], ctx);
+    const r = await __validateChain(-1, z.number(), [isPos, later]);
     expect(isFailure(r)).toBe(true);
     expect(later).not.toHaveBeenCalled();
   });
 
   it("threads transformed value through the chain", async () => {
     // 2 -> double -> 4 -> isEven
-    const r = await __validateChain(2, z.number(), [doubleIt, isEven], ctx);
+    const r = await __validateChain(2, z.number(), [doubleIt, isEven]);
     expect(isSuccess(r)).toBe(true);
     expect((r as { value: number }).value).toBe(4);
   });
 
   it("forwards an incoming failure unchanged", async () => {
     const f = failure("upstream");
-    const r = await __validateChain(f, z.number(), [isPos], ctx);
+    const r = await __validateChain(f, z.number(), [isPos]);
     expect(r).toBe(f);
   });
 
   it("empty validator list still runs Zod parse", async () => {
-    const r = await __validateChain(3, z.number(), [], ctx);
+    const r = await __validateChain(3, z.number(), []);
     expect(isSuccess(r)).toBe(true);
     expect((r as { value: number }).value).toBe(3);
   });
@@ -65,9 +65,9 @@ describe("__validateChainRecursive", () => {
       validators: [],
       element: { kind: "leaf", schema: z.number(), validators: [isPos] },
     };
-    const ok = await __validateChainRecursive([1, 2, 3], desc, ctx);
+    const ok = await __validateChainRecursive([1, 2, 3], desc);
     expect(isSuccess(ok)).toBe(true);
-    const bad = await __validateChainRecursive([1, -2, 3], desc, ctx);
+    const bad = await __validateChainRecursive([1, -2, 3], desc);
     expect(isFailure(bad)).toBe(true);
   });
 
@@ -80,10 +80,10 @@ describe("__validateChainRecursive", () => {
         x: { kind: "leaf", schema: z.number(), validators: [isEven] },
       },
     };
-    expect(isSuccess(await __validateChainRecursive({ x: 4 }, desc, ctx))).toBe(
+    expect(isSuccess(await __validateChainRecursive({ x: 4 }, desc))).toBe(
       true,
     );
-    expect(isFailure(await __validateChainRecursive({ x: 5 }, desc, ctx))).toBe(
+    expect(isFailure(await __validateChainRecursive({ x: 5 }, desc))).toBe(
       true,
     );
   });
@@ -114,7 +114,7 @@ describe("__validateChainRecursive", () => {
         },
       ],
     };
-    await __validateChainRecursive(7, desc, ctx);
+    await __validateChainRecursive(7, desc);
     expect(numCalled).toHaveBeenCalledTimes(1);
     expect(strCalled).not.toHaveBeenCalled();
   });
@@ -132,7 +132,7 @@ describe("__validateChainRecursive", () => {
       },
     };
     expect(
-      isSuccess(await __validateChainRecursive(null, desc, ctx)),
+      isSuccess(await __validateChainRecursive(null, desc)),
     ).toBe(true);
     expect(inner).not.toHaveBeenCalled();
   });
@@ -152,7 +152,7 @@ describe("__validateChainRecursive", () => {
     let v: unknown = 1;
     for (let i = 0; i < 5; i++) v = [v];
 
-    const r = await __validateChainRecursive(v, desc, ctx, { maxDepth: 3 });
+    const r = await __validateChainRecursive(v, desc, { maxDepth: 3 });
     expect(isFailure(r)).toBe(true);
     const err = (r as { error: { reason: string; limit: number; kind: string; valuePreview: unknown } }).error;
     expect(err.reason).toMatch(/recursion depth/);

--- a/packages/agency-lang/lib/runtime/validateChain.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.ts
@@ -9,12 +9,12 @@ import { AgencyFunction } from "./agencyFunction.js";
  *    users can import `success` / `failure` from the agency-lang runtime
  *    and return whichever applies);
  *  - an `AgencyFunction` (an Agency `def` referenced by name), which is
- *    invoked via `.invoke({ type: "positional", args: [value] }, { ctx })`
- *    so we go through the same call infrastructure as `__call(...)`.
+ *    invoked via `.invoke({ type: "positional", args: [value] })` so we
+ *    go through the same call infrastructure as `__call(...)`.
  *
- * Plain JS validators do not receive `ctx`. If you need access to the
- * execution context, write the validator as an Agency `def` and let the
- * normal invocation machinery thread `ctx` through for you.
+ * Validators that need access to the execution context read it from the
+ * active `agencyStore` ALS frame via `getRuntimeContext()`. There is no
+ * `ctx` arg to thread through.
  */
 export type AgencyValidator =
   | ((value: unknown) => Promise<ResultValue> | ResultValue)
@@ -22,7 +22,6 @@ export type AgencyValidator =
 
 async function callValidator(
   v: AgencyValidator,
-  _ctx: unknown,
   value: unknown,
 ): Promise<ResultValue> {
   if (AgencyFunction.isAgencyFunction(v)) {
@@ -47,7 +46,6 @@ export async function __validateChain(
   value: unknown,
   schema: z.ZodType,
   validators: AgencyValidator[],
-  ctx: unknown,
 ): Promise<ResultValue> {
   // Don't validate failures — surface the original error unchanged.
   if (isFailure(value)) return value as ResultValue;
@@ -66,11 +64,7 @@ export async function __validateChain(
   let current: ResultValue = success(raw);
   for (const v of validators) {
     if (!isSuccess(current)) return current;
-    current = await callValidator(
-      v,
-      ctx,
-      (current as { value: unknown }).value,
-    );
+    current = await callValidator(v, (current as { value: unknown }).value);
   }
   return current;
 }
@@ -128,17 +122,15 @@ export type RecursiveValidationOpts = {
 export async function __validateChainRecursive(
   value: unknown,
   descriptor: TypeValidationDescriptor,
-  ctx: unknown,
   opts?: RecursiveValidationOpts,
 ): Promise<ResultValue> {
   const maxDepth = opts?.maxDepth ?? 64;
-  return walk(value, descriptor, ctx, 0, maxDepth);
+  return walk(value, descriptor, 0, maxDepth);
 }
 
 async function walk(
   value: unknown,
   descriptor: TypeValidationDescriptor,
-  ctx: unknown,
   depth: number,
   maxDepth: number,
 ): Promise<ResultValue> {
@@ -157,7 +149,6 @@ async function walk(
     value,
     descriptor.schema,
     descriptor.validators,
-    ctx,
   );
   if (!isSuccess(own)) return own;
   const parsed = (own as { value: unknown }).value;
@@ -171,7 +162,7 @@ async function walk(
       if (parsed === null || parsed === undefined) {
         return success(parsed);
       }
-      const inner = await walk(parsed, descriptor.inner, ctx, depth + 1, maxDepth);
+      const inner = await walk(parsed, descriptor.inner, depth + 1, maxDepth);
       return inner;
     }
 
@@ -179,7 +170,7 @@ async function walk(
       if (!Array.isArray(parsed)) return success(parsed);
       const out: unknown[] = [];
       for (const el of parsed) {
-        const r = await walk(el, descriptor.element, ctx, depth + 1, maxDepth);
+        const r = await walk(el, descriptor.element, depth + 1, maxDepth);
         if (!isSuccess(r)) return r;
         out.push((r as { value: unknown }).value);
       }
@@ -195,7 +186,6 @@ async function walk(
         const r = await walk(
           (parsed as Record<string, unknown>)[key],
           childDesc,
-          ctx,
           depth + 1,
           maxDepth,
         );
@@ -208,7 +198,7 @@ async function walk(
     case "union": {
       const branch = descriptor.branches.find((b) => b.test(parsed));
       if (!branch) return success(parsed);
-      return walk(parsed, branch.descriptor, ctx, depth + 1, maxDepth);
+      return walk(parsed, branch.descriptor, depth + 1, maxDepth);
     }
   }
 }

--- a/packages/agency-lang/lib/runtime/validateChain.ts
+++ b/packages/agency-lang/lib/runtime/validateChain.ts
@@ -22,14 +22,14 @@ export type AgencyValidator =
 
 async function callValidator(
   v: AgencyValidator,
-  ctx: unknown,
+  _ctx: unknown,
   value: unknown,
 ): Promise<ResultValue> {
   if (AgencyFunction.isAgencyFunction(v)) {
-    return (await (v as AgencyFunction).invoke(
-      { type: "positional", args: [value] },
-      { ctx },
-    )) as ResultValue;
+    return (await (v as AgencyFunction).invoke({
+      type: "positional",
+      args: [value],
+    })) as ResultValue;
   }
   return (v as (x: unknown) => Promise<ResultValue> | ResultValue)(value);
 }

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -135,22 +135,16 @@ async function __initializeGlobals(__ctx) {
   await __call(print, {
     type: "positional",
     args: [getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "nums")]
-  }, {
-    ctx: __ctx
   })
   __ctx.globals.set("arrayAndObject.agency", "names", [`Alice`, `Bob`, `Charlie`])
   await __call(print, {
     type: "positional",
     args: [getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "names")]
-  }, {
-    ctx: __ctx
   })
   __ctx.globals.set("arrayAndObject.agency", "matrix", [[1, 2], [3, 4], [5, 6]])
   await __call(print, {
     type: "positional",
     args: [getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "matrix")]
-  }, {
-    ctx: __ctx
   })
   __ctx.globals.set("arrayAndObject.agency", "person", {
     "name": `Alice`,
@@ -159,8 +153,6 @@ async function __initializeGlobals(__ctx) {
   await __call(print, {
     type: "positional",
     args: [getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "person")]
-  }, {
-    ctx: __ctx
   })
   __ctx.globals.set("arrayAndObject.agency", "address", {
     "street": `123 Main St`,
@@ -170,8 +162,6 @@ async function __initializeGlobals(__ctx) {
   await __call(print, {
     type: "positional",
     args: [getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "address")]
-  }, {
-    ctx: __ctx
   })
   __ctx.globals.set("arrayAndObject.agency", "user", {
     "name": `Bob`,
@@ -180,8 +170,6 @@ async function __initializeGlobals(__ctx) {
   await __call(print, {
     type: "positional",
     args: [getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "user")]
-  }, {
-    ctx: __ctx
   })
   __ctx.globals.set("arrayAndObject.agency", "users", [{
     "name": `Alice`,
@@ -193,8 +181,6 @@ async function __initializeGlobals(__ctx) {
   await __call(print, {
     type: "positional",
     args: [getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "users")]
-  }, {
-    ctx: __ctx
   })
   __ctx.globals.set("arrayAndObject.agency", "config", {
     "server": {
@@ -206,22 +192,16 @@ async function __initializeGlobals(__ctx) {
   await __call(print, {
     type: "positional",
     args: [getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "config")]
-  }, {
-    ctx: __ctx
   })
   __ctx.globals.set("arrayAndObject.agency", "firstNum", getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "nums")[0])
   await __call(print, {
     type: "positional",
     args: [getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "firstNum")]
-  }, {
-    ctx: __ctx
   })
   __ctx.globals.set("arrayAndObject.agency", "personName", getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "person").name)
   await __call(print, {
     type: "positional",
     args: [getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "personName")]
-  }, {
-    ctx: __ctx
   })
 }
 async function __registerTopLevelCallbacks(__ctx) {

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -298,10 +298,13 @@ __stack.branches = (__stack.branches || {});
 __stack.branches["1"] = {
           stack: __forked
         };
-__stack.locals.x = agencyStore.run({ ...getRuntimeContext(), stack: __forked }, () => __call(compute, {
-  type: "positional",
-  args: [5]
-}));
+__stack.locals.x = agencyStore.run({
+          ...getRuntimeContext(),
+          stack: __forked
+        }, () => __call(compute, {
+          type: "positional",
+          args: [5]
+        }));
 __self.__pendingKey_x = getRuntimeContext().ctx.pendingPromises.add(__stack.locals.x, (val) => { __stack.locals.x = val; });
       });
       await runner.branchStep(2, "2", async (runner) => {
@@ -315,10 +318,13 @@ __stack.branches = (__stack.branches || {});
 __stack.branches["2"] = {
           stack: __forked
         };
-__stack.locals.y = agencyStore.run({ ...getRuntimeContext(), stack: __forked }, () => __call(compute, {
-  type: "positional",
-  args: [10]
-}));
+__stack.locals.y = agencyStore.run({
+          ...getRuntimeContext(),
+          stack: __forked
+        }, () => __call(compute, {
+          type: "positional",
+          args: [10]
+        }));
 __self.__pendingKey_y = getRuntimeContext().ctx.pendingPromises.add(__stack.locals.y, (val) => { __stack.locals.y = val; });
       });
       await runner.step(3, async (runner) => {

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -298,12 +298,10 @@ __stack.branches = (__stack.branches || {});
 __stack.branches["1"] = {
           stack: __forked
         };
-__stack.locals.x = __call(compute, {
-          type: "positional",
-          args: [5]
-        }, {
-          stateStack: __forked
-        });
+__stack.locals.x = agencyStore.run({ ...getRuntimeContext(), stack: __forked }, () => __call(compute, {
+  type: "positional",
+  args: [5]
+}));
 __self.__pendingKey_x = getRuntimeContext().ctx.pendingPromises.add(__stack.locals.x, (val) => { __stack.locals.x = val; });
       });
       await runner.branchStep(2, "2", async (runner) => {
@@ -317,12 +315,10 @@ __stack.branches = (__stack.branches || {});
 __stack.branches["2"] = {
           stack: __forked
         };
-__stack.locals.y = __call(compute, {
-          type: "positional",
-          args: [10]
-        }, {
-          stateStack: __forked
-        });
+__stack.locals.y = agencyStore.run({ ...getRuntimeContext(), stack: __forked }, () => __call(compute, {
+  type: "positional",
+  args: [10]
+}));
 __self.__pendingKey_y = getRuntimeContext().ctx.pendingPromises.add(__stack.locals.y, (val) => { __stack.locals.y = val; });
       });
       await runner.step(3, async (runner) => {

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -304,12 +304,10 @@ __stack.branches = (__stack.branches || {});
 __stack.branches["1"] = {
           stack: __forked
         };
-getRuntimeContext().ctx.pendingPromises.add(__call(append, {
+getRuntimeContext().ctx.pendingPromises.add(agencyStore.run({ ...getRuntimeContext(), stack: __forked }, () => __call(append, {
   type: "positional",
   args: [1, `hello`]
-}, {
-  stateStack: __forked
-}))
+})))
       });
       await runner.branchStep(2, "2", async (runner) => {
 if ((__stack.branches && __stack.branches["2"])) {
@@ -322,12 +320,10 @@ __stack.branches = (__stack.branches || {});
 __stack.branches["2"] = {
           stack: __forked
         };
-getRuntimeContext().ctx.pendingPromises.add(__call(append, {
+getRuntimeContext().ctx.pendingPromises.add(agencyStore.run({ ...getRuntimeContext(), stack: __forked }, () => __call(append, {
   type: "positional",
   args: [0.5, `world`]
-}, {
-  stateStack: __forked
-}))
+})))
       });
       await runner.step(3, async (runner) => {
 runner.halt({

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -304,7 +304,10 @@ __stack.branches = (__stack.branches || {});
 __stack.branches["1"] = {
           stack: __forked
         };
-getRuntimeContext().ctx.pendingPromises.add(agencyStore.run({ ...getRuntimeContext(), stack: __forked }, () => __call(append, {
+getRuntimeContext().ctx.pendingPromises.add(agencyStore.run({
+  ...getRuntimeContext(),
+  stack: __forked
+}, () => __call(append, {
   type: "positional",
   args: [1, `hello`]
 })))
@@ -320,7 +323,10 @@ __stack.branches = (__stack.branches || {});
 __stack.branches["2"] = {
           stack: __forked
         };
-getRuntimeContext().ctx.pendingPromises.add(agencyStore.run({ ...getRuntimeContext(), stack: __forked }, () => __call(append, {
+getRuntimeContext().ctx.pendingPromises.add(agencyStore.run({
+  ...getRuntimeContext(),
+  stack: __forked
+}, () => __call(append, {
   type: "positional",
   args: [0.5, `world`]
 })))

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -172,10 +172,6 @@ await callHook({
 __stack.locals.cp = await __call(checkpoint, {
           type: "positional",
           args: []
-        }, {
-          moduleId: "checkpoint-restore.agency",
-          scopeName: "main",
-          stepPath: "1"
         });
 if (hasInterrupts(__stack.locals.cp)) {
           await getRuntimeContext().ctx.pendingPromises.awaitAll()

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -134,14 +134,10 @@ async function __initializeGlobals(__ctx) {
   await __call(greet, {
     type: "positional",
     args: [`world`]
-  }, {
-    ctx: __ctx
   })
   await __call(greet, {
     type: "positional",
     args: [`world`, `Hi`]
-  }, {
-    ctx: __ctx
   })
 }
 async function __registerTopLevelCallbacks(__ctx) {

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -137,8 +137,6 @@ async function __initializeGlobals(__ctx) {
     namedArgs: {
       name: `world`
     }
-  }, {
-    ctx: __ctx
   })
   await __call(greet, {
     type: "named",
@@ -147,8 +145,6 @@ async function __initializeGlobals(__ctx) {
       name: `world`,
       greeting: `Hi`
     }
-  }, {
-    ctx: __ctx
   })
 }
 async function __registerTopLevelCallbacks(__ctx) {

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -134,14 +134,10 @@ async function __initializeGlobals(__ctx) {
   await __call(greet, {
     type: "positional",
     args: [`world`]
-  }, {
-    ctx: __ctx
   })
   await __call(greet, {
     type: "positional",
     args: [`world`, `Hi`]
-  }, {
-    ctx: __ctx
   })
 }
 async function __registerTopLevelCallbacks(__ctx) {

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -135,8 +135,6 @@ async function __initializeGlobals(__ctx) {
   __ctx.globals.set("setLLMClient.agency", "client", await __call(SimpleOpenAIClient, {
     type: "positional",
     args: []
-  }, {
-    ctx: __ctx
   }))
   await setLLMClient(getRuntimeContext().ctx.globals.get("setLLMClient.agency", "client"))
 }

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -134,8 +134,6 @@ async function __initializeGlobals(__ctx) {
   await __call(log, {
     type: "positional",
     args: [`INFO`, `hello`, `world`]
-  }, {
-    ctx: __ctx
   })
 }
 async function __registerTopLevelCallbacks(__ctx) {


### PR DESCRIPTION
## What

Moves the per-call-site checkpoint location into the `agencyStore` ALS frame, then drops the trailing `state` positional from `AgencyFunction.invoke`, `_invokeInner`, `_fn`, `__call`, and `__callMethod`.

Closes the loop on the PR #206 migration: with this change, the only way to plumb a value into a called Agency function is the ALS frame. The "extra positional arg = magic runtime context" pattern that a future editor might extend is gone from the public-ish surfaces.

## Why

Before this PR, `AgencyFunction.invoke(descriptor, state?)` carried a `state?: unknown` trailing arg whose only surviving consumer was the per-call-site checkpoint location `{moduleId, scopeName, stepPath}` that codegen emitted for `checkpoint()`. PR #206 had already cut the codegen's dependency on `__state` inside generated function bodies; the invoke-level positional was vestigial.

Leaving it in would invite the next person reading `state?: unknown` to assume "extra positional arg = runtime plumbing pattern" and extend it. Removing it forces every future caller through the ALS frame, which is the right answer.

## How

Three tasks, all in one commit per the plan's "code + templates" / "fixtures" split:

1. **Task 1 — ALS plumbing** (`asyncContext.ts`, `runner.ts`):
   - New `CallsiteLocation` type + `callsite?` slot on `AgencyStore`.
   - `withCallsite(loc, fn)` overrides the active frame's callsite.
   - `withPushedHandler(ctx, handler, fn)` encapsulates the push/try/finally shared by `AgencyFunction.invoke()`'s preapprove branch and (in a future PR) `agency.withHandler`. Co-locating it here avoids a future circular import between `agencyFunction.ts` and the namespace module.
   - `Runner.runInScope` seeds `callsite: { moduleId, scopeName, stepPath: this.path.join(".") }` on every per-step ALS frame.

2. **Task 2 — checkpoint reads from ALS** (`checkpoint.ts`, `typescriptBuilder.ts`):
   - `checkpoint()` reads `{ moduleId, scopeName, stepPath }` from `getRuntimeContext().callsite` instead of accepting a trailing arg. Missing-callsite paths (bootstrap scope) fall back to the empty `""::""::""` location — same as today's `__state == null` branch.
   - Codegen drops the `checkpoint`-only emission of `{ moduleId, scopeName, stepPath }` extras.

3. **Task 3 — drop the trailing state arg** (`agencyFunction.ts`, `call.ts`, `typescriptBuilder.ts`, plus all in-tree TS callers):
   - `AgencyFunction.invoke()` collapses from a manual `ctx.pushHandler`/try/finally block to a one-line `withPushedHandler` wrap.
   - `_invokeInner()` drops the trailing `state` param and the `_fn(...args, state)` spread.
   - `__call(target, descriptor, optional?)` / `__callMethod(obj, prop, descriptor, optional?)` drop the `stateExtras` positional; the unused `maybeRunWithForkedStack` helper is deleted.
   - Codegen drops every `extras` argument from emitted `__call` / `__callMethod` invocations, including the `insideGlobalInit` branch's `{ ctx: __ctx }` (bootstrap frame seeds ALS already).

### Async-fork operator decision

The `{ stateStack: __forked }` extras path that codegen emits for `async helper()` unassigned calls was the only place where `__call`'s extras did meaningful work at runtime. Rather than carrying the special case across the cleanup, the codegen now wraps that call site in an inline `agencyStore.run` frame:

```ts
// before
await __call(target, descr, { stateStack: __forked });

// after
await agencyStore.run(
  { ...getRuntimeContext(), stack: __forked },
  () => __call(target, descr),
);
```

The callee picks up the branch's isolated stack via `getRuntimeContext()` — same end result, but the ALS frame is the only mechanism.

### Other TS call sites that historically passed `{ ctx, stateStack }` to `invoke()`

- `hooks.ts` `invokeCallback`: when `stateStack` is provided, the callback now runs inside an `agencyStore.run` frame that overrides `stack`.
- `prompt.ts` per-tool-call invocation: wraps in an `agencyStore.run` frame seeded with the per-tool `ThreadStore` and the branch `StateStack`.
- `validateChain.ts`: drops the `{ ctx }` arg entirely — invoke no longer reads it.

## Risk surface — PR #206 regression class

The class of regression that bit PR #206 was preapprove handlers + parallel/fork branches: a bug that skips the handler push (or pop) leaves the stack in an inconsistent state that only surfaces under load. To pin that contract:

- `agencyFunction.test.ts` — three new tests covering `withPushedHandler` correctness for preapproved tools (handler installed during call, popped on normal return, popped on throw, no-op for non-preapproved fns).
- `asyncContext.test.ts` — `withPushedHandler` pops in both finally paths.
- `runner.test.ts` — load-bearing test that `Runner.runInScope` actually seeds the ALS `callsite` slot. Without this, a future regression that deletes the `callsite: { ... }` block from `runInScope` would silently degrade every checkpoint to `""::""::""` and every `withCallsite` test would still pass.

Smoke tests run locally:

- `pnpm run agency test tests/agency/preapprove.test.json` — 5/5 ✓
- `pnpm run agency test tests/agency/fork/` — 67/67 ✓ across 65 files
- `pnpm run agency test tests/agency/interrupts/` — 16/16 ✓ across 11 files

## Validation

- `pnpm tsc --noEmit` ✓
- `pnpm run lint:structure` ✓
- `pnpm test:run` — 4425/4425 ✓
- `make` builds cleanly ✓
- Fixture spot-check: no `__call(..., { moduleId: ... })` and no `__call(..., { stateStack: ... })` remain — confirmed via `grep -nE "__call\(.+, \{" tests/typescriptGenerator/`.

## CHANGELOG note

External callers that imported `__call` / `__callMethod` from `agency-lang/runtime` should drop the `stateExtras` positional from their call sites. The arg was always ignored by `__call` after the ALS migration; this PR removes the type-level signature.
