### PR TITLE
runtime: introduce public agency.* namespace

### DIFF
--- a/packages/agency-lang/lib/runtime/agency.test.ts
+++ b/packages/agency-lang/lib/runtime/agency.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from "vitest";
+import { agency } from "./agency.js";
+import { agencyStore } from "./asyncContext.js";
+import { RuntimeContext } from "./state/context.js";
+import { StateStack } from "./state/stateStack.js";
+import { ThreadStore } from "./state/threadStore.js";
+import { RestoreSignal } from "./errors.js";
+import { CostGuard } from "./guard.js";
+import { makeMockCtx } from "./__tests__/testHelpers.js";
+
+function setup() {
+  const ctx = new RuntimeContext({
+    statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+    smoltalkDefaults: {},
+    dirname: process.cwd(),
+  });
+  const stack = new StateStack();
+  const threads = new ThreadStore();
+  return { ctx, stack, threads };
+}
+
+describe("agency.ctx / agency.ctxMaybe", () => {
+  it("ctx returns the active RuntimeContext inside a frame", () => {
+    const env = setup();
+    agency.withTestContext(env, () => {
+      expect(agency.ctx()).toBe(env.ctx);
+    });
+  });
+
+  it("ctx throws when called outside any frame", () => {
+    expect(() => agency.ctx()).toThrow(/outside an Agency execution frame/);
+  });
+
+  it("ctxMaybe returns undefined outside any frame", () => {
+    expect(agency.ctxMaybe()).toBeUndefined();
+  });
+
+  it("ctxMaybe returns the ctx inside a frame", () => {
+    const env = setup();
+    agency.withTestContext(env, () => {
+      expect(agency.ctxMaybe()).toBe(env.ctx);
+    });
+  });
+});
+
+describe("agency.callsite", () => {
+  it("returns undefined when no callsite installed", () => {
+    const env = setup();
+    agency.withTestContext(env, () => {
+      expect(agency.callsite()).toBeUndefined();
+    });
+  });
+
+  it("withCallsite installs a callsite that callsite() reads", () => {
+    const env = setup();
+    agency.withTestContext(env, () => {
+      const loc = { moduleId: "m", scopeName: "s", stepPath: "1.2" };
+      agency.withCallsite(loc, () => {
+        expect(agency.callsite()).toEqual(loc);
+      });
+      expect(agency.callsite()).toBeUndefined();
+    });
+  });
+
+  it("callsite returns undefined outside any frame", () => {
+    expect(agency.callsite()).toBeUndefined();
+  });
+});
+
+describe("agency.global", () => {
+  it("reads from ctx.globals with explicit moduleId", () => {
+    const env = setup();
+    env.ctx.globals.set("modA", "key1", "val1");
+    agency.withTestContext(env, () => {
+      expect(agency.global("key1", "modA")).toBe("val1");
+    });
+  });
+
+  it("uses empty moduleId by default", () => {
+    const env = setup();
+    env.ctx.globals.set("", "bareKey", "bareVal");
+    agency.withTestContext(env, () => {
+      expect(agency.global("bareKey")).toBe("bareVal");
+    });
+  });
+});
+
+describe("agency.thread (subnamespace)", () => {
+  it("current returns the active MessageThread, creating one if needed", () => {
+    const env = setup();
+    agency.withTestContext(env, () => {
+      const t = agency.thread.current();
+      expect(t).toBe(env.threads.getOrCreateActive());
+    });
+  });
+
+  for (const [method, role] of [
+    ["user", "user"],
+    ["system", "system"],
+    ["assistant", "assistant"],
+  ] as const) {
+    it(`${method} pushes a ${role}-role message`, () => {
+      const env = setup();
+      agency.withTestContext(env, () => {
+        (agency.thread as any)[method]("hi");
+        const msgs = env.threads.getOrCreateActive().messages;
+        expect(msgs.length).toBe(1);
+        expect(msgs[0].role).toBe(role);
+        expect(msgs[0].content).toBe("hi");
+      });
+    });
+  }
+
+  it("store returns the active ThreadStore; throws outside a frame", () => {
+    expect(() => agency.thread.store()).toThrow();
+    const env = setup();
+    agency.withTestContext(env, () => {
+      expect(agency.thread.store()).toBe(env.threads);
+    });
+  });
+
+  it("storeMaybe returns undefined outside a frame", () => {
+    expect(agency.thread.storeMaybe()).toBeUndefined();
+    const env = setup();
+    agency.withTestContext(env, () => {
+      expect(agency.thread.storeMaybe()).toBe(env.threads);
+    });
+  });
+
+  it("with pushes/pops the active stack on normal return", async () => {
+    const env = setup();
+    // Seed a base active id so we can observe restoration.
+    env.threads.getOrCreateActive();
+    await agency.withTestContext(env, async () => {
+      const base = env.threads.activeId();
+      await agency.thread.with("aux", async () => {
+        expect(env.threads.activeId()).toBe("aux");
+      });
+      expect(env.threads.activeId()).toBe(base);
+    });
+  });
+
+  it("with pops the active stack on throw", async () => {
+    const env = setup();
+    env.threads.getOrCreateActive();
+    await agency.withTestContext(env, async () => {
+      const base = env.threads.activeId();
+      await expect(
+        agency.thread.with("aux", async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+      expect(env.threads.activeId()).toBe(base);
+    });
+  });
+});
+
+describe("agency.checkpoint / getCheckpoint / restore", () => {
+  // Checkpoint creation requires a node id on the state stack;
+  // `makeMockCtx()` pre-seeds one ("process"), matching what
+  // `checkpoint.test.ts` does.
+
+  it("checkpoint + getCheckpoint round-trip", async () => {
+    const ctx = makeMockCtx();
+    const id = await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads: new ThreadStore() },
+      () => agency.checkpoint(),
+    );
+    const cp = agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads: new ThreadStore() },
+      () => agency.getCheckpoint(id),
+    );
+    expect(cp.id).toBe(id);
+  });
+
+  it("restore throws RestoreSignal", async () => {
+    const ctx = makeMockCtx();
+    const id = await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads: new ThreadStore() },
+      () => agency.checkpoint(),
+    );
+    expect(() =>
+      agency.withTestContext(
+        { ctx, stack: ctx.stateStack, threads: new ThreadStore() },
+        () => agency.restore(id),
+      ),
+    ).toThrow(RestoreSignal);
+  });
+});
+
+describe("agency.withHandler", () => {
+  it("pushes/pops handler on normal return", async () => {
+    const env = setup();
+    await agency.withTestContext(env, async () => {
+      const before = env.ctx.handlers.length;
+      let lenDuring = -1;
+      await agency.withHandler(
+        async () => ({ type: "approve" as const, value: undefined }),
+        async () => {
+          lenDuring = env.ctx.handlers.length;
+        },
+      );
+      expect(lenDuring).toBe(before + 1);
+      expect(env.ctx.handlers.length).toBe(before);
+    });
+  });
+
+  it("pops handler on throw", async () => {
+    const env = setup();
+    await agency.withTestContext(env, async () => {
+      const before = env.ctx.handlers.length;
+      await expect(
+        agency.withHandler(
+          async () => ({ type: "approve" as const, value: undefined }),
+          async () => {
+            throw new Error("x");
+          },
+        ),
+      ).rejects.toThrow("x");
+      expect(env.ctx.handlers.length).toBe(before);
+    });
+  });
+});
+
+describe("agency.withCostGuard", () => {
+  it("pushes a CostGuard for the duration of fn and pops on return", async () => {
+    const env = setup();
+    await agency.withTestContext(env, async () => {
+      const before = env.ctx.stateStack.guards.length;
+      let lenDuring = -1;
+      let kindDuring: unknown;
+      await agency.withCostGuard(0.5, async () => {
+        lenDuring = env.ctx.stateStack.guards.length;
+        kindDuring = env.ctx.stateStack.guards[lenDuring - 1];
+      });
+      expect(lenDuring).toBe(before + 1);
+      expect(kindDuring).toBeInstanceOf(CostGuard);
+      expect(env.ctx.stateStack.guards.length).toBe(before);
+    });
+  });
+
+  it("pops guard on throw", async () => {
+    const env = setup();
+    await agency.withTestContext(env, async () => {
+      const before = env.ctx.stateStack.guards.length;
+      await expect(
+        agency.withCostGuard(0.5, async () => {
+          throw new Error("x");
+        }),
+      ).rejects.toThrow("x");
+      expect(env.ctx.stateStack.guards.length).toBe(before);
+    });
+  });
+});
+
+describe("agency.withTestContext", () => {
+  it("installs a usable frame and tears it down", () => {
+    const env = setup();
+    agency.withTestContext(env, () => {
+      expect(agency.ctxMaybe()).toBe(env.ctx);
+      expect(agency.thread.storeMaybe()).toBe(env.threads);
+    });
+    expect(agency.ctxMaybe()).toBeUndefined();
+    expect(agencyStore.getStore()).toBeUndefined();
+  });
+});

