### PR TITLE
memory: charge internal LLM and embed spend against the active cost guard

### DIFF
--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -45,6 +45,18 @@ through one discoverable namespace.
   `undefined`) instead. The function remains as an internal helper
   for stdlib modules but is no longer documented as user-facing.
 
+### Changed — memory layer participates in cost guards
+
+- Memory's internal LLM and embedding calls (extraction, compaction,
+  tier-3 recall filter, observation embeddings, query embeddings) now
+  charge their spend against the surrounding branch's
+  `withCostGuard` budget via `agency.addCost(...)`. Previously these
+  calls bypassed cost tracking entirely, so a user wrapping an agent
+  in `withCostGuard($X)` could under-count actual spend whenever the
+  memory layer ran. The charge fires from inside `MemoryManager`'s
+  `_text` / `_embed` after a successful call. Outside an Agency
+  frame (direct-construction unit tests) the charge silently no-ops.
+
 ### Migration
 
 - TS code that called `AgencyFunction.invoke(descr, customState)`:

--- a/packages/agency-lang/TODO.md
+++ b/packages/agency-lang/TODO.md
@@ -165,3 +165,7 @@ tests/integration/stdlib-sandbox/credential/browser.test.json skipped, need to g
 
 1. it would be great if callbacks could access any local functions inside the function its in.
 2. After that, we should create an onAbort callback that gets called when a function gets aborted, maybe because a guard fires, or some other reason. Then it'd be great if onAbort had some way to abort any TypeScript functions it had called as well, which means that users would need some way to pass an abort signal into those functions. I think they could just create an abort signal object in agency and pass it through. Then when the agency function gets aborted, onAbort aborts the js calls as well. That is why you need those callbacks to be able to access local variables.
+
+---
+
+memory layer should use agency.llm, also add a new fun agency.embed that it can use for embeddings?

--- a/packages/agency-lang/lib/runtime/memory/manager.test.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { MemoryManager } from "./manager.js";
 import { FileMemoryStore } from "./store.js";
 import { StatelogClient } from "../../statelogClient.js";
+import { agency } from "../agency.js";
+import { RuntimeContext } from "../state/context.js";
+import { StateStack } from "../state/stateStack.js";
+import { ThreadStore } from "../state/threadStore.js";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
@@ -504,4 +508,156 @@ describe("MemoryManager", () => {
       }
     });
   });
