### PR TITLE
runtime: give LLM tool invocations a fresh ThreadStore

### DIFF
--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -2,7 +2,7 @@ import * as smoltalk from "smoltalk";
 import { PromptResult, ToolCallJSON } from "smoltalk";
 import { createLogger } from "../logger.js";
 import { AgencyFunction } from "./agencyFunction.js";
-import { getRuntimeContext } from "./asyncContext.js";
+import { agencyStore, getRuntimeContext } from "./asyncContext.js";
 import { AgencyCancelledError, isAbortError } from "./errors.js";
 import { isGuardExceededError } from "./guard.js";
 import { callHook, invokeCallbacks } from "./hooks.js";
@@ -16,6 +16,7 @@ import type { SourceLocationOpts } from "./state/checkpointStore.js";
 import type { RuntimeContext } from "./state/context.js";
 import { MessageThread } from "./state/messageThread.js";
 import { StateStack } from "./state/stateStack.js";
+import { ThreadStore } from "./state/threadStore.js";
 import { handleStreamingResponse } from "./streaming.js";
 import { GraphState } from "./types.js";
 import { extractResponse, updateTokenStats } from "./utils.js";
@@ -482,16 +483,35 @@ export async function runPrompt(args: {
       let toolResult: any;
       ctx.enterToolCall();
       try {
-        // The tool body runs inside whichever ALS frame the prompt
-        // loop is already in — that frame's `ctx` / `stack` / `threads`
-        // are the correct ones for this tool invocation (the prompt
-        // loop is entered from a `Runner.runInScope` body inside the
-        // branch). No extra wrap needed.
-        toolResult = await handler.invoke({
-          type: "named",
-          positionalArgs: [],
-          namedArgs,
-        });
+        // The tool body inherits the calling ALS frame's `ctx` and
+        // `stack` (the branch's per-tool-call stack, set up by
+        // `runBatch.runInBranchAlsFrame`) — those are correct for
+        // branch-aware cancellation and per-branch state. The
+        // `threads` slot, however, must NOT be inherited. If the tool
+        // body issues its own `llm()` call, that nested prompt would
+        // push messages into the OUTER prompt's MessageThread (whose
+        // last message is `assistant(tool_calls=[this tool])`),
+        // producing a thread shape OpenAI rejects with "An assistant
+        // message with 'tool_calls' must be followed by tool
+        // messages". A nested tool invocation is logically a fresh
+        // conversation, so install a fresh ThreadStore for the
+        // duration of this invoke. Pre-ALS, `setupFunction` produced
+        // the same outcome via its `state.threads || new ThreadStore()`
+        // fallback whenever a function was reached via tool dispatch.
+        const parentFrame = agencyStore.getStore();
+        const freshThreads = ThreadStore.withDefaultActive(ctx.statelogClient);
+        const invokeAsTool = () =>
+          handler.invoke({
+            type: "named",
+            positionalArgs: [],
+            namedArgs,
+          });
+        toolResult = parentFrame
+          ? await agencyStore.run(
+              { ...parentFrame, threads: freshThreads },
+              invokeAsTool,
+            )
+          : await invokeAsTool();
       } catch (error: unknown) {
         const errorMessage =
           error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
## Summary

Fixes a regression where a tool body's internal `llm(...)` call corrupts the outer prompt's message thread, causing OpenAI to reject the next API call with:

> `400 An assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'.`

## Background

When the LLM responds with `tool_calls`, `runPrompt` pushes an `assistant(tool_calls=[...])` message onto the shared `MessageThread`, then invokes each tool. The matching `tool(...)` response messages are pushed afterwards. OpenAI's API requires those tool responses to immediately follow the assistant message, or it rejects the next request.

Pre-ALS, `setupFunction` resolved `threads` as `state.threads || new ThreadStore()`. When a function was reached via LLM tool dispatch (no `state.threads` passed), it got its own fresh `ThreadStore` — so any internal `llm(...)` call started a brand-new conversation, independent of the caller's prompt.

The ALS migration (commit `3428c9c3`) removed that fallback: `setupFunction` now reads `threads` from the active `agencyStore` frame, which is the calling frame's `threads` (the outer prompt's `ThreadStore`). Tool bodies that called `llm(...)` internally would push their `user` message onto the same thread whose last entry was `assistant(tool_calls=[thisTool])`, producing a malformed sequence and a hard 400 from OpenAI.

## Symptoms

Reproduced by:
- `tests/agency/imports/foo.test.json` — the `agencyImport` node calls `ascii(...)` which itself does `return llm(...)`.
- `tests/agency/fork/llm-tools/nested-llm-interrupt.test.json` — three nested LLM/tool layers.

Both fail on main with the 400 above.

## Fix

At the LLM tool-dispatch site in `runInvokeStep` (`lib/runtime/prompt.ts`), install a fresh ALS frame whose `threads` slot is a new `ThreadStore` for the duration of `handler.invoke(...)`. `ctx` and `stack` are inherited from the calling frame (the per-branch stack set up by `runBatch.runInBranchAlsFrame`), preserving branch-aware cancellation, abort signals, and per-branch state. The tool result message is still pushed onto the outer prompt's `messages` (the closure captures the parent thread directly), so the OpenAI contract is satisfied: every `tool_calls` entry is followed by a `tool` response in the outer thread.

This restores the pre-ALS contract — invocation as a tool implies an isolated message scope — while leaving direct Agency-to-Agency `__call(...)` paths untouched.

## Verification

- `tests/agency/imports/foo.test.json` (all 4 nodes pass)
- `tests/agency/fork/llm-tools/nested-llm-interrupt.test.json` passes
- All 11 tests in `tests/agency/fork/llm-tools/` pass

## Scope

Production runtime fix only — single file (`lib/runtime/prompt.ts`), `+31 -11` lines. No tests changed in this PR. Surfaced while investigating two failing tests under PR #214 (tests-only follow-up); per the convention from PR #213's plan, runtime bugs surfaced by integration tests get filed as their own precursor PR rather than papered over with test-only workarounds.