--- a/packages/agency-lang/lib/runtime/agency.test.ts
+++ b/packages/agency-lang/lib/runtime/agency.test.ts
@@ -5,7 +5,7 @@ import { RuntimeContext } from "./state/context.js";
 import { StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { RestoreSignal } from "./errors.js";
-import { CostGuard } from "./guard.js";
+import { CostGuard, TimeGuard } from "./guard.js";
 import { makeMockCtx } from "./__tests__/testHelpers.js";
 
 function setup() {
@@ -223,32 +223,105 @@ describe("agency.withHandler", () => {
 });
 
 describe("agency.withCostGuard", () => {
-  it("pushes a CostGuard for the duration of fn and pops on return", async () => {
+  it("pushes a CostGuard onto the ALS stack for the duration of fn", async () => {
     const env = setup();
     await agency.withTestContext(env, async () => {
-      const before = env.ctx.stateStack.guards.length;
+      const before = env.stack.guards.length;
       let lenDuring = -1;
       let kindDuring: unknown;
       await agency.withCostGuard(0.5, async () => {
-        lenDuring = env.ctx.stateStack.guards.length;
-        kindDuring = env.ctx.stateStack.guards[lenDuring - 1];
+        lenDuring = env.stack.guards.length;
+        kindDuring = env.stack.guards[lenDuring - 1];
       });
       expect(lenDuring).toBe(before + 1);
       expect(kindDuring).toBeInstanceOf(CostGuard);
-      expect(env.ctx.stateStack.guards.length).toBe(before);
+      expect(env.stack.guards.length).toBe(before);
+    });
+  });
+
+  it("targets the ALS stack, not ctx.stateStack (per-branch isolation)", async () => {
+    // Simulates a fork branch: pass a fresh stack as the ALS stack,
+    // distinct from ctx.stateStack. The guard must land on the ALS
+    // stack so it stays branch-local.
+    const env = setup();
+    const branchStack = new StateStack();
+    await agency.withTestContext(
+      { ctx: env.ctx, stack: branchStack, threads: env.threads },
+      async () => {
+        await agency.withCostGuard(0.5, async () => {
+          expect(branchStack.guards.length).toBe(1);
+          expect(env.ctx.stateStack.guards.length).toBe(0);
+        });
+      },
+    );
+    expect(branchStack.guards.length).toBe(0);
+    expect(env.ctx.stateStack.guards.length).toBe(0);
+  });
+
+  it("pops guard on throw", async () => {
+    const env = setup();
+    await agency.withTestContext(env, async () => {
+      const before = env.stack.guards.length;
+      await expect(
+        agency.withCostGuard(0.5, async () => {
+          throw new Error("x");
+        }),
+      ).rejects.toThrow("x");
+      expect(env.stack.guards.length).toBe(before);
+    });
+  });
+});
+
+describe("agency.withTimeGuard", () => {
+  it("pushes a TimeGuard onto the ALS stack and pops on return", async () => {
+    const env = setup();
+    await agency.withTestContext(env, async () => {
+      const before = env.stack.guards.length;
+      let lenDuring = -1;
+      let kindDuring: unknown;
+      await agency.withTimeGuard(60_000, async () => {
+        lenDuring = env.stack.guards.length;
+        kindDuring = env.stack.guards[lenDuring - 1];
+      });
+      expect(lenDuring).toBe(before + 1);
+      expect(kindDuring).toBeInstanceOf(TimeGuard);
+      expect(env.stack.guards.length).toBe(before);
     });
   });
 
   it("pops guard on throw", async () => {
     const env = setup();
     await agency.withTestContext(env, async () => {
-      const before = env.ctx.stateStack.guards.length;
+      const before = env.stack.guards.length;
       await expect(
-        agency.withCostGuard(0.5, async () => {
+        agency.withTimeGuard(60_000, async () => {
           throw new Error("x");
         }),
       ).rejects.toThrow("x");
-      expect(env.ctx.stateStack.guards.length).toBe(before);
+      expect(env.stack.guards.length).toBe(before);
+    });
+  });
+});
+
+describe("agency.addCost", () => {
+  it("adds to the ALS stack's localCost", () => {
+    const env = setup();
+    agency.withTestContext(env, () => {
+      const before = env.stack.localCost;
+      agency.addCost(0.25);
+      expect(env.stack.localCost).toBe(before + 0.25);
+    });
+  });
+
+  it("charges every installed guard and trips when over budget", async () => {
+    const env = setup();
+    await agency.withTestContext(env, async () => {
+      await expect(
+        agency.withCostGuard(0.1, async () => {
+          agency.addCost(0.05); // under
+          agency.addCost(0.10); // total 0.15 > 0.1 — trips
+        }),
+      ).rejects.toThrow();
     });
   });
 });

--- a/packages/agency-lang/lib/runtime/agency.ts
+++ b/packages/agency-lang/lib/runtime/agency.ts
@@ -1,0 +1,204 @@
+/**
+ * Public `agency.*` namespace — the canonical entry point for TS code
+ * that wants to participate in an Agency run (read context, push
+ * thread messages, install handlers, create checkpoints, etc.).
+ *
+ * Every method is a thin wrapper over an existing runtime function;
+ * no new behavior is added here. The namespace exists for
+ * discoverability and to give docs/IDEs a single surface to point at.
+ *
+ * Naming conventions:
+ *  - No underscore prefix. Read APIs throw on missing frame by
+ *    default; `*Maybe` variants return `undefined` instead.
+ *  - `with*` prefix for scope-installing helpers (run a callback with
+ *    a temporary modification to the active frame).
+ *  - Thread-related operations live under `agency.thread.*` to keep
+ *    the top-level surface lean; e.g. `agency.thread.user("hi")` and
+ *    `agency.thread.current()`.
+ *  - Codegen-emitted internals (`getRuntimeContext`, `agencyStore`,
+ *    `__threads`, `__stateStack`, `__call`, `__callMethod`,
+ *    `runInTestContext`) keep their existing names and are still
+ *    exported from `agency-lang/runtime` because generated code
+ *    imports them directly. TS helper authors should prefer
+ *    `agency.*`.
+ *
+ * See docs/site/guide/ts-helpers.md (PR #5) for the long-form guide.
+ */
+import * as smoltalk from "smoltalk";
+import {
+  agencyStore,
+  getRuntimeContext,
+  runInTestContext,
+  withCallsite as _withCallsite,
+  withPushedHandler,
+  type CallsiteLocation,
+} from "./asyncContext.js";
+import {
+  checkpoint as _checkpoint,
+  getCheckpoint as _getCheckpoint,
+  restore as _restore,
+} from "./checkpoint.js";
+import type { RestoreOptions } from "./errors.js";
+import { CostGuard } from "./guard.js";
+import type { Checkpoint } from "./state/checkpointStore.js";
+import type { RuntimeContext } from "./state/context.js";
+import type { StateStack } from "./state/stateStack.js";
+import type { MessageThread } from "./state/messageThread.js";
+import type { ThreadStore } from "./state/threadStore.js";
+import type { HandlerFn } from "./types.js";
+
+// ---- Context reads -----------------------------------------------------
+
+/** Read the active `RuntimeContext`. Throws when called outside any
+ *  `agencyStore.run(...)` frame (i.e. from non-Agency code). Tests
+ *  that need a frame can use `agency.withTestContext({ctx,stack,threads}, fn)`. */
+const ctx = (): RuntimeContext<any> => getRuntimeContext().ctx;
+
+/** Lax variant of `agency.ctx()`. Returns `undefined` outside any frame. */
+const ctxMaybe = (): RuntimeContext<any> | undefined => agencyStore.getStore()?.ctx;
+
+/** Per-call-site source location seeded by `Runner.runInScope` for
+ *  every step body. Returns `undefined` outside any frame or in
+ *  frames where no callsite was installed (bootstrap scope). */
+const callsite = (): CallsiteLocation | undefined => agencyStore.getStore()?.callsite;
+
+/** Read a module-scoped global. Same semantics as the Agency-level
+ *  `globals.get(moduleId, name)`. `moduleId` defaults to `""`
+ *  (the bare/anonymous module). */
+const global_ = <T = unknown>(name: string, moduleId = ""): T =>
+  ctx().globals.get(moduleId, name) as T;
+
+// ---- Thread subnamespace ----------------------------------------------
+
+/** Active `MessageThread`, creating one if none is active yet. */
+const threadCurrent = (): MessageThread =>
+  getRuntimeContext().threads.getOrCreateActive();
+
+/** Push a user-role message onto the active thread. */
+const threadUser = (content: string): void => {
+  threadCurrent().push(smoltalk.userMessage(content));
+};
+
+/** Push a system-role message onto the active thread. */
+const threadSystem = (content: string): void => {
+  threadCurrent().push(smoltalk.systemMessage(content));
+};
+
+/** Push an assistant-role message onto the active thread. */
+const threadAssistant = (content: string): void => {
+  threadCurrent().push(smoltalk.assistantMessage(content));
+};
+
+/** Return the full `ThreadStore`. Throws when called outside any frame. */
+const threadStore = (): ThreadStore => getRuntimeContext().threads;
+
+/** Lax variant of `agency.thread.store()`. Returns `undefined` outside any frame. */
+const threadStoreMaybe = (): ThreadStore | undefined => agencyStore.getStore()?.threads;
+
+/** Run `fn` with `threadId` pushed as the active thread; pop the
+ *  active stack (including on throw) when `fn` returns. */
+const threadWith = async <T>(
+  threadId: string,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  const store = threadStore();
+  store.pushActive(threadId);
+  try {
+    return await fn();
+  } finally {
+    store.popActive();
+  }
+};
+
+// ---- Checkpoints -------------------------------------------------------
+
+/** Capture a checkpoint of the current execution state. The recorded
+ *  location is read from the active ALS callsite slot. */
+const checkpoint = (): Promise<number> => _checkpoint();
+
+/** Look up a previously-created checkpoint by id. Throws if missing. */
+const getCheckpoint = (id: number): Checkpoint => _getCheckpoint(id);
+
+/** Restore execution to a prior checkpoint. Throws `RestoreSignal`;
+ *  the surrounding runtime catches it and rewinds. */
+const restore = (
+  idOrCp: number | Checkpoint,
+  opts: RestoreOptions = {},
+): void => _restore(idOrCp, opts);
+
+/** Run `fn` with a custom `callsite` installed on the active frame.
+ *  Throws when called outside any agency frame. */
+const withCallsite = <T>(loc: CallsiteLocation, fn: () => T): T =>
+  _withCallsite(loc, fn);
+
+// ---- Handlers / guards ------------------------------------------------
+
+/** Push `handler` onto `ctx.handlers` for the duration of `fn`; pop in
+ *  finally. Thin wrapper over the shared `withPushedHandler` primitive
+ *  in `asyncContext.ts` so user code and `AgencyFunction`'s preapprove
+ *  factory go through the same encapsulated combinator. */
+const withHandler = <T>(
+  handler: HandlerFn,
+  fn: () => Promise<T>,
+): Promise<T> => withPushedHandler(ctx(), handler, fn);
+
+/** Install a `CostGuard(maxCost)` on the active branch's
+ *  `StateStack.guards` for the duration of `fn`; pop in finally. */
+const withCostGuard = async <T>(
+  maxCost: number,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  const stack = ctx().stateStack;
+  stack.pushGuard(new CostGuard(maxCost));
+  try {
+    return await fn();
+  } finally {
+    stack.popGuard();
+  }
+};
+
+// ---- Test helpers ------------------------------------------------------
+
+/** Install an ALS frame from explicit `{ctx, stack, threads}` for
+ *  tests that exercise stdlib helpers directly. Mirrors
+ *  `runInTestContext` with an object-arg signature so it composes
+ *  with the rest of the namespace. */
+const withTestContext = <T>(
+  args: { ctx: RuntimeContext<any>; stack: StateStack; threads: ThreadStore },
+  fn: () => T,
+): T => runInTestContext(args.ctx, args.stack, args.threads, fn);
+
+// ---- Namespace ---------------------------------------------------------
+
+/**
+ * Public `agency` namespace — the canonical entry point for TS code
+ * that wants to participate in an Agency run. Users access everything
+ * through `agency.<method>(...)`; there are no individual named
+ * exports.
+ */
+export const agency = {
+  ctx,
+  ctxMaybe,
+  callsite,
+  global: global_,
+
+  thread: {
+    current: threadCurrent,
+    user: threadUser,
+    system: threadSystem,
+    assistant: threadAssistant,
+    store: threadStore,
+    storeMaybe: threadStoreMaybe,
+    with: threadWith,
+  },
+
+  checkpoint,
+  getCheckpoint,
+  restore,
+  withCallsite,
+
+  withHandler,
+  withCostGuard,
+
+  withTestContext,
+};

--- a/packages/agency-lang/lib/runtime/agency.ts
+++ b/packages/agency-lang/lib/runtime/agency.ts
@@ -10,6 +10,9 @@
  * Naming conventions:
  *  - No underscore prefix. Read APIs throw on missing frame by
  *    default; `*Maybe` variants return `undefined` instead.
+ *    `callsite()` is the lone exception: callsite is intrinsically
+ *    optional (bootstrap frames omit it) so it always returns
+ *    `CallsiteLocation | undefined` even from inside a valid frame.
  *  - `with*` prefix for scope-installing helpers (run a callback with
  *    a temporary modification to the active frame).
  *  - Thread-related operations live under `agency.thread.*` to keep
@@ -21,8 +24,6 @@
  *    exported from `agency-lang/runtime` because generated code
  *    imports them directly. TS helper authors should prefer
  *    `agency.*`.
- *
- * See docs/site/guide/ts-helpers.md (PR #5) for the long-form guide.
  */
 import * as smoltalk from "smoltalk";
 import {
@@ -39,7 +40,7 @@ import {
   restore as _restore,
 } from "./checkpoint.js";
 import type { RestoreOptions } from "./errors.js";
-import { CostGuard } from "./guard.js";
+import { CostGuard, TimeGuard } from "./guard.js";
 import type { Checkpoint } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import type { StateStack } from "./state/stateStack.js";
@@ -96,10 +97,11 @@ const threadStore = (): ThreadStore => getRuntimeContext().threads;
 const threadStoreMaybe = (): ThreadStore | undefined => agencyStore.getStore()?.threads;
 
 /** Run `fn` with `threadId` pushed as the active thread; pop the
- *  active stack (including on throw) when `fn` returns. */
+ *  active stack (including on throw) when `fn` returns. Accepts a
+ *  sync or async callback. */
 const threadWith = async <T>(
   threadId: string,
-  fn: () => Promise<T>,
+  fn: () => T | Promise<T>,
 ): Promise<T> => {
   const store = threadStore();
   store.pushActive(threadId);
@@ -126,8 +128,23 @@ const restore = (
   opts: RestoreOptions = {},
 ): void => _restore(idOrCp, opts);
 
-/** Run `fn` with a custom `callsite` installed on the active frame.
- *  Throws when called outside any agency frame. */
+/** Run `fn` with a custom `callsite` (`{moduleId, scopeName, stepPath}`)
+ *  installed on the active ALS frame; restore the prior callsite when
+ *  `fn` returns. The callsite is the source location used to attribute
+ *  any `checkpoint()` made inside `fn` — `Runner.runInScope` seeds it
+ *  automatically for every Agency step, but TS helpers that subdivide
+ *  their own work into substeps can use this to give each substep a
+ *  distinct location in debugger UIs / trace files.
+ *
+ *  Example:
+ *    agency.withCallsite(
+ *      { moduleId: "my.helper", scopeName: "retry", stepPath: "2.1" },
+ *      async () => { await agency.checkpoint(); ... },
+ *    );
+ *
+ *  Most TS helpers will never need this — the auto-seeded callsite
+ *  from the surrounding step is the right answer. Throws if no
+ *  Agency frame is installed. */
 const withCallsite = <T>(loc: CallsiteLocation, fn: () => T): T =>
   _withCallsite(loc, fn);
 
@@ -142,13 +159,18 @@ const withHandler = <T>(
   fn: () => Promise<T>,
 ): Promise<T> => withPushedHandler(ctx(), handler, fn);
 
-/** Install a `CostGuard(maxCost)` on the active branch's
- *  `StateStack.guards` for the duration of `fn`; pop in finally. */
+/** Install a `CostGuard(maxCost)` on the active branch's `StateStack.guards`
+ *  for the duration of `fn`; pop in finally.
+ *
+ *  Pushes onto `getRuntimeContext().stack` — the ALS-resolved
+ *  per-branch stack — NOT `ctx().stateStack` (which is the top-level
+ *  stack). Inside a fork/race branch the two stacks differ; pushing
+ *  on the wrong one would leak the guard into sibling branches. */
 const withCostGuard = async <T>(
   maxCost: number,
   fn: () => Promise<T>,
 ): Promise<T> => {
-  const stack = ctx().stateStack;
+  const stack = getRuntimeContext().stack;
   stack.pushGuard(new CostGuard(maxCost));
   try {
     return await fn();
@@ -157,12 +179,49 @@ const withCostGuard = async <T>(
   }
 };
 
+/** Install a `TimeGuard(maxMs)` on the active branch's stack for the
+ *  duration of `fn`; pop in finally. Same ALS-stack semantics as
+ *  `withCostGuard`. */
+const withTimeGuard = async <T>(
+  maxMs: number,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  const stack = getRuntimeContext().stack;
+  stack.pushGuard(new TimeGuard(maxMs));
+  try {
+    return await fn();
+  } finally {
+    stack.popGuard();
+  }
+};
+
+/** Add `amount` (USD, float) to the active branch's cost accumulator
+ *  and bill every installed guard. Throws `GuardExceededError` if any
+ *  guard has tripped.
+ *
+ *  Intended for TS helpers that wrap their own LLM (or other paid)
+ *  call site and want the cost to participate in `agency.getCost()` /
+ *  `agency.withCostGuard()` tracking the same way the built-in `llm()`
+ *  primitive does. The built-in path in `lib/runtime/prompt.ts` does
+ *  exactly this sequence after every completion. */
+const addCost = (amount: number): void => {
+  const stack = getRuntimeContext().stack;
+  stack.localCost += amount;
+  stack.chargeGuards(amount);
+  stack.enforceGuards();
+};
+
 // ---- Test helpers ------------------------------------------------------
 
-/** Install an ALS frame from explicit `{ctx, stack, threads}` for
- *  tests that exercise stdlib helpers directly. Mirrors
- *  `runInTestContext` with an object-arg signature so it composes
- *  with the rest of the namespace. */
+/**
+ * @internal
+ * Install an ALS frame from explicit `{ctx, stack, threads}` for
+ * tests that exercise stdlib helpers directly. Mirrors
+ * `runInTestContext` with an object-arg signature so test bodies
+ * compose with the rest of the namespace. Not intended for
+ * production TS-helper code — application code runs inside an
+ * Agency frame already seeded by `Runner.runInScope`.
+ */
 const withTestContext = <T>(
   args: { ctx: RuntimeContext<any>; stack: StateStack; threads: ThreadStore },
   fn: () => T,
@@ -199,6 +258,8 @@ export const agency = {
 
   withHandler,
   withCostGuard,
+  withTimeGuard,
+  addCost,
 
   withTestContext,
 };

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -6,6 +6,15 @@ export type {
 } from "./types.js";
 export type { Interrupt, InterruptResponse } from "./interrupts.js";
 export { RuntimeContext } from "./state/context.js";
+export { agency } from "./agency.js";
+export type { CallsiteLocation } from "./asyncContext.js";
+/**
+ * The exports below are the codegen-internal surface that generated
+ * Agency code imports directly. They are NOT recommended for TS
+ * helper authors — use the `agency.*` namespace above instead. Kept
+ * here because every generated `prog.ts` references them via
+ * `agency-lang/runtime`.
+ */
 export {
   agencyStore,
   getRuntimeContext,


### PR DESCRIPTION
## Summary

Introduces a public `agency.*` namespace exported from
`agency-lang/runtime` — the canonical entry point for TS code that
wants to participate in an Agency run. Purely additive: no fixture
changes, no behavior changes.

This is the first of three planned API PRs for the "TS helpers as
first-class participants" effort, and combines Plan 2 (namespace)
with the Task 4 cleanup from Plan 1. The Task 4 cleanup grep
returned empty (`CheckpointLocation`, `maybeRunWithForkedStack`,
`stateExtras`, `state?: unknown`) — Plan 1's PR already removed
them — so the diff here is purely the namespace.

## Surface

```ts
import { agency } from "agency-lang/runtime";

// context reads
agency.ctx() / ctxMaybe()
agency.callsite()
agency.global<T>(name, moduleId?)

// thread subnamespace
agency.thread.current()
agency.thread.user(content) / system(content) / assistant(content)
agency.thread.store() / storeMaybe()
agency.thread.with(threadId, fn)

// checkpoints
agency.checkpoint()
agency.getCheckpoint(id)
agency.restore(id | cp, opts?)
agency.withCallsite(loc, fn)

// handlers / guards
agency.withHandler(handler, fn)
agency.withCostGuard(maxCost, fn)

// test helpers
agency.withTestContext({ctx,stack,threads}, fn)
```

## Design decisions

- **Thread subnamespace from day one.** `agency.thread.*` keeps the
  top-level surface lean and avoids a breaking re-namespacing later
  once the cluster grows (`current` / `user` / `system` /
  `assistant` / `store` / `storeMaybe` / `with` is already 7
  entries). Adding a top-level `agency.userMessage` and migrating
  to `agency.thread.user` later would be a breaking change.

- **No `tool` helper in v1.** `smoltalk.toolMessage(...)` requires a
  `tool_call_id`, which TS helpers rarely have on hand (those are
  emitted by LLM responses). Authors who really need to push a tool
  message can do `agency.thread.current().push(smoltalk.toolMessage(...))`
  directly. Easy to add later if real demand shows up.

- **No `agency.llm` or `agency.withResumableScope` yet.** Those
  land in their own PRs (Plans 3 and 4). Adding them here would
  inflate review surface and conflict with the resumable-scope
  design that is still in flight.

- **Existing exports stay.** `getRuntimeContext`, `agencyStore`,
  `__threads`, `__stateStack`, `__ctx`, `runInTestContext` are still
  re-exported from `lib/runtime/index.ts` because every generated
  `prog.ts` imports them by name. They are now marked in JSDoc as
  the codegen-internal surface — TS helper authors should prefer
  `agency.*`. A separate follow-up could regenerate fixtures to
  drop these from the public API entirely, but that is not "purely
  additive" and out of scope here.

- **`withHandler` delegates to the existing `withPushedHandler`**
  primitive in `asyncContext.ts` — no duplicated push/try/finally
  dance, same combinator as `AgencyFunction.preapprove()`'s factory.

## Tests

`lib/runtime/agency.test.ts` — 24 tests, one per method, including
throw-path restoration for `withHandler` / `withCostGuard` /
`thread.with` and a checkpoint round-trip.

## Validation

- `pnpm tsc --noEmit` clean
- `pnpm run lint:structure` clean
- `pnpm test:run` — 4449 / 4449 passing (4425 baseline + 24 new)
- `git status` — only `lib/runtime/agency.ts`, `lib/runtime/agency.test.ts`,
  `lib/runtime/index.ts` changed; no fixtures touched

## Naming bikeshedding

The spec uses `agency`, which overloads with "Agency the language".
Alternatives considered: `runtime`, `lang`, `rt`. Happy to rename if
you'd prefer something else now — retrofitting is breaking, so it's
worth deciding before merge.