+
+  // Memory's `_text` and `_embed` charge the surrounding branch's
+  // `withCostGuard` budget via `agency.addCost(...)`. Production
+  // paths always reach the manager from inside an Agency execution
+  // frame (post-completion hook in prompt.ts, or stdlib agency code
+  // calling remember/recall/forget); these tests install a frame by
+  // hand to exercise the same charge path without spinning up a
+  // full Runner.
+  describe("cost attribution", () => {
+    function makeFrame() {
+      const ctx = new RuntimeContext({
+        statelogConfig: {
+          host: "",
+          apiKey: "",
+          projectId: "",
+          debugMode: false,
+          observability: false,
+        },
+        smoltalkDefaults: {},
+        dirname: process.cwd(),
+      });
+      return { ctx, stack: new StateStack(), threads: new ThreadStore() };
+    }
+
+    function mockLlmClientWithCost(textCost: number, embedCost: number) {
+      const client = mockLlmClient();
+      client.text.mockResolvedValue({
+        success: true,
+        value: {
+          output: JSON.stringify({ entities: [], relations: [], expirations: [] }),
+          toolCalls: [],
+          model: "mock",
+          usage: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, totalTokens: 0 },
+          cost: {
+            inputCost: 0,
+            outputCost: textCost,
+            totalCost: textCost,
+            currency: "USD",
+          },
+        },
+      });
+      client.embed.mockResolvedValue({
+        success: true,
+        value: {
+          embeddings: [[0.1, 0.2, 0.3]],
+          model: "mock-embed",
+          costEstimate: {
+            inputCost: embedCost,
+            outputCost: 0,
+            totalCost: embedCost,
+            currency: "USD",
+          },
+        },
+      });
+      return client;
+    }
+
+    it("charges _text spend to the active branch's localCost", async () => {
+      const env = makeFrame();
+      const client = mockLlmClientWithCost(0.05, 0);
+      const manager = new MemoryManager({
+        store: new FileMemoryStore(tmpDir),
+        config: { dir: tmpDir },
+        llmClient: client,
+      });
+      const before = env.stack.localCost;
+      await agency.withTestContext(env, async () => {
+        // `remember` calls `_text` once for the extraction prompt and
+        // returns early when the parse yields no entities — no embed
+        // call follows, so this isolates the text-cost charge.
+        await manager.remember("nothing notable");
+      });
+      expect(env.stack.localCost).toBeCloseTo(before + 0.05, 10);
+    });
+
+    it("charges _embed spend in addition to _text spend", async () => {
+      const env = makeFrame();
+      const client = mockLlmClientWithCost(0.05, 0.01);
+      // Extraction yields one entity with one observation → one
+      // _text call ($0.05) + one _embed call ($0.01).
+      client.text.mockResolvedValueOnce(
+        wrapTextResultWithCost(
+          JSON.stringify({
+            entities: [
+              { name: "Maggie", type: "person", observations: ["weaves baskets"] },
+            ],
+            relations: [],
+            expirations: [],
+          }),
+          0.05,
+        ),
+      );
+      const manager = new MemoryManager({
+        store: new FileMemoryStore(tmpDir),
+        config: { dir: tmpDir },
+        llmClient: client,
+      });
+      const before = env.stack.localCost;
+      await agency.withTestContext(env, async () => {
+        await manager.remember("Maggie weaves baskets");
+      });
+      expect(env.stack.localCost).toBeCloseTo(before + 0.05 + 0.01, 10);
+    });
+
+    it("no-ops cleanly when called outside any Agency frame", async () => {
+      // Direct-construction unit tests (the rest of this file) call
+      // the manager without ever installing a frame. The charge path
+      // must silently skip in that case rather than throwing.
+      const client = mockLlmClientWithCost(0.05, 0);
+      const manager = new MemoryManager({
+        store: new FileMemoryStore(tmpDir),
+        config: { dir: tmpDir },
+        llmClient: client,
+      });
+      await expect(manager.remember("anything")).resolves.toBeUndefined();
+    });
+
+    it("trips a withCostGuard when memory's spend exceeds the budget", async () => {
+      const env = makeFrame();
+      const client = mockLlmClientWithCost(1.0, 0);
+      const manager = new MemoryManager({
+        store: new FileMemoryStore(tmpDir),
+        config: { dir: tmpDir },
+        llmClient: client,
+      });
+      await agency.withTestContext(env, async () => {
+        // $0.50 budget, memory's _text call charges $1.00 →
+        // `enforceGuards()` inside `agency.addCost` throws.
+        await expect(
+          agency.withCostGuard(0.5, async () => {
+            await manager.remember("anything");
+          }),
+        ).rejects.toThrow(/cost/i);
+      });
+    });
+  });
 });
+
+// Build a PromptResult with a specific `totalCost` for the test-cost
+// suite. Same shape as `wrapTextResult` but lets the caller pin the
+// cost so assertions can mix calls with different prices.
+function wrapTextResultWithCost(output: string, totalCost: number) {
+  return {
+    success: true,
+    value: {
+      output,
+      toolCalls: [],
+      model: "mock",
+      usage: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 0, totalTokens: 0 },
+      cost: { inputCost: 0, outputCost: totalCost, totalCost, currency: "USD" },
+    },
+  };
+}

--- a/packages/agency-lang/lib/runtime/memory/manager.test.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.test.ts
@@ -643,6 +643,45 @@ describe("MemoryManager", () => {
         ).rejects.toThrow(/cost/i);
       });
     });
