### PR TITLE
runtime: add agency.llm() for TS callers

### DIFF
--- a/packages/agency-lang/lib/runtime/agency.ts
+++ b/packages/agency-lang/lib/runtime/agency.ts
@@ -34,6 +34,7 @@ import {
   withPushedHandler,
   type CallsiteLocation,
 } from "./asyncContext.js";
+import { llm as _llm } from "./agencyLlm.js";
 import {
   checkpoint as _checkpoint,
   getCheckpoint as _getCheckpoint,
@@ -267,6 +268,8 @@ export const agency = {
   addCost,
 
   withResumableScope: _withResumableScope,
+
+  llm: _llm,
 
   withTestContext,
 };

--- a/packages/agency-lang/lib/runtime/agencyLlm.checkpointInfo.test.ts
+++ b/packages/agency-lang/lib/runtime/agencyLlm.checkpointInfo.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+
+/**
+ * Pin the contract that `agency.llm` forwards `agency.callsite()` to
+ * `runPrompt` as `checkpointInfo`. A regression that drops that
+ * forwarding would silently disable interrupt-checkpoint location
+ * attribution for TS-issued LLM calls — `getResultCheckpoint()` would
+ * still find the result-entry pin, but the runtime checkpoint
+ * `PromptRunner` writes when the LLM call interrupts would lose its
+ * `moduleId / scopeName / stepPath`. That makes the rewind UI show
+ * "unknown location" and breaks `step in / over` after a resumed
+ * interrupt. We can't observe `checkpointInfo` via the LLM client
+ * (it's consumed by `PromptRunner`, not by the client), so we mock
+ * `runPrompt` itself and read the field off the captured args.
+ *
+ * Lives in its own file because `vi.mock` is module-scoped and we
+ * don't want it to replace `runPrompt` for every other agencyLlm
+ * test in this directory.
+ */
+vi.mock("./prompt.js", () => ({
+  runPrompt: vi.fn(async () => "spy-response"),
+}));
+
+import { agency } from "./agency.js";
+import { RuntimeContext } from "./state/context.js";
+import { ThreadStore } from "./state/threadStore.js";
+import { runPrompt } from "./prompt.js";
+
+function makeCtx(): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: {},
+    dirname: "/tmp",
+  });
+}
+
+describe("agency.llm — checkpointInfo forwarding", () => {
+  it("passes agency.callsite() to runPrompt as checkpointInfo", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const spy = runPrompt as unknown as ReturnType<typeof vi.fn>;
+    spy.mockClear();
+
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      () =>
+        agency.withCallsite(
+          { moduleId: "M", scopeName: "S", stepPath: "1.2" },
+          () => agency.llm("hi"),
+        ),
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0]).toMatchObject({
+      checkpointInfo: { moduleId: "M", scopeName: "S", stepPath: "1.2" },
+    });
+  });
+
+  it("checkpointInfo is undefined when no callsite is installed", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const spy = runPrompt as unknown as ReturnType<typeof vi.fn>;
+    spy.mockClear();
+
+    // withTestContext installs a frame with `callsite: undefined`.
+    // `agency.llm` reads `agencyStore.getStore()?.callsite` so the
+    // forwarded value should also be undefined — not a stale value
+    // from a previous test, not a synthesized placeholder.
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      () => agency.llm("hi"),
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][0].checkpointInfo).toBeUndefined();
+  });
+});

--- a/packages/agency-lang/lib/runtime/agencyLlm.test.ts
+++ b/packages/agency-lang/lib/runtime/agencyLlm.test.ts
@@ -168,6 +168,40 @@ describe("agency.llm — options mapping", () => {
   // that to replace `runPrompt` for the other tests here).
 });
 
