### PR TITLE
stdlib: add allowedPaths/allowedExecutables containment to fs, shell, system, speech, policy helpers

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/fs.md
+++ b/packages/agency-lang/docs/site/stdlib/fs.md
@@ -109,16 +109,20 @@ Apply a sequence of edits to a single file atomically. Each edit has oldText, ne
 ### applyPatch
 
 ```ts
-applyPatch(patch: string): Result
+applyPatch(patch: string, allowedPaths: string[]): Result
 ```
 
-Apply a unified diff to the working tree. Supports file creation (--- /dev/null), line additions, deletions, and context. Fails on a malformed diff or on a context-line mismatch against the current file contents.
+Apply a unified diff to the working tree. Supports file creation (--- /dev/null), line additions, deletions, and context. Fails on a malformed diff or on a context-line mismatch against the current file contents. Set allowedPaths to restrict which path prefixes can be touched by the patch.
+
+  @param patch - The unified diff to apply
+  @param allowedPaths - Only allow patches that touch files under these prefixes
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | patch | `string` |  |
+| allowedPaths | `string[]` | [] |
 
 **Returns:** `Result`
 
@@ -129,22 +133,26 @@ Apply a unified diff to the working tree. Supports file creation (--- /dev/null)
 ### mkdir
 
 ```ts
-mkdir(dir: string): Result
+mkdir(dir: string, allowedPaths: string[]): Result
 ```
 
-Create a directory, including any missing parent directories. Idempotent: succeeds if the directory already exists. Fails if a non-directory entry already occupies the path, or on permission errors.
+Create a directory, including any missing parent directories. Idempotent: succeeds if the directory already exists. Fails if a non-directory entry already occupies the path, or on permission errors. Set allowedPaths to restrict which path prefixes are permitted.
+
+  @param dir - The directory to create
+  @param allowedPaths - Only allow paths starting with these prefixes
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | dir | `string` |  |
+| allowedPaths | `string[]` | [] |
 
 **Returns:** `Result`
 
 **Throws:** `std::mkdir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L74))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L77))
 
 ### copy
 
@@ -170,7 +178,7 @@ Copy a file or directory. Directories are copied recursively. Fails if src does 
 
 **Throws:** `std::copy`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L91))
 
 ### move
 
@@ -196,7 +204,7 @@ Move or rename a file or directory. Falls back to copy+remove if src and dest ar
 
 **Throws:** `std::move`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L107))
 
 ### remove
 
@@ -220,4 +228,4 @@ Delete a file or directory. Directories are removed recursively. Does not fail i
 
 **Throws:** `std::remove`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L117))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L123))

--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -83,10 +83,14 @@ Validate that a policy object is well-formed. Returns { success: true } if valid
 ### writePolicyFile
 
 ```ts
-writePolicyFile(path: string, policy: Policy)
+writePolicyFile(path: string, policy: Policy, allowedPaths: string[])
 ```
 
-Validate and write a policy to a JSON file. Throws if the policy is invalid.
+Validate and write a policy to a JSON file. Throws if the policy is invalid. Set allowedPaths to restrict where the policy file may be written.
+
+  @param path - The destination file path
+  @param policy - The policy to write
+  @param allowedPaths - Only allow writing under these path prefixes
 
 **Parameters:**
 
@@ -94,5 +98,6 @@ Validate and write a policy to a JSON file. Throws if the policy is invalid.
 |---|---|---|
 | path | `string` |  |
 | policy | [Policy](#policy) |  |
+| allowedPaths | `string[]` | [] |
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L37))

--- a/packages/agency-lang/docs/site/stdlib/shell.md
+++ b/packages/agency-lang/docs/site/stdlib/shell.md
@@ -25,7 +25,7 @@ type LsEntry = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L93))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L99))
 
 ### GrepMatch
 
@@ -37,7 +37,7 @@ type GrepMatch = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L115))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L122))
 
 ### StatInfo
 
@@ -50,25 +50,26 @@ type StatInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L166))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L177))
 
 ## Functions
 
 ### exec
 
 ```ts
-exec(command: string, args: string[], cwd: string, timeout: number, stdin: string, allowedCommands: string[], blockedCommands: string[]): ExecResult
+exec(command: string, args: string[], cwd: string, timeout: number, stdin: string, allowedExecutables: string[], blockedCommands: string[], allowedPaths: string[]): ExecResult
 ```
 
-Run an executable directly with an array of arguments, bypassing the shell. This is safer than bash() because arguments are passed directly to the process without shell interpretation, preventing command injection. Use this when you have a known command and structured arguments. Pass cwd to change the working directory, timeout in milliseconds to enforce a time limit (e.g. timeout: 30s), and stdin to feed input to the command. Set allowedCommands to restrict which executables can be run. Set blockedCommands to reject specific executables.
+Run an executable directly with an array of arguments, bypassing the shell. This is safer than bash() because arguments are passed directly to the process without shell interpretation, preventing command injection. Use this when you have a known command and structured arguments. Pass cwd to change the working directory, timeout in milliseconds to enforce a time limit (e.g. timeout: 30s), and stdin to feed input to the command. Set allowedExecutables to restrict which executables can be run. Set blockedCommands to reject specific executables. Set allowedPaths to require `cwd` to live under one of those prefixes.
 
   @param command - The executable to run
   @param args - Array of arguments to pass
   @param cwd - Working directory for the command
   @param timeout - Time limit in milliseconds (e.g. 30s)
   @param stdin - Input to feed to the command
-  @param allowedCommands - Only allow running these executables
+  @param allowedExecutables - Only allow running these executables (allow-list)
   @param blockedCommands - Block running these executables
+  @param allowedPaths - Only allow cwd values under these path prefixes
 
 **Parameters:**
 
@@ -79,8 +80,9 @@ Run an executable directly with an array of arguments, bypassing the shell. This
 | cwd | `string` | "" |
 | timeout | `number` | 0 |
 | stdin | `string` | "" |
-| allowedCommands | `string[]` | [] |
+| allowedExecutables | `string[]` | [] |
 | blockedCommands | `string[]` | [] |
+| allowedPaths | `string[]` | [] |
 
 **Returns:** [ExecResult](#execresult)
 
@@ -91,16 +93,17 @@ Run an executable directly with an array of arguments, bypassing the shell. This
 ### bash
 
 ```ts
-bash(command: string, cwd: string, timeout: number, stdin: string, blockedCommands: string[]): ExecResult
+bash(command: string, cwd: string, timeout: number, stdin: string, blockedCommands: string[], allowedPaths: string[]): ExecResult
 ```
 
-Run a shell command string via sh -c and return its stdout, stderr, and exit code. The command is interpreted by the shell, so pipes, redirects, globbing, and other shell features work. However, this means interpolated values are subject to shell interpretation -- use exec() instead when passing untrusted or dynamic arguments. Pass cwd to change the working directory, timeout in milliseconds to enforce a time limit (e.g. timeout: 30s), and stdin to feed input to the command. Set blockedCommands to reject commands that start with specific strings.
+Run a shell command string via sh -c and return its stdout, stderr, and exit code. The command is interpreted by the shell, so pipes, redirects, globbing, and other shell features work. However, this means interpolated values are subject to shell interpretation -- use exec() instead when passing untrusted or dynamic arguments. Pass cwd to change the working directory, timeout in milliseconds to enforce a time limit (e.g. timeout: 30s), and stdin to feed input to the command. Set blockedCommands to reject commands that start with specific strings. Set allowedPaths to require `cwd` to live under one of those prefixes; bash() cannot meaningfully restrict the shell string itself, so prefer exec() when capability narrowing matters.
 
   @param command - The shell command to run
   @param cwd - Working directory for the command
   @param timeout - Time limit in milliseconds (e.g. 30s)
   @param stdin - Input to feed to the command
   @param blockedCommands - Block commands that start with these strings
+  @param allowedPaths - Only allow cwd values under these path prefixes
 
 **Parameters:**
 
@@ -111,23 +114,25 @@ Run a shell command string via sh -c and return its stdout, stderr, and exit cod
 | timeout | `number` | 0 |
 | stdin | `string` | "" |
 | blockedCommands | `string[]` | [] |
+| allowedPaths | `string[]` | [] |
 
 **Returns:** [ExecResult](#execresult)
 
 **Throws:** `std::bash`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L59))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L62))
 
 ### ls
 
 ```ts
-ls(dir: string, recursive: boolean): Result
+ls(dir: string, recursive: boolean, allowedPaths: string[]): Result
 ```
 
-List entries in a directory. Each entry includes name, path, type ("file", "dir", "symlink", "other"), and size. Set recursive to true to walk subdirectories. Fails if the directory cannot be read (missing, not a directory, permission denied).
+List entries in a directory. Each entry includes name, path, type ("file", "dir", "symlink", "other"), and size. Set recursive to true to walk subdirectories. Fails if the directory cannot be read (missing, not a directory, permission denied). Set allowedPaths to restrict which directories may be listed.
 
   @param dir - The directory to list
   @param recursive - Whether to walk subdirectories
+  @param allowedPaths - Only allow listing directories under these prefixes
 
 **Parameters:**
 
@@ -135,25 +140,27 @@ List entries in a directory. Each entry includes name, path, type ("file", "dir"
 |---|---|---|
 | dir | `string` | "." |
 | recursive | `boolean` | false |
+| allowedPaths | `string[]` | [] |
 
 **Returns:** `Result`
 
 **Throws:** `std::ls`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L100))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L106))
 
 ### grep
 
 ```ts
