### PR TITLE
stdlib(fs): add printDiff() and edit(printDiff: true) for colored diffs

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/fs.md
+++ b/packages/agency-lang/docs/site/stdlib/fs.md
@@ -35,7 +35,7 @@ type PatchResult = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L35))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L50))
 
 ### Workspace
 
@@ -71,14 +71,14 @@ export type Workspace = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L124))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L139))
 
 ## Functions
 
 ### edit
 
 ```ts
-edit(filename: string, edits: Edit[], dir: string): Result
+edit(filename: string, edits: Edit[], dir: string, printDiff: boolean): Result
 ```
 
 Edit a single file by applying one or more text replacements atomically. Each edit has `oldText`, `newText`, and `replaceAll`. Every edit's `oldText` must match a unique, non-overlapping region of the original file (matches are looked up against the file as it stands when the edit runs, after earlier edits). Set `replaceAll: true` on an edit to replace every occurrence. When any edit fails, nothing is written.
@@ -88,6 +88,7 @@ Edit a single file by applying one or more text replacements atomically. Each ed
   @param filename - The file to edit
   @param edits - Array of edit objects with oldText, newText, replaceAll
   @param dir - The directory to resolve the filename against (defaults to ".")
+  @param printDiff - When true, print a colored diff to stdout after the edit applies
 
 **Parameters:**
 
@@ -96,12 +97,36 @@ Edit a single file by applying one or more text replacements atomically. Each ed
 | filename | `string` |  |
 | edits | `Edit[]` |  |
 | dir | `string` | "." |
+| printDiff | `boolean` | false |
 
 **Returns:** `Result`
 
 **Throws:** `std::edit`
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L16))
+
+### printDiff
+
+```ts
+printDiff(oldText: string, newText: string)
+```
+
+Print a colored, line-based diff of `oldText` vs `newText` to stdout.
+  Deletions are shown in red with a `-` prefix, insertions in green
+  with a `+` prefix, unchanged context is dimmed. Useful for showing
+  what an edit actually changed before / after committing it.
+
+  @param oldText - The original text
+  @param newText - The replacement text
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| oldText | `string` |  |
+| newText | `string` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L37))
 
 ### applyPatch
 
@@ -125,7 +150,7 @@ Apply a unified diff to the working tree. Supports file creation (--- /dev/null)
 
 **Throws:** `std::applyPatch`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L40))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L55))
 
 ### mkdir
 
@@ -149,7 +174,7 @@ Create a directory, including any missing parent directories. Idempotent: succee
 
 **Throws:** `std::mkdir`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L69))
 
 ### copy
 
@@ -175,7 +200,7 @@ Copy a file or directory. Directories are copied recursively. Fails if src does 
 
 **Throws:** `std::copy`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L68))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L83))
 
 ### move
 
@@ -201,7 +226,7 @@ Move or rename a file or directory. Falls back to copy+remove if src and dest ar
 
 **Throws:** `std::move`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L84))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L99))
 
 ### remove
 
@@ -225,7 +250,7 @@ Delete a file or directory. Directories are removed recursively. Does not fail i
 
 **Throws:** `std::remove`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L100))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L115))
 
 ### openDir
 