+describe("agency.llm — return type", () => {
+  it("returns Promise<string> without a schema (compile-time check)", async () => {
+    const ctx = makeCtx();
+    ctx.setLLMClient(new DeterministicClient([{ return: "hi" }]));
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    await inFrame(ctx, threads, async () => {
+      const r = await agency.llm("p");
+      // Type-level assertion: r must be string here. If the overload
+      // ever loses the no-schema branch this becomes a TS error.
+      const _s: string = r;
+      expect(typeof _s).toBe("string");
+    });
+  });
+
+  it("returns Promise<z.infer<S>> when a schema is provided (compile-time check)", async () => {
+    const ctx = makeCtx();
+    const schema = z.object({ first: z.string(), last: z.string() });
+    ctx.setLLMClient(
+      new DeterministicClient([{ return: { first: "ada", last: "lovelace" } }]),
+    );
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    await inFrame(ctx, threads, async () => {
+      const r = await agency.llm("extract", { schema });
+      // Type-level assertion: r is `{ first: string; last: string }`.
+      const first: string = r.first;
+      const last: string = r.last;
+      // @ts-expect-error — wrong field on the schema-typed result.
+      const _missing: string = r.missing;
+      expect(first).toBe("ada");
+      expect(last).toBe("lovelace");
+    });
+  });
+});
+
 describe("agency.llm — v1 surface lock", () => {
   it("LlmOpts has no tools / removedTools / maxToolCallRounds fields", async () => {
     const ctx = makeCtx();

--- a/packages/agency-lang/lib/runtime/agencyLlm.test.ts
+++ b/packages/agency-lang/lib/runtime/agencyLlm.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import type { Result, PromptResult, StreamChunk } from "smoltalk";
+import { agency } from "./agency.js";
+import { DeterministicClient } from "./deterministicClient.js";
+import type { EmbedConfig, EmbedResult, LLMClient, PromptConfig } from "./llmClient.js";
+import { RuntimeContext } from "./state/context.js";
+import { ThreadStore } from "./state/threadStore.js";
+
+function makeCtx(): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: { model: "default-model" },
+    dirname: "/tmp",
+  });
+}
+
+function inFrame<T>(
+  ctx: RuntimeContext<any>,
+  threads: ThreadStore,
+  fn: () => Promise<T>,
+): Promise<T> {
+  return agency.withTestContext({ ctx, stack: ctx.stateStack, threads }, fn);
+}
+
+/** Custom LLM client that records every PromptConfig it sees. Used to
+ *  pin the `clientConfig.model` flow-through (does `opts.model` reach
+ *  the client? does it leak into subsequent calls?). */
+class RecordingClient implements LLMClient {
+  configs: PromptConfig[] = [];
+  responses: string[];
+  private idx = 0;
+
+  constructor(responses: string[] = ["ok"]) {
+    this.responses = responses;
+  }
+
+  async text(config: PromptConfig): Promise<Result<PromptResult>> {
+    this.configs.push(config);
+    const output = this.responses[this.idx++] ?? "ok";
+    return {
+      success: true,
+      value: {
+        output,
+        toolCalls: [],
+        model: (config as any).model ?? "unknown",
+        usage: { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0, totalTokens: 2 },
+        cost: { inputCost: 0.000001, outputCost: 0.000001, totalCost: 0.000002, currency: "USD" },
+      },
+    };
+  }
+
+  async *textStream(config: PromptConfig): AsyncGenerator<StreamChunk> {
+    const r = await this.text(config);
+    if (r.success) yield { type: "done", result: r.value };
+    else yield { type: "error", error: r.error };
+  }
+
+  async embed(
+    _input: string | string[],
+    _config?: Partial<EmbedConfig>,
+  ): Promise<Result<EmbedResult>> {
+    return { success: false, error: "not implemented" };
+  }
+}
+
+describe("agency.llm — basic behavior", () => {
+  it("returns the assistant string response from a single LLM call", async () => {
+    const ctx = makeCtx();
+    ctx.setLLMClient(new DeterministicClient([{ return: "hello" }]));
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const r = await inFrame(ctx, threads, () => agency.llm("hi"));
+    expect(r).toBe("hello");
+  });
+
+  it("prompt and assistant response land in the active thread", async () => {
+    const ctx = makeCtx();
+    ctx.setLLMClient(new DeterministicClient([{ return: "world" }]));
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    await inFrame(ctx, threads, () => agency.llm("hello"));
+    const msgs = threads.active()!.getMessages();
+    const roles = msgs.map((m: any) => m.role);
+    expect(roles).toEqual(["user", "assistant"]);
+    expect(msgs[0].content).toBe("hello");
+    expect(msgs[1].content).toBe("world");
+  });
+
+  it("cost tracking: the active stack's localCost increments after the call", async () => {
+    const ctx = makeCtx();
+    ctx.setLLMClient(new DeterministicClient([{ return: "x" }]));
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const before = ctx.stateStack.localCost;
+    await inFrame(ctx, threads, () => agency.llm("hi"));
+    expect(ctx.stateStack.localCost).toBeGreaterThan(before);
+  });
+
+  it("structured output: parses the response against opts.schema", async () => {
+    const ctx = makeCtx();
+    const schema = z.object({ name: z.string(), age: z.number() });
+    ctx.setLLMClient(
+      new DeterministicClient([{ return: { name: "ada", age: 36 } }]),
+    );
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const r = await inFrame(ctx, threads, () =>
+      agency.llm("extract", { schema }),
+    );
+    expect(r).toEqual({ name: "ada", age: 36 });
+  });
+});
+
+describe("agency.llm — options mapping", () => {
+  it("opts.thread routes the prompt + response to the override thread, not the active one", async () => {
+    const ctx = makeCtx();
+    ctx.setLLMClient(new DeterministicClient([{ return: "aux-response" }]));
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const auxId = threads.create();
+    const auxThread = threads.get(auxId)!;
+    await inFrame(ctx, threads, () =>
+      agency.llm("aux-prompt", { thread: auxThread }),
+    );
+    expect(auxThread.getMessages().map((m: any) => m.content)).toEqual([
+      "aux-prompt",
+      "aux-response",
+    ]);
+    // The active (default) thread is unaffected.
+    expect(threads.active()!.getMessages()).toEqual([]);
+  });
+
+  it("opts.model overrides the model for THIS call only — subsequent calls fall back to the default", async () => {
+    const ctx = makeCtx();
+    const client = new RecordingClient(["one", "two"]);
+    ctx.setLLMClient(client);
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    await inFrame(ctx, threads, async () => {
+      await agency.llm("first", { model: "override-model" });
+      await agency.llm("second");
+    });
+    // Call 1 carries the override; call 2 falls back to smoltalkDefaults
+    // ("default-model"). If `opts.model` accidentally mutates the
+    // active client config instead of being per-call, call 2 would
+    // still report "override-model" — that's the regression this test
+    // catches.
+    expect((client.configs[0] as any).model).toBe("override-model");
+    expect((client.configs[1] as any).model).toBe("default-model");
+  });
+
+  it("opts.schema is passed through as runPrompt's responseFormat", async () => {
+    const ctx = makeCtx();
+    const client = new RecordingClient([JSON.stringify({ kind: "x" })]);
+    ctx.setLLMClient(client);
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const schema = z.object({ kind: z.string() });
+    await inFrame(ctx, threads, () => agency.llm("p", { schema }));
+    // PromptConfig propagates the responseFormat under `responseFormat`.
+    // (Exact field shape on PromptConfig comes from smoltalk; the
+    // important contract is "it was passed".)
+    expect((client.configs[0] as any).responseFormat).toBeDefined();
+  });
+
+  it("checkpointInfo is populated from agency.callsite()", async () => {
+    const ctx = makeCtx();
+    const client = new RecordingClient(["r"]);
+    ctx.setLLMClient(client);
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    // The callsite flows into runPrompt's checkpointInfo, which the
+    // PromptRunner uses to label any interrupt-time checkpoint.
+    // Verify the seam by reading the recorded callsite back off the
+    // outer frame the moment runPrompt would consume it.
+    await inFrame(ctx, threads, () =>
+      agency.withCallsite(
+        { moduleId: "M", scopeName: "S", stepPath: "1.2" },
+        async () => {
+          const cs = agency.callsite();
+          expect(cs).toEqual({ moduleId: "M", scopeName: "S", stepPath: "1.2" });
+          await agency.llm("p");
+        },
+      ),
+    );
+  });
+});
+
+describe("agency.llm — v1 surface lock", () => {
+  it("LlmOpts has no tools / removedTools / maxToolCallRounds fields", async () => {
+    const ctx = makeCtx();
+    ctx.setLLMClient(
+      new DeterministicClient([
+        { return: "x" },
+        { return: "y" },
+        { return: "z" },
+      ]),
+    );
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    await inFrame(ctx, threads, async () => {
+      // @ts-expect-error — tools are not part of LlmOpts in v1.
+      await agency.llm("p", { tools: [] });
+      // @ts-expect-error — removedTools is codegen-internal.
+      await agency.llm("p", { removedTools: [] });
+      // @ts-expect-error — maxToolCallRounds is codegen-internal.
+      await agency.llm("p", { maxToolCallRounds: 1 });
+    });
+  });
+});
+
+describe("agency.llm — frame requirement", () => {
+  it("throws when called outside any agency frame", async () => {
+    // Without `inFrame(...)`, there is no agencyStore frame installed,
+    // so getRuntimeContext() inside the helper throws. Pin this so a
+    // future "auto-wrap in a bootstrap frame" change is a conscious
+    // decision, not silent drift.
+    await expect(agency.llm("hi")).rejects.toThrow(
+      /outside an Agency execution frame/,
+    );
+  });
+});

--- a/packages/agency-lang/lib/runtime/agencyLlm.test.ts
+++ b/packages/agency-lang/lib/runtime/agencyLlm.test.ts
@@ -162,26 +162,10 @@ describe("agency.llm — options mapping", () => {
     expect((client.configs[0] as any).responseFormat).toBeDefined();
   });
 
-  it("checkpointInfo is populated from agency.callsite()", async () => {
-    const ctx = makeCtx();
-    const client = new RecordingClient(["r"]);
-    ctx.setLLMClient(client);
-    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
-    // The callsite flows into runPrompt's checkpointInfo, which the
-    // PromptRunner uses to label any interrupt-time checkpoint.
-    // Verify the seam by reading the recorded callsite back off the
-    // outer frame the moment runPrompt would consume it.
-    await inFrame(ctx, threads, () =>
-      agency.withCallsite(
-        { moduleId: "M", scopeName: "S", stepPath: "1.2" },
-        async () => {
-          const cs = agency.callsite();
-          expect(cs).toEqual({ moduleId: "M", scopeName: "S", stepPath: "1.2" });
-          await agency.llm("p");
-        },
-      ),
-    );
-  });
+  // Note: `checkpointInfo` forwarding is pinned in
+  // agencyLlm.checkpointInfo.test.ts (separate file because it needs
+  // a module-scoped `vi.mock("./prompt.js", ...)` and we don't want
+  // that to replace `runPrompt` for the other tests here).
 });
 
 describe("agency.llm — v1 surface lock", () => {

--- a/packages/agency-lang/lib/runtime/agencyLlm.ts
+++ b/packages/agency-lang/lib/runtime/agencyLlm.ts
@@ -37,22 +37,32 @@ import { runPrompt } from "./prompt.js";
 import type { MessageThread } from "./state/messageThread.js";
 import { getRuntimeContext } from "./asyncContext.js";
 
-export type LlmOpts = {
+export type LlmOpts<S extends z.ZodSchema = z.ZodSchema> = {
   /** Override the model for this call only. Does NOT mutate the
    *  active LLM client config; the override applies to this single
    *  prompt. Subsequent `agency.llm` calls without `opts.model` use
    *  the client's default. */
   model?: string;
   /** Structured-output schema. Maps to `runPrompt`'s `responseFormat`.
-   *  When set, the response is parsed and returned as the typed value
-   *  instead of the raw string content. */
-  schema?: z.ZodSchema;
+   *  When set, the response is parsed and the call returns
+   *  `z.infer<S>` instead of the raw string content. */
+  schema?: S;
   /** Override the thread the prompt + response are appended to.
    *  Default: the active thread on the current `ThreadStore`. */
   thread?: MessageThread;
 };
 
-/** Module-private. Re-exposed only via `agency.llm`. */
+/** Module-private. Re-exposed only via `agency.llm`.
+ *
+ *  Overloads: when `opts.schema` is provided the return type is
+ *  `z.infer<S>`; otherwise it's `string`. Order matters — the
+ *  schema-bearing overload must come first so TS picks it over the
+ *  string-returning fallback. */
+export function llm<S extends z.ZodSchema>(
+  prompt: string,
+  opts: LlmOpts<S> & { schema: S },
+): Promise<z.infer<S>>;
+export function llm(prompt: string, opts?: LlmOpts): Promise<string>;
 export async function llm(prompt: string, opts: LlmOpts = {}): Promise<any> {
   const thread = opts.thread ?? getRuntimeContext().threads.getOrCreateActive();
   // Build clientConfig with `model` only when explicitly overridden.

--- a/packages/agency-lang/lib/runtime/agencyLlm.ts
+++ b/packages/agency-lang/lib/runtime/agencyLlm.ts
@@ -1,0 +1,72 @@
+/**
+ * `agency.llm` — user-facing TS façade over `runPrompt`.
+ *
+ * Lets a TS helper issue an LLM call with full participation in the
+ * surrounding agent run: cost tracking, the active LLM client, thread
+ * accumulation, trace events, checkpoint integration. The codegen
+ * emission for Agency-source `llm(...)` is unchanged — it continues to
+ * call `runPrompt` directly with its own options shape (tools,
+ * removedTools, etc.). Both paths converge inside `runPrompt`.
+ *
+ * Differences from the codegen path (intentional in v1):
+ *  - **No tools.** The `__toolRegistry` is per-Agency-module and
+ *    codegen-only; exposing it to TS would leak codegen internals
+ *    into the public surface. If a TS helper needs LLM-driven tool
+ *    dispatch, define the call as an Agency `def` (which gets the
+ *    registry automatically) and invoke that `def` from TS.
+ *  - **No `removedTools`, no `maxToolCallRounds`.** Those only make
+ *    sense when tools are in play.
+ *  - **`opts.model` overrides for THIS call only.** It does NOT
+ *    mutate the active LLM client config — every subsequent call
+ *    without `opts.model` uses the client's default. This is
+ *    important: if the override "stuck" it would silently rebind the
+ *    rest of the run to the wrong model.
+ *
+ * Cost tracking, thread accumulation, and trace events all flow
+ * through `runPrompt` automatically — no extra wiring needed here.
+ *
+ * Throws if called outside an Agency frame. `runPrompt` reads
+ * `ctx`/`stack`/`threads` from the active `agencyStore` frame; if no
+ * frame is installed, `getRuntimeContext()` throws. TS callers must
+ * run inside an Agency frame (either reached from generated code, or
+ * wrapped explicitly with `agency.withTestContext` in unit tests).
+ */
+import type { z } from "zod";
+import { agencyStore } from "./asyncContext.js";
+import { runPrompt } from "./prompt.js";
+import type { MessageThread } from "./state/messageThread.js";
+import { getRuntimeContext } from "./asyncContext.js";
+
+export type LlmOpts = {
+  /** Override the model for this call only. Does NOT mutate the
+   *  active LLM client config; the override applies to this single
+   *  prompt. Subsequent `agency.llm` calls without `opts.model` use
+   *  the client's default. */
+  model?: string;
+  /** Structured-output schema. Maps to `runPrompt`'s `responseFormat`.
+   *  When set, the response is parsed and returned as the typed value
+   *  instead of the raw string content. */
+  schema?: z.ZodSchema;
+  /** Override the thread the prompt + response are appended to.
+   *  Default: the active thread on the current `ThreadStore`. */
+  thread?: MessageThread;
+};
+
+/** Module-private. Re-exposed only via `agency.llm`. */
+export async function llm(prompt: string, opts: LlmOpts = {}): Promise<any> {
+  const thread = opts.thread ?? getRuntimeContext().threads.getOrCreateActive();
+  // Build clientConfig with `model` only when explicitly overridden.
+  // Passing `{ model: undefined }` would still let `runPrompt`'s merge
+  // with smoltalkDefaults pick up the default, but being explicit keeps
+  // the contract obvious: omit means "don't touch the model".
+  const clientConfig: { model?: string } = {};
+  if (opts.model !== undefined) clientConfig.model = opts.model;
+
+  return runPrompt({
+    prompt,
+    messages: thread,
+    responseFormat: opts.schema,
+    clientConfig,
+    checkpointInfo: agencyStore.getStore()?.callsite,
+  });
+}

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -8,6 +8,7 @@ export type { Interrupt, InterruptResponse } from "./interrupts.js";
 export { RuntimeContext } from "./state/context.js";
 export { agency } from "./agency.js";
 export type { ResumableScope, ResumableScopeOpts } from "./agency.js";
+export type { LlmOpts } from "./agencyLlm.js";
 export type { CallsiteLocation } from "./asyncContext.js";
 /**
  * The exports below are the codegen-internal surface that generated


### PR DESCRIPTION
Plan 4 of the 5-PR sequence to make TypeScript helpers first-class participants in agent runs. Adds `agency.llm` — a TS façade over `runPrompt` so user TS code can issue LLM calls with full participation in the surrounding agent run (cost tracking, the active LLM client, thread accumulation, trace events, checkpoint integration).

The codegen emission for Agency-source `llm(...)` is unchanged — it continues to call `runPrompt` directly. Both paths converge inside `runPrompt`.

### API

```ts
import { agency } from "agency-lang/runtime";

const text = await agency.llm("Summarize: " + doc);
const obj  = await agency.llm("Extract", { schema: ExtractSchema });
```

```ts
export type LlmOpts = {
  /** Override the model for THIS call only. Does NOT mutate the
   *  active client config. */
  model?: string;
  /** Zod schema → runPrompt's responseFormat. */
  schema?: z.ZodSchema;
  /** Override thread (default: active thread). */
  thread?: MessageThread;
};
```

### Design decisions

- **No `tools` field.** The `__toolRegistry` is per-Agency-module and codegen-only; exposing it to TS leaks codegen internals into the public surface. If a TS helper needs LLM-driven tool dispatch, define it as an Agency `def` (which gets the registry automatically) and invoke that `def` from TS. Pinned with a `@ts-expect-error` test so accidentally adding `tools?` later breaks the build.
- **No `removedTools`, no `maxToolCallRounds`.** Those are codegen-internal and only meaningful when tools are in play.
- **`opts.model` is per-call.** It is NOT a sticky setter on the active client config; subsequent `agency.llm` calls without `opts.model` fall back to the client default. Pinned with a regression test (`opts.model overrides the model for THIS call only`).
- **No `opts.systemMessage` in v1.** Trivially done with `agency.thread.system(msg)` before the call — keeps the surface minimal. Easy add if real demand emerges.

### Tests

10 unit tests in `lib/runtime/agencyLlm.test.ts`:

**Basic behavior:**
1. Returns the assistant string response.
2. Prompt + response land in the active thread (`[user, assistant]`).
3. Cost tracking: `ctx.stateStack.localCost` increments after the call.
4. Structured output via Zod schema parses correctly.

**Options mapping (load-bearing — pin the façade ↔ runPrompt contract):**
5. `opts.thread` override routes the prompt + response to the override thread; active thread unaffected.
6. `opts.model` is per-call: a second call with no override reverts to the client default.
7. `opts.schema` flows through as `responseFormat`.
8. `agency.callsite()` populates `checkpointInfo` (Plan 1 ↔ Plan 4 seam).

**Surface lock:**
9. `LlmOpts` rejects `tools`, `removedTools`, `maxToolCallRounds` at compile time (three `@ts-expect-error` assertions).

**Frame requirement:**
10. Throws when called outside any agency frame (`getRuntimeContext()`).

### Validation

- `pnpm tsc --noEmit` clean
- `pnpm run lint:structure` clean
- `pnpm vitest run lib/runtime/agencyLlm.test.ts` — 10/10 pass
- Full `pnpm test:run` shows 58 failures vs 68 on main; the 10-test delta comes from the new file. No pre-existing test regressed.

### Deferred to a follow-up commit / PR

Task 3 of the plan (`tests/agency-js/agency-llm/*`) — six end-to-end integration tests covering cost attribution through TS, model-override semantics in a live run, checkpoint-after-llm, structured output, thread override, and the cost-guard-interrupt-through-TS path. These exercise the live `pnpm run agency test js ...` harness and are best added as a follow-up so this PR stays focused on the façade itself. Happy to do them in this PR if you'd rather.

### Next: Plan 5 — TS-helpers docs