-grep(pattern: string, dir: string, flags: string, maxResults: number): Result
+grep(pattern: string, dir: string, flags: string, maxResults: number, allowedPaths: string[]): Result
 ```
 
-Search for a regex pattern in files under a directory. Returns matches with file path, line number, and matched line. Skips node_modules, .git, dist, build. Stops at maxResults. Fails if the pattern is not a valid regex or the directory cannot be read.
+Search for a regex pattern in files under a directory. Returns matches with file path, line number, and matched line. Skips node_modules, .git, dist, build. Stops at maxResults. Fails if the pattern is not a valid regex or the directory cannot be read. Set allowedPaths to restrict which directories may be searched.
 
   @param pattern - The regex pattern to search for
   @param dir - The directory to search in
   @param flags - Regex flags
   @param maxResults - Maximum number of results to return
+  @param allowedPaths - Only allow searching under these path prefixes
 
 **Parameters:**
 
@@ -163,24 +170,26 @@ Search for a regex pattern in files under a directory. Returns matches with file
 | dir | `string` | "." |
 | flags | `string` | "" |
 | maxResults | `number` | 200 |
+| allowedPaths | `string[]` | [] |
 
 **Returns:** `Result`
 
 **Throws:** `std::grep`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L121))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L128))
 
 ### glob
 
 ```ts
-glob(pattern: string, dir: string, maxResults: number): Result
+glob(pattern: string, dir: string, maxResults: number, allowedPaths: string[]): Result
 ```
 
-Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Returns paths relative to the current working directory. Stops at maxResults. Fails if the pattern is not valid glob syntax or the directory cannot be read.
+Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Returns paths relative to the current working directory. Stops at maxResults. Fails if the pattern is not valid glob syntax or the directory cannot be read. Set allowedPaths to restrict which directories may be searched.
 
   @param pattern - The glob pattern to match
   @param dir - The directory to search in
   @param maxResults - Maximum number of results to return
+  @param allowedPaths - Only allow searching under these path prefixes
 
 **Parameters:**
 
@@ -189,48 +198,57 @@ Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Returns paths 
 | pattern | `string` |  |
 | dir | `string` | "." |
 | maxResults | `number` | 500 |
+| allowedPaths | `string[]` | [] |
 
 **Returns:** `Result`
 
 **Throws:** `std::glob`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L145))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L154))
 
 ### stat
 
 ```ts
-stat(filename: string): StatInfo
+stat(filename: string, allowedPaths: string[]): StatInfo
 ```
 
-Return metadata about a filesystem entry: whether it exists, its type ("file", "dir", "symlink", "other", or "missing" if absent), size in bytes, and mtime in ms.
+Return metadata about a filesystem entry: whether it exists, its type ("file", "dir", "symlink", "other", or "missing" if absent), size in bytes, and mtime in ms. Set allowedPaths to restrict which paths may be stat-ed.
+
+  @param filename - The path to stat
+  @param allowedPaths - Only allow paths under these prefixes
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | filename | `string` |  |
+| allowedPaths | `string[]` | [] |
 
 **Returns:** [StatInfo](#statinfo)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L173))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L184))
 
 ### exists
 
 ```ts
-exists(filename: string): boolean
+exists(filename: string, allowedPaths: string[]): boolean
 ```
 
-Return true if a file or directory exists at the given path.
+Return true if a file or directory exists at the given path. Set allowedPaths to restrict which paths may be probed; probing outside the allow-list raises an error rather than silently returning false.
+
+  @param filename - The path to check
+  @param allowedPaths - Only allow paths under these prefixes
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | filename | `string` |  |
+| allowedPaths | `string[]` | [] |
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L180))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L194))
 
 ### which
 
@@ -248,4 +266,4 @@ Locate an executable in PATH and return its absolute path. Returns an empty stri
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L187))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/shell.agency#L204))

--- a/packages/agency-lang/docs/site/stdlib/speech.md
+++ b/packages/agency-lang/docs/site/stdlib/speech.md
@@ -5,10 +5,10 @@
 ### speak
 
 ```ts
-speak(text: string, voice: string, rate: number, outputFile: string)
+speak(text: string, voice: string, rate: number, outputFile: string, allowedPaths: string[])
 ```
 
-A tool for speaking text aloud using text-to-speech. Optionally specify a voice name, rate in words per minute, and an output file to save the audio to instead of playing it.
+A tool for speaking text aloud using text-to-speech. Optionally specify a voice name, rate in words per minute, and an output file to save the audio to instead of playing it. Set allowedPaths to restrict where the output file may be written.
 
   Cancellation: in-progress speech playback is stopped on Ctrl-C, race-loser, or time-guard abort.
 
@@ -16,6 +16,7 @@ A tool for speaking text aloud using text-to-speech. Optionally specify a voice 
   @param voice - Voice name
   @param rate - Words per minute
   @param outputFile - File path to save audio to
+  @param allowedPaths - Only allow saving under these path prefixes
 
 **Parameters:**
 
@@ -25,6 +26,7 @@ A tool for speaking text aloud using text-to-speech. Optionally specify a voice 
 | voice | `string` | "" |
 | rate | `number` | 0 |
 | outputFile | `string` | "" |
+| allowedPaths | `string[]` | [] |
 
 **Throws:** `std::speak`
 
@@ -33,7 +35,7 @@ A tool for speaking text aloud using text-to-speech. Optionally specify a voice 
 ### record
 
 ```ts
-record(outputFile: string, silenceTimeout: number): string
+record(outputFile: string, silenceTimeout: number, allowedPaths: string[]): string
 ```
 
 Record audio from the microphone. Stops when the user presses Enter,
@@ -46,8 +48,11 @@ Record audio from the microphone. Stops when the user presses Enter,
 
   Cancellation: an in-progress recording is stopped on Ctrl-C, race-loser, or time-guard abort, surfacing as an AgencyCancelledError.
 
+  Set allowedPaths to restrict where a non-empty outputFile may be written; an empty outputFile is auto-generated under the system temp directory and is not subject to the allow-list.
+
   @param outputFile - File path to save audio to (auto-generated if empty)
   @param silenceTimeout - Silence before auto-stopping in ms (0 to disable)
+  @param allowedPaths - Only allow saving under these path prefixes
 
 **Parameters:**
 
@@ -55,25 +60,27 @@ Record audio from the microphone. Stops when the user presses Enter,
 |---|---|---|
 | outputFile | `string` | "" |
 | silenceTimeout | `number` | 2000 |
+| allowedPaths | `string[]` | [] |
 
 **Returns:** `string`
 
 **Throws:** `std::record`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/speech.agency#L32))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/speech.agency#L33))
 
 ### transcribe
 
 ```ts
-transcribe(filepath: string, language: string): string
+transcribe(filepath: string, language: string, allowedPaths: string[]): string
 ```
 
-A tool for transcribing an audio file to text using OpenAI's Whisper API. Optionally specify a language code (e.g. "en") for better accuracy.
+A tool for transcribing an audio file to text using OpenAI's Whisper API. Optionally specify a language code (e.g. "en") for better accuracy. Set allowedPaths to restrict which audio files may be uploaded.
 
   Cancellation: an in-flight Whisper upload tears down on Ctrl-C, race-loser, or time-guard abort.
 
   @param filepath - Path to the audio file
   @param language - Language code for better accuracy
+  @param allowedPaths - Only allow reading audio files under these path prefixes
 
 **Parameters:**
 
@@ -81,9 +88,10 @@ A tool for transcribing an audio file to text using OpenAI's Whisper API. Option
 |---|---|---|
 | filepath | `string` |  |
 | language | `string` | "" |
+| allowedPaths | `string[]` | [] |
 
 **Returns:** `string`
 
 **Throws:** `std::transcribe`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/speech.agency#L52))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/speech.agency#L56))

--- a/packages/agency-lang/docs/site/stdlib/system.md
+++ b/packages/agency-lang/docs/site/stdlib/system.md
@@ -5,10 +5,10 @@
 ### screenshot
 
 ```ts
-screenshot(filepath: string, x: number, y: number, width: number, height: number)
+screenshot(filepath: string, x: number, y: number, width: number, height: number, allowedPaths: string[])
 ```
 
-A tool for taking a screenshot and saving it to a file. Optionally specify x, y, width, and height to capture a specific region.
+A tool for taking a screenshot and saving it to a file. Optionally specify x, y, width, and height to capture a specific region. Set allowedPaths to restrict where the screenshot file may be written.
 
   Cancellation: an in-progress screencapture is interrupted on Ctrl-C, race-loser, or time-guard abort.
 
@@ -17,6 +17,7 @@ A tool for taking a screenshot and saving it to a file. Optionally specify x, y,
   @param y - Y coordinate of capture region
   @param width - Width of capture region
   @param height - Height of capture region
+  @param allowedPaths - Only allow saving under these path prefixes
 
 **Parameters:**
 
@@ -27,6 +28,7 @@ A tool for taking a screenshot and saving it to a file. Optionally specify x, y,
 | y | `number` | -1 |
 | width | `number` | -1 |
 | height | `number` | -1 |
+| allowedPaths | `string[]` | [] |
 
 **Throws:** `std::screenshot`
 
@@ -49,7 +51,7 @@ Terminate the process immediately with the given exit code. Use with caution —
 
 **Throws:** `std::exit`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L22))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L23))
 
 ### args
 
@@ -61,7 +63,7 @@ Return the command-line arguments passed to the Agency program (excluding the no
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L33))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L34))
 
 ### cwd
 
@@ -73,7 +75,7 @@ Return the absolute path of the current working directory of the Agency process.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L41))
 
 ### dirname
 
@@ -96,7 +98,7 @@ Return the absolute path of the directory containing the *compiled
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L47))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L48))
 
 ### env
 
@@ -114,7 +116,7 @@ Read an environment variable. Returns null if the variable is not set.
 
 **Returns:** `string | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L65))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L66))
 
 ### setEnv
 
