### PR TITLE
Add ~ expansion to stdlib path resolution

### DIFF
--- a/packages/agency-lang/docs/dev/coding-standards.md
+++ b/packages/agency-lang/docs/dev/coding-standards.md
@@ -116,3 +116,13 @@ When adding new features, put as much logic as possible in `lib/runtime/` (where
 Always create new commits. Never use `git push --force` or `git commit --amend`.
 
 **Rationale:** Force-pushing and amending can destroy work and make history hard to follow.
+
+---
+
+### Route path arguments through `resolveDir` / `resolvePath`
+
+Any new stdlib function in `lib/stdlib/` that takes a `dir`, `cwd`, `src`, `dest`, or `path` argument MUST resolve it via [`resolveDir`](../../lib/stdlib/resolveDir.ts) (for directories) or [`resolvePath`](../../lib/stdlib/resolvePath.ts) (for the dir-plus-filename case). Do NOT call `path.resolve(moduleDir, …)` or `path.resolve(process.cwd(), …)` directly on user-supplied paths.
+
+`resolveDir`/`resolvePath` delegate to [`expandPath`](../../lib/stdlib/expandPath.ts), which is the single owner of path-shorthand policy (today: leading `~`; later: env vars, normalization, etc.). Inlining `path.resolve` at a new call site encodes the policy locally, so any future expansion rule has to be added at every site — exactly the "inconsistent patterns" anti-pattern this module exists to prevent.
+
+For options-only `allowedPaths` shapes, `assertContained` already runs each entry through `expandPath`, so a policy that says `allowedPaths: ["~/.agency"]` works for free.

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-29-tilde-expansion-in-stdlib.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-29-tilde-expansion-in-stdlib.md
@@ -1,0 +1,418 @@
+# Home-Directory (`~`) Expansion in Stdlib Path Resolution — Implementation Plan
+
+## Goal
+
+Let users write `~/notes.md`, `~/.agency/memory`, etc. in any
+filesystem-touching stdlib function and have `~` expand to the user's
+home directory. Today the stdlib treats `~` as a literal directory
+name, which silently does the wrong thing.
+
+**Stronger requirement:** any path-resolving stdlib function — present
+or future — should pick up `~` (and any later path-expansion rules)
+**by going through one resolver, not by re-implementing the policy at
+the call site.** This is the part of the plan that pays for itself
+the next time we add a path rule (env-var expansion, normalization,
+allow-list overlay, etc.).
+
+## Verification before writing code
+
+> Grep `lib/` for any existing path-expansion utility before adding a
+> new one. As of writing:
+>
+> - `lib/stdlib/path.ts` exposes only thin wrappers around node `path`
+>   (`_join`, `_resolve`, `_basename`, `_dirname`, `_extname`,
+>   `_relative`, `_isAbsolute`) — no expansion.
+> - `lib/stdlib/resolvePath.ts` resolves `(dir, filename)` against the
+>   module directory with traversal / symlink-escape checks. No `~`
+>   handling.
+> - `os.homedir()` is used ad-hoc in `lib/stdlib/oauth.ts`,
+>   `lib/cli/schedule/backends/{launchd,systemd}.ts`,
+>   `lib/cli/schedule/index.ts`, `lib/mcp/setup.ts`,
+>   `lib/serve/policyStore.ts`. None of those are a reusable helper.
+>
+> If something has been added since, prefer reusing it over creating
+> a new one.
+
+## Scope: which APIs
+
+Every stdlib entry point that resolves a filesystem path. Concretely:
+
+**Built-ins ([`lib/stdlib/builtins.ts`](../../../lib/stdlib/builtins.ts)):**
+- `_read`, `_write`, `_readImage` — `dir` arg (filename stays relative).
+
+**Shell tools ([`lib/stdlib/shell.ts`](../../../lib/stdlib/shell.ts)):**
+- `_ls`, `_grep`, `_glob`, `_stat`, `_exists` — `dir` arg.
+- `_exec`, `_bash` — `cwd` arg.
+- `_which` — scans PATH, no user dir input; skip.
+
+**Filesystem tools ([`lib/stdlib/fs.ts`](../../../lib/stdlib/fs.ts)):**
+- `_copy`, `_move`, `_remove`, `_mkdir`, `_edit`, `_applyPatch`,
+  etc. — every `src` / `dest` / `path` / `dir` arg.
+
+**Allow-list policy fields ([`lib/stdlib/assertContained.ts`](../../../lib/stdlib/assertContained.ts)):**
+- `allowedPaths: ["~/.agency", ...]` must expand the same way, or
+  policies break for users who write `~` in them.
+
+**Memory store path** (after the memory-config PR lands):
+- `dir` passed to `enableMemory({ dir: "~/.agency/memory" })`. Comes
+  for free because the memory plan resolves through this same helper.
+
+## Design: one resolver, no inlined policy
+
+### Anti-pattern this plan refuses
+
+The naive approach is to insert `expandHome(dir)` at every existing
+`path.resolve(moduleDir, dir)` site. That gives `~` expansion but
+encodes the path-resolution policy ("expand, then resolve against
+module dir") at ~15 call sites. The next rule we add (env vars, NFC
+normalization, allow-list overlay) has to be inserted at all 15
+sites again — and any *new* stdlib function added in the future has
+to remember to do the same dance. That is the
+[`inconsistent patterns`](../../dev/anti-patterns.md#inconsistent-patterns)
+anti-pattern about to be born.
+
+### What this plan does instead
+
+Two layered helpers; call sites consume the second.
+
+**Layer 1 — `expandPath(p)` in `lib/stdlib/expandPath.ts`** — pure
+string transform. Single source of truth for "user-typed path string →
+expanded string." Today it only handles leading `~`; the function
+exists so the next expansion rule (env vars, NFC, anything) lands in
+one place.
+
+```ts
+import os from "os";
+import path from "path";
+
+/**
+ * Expand user-shorthand prefixes in a path string. Currently:
+ *
+ * - `~` alone → $HOME
+ * - `~/foo` (or `~\foo` on Windows) → $HOME/foo
+ * - `~user/...` throws (POSIX-only, platform complexity not worth it).
+ * - everything else returns unchanged.
+ *
+ * This is the single owner of path-shorthand policy for the stdlib.
+ * Future rules (env-var expansion, NFC normalization, etc.) land
+ * here, not at call sites.
+ *
+ * Does NOT resolve to an absolute path — callers still pass the
+ * result through path.resolve / resolvePath / resolveDir.
+ */
+export function expandPath(p: string): string;
+```
+
+Plus `expandPath.test.ts`.
+
+**Layer 2 — `resolveDir(dir)` in `lib/stdlib/resolveDir.ts`** — the
+"dir-only" resolver shared by every stdlib site that today writes
+`path.resolve(moduleDir, dir)`. It runs `expandPath` first, then
+resolves against the module dir, then asserts containment. This is
+the resolver call sites consume.
+
+```ts
+import path from "path";
+import { getModuleDir } from "../runtime/asyncContext.js";
+import { expandPath } from "./expandPath.js";
+import { assertContained } from "./assertContained.js";
+
+/**
+ * Resolve a directory argument the way every path-taking stdlib
+ * function should: expand user shorthands, resolve against the
+ * module dir, assert it lives under allowedPaths.
+ *
+ * Returns the absolute, validated directory.
+ *
+ * Mirrors what `resolvePath(dir, filename)` does at the `dir` level.
+ * If you're writing a new stdlib function that takes a `dir`-like
+ * arg, USE THIS — don't re-implement the policy.
+ */
+export async function resolveDir(
+  dir: string,
+  allowedPaths: string[] = [],
+): Promise<string>;
+```
+
+The existing two-step
+[`resolvePath(dir, filename)`](../../../lib/stdlib/resolvePath.ts)
+delegates its dir step to `resolveDir`, so `read`/`write`/`edit` get
+`~` support without further changes.
+
+`assertContained` calls `expandPath` on each entry of `allowedPaths`
+once on entry, so a policy that says `allowedPaths: ["~/.agency"]`
+matches paths resolved under `os.homedir() + "/.agency"`.
+
+### Call-site result
+
+`shell.ts`, `fs.ts`, and `builtins.ts` lose every inlined
+`path.resolve(moduleDir, dir)` and gain a single call:
+
+```ts
+// Before
+const moduleDir = getModuleDir();
+const root = path.resolve(moduleDir, dir);
+await assertContained(root, allowedPaths ?? [], moduleDir);
+
+// After
+const root = await resolveDir(dir, allowedPaths);
+```
+
+The policy lives in `resolveDir` exclusively. Any future rule we add
+to `expandPath` or `resolveDir` lands at every site automatically.
+
+## Convention for future code
+
+Add a one-paragraph note to
+[`docs/dev/coding-standards.md`](../../dev/coding-standards.md) (or
+its closest neighbor) that any new stdlib function taking a `dir` /
+`cwd` / `path` argument MUST resolve it via `resolveDir` (for
+directories) or `resolvePath` (for the dir-plus-filename case). Code
+that calls `path.resolve` directly on user input is rejected at
+review.
+
+A structural lint check (added to `pnpm run lint:structure` per
+[AGENTS.md](../../../AGENTS.md)) can enforce this cheaply by flagging
+`path.resolve` calls inside `lib/stdlib/` that aren't in
+`resolveDir.ts` / `resolvePath.ts`. Optional follow-up; the doc note
+covers it for now.
+
+## Edge cases & decisions
+
+1. **Quoted `~`** — strings arrive from Agency source verbatim; no
+   shell processing. `"~/foo"` and `'~/foo'` both reach the helper as
+   `~/foo`.
+
+2. **`~` in the middle of a path** — `/etc/~/foo` etc. Not expanded.
+   `expandPath` only touches a leading `~`. Documented in the doc
+   comment.
+
+3. **No `HOME` env var** — `os.homedir()` falls back to platform-
+   specific lookup on POSIX; rarely returns `undefined`. Defensive
+   check: if `os.homedir()` returns falsy, throw with a clear
+   message. Never silently keep `~`.
+
+4. **Windows** — `os.homedir()` returns `C:\Users\Foo`; `path.join`
+   handles separators. `~/foo` and `~\foo` both work via the
+   `path.sep` check.
+
+5. **Symlink-target check** in `resolvePath` / `resolveDir` runs
+   *after* `~` expansion. No interaction.
+
+6. **Existing absolute-path policy** — `read("/etc/passwd", "...")`
+   still throws because *filename* is absolute. Tilde expansion of
+   `~/foo` happens at the `dir` level only.
+
+## Tests
+
+### Unit — `lib/stdlib/expandPath.test.ts` (new)
+
+- `expandPath("~")` returns `os.homedir()`
+- `expandPath("~/foo")` returns `path.join(home, "foo")`
+- `expandPath("~\\foo")` on Windows returns `path.join(home, "foo")`
+- `expandPath("notilde")` returns input unchanged
+- `expandPath("/abs/~/foo")` returns input unchanged (no mid-path
+  expansion)
+- `expandPath("~user/foo")` throws
+- `expandPath("")` returns input unchanged
+
+### Unit — `lib/stdlib/resolveDir.test.ts` (new)
+
+- Resolves `~/proj` under `os.homedir()`
+- Resolves `./sub` against module dir (existing behavior preserved)
+- Enforces `allowedPaths` after expansion
+
+### Unit — `lib/stdlib/resolvePath.test.ts` (extend)
+
+- `resolvePath("~/notes", "x.md")` resolves under `os.homedir()`
+- Still rejects absolute filename when dir is `~/...`
+- Still rejects `..` traversal under `~/...`
+
+### Unit — `lib/stdlib/assertContained.test.ts` (extend)
+
+- A policy with `allowedPaths: ["~/proj"]` accepts a path resolved to
+  `os.homedir() + "/proj/sub"`.
+
+### Agency execution test — `tests/agency/tilde-paths.agency` (new)
+
+```agency
+import { stat } from "std::shell"
+
+node main() {
+  // Probe a path that should exist for any user.
+  const r = stat("~", "")
+  assert(r.exists)
+  return "ok"
+}
+```
+
+Side-effect-free — no writes under the user's home.
+
+### Manual smoke
+
+After the memory-config PR lands, verify
+`enableMemory({ dir: "~/.agency/memory" })` creates
+`$HOME/.agency/memory`.
+
+### Test gaps — what could break that the tests above wouldn't catch
+
+The listed tests cover the helper in isolation, but the **value** of
+this PR is consistency across every stdlib path-taking function.
+The biggest risk class is "one call site in `shell.ts` / `fs.ts` /
+`builtins.ts` is forgotten in the migration, and `~` silently
+half-works." Per-helper unit tests can't catch that.
+
+**Gap 1: Per-function integration coverage.** Every migrated stdlib
+function needs at least one call with `~/...` to prove `~` expands
+on that specific code path. If `_glob`'s `dir` arg is missed during
+migration but `_ls`'s isn't, only an integration test on `_glob`
+exposes it.
+**Add:** `tests/agency/tilde-paths.agency` extended to exercise
+every migrated entry point at least once:
+
+```agency
+import { ls, glob, grep, stat, exists, bash, exec } from "std::shell"
+import { read } from "std::"   // built-in
+
+node main() {
+  assert(stat("~", "").exists)
+  assert(exists("~/", ""))                     // exists(filename, dir)
+  // ls/glob/grep — empty dir output is fine; goal is "doesn't throw"
+  ls("~", false)
+  glob("*", "~")
+  grep("nomatch_pattern_xyz", "~", "", 10)
+  // exec/bash cwd
+  exec("pwd", [], "~")
+  bash("pwd", "~")
+  return "ok"
+}
+```
+
+Each line probes a distinct code path that the unit tests don't
+cover. Side-effect-free (no writes under `$HOME`).
+
+**Gap 2: Inline `path.resolve` regression guard.** If a future stdlib
+function takes a `dir` arg and uses `path.resolve(moduleDir, dir)`
+directly instead of `resolveDir`, none of the existing tests catch
+it.
+**Add:** structural-lint check in `pnpm run lint:structure` that
+flags `path.resolve` calls inside `lib/stdlib/` outside of
+`resolvePath.ts` and `resolveDir.ts`. This is the test for the
+*convention*, not a specific bug. Without it, drift is inevitable.
+
+Implementation: AST-grep the existing structural-lint script for the
+forbidden pattern. Same shape as the other rules in
+`scripts/lint-structure.ts` (or wherever it lives — confirm during
+implementation).
+
+**Gap 3: `allowedPaths` negative path.** Listed test covers
+`allowedPaths: ["~/proj"]` accepting `$HOME/proj/sub`. Missing: a
+path outside the allow-list (e.g., `/tmp/x`) is **rejected** after
+the expansion. Without the negative case, a bug that expands
+everything to a no-op allow-list would pass the positive test.
+**Add:** to `lib/stdlib/assertContained.test.ts`, the rejection case.
+
+**Gap 4: Symlink escape under `~/...`.** `resolvePath` has a symlink-
+escape check that runs after path resolution. The check must continue
+to fire when the input dir is `~/foo` (resolved to `$HOME/foo`) and
+the symlinked target escapes.
+**Add:** `lib/stdlib/resolvePath.test.ts` — set up a temp symlink
+under a fake `HOME`, point a `~/...` path through it, assert escape
+is detected.
+
+**Gap 5: `HOME` env missing.** Helper throws when `os.homedir()`
+returns falsy. Listed in design, no test.
+**Add:** `lib/stdlib/expandPath.test.ts` — mock `os.homedir` to
+return `""` (or `undefined`), assert `expandPath("~/foo")` throws
+with a clear message. Vitest supports this via `vi.spyOn(os, "homedir")`.
+
+**Gap 6: Absolute path unchanged.** `expandPath("/etc/passwd")` and
+`expandPath("C:\\Users\\Foo")` must return the input unchanged. Bug
+that mistakenly expands every input (e.g. a misplaced `||`) would
+silently break unrelated absolute-path tests.
+**Add:** explicit cases in `expandPath.test.ts`.
+
+**Gap 7: Windows `~\foo`.** Listed but CI is presumably Linux/macOS.
+The test needs to mock `path.sep` (or use `path.win32` explicitly)
+so it runs cross-platform.
+**Add:** to `expandPath.test.ts`, a case using `path.win32.sep`
+explicitly rather than the platform-default `path.sep`, so the test
+actually runs on POSIX CI.
+
+**Gap 8: `~` inside an `exec`/`bash` *argument* (not cwd).** This
+PR only expands path-argument fields (`dir`, `cwd`, `src`, `dest`,
+`filename`, `allowedPaths`). It does **not** expand `~` inside the
+shell command string of `bash("ls ~/foo")` — that's the shell's job
+and we shouldn't pre-process command strings. Worth a test that
+documents this boundary so a future change doesn't accidentally
+expand them.
+**Add:** to `tests/agency/tilde-paths.agency`, a comment + assertion
+that `bash("echo ~", ".")` echoes `~` literally when stdin is empty
+and no shell expansion happens (or echoes the path if the shell does
+expand it). Either way the test documents which layer owns the
+expansion.
+
+**Gap 9: Module-dir resolution still works for non-`~` inputs.**
+A bug in `resolveDir` that always expands or always routes through
+`os.homedir()` would break every existing relative-path call.
+**Add:** to `resolveDir.test.ts`, an explicit non-tilde relative
+path case asserting it resolves against the module dir (not `$HOME`,
+not cwd) — verifies the existing behavior is preserved.
+
+**Gap 10: Frame fields propagated through `_read` / `_write`.**
+After migrating `builtins.ts` (`_read`, `_write`, `_readImage`),
+verify `read("notes.md", "~/proj")` resolves to `$HOME/proj/notes.md`
+and `read("notes.md", "./local")` still resolves against the module
+dir. The two should differ only in the `dir` value.
+**Add:** to existing built-ins test file (or the agency execution
+test), one case for each.
+
+The listed tests stay; gaps above are additive.
+
+## Migration & rollout
+
+- **Backward compatible** unless a user has a literal `~` directory
+  in their working dir AND relies on stdlib treating it as such. That
+  combination is implausible; document the workaround (`./~`) if it
+  ever surfaces.
+- **No deprecations.** Additive — paths not starting with `~` behave
+  identically.
+- **Single PR.** Adds two new helper files + one new test file each,
+  plus ~15 mechanical *deletions* and *replacements* across `shell.ts`,
+  `fs.ts`, `builtins.ts`, `resolvePath.ts`, `assertContained.ts`.
+- **Order vs. memory PR.** Independent. Either can land first.
+
+## File checklist
+
+New:
+- [`lib/stdlib/expandPath.ts`](../../../lib/stdlib/expandPath.ts) — single owner of path-shorthand policy
+- [`lib/stdlib/expandPath.test.ts`](../../../lib/stdlib/expandPath.test.ts)
+- [`lib/stdlib/resolveDir.ts`](../../../lib/stdlib/resolveDir.ts) — dir-arg resolver shared by all stdlib sites
+- [`lib/stdlib/resolveDir.test.ts`](../../../lib/stdlib/resolveDir.test.ts)
+
+Modified — internal:
+- [`lib/stdlib/resolvePath.ts`](../../../lib/stdlib/resolvePath.ts) — dir step delegates to `resolveDir`
+- [`lib/stdlib/assertContained.ts`](../../../lib/stdlib/assertContained.ts) — expand each `allowedPaths` entry via `expandPath` on entry
+
+Modified — call sites collapse to `resolveDir(dir, allowedPaths)`:
+- [`lib/stdlib/shell.ts`](../../../lib/stdlib/shell.ts) — `_ls`, `_grep`, `_glob`, `_stat`, `_exists`, `_exec` cwd, `_bash` cwd
+- [`lib/stdlib/fs.ts`](../../../lib/stdlib/fs.ts) — every `path.resolve(process.cwd(), …)` and `path.resolve(moduleDir, …)` site
+- [`lib/stdlib/builtins.ts`](../../../lib/stdlib/builtins.ts) — `_read`, `_write`, `_readImage` (if not already routed through `resolvePath`)
+
+Docs:
+- [`docs/dev/coding-standards.md`](../../dev/coding-standards.md) — paragraph: "new path-taking stdlib functions must route through `resolveDir` / `resolvePath`"
+- Optional: structural lint check enforcing the above; deferrable
+- User-facing note in [`docs/site/guide/`](../../site/guide/)
+  wherever path arguments are discussed; also call out `~` in
+  [`docs/site/cli/policy.md`](../../site/cli/policy.md) for
+  `allowedPaths`.
+
+## Out of scope
+
+- Environment variable expansion (`$HOME`, `$XDG_CONFIG_HOME`). Tilde
+  is the common case; env vars need a separate decision and will land
+  inside `expandPath` when they do.
+- `~user/...` expansion. Documented as unsupported, throws clearly.
+- Mid-path `~` expansion. Not supported — same reason.
+- Changing where module dir vs. cwd is used to resolve relative
+  non-tilde paths. Orthogonal design decision.

--- a/packages/agency-lang/lib/stdlib/assertContained.test.ts
+++ b/packages/agency-lang/lib/stdlib/assertContained.test.ts
@@ -127,4 +127,13 @@ describe("assertContained ~ expansion", () => {
       assertContained("/tmp/some-other-thing", ["~/proj"]),
     ).rejects.toThrow(/not under/);
   });
+
+  it("accepts a ~-prefixed target against an absolute allowlist (target gets expanded too)", async () => {
+    // Mirror image of the test above — exercises that expansion is
+    // applied to the *target* path, not only to allowlist entries.
+    const allowedAbs = path.join(os.homedir(), "proj");
+    await expect(
+      assertContained("~/proj/file.txt", [allowedAbs]),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/packages/agency-lang/lib/stdlib/assertContained.test.ts
+++ b/packages/agency-lang/lib/stdlib/assertContained.test.ts
@@ -112,3 +112,19 @@ describe("assertContained", () => {
     ).resolves.toBeUndefined();
   });
 });
+
+describe("assertContained ~ expansion", () => {
+  it("accepts a path resolved under ~/proj when allowlist includes ~/proj", async () => {
+    const target = path.join(os.homedir(), "proj", "sub");
+    await expect(
+      assertContained(target, ["~/proj"]),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a path outside ~/proj when allowlist is ~/proj", async () => {
+    // Use a deliberately-outside-home absolute target.
+    await expect(
+      assertContained("/tmp/some-other-thing", ["~/proj"]),
+    ).rejects.toThrow(/not under/);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/assertContained.ts
+++ b/packages/agency-lang/lib/stdlib/assertContained.ts
@@ -1,6 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
 import process from "process";
+import { expandPath } from "./expandPath.js";
 
 /**
  * Assert that `target` resolves inside at least one of `allowedRoots`.
@@ -43,13 +44,17 @@ export async function assertContained(
   // `resolvePath`) should pass `getModuleDir()` so a relative entry in
   // `allowedPaths` sits in the same root as the data the tool is
   // operating on.
-  const lexicalTarget = path.resolve(baseDir, target);
+  //
+  // Each entry is run through `expandPath` first so a policy that
+  // says `allowedPaths: ["~/proj"]` matches paths resolved under
+  // `os.homedir() + "/proj"`.
+  const lexicalTarget = path.resolve(baseDir, expandPath(target));
   const realTarget = await realpathOrLexicalAncestor(lexicalTarget);
 
   const realRoots: string[] = [];
   for (const root of allowedRoots) {
     if (root.trim() === "") continue;
-    const lexicalRoot = path.resolve(baseDir, root);
+    const lexicalRoot = path.resolve(baseDir, expandPath(root));
     realRoots.push(await realpathOrSelf(lexicalRoot));
   }
 

--- a/packages/agency-lang/lib/stdlib/expandPath.test.ts
+++ b/packages/agency-lang/lib/stdlib/expandPath.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import { expandPath } from "./expandPath.js";
+
+describe("expandPath", () => {
+  it("expands ~ alone to os.homedir()", () => {
+    expect(expandPath("~")).toBe(os.homedir());
+  });
+
+  it("expands ~/foo to homedir/foo", () => {
+    expect(expandPath("~/foo")).toBe(path.join(os.homedir(), "foo"));
+  });
+
+  it("expands ~/nested/path", () => {
+    expect(expandPath("~/.agency/memory")).toBe(
+      path.join(os.homedir(), ".agency/memory"),
+    );
+  });
+
+  it("returns input unchanged when there is no ~", () => {
+    expect(expandPath("notilde")).toBe("notilde");
+    expect(expandPath("./relative")).toBe("./relative");
+    expect(expandPath("/etc/passwd")).toBe("/etc/passwd");
+  });
+
+  it("does not expand ~ in the middle of a path", () => {
+    expect(expandPath("/etc/~/foo")).toBe("/etc/~/foo");
+    expect(expandPath("./sub/~user/x")).toBe("./sub/~user/x");
+  });
+
+  it("rejects ~user/foo with a clear message", () => {
+    expect(() => expandPath("~user/foo")).toThrow(/~user/);
+    expect(() => expandPath("~root")).toThrow(/~user/);
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(expandPath("")).toBe("");
+  });
+
+  it("throws a clear error when os.homedir returns falsy", () => {
+    const spy = vi.spyOn(os, "homedir").mockReturnValue("");
+    try {
+      expect(() => expandPath("~/foo")).toThrow(/HOME/i);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("leaves Windows-style absolute paths unchanged", () => {
+    expect(expandPath("C:\\Users\\Foo")).toBe("C:\\Users\\Foo");
+  });
+
+  it("treats backslash after ~ as a separator (Windows-style ~\\foo)", () => {
+    // Cross-platform: even on POSIX we accept `\` after `~` as a
+    // separator so a Windows-shaped path string from a config file
+    // or stdin doesn't surprise users who copy-pasted across
+    // platforms. The tail's joined via path.join, so on POSIX you
+    // get `$HOME/foo` and on Windows `$HOME\foo`.
+    expect(expandPath("~\\foo")).toBe(path.join(os.homedir(), "foo"));
+  });
+});

--- a/packages/agency-lang/lib/stdlib/expandPath.test.ts
+++ b/packages/agency-lang/lib/stdlib/expandPath.test.ts
@@ -8,8 +8,20 @@ describe("expandPath", () => {
     expect(expandPath("~")).toBe(os.homedir());
   });
 
+  it("expands ~/ (trailing slash only) to os.homedir()", () => {
+    // Falls through to path.join(home, "") which normalizes to home.
+    expect(expandPath("~/")).toBe(os.homedir());
+  });
+
   it("expands ~/foo to homedir/foo", () => {
     expect(expandPath("~/foo")).toBe(path.join(os.homedir(), "foo"));
+  });
+
+  it("normalizes ~//foo (double separator) to homedir/foo", () => {
+    // Guards against a regression if anyone swaps path.join for
+    // path.resolve — path.resolve would treat /foo as absolute and
+    // drop the home prefix entirely.
+    expect(expandPath("~//foo")).toBe(path.join(os.homedir(), "foo"));
   });
 
   it("expands ~/nested/path", () => {

--- a/packages/agency-lang/lib/stdlib/expandPath.test.ts
+++ b/packages/agency-lang/lib/stdlib/expandPath.test.ts
@@ -50,10 +50,31 @@ describe("expandPath", () => {
     expect(expandPath("")).toBe("");
   });
 
-  it("throws a clear error when os.homedir returns falsy", () => {
+  it("returns undefined/null unchanged (sentinel passthrough)", () => {
+    // Some call sites guard before invoking; these passthroughs exist
+    // so a sentinel value reaches the next layer rather than crashing
+    // inside expandPath itself.
+    expect(expandPath(undefined as unknown as string)).toBe(undefined);
+    expect(expandPath(null as unknown as string)).toBe(null);
+  });
+
+  it("throws a clear error when os.homedir returns falsy (~/foo form)", () => {
     const spy = vi.spyOn(os, "homedir").mockReturnValue("");
     try {
       expect(() => expandPath("~/foo")).toThrow(/HOME/i);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("throws the same error for `~` alone when homedir is missing", () => {
+    // Guards against a regression where someone reorders the function
+    // and the `if (p === "~") return home;` branch runs before the
+    // empty-home check — in which case `expandPath("~")` would
+    // silently return `""` instead of throwing.
+    const spy = vi.spyOn(os, "homedir").mockReturnValue("");
+    try {
+      expect(() => expandPath("~")).toThrow(/HOME/i);
     } finally {
       spy.mockRestore();
     }

--- a/packages/agency-lang/lib/stdlib/expandPath.ts
+++ b/packages/agency-lang/lib/stdlib/expandPath.ts
@@ -18,6 +18,15 @@ import path from "node:path";
  * `resolveDir`, which call this helper first — never re-implement
  * the policy locally.
  *
+ * Layering: `expandPath` is intentionally a **pure string transform**
+ * with no async, no ALS access, and no base-directory awareness. The
+ * "resolve relative paths against the right base (moduleDir vs cwd)
+ * and assert containment" policy lives one layer up in `resolveDir`
+ * (and `resolvePath` for the dir+filename case). Keeping the layers
+ * split means `expandPath` is trivially testable in isolation, and
+ * each caller picks the base it wants without this helper having to
+ * fan out into runtime context.
+ *
  * Does NOT resolve to an absolute path — callers still pass the
  * result through `path.resolve` / `resolvePath` / `resolveDir`.
  *

--- a/packages/agency-lang/lib/stdlib/expandPath.ts
+++ b/packages/agency-lang/lib/stdlib/expandPath.ts
@@ -1,0 +1,53 @@
+import os from "node:os";
+import path from "node:path";
+
+/**
+ * Expand user-shorthand prefixes in a path string. Currently:
+ *
+ * - `~` alone → `$HOME`
+ * - `~/foo` (or `~\foo` on Windows) → `$HOME/foo`
+ * - `~user/...` throws (POSIX-only; the platform complexity isn't
+ *   worth the small payoff — also lets people write a literal
+ *   `~user-typed-name` dir at the project root by quoting `./~user...`).
+ * - everything else returns unchanged.
+ *
+ * This is the single owner of path-shorthand policy for the stdlib.
+ * Future rules (env-var expansion, NFC normalization, etc.) land
+ * here, not at call sites. Anything in `lib/stdlib/` that resolves
+ * a user-typed path string MUST route through `resolvePath` /
+ * `resolveDir`, which call this helper first — never re-implement
+ * the policy locally.
+ *
+ * Does NOT resolve to an absolute path — callers still pass the
+ * result through `path.resolve` / `resolvePath` / `resolveDir`.
+ *
+ * `expandPath("")` returns `""` unchanged so empty-string sentinels
+ * pass through (callers that disallow empty dir handle that
+ * themselves with a clearer error).
+ */
+export function expandPath(p: string): string {
+  if (p === "" || p === undefined || p === null) return p;
+  if (!p.startsWith("~")) return p;
+
+  // `~user/...` is unsupported — reject it explicitly. The condition
+  // "starts with `~` and the next char is a non-separator other char"
+  // catches both `~root` and `~root/foo`.
+  if (p.length > 1 && p[1] !== "/" && p[1] !== path.sep && p[1] !== "\\") {
+    throw new Error(
+      `expandPath: \`~user/...\` (per-user home) is not supported; got "${p}". Use $HOME or an absolute path instead.`,
+    );
+  }
+
+  const home = os.homedir();
+  if (!home) {
+    throw new Error(
+      "expandPath: cannot expand `~` because os.homedir() returned no value (no HOME env var on POSIX, no USERPROFILE on Windows).",
+    );
+  }
+
+  // p is now either `~` exactly, or `~` + separator + tail.
+  if (p === "~") return home;
+  // Strip the leading `~` plus the separator character (length 2).
+  const tail = p.slice(2);
+  return path.join(home, tail);
+}

--- a/packages/agency-lang/lib/stdlib/fs.ts
+++ b/packages/agency-lang/lib/stdlib/fs.ts
@@ -4,7 +4,9 @@ import path from "path";
 import process from "process";
 import diff_match_patch from "diff-match-patch";
 import { resolvePath } from "./resolvePath.js";
+import { resolveDir } from "./resolveDir.js";
 import { assertContained } from "./assertContained.js";
+import { expandPath } from "./expandPath.js";
 import { formatDiff } from "../utils/diff.js";
 
 export { resolvePath } from "./resolvePath.js";
@@ -100,10 +102,10 @@ export async function _applyPatch(
   const touched: string[] = [];
 
   for (const f of files) {
-    const full = path.resolve(process.cwd(), f.path);
-    // Every file the diff touches is gated by `allowedPaths`. No-op
-    // when the caller passes nothing (status quo).
-    await assertContained(full, allowedPaths ?? []);
+    // Resolve via `resolveDir` (cwd-anchored — fs ops are
+    // process-cwd-relative, not module-dir-relative). This expands
+    // `~` and runs the allow-list check in one place.
+    const full = await resolveDir(f.path, allowedPaths ?? [], "cwd");
     let original = "";
     if (f.isNew) {
       original = "";
@@ -225,8 +227,7 @@ export async function _mkdir(
   dir: string,
   allowedPaths?: string[],
 ): Promise<void> {
-  const full = path.resolve(process.cwd(), dir);
-  await assertContained(full, allowedPaths ?? []);
+  const full = await resolveDir(dir, allowedPaths ?? [], "cwd");
   await fs.mkdir(full, { recursive: true });
 }
 
@@ -235,10 +236,8 @@ export async function _copy(
   dest: string,
   allowedPaths?: string[],
 ): Promise<void> {
-  const srcFull = path.resolve(process.cwd(), src);
-  const destFull = path.resolve(process.cwd(), dest);
-  await assertContained(srcFull, allowedPaths ?? []);
-  await assertContained(destFull, allowedPaths ?? []);
+  const srcFull = await resolveDir(src, allowedPaths ?? [], "cwd");
+  const destFull = await resolveDir(dest, allowedPaths ?? [], "cwd");
   await fs.cp(srcFull, destFull, { recursive: true });
 }
 
@@ -247,10 +246,8 @@ export async function _move(
   dest: string,
   allowedPaths?: string[],
 ): Promise<void> {
-  const srcFull = path.resolve(process.cwd(), src);
-  const destFull = path.resolve(process.cwd(), dest);
-  await assertContained(srcFull, allowedPaths ?? []);
-  await assertContained(destFull, allowedPaths ?? []);
+  const srcFull = await resolveDir(src, allowedPaths ?? [], "cwd");
+  const destFull = await resolveDir(dest, allowedPaths ?? [], "cwd");
   await rejectDangerousPath(src, "move", "source");
   try {
     await fs.rename(srcFull, destFull);
@@ -268,8 +265,7 @@ export async function _remove(
   target: string,
   allowedPaths?: string[],
 ): Promise<void> {
-  const full = path.resolve(process.cwd(), target);
-  await assertContained(full, allowedPaths ?? []);
+  const full = await resolveDir(target, allowedPaths ?? [], "cwd");
   await rejectDangerousPath(target, "remove", "target");
   await fs.rm(full, { recursive: true, force: true });
 }
@@ -283,7 +279,9 @@ export async function rejectDangerousPath(
   if (trimmed === "") {
     throw new Error(`${op}: ${role} must not be empty`);
   }
-  const lexical = path.resolve(process.cwd(), trimmed);
+  // Expand `~` first so the home / top-level checks below are
+  // performed against the actual target, not the literal `~/foo`.
+  const lexical = path.resolve(process.cwd(), expandPath(trimmed));
   const [real, homeReal, cwdReal] = await Promise.all([
     realpathOrResolve(lexical),
     realpathOrResolve(os.homedir()),

--- a/packages/agency-lang/lib/stdlib/fs.ts
+++ b/packages/agency-lang/lib/stdlib/fs.ts
@@ -5,7 +5,6 @@ import process from "process";
 import diff_match_patch from "diff-match-patch";
 import { resolvePath } from "./resolvePath.js";
 import { resolveDir } from "./resolveDir.js";
-import { assertContained } from "./assertContained.js";
 import { expandPath } from "./expandPath.js";
 import { formatDiff } from "../utils/diff.js";
 

--- a/packages/agency-lang/lib/stdlib/policy.ts
+++ b/packages/agency-lang/lib/stdlib/policy.ts
@@ -1,8 +1,6 @@
 import { validatePolicy } from "@/runtime/policy.js";
 import { writeFileSync } from "fs";
-import path from "path";
-import process from "process";
-import { assertContained } from "./assertContained.js";
+import { resolveDir } from "./resolveDir.js";
 export { checkPolicy as _checkPolicy, validatePolicy as _validatePolicy } from "@/runtime/policy.js";
 import type { Policy } from "@/runtime/policy.js";
 
@@ -13,7 +11,8 @@ export async function _writePolicyFile(
 ) {
   const result = validatePolicy(policy);
   if (!result.success) throw new Error(`Invalid policy: ${result.error}`);
-  const full = path.resolve(process.cwd(), filePath);
-  await assertContained(full, allowedPaths ?? []);
+  // `resolveDir` (cwd-anchored) handles `~` expansion + allow-list
+  // enforcement uniformly with the fs.ts / system.ts / speech.ts call sites.
+  const full = await resolveDir(filePath, allowedPaths ?? [], "cwd");
   writeFileSync(full, JSON.stringify(policy, null, 2) + "\n", { mode: 0o600 });
 }

--- a/packages/agency-lang/lib/stdlib/resolveDir.test.ts
+++ b/packages/agency-lang/lib/stdlib/resolveDir.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { resolveDir } from "./resolveDir.js";
+import { agencyStore } from "../runtime/asyncContext.js";
 
 describe("resolveDir", () => {
   let tmpRoot: string;
@@ -62,5 +63,30 @@ describe("resolveDir", () => {
     await expect(
       resolveDir(path.join(tmpRoot, "outside"), [allowed]),
     ).rejects.toThrow(/not under/);
+  });
+
+  it("anchors relative paths to moduleDir from an active ALS frame", async () => {
+    // The default base ("moduleDir") branch is normally exercised via
+    // the ALS-seeded moduleDir, not the process.cwd() fallback. This
+    // test installs an explicit ALS frame to prove `resolveDir` reads
+    // from there.
+    const fakeModuleDir = fs.realpathSync(tmpRoot);
+    const result = await agencyStore.run(
+      {
+        ctx: {} as any,
+        stack: {} as any,
+        threads: {} as any,
+        moduleDir: fakeModuleDir,
+      },
+      () => resolveDir("./prompts"),
+    );
+    expect(result).toBe(path.join(fakeModuleDir, "prompts"));
+  });
+
+  it("validates tilde-in-target against a tilde-in-allowlist (cross product)", async () => {
+    // Exercises that expansion is applied symmetrically: both target
+    // and allowlist entries reach `assertContained` already expanded.
+    const result = await resolveDir("~/sandbox/work", ["~/sandbox"]);
+    expect(result).toBe(path.join(os.homedir(), "sandbox", "work"));
   });
 });

--- a/packages/agency-lang/lib/stdlib/resolveDir.test.ts
+++ b/packages/agency-lang/lib/stdlib/resolveDir.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { resolveDir } from "./resolveDir.js";
+
+describe("resolveDir", () => {
+  let tmpRoot: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "resolvedir-"));
+    process.chdir(tmpRoot);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("expands ~ to the home directory", async () => {
+    // Use the inside-home/no-op-allowedPaths case so the test doesn't
+    // depend on any path inside $HOME existing.
+    const result = await resolveDir("~");
+    expect(result).toBe(os.homedir());
+  });
+
+  it("expands ~/sub to homedir/sub without requiring it to exist", async () => {
+    const result = await resolveDir("~/some-nonexistent-subdir-xyz");
+    expect(result).toBe(path.join(os.homedir(), "some-nonexistent-subdir-xyz"));
+  });
+
+  it("resolves a relative non-tilde path against the module dir (default)", async () => {
+    // Outside an Agency frame, getModuleDir() falls back to process.cwd();
+    // tmpRoot IS the cwd because of beforeEach. Confirm relative paths
+    // anchor there (NOT $HOME). `resolveDir` does NOT pre-create the
+    // dir (unlike normalizeMemoryFrame); callers that need it created
+    // do that themselves. So we compare lexically against realpath of
+    // the existing tmpRoot.
+    const result = await resolveDir("./sub");
+    expect(result).toBe(path.join(fs.realpathSync(tmpRoot), "sub"));
+    expect(result).not.toContain(os.homedir());
+  });
+
+  it("resolves against cwd explicitly when base=\"cwd\"", async () => {
+    const result = await resolveDir("./cwd-anchored", [], "cwd");
+    expect(result).toBe(path.join(fs.realpathSync(tmpRoot), "cwd-anchored"));
+  });
+
+  it("accepts an allow-list and validates containment", async () => {
+    const allowed = path.join(tmpRoot, "allowed-root");
+    fs.mkdirSync(allowed, { recursive: true });
+    const target = path.join("allowed-root", "inside");
+    const result = await resolveDir(target, [allowed]);
+    expect(result.startsWith(fs.realpathSync(allowed))).toBe(true);
+  });
+
+  it("throws when the resolved path is outside the allow-list", async () => {
+    const allowed = path.join(tmpRoot, "allowed-root");
+    fs.mkdirSync(allowed, { recursive: true });
+    await expect(
+      resolveDir(path.join(tmpRoot, "outside"), [allowed]),
+    ).rejects.toThrow(/not under/);
+  });
+});

--- a/packages/agency-lang/lib/stdlib/resolveDir.ts
+++ b/packages/agency-lang/lib/stdlib/resolveDir.ts
@@ -1,0 +1,40 @@
+import path from "node:path";
+import process from "node:process";
+import { getModuleDir } from "../runtime/asyncContext.js";
+import { assertContained } from "./assertContained.js";
+import { expandPath } from "./expandPath.js";
+
+/**
+ * Resolve a directory argument the way every path-taking stdlib
+ * function should:
+ *
+ *  1. Expand user shorthands (currently `~`, eventually env vars and
+ *     normalization) via `expandPath`.
+ *  2. Resolve against `base` (default: module dir) so a relative
+ *     entry sits next to the Agency module that owns it. Shell-like
+ *     callers (`_exec`/`_bash`) and fs-like callers (`_mkdir`/`_copy`/
+ *     `_move`/`_remove`) pass `process.cwd()` because their relative
+ *     paths should mean "the user's working directory" rather than
+ *     "the module dir."
+ *  3. Assert containment against `allowedPaths` so a policy can
+ *     reject paths outside the allow-list.
+ *
+ * Returns the absolute, validated directory.
+ *
+ * Mirrors what `resolvePath(dir, filename)` does at the `dir` level.
+ * If you're writing a new stdlib function that takes a `dir`-like
+ * arg, USE THIS — don't re-implement the policy. Doing so encodes
+ * the policy at one site, so future rules added to `expandPath` /
+ * `resolveDir` propagate everywhere automatically.
+ */
+export async function resolveDir(
+  dir: string,
+  allowedPaths: string[] = [],
+  base?: "moduleDir" | "cwd",
+): Promise<string> {
+  const expanded = expandPath(dir);
+  const baseDir = base === "cwd" ? process.cwd() : getModuleDir();
+  const root = path.resolve(baseDir, expanded);
+  await assertContained(root, allowedPaths, baseDir);
+  return root;
+}

--- a/packages/agency-lang/lib/stdlib/resolvePath.test.ts
+++ b/packages/agency-lang/lib/stdlib/resolvePath.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { resolvePath } from "./resolvePath.js";
 import { agencyStore } from "../runtime/asyncContext.js";
 import path from "path";
+import os from "node:os";
 
 describe("resolvePath", () => {
   it("rejects empty dir", async () => {
@@ -73,5 +74,35 @@ describe("resolvePath with ALS moduleDir", () => {
       () => resolvePath("/tmp", "foo.txt"),
     );
     expect(result).toBe(path.resolve("/tmp", "foo.txt"));
+  });
+});
+
+describe("resolvePath ~ expansion", () => {
+  it("expands ~ in dir", async () => {
+    const result = await resolvePath("~", "x.md");
+    expect(result).toBe(path.join(os.homedir(), "x.md"));
+  });
+
+  it("expands ~/foo in dir", async () => {
+    const result = await resolvePath("~/notes", "x.md");
+    expect(result).toBe(path.join(os.homedir(), "notes", "x.md"));
+  });
+
+  it("still rejects absolute filename when dir starts with ~", async () => {
+    await expect(resolvePath("~/notes", "/etc/passwd")).rejects.toThrow(
+      "must not be absolute",
+    );
+  });
+
+  it("rejects ~-prefixed filename", async () => {
+    await expect(resolvePath(".", "~/foo")).rejects.toThrow(
+      "must not be absolute",
+    );
+  });
+
+  it("rejects .. traversal under ~/...", async () => {
+    await expect(resolvePath("~/notes", "../escape")).rejects.toThrow(
+      "escapes directory",
+    );
   });
 });

--- a/packages/agency-lang/lib/stdlib/resolvePath.ts
+++ b/packages/agency-lang/lib/stdlib/resolvePath.ts
@@ -1,7 +1,6 @@
 import fs from "fs/promises";
 import path from "path";
 import { resolveDir } from "./resolveDir.js";
-import { expandPath } from "./expandPath.js";
 
 /**
  * Resolve a filename relative to a directory with security checks.
@@ -27,7 +26,7 @@ export async function resolvePath(dir: string, filename: string): Promise<string
     throw new Error(`dir must not be empty. Use "." for the current directory.`);
   }
   if (path.isAbsolute(filename) || filename.startsWith("~")) {
-    throw new Error(`Filename must not be absolute when dir is specified (got "${filename}").`);
+    throw new Error(`Filename must not be absolute or start with "~" when dir is specified (got "${filename}").`);
   }
   // Delegate the dir step to the shared `resolveDir` so `~` expansion
   // and any future path-policy rules apply uniformly. We pass `[]` for

--- a/packages/agency-lang/lib/stdlib/resolvePath.ts
+++ b/packages/agency-lang/lib/stdlib/resolvePath.ts
@@ -1,6 +1,7 @@
 import fs from "fs/promises";
 import path from "path";
-import { getModuleDir } from "../runtime/asyncContext.js";
+import { resolveDir } from "./resolveDir.js";
+import { expandPath } from "./expandPath.js";
 
 /**
  * Resolve a filename relative to a directory with security checks.
@@ -11,9 +12,13 @@ import { getModuleDir } from "../runtime/asyncContext.js";
  * this run), not `process.cwd()`. This matches what users want when
  * they ship a co-located resource bundle (`prompts/`, `fixtures/`, etc.)
  * next to their `.agency` file. Absolute `dir` arguments are unaffected
- * because `path.resolve` returns them unchanged.
+ * because `path.resolve` returns them unchanged. `~` and other
+ * shorthand prefixes are expanded at the dir level via `resolveDir`
+ * (which itself delegates to `expandPath`) — the `filename` argument
+ * is NOT expanded because absolute / `~`-prefixed filenames are
+ * rejected anyway.
  *
- * Outside an Agency execution frame, `getModuleDir()` falls back to
+ * Outside an Agency execution frame, `resolveDir` falls back to
  * `process.cwd()`, preserving the previous behaviour for standalone
  * test invocations.
  */
@@ -21,10 +26,15 @@ export async function resolvePath(dir: string, filename: string): Promise<string
   if (!dir) {
     throw new Error(`dir must not be empty. Use "." for the current directory.`);
   }
-  if (path.isAbsolute(filename)) {
+  if (path.isAbsolute(filename) || filename.startsWith("~")) {
     throw new Error(`Filename must not be absolute when dir is specified (got "${filename}").`);
   }
-  const baseDir = path.resolve(getModuleDir(), dir);
+  // Delegate the dir step to the shared `resolveDir` so `~` expansion
+  // and any future path-policy rules apply uniformly. We pass `[]` for
+  // `allowedPaths` here because `resolvePath` is the lower-level
+  // helper — callers that need allow-list enforcement layer it on
+  // separately (see e.g. the `_ls`/`_grep`/`_glob` call sites).
+  const baseDir = await resolveDir(dir);
   const full = path.resolve(baseDir, filename);
 
   // Lexical check against the unresolved baseDir (catches .. early)

--- a/packages/agency-lang/lib/stdlib/shell.test.ts
+++ b/packages/agency-lang/lib/stdlib/shell.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { __internal_exec, __internal_bash } from "./shell.js";
+import { RuntimeContext } from "../runtime/state/context.js";
+import { StateStack } from "../runtime/state/stateStack.js";
+import { ThreadStore } from "../runtime/state/threadStore.js";
+
+/**
+ * Focused tests for the `~`-expansion + allow-list behavior on the
+ * `cwd` argument of `_exec`/`_bash`. Uses the ctx-injected
+ * `__internal_*` wrappers (same pattern as
+ * lib/stdlib/abortable.test.ts) so the tests run without needing an
+ * ALS frame installed.
+ *
+ * Regression target: before PR #222 the `cwd` was passed through to
+ * `spawn()` literally — `cwd: "~/proj"` would fail with ENOENT.
+ * After, `execImpl`/`bashImpl` route the cwd through
+ * `resolveDir(cwd, allowed, "cwd")` which expands and
+ * allow-list-checks before spawn.
+ */
+
+function makeMockCtx(): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: {},
+    dirname: "/tmp",
+  });
+}
+
+describe("_exec / _bash cwd ~ expansion", () => {
+  let fakeHome: string;
+  let homedirSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "shell-home-"));
+    homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
+  });
+
+  afterEach(() => {
+    homedirSpy.mockRestore();
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it("_exec spawns inside the expanded ~ cwd", async () => {
+    // `pwd` prints the cwd the child was launched in. If `~` wasn't
+    // expanded, spawn() would throw ENOENT before pwd ever ran.
+    const ctx = makeMockCtx();
+    const result = await __internal_exec(
+      ctx,
+      new StateStack(),
+      new ThreadStore(),
+      "pwd",
+      [],
+      "~",
+      0,
+      "",
+    );
+    expect(result.exitCode).toBe(0);
+    // realpath because /var/folders → /private/var/folders on macOS,
+    // and the child's pwd reflects the realpath.
+    expect(result.stdout.trim()).toBe(fs.realpathSync(fakeHome));
+  });
+
+  it("_bash spawns inside the expanded ~ cwd", async () => {
+    const ctx = makeMockCtx();
+    const result = await __internal_bash(
+      ctx,
+      new StateStack(),
+      new ThreadStore(),
+      "pwd",
+      "~",
+      0,
+      "",
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe(fs.realpathSync(fakeHome));
+  });
+
+  it("_exec passes allow-list check when cwd is ~ and allowlist allows ~", async () => {
+    // Cross product: tilde in cwd AND tilde in allowlist. `resolveDir`
+    // expands both and `assertContained` should accept.
+    const ctx = makeMockCtx();
+    const result = await __internal_exec(
+      ctx,
+      new StateStack(),
+      new ThreadStore(),
+      "pwd",
+      [],
+      "~",
+      0,
+      "",
+      { allowedPaths: ["~"] },
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("_exec rejects ~ cwd when allowlist excludes home", async () => {
+    // Sanity: the allow-list still enforces correctly under expansion.
+    const ctx = makeMockCtx();
+    await expect(
+      __internal_exec(
+        ctx,
+        new StateStack(),
+        new ThreadStore(),
+        "pwd",
+        [],
+        "~",
+        0,
+        "",
+        { allowedPaths: ["/tmp/agency-disallowed-root-xyz"] },
+      ),
+    ).rejects.toThrow(/not under/);
+  });
+
+  it("_exec with empty cwd inherits the parent process cwd (no migration regression)", async () => {
+    // Before the migration, empty `cwd` meant "use spawn's default
+    // (inherit parent cwd)". The migration introduced a `cwd ? ... : ""`
+    // ternary; this test pins that empty-string sentinel still works.
+    const ctx = makeMockCtx();
+    const result = await __internal_exec(
+      ctx,
+      new StateStack(),
+      new ThreadStore(),
+      "pwd",
+      [],
+      "",
+      0,
+      "",
+    );
+    expect(result.exitCode).toBe(0);
+    // Reflects process.cwd(), not fakeHome.
+    expect(result.stdout.trim()).not.toBe(fs.realpathSync(fakeHome));
+  });
+});

--- a/packages/agency-lang/lib/stdlib/shell.ts
+++ b/packages/agency-lang/lib/stdlib/shell.ts
@@ -26,6 +26,8 @@ import {
 } from "./abortable.js";
 import { checkAllowBlockList } from "./allowBlockList.js";
 import { assertContained } from "./assertContained.js";
+import { expandPath } from "./expandPath.js";
+import { resolveDir } from "./resolveDir.js";
 import { resolvePath } from "./resolvePath.js";
 
 function buildSpawnOptions(
@@ -84,11 +86,17 @@ async function execImpl(
     options?.blockedCommands ?? [],
   );
   if (cmdError) throw new Error(cmdError);
-  if (cwd && options?.allowedPaths && options.allowedPaths.length > 0) {
-    await assertContained(cwd, options.allowedPaths);
+  // Expand `~` in the user-supplied cwd before either containment-check
+  // or spawn, so `exec(..., cwd: "~/proj")` works as expected. We
+  // intentionally DO NOT route this through `resolveDir` because that
+  // would change a relative `cwd: "./sub"` from "subdir of process.cwd()
+  // (which is the existing default)" to "subdir of moduleDir."
+  const cwdExpanded = expandPath(cwd);
+  if (cwdExpanded && options?.allowedPaths && options.allowedPaths.length > 0) {
+    await assertContained(cwdExpanded, options.allowedPaths);
   }
   const signal = ctx.getAbortSignal(stack);
-  return abortableSpawn(command, args, buildSpawnOptions(cwd, timeout, stdin, signal));
+  return abortableSpawn(command, args, buildSpawnOptions(cwdExpanded, timeout, stdin, signal));
 }
 
 /** Deprecated context-injected wrapper kept during the ALS migration;
@@ -157,11 +165,13 @@ async function bashImpl(
       }
     }
   }
-  if (cwd && options?.allowedPaths && options.allowedPaths.length > 0) {
-    await assertContained(cwd, options.allowedPaths);
+  // See `execImpl` for why we expandPath but don't resolveDir.
+  const cwdExpanded = expandPath(cwd);
+  if (cwdExpanded && options?.allowedPaths && options.allowedPaths.length > 0) {
+    await assertContained(cwdExpanded, options.allowedPaths);
   }
   const signal = ctx.getAbortSignal(stack);
-  return abortableSpawn("sh", ["-c", command], buildSpawnOptions(cwd, timeout, stdin, signal));
+  return abortableSpawn("sh", ["-c", command], buildSpawnOptions(cwdExpanded, timeout, stdin, signal));
 }
 
 /** Deprecated context-injected wrapper kept during the ALS migration;
@@ -206,11 +216,11 @@ export async function _ls(
   // Resolve relative `dir` against the calling module's directory (same
   // policy as `read`/`write`), so co-located resource folders work no
   // matter where the process was launched from. Absolute paths pass
-  // through unchanged. `allowedPaths` is resolved against the same
-  // base — relative roots like `"."` mean "the same dir as `dir`".
-  const moduleDir = getModuleDir();
-  const root = path.resolve(moduleDir, dir);
-  await assertContained(root, allowedPaths ?? [], moduleDir);
+  // through unchanged. `~` is expanded; `allowedPaths` is resolved
+  // against the same base — relative roots like `"."` mean "the same
+  // dir as `dir`". All policy lives in `resolveDir` so future rules
+  // (env vars, normalization, etc.) propagate automatically.
+  const root = await resolveDir(dir, allowedPaths ?? []);
   const out: LsEntry[] = [];
 
   async function walk(current: string): Promise<void> {
@@ -301,9 +311,7 @@ export async function _grep(
   // See `_ls` for the resolution policy. `dir` is module-relative;
   // returned `file` paths are relative to `dir` so callers can hand
   // them to `read(file, dir)` directly.
-  const moduleDir = getModuleDir();
-  const root = path.resolve(moduleDir, dir);
-  await assertContained(root, allowedPaths ?? [], moduleDir);
+  const root = await resolveDir(dir, allowedPaths ?? []);
   const re = new RegExp(pattern, flags || undefined);
   const results: GrepMatch[] = [];
 
@@ -342,9 +350,7 @@ export async function _glob(
   // See `_ls` for the resolution policy. `dir` is module-relative;
   // returned paths are relative to `dir` so callers can hand them to
   // `read(path, dir)` directly without `basename(...)` gymnastics.
-  const moduleDir = getModuleDir();
-  const root = path.resolve(moduleDir, dir);
-  await assertContained(root, allowedPaths ?? [], moduleDir);
+  const root = await resolveDir(dir, allowedPaths ?? []);
   const re = globToRegExp(pattern);
   const results: string[] = [];
 
@@ -443,7 +449,10 @@ export type StatInfo = {
  */
 async function resolveProbePath(dir: string, filename: string): Promise<string> {
   if (dir === "") {
-    return path.resolve(process.cwd(), filename);
+    // No dir provided — treat `filename` as a probe path that may
+    // include `~` shorthand. Expand first so `_stat("~", "")` /
+    // `_exists("~/foo", "")` work as users expect.
+    return path.resolve(process.cwd(), expandPath(filename));
   }
   return resolvePath(dir, filename);
 }

--- a/packages/agency-lang/lib/stdlib/shell.ts
+++ b/packages/agency-lang/lib/stdlib/shell.ts
@@ -26,7 +26,6 @@ import {
 } from "./abortable.js";
 import { checkAllowBlockList } from "./allowBlockList.js";
 import { assertContained } from "./assertContained.js";
-import { expandPath } from "./expandPath.js";
 import { resolveDir } from "./resolveDir.js";
 import { resolvePath } from "./resolvePath.js";
 
@@ -86,17 +85,17 @@ async function execImpl(
     options?.blockedCommands ?? [],
   );
   if (cmdError) throw new Error(cmdError);
-  // Expand `~` in the user-supplied cwd before either containment-check
-  // or spawn, so `exec(..., cwd: "~/proj")` works as expected. We
-  // intentionally DO NOT route this through `resolveDir` because that
-  // would change a relative `cwd: "./sub"` from "subdir of process.cwd()
-  // (which is the existing default)" to "subdir of moduleDir."
-  const cwdExpanded = expandPath(cwd);
-  if (cwdExpanded && options?.allowedPaths && options.allowedPaths.length > 0) {
-    await assertContained(cwdExpanded, options.allowedPaths);
-  }
+  // Route through `resolveDir` (cwd-anchored) so `~` expansion +
+  // allow-list enforcement land in one place. Relative `cwd: "./sub"`
+  // stays anchored to `process.cwd()` (the existing semantics) because
+  // we pass `base: "cwd"`. Empty `cwd` is the "no override" sentinel —
+  // pass undefined to the spawn options so the child inherits the
+  // parent's cwd, matching the pre-migration behavior.
+  const cwdResolved = cwd
+    ? await resolveDir(cwd, options?.allowedPaths ?? [], "cwd")
+    : "";
   const signal = ctx.getAbortSignal(stack);
-  return abortableSpawn(command, args, buildSpawnOptions(cwdExpanded, timeout, stdin, signal));
+  return abortableSpawn(command, args, buildSpawnOptions(cwdResolved, timeout, stdin, signal));
 }
 
 /** Deprecated context-injected wrapper kept during the ALS migration;
@@ -165,13 +164,12 @@ async function bashImpl(
       }
     }
   }
-  // See `execImpl` for why we expandPath but don't resolveDir.
-  const cwdExpanded = expandPath(cwd);
-  if (cwdExpanded && options?.allowedPaths && options.allowedPaths.length > 0) {
-    await assertContained(cwdExpanded, options.allowedPaths);
-  }
+  // See `execImpl` for the cwd-resolution rationale.
+  const cwdResolved = cwd
+    ? await resolveDir(cwd, options?.allowedPaths ?? [], "cwd")
+    : "";
   const signal = ctx.getAbortSignal(stack);
-  return abortableSpawn("sh", ["-c", command], buildSpawnOptions(cwdExpanded, timeout, stdin, signal));
+  return abortableSpawn("sh", ["-c", command], buildSpawnOptions(cwdResolved, timeout, stdin, signal));
 }
 
 /** Deprecated context-injected wrapper kept during the ALS migration;
@@ -437,24 +435,35 @@ export type StatInfo = {
 };
 
 /**
- * Resolve `filename` for stat/exists.
+ * Resolve a probe path for `stat`/`exists`, applying the same path
+ * policy (shorthand expansion + allow-list containment) every other
+ * stdlib path-taking entry point uses.
  *
- * - If `dir` is the empty string (the legacy / unset sentinel), fall
- *   back to the original `process.cwd()`-anchored behavior. Absolute
- *   filenames are passed through unchanged.
- * - Otherwise resolve via `resolvePath(dir, filename)` so the call
- *   shares the same sandbox semantics as `read`/`write`/`edit`:
- *   filename must be relative, must not escape `dir`, and `dir` itself
- *   is resolved against the calling module's directory.
+ * - If `dir` is the empty string (the legacy / unset sentinel),
+ *   `filename` is treated as a stand-alone probe path anchored to
+ *   `process.cwd()`. Routed through `resolveDir` so `_stat("~", "")`
+ *   and `_exists("~/foo", "")` expand the shorthand.
+ * - Otherwise resolve via `resolvePath(dir, filename)` (which delegates
+ *   dir-expansion + module-dir anchoring to `resolveDir` and runs the
+ *   traversal / symlink-escape checks), then layer the allow-list
+ *   check on top — `resolvePath` doesn't take `allowedPaths` because
+ *   it's the lower-level helper.
+ *
+ * Probing for a path outside the allow-list is itself a containment
+ * violation — both `_stat` and `_exists` throw rather than silently
+ * report missing.
  */
-async function resolveProbePath(dir: string, filename: string): Promise<string> {
+async function resolveProbePath(
+  dir: string,
+  filename: string,
+  allowedPaths: string[],
+): Promise<string> {
   if (dir === "") {
-    // No dir provided — treat `filename` as a probe path that may
-    // include `~` shorthand. Expand first so `_stat("~", "")` /
-    // `_exists("~/foo", "")` work as users expect.
-    return path.resolve(process.cwd(), expandPath(filename));
+    return resolveDir(filename, allowedPaths, "cwd");
   }
-  return resolvePath(dir, filename);
+  const full = await resolvePath(dir, filename);
+  await assertContained(full, allowedPaths, getModuleDir());
+  return full;
 }
 
 export async function _stat(
@@ -462,9 +471,7 @@ export async function _stat(
   dir: string = "",
   allowedPaths?: string[],
 ): Promise<StatInfo> {
-  const full = await resolveProbePath(dir, filename);
-  const baseDir = dir === "" ? process.cwd() : getModuleDir();
-  await assertContained(full, allowedPaths ?? [], baseDir);
+  const full = await resolveProbePath(dir, filename, allowedPaths ?? []);
   try {
     const st = await fs.lstat(full);
     let type: StatInfo["type"] = "other";
@@ -487,11 +494,7 @@ export async function _exists(
   dir: string = "",
   allowedPaths?: string[],
 ): Promise<boolean> {
-  const full = await resolveProbePath(dir, filename);
-  // Probing for a path outside the allow-list is itself a containment
-  // violation — throw rather than silently return false.
-  const baseDir = dir === "" ? process.cwd() : getModuleDir();
-  await assertContained(full, allowedPaths ?? [], baseDir);
+  const full = await resolveProbePath(dir, filename, allowedPaths ?? []);
   try {
     await fs.access(full);
     return true;

--- a/packages/agency-lang/lib/stdlib/skills.test.ts
+++ b/packages/agency-lang/lib/stdlib/skills.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { _readSkill } from "./skills.js";
+
+describe("_readSkill", () => {
+  let fakeHome: string;
+  let homedirSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "skill-home-"));
+    homedirSpy = vi.spyOn(os, "homedir").mockReturnValue(fakeHome);
+  });
+
+  afterEach(() => {
+    homedirSpy.mockRestore();
+    fs.rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it("reads a skill at a ~/-prefixed path", () => {
+    // The bug this guards against: pre-fix, `_readSkill("~/foo.md")`
+    // resolved `~` as a literal directory name under the module dir,
+    // producing `<moduleDir>/~/foo.md` and throwing ENOENT instead of
+    // reading from the user's home.
+    const skillDir = path.join(fakeHome, ".agency", "skills");
+    fs.mkdirSync(skillDir, { recursive: true });
+    const skillPath = path.join(skillDir, "test-skill.md");
+    fs.writeFileSync(skillPath, "skill body");
+
+    expect(_readSkill("~/.agency/skills/test-skill.md")).toBe("skill body");
+  });
+
+  it("reads a skill at `~` alone (file directly under home)", () => {
+    const skillPath = path.join(fakeHome, "bare.md");
+    fs.writeFileSync(skillPath, "bare body");
+
+    // `_readSkill("~")` would refer to home directly — not a file. The
+    // meaningful case is `~/<filename>` since skills are files. This
+    // test covers the simplest valid tilde form.
+    expect(_readSkill("~/bare.md")).toBe("bare body");
+  });
+
+  it("still resolves a relative path against the module dir (no regression)", () => {
+    // Confirms the `expandPath` wrapper is a no-op on non-tilde paths.
+    // Outside an Agency frame, getModuleDir() falls back to process.cwd().
+    const cwd = process.cwd();
+    const targetPath = path.join(cwd, "relative-skill.md");
+    fs.writeFileSync(targetPath, "relative body");
+    try {
+      expect(_readSkill("relative-skill.md")).toBe("relative body");
+    } finally {
+      fs.rmSync(targetPath, { force: true });
+    }
+  });
+});

--- a/packages/agency-lang/lib/stdlib/skills.ts
+++ b/packages/agency-lang/lib/stdlib/skills.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import path from "path";
 import { getModuleDir } from "../runtime/asyncContext.js";
+import { expandPath } from "./expandPath.js";
 
 /**
  * Read a skill file colocated with the calling Agency module. The
@@ -9,9 +10,18 @@ import { getModuleDir } from "../runtime/asyncContext.js";
  * source `.agency` file) via the ALS frame seeded by `runNode` /
  * `runInBootstrapFrame`. Falls back to `process.cwd()` when called
  * outside any Agency execution frame (e.g. from non-Agency host code).
+ *
+ * `filepath` is passed through `expandPath` first so a user-typed
+ * `~/.agency/skills/foo.md` resolves to `$HOME/.agency/skills/foo.md`
+ * — same shorthand policy every other stdlib path-taking entry point
+ * follows (see docs/dev/coding-standards.md). We don't go through
+ * `resolvePath`/`resolveDir` because (a) the function is sync by
+ * design and `resolveDir` is async, and (b) skills are trusted
+ * colocated resources, so the allow-list / symlink-escape checks
+ * those helpers run aren't applicable here.
  */
 export function _readSkill(filepath: string): string {
   const dirname = getModuleDir();
-  const fullPath = path.resolve(dirname, filepath);
+  const fullPath = path.resolve(dirname, expandPath(filepath));
   return fs.readFileSync(fullPath, "utf8");
 }

--- a/packages/agency-lang/lib/stdlib/speech.ts
+++ b/packages/agency-lang/lib/stdlib/speech.ts
@@ -9,7 +9,7 @@ import { abortableExec } from "./abortable.js";
 import { runHttp } from "./http.js";
 import { AgencyCancelledError } from "../runtime/errors.js";
 import { getRuntimeContext } from "../runtime/asyncContext.js";
-import { assertContained } from "./assertContained.js";
+import { resolveDir } from "./resolveDir.js";
 import type { RuntimeContext } from "../runtime/state/context.js";
 import type { StateStack } from "../runtime/state/stateStack.js";
 import type { ThreadStore } from "../runtime/state/threadStore.js";
@@ -43,8 +43,9 @@ async function speakImpl(
         args.push("-r", String(rate));
       }
       if (outputFile !== "") {
-        const outPath = path.resolve(process.cwd(), outputFile);
-        await assertContained(outPath, allowedPaths ?? []);
+        // `resolveDir` (cwd-anchored) handles `~` expansion + allow-list
+        // enforcement uniformly with the fs.ts call sites.
+        const outPath = await resolveDir(outputFile, allowedPaths ?? [], "cwd");
         args.push("-o", outPath);
       }
       await abortableExec("say", args, ctx.getAbortSignal(stack));
@@ -108,11 +109,8 @@ async function recordImpl(
   }
 
   const outPath = outputFile
-    ? path.resolve(process.cwd(), outputFile)
+    ? await resolveDir(outputFile, allowedPaths ?? [], "cwd")
     : path.join(os.tmpdir(), `agency-rec-${nanoid()}.wav`);
-  if (outputFile) {
-    await assertContained(outPath, allowedPaths ?? []);
-  }
 
   const args = [outPath];
   if (silenceTimeout > 0) {
@@ -231,8 +229,7 @@ async function transcribeImpl(
     );
   }
 
-  const resolvedPath = path.resolve(process.cwd(), filepath);
-  await assertContained(resolvedPath, allowedPaths ?? []);
+  const resolvedPath = await resolveDir(filepath, allowedPaths ?? [], "cwd");
   const fileData = await readFile(resolvedPath);
   const filename = path.basename(resolvedPath);
 

--- a/packages/agency-lang/lib/stdlib/system.ts
+++ b/packages/agency-lang/lib/stdlib/system.ts
@@ -1,9 +1,8 @@
-import path from "path";
 import process from "process";
 import { detectPlatform } from "./utils.js";
 import { abortableExec } from "./abortable.js";
 import { getModuleDir, getRuntimeContext } from "../runtime/asyncContext.js";
-import { assertContained } from "./assertContained.js";
+import { resolveDir } from "./resolveDir.js";
 import type { RuntimeContext } from "../runtime/state/context.js";
 import type { StateStack } from "../runtime/state/stateStack.js";
 import type { ThreadStore } from "../runtime/state/threadStore.js";
@@ -108,8 +107,10 @@ async function screenshotImpl(
   allowedPaths?: string[],
 ): Promise<void> {
   const platform = await detectPlatform();
-  const resolvedPath = path.resolve(process.cwd(), filepath);
-  await assertContained(resolvedPath, allowedPaths ?? []);
+  // Route through `resolveDir` (cwd-anchored) so `~` expansion and
+  // allow-list enforcement land in one place — same pattern as
+  // `_mkdir`/`_copy`/`_remove` in fs.ts.
+  const resolvedPath = await resolveDir(filepath, allowedPaths ?? [], "cwd");
   const hasRegion = x >= 0 && y >= 0 && width >= 0 && height >= 0;
   const signal = ctx.getAbortSignal(stack);
 

--- a/packages/agency-lang/tests/agency/tilde-paths/tilde.agency
+++ b/packages/agency-lang/tests/agency/tilde-paths/tilde.agency
@@ -10,7 +10,10 @@ node main(): boolean {
   if (!homeStat.exists) {
     return false
   }
-  if (homeStat.type != `dir`) {
+  // _stat uses lstat, so if $HOME itself is a symlink the type will
+  // be "symlink" rather than "dir". Accept either — this test cares
+  // about ~ expansion, not the user's filesystem layout.
+  if (homeStat.type != `dir` && homeStat.type != `symlink`) {
     return false
   }
   // exists() with a `~`-prefixed filename and dir="" should expand

--- a/packages/agency-lang/tests/agency/tilde-paths/tilde.agency
+++ b/packages/agency-lang/tests/agency/tilde-paths/tilde.agency
@@ -1,0 +1,23 @@
+import { stat, exists } from "std::shell"
+
+// Probes home-directory-relative paths through every migrated entry
+// point. The test asserts that each call *runs* against the expected
+// expanded path; we use `stat`/`exists` on `~` (which is guaranteed
+// to exist for any user) so the test is side-effect-free and never
+// writes under the user's home.
+node main(): boolean {
+  const homeStat = stat(`~`, ``)
+  if (!homeStat.exists) {
+    return false
+  }
+  if (homeStat.type != `dir`) {
+    return false
+  }
+  // exists() with a `~`-prefixed filename and dir="" should expand
+  // the same way.
+  const homeExists = exists(`~`, ``)
+  if (!homeExists) {
+    return false
+  }
+  return true
+}

--- a/packages/agency-lang/tests/agency/tilde-paths/tilde.agency
+++ b/packages/agency-lang/tests/agency/tilde-paths/tilde.agency
@@ -1,10 +1,13 @@
 import { stat, exists } from "std::shell"
 
-// Probes home-directory-relative paths through every migrated entry
-// point. The test asserts that each call *runs* against the expected
-// expanded path; we use `stat`/`exists` on `~` (which is guaranteed
-// to exist for any user) so the test is side-effect-free and never
-// writes under the user's home.
+// Probes home-directory-relative paths through `stat`/`exists`. We
+// use `~` (which is guaranteed to exist for any user) so the test is
+// side-effect-free and never writes under the user's home.
+//
+// `exec`/`bash` cwd-expansion are covered in unit tests
+// (lib/stdlib/shell.test.ts) instead of here — the std::exec
+// interrupt fires before the spawn, so they can't run unattended
+// from a fixture without a handler block.
 node main(): boolean {
   const homeStat = stat(`~`, ``)
   if (!homeStat.exists) {

--- a/packages/agency-lang/tests/agency/tilde-paths/tilde.test.json
+++ b/packages/agency-lang/tests/agency/tilde-paths/tilde.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add ~ expansion to stdlib path resolution

Lets users write `~/notes.md`, `~/.agency/memory`, etc. in any
filesystem-touching stdlib function and have `~` expand to the user's
home directory. Previously `~` was treated as a literal directory
name, silently doing the wrong thing.

The expansion policy lives in one resolver, not at call sites:

- `lib/stdlib/expandPath.ts` — pure string transform, single owner of
  user-path-shorthand policy. Today only handles leading `~`; future
  rules (env vars, normalization) land here.
- `lib/stdlib/resolveDir.ts` — the "dir-only" resolver shared by
  every stdlib site that previously wrote `path.resolve(moduleDir, dir)`.
  Runs `expandPath`, resolves against the module dir, asserts
  containment.
- `lib/stdlib/resolvePath.ts` — delegates its dir step to
  `resolveDir`, so `read`/`write`/`edit` get `~` support for free.
- `lib/stdlib/assertContained.ts` — expands `~` in each `allowedPaths`
  entry, so policies that say `allowedPaths: ["~/.agency"]` match.

Call sites in `shell.ts`, `fs.ts`, and `builtins.ts` collapse from
two-line resolve+assert pairs to a single `resolveDir(dir, allowed)`
call.

Documents the convention in `docs/dev/coding-standards.md`: any new
stdlib function taking a `dir` / `cwd` / `path` arg MUST resolve it
via `resolveDir` (or `resolvePath`).

Plan: docs/superpowers/plans/2026-05-29-tilde-expansion-in-stdlib.md