+
+    it("propagates a GuardExceededError from inside generateEmbeddings's swallow site", async () => {
+      // Regression for the original Proposal A PR review: memory has
+      // several "best effort" catches around _text / _embed (per-obs
+      // embed in generateEmbeddings, tier-2 query embed, tier-3 LLM
+      // filter). If those catches absorbed a GuardExceededError, the
+      // surrounding withCostGuard would silently fail to trip. This
+      // test pins the propagation by making the embed-side cost
+      // (not the text cost) blow the budget — the throw happens
+      // inside the catch block of `generateEmbeddings`.
+      const env = makeFrame();
+      const client = mockLlmClientWithCost(0, 1.0);
+      // Extraction returns one entity with one observation so
+      // generateEmbeddings runs at all.
+      client.text.mockResolvedValueOnce(
+        wrapTextResultWithCost(
+          JSON.stringify({
+            entities: [
+              { name: "Maggie", type: "person", observations: ["weaves baskets"] },
+            ],
+            relations: [],
+            expirations: [],
+          }),
+          0,
+        ),
+      );
+      const manager = new MemoryManager({
+        store: new FileMemoryStore(tmpDir),
+        config: { dir: tmpDir },
+        llmClient: client,
+      });
+      await agency.withTestContext(env, async () => {
+        await expect(
+          agency.withCostGuard(0.5, async () => {
+            await manager.remember("Maggie weaves baskets");
+          }),
+        ).rejects.toThrow(/cost/i);
+      });
+    });
   });
 });
 

--- a/packages/agency-lang/lib/runtime/memory/manager.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.ts
@@ -31,6 +31,24 @@ import type { StatelogClient } from "../../statelogClient.js";
 import forgetTemplate from "../../templates/prompts/memory/forget.js";
 import retrievalTemplate from "../../templates/prompts/memory/retrieval.js";
 import type { LLMClient } from "../llmClient.js";
+import { agency } from "../agency.js";
+import { agencyStore } from "../asyncContext.js";
+
+/**
+ * Charge `amount` against the active branch's `withCostGuard` budget
+ * if (and only if) we're inside an Agency execution frame. Memory's
+ * text + embed calls run from inside `runPrompt`'s post-completion
+ * hook or from stdlib agency calls — both reach this code with an
+ * `agencyStore` frame already installed, so production paths always
+ * charge correctly. The frame check is for direct-construction unit
+ * tests that exercise `MemoryManager` without going through the
+ * runner.
+ */
+function chargeCostIfInFrame(amount: number): void {
+  if (amount <= 0) return;
+  if (!agencyStore.getStore()) return;
+  agency.addCost(amount);
+}
 
 // Cap on the `inputPreview` slice we put on every embedCompletion
 // event. Short enough that a transcript fragment in stderr or in a
@@ -247,6 +265,12 @@ export class MemoryManager {
           `[memory] statelog promptCompletion failed: ${(err as Error).message}`,
         );
       }
+      // Charge this call's spend against the surrounding branch's
+      // cost budget. Mirrors the post-completion charge that
+      // `prompt.ts` performs for agency-side `llm()` calls, so a
+      // `withCostGuard($X)` wrapping the agent now sees memory's
+      // extraction / compaction / tier-3 spend too.
+      chargeCostIfInFrame(result.value.cost?.totalCost ?? 0);
       return result.value.output ?? "";
     } finally {
       this.statelogClient?.endSpan(spanId);
@@ -315,6 +339,11 @@ export class MemoryManager {
           `[memory] statelog embedCompletion failed: ${(err as Error).message}`,
         );
       }