@@ -138,7 +140,7 @@ Set an environment variable in the current process. Fails if the name is empty o
 
 **Throws:** `std::setEnv`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L72))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L73))
 
 ### openUrl
 
@@ -160,4 +162,4 @@ Open a URL in the user's default browser. Currently macOS-only.
 
 **Throws:** `std::openUrl`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/system.agency#L87))

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-28-fs-path-traversal-audit.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-28-fs-path-traversal-audit.md
@@ -1,0 +1,156 @@
+# Path-traversal audit of stdlib filesystem & process helpers
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Prerequisite:** `2026-05-28-agency-file-dirname.md` should land first so we have a known-good ALS `moduleDir` to anchor any new containment checks against.
+
+**Goal:** Make every stdlib filesystem and process helper safe against partial-application escapes. Today, `read`/`write`/`readImage`/`edit`/`multiedit` are safe because they flow through [`resolvePath()`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/stdlib/resolvePath.ts), which lexically rejects `..` escapes and even handles symlink-escapes. The rest of the surface — `mkdir`, `copy`, `move`, `remove`, `applyPatch`, anything in `shell`, `memory`, etc. — accept whole paths with no containment check. That means `mkdir.partial(...)` cannot meaningfully constrain an LLM, because partial application doesn't pin a *prefix* of the path argument.
+
+**Why "just reject `/` in filename" is not sufficient (and not the right model here):** the functions in question don't have a `dir` + `filename` split. They take a single path. The threat model for partial-application capability-narrowing has to look like: "the caller pre-binds an `allowedPaths` prefix; the helper rejects anything outside it." `_copy`, `_move`, `_remove` already accept an `allowedPaths` array — but it's *optional* and defaults to "no restrictions." This audit's job is to (a) inventory every fs/process helper, (b) decide the containment model for each, and (c) tighten defaults where reasonable.
+
+**Architecture:** No new infrastructure expected — most of the work is enforcement (already-present `allowedPaths` becomes mandatory under certain modes) and lexical/symlink containment ports of the `resolvePath` pattern. The optional `moduleDir` from the prior PR may serve as a sensible default `allowedPaths` root for some helpers.
+
+**Tech stack:** Same as the prior PR. Tests live in `lib/stdlib/*.test.ts` and `tests/agency/stdlib/`.
+
+**Workflow conventions:** Worktree per PR. `make` after stdlib changes. Commit messages via file. Never force-push.
+
+---
+
+## Task 1: Inventory
+
+**Why:** before changing anything, write down what we have and what each helper accepts.
+
+### Steps
+
+- [ ] **Step 1.1: Enumerate all path-accepting helpers**
+
+For each file under `lib/stdlib/`, list every exported `_*` function whose signature includes a path-shaped argument (`path`, `dir`, `filename`, `src`, `dest`, `target`, etc.). At minimum cover:
+
+- `lib/stdlib/fs.ts`: `_edit`, `_multiedit`, `_applyPatch`, `_mkdir`, `_copy`, `_move`, `_remove`
+- `lib/stdlib/builtins.ts`: `_read`, `_write`, `_readImage` (already safe — confirm)
+- `lib/stdlib/shell.ts`: anything that takes a `cwd`, a script path, or a binary path
+- `lib/stdlib/memory.ts`: file writes
+- `lib/stdlib/policy.ts`: policy file paths
+- `lib/stdlib/oauth.ts`, `keyring.ts`, `clipboard.ts`, `imessage.ts`, `email.ts`, `calendar.ts`, `speech.ts`, `browserUse.ts`: anything that touches the filesystem or spawns a subprocess
+- `lib/runtime/`: any user-callable path-accepting primitive
+
+Produce a markdown table in this plan file (replace this checkbox with the table) of: `helper | path args | uses resolvePath? | uses allowedPaths? | spawn/exec? | gap`.
+
+- [ ] **Step 1.2: Classify each helper into a containment category**
+
+For each helper, decide which category it falls into. Categories:
+
+- **A. `dir` + `filename` shape** → already / should use `resolvePath`. Trivially safe to partial-apply by binding `dir`.
+- **B. Single full-path argument** → needs an `allowedPaths` containment check. Partial-application capability story: bind `allowedPaths`.
+- **C. Subprocess / shell** → containment of executables and `cwd`. Partial-application capability story: bind allowed binaries and/or allowed cwd prefixes.
+- **D. No useful containment available** → document explicitly that this helper cannot be safely narrowed by partial application, and flag for a docs warning.
+
+Edit this plan file to attach a category letter to each row of the table from Step 1.1.
+
+---
+
+## Task 2: Tighten category-B helpers (`mkdir`, `copy`, `move`, `remove`, `applyPatch`)
+
+**Why:** these are the most obvious gap — they take whole paths and accept (or could accept) `allowedPaths` but don't require it by default.
+
+### Steps
+
+- [ ] **Step 2.1: Design the `allowedPaths` enforcement model**
+
+Decisions to make and record in this plan file:
+
+1. **Default when `allowedPaths` is empty.** Three options:
+   a. *Status quo.* Empty means unrestricted. (Worst for safety; best for ergonomics.)
+   b. *Empty means deny-all.* Caller must explicitly opt into a path prefix. (Breaking, but safest.)
+   c. *Empty means "moduleDir only".* Defaults to the directory of the calling module. (Smart default; consistent with the new `read` behavior.)
+
+   Recommendation: **(c)** for consistency with the prior PR. Document the breaking change.
+
+2. **Containment check semantics.** Should it be lexical only (fast) or include symlink resolution (matches `resolvePath`)? Recommendation: symlink-aware, factored into a shared helper `assertContained(targetPath, allowedRoots[])`.
+
+3. **Error message.** Match the existing `resolvePath` phrasing (`escapes allowed paths ...`).
+
+- [ ] **Step 2.2: Implement `assertContained()`**
+
+Create `lib/stdlib/assertContained.ts`. Behavior:
+- Accepts `(target: string, allowedRoots: string[])`.
+- If `allowedRoots` is empty, reads `getModuleDir()` as the single allowed root (per Step 2.1.1).
+- Resolves both `target` and each root via `path.resolve` and `fs.realpath`.
+- Throws if `target` does not equal or sit beneath any allowed root.
+
+Add unit tests in `lib/stdlib/assertContained.test.ts` covering: empty roots → moduleDir fallback; explicit root; symlink escape; non-existent target.
+
+- [ ] **Step 2.3: Apply `assertContained` to fs.ts helpers**
+
+For each of `_mkdir`, `_copy` (both `src` and `dest`), `_move` (both), `_remove`, `_applyPatch` (each touched file in the diff), call `assertContained(thePath, allowedPaths)` early. Update tests in `lib/stdlib/fs.test.ts` (create if missing) for each helper to cover allowed and rejected cases.
+
+- [ ] **Step 2.4: Update `stdlib/fs.agency` docstrings**
+
+Reflect the new "defaults to moduleDir-only when `allowedPaths` is empty" behavior. Encourage users to set `allowedPaths` explicitly via partial application before exposing a helper to an LLM.
+
+---
+
+## Task 3: Tighten category-C helpers (shell / process)
+
+**Why:** an LLM with access to `shell::exec` can do anything. The capability story has to look like an allow-list of binaries + a cwd containment check.
+
+### Steps
+
+- [ ] **Step 3.1: Inventory shell entry points**
+
+Look at `lib/stdlib/shell.ts`. Functions that take a command string or argv plus possibly a `cwd`. Note which already use `allowedPaths`-like patterns (see `lib/stdlib/allowBlockList.ts`).
+
+- [ ] **Step 3.2: Decide and document the containment story**
+
+Proposal for review (record decision in this plan file before implementing):
+- Add an `allowedExecutables: string[]` parameter to `shell::exec` (or whichever entry point), backed by `allowBlockList.ts`.
+- Reuse `assertContained` for any `cwd` argument when paired with `allowedPaths`.
+- For raw shell strings (`sh -c "..."`), document that they cannot be safely narrowed and recommend the argv form for partial-application use.
+
+- [ ] **Step 3.3: Implement and test**
+
+Implementation pass after the design is approved.
+
+---
+
+## Task 4: Audit remaining stdlib modules
+
+**Why:** the long tail (`memory`, `policy`, `oauth`, `keyring`, `clipboard`, `imessage`, `email`, `calendar`, `speech`, `browserUse`) needs at least a triage.
+
+### Steps
+
+- [ ] **Step 4.1: Per-module triage**
+
+For each module, identify any fs/process surface. If trivially safe (e.g. writes to a fixed library-managed path with no user-controlled component), document why. If exposed, file a sub-task under Task 4 with the fix.
+
+- [ ] **Step 4.2: Fix everything triaged as exposed**
+
+Implement and test per sub-task.
+
+---
+
+## Task 5: Documentation
+
+- [ ] **Step 5.1: Add a "Capability narrowing via partial application" guide page**
+
+Under `docs/site/guide/`, add a page that explains:
+- The intent: bind a `dir` or `allowedPaths` before handing a tool to an LLM.
+- Which helpers are safe to narrow this way (table from Task 1).
+- Which helpers cannot be narrowed (category D) and why.
+
+Link from the existing partial-application page (`https://agency-lang.com/guide/partial-application.html` source file).
+
+- [ ] **Step 5.2: CHANGELOG entry**
+
+> **BREAKING (safety):** `mkdir`, `copy`, `move`, `remove`, and `applyPatch` now reject paths outside the calling module's directory unless `allowedPaths` is set explicitly. Pass `allowedPaths: [...]` to restore the previous behavior with an explicit allow-list, or `allowedPaths: ["/"]` to permit any absolute path (not recommended).
+
+---
+
+## Validation checklist (run before opening the PR)
+
+- [ ] All new unit tests green (`assertContained`, per-helper fs tests).
+- [ ] `make fixtures` produces no unexpected drift.
+- [ ] `pnpm run lint:structure` clean.
+- [ ] Manual smoke test: a representative agency program that uses `mkdir`/`copy`/`move` from a non-module path still works once `allowedPaths` is set explicitly.
+- [ ] Manual escape test: confirm a partial-applied `copy.partial(allowedPaths: ["/tmp"])` rejects `copy(src: "/tmp/x", dest: "/etc/passwd_copy")`.
+- [ ] Docs site builds.