@@ -277,4 +302,4 @@ Build a Workspace anchored at `dir` — a bundle of file-system tools
 
 **Returns:** [Workspace](#workspace)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L140))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/fs.agency#L155))

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -230,6 +230,12 @@ node main() {
      package managers). Prefer the dedicated file tools above for file
      operations; use `bash` for everything else. The user is asked to
      approve each command.
+  7. Whenever you show the user a code snippet in your reply, first
+     call `highlight(code)` and emit the returned string verbatim
+     instead of the raw source. The tool renders the snippet with
+     terminal colors so the user can read it more easily. Skip
+     highlighting for inline identifiers or one-token excerpts; use
+     it for any multi-line block.
 
   Keep replies brief. Show code, not commentary.
   """

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -249,12 +249,20 @@ node main() {
     let userMsg = input("What would you like to do? ")
     while (userMsg != "exit" && userMsg != "quit") {
       handle {
-        // Spread `workspace.tools` so a `setCwd` from the previous
-        // turn picks up here (the binding is refreshed each iteration).
+        // List workspace tools explicitly so we can PFA `printDiff: true`
+        // onto `edit` — every edit the LLM runs prints a colored diff
+        // to the console before / after the change, so the user can
+        // eyeball what actually got written.
         const reply = llm(userMsg, {
           tools: [
             setCwd,
-            ...workspace.tools,
+            workspace.read,
+            workspace.write,
+            workspace.edit.partial(printDiff: true),
+            workspace.ls,
+            workspace.glob,
+            workspace.grep,
+            workspace.bash,
             typecheck,
             docSkill,
             highlight.partial(language: "ts"),

--- a/packages/agency-lang/lib/stdlib/fs.ts
+++ b/packages/agency-lang/lib/stdlib/fs.ts
@@ -5,8 +5,19 @@ import process from "process";
 import diff_match_patch from "diff-match-patch";
 import { resolvePath } from "./resolvePath.js";
 import { assertContained } from "./assertContained.js";
+import { formatDiff } from "../utils/diff.js";
 
 export { resolvePath } from "./resolvePath.js";
+
+/**
+ * Print a colored, line-based diff of `oldText` vs `newText` to
+ * stdout. Deletions are red, insertions are green, unchanged context
+ * is dimmed. Used both as a standalone Agency tool (`std::fs::printDiff`)
+ * and as the side effect of `edit(..., printDiff: true)`.
+ */
+export function _printDiff(oldText: string, newText: string): void {
+  console.log(formatDiff(oldText, newText));
+}
 
 export type MultiEdit = {
   oldText: string;
@@ -24,9 +35,11 @@ export async function _multiedit(
   dir: string,
   filename: string,
   edits: MultiEdit[],
+  printDiff: boolean = false,
 ): Promise<MultiEditResult> {
   const full = await resolvePath(dir, filename);
   let contents = await fs.readFile(full, "utf8");
+  const original = contents;
   let total = 0;
 
   for (let i = 0; i < edits.length; i++) {
@@ -68,6 +81,9 @@ export async function _multiedit(
   }
 
   await fs.writeFile(full, contents, "utf8");
+  if (printDiff && original !== contents) {
+    _printDiff(original, contents);
+  }
   return { replacements: total, path: filename, edits: edits.length };
 }
 

--- a/packages/agency-lang/stdlib/fs.agency
+++ b/packages/agency-lang/stdlib/fs.agency
@@ -1,4 +1,4 @@
-import { _multiedit, _applyPatch, _mkdir, _copy, _move, _remove } from "agency-lang/stdlib-lib/fs.js"
+import { _multiedit, _applyPatch, _mkdir, _copy, _move, _remove, _printDiff } from "agency-lang/stdlib-lib/fs.js"
 import { bash, glob, ls, grep } from "std::shell"
 
 type Edit = {
@@ -13,7 +13,7 @@ type EditResult = {
   edits: number
 }
 
-export def edit(filename: string, edits: Edit[], dir: string = "."): Result {
+export def edit(filename: string, edits: Edit[], dir: string = ".", printDiff: boolean = false): Result {
   """
   Edit a single file by applying one or more text replacements atomically. Each edit has `oldText`, `newText`, and `replaceAll`. Every edit's `oldText` must match a unique, non-overlapping region of the original file (matches are looked up against the file as it stands when the edit runs, after earlier edits). Set `replaceAll: true` on an edit to replace every occurrence. When any edit fails, nothing is written.
 
@@ -22,14 +22,29 @@ export def edit(filename: string, edits: Edit[], dir: string = "."): Result {
   @param filename - The file to edit
   @param edits - Array of edit objects with oldText, newText, replaceAll
   @param dir - The directory to resolve the filename against (defaults to ".")
+  @param printDiff - When true, print a colored diff to stdout after the edit applies
   """
   return interrupt std::edit("Are you sure you want to apply these edits?", {
     dir: dir,
     filename: filename,
-    edits: edits
+    edits: edits,
+    printDiff: printDiff
   })
 
-  return try _multiedit(dir, filename, edits)
+  return try _multiedit(dir, filename, edits, printDiff)
+}
+
+export safe def printDiff(oldText: string, newText: string) {
+  """
+  Print a colored, line-based diff of `oldText` vs `newText` to stdout.
+  Deletions are shown in red with a `-` prefix, insertions in green
+  with a `+` prefix, unchanged context is dimmed. Useful for showing
+  what an edit actually changed before / after committing it.
+
+  @param oldText - The original text
+  @param newText - The replacement text
+  """
+  _printDiff(oldText, newText)
 }
 
 type PatchResult = {


### PR DESCRIPTION
Follow-up to #220 — addresses the last unresolved review comment asking for a way to print a colored diff per edit.

## What

- New stdlib helper `printDiff(oldText, newText)` in `std::fs` — prints a colored line-based diff (red `-` deletions, green `+` insertions, dimmed context) to stdout. Reuses the existing `formatDiff` helper in `lib/utils/diff.ts` so we get the same look as the test runner.
- New `printDiff: boolean = false` param on `edit()`. When `true`, the diff is printed immediately after the file is rewritten. Threaded through `_multiedit` so the same code path serves both the standalone tool and the edit side-effect.
- Agency Agent: PFA `workspace.edit` with `printDiff: true` so every LLM-driven edit prints a diff to the console before / after the change — the user can eyeball what actually got written.

## Verified

- `make` clean.
- `pnpm run agency typecheck lib/agents/agency-agent/agent.agency` → no errors.
- Smoke test: `printDiff("hello\nworld\nfoo\n", "hello\nthere\nfoo\n")` → expected red `- world`, green `+ there`, dimmed `hello`/`foo`. ✅
- Smoke test: `edit(file, [...], ".", true)` prints the same diff after writing. ✅