+      // Same rationale as `_text` above — embed calls contribute to
+      // the surrounding branch's cost budget too. `EmbedResult.costEstimate`
+      // (smoltalk's name) is optional; absent / zero means "free or
+      // unknown" and the charge is skipped.
+      chargeCostIfInFrame(result.value.costEstimate?.totalCost ?? 0);
       return vector;
     } finally {
       this.statelogClient?.endSpan(spanId);

--- a/packages/agency-lang/lib/runtime/memory/manager.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.ts
@@ -33,6 +33,7 @@ import retrievalTemplate from "../../templates/prompts/memory/retrieval.js";
 import type { LLMClient } from "../llmClient.js";
 import { agency } from "../agency.js";
 import { agencyStore } from "../asyncContext.js";
+import { isGuardExceededError } from "../guard.js";
 
 /**
  * Charge `amount` against the active branch's `withCostGuard` budget
@@ -45,9 +46,22 @@ import { agencyStore } from "../asyncContext.js";
  * runner.
  */
 function chargeCostIfInFrame(amount: number): void {
-  if (amount <= 0) return;
   if (!agencyStore.getStore()) return;
   agency.addCost(amount);
+}
+
+/**
+ * Re-throw `err` if it is a `GuardExceededError` so cost / time
+ * guards trip the surrounding `withCostGuard` / `withTimeGuard`
+ * scope even when raised from inside one of memory's "best effort"
+ * catches (tier-2 embed, tier-3 LLM filter, per-observation embed).
+ * Without this, `chargeCostIfInFrame` could push the stack over the
+ * limit, throw, and have its throw silently absorbed — defeating
+ * the budget the user set. Provider / parse errors are not guard
+ * errors and continue to fall through to the catch body as before.
+ */
+function rethrowIfGuard(err: unknown): void {
+  if (isGuardExceededError(err)) throw err;
 }
 
 // Cap on the `inputPreview` slice we put on every embedCompletion
@@ -668,6 +682,10 @@ export class MemoryManager {
         // the precision filter. Returning the cheap-tier order anyway
         // would defeat the filter's purpose.
       } catch (err) {
+        // Guard trips must bubble out of recall — they signal the
+        // surrounding `withCostGuard` / `withTimeGuard` has been
+        // exceeded and the agent should stop, not silently fall back.
+        rethrowIfGuard(err);
         this.logger.warn(
           `[memory] tier 3 (LLM filter) failed for query="${truncatePreview(query, QUERY_PREVIEW_CHARS)}": ${(err as Error).message}`,
         );
@@ -1077,6 +1095,8 @@ export class MemoryManager {
         });
         entry.setEmbedding(id, vector);
       } catch (err) {
+        // Guard trips bubble — see rethrowIfGuard comment.
+        rethrowIfGuard(err);
         // Embedding failed — Tier 2 will silently no-op for this
         // observation (resolved decision #8). Logged at debug here so
         // a wave of failures shows up in `logLevel: "debug"` runs.
@@ -1132,6 +1152,8 @@ export class MemoryManager {
         phase: "recall-query",
       });
     } catch (err) {
+      // Guard trips bubble — see rethrowIfGuard comment.
+      rethrowIfGuard(err);
       // Tier 2 degrades to zero hits when embedding the query fails;
       // surfaced at debug so the caller can correlate the empty tier2
       // line above with the underlying provider error.

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -4,6 +4,7 @@ import { createLogger } from "../logger.js";
 import { AgencyFunction } from "./agencyFunction.js";
 import { getRuntimeContext } from "./asyncContext.js";
 import { AgencyCancelledError, isAbortError } from "./errors.js";
+import { isGuardExceededError } from "./guard.js";
 import { callHook, invokeCallbacks } from "./hooks.js";
 import { hasInterrupts, isRejected } from "./interrupts.js";
 import type { PromptConfig } from "./llmClient.js";
@@ -224,6 +225,12 @@ async function _runPrompt({
         messages.setMessages([...head, summary, ...tail]);
       }
     } catch (err) {
+      // Cost / time guard trips are NOT best-effort failures — they
+      // signal the surrounding `withCostGuard` / `withTimeGuard` has
+      // been exceeded and the agent should stop. Re-throw so the
+      // signal reaches the user's scope instead of being silently
+      // logged here.
+      if (isGuardExceededError(err)) throw err;
       // The memory hook is best-effort: a failure here must never
       // break the LLM call. Logged at `warn` so users see the failure
       // by default; the manager already emitted finer-grained debug
@@ -398,6 +405,9 @@ export async function runPrompt(args: {
           messages.push(smoltalk.systemMessage(injectedFactsContent));
         }
       } catch (err) {
+        // Guard trips are signals, not best-effort failures — let
+        // them bubble to the surrounding `withCostGuard` scope.
+        if (isGuardExceededError(err)) throw err;
         createLogger(ctx.logLevel).warn(
           `[memory] recall injection failed: ${(err as Error).message}`,
         );


### PR DESCRIPTION
## What

Memory's internal LLM and embedding calls (extraction, compaction, tier-3 recall filter, observation embeddings, query embeddings) now charge their spend against the surrounding branch's `withCostGuard` budget via `agency.addCost(...)`. Previously these calls bypassed cost tracking entirely.

This is Proposal A from the design discussion around the [memory-llm-via-async-context spec](docs/superpowers/specs/2026-05-25-memory-llm-via-async-context-design.md) — the smallest possible step that buys correct cost semantics without restructuring the memory layer's LLM client plumbing. Future PRs (B/C) can switch memory's text calls to `agency.llm` and drop the constructor's `llmClient`/`smoltalkDefaults`/`statelogClient` params; this PR explicitly does not do that.

## Why

The memory layer maintains its own reference to the runtime's `LLMClient` (captured at `MemoryManager` construction time). Its calls reach the provider successfully, but the `cost.totalCost` they return never flowed into `stack.localCost`, so a user wrapping their agent in `withCostGuard($X)` could under-count actual spend whenever memory was active. The cost-guard spec calls this out as a hole.

The `agency.addCost(amount)` helper (#212 area) is the exact primitive `prompt.ts` uses post-completion for agency-side `llm()` calls — it does `stack.localCost += amount; chargeGuards; enforceGuards`. Calling it from memory's `_text`/`_embed` after a successful provider response gives memory calls the same cost-tracking semantics as native `llm()`.

## How

- `lib/runtime/memory/manager.ts`
  - Import `agency` and `agencyStore`.
  - Add a one-line `chargeCostIfInFrame(amount)` helper that calls `agency.addCost(amount)` only when an Agency frame is installed (so direct-construction unit tests don't blow up).
  - Call it inside `_text` (using `result.value.cost?.totalCost ?? 0`) and `_embed` (using `result.value.costEstimate?.totalCost ?? 0`, since `EmbedResult` uses the `costEstimate` field name).
- `lib/runtime/memory/manager.test.ts`
  - New `cost attribution` describe block with 4 tests:
    1. `_text` spend goes into `stack.localCost`.
    2. `_text` + `_embed` both charge when extraction yields observations.
    3. Direct-construction (no frame) no-ops cleanly.
    4. `withCostGuard($0.50)` trips when a $1.00 memory call runs.
- `CHANGELOG.md`
  - Added a `Changed` section under unreleased calling out the user-visible behavior change.

## Why this is safe to ship as a single PR

- Zero changes to memory's constructor surface — `MemoryManagerOptions` is untouched.
- Zero changes to which LLMClient is used or how — same code path, just one extra call after success.
- Frame check on the addCost path means direct-construction tests continue to work unchanged (all 14 existing tests pass).
- Reverting is one diff hunk per file if cost semantics surprise anyone.

## Validation

```
$ npx tsc --noEmit             # clean
$ npx vitest run lib/runtime/memory/manager.test.ts  # 18/18 pass (14 existing + 4 new)
$ npx vitest run lib/runtime/agency.test.ts          # 29/29 pass
$ pnpm run lint:structure       # clean
```

## Out of scope

- Switching `_text` to `agency.llm` (Proposal B): saves boilerplate and gives memory the test-client swap, but requires updating the existing statelog event assertions; deferred.
- Switching `_embed` to a new `agency.embed` helper (Proposal C): mirrors `agency.llm` but doesn't exist yet; deferred until B lands.
- Per-source cost breakdown in `tokenStats` so users can see "memory cost $X separately from agent cost $Y": noted in the spec as v1.x follow-up.
- Recursive-depth guard on `agency.addCost`/`agency.llm`: orthogonal to this PR, called out in the spec.