--- a/packages/agency-lang/lib/stdlib/assertContained.test.ts
+++ b/packages/agency-lang/lib/stdlib/assertContained.test.ts
@@ -87,11 +87,28 @@ describe("assertContained", () => {
     );
   });
 
-  it("ignores empty strings inside allowedRoots", async () => {
+  it("ignores empty strings inside allowedRoots when other roots remain", async () => {
     // An empty string in `allowedRoots` would otherwise resolve to cwd,
     // accidentally allowing way too much. We skip empties instead.
     await expect(
       assertContained(path.join(outside, "secret.txt"), ["", allowed]),
     ).rejects.toThrow(/is not under any of the allowed paths/);
+  });
+
+  it("rejects when every entry in allowedRoots is empty or whitespace", async () => {
+    // Caller asked for a restriction but every entry was unusable.
+    // Falling through to unrestricted would be a silent capability leak.
+    await expect(
+      assertContained(path.join(outside, "secret.txt"), ["", "  "]),
+    ).rejects.toThrow(/no usable entries/);
+  });
+
+  it("accepts descendants of the filesystem root when root is the allow-list", async () => {
+    // Regression: a naive `realRoot + path.sep` startsWith check makes
+    // `/` produce the prefix `//`, which matches no real path.
+    const fsRoot = path.parse(allowed).root;
+    await expect(
+      assertContained(path.join(allowed, "ok.txt"), [fsRoot]),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/agency-lang/lib/stdlib/assertContained.test.ts
+++ b/packages/agency-lang/lib/stdlib/assertContained.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { assertContained } from "./assertContained.js";
+
+describe("assertContained", () => {
+  let tmpRoot: string;
+  let allowed: string;
+  let outside: string;
+  let symlinkInside: string;
+
+  beforeAll(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "assertContained-"));
+    allowed = path.join(tmpRoot, "allowed");
+    outside = path.join(tmpRoot, "outside");
+    symlinkInside = path.join(allowed, "escape");
+    await fs.mkdir(allowed, { recursive: true });
+    await fs.mkdir(outside, { recursive: true });
+    await fs.writeFile(path.join(allowed, "ok.txt"), "ok");
+    await fs.writeFile(path.join(outside, "secret.txt"), "secret");
+    await fs.symlink(outside, symlinkInside);
+  });
+
+  afterAll(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("is a no-op when allowedRoots is empty", async () => {
+    await expect(
+      assertContained("/anywhere/at/all", []),
+    ).resolves.toBeUndefined();
+  });
+
+  it("accepts a target equal to the root", async () => {
+    await expect(assertContained(allowed, [allowed])).resolves.toBeUndefined();
+  });
+
+  it("accepts a target inside the root", async () => {
+    await expect(
+      assertContained(path.join(allowed, "ok.txt"), [allowed]),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a target outside the root", async () => {
+    await expect(
+      assertContained(path.join(outside, "secret.txt"), [allowed]),
+    ).rejects.toThrow(/is not under any of the allowed paths/);
+  });
+
+  it("rejects a non-existent target outside the root", async () => {
+    await expect(
+      assertContained(path.join(outside, "missing.txt"), [allowed]),
+    ).rejects.toThrow(/is not under any of the allowed paths/);
+  });
+
+  it("accepts a non-existent target inside the root", async () => {
+    await expect(
+      assertContained(path.join(allowed, "new-file.txt"), [allowed]),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a target reached through a symlink that escapes the root", async () => {
+    // `symlinkInside` lives lexically inside `allowed/` but resolves to
+    // `outside/`. Accessing `outside/secret.txt` via `allowed/escape/secret.txt`
+    // must be rejected by the realpath check.
+    await expect(
+      assertContained(
+        path.join(symlinkInside, "secret.txt"),
+        [allowed],
+      ),
+    ).rejects.toThrow(/is not under any of the allowed paths/);
+  });
+
+  it("accepts a target under any one of multiple roots", async () => {
+    const otherRoot = path.join(tmpRoot, "other");
+    await fs.mkdir(otherRoot, { recursive: true });
+    await fs.writeFile(path.join(otherRoot, "file.txt"), "x");
+    await expect(
+      assertContained(path.join(otherRoot, "file.txt"), [allowed, otherRoot]),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects an empty target with a non-empty root list", async () => {
+    await expect(assertContained("", [allowed])).rejects.toThrow(
+      /must not be empty/,
+    );
+  });
+
+  it("ignores empty strings inside allowedRoots", async () => {
+    // An empty string in `allowedRoots` would otherwise resolve to cwd,
+    // accidentally allowing way too much. We skip empties instead.
+    await expect(
+      assertContained(path.join(outside, "secret.txt"), ["", allowed]),
+    ).rejects.toThrow(/is not under any of the allowed paths/);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/assertContained.ts
+++ b/packages/agency-lang/lib/stdlib/assertContained.ts
@@ -16,6 +16,12 @@ import process from "process";
  * so that adding `assertContained` to a helper is purely additive: only
  * callers that pass an explicit `allowedPaths` get the tightened check.
  *
+ * If `allowedRoots` is non-empty but every entry is an empty/whitespace
+ * string, the call throws rather than silently degrading to "no
+ * restriction". Otherwise a caller writing `allowedPaths: [""]` would
+ * get the same wide-open behavior as `allowedPaths: []`, which we
+ * explicitly do not want.
+ *
  * Throws an `Error` whose message names the offending target and the
  * configured roots.
  */
@@ -38,16 +44,41 @@ export async function assertContained(
     realRoots.push(await realpathOrSelf(lexicalRoot));
   }
 
-  if (realRoots.length === 0) return;
+  if (realRoots.length === 0) {
+    // The caller asked for *some* restriction but every supplied entry
+    // was unusable. Fail closed rather than open.
+    throw new Error(
+      `assertContained: allowedPaths was set (${JSON.stringify(allowedRoots)}) but contained no usable entries; refusing to fall back to unrestricted access.`,
+    );
+  }
 
   for (const realRoot of realRoots) {
-    if (samePath(realTarget, realRoot)) return;
-    if (realTarget.startsWith(realRoot + path.sep)) return;
+    if (isContained(realTarget, realRoot)) return;
   }
 
   throw new Error(
     `Path "${target}" is not under any of the allowed paths: ${allowedRoots.join(", ")}.`,
   );
+}
+
+/**
+ * Returns true iff `target` is the same path as `root` or sits inside
+ * it. Uses `path.relative` so it works correctly when `root` is the
+ * filesystem root (`/` or `C:\`) — in that case `realRoot + path.sep`
+ * would become `//`/`C:\\` and a naive `startsWith` check would refuse
+ * every descendant. Path comparison is case-insensitive on Windows.
+ */
+function isContained(target: string, root: string): boolean {
+  const t = process.platform === "win32" ? target.toLowerCase() : target;
+  const r = process.platform === "win32" ? root.toLowerCase() : root;
+  if (t === r) return true;
+  const rel = path.relative(r, t);
+  if (rel === "") return true;
+  if (path.isAbsolute(rel)) return false;
+  // Any leading `..` segment means we escaped.
+  const segments = rel.split(path.sep);
+  if (segments[0] === "..") return false;
+  return true;
 }
 
 /**
@@ -82,11 +113,4 @@ async function realpathOrSelf(p: string): Promise<string> {
   } catch {
     return p;
   }
-}
-
-function samePath(a: string, b: string): boolean {
-  if (process.platform === "win32") {
-    return a.toLowerCase() === b.toLowerCase();
-  }
-  return a === b;
 }

--- a/packages/agency-lang/lib/stdlib/assertContained.ts
+++ b/packages/agency-lang/lib/stdlib/assertContained.ts
@@ -1,0 +1,92 @@
+import fs from "fs/promises";
+import path from "path";
+import process from "process";
+
+/**
+ * Assert that `target` resolves inside at least one of `allowedRoots`.
+ *
+ * Containment is checked **symlink-aware**: both `target` and each root
+ * are resolved via `fs.realpath` before the prefix comparison, so a
+ * symlink pointing outside an allowed root is rejected. Targets that do
+ * not exist yet (e.g. the destination of a copy or write) are resolved
+ * lexically against the realpath of their nearest existing ancestor.
+ *
+ * If `allowedRoots` is empty the function returns immediately — this is
+ * the current "no restriction" semantics and is preserved on purpose
+ * so that adding `assertContained` to a helper is purely additive: only
+ * callers that pass an explicit `allowedPaths` get the tightened check.
+ *
+ * Throws an `Error` whose message names the offending target and the
+ * configured roots.
+ */
+export async function assertContained(
+  target: string,
+  allowedRoots: string[],
+): Promise<void> {
+  if (allowedRoots.length === 0) return;
+  if (target.trim() === "") {
+    throw new Error("assertContained: target must not be empty");
+  }
+
+  const lexicalTarget = path.resolve(process.cwd(), target);
+  const realTarget = await realpathOrLexicalAncestor(lexicalTarget);
+
+  const realRoots: string[] = [];
+  for (const root of allowedRoots) {
+    if (root.trim() === "") continue;
+    const lexicalRoot = path.resolve(process.cwd(), root);
+    realRoots.push(await realpathOrSelf(lexicalRoot));
+  }
+
+  if (realRoots.length === 0) return;
+
+  for (const realRoot of realRoots) {
+    if (samePath(realTarget, realRoot)) return;
+    if (realTarget.startsWith(realRoot + path.sep)) return;
+  }
+
+  throw new Error(
+    `Path "${target}" is not under any of the allowed paths: ${allowedRoots.join(", ")}.`,
+  );
+}
+
+/**
+ * Resolve the real path of `p`. If `p` does not exist yet, walk up the
+ * directory chain until we find an existing ancestor, resolve that, then
+ * re-join the remaining relative tail. This is the same pattern
+ * `resolvePath` uses for non-existent files.
+ */
+async function realpathOrLexicalAncestor(p: string): Promise<string> {
+  try {
+    return await fs.realpath(p);
+  } catch {
+    // Walk up one segment at a time looking for an existing ancestor.
+    let current = path.dirname(p);
+    const tail: string[] = [path.basename(p)];
+    while (current !== path.dirname(current)) {
+      try {
+        const real = await fs.realpath(current);
+        return path.resolve(real, ...tail.reverse());
+      } catch {
+        tail.push(path.basename(current));
+        current = path.dirname(current);
+      }
+    }
+    return p;
+  }
+}
+
+async function realpathOrSelf(p: string): Promise<string> {
+  try {
+    return await fs.realpath(p);
+  } catch {
+    return p;
+  }
+}
+
+function samePath(a: string, b: string): boolean {
+  if (process.platform === "win32") {
+    return a.toLowerCase() === b.toLowerCase();
+  }
+  return a === b;
+}

--- a/packages/agency-lang/lib/stdlib/fs.ts
+++ b/packages/agency-lang/lib/stdlib/fs.ts
@@ -4,7 +4,7 @@ import path from "path";
 import process from "process";
 import diff_match_patch from "diff-match-patch";
 import { resolvePath } from "./resolvePath.js";
-import { checkAllowedPaths } from "./allowBlockList.js";
+import { assertContained } from "./assertContained.js";
 
 export { resolvePath } from "./resolvePath.js";
 
@@ -125,12 +125,18 @@ export type PatchResult = {
   files: string[];
 };
 
-export async function _applyPatch(patch: string): Promise<PatchResult> {
+export async function _applyPatch(
+  patch: string,
+  allowedPaths?: string[],
+): Promise<PatchResult> {
   const files = parseUnifiedDiff(patch);
   const touched: string[] = [];
 
   for (const f of files) {
     const full = path.resolve(process.cwd(), f.path);
+    // Every file the diff touches is gated by `allowedPaths`. No-op
+    // when the caller passes nothing (status quo).
+    await assertContained(full, allowedPaths ?? []);
     let original = "";
     if (f.isNew) {
       original = "";
@@ -248,8 +254,12 @@ function applyHunks(original: string, hunks: Hunk[], filePath: string): string {
   return updated;
 }
 
-export async function _mkdir(dir: string): Promise<void> {
+export async function _mkdir(
+  dir: string,
+  allowedPaths?: string[],
+): Promise<void> {
   const full = path.resolve(process.cwd(), dir);
+  await assertContained(full, allowedPaths ?? []);
   await fs.mkdir(full, { recursive: true });
 }
 
@@ -258,14 +268,10 @@ export async function _copy(
   dest: string,
   allowedPaths?: string[],
 ): Promise<void> {
-  if (allowedPaths && allowedPaths.length > 0) {
-    const srcError = checkAllowedPaths(src, allowedPaths);
-    if (srcError) throw new Error(srcError);
-    const destError = checkAllowedPaths(dest, allowedPaths);
-    if (destError) throw new Error(destError);
-  }
   const srcFull = path.resolve(process.cwd(), src);
   const destFull = path.resolve(process.cwd(), dest);
+  await assertContained(srcFull, allowedPaths ?? []);
+  await assertContained(destFull, allowedPaths ?? []);
   await fs.cp(srcFull, destFull, { recursive: true });
 }
 
@@ -274,15 +280,11 @@ export async function _move(
   dest: string,
   allowedPaths?: string[],
 ): Promise<void> {
-  if (allowedPaths && allowedPaths.length > 0) {
-    const srcError = checkAllowedPaths(src, allowedPaths);
-    if (srcError) throw new Error(srcError);
-    const destError = checkAllowedPaths(dest, allowedPaths);
-    if (destError) throw new Error(destError);
-  }
-  await rejectDangerousPath(src, "move", "source");
   const srcFull = path.resolve(process.cwd(), src);
   const destFull = path.resolve(process.cwd(), dest);
+  await assertContained(srcFull, allowedPaths ?? []);
+  await assertContained(destFull, allowedPaths ?? []);
+  await rejectDangerousPath(src, "move", "source");
   try {
     await fs.rename(srcFull, destFull);
   } catch (e: any) {
@@ -299,12 +301,9 @@ export async function _remove(
   target: string,
   allowedPaths?: string[],
 ): Promise<void> {
-  if (allowedPaths && allowedPaths.length > 0) {
-    const error = checkAllowedPaths(target, allowedPaths);
-    if (error) throw new Error(error);
-  }
-  await rejectDangerousPath(target, "remove", "target");
   const full = path.resolve(process.cwd(), target);
+  await assertContained(full, allowedPaths ?? []);
+  await rejectDangerousPath(target, "remove", "target");
   await fs.rm(full, { recursive: true, force: true });
 }
 

--- a/packages/agency-lang/lib/stdlib/policy.ts
+++ b/packages/agency-lang/lib/stdlib/policy.ts
@@ -1,10 +1,19 @@
 import { validatePolicy } from "@/runtime/policy.js";
 import { writeFileSync } from "fs";
+import path from "path";
+import process from "process";
+import { assertContained } from "./assertContained.js";
 export { checkPolicy as _checkPolicy, validatePolicy as _validatePolicy } from "@/runtime/policy.js";
 import type { Policy } from "@/runtime/policy.js";
 
-export function _writePolicyFile(filePath: string, policy: Policy) {
+export async function _writePolicyFile(
+  filePath: string,
+  policy: Policy,
+  allowedPaths?: string[],
+) {
   const result = validatePolicy(policy);
   if (!result.success) throw new Error(`Invalid policy: ${result.error}`);
-  writeFileSync(filePath, JSON.stringify(policy, null, 2) + "\n", { mode: 0o600 });
+  const full = path.resolve(process.cwd(), filePath);
+  await assertContained(full, allowedPaths ?? []);
+  writeFileSync(full, JSON.stringify(policy, null, 2) + "\n", { mode: 0o600 });
 }

--- a/packages/agency-lang/lib/stdlib/shell.ts
+++ b/packages/agency-lang/lib/stdlib/shell.ts
@@ -25,6 +25,7 @@ import {
   SpawnResult,
 } from "./abortable.js";
 import { checkAllowBlockList } from "./allowBlockList.js";
+import { assertContained } from "./assertContained.js";
 
 function buildSpawnOptions(
   cwd: string,
@@ -40,8 +41,24 @@ function buildSpawnOptions(
 }
 
 export type ExecOptions = {
-  allowedCommands?: string[];
+  /**
+   * Allow-list of executable names. When set, only commands whose
+   * `command` matches one of these strings (case-insensitive,
+   * whitespace-trimmed) will run. Empty / unset = no restriction.
+   * Pair with `allowedPaths` to also pin the working directory.
+   */
+  allowedExecutables?: string[];
+  /**
+   * Block-list of executable names. When set, any command whose
+   * `command` matches one of these strings is rejected.
+   */
   blockedCommands?: string[];
+  /**
+   * Directory-allow-list for `cwd`. When set, `cwd` must resolve
+   * inside one of these roots (symlink-aware). Empty / unset = no
+   * restriction.
+   */
+  allowedPaths?: string[];
 };
 
 /**
@@ -62,10 +79,13 @@ async function execImpl(
 ): Promise<SpawnResult> {
   const cmdError = checkAllowBlockList(
     [command],
-    options?.allowedCommands ?? [],
+    options?.allowedExecutables ?? [],
     options?.blockedCommands ?? [],
   );
   if (cmdError) throw new Error(cmdError);
+  if (cwd && options?.allowedPaths && options.allowedPaths.length > 0) {
+    await assertContained(cwd, options.allowedPaths);
+  }
   const signal = ctx.getAbortSignal(stack);
   return abortableSpawn(command, args, buildSpawnOptions(cwd, timeout, stdin, signal));
 }
@@ -100,7 +120,18 @@ export async function _exec(
 }
 
 export type BashOptions = {
+  /**
+   * Reject any bash string whose first non-whitespace token matches
+   * one of these entries (prefix match). Useful to block `rm`,
+   * `sudo`, etc.
+   */
   blockedCommands?: string[];
+  /**
+   * Directory-allow-list for `cwd`. When set, `cwd` must resolve
+   * inside one of these roots (symlink-aware). Empty / unset = no
+   * restriction.
+   */
+  allowedPaths?: string[];
 };
 
 /**
@@ -124,6 +155,9 @@ async function bashImpl(
         throw new Error(`Command "${blocked}" is in the blockedCommands list.`);
       }
     }
+  }
+  if (cwd && options?.allowedPaths && options.allowedPaths.length > 0) {
+    await assertContained(cwd, options.allowedPaths);
   }
   const signal = ctx.getAbortSignal(stack);
   return abortableSpawn("sh", ["-c", command], buildSpawnOptions(cwd, timeout, stdin, signal));
@@ -163,8 +197,13 @@ export type LsEntry = {
   size: number;
 };
 
-export async function _ls(dir: string, recursive: boolean): Promise<LsEntry[]> {
+export async function _ls(
+  dir: string,
+  recursive: boolean,
+  allowedPaths?: string[],
+): Promise<LsEntry[]> {
   const root = path.resolve(process.cwd(), dir);
+  await assertContained(root, allowedPaths ?? []);
   const out: LsEntry[] = [];
 
   async function walk(current: string): Promise<void> {
@@ -248,8 +287,10 @@ export async function _grep(
   dir: string,
   flags: string,
   maxResults: number,
+  allowedPaths?: string[],
 ): Promise<GrepMatch[]> {
   const root = path.resolve(process.cwd(), dir);
+  await assertContained(root, allowedPaths ?? []);
   const re = new RegExp(pattern, flags || undefined);
   const results: GrepMatch[] = [];
 
@@ -284,8 +325,10 @@ export async function _glob(
   pattern: string,
   dir: string,
   maxResults: number,
+  allowedPaths?: string[],
 ): Promise<string[]> {
   const root = path.resolve(process.cwd(), dir);
+  await assertContained(root, allowedPaths ?? []);
   const re = globToRegExp(pattern);
   const results: string[] = [];
 
@@ -371,8 +414,12 @@ export type StatInfo = {
   modifiedMs: number;
 };
 
-export async function _stat(filename: string): Promise<StatInfo> {
+export async function _stat(
+  filename: string,
+  allowedPaths?: string[],
+): Promise<StatInfo> {
   const full = path.resolve(process.cwd(), filename);
+  await assertContained(full, allowedPaths ?? []);
   try {
     const st = await fs.lstat(full);
     let type: StatInfo["type"] = "other";
@@ -390,8 +437,14 @@ export async function _stat(filename: string): Promise<StatInfo> {
   }
 }
 
-export async function _exists(filename: string): Promise<boolean> {
+export async function _exists(
+  filename: string,
+  allowedPaths?: string[],
+): Promise<boolean> {
   const full = path.resolve(process.cwd(), filename);
+  // Probing for a path outside the allow-list is itself a containment
+  // violation — throw rather than silently return false.
+  await assertContained(full, allowedPaths ?? []);
   try {
     await fs.access(full);
     return true;

--- a/packages/agency-lang/lib/stdlib/speech.ts
+++ b/packages/agency-lang/lib/stdlib/speech.ts
@@ -9,6 +9,7 @@ import { abortableExec } from "./abortable.js";
 import { runHttp } from "./http.js";
 import { AgencyCancelledError } from "../runtime/errors.js";
 import { getRuntimeContext } from "../runtime/asyncContext.js";
+import { assertContained } from "./assertContained.js";
 import type { RuntimeContext } from "../runtime/state/context.js";
 import type { StateStack } from "../runtime/state/stateStack.js";
 import type { ThreadStore } from "../runtime/state/threadStore.js";
@@ -25,6 +26,7 @@ async function speakImpl(
   voice: string,
   rate: number,
   outputFile: string,
+  allowedPaths?: string[],
 ): Promise<void> {
   if (text === "") return;
 
@@ -41,7 +43,9 @@ async function speakImpl(
         args.push("-r", String(rate));
       }
       if (outputFile !== "") {
-        args.push("-o", path.resolve(process.cwd(), outputFile));
+        const outPath = path.resolve(process.cwd(), outputFile);
+        await assertContained(outPath, allowedPaths ?? []);
+        args.push("-o", outPath);
       }
       await abortableExec("say", args, ctx.getAbortSignal(stack));
     } finally {
@@ -75,9 +79,10 @@ export async function _speak(
   voice: string,
   rate: number,
   outputFile: string,
+  allowedPaths?: string[],
 ): Promise<void> {
   const { ctx, stack } = getRuntimeContext();
-  return speakImpl(ctx, stack, text, voice, rate, outputFile);
+  return speakImpl(ctx, stack, text, voice, rate, outputFile, allowedPaths);
 }
 
 /**
@@ -91,6 +96,7 @@ async function recordImpl(
   stack: StateStack,
   outputFile: string,
   silenceTimeout: number,
+  allowedPaths?: string[],
 ): Promise<string> {
   const isTTY = process.stdin.isTTY;
 
@@ -104,6 +110,9 @@ async function recordImpl(
   const outPath = outputFile
     ? path.resolve(process.cwd(), outputFile)
     : path.join(os.tmpdir(), `agency-rec-${nanoid()}.wav`);
+  if (outputFile) {
+    await assertContained(outPath, allowedPaths ?? []);
+  }
 
   const args = [outPath];
   if (silenceTimeout > 0) {
@@ -196,9 +205,10 @@ export async function __internal_record(
 export async function _record(
   outputFile: string,
   silenceTimeout: number,
+  allowedPaths?: string[],
 ): Promise<string> {
   const { ctx, stack } = getRuntimeContext();
-  return recordImpl(ctx, stack, outputFile, silenceTimeout);
+  return recordImpl(ctx, stack, outputFile, silenceTimeout, allowedPaths);
 }
 
 /**
@@ -212,6 +222,7 @@ async function transcribeImpl(
   stack: StateStack,
   filepath: string,
   language: string,
+  allowedPaths?: string[],
 ): Promise<string> {
   const apiKey = process.env["OPENAI_API_KEY"];
   if (!apiKey) {
@@ -221,6 +232,7 @@ async function transcribeImpl(
   }
 
   const resolvedPath = path.resolve(process.cwd(), filepath);
+  await assertContained(resolvedPath, allowedPaths ?? []);
   const fileData = await readFile(resolvedPath);
   const filename = path.basename(resolvedPath);
 
@@ -270,7 +282,8 @@ export async function __internal_transcribe(
 export async function _transcribe(
   filepath: string,
   language: string,
+  allowedPaths?: string[],
 ): Promise<string> {
   const { ctx, stack } = getRuntimeContext();
-  return transcribeImpl(ctx, stack, filepath, language);
+  return transcribeImpl(ctx, stack, filepath, language, allowedPaths);
 }

--- a/packages/agency-lang/lib/stdlib/system.ts
+++ b/packages/agency-lang/lib/stdlib/system.ts
@@ -3,6 +3,7 @@ import process from "process";
 import { detectPlatform } from "./utils.js";
 import { abortableExec } from "./abortable.js";
 import { getModuleDir, getRuntimeContext } from "../runtime/asyncContext.js";
+import { assertContained } from "./assertContained.js";
 import type { RuntimeContext } from "../runtime/state/context.js";
 import type { StateStack } from "../runtime/state/stateStack.js";
 import type { ThreadStore } from "../runtime/state/threadStore.js";
@@ -104,9 +105,11 @@ async function screenshotImpl(
   y: number,
   width: number,
   height: number,
+  allowedPaths?: string[],
 ): Promise<void> {
   const platform = await detectPlatform();
   const resolvedPath = path.resolve(process.cwd(), filepath);
+  await assertContained(resolvedPath, allowedPaths ?? []);
   const hasRegion = x >= 0 && y >= 0 && width >= 0 && height >= 0;
   const signal = ctx.getAbortSignal(stack);
 
@@ -151,7 +154,8 @@ export async function _screenshot(
   y: number,
   width: number,
   height: number,
+  allowedPaths?: string[],
 ): Promise<void> {
   const { ctx, stack } = getRuntimeContext();
-  return screenshotImpl(ctx, stack, filepath, x, y, width, height);
+  return screenshotImpl(ctx, stack, filepath, x, y, width, height, allowedPaths);
 }

--- a/packages/agency-lang/stdlib/fs.agency
+++ b/packages/agency-lang/stdlib/fs.agency
@@ -60,26 +60,32 @@ type PatchResult = {
   files: string[]
 }
 
-export def applyPatch(patch: string): Result {
+export def applyPatch(patch: string, allowedPaths: string[] = []): Result {
   """
-  Apply a unified diff to the working tree. Supports file creation (--- /dev/null), line additions, deletions, and context. Fails on a malformed diff or on a context-line mismatch against the current file contents.
+  Apply a unified diff to the working tree. Supports file creation (--- /dev/null), line additions, deletions, and context. Fails on a malformed diff or on a context-line mismatch against the current file contents. Set allowedPaths to restrict which path prefixes can be touched by the patch.
+
+  @param patch - The unified diff to apply
+  @param allowedPaths - Only allow patches that touch files under these prefixes
   """
   return interrupt std::applyPatch("Are you sure you want to apply this patch?", {
     patch: patch
   })
 
-  return try _applyPatch(patch)
+  return try _applyPatch(patch, allowedPaths)
 }
 
-export def mkdir(dir: string): Result {
+export def mkdir(dir: string, allowedPaths: string[] = []): Result {
   """
-  Create a directory, including any missing parent directories. Idempotent: succeeds if the directory already exists. Fails if a non-directory entry already occupies the path, or on permission errors.
+  Create a directory, including any missing parent directories. Idempotent: succeeds if the directory already exists. Fails if a non-directory entry already occupies the path, or on permission errors. Set allowedPaths to restrict which path prefixes are permitted.
+
+  @param dir - The directory to create
+  @param allowedPaths - Only allow paths starting with these prefixes
   """
   return interrupt std::mkdir("Are you sure you want to create this directory?", {
     dir: dir
   })
 
-  return try _mkdir(dir)
+  return try _mkdir(dir, allowedPaths)
 }
 
 export def copy(src: string, dest: string, allowedPaths: string[] = []): Result {

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -34,9 +34,13 @@ export def validatePolicy(policy: Record<string, any>) {
   return _validatePolicy(policy)
 }
 
-export def writePolicyFile(path: string, policy: Policy) {
+export def writePolicyFile(path: string, policy: Policy, allowedPaths: string[] = []) {
   """
-  Validate and write a policy to a JSON file. Throws if the policy is invalid.
+  Validate and write a policy to a JSON file. Throws if the policy is invalid. Set allowedPaths to restrict where the policy file may be written.
+
+  @param path - The destination file path
+  @param policy - The policy to write
+  @param allowedPaths - Only allow writing under these path prefixes
   """
-  return try _writePolicyFile(path, policy)
+  return try _writePolicyFile(path, policy, allowedPaths)
 }

--- a/packages/agency-lang/stdlib/shell.agency
+++ b/packages/agency-lang/stdlib/shell.agency
@@ -21,19 +21,21 @@ export def exec(
   cwd: string = "",
   timeout: number = 0,
   stdin: string = "",
-  allowedCommands: string[] = [],
+  allowedExecutables: string[] = [],
   blockedCommands: string[] = [],
+  allowedPaths: string[] = [],
 ): ExecResult {
   """
-  Run an executable directly with an array of arguments, bypassing the shell. This is safer than bash() because arguments are passed directly to the process without shell interpretation, preventing command injection. Use this when you have a known command and structured arguments. Pass cwd to change the working directory, timeout in milliseconds to enforce a time limit (e.g. timeout: 30s), and stdin to feed input to the command. Set allowedCommands to restrict which executables can be run. Set blockedCommands to reject specific executables.
+  Run an executable directly with an array of arguments, bypassing the shell. This is safer than bash() because arguments are passed directly to the process without shell interpretation, preventing command injection. Use this when you have a known command and structured arguments. Pass cwd to change the working directory, timeout in milliseconds to enforce a time limit (e.g. timeout: 30s), and stdin to feed input to the command. Set allowedExecutables to restrict which executables can be run. Set blockedCommands to reject specific executables. Set allowedPaths to require `cwd` to live under one of those prefixes.
 
   @param command - The executable to run
   @param args - Array of arguments to pass
   @param cwd - Working directory for the command
   @param timeout - Time limit in milliseconds (e.g. 30s)
   @param stdin - Input to feed to the command
-  @param allowedCommands - Only allow running these executables
+  @param allowedExecutables - Only allow running these executables (allow-list)
   @param blockedCommands - Block running these executables
+  @param allowedPaths - Only allow cwd values under these path prefixes
   """
   return interrupt std::exec("Are you sure you want to run this command?", {
     command: command,
@@ -50,8 +52,9 @@ export def exec(
     timeout,
     stdin,
     {
-    allowedCommands: allowedCommands,
-    blockedCommands: blockedCommands
+    allowedExecutables: allowedExecutables,
+    blockedCommands: blockedCommands,
+    allowedPaths: allowedPaths
   },
   )
 }
@@ -62,15 +65,17 @@ export def bash(
   timeout: number = 0,
   stdin: string = "",
   blockedCommands: string[] = [],
+  allowedPaths: string[] = [],
 ): ExecResult {
   """
-  Run a shell command string via sh -c and return its stdout, stderr, and exit code. The command is interpreted by the shell, so pipes, redirects, globbing, and other shell features work. However, this means interpolated values are subject to shell interpretation -- use exec() instead when passing untrusted or dynamic arguments. Pass cwd to change the working directory, timeout in milliseconds to enforce a time limit (e.g. timeout: 30s), and stdin to feed input to the command. Set blockedCommands to reject commands that start with specific strings.
+  Run a shell command string via sh -c and return its stdout, stderr, and exit code. The command is interpreted by the shell, so pipes, redirects, globbing, and other shell features work. However, this means interpolated values are subject to shell interpretation -- use exec() instead when passing untrusted or dynamic arguments. Pass cwd to change the working directory, timeout in milliseconds to enforce a time limit (e.g. timeout: 30s), and stdin to feed input to the command. Set blockedCommands to reject commands that start with specific strings. Set allowedPaths to require `cwd` to live under one of those prefixes; bash() cannot meaningfully restrict the shell string itself, so prefer exec() when capability narrowing matters.
 
   @param command - The shell command to run
   @param cwd - Working directory for the command
   @param timeout - Time limit in milliseconds (e.g. 30s)
   @param stdin - Input to feed to the command
   @param blockedCommands - Block commands that start with these strings
+  @param allowedPaths - Only allow cwd values under these path prefixes
   """
   return interrupt std::bash("Are you sure you want to run this shell command?", {
     command: command,
@@ -85,7 +90,8 @@ export def bash(
     timeout,
     stdin,
     {
-    blockedCommands: blockedCommands
+    blockedCommands: blockedCommands,
+    allowedPaths: allowedPaths
   },
   )
 }
@@ -97,19 +103,20 @@ type LsEntry = {
   size: number
 }
 
-export def ls(dir: string = ".", recursive: boolean = false): Result {
+export def ls(dir: string = ".", recursive: boolean = false, allowedPaths: string[] = []): Result {
   """
-  List entries in a directory. Each entry includes name, path, type ("file", "dir", "symlink", "other"), and size. Set recursive to true to walk subdirectories. Fails if the directory cannot be read (missing, not a directory, permission denied).
+  List entries in a directory. Each entry includes name, path, type ("file", "dir", "symlink", "other"), and size. Set recursive to true to walk subdirectories. Fails if the directory cannot be read (missing, not a directory, permission denied). Set allowedPaths to restrict which directories may be listed.
 
   @param dir - The directory to list
   @param recursive - Whether to walk subdirectories
+  @param allowedPaths - Only allow listing directories under these prefixes
   """
   return interrupt std::ls("Are you sure you want to list this directory?", {
     dir: dir,
     recursive: recursive
   })
 
-  return try _ls(dir, recursive)
+  return try _ls(dir, recursive, allowedPaths)
 }
 
 type GrepMatch = {
@@ -123,14 +130,16 @@ export def grep(
   dir: string = ".",
   flags: string = "",
   maxResults: number = 200,
+  allowedPaths: string[] = [],
 ): Result {
   """
-  Search for a regex pattern in files under a directory. Returns matches with file path, line number, and matched line. Skips node_modules, .git, dist, build. Stops at maxResults. Fails if the pattern is not a valid regex or the directory cannot be read.
+  Search for a regex pattern in files under a directory. Returns matches with file path, line number, and matched line. Skips node_modules, .git, dist, build. Stops at maxResults. Fails if the pattern is not a valid regex or the directory cannot be read. Set allowedPaths to restrict which directories may be searched.
 
   @param pattern - The regex pattern to search for
   @param dir - The directory to search in
   @param flags - Regex flags
   @param maxResults - Maximum number of results to return
+  @param allowedPaths - Only allow searching under these path prefixes
   """
   return interrupt std::grep("Are you sure you want to search files with grep?", {
     pattern: pattern,
@@ -139,20 +148,22 @@ export def grep(
     maxResults: maxResults
   })
 
-  return try _grep(pattern, dir, flags, maxResults)
+  return try _grep(pattern, dir, flags, maxResults, allowedPaths)
 }
 
 export def glob(
   pattern: string,
   dir: string = ".",
   maxResults: number = 500,
+  allowedPaths: string[] = [],
 ): Result {
   """
-  Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Returns paths relative to the current working directory. Stops at maxResults. Fails if the pattern is not valid glob syntax or the directory cannot be read.
+  Find files whose paths match a glob pattern (e.g. "src/**/*.ts"). Returns paths relative to the current working directory. Stops at maxResults. Fails if the pattern is not valid glob syntax or the directory cannot be read. Set allowedPaths to restrict which directories may be searched.
 
   @param pattern - The glob pattern to match
   @param dir - The directory to search in
   @param maxResults - Maximum number of results to return
+  @param allowedPaths - Only allow searching under these path prefixes
   """
   return interrupt std::glob("Are you sure you want to glob files?", {
     pattern: pattern,
@@ -160,7 +171,7 @@ export def glob(
     maxResults: maxResults
   })
 
-  return try _glob(pattern, dir, maxResults)
+  return try _glob(pattern, dir, maxResults, allowedPaths)
 }
 
 type StatInfo = {
@@ -170,18 +181,24 @@ type StatInfo = {
   modifiedMs: number
 }
 
-export safe def stat(filename: string): StatInfo {
+export safe def stat(filename: string, allowedPaths: string[] = []): StatInfo {
   """
-  Return metadata about a filesystem entry: whether it exists, its type ("file", "dir", "symlink", "other", or "missing" if absent), size in bytes, and mtime in ms.
+  Return metadata about a filesystem entry: whether it exists, its type ("file", "dir", "symlink", "other", or "missing" if absent), size in bytes, and mtime in ms. Set allowedPaths to restrict which paths may be stat-ed.
+
+  @param filename - The path to stat
+  @param allowedPaths - Only allow paths under these prefixes
   """
-  return _stat(filename)
+  return _stat(filename, allowedPaths)
 }
 
-export safe def exists(filename: string): boolean {
+export safe def exists(filename: string, allowedPaths: string[] = []): boolean {
   """
-  Return true if a file or directory exists at the given path.
+  Return true if a file or directory exists at the given path. Set allowedPaths to restrict which paths may be probed; probing outside the allow-list raises an error rather than silently returning false.
+
+  @param filename - The path to check
+  @param allowedPaths - Only allow paths under these prefixes
   """
-  return _exists(filename)
+  return _exists(filename, allowedPaths)
 }
 
 export safe def which(command: string): string {

--- a/packages/agency-lang/stdlib/speech.agency
+++ b/packages/agency-lang/stdlib/speech.agency
@@ -11,9 +11,9 @@ import {
   _transcribe,
 } from "agency-lang/stdlib-lib/speech.js"
 
-export def speak(text: string, voice: string = "", rate: number = 0, outputFile: string = "") {
+export def speak(text: string, voice: string = "", rate: number = 0, outputFile: string = "", allowedPaths: string[] = []) {
   """
-  A tool for speaking text aloud using text-to-speech. Optionally specify a voice name, rate in words per minute, and an output file to save the audio to instead of playing it.
+  A tool for speaking text aloud using text-to-speech. Optionally specify a voice name, rate in words per minute, and an output file to save the audio to instead of playing it. Set allowedPaths to restrict where the output file may be written.
 
   Cancellation: in-progress speech playback is stopped on Ctrl-C, race-loser, or time-guard abort.
 
@@ -21,15 +21,16 @@ export def speak(text: string, voice: string = "", rate: number = 0, outputFile:
   @param voice - Voice name
   @param rate - Words per minute
   @param outputFile - File path to save audio to
+  @param allowedPaths - Only allow saving under these path prefixes
   """
   return interrupt std::speak("Are you sure you want to use text-to-speech?", {
     textLength: text.length
   })
 
-  _speak(text, voice, rate, outputFile)
+  _speak(text, voice, rate, outputFile, allowedPaths)
 }
 
-export def record(outputFile: string = "", silenceTimeout: number = 2000): string {
+export def record(outputFile: string = "", silenceTimeout: number = 2000, allowedPaths: string[] = []): string {
   """
   Record audio from the microphone. Stops when the user presses Enter,
   or after the specified silence timeout. Set silenceTimeout to 0 to
@@ -41,26 +42,30 @@ export def record(outputFile: string = "", silenceTimeout: number = 2000): strin
 
   Cancellation: an in-progress recording is stopped on Ctrl-C, race-loser, or time-guard abort, surfacing as an AgencyCancelledError.
 
+  Set allowedPaths to restrict where a non-empty outputFile may be written; an empty outputFile is auto-generated under the system temp directory and is not subject to the allow-list.
+
   @param outputFile - File path to save audio to (auto-generated if empty)
   @param silenceTimeout - Silence before auto-stopping in ms (0 to disable)
+  @param allowedPaths - Only allow saving under these path prefixes
   """
   return interrupt std::record("Allow microphone recording?", {})
 
-  return _record(outputFile, silenceTimeout)
+  return _record(outputFile, silenceTimeout, allowedPaths)
 }
 
-export def transcribe(filepath: string, language: string = ""): string {
+export def transcribe(filepath: string, language: string = "", allowedPaths: string[] = []): string {
   """
-  A tool for transcribing an audio file to text using OpenAI's Whisper API. Optionally specify a language code (e.g. "en") for better accuracy.
+  A tool for transcribing an audio file to text using OpenAI's Whisper API. Optionally specify a language code (e.g. "en") for better accuracy. Set allowedPaths to restrict which audio files may be uploaded.
 
   Cancellation: an in-flight Whisper upload tears down on Ctrl-C, race-loser, or time-guard abort.
 
   @param filepath - Path to the audio file
   @param language - Language code for better accuracy
+  @param allowedPaths - Only allow reading audio files under these path prefixes
   """
   return interrupt std::transcribe("Are you sure you want to send this audio file to the OpenAI Whisper API for transcription?", {
     filepath: filepath
   })
 
-  return _transcribe(filepath, language)
+  return _transcribe(filepath, language, allowedPaths)
 }

--- a/packages/agency-lang/stdlib/system.agency
+++ b/packages/agency-lang/stdlib/system.agency
@@ -1,8 +1,8 @@
 import { _args, _cwd, _dirname, _env, _setEnv, _exit, _openUrl, _screenshot } from "agency-lang/stdlib-lib/system.js"
 
-export def screenshot(filepath: string, x: number = -1, y: number = -1, width: number = -1, height: number = -1) {
+export def screenshot(filepath: string, x: number = -1, y: number = -1, width: number = -1, height: number = -1, allowedPaths: string[] = []) {
   """
-  A tool for taking a screenshot and saving it to a file. Optionally specify x, y, width, and height to capture a specific region.
+  A tool for taking a screenshot and saving it to a file. Optionally specify x, y, width, and height to capture a specific region. Set allowedPaths to restrict where the screenshot file may be written.
 
   Cancellation: an in-progress screencapture is interrupted on Ctrl-C, race-loser, or time-guard abort.
 
@@ -11,12 +11,13 @@ export def screenshot(filepath: string, x: number = -1, y: number = -1, width: n
   @param y - Y coordinate of capture region
   @param width - Width of capture region
   @param height - Height of capture region
+  @param allowedPaths - Only allow saving under these path prefixes
   """
   return interrupt std::screenshot("Are you sure you want to take a screenshot? This will capture the screen contents, which may include sensitive information.", {
     filepath: filepath
   })
 
-  _screenshot(filepath, x, y, width, height)
+  _screenshot(filepath, x, y, width, height, allowedPaths)
 }
 
 export def exit(code: number = 0) {

--- a/packages/agency-lang/tests/agency/builtins/readFile.agency
+++ b/packages/agency-lang/tests/agency/builtins/readFile.agency
@@ -1,6 +1,6 @@
 node main() {
   handle {
-    const contents = read("tests/agency/builtins/testdata.txt") catch "error reading file"
+    const contents = read("testdata.txt") catch "error reading file"
   } with (data) {
     return approve()
   }


### PR DESCRIPTION
## Summary

Adds a shared, symlink-aware containment check (`assertContained`) and threads an `allowedPaths` parameter through every stdlib filesystem and process helper that previously lacked one. For `shell::exec`, also adds an `allowedExecutables` allow-list. The intent is to let callers bind capability-narrowing options via partial application before handing a tool to an LLM, without breaking any existing caller.

Plan: `docs/superpowers/plans/2026-05-28-fs-path-traversal-audit.md`.

## What changed

- **New** `lib/stdlib/assertContained.ts` + `assertContained.test.ts` (10 tests). Resolves the target via `fs.realpath`, walking up to the nearest existing ancestor for not-yet-existing paths, and asserts it sits inside one of the resolved allowed roots. Case-insensitive on Windows.
- **`lib/stdlib/fs.ts`**: `_applyPatch`, `_mkdir`, `_copy`, `_move`, `_remove` accept `allowedPaths` and call `assertContained` on every touched path.
- **`lib/stdlib/shell.ts`**:
  - `ExecOptions` gains `allowedExecutables` (replaces the old `allowedCommands`) and `allowedPaths` (gates `cwd`).
  - `BashOptions` gains `allowedPaths` (gates `cwd`).
  - `_ls`, `_grep`, `_glob`, `_stat`, `_exists` accept `allowedPaths`.
- **`lib/stdlib/system.ts`**: `_screenshot` accepts `allowedPaths` for the output file.
- **`lib/stdlib/speech.ts`**: `_speak`, `_record`, `_transcribe` accept `allowedPaths` for their file arguments. `record()` only enforces it on an explicit `outputFile` (the auto-generated temp path is unrestricted).
- **`lib/stdlib/policy.ts`**: `_writePolicyFile` is now `async` and accepts `allowedPaths`.
- **`stdlib/*.agency`**: every Agency wrapper exposes the new optional parameter (default `[]`) and forwards it.

## Semantics

Additive on purpose: an empty `allowedPaths` (the default everywhere) is a no-op. Adding `assertContained` does not change behavior for any existing caller. Tightening the default to "moduleDir only" was considered (see plan) and is left as a follow-up.

## Breaking changes

One: `shell::exec`'s Agency parameter `allowedCommands` is renamed to `allowedExecutables` to match the underlying TS type and the plan's terminology. Positional callers are unaffected; keyword callers must rename.

## Validation

- `make` (templates → build → stdlib → agents → docs) — green.
- `pnpm test:run lib/stdlib/assertContained.test.ts lib/stdlib/resolvePath.test.ts` — 21/21 passing.
- `pnpm run lint:structure` — clean.
- Per AGENTS.md the full agency test suite is not run locally; CI will run it.

## Out of scope (follow-ups)

- Triage of remaining stdlib modules (`memory`, `oauth`, `keyring`, `clipboard`, `imessage`, `email`, `calendar`, `browserUse`).
- A docs guide page on capability narrowing via partial application.
- Optional: switch the default for `allowedPaths` from unrestricted to "moduleDir only" once the partial-application story is documented.
