### PR TITLE
tests: integration coverage for agency.* TS helpers

### DIFF
--- a/packages/agency-lang/docs/superpowers/plans/2026-05-27-ts-helper-integration-tests.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-27-ts-helper-integration-tests.md
@@ -1,0 +1,250 @@
+# TS-helper integration tests (as agency tests)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** close the integration-coverage gap surfaced by the post-PR-211 self-review of the TS-helpers surface (`agency.*` namespace, `withResumableScope`, `agency.interrupt`, `agency.withCostGuard`, `agency.withHandler`). Unit tests cover per-call contracts; **load-bearing behaviors** (resumability across interrupts, handler interception, cost-guard trips, fork-branch isolation) are not exercised end-to-end.
+
+**Why agency tests, not a new vitest harness:** the question we are testing is *"does TS code calling `agency.*` participate in agent runs correctly?"* — i.e. `agency code calling JS`. That's the natural domain of `tests/agency/`: the .agency file is the entry, it imports a `.js` helper, the helper uses `agency.*`. The test runner already drives interrupt round-trips declaratively via `interruptHandlers: [{action, expectedMessage, value}]` in `.test.json`. No new test infrastructure needed.
+
+`tests/agency-js/` is *JS calling agency* — needed only when an external JS driver has to feed user responses back. That's not what we're testing here.
+
+This plan supersedes both `2026-05-27-runtime-integration-harness.md` and `2026-05-27-missing-integration-tests.md`. Delete those after this PR merges.
+
+**Prerequisites (must be merged):**
+1. `2026-05-27-callsite-als-and-drop-state-arg.md` (#207)
+2. `2026-05-27-agency-namespace.md` (#208)
+3. `2026-05-27-resumable-scope.md` (#209)
+4. `2026-05-27-agency-llm.md` (#210)
+5. `2026-05-27-ts-helpers-docs.md` (#211)
+6. `agency.interrupt()` (#212) — merged
+
+**Architecture:** every test in this plan lives in `tests/agency/ts-helpers/` as a triplet:
+- `<name>.agency` — entry that imports the `.js` helper, calls it from `node main()`, returns whatever the assertion needs.
+- `<name>.js` — the actual TS-helper-using code (written as JS — no compilation step).
+- `<name>.test.json` — `expectedOutput`, `evaluationCriteria`, and (if the helper raises interrupts) an `interruptHandlers` array declaring the round-trip.
+
+No new runtime code. No new test infrastructure. If a test reveals a bug, file a precursor PR to fix it before landing this PR — don't paper over with test-only workarounds.
+
+**Tech stack:** existing `tests/agency/` runner (`pnpm run agency test <dir>`); JS helpers import from `agency-lang/runtime`; declarative interrupt rounds via `.test.json`'s `interruptHandlers`.
+
+**Workflow conventions:** worktree per PR, validate with `pnpm tsc --noEmit && pnpm run lint:structure && pnpm run agency test tests/agency/ts-helpers/`, commit messages via file, never force-push or amend.
+
+**Anti-pattern review** (`docs/dev/anti-patterns.md`): re-read before opening the PR. The triplet structure is intentionally declarative — assertions live in `.test.json`, not in imperative JS code. If a future revision adds JS-side `expect` calls, that's a regression toward the imperative anti-pattern.
+
+---
+
+## Test inventory (7 tests)
+
+Each test pins one load-bearing behavior. Listed in landing order — earlier tests are simpler and de-risk later ones.
+
+### Test 1: `resumable-scope-resume`
+
+**Pins:** on resume after an interrupt, completed `s.step(...)` bodies are skipped and cached return values are used; the in-flight step re-runs from scratch and finds the user's response on the second pass.
+
+**Why it matters:** the entire point of `withResumableScope` is that interrupted runs replay correctly. Today the unit test "re-running a scope with the same frame skips completed steps" admits in its comment that it does not exercise the real resume path.
+
+**Shape:**
+```
+resumable-scope-resume.agency:
+  import { runScope, getCalls } from "./resumable-scope-resume.js"
+  node main() {
+    const result = runScope()
+    return { result: result, calls: getCalls() }
+  }
+
+resumable-scope-resume.js:
+  - exports runScope() that uses agency.withResumableScope with 3 steps
+  - middle step calls agency.interrupt
+  - tracks call counts per step
+
+resumable-scope-resume.test.json:
+  - interruptHandlers: [{action:"approve", value:"resumed", expectedMessage:"wait"}]
+  - expectedOutput verifies calls = {s1:1, s2:2, s3:1} and result reflects "resumed"
+```
+
+### Test 2: `interrupt-handler-approve`
+
+**Pins:** `agency.withHandler` returning `approve(value)` makes `agency.interrupt(...)` resolve to that approve outcome; the run continues to completion in the same pass (no halt, no resume).
+
+**Shape:**
+```
+interrupt-handler-approve.agency:
+  import { run } from "./interrupt-handler-approve.js"
+  node main() { return run() }
+
+interrupt-handler-approve.js:
+  - wraps agency.interrupt({kind, message, data}) in agency.withHandler(approver)
+  - approver returns approve("handled")
+  - returns the response
+
+interrupt-handler-approve.test.json:
+  - no interruptHandlers (run never propagates)
+  - expectedOutput: {"type":"approve","value":"handled"}
+```
+
+### Test 3: `interrupt-handler-reject`
+
+**Pins:** `agency.withHandler` returning `reject(value)` makes `agency.interrupt(...)` resolve to that reject outcome.
+
+Mirrors Test 2 but with reject. Two separate tests not one combined: makes failures point at the broken path directly.
+
+### Test 4: `interrupt-resume-idempotency`
+
+**Pins:** when no handler intercepts, `agency.interrupt(...)` halts with a checkpoint, the runner accepts a user response via `respondToInterrupts`, and the second pass through the same call site returns the response without re-firing the handler chain or creating another checkpoint.
+
+This is the integration version of unit test 4 in PR #212's `agencyInterrupt.test.ts`. The unit test simulates the post-restore state by manually setting `frame.locals[__interrupt_0]`; this test exercises the real `respondToInterrupts` cycle via `.test.json`'s `interruptHandlers`.
+
+**Shape:**
+```
+interrupt-resume-idempotency.agency:
+  import { run, getHandlerCalls } from "./interrupt-resume-idempotency.js"
+  node main() {
+    const result = run()
+    return { result: result, handlerCalls: getHandlerCalls() }
+  }
+
+interrupt-resume-idempotency.js:
+  - run() pushes a handler that just COUNTS calls (returns undefined / propagate)
+  - inside, calls agency.interrupt; returns response.value
+  - getHandlerCalls() returns counter
+
+interrupt-resume-idempotency.test.json:
+  - interruptHandlers: [{action:"approve", value:"user-said-yes", expectedMessage:"?"}]
+  - expectedOutput: handlerCalls === 1 (NOT 2 — handler must not re-fire on resume)
+                    result === "user-said-yes"
+```
+
+If `handlerCalls === 2`, the resume-idempotency is broken.
+
+### Test 5: `halt-trycatch-cleanup`
+
+**Pins:** `s.halt(value)` does not throw — surrounding `try/finally` runs, subsequent `s.step(...)` short-circuits but the body keeps running until natural exit.
+
+**Shape:**
+```
+halt-trycatch-cleanup.agency:
+  import { run, getCleanup } from "./halt-trycatch-cleanup.js"
+  node main() {
+    const result = run()
+    return { result: result, cleanup: getCleanup() }
+  }
+
+halt-trycatch-cleanup.js:
+  - run() uses withResumableScope; body has try/finally
+  - inside try: s.step("a"); s.halt("halted"); s.step("b")
+  - finally: pushes "ran" to cleanup array
+
+halt-trycatch-cleanup.test.json:
+  - expectedOutput: result === "halted", cleanup === ["ran"]
+```
+
+### Test 6: `cost-guard-trips`
+
+**Pins:** `agency.withCostGuard(maxCost, fn)` trips when `agency.addCost(...)` pushes accumulated cost past the budget; the trip surfaces as a catchable error so the helper can return a structured failure.
+
+**Shape:**
+```
+cost-guard-trips.agency:
+  import { run } from "./cost-guard-trips.js"
+  node main() { return run() }
+
+cost-guard-trips.js:
+  - run() wraps work in agency.withCostGuard(0.01, async () => {...})
+  - inside: agency.addCost(0.05) — over budget
+  - catches the GuardExceededError, returns {tripped: true, cost: ...}
+
+cost-guard-trips.test.json:
+  - expectedOutput: {"tripped":true,...}
+  - evaluationCriteria: exact (or llmJudge if message text varies)
+```
+
+If `addCost` doesn't trigger trip enforcement at the time of writing, this test discovers it and the right move is to file a precursor PR fixing the bug.
+
+### Test 7: `fork-branch-isolation`
+
+**Pins:** when an agency `fork` runs branches that each call a TS function adding cost, each branch's spend is attributed to its own branch stack and doesn't leak across siblings.
+
+**Shape:**
+```
+fork-branch-isolation.agency:
+  import { addAndReport } from "./fork-branch-isolation.js"
+  node main() {
+    const results = fork([1, 2, 3]) as i {
+      return addAndReport(i * 0.01)
+    }
+    return results
+  }
+
+fork-branch-isolation.js:
+  - addAndReport(amount) calls agency.addCost(amount), returns the per-branch
+    stack.localCost (read via getRuntimeContext().stack.localCost)
+  - assertion: each branch sees only its own contribution (plus the seed
+    from parent, if any) — not the sum of siblings'
+
+fork-branch-isolation.test.json:
+  - expectedOutput: per-branch costs are {0.01, 0.02, 0.03} (each branch's
+    own contribution), NOT {0.06, 0.06, 0.06}
+```
+
+If branches DO leak, this test surfaces it; file a precursor PR for the runtime fix.
+
+---
+
+## Steps
+
+- [x] **Step 1: Create worktree** (already done — `ts-helper-integration-tests`)
+
+- [ ] **Step 2: Land tests one at a time**
+
+Order: 2 → 3 → 5 → 1 → 4 → 6 → 7. Rationale:
+- 2 and 3 (handler approve/reject) are the simplest, no interrupt propagation. De-risk the .agency-imports-js setup first.
+- 5 (halt cleanup) is similar simplicity.
+- 1 (resumable-scope-resume) adds interrupt round-trips — uses `.test.json` interruptHandlers for the first time.
+- 4 (resume idempotency) reuses the round-trip mechanism.
+- 6 (cost-guard) introduces `addCost` enforcement.
+- 7 (fork-branch isolation) is most likely to surface infrastructure issues.
+
+For each test:
+1. Write the `.js` helper.
+2. Write the `.agency` entry.
+3. Write the `.test.json` with assertions.
+4. Run: `pnpm run agency test tests/agency/ts-helpers/<name>.agency 2>&1 | tee /tmp/<name>.log | tail -30`.
+5. Iterate until green. If the test reveals a runtime bug, stop and file a precursor PR.
+
+- [ ] **Step 3: Validate full suite**
+
+```bash
+pnpm tsc --noEmit
+pnpm run lint:structure
+pnpm run agency test tests/agency/ts-helpers/ 2>&1 | tee /tmp/all.log | tail -30
+```
+
+- [ ] **Step 4: Commit + push + PR**
+
+PR title: `tests: integration coverage for agency.* TS helpers`
+
+PR body covers:
+- The 7 load-bearing behaviors pinned.
+- Why agency tests (not agency-js, not a new vitest harness): agency-code-calling-JS is the natural fit; existing `interruptHandlers` mechanism already provides declarative round-trip.
+- Any bugs surfaced and the precursor PRs that fixed them.
+- Note that this brings the testing story for the 5-PR series to genuine integration coverage; the per-call unit tests are kept.
+- Lists the two superseded plan files for future cleanup.
+
+---
+
+## Verification checklist
+
+- [ ] `pnpm tsc --noEmit` clean
+- [ ] `pnpm run lint:structure` clean
+- [ ] All 7 tests pass under `pnpm run agency test tests/agency/ts-helpers/`
+- [ ] Each test is a self-contained triplet (`.agency` + `.js` + `.test.json`); no shared mutable state across tests
+- [ ] No JS-side `expect` / `assert` calls — assertions live in `.test.json` (declarative)
+- [ ] No production code changes (any bugs found were fixed in precursor PRs and merged first)
+- [ ] PR body cross-links every test to the load-bearing claim it pins
+
+## Open questions / risks
+
+- **`agency.addCost` enforcement timing.** Need to verify it trips synchronously rather than on the next LLM call. If it requires an LLM call to enforce, Test 6 needs an LLM mock; rework accordingly.
+- **Per-branch cost reading from JS.** `getRuntimeContext().stack.localCost` is the path. If the ALS frame inside a fork branch carries the parent stack (not the branch stack), Test 7's helper reads the wrong value. Audit `runBatch.ts` before writing the test.
+- **Test 4 handler counter visibility.** The handler is closure-over the same module-level counter the entry reads at the end. Module state survives across the resume cycle because both passes import the same compiled `.js` instance.
+- **`.test.json` interruptHandlers limitation.** Today it dispatches by FIFO order, not by interrupt kind/data. All 7 tests above produce at most one interrupt, so this is fine. If a future test produces multiple distinct interrupts in a single run, we may need to extend the test runner's matching logic (out of scope for this PR).

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-27-ts-helper-integration-tests.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-27-ts-helper-integration-tests.md
@@ -18,10 +18,10 @@ This plan supersedes both `2026-05-27-runtime-integration-harness.md` and `2026-
 5. `2026-05-27-ts-helpers-docs.md` (#211)
 6. `agency.interrupt()` (#212) — merged
 
-**Architecture:** every test in this plan lives in `tests/agency/ts-helpers/` as a triplet:
-- `<name>.agency` — entry that imports the `.js` helper, calls it from `node main()`, returns whatever the assertion needs.
-- `<name>.js` — the actual TS-helper-using code (written as JS — no compilation step).
-- `<name>.test.json` — `expectedOutput`, `evaluationCriteria`, and (if the helper raises interrupts) an `interruptHandlers` array declaring the round-trip.
+**Architecture:** every test in this plan lives in `tests/agency/ts-helpers/<name>/` as a triplet of three sibling files inside its own subdirectory:
+- `agent.agency` — entry that imports `./helper.js`, calls it from `node main()`, returns whatever the assertion needs.
+- `helper.js` — the actual TS-helper-using code (written as JS — no compilation step). `.js` files are gitignored repo-wide, so each helper must be `git add -f`'d.
+- `agent.test.json` — `expectedOutput`, `evaluationCriteria`, and (if the helper raises interrupts) an `interruptHandlers` array declaring the round-trip.
 
 No new runtime code. No new test infrastructure. If a test reveals a bug, file a precursor PR to fix it before landing this PR — don't paper over with test-only workarounds.
 
@@ -33,7 +33,7 @@ No new runtime code. No new test infrastructure. If a test reveals a bug, file a
 
 ---
 
-## Test inventory (7 tests)
+## Test inventory (9 tests)
 
 Each test pins one load-bearing behavior. Listed in landing order — earlier tests are simpler and de-risk later ones.
 
@@ -45,19 +45,19 @@ Each test pins one load-bearing behavior. Listed in landing order — earlier te
 
 **Shape:**
 ```
-resumable-scope-resume.agency:
-  import { runScope, getCalls } from "./resumable-scope-resume.js"
+resumable-scope-resume/agent.agency:
+  import { runScope, getCalls } from "./helper.js"
   node main() {
     const result = runScope()
     return { result: result, calls: getCalls() }
   }
 
-resumable-scope-resume.js:
+resumable-scope-resume/helper.js:
   - exports runScope() that uses agency.withResumableScope with 3 steps
   - middle step calls agency.interrupt
   - tracks call counts per step
 
-resumable-scope-resume.test.json:
+resumable-scope-resume/agent.test.json:
   - interruptHandlers: [{action:"approve", value:"resumed", expectedMessage:"wait"}]
   - expectedOutput verifies calls = {s1:1, s2:2, s3:1} and result reflects "resumed"
 ```
@@ -68,16 +68,16 @@ resumable-scope-resume.test.json:
 
 **Shape:**
 ```
-interrupt-handler-approve.agency:
-  import { run } from "./interrupt-handler-approve.js"
+interrupt-handler-approve/agent.agency:
+  import { run } from "./helper.js"
   node main() { return run() }
 
-interrupt-handler-approve.js:
+interrupt-handler-approve/helper.js:
   - wraps agency.interrupt({kind, message, data}) in agency.withHandler(approver)
   - approver returns approve("handled")
   - returns the response
 
-interrupt-handler-approve.test.json:
+interrupt-handler-approve/agent.test.json:
   - no interruptHandlers (run never propagates)
   - expectedOutput: {"type":"approve","value":"handled"}
 ```
@@ -96,19 +96,19 @@ This is the integration version of unit test 4 in PR #212's `agencyInterrupt.tes
 
 **Shape:**
 ```
-interrupt-resume-idempotency.agency:
-  import { run, getHandlerCalls } from "./interrupt-resume-idempotency.js"
+interrupt-resume-idempotency/agent.agency:
+  import { run, getHandlerCalls } from "./helper.js"
   node main() {
     const result = run()
     return { result: result, handlerCalls: getHandlerCalls() }
   }
 
-interrupt-resume-idempotency.js:
+interrupt-resume-idempotency/helper.js:
   - run() pushes a handler that just COUNTS calls (returns undefined / propagate)
   - inside, calls agency.interrupt; returns response.value
   - getHandlerCalls() returns counter
 
-interrupt-resume-idempotency.test.json:
+interrupt-resume-idempotency/agent.test.json:
   - interruptHandlers: [{action:"approve", value:"user-said-yes", expectedMessage:"?"}]
   - expectedOutput: handlerCalls === 1 (NOT 2 — handler must not re-fire on resume)
                     result === "user-said-yes"
@@ -122,19 +122,19 @@ If `handlerCalls === 2`, the resume-idempotency is broken.
 
 **Shape:**
 ```
-halt-trycatch-cleanup.agency:
-  import { run, getCleanup } from "./halt-trycatch-cleanup.js"
+halt-trycatch-cleanup/agent.agency:
+  import { run, getCleanup } from "./helper.js"
   node main() {
     const result = run()
     return { result: result, cleanup: getCleanup() }
   }
 
-halt-trycatch-cleanup.js:
+halt-trycatch-cleanup/helper.js:
   - run() uses withResumableScope; body has try/finally
   - inside try: s.step("a"); s.halt("halted"); s.step("b")
   - finally: pushes "ran" to cleanup array
 
-halt-trycatch-cleanup.test.json:
+halt-trycatch-cleanup/agent.test.json:
   - expectedOutput: result === "halted", cleanup === ["ran"]
 ```
 
@@ -144,18 +144,19 @@ halt-trycatch-cleanup.test.json:
 
 **Shape:**
 ```
-cost-guard-trips.agency:
-  import { run } from "./cost-guard-trips.js"
+cost-guard-trips/agent.agency:
+  import { run } from "./helper.js"
   node main() { return run() }
 
-cost-guard-trips.js:
+cost-guard-trips/helper.js:
   - run() wraps work in agency.withCostGuard(0.01, async () => {...})
   - inside: agency.addCost(0.05) — over budget
-  - catches the GuardExceededError, returns {tripped: true, cost: ...}
+  - catches the GuardExceededError (via isGuardExceededError), returns
+    {tripped, type, limit, spent}
 
-cost-guard-trips.test.json:
-  - expectedOutput: {"tripped":true,...}
-  - evaluationCriteria: exact (or llmJudge if message text varies)
+cost-guard-trips/agent.test.json:
+  - expectedOutput: {"tripped":true,"type":"cost","limit":0.01,"spent":0.05}
+  - evaluationCriteria: exact
 ```
 
 If `addCost` doesn't trigger trip enforcement at the time of writing, this test discovers it and the right move is to file a precursor PR fixing the bug.
@@ -166,27 +167,63 @@ If `addCost` doesn't trigger trip enforcement at the time of writing, this test 
 
 **Shape:**
 ```
-fork-branch-isolation.agency:
-  import { addAndReport } from "./fork-branch-isolation.js"
+fork-branch-isolation/agent.agency:
+  import { addAndReport } from "./helper.js"
   node main() {
-    const results = fork([1, 2, 3]) as i {
-      return addAndReport(i * 0.01)
+    let results = fork([1, 2, 3]) as i {
+      return addAndReport(i)
     }
     return results
   }
 
-fork-branch-isolation.js:
+fork-branch-isolation/helper.js:
   - addAndReport(amount) calls agency.addCost(amount), returns the per-branch
     stack.localCost (read via getRuntimeContext().stack.localCost)
   - assertion: each branch sees only its own contribution (plus the seed
     from parent, if any) — not the sum of siblings'
 
-fork-branch-isolation.test.json:
-  - expectedOutput: per-branch costs are {0.01, 0.02, 0.03} (each branch's
-    own contribution), NOT {0.06, 0.06, 0.06}
+fork-branch-isolation/agent.test.json:
+  - expectedOutput: per-branch costs are [1, 2, 3] (each branch's own
+    contribution as integers — avoids the floating-point fuzz of fractional
+    multipliers like i * 0.01), NOT [6, 6, 6]
 ```
 
 If branches DO leak, this test surfaces it; file a precursor PR for the runtime fix.
+
+### Test 8: `agency-handle-approves-ts-interrupt`
+
+**Pins:** an agency `handle ... with (i) { return approve(value) }` block intercepts an `agency.interrupt(...)` raised from a TS helper called inside the block. Documented contract in `agencyInterrupt.ts`:
+
+> a TS function called from Agency code can have its `agency.interrupt(...)` caught by a `handle` block defined in the calling Agency code
+
+This is the cross-surface direction of Tests 2/3: those install a TS-side `agency.withHandler` and raise from TS; this one installs an agency-side `handle` block and raises from TS.
+
+**Shape:**
+```
+agency-handle-approves-ts-interrupt/agent.agency:
+  import { raise } from "./helper.js"
+  node main() {
+    handle {
+      return raise()
+    } with (i) {
+      return approve("from-agency")
+    }
+  }
+
+agency-handle-approves-ts-interrupt/helper.js:
+  - raise() calls agency.interrupt({kind:"test::ask", message, data})
+  - returns the InterruptResponse object
+
+agency-handle-approves-ts-interrupt/agent.test.json:
+  - no interruptHandlers (the agency handle intercepts before the user)
+  - expectedOutput: {"type":"approve","value":"from-agency"}
+```
+
+### Test 9: `agency-handle-rejects-ts-interrupt`
+
+**Pins:** mirror of Test 8, but the agency `handle` block returns `reject(value)`. Two separate tests not one combined: same rationale as Tests 2/3 — a regression points at exactly which path broke.
+
+**Shape:** identical to Test 8 with `reject("blocked-by-agency")` in the `with` block and `expectedOutput: {"type":"reject","value":"blocked-by-agency"}` in the `.test.json`.
 
 ---
 
@@ -196,20 +233,23 @@ If branches DO leak, this test surfaces it; file a precursor PR for the runtime 
 
 - [ ] **Step 2: Land tests one at a time**
 
-Order: 2 → 3 → 5 → 1 → 4 → 6 → 7. Rationale:
+Order: 2 → 3 → 5 → 1 → 4 → 6 → 7 → 8 → 9. Rationale:
 - 2 and 3 (handler approve/reject) are the simplest, no interrupt propagation. De-risk the .agency-imports-js setup first.
 - 5 (halt cleanup) is similar simplicity.
 - 1 (resumable-scope-resume) adds interrupt round-trips — uses `.test.json` interruptHandlers for the first time.
 - 4 (resume idempotency) reuses the round-trip mechanism.
 - 6 (cost-guard) introduces `addCost` enforcement.
 - 7 (fork-branch isolation) is most likely to surface infrastructure issues.
+- 8 and 9 (agency-handle approves/rejects TS interrupt) added after first review feedback; pin the cross-surface direction of Tests 2/3.
 
 For each test:
-1. Write the `.js` helper.
-2. Write the `.agency` entry.
-3. Write the `.test.json` with assertions.
-4. Run: `pnpm run agency test tests/agency/ts-helpers/<name>.agency 2>&1 | tee /tmp/<name>.log | tail -30`.
-5. Iterate until green. If the test reveals a runtime bug, stop and file a precursor PR.
+1. Create the per-test directory: `tests/agency/ts-helpers/<name>/`.
+2. Write `helper.js` (the JS helper using `agency.*`).
+3. Write `agent.agency` (entry that imports `./helper.js` and calls it from `node main()`).
+4. Write `agent.test.json` with assertions.
+5. Run: `pnpm run agency test tests/agency/ts-helpers/<name>/agent.agency 2>&1 | tee /tmp/<name>.log | tail -30`.
+6. Iterate until green. If the test reveals a runtime bug, stop and file a precursor PR.
+7. `git add -f tests/agency/ts-helpers/<name>/helper.js` (the .js files are gitignored repo-wide).
 
 - [ ] **Step 3: Validate full suite**
 
@@ -224,7 +264,7 @@ pnpm run agency test tests/agency/ts-helpers/ 2>&1 | tee /tmp/all.log | tail -30
 PR title: `tests: integration coverage for agency.* TS helpers`
 
 PR body covers:
-- The 7 load-bearing behaviors pinned.
+- The 9 load-bearing behaviors pinned.
 - Why agency tests (not agency-js, not a new vitest harness): agency-code-calling-JS is the natural fit; existing `interruptHandlers` mechanism already provides declarative round-trip.
 - Any bugs surfaced and the precursor PRs that fixed them.
 - Note that this brings the testing story for the 5-PR series to genuine integration coverage; the per-call unit tests are kept.
@@ -236,8 +276,8 @@ PR body covers:
 
 - [ ] `pnpm tsc --noEmit` clean
 - [ ] `pnpm run lint:structure` clean
-- [ ] All 7 tests pass under `pnpm run agency test tests/agency/ts-helpers/`
-- [ ] Each test is a self-contained triplet (`.agency` + `.js` + `.test.json`); no shared mutable state across tests
+- [ ] All 9 tests pass under `pnpm run agency test tests/agency/ts-helpers/`
+- [ ] Each test is a self-contained triplet (`<name>/agent.agency` + `<name>/helper.js` + `<name>/agent.test.json`); no shared mutable state across tests
 - [ ] No JS-side `expect` / `assert` calls — assertions live in `.test.json` (declarative)
 - [ ] No production code changes (any bugs found were fixed in precursor PRs and merged first)
 - [ ] PR body cross-links every test to the load-bearing claim it pins
@@ -247,4 +287,4 @@ PR body covers:
 - **`agency.addCost` enforcement timing.** Need to verify it trips synchronously rather than on the next LLM call. If it requires an LLM call to enforce, Test 6 needs an LLM mock; rework accordingly.
 - **Per-branch cost reading from JS.** `getRuntimeContext().stack.localCost` is the path. If the ALS frame inside a fork branch carries the parent stack (not the branch stack), Test 7's helper reads the wrong value. Audit `runBatch.ts` before writing the test.
 - **Test 4 handler counter visibility.** The handler is closure-over the same module-level counter the entry reads at the end. Module state survives across the resume cycle because both passes import the same compiled `.js` instance.
-- **`.test.json` interruptHandlers limitation.** Today it dispatches by FIFO order, not by interrupt kind/data. All 7 tests above produce at most one interrupt, so this is fine. If a future test produces multiple distinct interrupts in a single run, we may need to extend the test runner's matching logic (out of scope for this PR).
+- **`.test.json` interruptHandlers limitation.** Today it dispatches by FIFO order, not by interrupt kind/data. All 9 tests above produce at most one interrupt, so this is fine. If a future test produces multiple distinct interrupts in a single run, we may need to extend the test runner's matching logic (out of scope for this PR).

--- a/packages/agency-lang/tests/agency/ts-helpers/agency-handle-approves-ts-interrupt/agent.agency
+++ b/packages/agency-lang/tests/agency/ts-helpers/agency-handle-approves-ts-interrupt/agent.agency
@@ -1,0 +1,9 @@
+import { raise } from "./helper.js"
+
+node main() {
+  handle {
+    return raise()
+  } with (i) {
+    return approve("from-agency")
+  }
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/agency-handle-approves-ts-interrupt/agent.test.json
+++ b/packages/agency-lang/tests/agency/ts-helpers/agency-handle-approves-ts-interrupt/agent.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"type\":\"approve\",\"value\":\"from-agency\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/agency-handle-approves-ts-interrupt/helper.js
+++ b/packages/agency-lang/tests/agency/ts-helpers/agency-handle-approves-ts-interrupt/helper.js
@@ -1,0 +1,17 @@
+import { agency } from "agency-lang/runtime";
+
+// Raises `agency.interrupt(...)` from JS. The agency `handle ... with`
+// block in agent.agency intercepts it via the SAME `ctx.handlers`
+// stack the codegen interrupts use. This pins the contract called
+// out in agencyInterrupt.ts's header comment:
+//   "a TS function called from Agency code can have its
+//    agency.interrupt(...) caught by a handle block defined in the
+//    calling Agency code"
+export async function raise() {
+  const resp = await agency.interrupt({
+    kind: "test::ask",
+    message: "needs approval",
+    data: { foo: 1 },
+  });
+  return resp;
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/agency-handle-rejects-ts-interrupt/agent.agency
+++ b/packages/agency-lang/tests/agency/ts-helpers/agency-handle-rejects-ts-interrupt/agent.agency
@@ -1,0 +1,9 @@
+import { raise } from "./helper.js"
+
+node main() {
+  handle {
+    return raise()
+  } with (i) {
+    return reject("blocked-by-agency")
+  }
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/agency-handle-rejects-ts-interrupt/agent.test.json
+++ b/packages/agency-lang/tests/agency/ts-helpers/agency-handle-rejects-ts-interrupt/agent.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"type\":\"reject\",\"value\":\"blocked-by-agency\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/agency-handle-rejects-ts-interrupt/helper.js
+++ b/packages/agency-lang/tests/agency/ts-helpers/agency-handle-rejects-ts-interrupt/helper.js
@@ -1,0 +1,15 @@
+import { agency } from "agency-lang/runtime";
+
+// Mirror of agency-handle-approves-ts-interrupt: JS raises an
+// interrupt with `agency.interrupt(...)`, and the agency `handle`
+// block in agent.agency intercepts it via `reject(...)`. Pins the
+// reject-from-agency-handle path of the cross-surface handler
+// stack documented in agencyInterrupt.ts.
+export async function raise() {
+  const resp = await agency.interrupt({
+    kind: "test::ask",
+    message: "needs approval",
+    data: { foo: 1 },
+  });
+  return resp;
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/cost-guard-trips/agent.agency
+++ b/packages/agency-lang/tests/agency/ts-helpers/cost-guard-trips/agent.agency
@@ -1,0 +1,5 @@
+import { run } from "./helper.js"
+
+node main() {
+  return run()
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/cost-guard-trips/agent.test.json
+++ b/packages/agency-lang/tests/agency/ts-helpers/cost-guard-trips/agent.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"tripped\":true,\"type\":\"cost\",\"limit\":0.01,\"spent\":0.05}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/cost-guard-trips/helper.js
+++ b/packages/agency-lang/tests/agency/ts-helpers/cost-guard-trips/helper.js
@@ -1,0 +1,28 @@
+import { agency, isGuardExceededError } from "agency-lang/runtime";
+
+// `agency.addCost` charges every installed guard then calls
+// `stack.enforceGuards()`, which throws `GuardExceededError`
+// synchronously when a CostGuard's spent total exceeds its limit.
+// This test pins that the trip propagates as a catchable error
+// inside the helper, so user code can surface a structured failure
+// without halting the whole run.
+export async function run() {
+  try {
+    return await agency.withCostGuard(0.01, async () => {
+      // Single over-budget charge — 0.05 > 0.01 limit. enforceGuards
+      // throws on this line, before the function ever returns.
+      agency.addCost(0.05);
+      return { tripped: false };
+    });
+  } catch (e) {
+    if (isGuardExceededError(e)) {
+      return {
+        tripped: true,
+        type: e.type,
+        limit: e.limit,
+        spent: e.spent,
+      };
+    }
+    throw e;
+  }
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/fork-branch-isolation/agent.agency
+++ b/packages/agency-lang/tests/agency/ts-helpers/fork-branch-isolation/agent.agency
@@ -1,0 +1,8 @@
+import { addAndReport } from "./helper.js"
+
+node main() {
+  let results = fork([1, 2, 3]) as i {
+    return addAndReport(i)
+  }
+  return results
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/fork-branch-isolation/agent.test.json
+++ b/packages/agency-lang/tests/agency/ts-helpers/fork-branch-isolation/agent.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[1,2,3]",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/fork-branch-isolation/helper.js
+++ b/packages/agency-lang/tests/agency/ts-helpers/fork-branch-isolation/helper.js
@@ -1,0 +1,13 @@
+import { agency, getRuntimeContext } from "agency-lang/runtime";
+
+// Charges `amount` to the active branch's CostGuard accumulator,
+// then reads back `stack.localCost` from the ALS-resolved per-branch
+// stack. If branch isolation works, each branch sees only its own
+// contribution (plus seedCost from the parent, which is 0 here
+// because the parent does no addCost before the fork). If sibling
+// branches leaked into each other's stacks, all three branches
+// would see the sum.
+export async function addAndReport(amount) {
+  agency.addCost(amount);
+  return getRuntimeContext().stack.localCost;
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/halt-trycatch-cleanup/agent.agency
+++ b/packages/agency-lang/tests/agency/ts-helpers/halt-trycatch-cleanup/agent.agency
@@ -1,0 +1,6 @@
+import { run, getCleanup } from "./helper.js"
+
+node main() {
+  const result = run()
+  return { result: result, cleanup: getCleanup() }
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/halt-trycatch-cleanup/agent.test.json
+++ b/packages/agency-lang/tests/agency/ts-helpers/halt-trycatch-cleanup/agent.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"result\":\"halted\",\"cleanup\":[\"ran\"]}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/halt-trycatch-cleanup/helper.js
+++ b/packages/agency-lang/tests/agency/ts-helpers/halt-trycatch-cleanup/helper.js
@@ -1,0 +1,26 @@
+import { agency } from "agency-lang/runtime";
+
+// Module-scoped because the agency entry reads it after the scope
+// returns; the scope's internal `try/finally` mutates it. Surviving
+// a `s.halt(...)` call is the load-bearing claim.
+let cleanupCalls = [];
+
+export function getCleanup() {
+  return cleanupCalls;
+}
+
+export async function run() {
+  cleanupCalls = [];
+  const result = await agency.withResumableScope({ name: "halt" }, async (s) => {
+    try {
+      await s.step(() => "a");
+      s.halt("halted");
+      // s.step short-circuits via shouldSkip after halt, but the
+      // surrounding try/finally MUST still run — that's what we pin.
+      await s.step(() => "b");
+    } finally {
+      cleanupCalls.push("ran");
+    }
+  });
+  return result;
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/interrupt-handler-approve/agent.agency
+++ b/packages/agency-lang/tests/agency/ts-helpers/interrupt-handler-approve/agent.agency
@@ -1,0 +1,6 @@
+import { run } from "./helper.js"
+
+node main() {
+  const result = run()
+  return result
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/interrupt-handler-approve/agent.test.json
+++ b/packages/agency-lang/tests/agency/ts-helpers/interrupt-handler-approve/agent.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"type\":\"approve\",\"value\":\"handled\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/interrupt-handler-approve/helper.js
+++ b/packages/agency-lang/tests/agency/ts-helpers/interrupt-handler-approve/helper.js
@@ -1,0 +1,20 @@
+import { agency, approve } from "agency-lang/runtime";
+
+// Wraps `agency.interrupt(...)` in `agency.withHandler(approver)`.
+// `approver` returns `approve("handled")`, so the interrupt is
+// intercepted inside the handler chain and `agency.interrupt`
+// resolves to that approve outcome — the run continues to
+// completion in the same pass with no halt and no resume.
+export async function run() {
+  return agency.withHandler(
+    async () => approve("handled"),
+    async () => {
+      const resp = await agency.interrupt({
+        kind: "test",
+        message: "needs approval",
+        data: { foo: 1 },
+      });
+      return resp;
+    },
+  );
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/interrupt-handler-reject/agent.agency
+++ b/packages/agency-lang/tests/agency/ts-helpers/interrupt-handler-reject/agent.agency
@@ -1,0 +1,6 @@
+import { run } from "./helper.js"
+
+node main() {
+  const result = run()
+  return result
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/interrupt-handler-reject/agent.test.json
+++ b/packages/agency-lang/tests/agency/ts-helpers/interrupt-handler-reject/agent.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"type\":\"reject\",\"value\":\"nope\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/interrupt-handler-reject/helper.js
+++ b/packages/agency-lang/tests/agency/ts-helpers/interrupt-handler-reject/helper.js
@@ -1,0 +1,19 @@
+import { agency, reject } from "agency-lang/runtime";
+
+// Mirror of `interrupt-handler-approve` for the reject path. The
+// handler returns `reject("nope")`, so `agency.interrupt` resolves
+// to that reject outcome and the run continues to completion in
+// the same pass.
+export async function run() {
+  return agency.withHandler(
+    async () => reject("nope"),
+    async () => {
+      const resp = await agency.interrupt({
+        kind: "test",
+        message: "needs approval",
+        data: {},
+      });
+      return resp;
+    },
+  );
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/interrupt-resume-idempotency/agent.agency
+++ b/packages/agency-lang/tests/agency/ts-helpers/interrupt-resume-idempotency/agent.agency
@@ -1,0 +1,6 @@
+import { run, getHandlerCalls } from "./helper.js"
+
+node main() {
+  const result = run()
+  return { result: result, handlerCalls: getHandlerCalls() }
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/interrupt-resume-idempotency/agent.test.json
+++ b/packages/agency-lang/tests/agency/ts-helpers/interrupt-resume-idempotency/agent.test.json
@@ -1,0 +1,21 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"result\":\"user-said-yes\",\"handlerCalls\":1}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "value": "user-said-yes",
+          "expectedMessage": "?"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/interrupt-resume-idempotency/helper.js
+++ b/packages/agency-lang/tests/agency/ts-helpers/interrupt-resume-idempotency/helper.js
@@ -1,0 +1,35 @@
+import { agency } from "agency-lang/runtime";
+
+// Module-level counter so the agency entry can read it after the
+// resume cycle completes. The load-bearing claim:
+//   - First pass: body calls agency.interrupt, no persisted id,
+//     handler fires (counter = 1), returns undefined to propagate,
+//     interrupt halts.
+//   - Resume: body re-runs, agency.interrupt sees the persisted id
+//     in frame.locals and returns the user's response immediately
+//     WITHOUT consulting the handler chain. Counter must stay at 1.
+let handlerCalls = 0;
+
+export function getHandlerCalls() {
+  return handlerCalls;
+}
+
+export async function run() {
+  // NOTE: do NOT reset `handlerCalls` here — resume re-enters `run()`
+  // from the top, and a reset would clobber the first pass's count.
+  return agency.withHandler(
+    async () => {
+      handlerCalls += 1;
+      // Return undefined => no decision; propagate to user.
+      return undefined;
+    },
+    async () => {
+      const resp = await agency.interrupt({
+        kind: "ask",
+        message: "?",
+        data: null,
+      });
+      return resp.value;
+    },
+  );
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/resumable-scope-resume/agent.agency
+++ b/packages/agency-lang/tests/agency/ts-helpers/resumable-scope-resume/agent.agency
@@ -1,0 +1,6 @@
+import { runScope, getCalls } from "./helper.js"
+
+node main() {
+  const result = runScope()
+  return { result: result, calls: getCalls() }
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/resumable-scope-resume/agent.test.json
+++ b/packages/agency-lang/tests/agency/ts-helpers/resumable-scope-resume/agent.test.json
@@ -1,0 +1,21 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"result\":{\"v1\":\"first\",\"v2\":\"resumed\",\"v3\":\"third\"},\"calls\":{\"s1\":1,\"s2\":2,\"s3\":1}}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ],
+      "interruptHandlers": [
+        {
+          "action": "approve",
+          "value": "resumed",
+          "expectedMessage": "wait"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ts-helpers/resumable-scope-resume/helper.js
+++ b/packages/agency-lang/tests/agency/ts-helpers/resumable-scope-resume/helper.js
@@ -1,0 +1,38 @@
+import { agency } from "agency-lang/runtime";
+
+// Per-step execution counters. Initialized ONCE at module load —
+// not reset inside `runScope` because resume re-enters runScope from
+// the top, and a per-call reset would clobber the first pass's
+// counts. The load-bearing claim:
+//   - s1 ran once (cached on resume)
+//   - s2 ran twice (in-flight when interrupt fired; replayed on
+//     resume, this time finding the persisted response)
+//   - s3 ran once (only after resume completes the in-flight step)
+const calls = { s1: 0, s2: 0, s3: 0 };
+
+export function getCalls() {
+  return calls;
+}
+
+export async function runScope() {
+  return agency.withResumableScope({ name: "test" }, async (s) => {
+    const v1 = await s.step(() => {
+      calls.s1 += 1;
+      return "first";
+    });
+    const v2 = await s.step(async () => {
+      calls.s2 += 1;
+      const resp = await agency.interrupt({
+        kind: "pause",
+        message: "wait",
+        data: v1,
+      });
+      return resp.value;
+    });
+    const v3 = await s.step(() => {
+      calls.s3 += 1;
+      return "third";
+    });
+    return { v1: v1, v2: v2, v3: v3 };
+  });
+}


### PR DESCRIPTION
Adds 7 integration tests under `tests/agency/ts-helpers/` pinning the load-bearing behaviors of the `agency.*` TS-helpers surface (`agency.withResumableScope`, `agency.interrupt`, `agency.withHandler`, `agency.withCostGuard`, `agency.addCost`). The per-call unit tests added in PRs #207–#212 cover individual contracts; this PR closes the integration-coverage gap surfaced by the post-PR-211 self-review.

## Why agency tests (not agency-js, not a new vitest harness)

The question we are testing is *"does TS code calling `agency.*` participate in agent runs correctly?"* — i.e. **agency code calling JS**. That's the natural domain of `tests/agency/`: the `.agency` file is the entry, it imports a `.js` helper, the helper uses `agency.*`. The runner already drives interrupt round-trips declaratively via `interruptHandlers` in `.test.json`. No new test infrastructure was needed.

## Tests

Each test is a self-contained triplet (`agent.agency` + `helper.js` + `agent.test.json`) with assertions in `.test.json`:

| Test | Load-bearing behavior pinned |
| --- | --- |
| `resumable-scope-resume` | `withResumableScope` skips completed `s.step(...)` bodies on resume and re-runs the in-flight step from scratch, where it finds the user's response on the second pass. |
| `interrupt-handler-approve` | `agency.withHandler` returning `approve(value)` makes `agency.interrupt` resolve to that outcome with no halt and no resume. |
| `interrupt-handler-reject` | Same shape as approve but with `reject(value)`. |
| `interrupt-resume-idempotency` | When a handler propagates, `agency.interrupt` halts with a checkpoint; on resume, the persisted interrupt id short-circuits the second pass so the handler chain does NOT re-fire (counter stays at 1). |
| `halt-trycatch-cleanup` | `s.halt(value)` does not throw — surrounding `try/finally` still runs while subsequent `s.step(...)` calls short-circuit. |
| `cost-guard-trips` | `agency.addCost` over budget throws `GuardExceededError` synchronously, catchable inside the helper for structured failure reporting. |
| `fork-branch-isolation` | Per-branch `agency.addCost` contributions are attributed to each branch's own stack and do not leak across siblings. |

## Validation

- `pnpm tsc --noEmit` clean
- `pnpm run lint:structure` clean
- `pnpm run agency test tests/agency/ts-helpers/` — 7/7 pass
- No production code changes; this PR is tests-only
- No JS-side `expect` / `assert` calls — assertions live in `.test.json` (declarative)

## Follow-ups

This plan supersedes both `docs/superpowers/plans/2026-05-27-runtime-integration-harness.md` and `docs/superpowers/plans/2026-05-27-missing-integration-tests.md`. Both can be deleted in a follow-up cleanup.
