### PR TITLE
Add memory configuration in Agency code

### DIFF
--- a/packages/agency-lang/docs/site/guide/memory.md
+++ b/packages/agency-lang/docs/site/guide/memory.md
@@ -158,18 +158,19 @@ Because each fork branch has its own state stack, frames pushed in
 one branch never bleed into siblings:
 
 ```ts
-fork {
-  branch {
-    memory({ dir: "./mem-a" }) as { remember("alice fact") }
-  }
-  branch {
-    memory({ dir: "./mem-b" }) as { remember("bob fact") }
+const dirs = ["./mem-a", "./mem-b"]
+fork(dirs) as dir {
+  memory({ dir: dir }) as {
+    remember("a fact scoped to this branch")
   }
 }
 ```
 
-Both branches share the process-wide store cache, so two branches
-pushing the same `dir` share one `MemoryManager` instance.
+Both branches share the process-wide *store* cache, so two branches
+that resolve to the same physical `dir` share one `FileMemoryStore`
+instance. Each execCtx still wraps that store in its own
+`MemoryManager` (with its own statelog client and log level), so the
+sharing is at the on-disk layer only.
 
 ### `setMemoryId` is orthogonal
 

--- a/packages/agency-lang/docs/site/guide/memory.md
+++ b/packages/agency-lang/docs/site/guide/memory.md
@@ -84,6 +84,102 @@ All other fields are optional with sensible defaults:
 | `compaction.threshold` | Threshold above which compaction runs. |
 | `embeddings.model` | Embedding model name (forwarded to smoltalk's `embed`). |
 
+## Configuring memory in code
+
+You can also enable, reconfigure, or disable memory directly from
+Agency code. This is useful for multi-tenant agents that want a
+different store per user, library helpers that want a side store
+without affecting the caller, and fork branches that each want their
+own memory.
+
+Three functions live in `std::memory`:
+
+```ts
+import { enableMemory, disableMemory, memory } from "std::memory"
+```
+
+### `enableMemory(config)`
+
+Push a memory frame onto the active branch. Subsequent
+`remember`/`recall`/`forget` calls in this branch use the new
+config.
+
+```ts
+enableMemory({ dir: "./mem-user-alice" })
+remember("alice's favourite colour is blue")
+```
+
+- `dir` is resolved against the **current working directory** (the
+  same as `agency.json`'s `memory.dir`, deliberately NOT the module
+  dir like `read`/`write`).
+- The directory is auto-created.
+- Storage is shared process-wide by absolute dir, so multiple calls
+  (or multiple runs) using the same `dir` share one underlying
+  store.
+- Pushing the same `dir` as the current top is a no-op (safe to call
+  in `main()` even when a `static const _ = enableMemory({...})`
+  already ran).
+- Pushing a different `dir` stacks the new frame on top.
+
+### `disableMemory()`
+
+Pop the top memory frame from the active branch. Frame-scoped: a
+`disableMemory()` inside a fork branch only affects that branch.
+
+> **Warning:** `disableMemory()` pops whatever is on top, including
+> the JSON-seeded bottom frame from `agency.json`. Library authors
+> should not call this casually — they will shadow the caller's
+> configured memory. Prefer the block form below for lexical scoping.
+
+### `memory(config) as { ... }`
+
+The block form. Pushes a frame on entry, pops it on exit (including
+on throw / interrupt).
+
+```ts
+memory({ dir: "./mem-user-alice" }) as {
+  remember("alice's favourite colour is blue")
+  print(recall("alice"))
+}
+// Frame is popped here — the next remember/recall sees whatever was
+// active before this block.
+```
+
+### Precedence
+
+Code wins over `agency.json`. The JSON config is seeded as the
+bottom-of-stack frame on every run; any `enableMemory(...)` or
+`memory({...}) as { ... }` pushes on top. The active frame is always
+the top of the stack.
+
+### Per-fork memory
+
+Because each fork branch has its own state stack, frames pushed in
+one branch never bleed into siblings:
+
+```ts
+fork {
+  branch {
+    memory({ dir: "./mem-a" }) as { remember("alice fact") }
+  }
+  branch {
+    memory({ dir: "./mem-b" }) as { remember("bob fact") }
+  }
+}
+```
+
+Both branches share the process-wide store cache, so two branches
+pushing the same `dir` share one `MemoryManager` instance.
+
+### `setMemoryId` is orthogonal
+
+`setMemoryId(...)` updates the active scope id (lives on the
+state stack's `other.memoryId`) and is *independent* of which frame
+is on top. A library helper that opens a side store does not
+clobber the caller's `setMemoryId`. If you want a fresh scope when
+switching stores, call `setMemoryId(...)` explicitly inside the
+block.
+
 ## The `std::memory` module
 
 Import the functions you need from `std::memory`:

--- a/packages/agency-lang/docs/site/guide/ts-helpers.md
+++ b/packages/agency-lang/docs/site/guide/ts-helpers.md
@@ -246,6 +246,43 @@ agency.addCost(cost);
 
 ---
 
+## Memory
+
+TS helpers reach Agency's memory layer through `agency.memory.*`. Every method mirrors a function in `std::memory`, so a TS helper can do the same push/configure/recall/forget operations Agency code can.
+
+```ts
+import { agency, type MemoryConfig } from "agency-lang/runtime";
+
+export async function withUserMemory<T>(
+  userId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  await agency.memory.enable({ dir: `./mem/${userId}` });
+  await agency.memory.setId(userId);
+  try {
+    return await fn();
+  } finally {
+    agency.memory.disable();
+  }
+}
+```
+
+### Methods
+
+| Method | What it does |
+| --- | --- |
+| `agency.memory.enable(config)` | Push a memory frame; `config.dir` resolves against `process.cwd()`. Same dir as top is a no-op. |
+| `agency.memory.disable()` | Pop the top frame. Includes the JSON-seeded bottom frame — use the block form in Agency for lexical scoping. |
+| `agency.memory.setId(id)` | Update the scope id. Orthogonal to frames — persists across push/pop. |
+| `agency.memory.enabled()` | `true` iff a frame is currently active. |
+| `agency.memory.remember(content)` | Extract + store facts. No-op when no frame is active. |
+| `agency.memory.recall(query)` | Retrieve facts as a formatted string. Empty when no frame or no match. |
+| `agency.memory.forget(query)` | Soft-delete matching facts. |
+
+The `MemoryConfig` type is re-exported from `agency-lang/runtime` so TS helpers can accept it as a parameter without reaching into the internals.
+
+---
+
 ## Resumable scopes
 
 A resumable scope wraps a TS body in the same substep-counter + serialized-frame machinery generated Agency function bodies use. Interrupts that happen inside a step body re-enter exactly where they left off on resume: already-completed steps are skipped, and the deepest in-flight step re-runs from scratch.

--- a/packages/agency-lang/docs/site/stdlib/memory.md
+++ b/packages/agency-lang/docs/site/stdlib/memory.md
@@ -31,13 +31,13 @@ type ForgetResult = {
 export type MemoryConfig = {
   dir: string;
   model?: string;
-  autoExtract?: { interval: number };
-  compaction?: { trigger: string; threshold: number };
-  embeddings?: { model: string }
+  autoExtract?: { interval: number | undefined };
+  compaction?: { trigger: "token" | "messages" | undefined; threshold: number | undefined };
+  embeddings?: { model: string | undefined }
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L20))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L22))
 
 ## Functions
 
@@ -67,7 +67,7 @@ Set the memory scope for this agent run. Call this before other
 |---|---|---|
 | id | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L48))
 
 ### enableMemory
 
@@ -104,7 +104,7 @@ Turn memory on for the current execution branch using `config`.
 |---|---|---|
 | config | [MemoryConfig](#memoryconfig) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L64))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L67))
 
 ### disableMemory
 
@@ -123,22 +123,31 @@ Pop the top memory frame from the current branch's stateStack.
   Prefer the block form `memory({...}) as { ... }` for lexical
   scoping, which restores the previous frame on exit.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L92))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L95))
 
 ### memory
 
 ```ts
-memory(config: MemoryConfig, block: () => any): any
+memory(config: MemoryConfig, block: () => any): Result
 ```
 
 Run `block` with `config` pushed as the active memory frame; pop
-  the frame when the block returns (or throws).
+  the frame when the block returns (or fails). Mirrors the `guard()`
+  pattern in `std::thread` so push/pop balancing flows through the
+  same `try` expression — Agency has no `finally`, so the agency-side
+  body uses `try block()` to capture the result and runs `pop` after.
 
-  The block form of `enableMemory` / `disableMemory`. Prefer this
-  whenever the memory frame should be lexically scoped.
+  The pop only fires when the push actually happened: `_pushMemoryFrame`
+  returns `false` if the new frame's dir matches the current top
+  (dedup), and the matching no-pop preserves the caller's frame
+  instead of unbalancing it. This fixes the prior `_memoryBlock`
+  unbalanced-pop bug.
+
+  Returns a `Result` (success holds the block's return value, failure
+  holds an error from inside the block). Same convention as `guard()`.
 
   Example:
-    memory({ dir: "./mem-user-a" }) as {
+    const r = memory({ dir: "./mem-user-a" }) as {
       remember("alice's favorite color is blue")
     }
 
@@ -150,11 +159,11 @@ Run `block` with `config` pushed as the active memory frame; pop
 | Name | Type | Default |
 |---|---|---|
 | config | [MemoryConfig](#memoryconfig) |  |
-| block | `() => any` |  |
+| block | `() => any` | null |
 
-**Returns:** `any`
+**Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L108))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L111))
 
 ### remember
 
@@ -179,7 +188,7 @@ Extract and store structured facts from the given text into the
 |---|---|---|
 | content | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L127))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L144))
 
 ### recall
 
@@ -204,7 +213,7 @@ Retrieve relevant facts from the knowledge graph as a formatted
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L149))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L166))
 
 ### forget
 
@@ -228,4 +237,4 @@ Soft-delete facts matching the query from the knowledge graph.
 |---|---|---|
 | query | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L163))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L180))

--- a/packages/agency-lang/docs/site/stdlib/memory.md
+++ b/packages/agency-lang/docs/site/stdlib/memory.md
@@ -25,6 +25,20 @@ type ForgetResult = {
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L12))
 
+### MemoryConfig
+
+```ts
+export type MemoryConfig = {
+  dir: string;
+  model?: string;
+  autoExtract?: { interval: number };
+  compaction?: { trigger: string; threshold: number };
+  embeddings?: { model: string }
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L20))
+
 ## Functions
 
 ### setMemoryId
@@ -37,8 +51,13 @@ Set the memory scope for this agent run. Call this before other
   memory operations to scope reads and writes to a specific user,
   thread, or workspace. If never called, the scope defaults to "default".
 
-  Memory must be enabled in agency.json for this to do anything; without
-  configuration this is a no-op.
+  Memory must be enabled (either via `agency.json` or via
+  `enableMemory(...)`) for this to do anything; without configuration
+  this is a no-op.
+
+  The id is orthogonal to which memory frame is active — it persists
+  across `enableMemory` / `disableMemory` calls. If you want a fresh
+  scope when switching stores, call `setMemoryId(...)` explicitly.
 
   @param id - A unique identifier for the memory scope (e.g. user ID)
 
@@ -48,7 +67,94 @@ Set the memory scope for this agent run. Call this before other
 |---|---|---|
 | id | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L31))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L45))
+
+### enableMemory
+
+```ts
+enableMemory(config: MemoryConfig)
+```
+
+Turn memory on for the current execution branch using `config`.
+
+  Pushes a new memory frame onto the active stateStack. Storage is
+  shared process-wide by absolute directory, so multiple calls
+  (across runs, forks, or modules) that point at the same dir share
+  one underlying store.
+
+  Same-dir push is a no-op — the common pattern of declaring
+  `static const _ = enableMemory({...})` AND calling
+  `enableMemory({...})` from `main()` is safe. Pushing a different
+  dir stacks the new frame on top; pop with `disableMemory()` or
+  use the block form `memory({...}) as { ... }` for lexical scoping.
+
+  `config.dir` is resolved against `process.cwd()` (NOT the module
+  dir, deliberately — mirrors how `agency.json`'s `memory.dir` is
+  resolved so the same string in JSON and in code points at the same
+  place). The directory is auto-created if missing.
+
+  Per-fork: each fork branch has its own frame stack, so an
+  `enableMemory` in one branch does not affect siblings.
+
+  @param config - Memory configuration with `dir` required
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| config | [MemoryConfig](#memoryconfig) |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L64))
+
+### disableMemory
+
+```ts
+disableMemory()
+```
+
+Pop the top memory frame from the current branch's stateStack.
+
+  Frame-scoped: a `disableMemory()` inside a fork branch only
+  affects that branch.
+
+  WARNING: this pops whatever is on top, including the JSON-seeded
+  bottom frame from `agency.json`. Library authors should not call
+  this casually — they will shadow the caller's configured memory.
+  Prefer the block form `memory({...}) as { ... }` for lexical
+  scoping, which restores the previous frame on exit.
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L92))
+
+### memory
+
+```ts
+memory(config: MemoryConfig, block: () => any): any
+```
+
+Run `block` with `config` pushed as the active memory frame; pop
+  the frame when the block returns (or throws).
+
+  The block form of `enableMemory` / `disableMemory`. Prefer this
+  whenever the memory frame should be lexically scoped.
+
+  Example:
+    memory({ dir: "./mem-user-a" }) as {
+      remember("alice's favorite color is blue")
+    }
+
+  @param config - Memory configuration with `dir` required
+  @param block - The code to run with the frame active
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| config | [MemoryConfig](#memoryconfig) |  |
+| block | `() => any` |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L108))
 
 ### remember
 
@@ -73,7 +179,7 @@ Extract and store structured facts from the given text into the
 |---|---|---|
 | content | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L127))
 
 ### recall
 
@@ -98,7 +204,7 @@ Retrieve relevant facts from the knowledge graph as a formatted
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L67))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L149))
 
 ### forget
 
@@ -122,4 +228,4 @@ Soft-delete facts matching the query from the knowledge graph.
 |---|---|---|
 | query | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L81))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L163))

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-29-memory-config-in-code.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-29-memory-config-in-code.md
@@ -1,0 +1,658 @@
+# Memory Configuration in Agency Code — Implementation Plan
+
+## Goal
+
+Let Agency code enable, configure, and disable memory directly, without
+requiring a `memory` block in `agency.json`. Support per-thread / per-fork
+memory by moving memory configuration onto the stateStack. All new
+surface lives in the `std::memory` module.
+
+## User-visible API (final)
+
+Three new exports added to
+[`stdlib/memory.agency`](../../../stdlib/memory.agency):
+
+```agency
+// Function form — push a new memory frame onto the current stateStack.
+// Process-wide stores are cached by absolute dir, so multiple calls
+// with the same dir share storage. Repeating the same dir as the
+// current top frame is a no-op (so `static const _ = enableMemory(...)`
+// + an `enableMemory(...)` in `main` is safe). Pushing a different
+// dir stacks the new frame on top — pop it with `disableMemory()`.
+// Auto-creates the dir if missing.
+enableMemory({
+  dir: string,                 // required
+  model?: string,
+  autoExtract?: { interval: number },
+  compaction?: { trigger: string, threshold: number },
+  embeddings?: { model: string }
+})
+
+// Function form — turn memory off for the current stateStack frame.
+// Frame-scoped: a `disableMemory()` inside a fork branch only affects
+// that branch.
+disableMemory()
+
+// Block form — push a memory frame, run the body, pop the frame on
+// exit (including interrupt resume and exceptions). Implemented as a
+// plain function taking a block, per docs/site/guide/blocks.md — no
+// parser changes needed.
+memory({...}) as {
+  // code in here uses the new memory config
+  remember("...")
+}
+```
+
+All three are also valid tools an LLM can be passed.
+
+### Precedence
+
+Code wins over `agency.json`. The JSON config seeds the bottom of the
+config stack on every execCtx; any `enableMemory` / `memory` block
+pushes a new frame on top. The active config is always "top of stack."
+
+### Relative dir resolution
+
+Mirrors `agency.json`: `dir` resolves against `process.cwd()`. This
+deliberately differs from `read`/`write`/`ls`/`glob`/`grep` (which use
+the module dir) so the same string in `agency.json` and in code points
+at the same place. Documented explicitly in the `enableMemory` doc
+comment. `~` expansion lands separately in
+[`2026-05-29-tilde-expansion-in-stdlib.md`](./2026-05-29-tilde-expansion-in-stdlib.md);
+once that ships, `~/.agency/memory` works for free.
+
+## Architectural change (the "refactor" half)
+
+### Current shape
+
+[`lib/runtime/state/context.ts#L214-L301`](../../../lib/runtime/state/context.ts):
+- `Context.memoryConfig` and `Context.memoryStore` are set once from
+  `args.memory` (JSON-derived).
+- `createExecutionContext()` builds a `MemoryManager` per execCtx,
+  closing over `execCtx.stateStack` for the memoryId ref.
+- `execCtx.memoryManager` is the single live manager for the whole run.
+
+[`lib/runtime/state/stateStack.ts`](../../../lib/runtime/state/stateStack.ts)
+already carries `other: Record<string, any>` which is forked correctly
+and stores the active `memoryId`.
+
+### New shape
+
+**Memory frames on the stateStack, hidden behind methods.** The
+stateStack carries a stack of memory frames; callers never touch the
+array directly.
+
+```ts
+// lib/runtime/state/stateStack.ts
+interface MemoryFrame {
+  configKey: string;     // absolute, realpath'd dir
+  config: MemoryConfig;
+}
+
+class StateStack {
+  // Existing fields unchanged. `memoryFrames` lives in `other` so it
+  // serializes for free with the rest of stateStack.other and forks
+  // correctly via the existing deepClone path.
+
+  pushMemoryFrame(frame: MemoryFrame): void
+  popMemoryFrame(): MemoryFrame | undefined
+  topMemoryFrame(): MemoryFrame | undefined
+}
+```
+
+Every other site reads / mutates frames only through these three
+methods. The underlying array shape is an implementation detail.
+
+**Single source of truth: JSON config is just the bottom frame.** No
+separate "fallback" path. At `createExecutionContext`, if
+`args.memory` is set, push it onto the new execCtx's stateStack as
+the bottom frame. After that, the stack is the only thing anyone
+consults. The "code wins over JSON" rule is structural, not coded.
+
+```ts
+// lib/runtime/state/context.ts — in createExecutionContext
+if (this.jsonMemoryConfig) {
+  execCtx.stateStack.pushMemoryFrame(
+    await normalizeMemoryFrame(this.jsonMemoryConfig)
+  );
+}
+```
+
+`Context.memoryConfig` becomes the immutable JSON seed
+(`jsonMemoryConfig`), used only at execCtx creation. `Context.memoryStore`
+goes away — stores are looked up via the registry below when needed.
+
+**Process-wide store registry**, `lib/runtime/memory/registry.ts`:
+
+```ts
+const stores = new Map<string, FileMemoryStore>();
+export function getOrCreateStore(absDir: string, logLevel): FileMemoryStore
+```
+
+Keyed by absolute, realpath'd dir. First lookup creates the store and
+the dir (`mkdir -p`).
+
+> **Verification step before writing this file:** grep `lib/runtime/`
+> and `lib/stdlib/` for any existing keyed-singleton / cached-factory
+> pattern (`new Map<string,`, `getOrCreate`, registry / cache files)
+> to make sure we're not duplicating an idiom already in use.
+> Also check the `agency` namespace surface
+> ([lib/runtime/agency.ts](../../../lib/runtime/agency.ts)) for any
+> existing memory helpers — current grep shows none, but confirm
+> nothing has been added since.
+
+**Active-manager resolution.** Single method on `RuntimeContext`:
+
+```ts
+getActiveMemoryManager(): MemoryManager | undefined {
+  const frame = this.stateStack?.topMemoryFrame();
+  if (!frame) return undefined;
+  return this.getOrCreateManager(frame);   // cached per execCtx by configKey
+}
+```
+
+No fallback branch. No "if frame else default" special case. Top of
+stack or undefined. The per-execCtx manager cache prevents reconstruction
+on every call — needs its own statelog client / log level per execCtx,
+which is why it can't be process-wide.
+
+### Replacing direct `ctx.memoryManager` reads
+
+All call sites enumerated below switch from
+`ctx.memoryManager` → `ctx.getActiveMemoryManager()`:
+
+- [`lib/runtime/node.ts:356-358`](../../../lib/runtime/node.ts#L356-L358) (save on shutdown)
+- [`lib/runtime/prompt.ts:214-218`](../../../lib/runtime/prompt.ts#L214-L218) (onTurn / compactIfNeeded)
+- [`lib/runtime/prompt.ts:401-403`](../../../lib/runtime/prompt.ts#L401-L403) (recallForInjection)
+- All `_*` and `__internal_*` exports in
+  [`lib/stdlib/memory.ts`](../../../lib/stdlib/memory.ts) (~14 sites)
+
+For the save-on-shutdown path, iterate every cached manager and call
+`save()` — otherwise a fork that enabled a side store would lose its
+writes.
+
+## TypeScript helpers in `lib/stdlib/memory.ts`
+
+Once `StateStack.{push,pop,top}MemoryFrame` exist and
+`normalizeMemoryFrame(config)` owns "resolve + mkdir + return frame,"
+the helpers collapse to a handful of lines each. Imperative work is
+encapsulated in the StateStack methods and the normalization helper;
+these wrappers stay declarative.
+
+```ts
+// "What" lives here. "How" lives in normalizeMemoryFrame +
+// StateStack.{push,pop,top}MemoryFrame.
+
+export async function _enableMemory(config: MemoryConfig): Promise<void> {
+  const { stack } = getRuntimeContext();
+  if (!stack) return;
+  stack.pushMemoryFrame(await normalizeMemoryFrame(config));
+}
+
+export function _disableMemory(): void {
+  const { stack } = getRuntimeContext();
+  stack?.popMemoryFrame();
+}
+```
+
+`normalizeMemoryFrame(config)` lives in
+`lib/runtime/memory/frame.ts` and is the single owner of the
+"resolve dir, mkdir, build frame" policy. `StateStack.pushMemoryFrame`
+owns the idempotency policy:
+
+```ts
+// lib/runtime/state/stateStack.ts
+pushMemoryFrame(frame: MemoryFrame): void {
+  const top = this.topMemoryFrame();
+  // Same dir as top: no-op, so static-const + main double-call is safe.
+  // Different dir: stack on top. Callers pop with popMemoryFrame() or
+  // use the memory(){} block for lexical scoping.
+  if (top?.configKey === frame.configKey) return;
+  this.other.memoryFrames = [...(this.other.memoryFrames ?? []), frame];
+}
+```
+
+The block form is plain Agency `try/finally` — no TS helper needed
+(see `stdlib/memory.agency` below).
+
+## `agency.memory.*` TS-facing namespace
+
+[Per ts-helpers.md](../../site/guide/ts-helpers.md), TS code that
+participates in an Agency run reaches everything via the single
+`agency` namespace exported from
+[`lib/runtime/agency.ts`](../../../lib/runtime/agency.ts). Today that
+namespace has **no memory methods** (confirmed by grep). Adding them
+gives TS helpers symmetric access to what Agency code can do.
+
+Add a `memory` sub-namespace to the `agency` const:
+
+```ts
+// lib/runtime/agency.ts — additions only
+import {
+  _enableMemory, _disableMemory,
+  _setMemoryId, _shouldRunMemory,
+  _remember, _recall, _forget,
+} from "../stdlib/memory.js";
+
+const memoryEnable   = (config: MemoryConfig) => _enableMemory(config);
+const memoryDisable  = ()                     => _disableMemory();
+const memorySetId    = (id: string)           => _setMemoryId(id);
+const memoryEnabled  = ()                     => _shouldRunMemory();
+const memoryRemember = (content: string)      => _remember(content);
+const memoryRecall   = (query: string)        => _recall(query);
+const memoryForget   = (query: string)        => _forget(query);
+
+export const agency = {
+  // ... existing fields unchanged ...
+  memory: {
+    enable:   memoryEnable,
+    disable:  memoryDisable,
+    setId:    memorySetId,
+    enabled:  memoryEnabled,
+    remember: memoryRemember,
+    recall:   memoryRecall,
+    forget:   memoryForget,
+  },
+};
+```
+
+Naming: matches the namespace's pattern of action verbs without the
+"memory" prefix (compare `agency.thread.current()`, not
+`agency.thread.currentThread()`). `setId` because `agency.memory.set`
+would be ambiguous. `enabled` is a query, not a setter.
+
+TS helpers can now do:
+
+```ts
+import { agency } from "agency-lang/runtime";
+
+export async function rememberPreference(pref: string): Promise<void> {
+  await agency.memory.enable({ dir: "~/.agency/memory" });
+  agency.memory.setId(`user-${getUserId()}`);
+  await agency.memory.remember(pref);
+}
+```
+
+Each method just re-exports the underlying `_*` ALS-reading helper —
+no second code path. Behavior changes happen in one place.
+
+## Agency-side wrappers in `stdlib/memory.agency`
+
+```agency
+import {
+  _enableMemory,
+  _disableMemory,
+  _setMemoryId,
+  // ... existing imports
+} from "agency-lang/stdlib-lib/memory.js"
+
+export type MemoryConfig = {
+  dir: string;
+  model?: string;
+  autoExtract?: { interval: number };
+  compaction?: { trigger: string; threshold: number };
+  embeddings?: { model: string };
+}
+
+export def enableMemory(config: MemoryConfig) {
+  """
+  Push a memory frame onto the current execution stack. Auto-creates
+  `dir` if missing. `dir` resolves against the process cwd (matching
+  `agency.json` precisely, not the calling module directory).
+
+  Repeating the same dir as the current top frame is a no-op (so
+  `static const _ = enableMemory(...)` plus an `enableMemory(...)` at
+  the top of `main` is safe). Pushing a different dir stacks on top —
+  use `disableMemory()` to pop back, or the `memory(){}` block for
+  lexical scoping. `setMemoryId(...)` is NOT affected by push or pop;
+  storage (where) and scope (who) are orthogonal.
+
+  Settings here override `agency.json` for this frame and below.
+
+  @param config - Memory configuration (dir required)
+  """
+  _enableMemory(config)
+}
+
+export def disableMemory() {
+  """
+  Pop the top memory frame. Frame-scoped: a call inside a fork
+  branch only affects that branch.
+
+  Library authors: this pops whatever is on top, including the
+  bottom frame seeded from `agency.json`. Don't call this casually
+  in shared helpers — you can shadow the user's project-level memory
+  config.
+  """
+  _disableMemory()
+}
+
+export def memory(config: MemoryConfig, block: () => any): any {
+  """
+  Push a memory frame for the body, then pop it. Implemented in pure
+  Agency so the new frame survives interrupt/resume and exception
+  unwinding correctly.
+
+  Usage:
+
+      memory({ dir: ".project-memory" }) as {
+        remember("user prefers tabs")
+      }
+
+  @param config - Memory configuration (dir required)
+  @param block - Code to run with this memory active
+  """
+  enableMemory(config)
+  try {
+    return block()
+  } finally {
+    disableMemory()
+  }
+}
+```
+
+Note: Agency's `try/finally` already exists (used elsewhere in stdlib);
+if not, the block can use a `with`-style handler. Confirm during
+implementation.
+
+## JSON config seeding
+
+After the refactor:
+
+- `Context.jsonMemoryConfig` holds the JSON-derived config — immutable
+  after construction, used only by `createExecutionContext` to seed
+  the bottom frame.
+- `Context.memoryConfig` and `Context.memoryStore` are deleted. They
+  were "the active config" / "the active store" — concepts that no
+  longer exist; everything goes through the stateStack frame plus the
+  process-wide registry.
+- "Code overrides JSON" is structural: code's frames are above the
+  JSON-seeded bottom frame, so `topMemoryFrame()` returns the right
+  thing without a special case anywhere.
+
+## Serialization & resume
+
+Memory state moves cleanly through Agency's existing serialize/restore
+pipeline because frames are POJOs and stores live on disk.
+
+**What's serialized:**
+
+- `MemoryFrame` objects (`{configKey: string, config: MemoryConfig}`)
+  ride through the existing
+  [`StateStack.serialize()` / `deserialize()`](../../../lib/runtime/state/stateStack.ts#L535)
+  path as part of `stateStack.other`. The existing code does
+  `other: deepClone(this.other)` on save and
+  `stateStack.other = json.other || {}` on restore. No new code
+  needed.
+- `memoryId` continues to ride on `stateStack.other.memoryId` exactly
+  as today.
+
+**What's NOT serialized:**
+
+- `MemoryManager` instances. They're rebuilt lazily on first call
+  after resume: `getActiveMemoryManager()` looks at the top frame,
+  asks the registry for the store, constructs the manager, caches it
+  on the execCtx.
+- `FileMemoryStore` instances. The registry is process-local and
+  re-populated on first call after a new process starts. The actual
+  facts live on disk under the configured `dir`, so they survive
+  process death.
+
+**Three corner cases this plan must handle:**
+
+1. **Old checkpoints without `memoryFrames`.** Checkpoints saved
+   before this PR have no `memoryFrames` in `other`. On restore,
+   `topMemoryFrame()` would return undefined and memory would silently
+   go dark even if `agency.json` enables it. **Mitigation:** in
+   `Context.createExecutionContext` (and any explicit restore path
+   that swaps the stateStack), after the swap, if
+   `stateStack.topMemoryFrame()` is undefined AND `this.jsonMemoryConfig`
+   is set, re-seed the bottom frame. Backward-compatible without
+   re-introducing the fallback special case (the seed lands as a real
+   frame).
+
+2. **Config change between save and resume.** If `agency.json`
+   changes between checkpoint save and resume, the saved frames win —
+   the stale JSON change is ignored until the user explicitly calls
+   `enableMemory(...)` again. This is the correct "faithful resume"
+   behavior; documented in the user-facing memory guide.
+
+3. **Fork branches.** Each fork's stateStack is independently deep-
+   cloned, so frame pushes in one branch don't bleed into siblings.
+   Two branches pushing the same `configKey` share one
+   `MemoryManager` from the execCtx cache — correct, because the
+   manager's only per-branch state (`memoryId`) is read live from the
+   active branch's stateStack on every call, not captured at
+   construction.
+
+## Wins, automatically
+
+After the refactor, this works:
+
+```agency
+fork {
+  branch {
+    memory({ dir: "./mem-a" }) as {
+      remember("alice fact")
+    }
+  }
+  branch {
+    memory({ dir: "./mem-b" }) as {
+      remember("bob fact")
+    }
+  }
+}
+```
+
+Because `stateStack.other` deep-clones on fork, each branch has its
+own `memoryFrames` stack. The registry caches both stores once per
+process.
+
+## Testing
+
+### Unit (TS) — `lib/runtime/memory/registry.test.ts` (new)
+
+- `getOrCreateStore` returns same instance for same absDir
+- creates dir if missing
+- different abs dirs → different stores
+
+### Unit (TS) — `lib/runtime/state/context.test.ts` (extend)
+
+- `getActiveMemoryManager()` returns undefined when nothing configured
+- returns JSON-derived manager when only JSON is set
+- returns frame manager when frame is pushed, ignoring JSON
+- pops back to JSON manager when frame is popped
+
+### Unit (TS) — `lib/stdlib/memory.test.ts` (extend)
+
+- `_enableMemory` no-op when pushing the same dir as the current top
+- `_enableMemory` stacks a different dir on top of the current frame
+- `_disableMemory` pops one frame
+- frames survive a roundtrip through stateStack serialize/deserialize
+  (important: the `memoryFrames` array must serialize cleanly)
+
+### Agency execution test — `tests/agency/memory-enable.agency` (new)
+
+```agency
+import { enableMemory, remember, recall, setMemoryId } from "std::memory"
+
+node main() {
+  enableMemory({ dir: ".test-mem" })
+  setMemoryId("test-1")
+  remember("the sky is blue")
+  const r = recall("sky")
+  assert(r != "")
+  return "ok"
+}
+```
+
+Add `.gitignore` entry for `.test-mem/` if needed; teardown in a
+`finally` block or test harness afterEach.
+
+### Agency execution test — `tests/agency/memory-block.agency` (new)
+
+Test the block form: memory is active inside, no-op outside.
+
+### Agency execution test — `tests/agency/memory-fork.agency` (new)
+
+Two fork branches, each pushing a different memory dir, each writing
+a distinct fact. Assert each store ends up with only its own fact.
+
+### Agency-js integration test — `tests/agency-js/memory-precedence/`
+
+agency.json with `memory: { dir: ".json-mem" }`, agency code that
+calls `enableMemory({ dir: ".code-mem" })`, assert writes land in
+`.code-mem` not `.json-mem`. Confirms code-wins-over-JSON.
+
+### Existing tests
+
+Run `lib/runtime/memory/*.test.ts` and `lib/stdlib/memory.test.ts`
+unchanged; the refactor must not regress them.
+
+### Test gaps — what could break that the tests above wouldn't catch
+
+The initial list focuses on the happy path. The audit below names
+the specific failures that the listed tests would silently miss, and
+the additional tests that close each gap. **Every bullet is a real
+correctness or regression risk, not paranoia.**
+
+**Gap 1: `agency.memory.*` namespace wiring.** If one of the seven
+sub-namespace methods is dropped, mistyped, or wired to the wrong
+underlying `_*` function, nothing in the listed tests would catch
+it — they all go through the Agency-side wrappers, not the TS
+namespace.
+**Add:** `lib/runtime/agency.test.ts` — call each of `agency.memory.{enable,disable,setId,enabled,remember,recall,forget}` inside `agency.withTestContext({...}, async () => {...})` and assert observable behavior. Mirrors how `agency.thread.*` is tested today.
+
+**Gap 2: Interrupt-resume across an `enableMemory`.** The whole point
+of frames-on-stateStack is that they survive interrupts. A serialize
+unit test verifies the shape; only an end-to-end test verifies that
+resumed code still sees the same memory frame.
+**Add:** `tests/agency/memory-interrupt.agency` — `enableMemory`, raise an interrupt, host resolves it, control resumes; `remember`/`recall` continue against the right dir. Confirms checkpoint/restore through the real Runner.
+
+**Gap 3: Manager cache invalidation on pop.** Two frames pushed
+(A, then B), then B popped. Listed tests check that B's manager is
+returned while B is on top, but don't check that popping back returns
+A's manager (not a stale B, not undefined, not a fresh A that drops
+state).
+**Add:** test in `lib/runtime/state/context.test.ts` — push A, get manager, push B, get manager, pop B, get manager again; assert third manager is the same instance as the first.
+
+**Gap 4: Old-checkpoint re-seeding.** The corner-case mitigation
+(re-seed JSON bottom frame when restoring a stateStack that lacks
+`memoryFrames`) is untested.
+**Add:** test in `lib/runtime/state/context.test.ts` — construct a `Context` with `jsonMemoryConfig` set, restore from a fake serialized stateStack that has `other.memoryId` but no `other.memoryFrames`, assert `topMemoryFrame()` returns the JSON-derived frame.
+
+**Gap 5: `_disableMemory` against the JSON-seeded bottom frame.**
+**Resolved:** `disableMemory()` pops whatever is on top, including
+the JSON-seeded bottom frame. Memory then goes off until the next
+`enableMemory()`. Keeps "stack is the single source of truth" as an
+invariant; no special case for the bottom frame.
+**Add:** test in `lib/stdlib/memory.test.ts` — JSON config seeded,
+no user frames pushed, `_disableMemory` called, assert
+`getActiveMemoryManager()` returns undefined and a follow-up
+`remember` is a no-op. Also document in the user-facing memory guide
+that library authors should not call `disableMemory()` casually —
+they will shadow user JSON config.
+
+**Gap 6: `memoryId` semantics across a frame push.** **Resolved:**
+`enableMemory()` does **not** touch `memoryId`. Storage (which dir)
+and scope (which id) are orthogonal — `memoryId` lives on
+`stateStack.other.memoryId` and persists across frame pushes and
+pops. A library helper that opens a side store cannot accidentally
+clobber the caller's `setMemoryId`. If a caller wants a fresh scope
+when switching stores, they call `setMemoryId("default")` (or
+whatever) explicitly.
+**Add:** test in `tests/agency/memory-id-across-frames.agency` —
+`setMemoryId("alice")`, `enableMemory({dir: A})`, write fact,
+`enableMemory({dir: B})` (different dir), write fact;
+assert both stores contain a fact under scope `alice`. Pop back to
+A and assert id is still `alice`.
+
+**Gap 7: `StateStack` push/pop/top semantics in isolation.** The
+Agency-side tests exercise the wrappers; the StateStack methods
+themselves should also be tested unit-level so the stack invariants
+survive refactoring.
+**Add:** test in `lib/runtime/state/stateStack.test.ts` — direct
+push/pop/top calls covering: same-dir push is a no-op, different-dir
+push stacks, pop returns to previous top, pop on empty returns
+undefined, the frames array survives deep-clone across forks.
+
+**Gap 8: `MemoryConfig` round-trips intact through serialize.** The
+"frames survive serialize/deserialize" test exists but probably
+only checks the array shape. Confirm nested fields (`autoExtract`,
+`compaction`, `embeddings`) survive.
+**Add:** to the existing roundtrip test, assert deep equality of the
+full config object after deserialize.
+
+**Gap 9: Cross-execCtx store sharing.** Plan claims the registry is
+process-wide. If two execCtxs in the same process push the same dir,
+they should share the underlying `FileMemoryStore` (otherwise writes
+from one are invisible to the other until disk reload).
+**Add:** `lib/runtime/memory/registry.test.ts` — create two stores via
+the registry with the same dir, assert reference equality.
+
+**Gap 10: Absolute vs relative dir input.** `enableMemory({dir: "/abs/path"})`
+should not be re-resolved against cwd. `enableMemory({dir: "./mem"})`
+should be. `enableMemory({dir: "~/.agency/mem"})` (after the tilde
+PR lands) should expand.
+**Add:** `lib/runtime/memory/frame.test.ts` — three cases for
+`normalizeMemoryFrame`, asserting the resulting `configKey` for each.
+
+**Gap 11: agency-js test for `agency.memory.*`.** TS helper that
+calls `agency.memory.remember(...)` should be reachable from Agency
+code under a real Runner.
+**Add:** `tests/agency-js/memory-ts-namespace/` — agency.json with
+memory enabled; TS helper exported from `helpers.ts` that
+`agency.memory.remember`s a fact; Agency code calls the helper then
+`recall`s the fact.
+
+The two existing "agency-js memory-precedence" and "agency
+memory-fork" tests stay; the gaps above are additive, not
+replacements.
+
+## Migration & rollout
+
+- **Backward compatible.** Existing agents that rely on `agency.json`
+  memory config keep working — the JSON config becomes the bottom-of-
+  stack default with identical behavior.
+- **No deprecations.** The existing `setMemoryId` API is unchanged.
+- **Single PR.** Combining the refactor and the new API into one PR
+  is fine because the block form is just `try/finally` around the
+  two new functions — no parser changes (confirmed via
+  [`docs/site/guide/blocks.md`](../../site/guide/blocks.md)).
+- **Build.** Touches stdlib → run `make` after editing
+  `stdlib/memory.agency`.
+
+## File checklist
+
+Runtime — new:
+- [`lib/runtime/memory/registry.ts`](../../../lib/runtime/memory/registry.ts) — process-wide `getOrCreateStore`
+- [`lib/runtime/memory/registry.test.ts`](../../../lib/runtime/memory/registry.test.ts)
+- [`lib/runtime/memory/frame.ts`](../../../lib/runtime/memory/frame.ts) — `normalizeMemoryFrame(config)`: resolve dir, mkdir, return `MemoryFrame`
+- [`lib/runtime/memory/frame.test.ts`](../../../lib/runtime/memory/frame.test.ts)
+
+Runtime — modified:
+- [`lib/runtime/state/stateStack.ts`](../../../lib/runtime/state/stateStack.ts) — add `pushMemoryFrame` / `popMemoryFrame` / `topMemoryFrame` (own the same-dir idempotency rule), `MemoryFrame` type
+- [`lib/runtime/state/context.ts`](../../../lib/runtime/state/context.ts) — rename `memoryConfig` → `jsonMemoryConfig`; drop `memoryStore` and `memoryManager`; add `getActiveMemoryManager` with per-execCtx cache keyed by `configKey`; seed JSON config as bottom frame in `createExecutionContext`
+- [`lib/runtime/agency.ts`](../../../lib/runtime/agency.ts) — add `agency.memory.{enable,disable,setId,enabled,remember,recall,forget}` sub-namespace
+- [`lib/runtime/index.ts`](../../../lib/runtime/index.ts) — re-export `MemoryConfig` type alongside existing type exports
+- [`lib/runtime/node.ts`](../../../lib/runtime/node.ts) — save-all-cached-managers on shutdown (iterate the per-execCtx cache)
+- [`lib/runtime/prompt.ts`](../../../lib/runtime/prompt.ts) — read via `ctx.getActiveMemoryManager()` (3 sites)
+- [`lib/stdlib/memory.ts`](../../../lib/stdlib/memory.ts) — all `_*` and `__internal_*` exports switch to `ctx.getActiveMemoryManager()`; add `_enableMemory`, `_disableMemory`
+
+Stdlib (Agency):
+- [`stdlib/memory.agency`](../../../stdlib/memory.agency) — add `enableMemory`, `disableMemory`, `memory(config, block)`, `MemoryConfig` type
+
+Docs:
+- [`docs/site/guide/memory.md`](../../site/guide/memory.md) — new section "Configuring memory in code" covering the three Agency functions, the precedence rule, and the per-fork pattern
+- [`docs/site/guide/ts-helpers.md`](../../site/guide/ts-helpers.md) — new section "Memory" covering `agency.memory.*`
+
+Tests: as listed above.
+
+## Out of scope
+
+- Generic `configure(...)` block. Deferred per user decision.
+- Client (model, headers, baseUrl) config in code. Same pattern when
+  needed.
+- `~` expansion in path resolution — separate PR.
+- Cross-process memory store coordination (locking, etc.) — not a new
+  problem introduced here.

--- a/packages/agency-lang/lib/runtime/agency.test.ts
+++ b/packages/agency-lang/lib/runtime/agency.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { agency } from "./agency.js";
 import { agencyStore } from "./asyncContext.js";
 import { RuntimeContext } from "./state/context.js";
@@ -6,6 +9,7 @@ import { StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { RestoreSignal } from "./errors.js";
 import { CostGuard, TimeGuard } from "./guard.js";
+import { _resetStoreRegistry } from "./memory/index.js";
 import { makeMockCtx } from "./__tests__/testHelpers.js";
 
 function setup() {
@@ -335,5 +339,108 @@ describe("agency.withTestContext", () => {
     });
     expect(agency.ctxMaybe()).toBeUndefined();
     expect(agencyStore.getStore()).toBeUndefined();
+  });
+});
+
+describe("agency.memory.*", () => {
+  let tmpRoot: string;
+
+  function makeMemCtx(memory?: { dir: string }) {
+    const ctx = new RuntimeContext({
+      statelogConfig: { host: "", apiKey: "", projectId: "", debugMode: false, observability: false },
+      smoltalkDefaults: {},
+      dirname: process.cwd(),
+      memory,
+    });
+    return ctx;
+  }
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "agencymem-"));
+    _resetStoreRegistry();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    _resetStoreRegistry();
+  });
+
+  it("agency.memory.enabled returns false when no frame is active", async () => {
+    const ctx = makeMemCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    agency.withTestContext(
+      { ctx: execCtx, stack: execCtx.stateStack, threads: new ThreadStore() },
+      () => {
+        expect(agency.memory.enabled()).toBe(false);
+      },
+    );
+  });
+
+  it("agency.memory.enable pushes a frame and enabled() returns true", async () => {
+    const ctx = makeMemCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await agency.withTestContext(
+      { ctx: execCtx, stack: execCtx.stateStack, threads: new ThreadStore() },
+      async () => {
+        await agency.memory.enable({ dir: tmpRoot });
+        expect(agency.memory.enabled()).toBe(true);
+      },
+    );
+  });
+
+  it("agency.memory.disable pops the active frame; enabled() returns false again", async () => {
+    const ctx = makeMemCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await agency.withTestContext(
+      { ctx: execCtx, stack: execCtx.stateStack, threads: new ThreadStore() },
+      async () => {
+        await agency.memory.enable({ dir: tmpRoot });
+        expect(agency.memory.enabled()).toBe(true);
+        agency.memory.disable();
+        expect(agency.memory.enabled()).toBe(false);
+      },
+    );
+  });
+
+  it("agency.memory.setId updates the memoryId on the active stack", async () => {
+    const ctx = makeMemCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await agency.withTestContext(
+      { ctx: execCtx, stack: execCtx.stateStack, threads: new ThreadStore() },
+      async () => {
+        await agency.memory.enable({ dir: tmpRoot });
+        await agency.memory.setId("alice");
+        expect(execCtx.stateStack.other.memoryId).toBe("alice");
+      },
+    );
+  });
+
+  it("agency.memory.remember / recall round-trips through the active store", async () => {
+    const ctx = makeMemCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await agency.withTestContext(
+      { ctx: execCtx, stack: execCtx.stateStack, threads: new ThreadStore() },
+      async () => {
+        await agency.memory.enable({ dir: tmpRoot });
+        await agency.memory.setId("alice");
+        // remember + forget rely on LLM calls so we skip them here;
+        // call recall to exercise the wiring and assert it returns a
+        // string (empty when there is nothing to recall).
+        const r = await agency.memory.recall("anything");
+        expect(typeof r).toBe("string");
+      },
+    );
+  });
+
+  it("agency.memory.forget no-ops when memory is off", async () => {
+    const ctx = makeMemCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await agency.withTestContext(
+      { ctx: execCtx, stack: execCtx.stateStack, threads: new ThreadStore() },
+      async () => {
+        // No enableMemory call → forget should resolve to undefined.
+        await expect(agency.memory.forget("anything")).resolves.toBeUndefined();
+      },
+    );
   });
 });

--- a/packages/agency-lang/lib/runtime/agency.ts
+++ b/packages/agency-lang/lib/runtime/agency.ts
@@ -57,6 +57,16 @@ import type { StateStack } from "./state/stateStack.js";
 import type { MessageThread } from "./state/messageThread.js";
 import type { ThreadStore } from "./state/threadStore.js";
 import type { HandlerFn } from "./types.js";
+import type { MemoryConfig } from "./memory/types.js";
+import {
+  _enableMemory,
+  _disableMemory,
+  _setMemoryId,
+  _shouldRunMemory,
+  _remember,
+  _recall,
+  _forget,
+} from "../stdlib/memory.js";
 
 // ---- Context reads -----------------------------------------------------
 
@@ -221,6 +231,36 @@ const addCost = (amount: number): void => {
   stack.enforceGuards();
 };
 
+// ---- Memory subnamespace ---------------------------------------------
+
+/** Push a memory frame onto the active branch's stateStack. See
+ *  `stdlib/memory.agency`'s `enableMemory` for the user-facing
+ *  contract — same dir as top is a no-op, different dir stacks. */
+const memoryEnable = (config: MemoryConfig): Promise<void> =>
+  _enableMemory(config);
+
+/** Pop the top memory frame on the active branch's stateStack.
+ *  Pops the JSON-seeded bottom frame too — library authors should
+ *  not call this casually. */
+const memoryDisable = (): void => _disableMemory();
+
+/** Set the memory scope id (orthogonal to which frame is active —
+ *  persists across pushes/pops). */
+const memorySetId = (id: string): Promise<void> => _setMemoryId(id);
+
+/** `true` iff a memory frame is currently active on the branch. */
+const memoryEnabled = (): boolean => _shouldRunMemory();
+
+/** Extract + store facts from `content`. No-op when no frame is active. */
+const memoryRemember = (content: string): Promise<void> => _remember(content);
+
+/** Retrieve facts as a formatted string. Empty string when no frame
+ *  is active or nothing matches. */
+const memoryRecall = (query: string): Promise<string> => _recall(query);
+
+/** Soft-delete facts matching `query`. No-op when no frame is active. */
+const memoryForget = (query: string): Promise<void> => _forget(query);
+
 // ---- Test helpers ------------------------------------------------------
 
 /**
@@ -277,7 +317,18 @@ export const agency = {
 
   interrupt,
 
+  memory: {
+    enable: memoryEnable,
+    disable: memoryDisable,
+    setId: memorySetId,
+    enabled: memoryEnabled,
+    remember: memoryRemember,
+    recall: memoryRecall,
+    forget: memoryForget,
+  },
+
   withTestContext,
 };
 
 export type { InterruptOpts, ResumableScope, ResumableScopeOpts };
+export type { MemoryConfig };

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -139,3 +139,4 @@ export type {
   RecursiveValidationOpts,
 } from "./validateChain.js";
 export { CoverageCollector } from "./coverageCollector.js";
+export type { MemoryConfig } from "./memory/types.js";

--- a/packages/agency-lang/lib/runtime/memory/frame.test.ts
+++ b/packages/agency-lang/lib/runtime/memory/frame.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { normalizeMemoryFrame } from "./frame.js";
+import { MemoryFrame } from "./frame.js";
 
-describe("normalizeMemoryFrame", () => {
+describe("MemoryFrame", () => {
   let tmpRoot: string;
   let originalCwd: string;
 
@@ -20,7 +20,7 @@ describe("normalizeMemoryFrame", () => {
   });
 
   it("resolves a relative dir against process.cwd() and mkdir-p's it", () => {
-    const frame = normalizeMemoryFrame({ dir: "./relmem" });
+    const frame = new MemoryFrame({ dir: "./relmem" });
     // realpath canonicalizes the tmp root too (on macOS /tmp -> /private/tmp).
     expect(frame.configKey).toBe(
       fs.realpathSync(path.resolve(tmpRoot, "relmem")),
@@ -30,13 +30,13 @@ describe("normalizeMemoryFrame", () => {
 
   it("does not re-resolve an already-absolute dir against cwd", () => {
     const absoluteDir = path.join(tmpRoot, "absmem");
-    const frame = normalizeMemoryFrame({ dir: absoluteDir });
+    const frame = new MemoryFrame({ dir: absoluteDir });
     expect(frame.configKey).toBe(fs.realpathSync(absoluteDir));
   });
 
   it("auto-creates a nested directory tree if missing", () => {
     const nested = "./deep/nested/mem";
-    const frame = normalizeMemoryFrame({ dir: nested });
+    const frame = new MemoryFrame({ dir: nested });
     expect(fs.existsSync(frame.configKey)).toBe(true);
     expect(frame.configKey).toContain("deep");
   });
@@ -49,12 +49,33 @@ describe("normalizeMemoryFrame", () => {
       compaction: { trigger: "messages" as const, threshold: 50 },
       embeddings: { model: "text-embedding-3-small" },
     };
-    const frame = normalizeMemoryFrame(config);
+    const frame = new MemoryFrame(config);
     expect(frame.config).toEqual(config);
   });
 
   it("throws on empty dir", () => {
-    expect(() => normalizeMemoryFrame({ dir: "" })).toThrow(/required/);
-    expect(() => normalizeMemoryFrame({ dir: "   " })).toThrow(/required/);
+    expect(() => new MemoryFrame({ dir: "" })).toThrow(/required/);
+    expect(() => new MemoryFrame({ dir: "   " })).toThrow(/required/);
+  });
+
+  describe("equals (static)", () => {
+    it("returns true for frames with same configKey, regardless of other config fields", () => {
+      const a = new MemoryFrame({ dir: "./eqmem", model: "gpt-4o" });
+      const b = new MemoryFrame({ dir: "./eqmem", model: "gpt-5" });
+      expect(MemoryFrame.equals(a, b)).toBe(true);
+    });
+
+    it("returns false for frames with different configKey", () => {
+      const a = new MemoryFrame({ dir: "./eq-a" });
+      const b = new MemoryFrame({ dir: "./eq-b" });
+      expect(MemoryFrame.equals(a, b)).toBe(false);
+    });
+
+    it("works on JSON-restored plain-object frames (no class prototype)", () => {
+      const a = new MemoryFrame({ dir: "./jsonmem" });
+      // Simulate the post-serialization shape: plain object, no prototype.
+      const restored = JSON.parse(JSON.stringify(a)) as MemoryFrame;
+      expect(MemoryFrame.equals(a, restored)).toBe(true);
+    });
   });
 });

--- a/packages/agency-lang/lib/runtime/memory/frame.test.ts
+++ b/packages/agency-lang/lib/runtime/memory/frame.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { normalizeMemoryFrame } from "./frame.js";
+
+describe("normalizeMemoryFrame", () => {
+  let tmpRoot: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "memframe-"));
+    process.chdir(tmpRoot);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("resolves a relative dir against process.cwd() and mkdir-p's it", () => {
+    const frame = normalizeMemoryFrame({ dir: "./relmem" });
+    // realpath canonicalizes the tmp root too (on macOS /tmp -> /private/tmp).
+    expect(frame.configKey).toBe(
+      fs.realpathSync(path.resolve(tmpRoot, "relmem")),
+    );
+    expect(fs.existsSync(frame.configKey)).toBe(true);
+  });
+
+  it("does not re-resolve an already-absolute dir against cwd", () => {
+    const absoluteDir = path.join(tmpRoot, "absmem");
+    const frame = normalizeMemoryFrame({ dir: absoluteDir });
+    expect(frame.configKey).toBe(fs.realpathSync(absoluteDir));
+  });
+
+  it("auto-creates a nested directory tree if missing", () => {
+    const nested = "./deep/nested/mem";
+    const frame = normalizeMemoryFrame({ dir: nested });
+    expect(fs.existsSync(frame.configKey)).toBe(true);
+    expect(frame.configKey).toContain("deep");
+  });
+
+  it("preserves full MemoryConfig on the frame so nested options survive", () => {
+    const config = {
+      dir: "./full-config-mem",
+      model: "gpt-4o",
+      autoExtract: { interval: 5 },
+      compaction: { trigger: "messages" as const, threshold: 50 },
+      embeddings: { model: "text-embedding-3-small" },
+    };
+    const frame = normalizeMemoryFrame(config);
+    expect(frame.config).toEqual(config);
+  });
+
+  it("throws on empty dir", () => {
+    expect(() => normalizeMemoryFrame({ dir: "" })).toThrow(/required/);
+    expect(() => normalizeMemoryFrame({ dir: "   " })).toThrow(/required/);
+  });
+});

--- a/packages/agency-lang/lib/runtime/memory/frame.ts
+++ b/packages/agency-lang/lib/runtime/memory/frame.ts
@@ -1,0 +1,50 @@
+/**
+ * Memory frames live on `StateStack.other.memoryFrames`. A frame
+ * is the unit of "where memory is configured right now" — pushed
+ * by `enableMemory(...)` (or the JSON-seeded bottom frame at
+ * `createExecutionContext`), popped by `disableMemory()` or the
+ * `memory(){}` block. The active frame is always "top of stack
+ * or none."
+ *
+ * `MemoryFrame` is intentionally small. It carries:
+ *  - `configKey`: the absolute, mkdir'd dir. Used both as the
+ *    storage location (passed to `getOrCreateStore`) AND as the
+ *    cache key for per-execCtx `MemoryManager` lookup. Two pushes
+ *    of the same `configKey` are deduped by `StateStack.pushMemoryFrame`,
+ *    so process-wide caching is consistent with stack-level identity.
+ *  - `config`: the full user-supplied `MemoryConfig`. The manager
+ *    needs the auxiliary fields (model, autoExtract, compaction,
+ *    embeddings) that don't participate in identity.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import type { MemoryConfig } from "./types.js";
+
+export type MemoryFrame = {
+  configKey: string;
+  config: MemoryConfig;
+};
+
+/**
+ * Single owner of "user-supplied MemoryConfig → MemoryFrame" policy.
+ *
+ *  - Resolves `config.dir` against `process.cwd()` (not the module
+ *    dir, deliberately — `agency.json`'s `memory.dir` does the same,
+ *    so the same string in JSON and in code points at the same
+ *    place).
+ *  - Auto-creates the directory tree if missing.
+ *  - Resolves symlinks via `fs.realpathSync` so two different paths
+ *    that point at the same physical dir dedupe through the
+ *    process-wide store registry.
+ *
+ * Throws if `config.dir` is empty.
+ */
+export function normalizeMemoryFrame(config: MemoryConfig): MemoryFrame {
+  if (!config.dir || config.dir.trim() === "") {
+    throw new Error("enableMemory: `dir` is required and must be non-empty.");
+  }
+  const resolved = path.resolve(process.cwd(), config.dir);
+  fs.mkdirSync(resolved, { recursive: true });
+  const configKey = fs.realpathSync(resolved);
+  return { configKey, config };
+}

--- a/packages/agency-lang/lib/runtime/memory/frame.ts
+++ b/packages/agency-lang/lib/runtime/memory/frame.ts
@@ -6,45 +6,53 @@
  * `memory(){}` block. The active frame is always "top of stack
  * or none."
  *
- * `MemoryFrame` is intentionally small. It carries:
+ * `MemoryFrame` carries:
  *  - `configKey`: the absolute, mkdir'd dir. Used both as the
  *    storage location (passed to `getOrCreateStore`) AND as the
  *    cache key for per-execCtx `MemoryManager` lookup. Two pushes
- *    of the same `configKey` are deduped by `StateStack.pushMemoryFrame`,
- *    so process-wide caching is consistent with stack-level identity.
+ *    of the same `configKey` are deduped by
+ *    `StateStack.pushMemoryFrame`, so process-wide caching is
+ *    consistent with stack-level identity.
  *  - `config`: the full user-supplied `MemoryConfig`. The manager
  *    needs the auxiliary fields (model, autoExtract, compaction,
  *    embeddings) that don't participate in identity.
+ *
+ * The constructor owns the policy ("resolve dir against
+ * `process.cwd()`, mkdir-p, realpath") — the same string in
+ * `agency.json` and in code lands at the same physical store.
+ *
+ * `MemoryFrame.equals` is static (not an instance method) on
+ * purpose: frames survive a JSON round-trip through StateStack
+ * serialization, which drops the class prototype. A plain object
+ * shape `{configKey, config}` still satisfies the type structurally,
+ * so any caller that uses `frame.equals(other)` after a checkpoint
+ * restore would `TypeError`. The static form works on both fresh
+ * `new MemoryFrame(...)` instances and JSON-restored plain shapes,
+ * which is what we need because checkpoint restore is real.
  */
 import fs from "node:fs";
 import path from "node:path";
 import type { MemoryConfig } from "./types.js";
 
-export type MemoryFrame = {
-  configKey: string;
-  config: MemoryConfig;
-};
+export class MemoryFrame {
+  readonly configKey: string;
+  readonly config: MemoryConfig;
 
-/**
- * Single owner of "user-supplied MemoryConfig → MemoryFrame" policy.
- *
- *  - Resolves `config.dir` against `process.cwd()` (not the module
- *    dir, deliberately — `agency.json`'s `memory.dir` does the same,
- *    so the same string in JSON and in code points at the same
- *    place).
- *  - Auto-creates the directory tree if missing.
- *  - Resolves symlinks via `fs.realpathSync` so two different paths
- *    that point at the same physical dir dedupe through the
- *    process-wide store registry.
- *
- * Throws if `config.dir` is empty.
- */
-export function normalizeMemoryFrame(config: MemoryConfig): MemoryFrame {
-  if (!config.dir || config.dir.trim() === "") {
-    throw new Error("enableMemory: `dir` is required and must be non-empty.");
+  constructor(config: MemoryConfig) {
+    if (!config.dir || config.dir.trim() === "") {
+      throw new Error("enableMemory: `dir` is required and must be non-empty.");
+    }
+    const resolved = path.resolve(process.cwd(), config.dir);
+    fs.mkdirSync(resolved, { recursive: true });
+    this.configKey = fs.realpathSync(resolved);
+    this.config = config;
   }
-  const resolved = path.resolve(process.cwd(), config.dir);
-  fs.mkdirSync(resolved, { recursive: true });
-  const configKey = fs.realpathSync(resolved);
-  return { configKey, config };
+
+  /** Frame identity is purely the resolved dir — two frames pointing
+   *  at the same realpath are interchangeable for stack-dedup and
+   *  manager-cache lookup, regardless of auxiliary config like
+   *  `model` or `compaction.threshold`. */
+  static equals(a: MemoryFrame, b: MemoryFrame): boolean {
+    return a.configKey === b.configKey;
+  }
 }

--- a/packages/agency-lang/lib/runtime/memory/index.ts
+++ b/packages/agency-lang/lib/runtime/memory/index.ts
@@ -9,5 +9,8 @@ export type {
   MemoryIdRef,
   ForgetResult,
 } from "./manager.js";
+export { getOrCreateStore, _resetStoreRegistry } from "./registry.js";
+export { normalizeMemoryFrame } from "./frame.js";
+export type { MemoryFrame } from "./frame.js";
 export { ExtractionResultSchema } from "./extraction.js";
 export type { ExtractionResult } from "./extraction.js";

--- a/packages/agency-lang/lib/runtime/memory/index.ts
+++ b/packages/agency-lang/lib/runtime/memory/index.ts
@@ -10,7 +10,6 @@ export type {
   ForgetResult,
 } from "./manager.js";
 export { getOrCreateStore, _resetStoreRegistry } from "./registry.js";
-export { normalizeMemoryFrame } from "./frame.js";
-export type { MemoryFrame } from "./frame.js";
+export { MemoryFrame } from "./frame.js";
 export { ExtractionResultSchema } from "./extraction.js";
 export type { ExtractionResult } from "./extraction.js";

--- a/packages/agency-lang/lib/runtime/memory/registry.test.ts
+++ b/packages/agency-lang/lib/runtime/memory/registry.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { getOrCreateStore, _resetStoreRegistry } from "./registry.js";
+import { FileMemoryStore } from "./store.js";
+
+describe("memory registry", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    _resetStoreRegistry();
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "memreg-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    _resetStoreRegistry();
+  });
+
+  it("returns the same instance for the same absDir", () => {
+    const a = getOrCreateStore(tmpRoot);
+    const b = getOrCreateStore(tmpRoot);
+    expect(a).toBe(b);
+    expect(a).toBeInstanceOf(FileMemoryStore);
+  });
+
+  it("returns different stores for different absDirs", () => {
+    const otherDir = fs.mkdtempSync(path.join(os.tmpdir(), "memreg-other-"));
+    try {
+      const a = getOrCreateStore(tmpRoot);
+      const b = getOrCreateStore(otherDir);
+      expect(a).not.toBe(b);
+    } finally {
+      fs.rmSync(otherDir, { recursive: true, force: true });
+    }
+  });
+
+  it("two execCtxs in the same process see the same underlying store", () => {
+    // Simulates two execCtxs both calling getOrCreateStore with the
+    // same absDir; the resulting stores must be reference-equal so
+    // writes from one are visible to the other without disk reload.
+    const execCtxAStore = getOrCreateStore(tmpRoot);
+    const execCtxBStore = getOrCreateStore(tmpRoot);
+    expect(execCtxAStore).toBe(execCtxBStore);
+  });
+});

--- a/packages/agency-lang/lib/runtime/memory/registry.ts
+++ b/packages/agency-lang/lib/runtime/memory/registry.ts
@@ -1,0 +1,45 @@
+/**
+ * Process-wide registry of `FileMemoryStore` instances keyed by
+ * absolute directory path. Stores are heavy (they own JSON file
+ * caches, embedding indices, and per-id directories), so creating
+ * a fresh one per execCtx that points at the same on-disk location
+ * would (a) waste memory and (b) cause two parallel runs in the
+ * same process to see stale writes from each other.
+ *
+ * Sharing by absolute dir gives us a single source of truth per
+ * physical store. Per-execCtx behaviour that differs (log level,
+ * statelog client, smoltalk defaults) lives on the `MemoryManager`
+ * wrapping the store, not on the store itself, so it's safe to
+ * share the underlying file layer.
+ *
+ * Keys are absolute paths from `normalizeMemoryFrame` (which mkdirs
+ * and resolves against `process.cwd()`); callers must NOT pass raw
+ * user input here. Tests can call `_resetStoreRegistry()` between
+ * cases to start clean.
+ */
+import { FileMemoryStore } from "./store.js";
+import type { LogLevel } from "../../logger.js";
+
+const stores: Record<string, FileMemoryStore> = {};
+
+/**
+ * Return the `FileMemoryStore` for `absDir`, creating it on first
+ * call. The directory itself must already exist (callers route
+ * through `normalizeMemoryFrame`, which mkdir-p's before reaching
+ * here).
+ */
+export function getOrCreateStore(
+  absDir: string,
+  logLevel?: LogLevel,
+): FileMemoryStore {
+  const existing = stores[absDir];
+  if (existing) return existing;
+  const store = new FileMemoryStore(absDir, logLevel);
+  stores[absDir] = store;
+  return store;
+}
+
+/** Test-only: drop all cached stores. */
+export function _resetStoreRegistry(): void {
+  for (const key of Object.keys(stores)) delete stores[key];
+}

--- a/packages/agency-lang/lib/runtime/memory/registry.ts
+++ b/packages/agency-lang/lib/runtime/memory/registry.ts
@@ -12,10 +12,39 @@
  * wrapping the store, not on the store itself, so it's safe to
  * share the underlying file layer.
  *
- * Keys are absolute paths from `normalizeMemoryFrame` (which mkdirs
- * and resolves against `process.cwd()`); callers must NOT pass raw
- * user input here. Tests can call `_resetStoreRegistry()` between
- * cases to start clean.
+ * Keys are absolute paths from `MemoryFrame`'s constructor (which
+ * mkdirs and resolves against `process.cwd()`); callers must NOT
+ * pass raw user input here. Tests can call `_resetStoreRegistry()`
+ * between cases to start clean.
+ *
+ * ## Interaction with the execution model
+ *
+ * (See https://agency-lang.com/guide/execution-model.html for the
+ * runtime's deterministic-replay invariants.)
+ *
+ * - **Multiple agent runs in the same process sharing one `absDir`:**
+ *   intentional. Both runs see the same `FileMemoryStore`, which
+ *   means writes from run A are visible to run B (and vice versa)
+ *   if they touch the same `memoryId`. That's the whole point of a
+ *   file-backed store — memory persists across runs and is shared
+ *   between concurrent agents working on the same workspace. Each
+ *   run still has its own `MemoryManager` wrapping the store
+ *   (per-execCtx statelog client, log level, smoltalk defaults).
+ * - **Relationship to `memoryId`:** `absDir` is *where* the store
+ *   lives on disk; `memoryId` (set via `setMemoryId(...)`) is
+ *   *which scope* inside it — the store keeps per-id subdirectories.
+ *   The two are orthogonal: one store can serve many ids, and the
+ *   same id can refer to different graphs under different `absDir`s.
+ *   `setMemoryId` lives on `stateStack.other.memoryId` and persists
+ *   across `enableMemory` / `disableMemory` calls, so switching
+ *   stores does NOT switch ids — call `setMemoryId(...)` explicitly
+ *   when you want a fresh scope for a new store.
+ * - **Determinism:** the store is shared *state*. Two concurrent
+ *   runs that read-modify-write the same `(absDir, memoryId)` race
+ *   the same way any two processes touching the same file would.
+ *   Memory is intentionally outside the deterministic-replay
+ *   contract — see `docs/dev/checkpointing.md` for which state IS
+ *   in the contract.
  */
 import { FileMemoryStore } from "./store.js";
 import type { LogLevel } from "../../logger.js";
@@ -25,8 +54,8 @@ const stores: Record<string, FileMemoryStore> = {};
 /**
  * Return the `FileMemoryStore` for `absDir`, creating it on first
  * call. The directory itself must already exist (callers route
- * through `normalizeMemoryFrame`, which mkdir-p's before reaching
- * here).
+ * through `MemoryFrame`'s constructor, which mkdir-p's before
+ * reaching here).
  */
 export function getOrCreateStore(
   absDir: string,

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -352,10 +352,11 @@ export async function runNode({
     execCtx.statelogClient.endSpan(agentRunSpanId); // end agentRun span
     // Persist any in-memory MemoryManager state. Writes are best-effort —
     // we never fail the run because of a save error, but we do log it so
-    // disk problems are visible.
-    if (execCtx.memoryManager) {
+    // disk problems are visible. Iterate every cached manager so a fork
+    // branch that opened a side store doesn't lose its writes.
+    for (const manager of execCtx.getAllCachedMemoryManagers()) {
       try {
-        await execCtx.memoryManager.save();
+        await manager.save();
       } catch (err) {
         console.warn(
           `[memory] save failed: ${(err as Error).message}`,

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -211,11 +211,12 @@ async function _runPrompt({
   // Tool-call results have not been pushed yet, so we operate on the
   // current message slice. Compaction is a best-effort hint — failures
   // never break the LLM call.
-  if (ctx.memoryManager) {
+  const memoryManager = ctx.getActiveMemoryManager();
+  if (memoryManager) {
     try {
       const original = messages.getMessages();
-      await ctx.memoryManager.onTurn(original);
-      const plan = await ctx.memoryManager.compactIfNeeded(original);
+      await memoryManager.onTurn(original);
+      const plan = await memoryManager.compactIfNeeded(original);
       if (plan) {
         // Reassemble the thread from the ORIGINAL smoltalk Message
         // instances so tool_call metadata, ids, and other class-level
@@ -398,9 +399,10 @@ export async function runPrompt(args: {
   // (re-entries after a later tool-batch bailout skip this step).
   await pr.step("initialLlmCall", async () => {
     let injectedFactsContent: string | null = null;
-    if (memoryOption && ctx.memoryManager) {
+    const recallManager = ctx.getActiveMemoryManager();
+    if (memoryOption && recallManager) {
       try {
-        const facts = await ctx.memoryManager.recallForInjection(prompt);
+        const facts = await recallManager.recallForInjection(prompt);
         if (facts) {
           injectedFactsContent = `Relevant context from memory:\n${facts}`;
           messages.push(smoltalk.systemMessage(injectedFactsContent));

--- a/packages/agency-lang/lib/runtime/state/context.test.ts
+++ b/packages/agency-lang/lib/runtime/state/context.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { RuntimeContext } from "./context.js";
+import { StateStack } from "./stateStack.js";
 import { AgencyCancelledError } from "../errors.js";
+import {
+  _resetStoreRegistry,
+  normalizeMemoryFrame,
+} from "../memory/index.js";
 
 function makeMockCtx() {
   return new RuntimeContext({
@@ -65,5 +73,118 @@ describe("RuntimeContext", () => {
       ctx.cleanup();
       expect(ctx.abortController.signal.aborted).toBe(true);
     });
+  });
+});
+
+describe("RuntimeContext memory frames", () => {
+  let tmpRoot: string;
+  let dirA: string;
+  let dirB: string;
+  let dirJson: string;
+
+  beforeEach(() => {
+    _resetStoreRegistry();
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ctxmem-"));
+    dirA = path.join(tmpRoot, "a");
+    dirB = path.join(tmpRoot, "b");
+    dirJson = path.join(tmpRoot, "json");
+    fs.mkdirSync(dirA);
+    fs.mkdirSync(dirB);
+    fs.mkdirSync(dirJson);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    _resetStoreRegistry();
+  });
+
+  function makeCtx(memory?: { dir: string }) {
+    return new RuntimeContext({
+      statelogConfig: {
+        host: "https://example.com",
+        apiKey: "test-api-key",
+        projectId: "test-project",
+        debugMode: false,
+      },
+      smoltalkDefaults: {},
+      dirname: tmpRoot,
+      memory,
+    });
+  }
+
+  it("getActiveMemoryManager() returns undefined when nothing is configured", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    expect(execCtx.getActiveMemoryManager()).toBeUndefined();
+  });
+
+  it("returns a JSON-seeded manager when only agency.json is set", async () => {
+    const ctx = makeCtx({ dir: dirJson });
+    const execCtx = await ctx.createExecutionContext("r1");
+    const m = execCtx.getActiveMemoryManager();
+    expect(m).toBeDefined();
+  });
+
+  it("frame push overrides JSON; pop returns to JSON manager (same instance)", async () => {
+    const ctx = makeCtx({ dir: dirJson });
+    const execCtx = await ctx.createExecutionContext("r1");
+    const jsonManager = execCtx.getActiveMemoryManager();
+    expect(jsonManager).toBeDefined();
+
+    execCtx.stateStack.pushMemoryFrame(normalizeMemoryFrame({ dir: dirA }));
+    const aManager = execCtx.getActiveMemoryManager();
+    expect(aManager).toBeDefined();
+    expect(aManager).not.toBe(jsonManager);
+
+    execCtx.stateStack.popMemoryFrame();
+    expect(execCtx.getActiveMemoryManager()).toBe(jsonManager);
+  });
+
+  it("manager cache survives push/pop/push (pop back returns the cached A)", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    execCtx.stateStack.pushMemoryFrame(normalizeMemoryFrame({ dir: dirA }));
+    const a1 = execCtx.getActiveMemoryManager();
+
+    execCtx.stateStack.pushMemoryFrame(normalizeMemoryFrame({ dir: dirB }));
+    const b = execCtx.getActiveMemoryManager();
+    expect(b).not.toBe(a1);
+
+    execCtx.stateStack.popMemoryFrame();
+    const a2 = execCtx.getActiveMemoryManager();
+    expect(a2).toBe(a1);
+  });
+
+  it("re-seeds the JSON bottom frame when restoring an old checkpoint without memoryFrames", async () => {
+    const ctx = makeCtx({ dir: dirJson });
+    const execCtx = await ctx.createExecutionContext("r1");
+
+    // Simulate an old-format stateStack: has `other.memoryId` but no
+    // `other.memoryFrames` (predates this feature).
+    const stack = new StateStack();
+    stack.other.memoryId = "alice";
+    execCtx.stateStack = stack;
+
+    const m = execCtx.getActiveMemoryManager();
+    expect(m).toBeDefined();
+    expect(execCtx.stateStack.topMemoryFrame()?.configKey).toBe(
+      fs.realpathSync(dirJson),
+    );
+  });
+
+  it("returns undefined after the user pops the JSON-seeded bottom frame", async () => {
+    // Per plan resolved decision (Gap 5): disableMemory() pops
+    // whatever is on top, including the JSON-seeded bottom frame.
+    // Memory then goes off until the next enableMemory(). The
+    // old-checkpoint re-seed deliberately does NOT fire after an
+    // explicit pop — `popMemoryFrame` leaves an empty array on the
+    // stack so we can distinguish "never set" from "explicitly
+    // emptied."
+    const ctx = makeCtx({ dir: dirJson });
+    const execCtx = await ctx.createExecutionContext("r1");
+    expect(execCtx.getActiveMemoryManager()).toBeDefined();
+
+    execCtx.stateStack.popMemoryFrame();
+    expect(execCtx.getActiveMemoryManager()).toBeUndefined();
   });
 });

--- a/packages/agency-lang/lib/runtime/state/context.test.ts
+++ b/packages/agency-lang/lib/runtime/state/context.test.ts
@@ -5,10 +5,7 @@ import path from "node:path";
 import { RuntimeContext } from "./context.js";
 import { StateStack } from "./stateStack.js";
 import { AgencyCancelledError } from "../errors.js";
-import {
-  _resetStoreRegistry,
-  normalizeMemoryFrame,
-} from "../memory/index.js";
+import { _resetStoreRegistry, MemoryFrame } from "../memory/index.js";
 
 function makeMockCtx() {
   return new RuntimeContext({
@@ -131,7 +128,7 @@ describe("RuntimeContext memory frames", () => {
     const jsonManager = execCtx.getActiveMemoryManager();
     expect(jsonManager).toBeDefined();
 
-    execCtx.stateStack.pushMemoryFrame(normalizeMemoryFrame({ dir: dirA }));
+    execCtx.stateStack.pushMemoryFrame(new MemoryFrame({ dir: dirA }));
     const aManager = execCtx.getActiveMemoryManager();
     expect(aManager).toBeDefined();
     expect(aManager).not.toBe(jsonManager);
@@ -143,10 +140,10 @@ describe("RuntimeContext memory frames", () => {
   it("manager cache survives push/pop/push (pop back returns the cached A)", async () => {
     const ctx = makeCtx();
     const execCtx = await ctx.createExecutionContext("r1");
-    execCtx.stateStack.pushMemoryFrame(normalizeMemoryFrame({ dir: dirA }));
+    execCtx.stateStack.pushMemoryFrame(new MemoryFrame({ dir: dirA }));
     const a1 = execCtx.getActiveMemoryManager();
 
-    execCtx.stateStack.pushMemoryFrame(normalizeMemoryFrame({ dir: dirB }));
+    execCtx.stateStack.pushMemoryFrame(new MemoryFrame({ dir: dirB }));
     const b = execCtx.getActiveMemoryManager();
     expect(b).not.toBe(a1);
 
@@ -167,7 +164,7 @@ describe("RuntimeContext memory frames", () => {
 
     const m = execCtx.getActiveMemoryManager();
     expect(m).toBeDefined();
-    expect(execCtx.stateStack.topMemoryFrame()?.configKey).toBe(
+    expect(execCtx.stateStack.activeMemoryFrame()?.configKey).toBe(
       fs.realpathSync(dirJson),
     );
   });

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -11,11 +11,9 @@ import type { AgencyCallbacks } from "../hooks.js";
 import type { InterruptResponse } from "../interrupts.js";
 import { LLMClient, SmoltalkClient } from "../llmClient.js";
 import { MemoryManager } from "../memory/manager.js";
-import { FileMemoryStore } from "../memory/store.js";
-import type {
-  MemoryConfig,
-  MemoryStore as MemoryStoreType,
-} from "../memory/types.js";
+import { normalizeMemoryFrame, type MemoryFrame } from "../memory/frame.js";
+import { getOrCreateStore } from "../memory/registry.js";
+import type { MemoryConfig } from "../memory/types.js";
 import { GlobalStore } from "../state/globalStore.js";
 import { StateStack } from "../state/stateStack.js";
 import { TraceWriter } from "../trace/traceWriter.js";
@@ -145,12 +143,23 @@ export class RuntimeContext<T> {
   maxRestores: number;
 
   // Memory layer (resolved decisions in
-  // docs/superpowers/plans/2026-05-12-memory-layer.md). The store is
-  // process-wide and shared across runs; each execCtx gets its own
-  // MemoryManager instance bound to its stateStack.
-  private memoryConfig?: MemoryConfig;
-  private memoryStore?: MemoryStoreType;
-  memoryManager?: MemoryManager;
+  // docs/superpowers/plans/2026-05-12-memory-layer.md and
+  // docs/superpowers/plans/2026-05-29-memory-config-in-code.md).
+  //
+  // `jsonMemoryConfig` is the immutable seed from `agency.json`'s
+  // `memory:` block. Each execCtx pushes it as the bottom frame on
+  // its stateStack at construction so the active config is always
+  // "top of stack or nothing." Code calls to `enableMemory(...)`
+  // push additional frames on top. The "code wins over JSON" rule
+  // is structural, not coded.
+  //
+  // Per-execCtx managers are cached by `configKey` so we don't
+  // rebuild a heavy MemoryManager every time stdlib code looks up
+  // the active manager. Cache lives on each execCtx (not on this
+  // parent context) because manager construction takes the
+  // execCtx's own statelog client / log level / llm client.
+  jsonMemoryConfig?: MemoryConfig;
+  private memoryManagerCache: Record<string, MemoryManager> = {};
 
   constructor(args: {
     statelogConfig: StatelogConfig;
@@ -211,12 +220,12 @@ export class RuntimeContext<T> {
       this.coverageCollector = getProcessCoverageCollector();
     }
 
+    // JSON-derived memory config is kept as an immutable seed; the
+    // actual store + manager are looked up lazily through
+    // `getActiveMemoryManager()` on each execCtx so there's a single
+    // source of truth (the active stateStack's frame stack).
     if (args.memory) {
-      this.memoryConfig = args.memory;
-      // Pass logLevel so the file store can chatter at debug about
-      // every read/write — handy for spotting "why isn't anything
-      // persisting?" without a debugger.
-      this.memoryStore = new FileMemoryStore(args.memory.dir, this.logLevel);
+      this.jsonMemoryConfig = args.memory;
     }
   }
 
@@ -265,42 +274,105 @@ export class RuntimeContext<T> {
     });
     execCtx.coverageCollector = this.coverageCollector;
 
-    // Memory layer: per-execCtx MemoryManager backed by the shared store.
-    // The memoryIdRef reads/writes stateStack.other.memoryId so the active
-    // id survives interrupt/resume (resolved decision #1). We capture
-    // execCtx in the closure rather than reading `this`, because the ref
-    // must always see execCtx's current stateStack (which can be replaced
-    // by restoreState).
-    if (this.memoryConfig && this.memoryStore) {
-      execCtx.memoryConfig = this.memoryConfig;
-      execCtx.memoryStore = this.memoryStore;
-      execCtx.memoryManager = new MemoryManager({
-        store: this.memoryStore,
-        config: this.memoryConfig,
-        llmClient: execCtx._llmClient,
-        smoltalkDefaults: execCtx.smoltalkDefaults,
-        source: this.traceConfig?.program ?? "agent",
-        // Reuse the per-execCtx StatelogClient so memory's own LLM/embed
-        // spans nest under the same trace as the agent's calls.
-        statelogClient: execCtx.statelogClient,
-        // Threshold for memory's internal logger; promoting this to
-        // "debug" in agency.json surfaces every tier/extract/compact
-        // step on stderr.
-        logLevel: execCtx.logLevel,
-        memoryIdRef: {
-          get: () => {
-            const id = execCtx.stateStack?.other?.memoryId;
-            return typeof id === "string" ? id : "default";
-          },
-          set: (id: string) => {
-            if (!execCtx.stateStack) return;
-            execCtx.stateStack.other.memoryId = id;
-          },
-        },
-      });
+    // Memory layer: per-execCtx state.
+    //   - jsonMemoryConfig is forwarded so `getActiveMemoryManager()`
+    //     can re-seed the bottom frame on resumes from old
+    //     checkpoints that pre-date frames-on-stateStack.
+    //   - memoryManagerCache is per-execCtx (statelog client, llm
+    //     client, log level are all per-execCtx).
+    //   - JSON config seeds the BOTTOM frame on the new stateStack;
+    //     after this point the active stack is the only source of
+    //     truth. Code-level `enableMemory(...)` pushes on top.
+    execCtx.jsonMemoryConfig = this.jsonMemoryConfig;
+    execCtx.memoryManagerCache = {};
+    if (this.jsonMemoryConfig) {
+      execCtx.stateStack.pushMemoryFrame(
+        normalizeMemoryFrame(this.jsonMemoryConfig),
+      );
     }
 
     return execCtx;
+  }
+
+  /**
+   * Resolve the active `MemoryManager` for the current stateStack.
+   *
+   * Single rule: top of `stateStack.other.memoryFrames` (accessed via
+   * `topMemoryFrame()`) wins. No fallback to a "default" manager —
+   * the JSON config gets seeded as the bottom frame at execCtx
+   * creation, so if JSON was set there will always be a frame and
+   * this never returns `undefined` for JSON-only setups.
+   *
+   * The one back-compat seam: a checkpoint written before
+   * `memoryFrames` existed (or one taken right after a user called
+   * `disableMemory()` on the JSON-seeded bottom frame) has no frames.
+   * If `jsonMemoryConfig` is set we re-seed it as a courtesy so old
+   * traces resume as before. If the user explicitly popped, they
+   * call `enableMemory(...)` again to turn it back on.
+   *
+   * Managers are cached per execCtx keyed by `configKey` so
+   * push/pop/push of the same dir reuses one instance — important
+   * for the "pop back to A returns A's manager" semantics.
+   */
+  getActiveMemoryManager(): MemoryManager | undefined {
+    if (!this.stateStack) return undefined;
+    let frame = this.stateStack.topMemoryFrame();
+    if (!frame && this.jsonMemoryConfig) {
+      // Old-checkpoint back-compat: stateStack restored without any
+      // memoryFrames at all. Re-seed the JSON bottom frame so
+      // resume behaves like a fresh run.
+      const memoryFramesArr = this.stateStack.other.memoryFrames as
+        | MemoryFrame[]
+        | undefined;
+      if (!memoryFramesArr) {
+        this.stateStack.pushMemoryFrame(
+          normalizeMemoryFrame(this.jsonMemoryConfig),
+        );
+        frame = this.stateStack.topMemoryFrame();
+      }
+    }
+    if (!frame) return undefined;
+
+    const cached = this.memoryManagerCache[frame.configKey];
+    if (cached) return cached;
+
+    const manager = new MemoryManager({
+      store: getOrCreateStore(frame.configKey, this.logLevel),
+      config: frame.config,
+      llmClient: this._llmClient,
+      smoltalkDefaults: this.smoltalkDefaults,
+      source: this.traceConfig?.program ?? "agent",
+      // Reuse the per-execCtx StatelogClient so memory's own LLM/embed
+      // spans nest under the same trace as the agent's calls.
+      statelogClient: this.statelogClient,
+      // Threshold for memory's internal logger; promoting this to
+      // "debug" in agency.json surfaces every tier/extract/compact
+      // step on stderr.
+      logLevel: this.logLevel,
+      memoryIdRef: {
+        // memoryId is orthogonal to which frame is active — it lives
+        // on `stateStack.other.memoryId` and persists across frame
+        // pushes/pops. We capture `this` (the execCtx) so the ref
+        // always sees the current stateStack (which can be replaced
+        // by `restoreState`).
+        get: () => {
+          const id = this.stateStack?.other?.memoryId;
+          return typeof id === "string" ? id : "default";
+        },
+        set: (id: string) => {
+          if (!this.stateStack) return;
+          this.stateStack.other.memoryId = id;
+        },
+      },
+    });
+    this.memoryManagerCache[frame.configKey] = manager;
+    return manager;
+  }
+
+  /** Iterate every cached memory manager. Used at shutdown so a
+   *  branch that opened a side store doesn't lose its writes. */
+  getAllCachedMemoryManagers(): MemoryManager[] {
+    return Object.values(this.memoryManagerCache);
   }
 
   /* Let's chat through what's going on here. Because since this function
@@ -409,6 +481,7 @@ export class RuntimeContext<T> {
     this.callbacks = null as any;
     this.handlers = null as any;
     this.traceWriter = null;
+    this.memoryManagerCache = {};
   }
 
   /** Get the most recent result-entry checkpoint for the current function. */

--- a/packages/agency-lang/lib/runtime/state/context.ts
+++ b/packages/agency-lang/lib/runtime/state/context.ts
@@ -11,7 +11,7 @@ import type { AgencyCallbacks } from "../hooks.js";
 import type { InterruptResponse } from "../interrupts.js";
 import { LLMClient, SmoltalkClient } from "../llmClient.js";
 import { MemoryManager } from "../memory/manager.js";
-import { normalizeMemoryFrame, type MemoryFrame } from "../memory/frame.js";
+import { MemoryFrame } from "../memory/frame.js";
 import { getOrCreateStore } from "../memory/registry.js";
 import type { MemoryConfig } from "../memory/types.js";
 import { GlobalStore } from "../state/globalStore.js";
@@ -286,9 +286,7 @@ export class RuntimeContext<T> {
     execCtx.jsonMemoryConfig = this.jsonMemoryConfig;
     execCtx.memoryManagerCache = {};
     if (this.jsonMemoryConfig) {
-      execCtx.stateStack.pushMemoryFrame(
-        normalizeMemoryFrame(this.jsonMemoryConfig),
-      );
+      execCtx.stateStack.pushMemoryFrame(new MemoryFrame(this.jsonMemoryConfig));
     }
 
     return execCtx;
@@ -298,7 +296,7 @@ export class RuntimeContext<T> {
    * Resolve the active `MemoryManager` for the current stateStack.
    *
    * Single rule: top of `stateStack.other.memoryFrames` (accessed via
-   * `topMemoryFrame()`) wins. No fallback to a "default" manager —
+   * `activeMemoryFrame()`) wins. No fallback to a "default" manager —
    * the JSON config gets seeded as the bottom frame at execCtx
    * creation, so if JSON was set there will always be a frame and
    * this never returns `undefined` for JSON-only setups.
@@ -316,20 +314,16 @@ export class RuntimeContext<T> {
    */
   getActiveMemoryManager(): MemoryManager | undefined {
     if (!this.stateStack) return undefined;
-    let frame = this.stateStack.topMemoryFrame();
-    if (!frame && this.jsonMemoryConfig) {
-      // Old-checkpoint back-compat: stateStack restored without any
-      // memoryFrames at all. Re-seed the JSON bottom frame so
-      // resume behaves like a fresh run.
-      const memoryFramesArr = this.stateStack.other.memoryFrames as
-        | MemoryFrame[]
-        | undefined;
-      if (!memoryFramesArr) {
-        this.stateStack.pushMemoryFrame(
-          normalizeMemoryFrame(this.jsonMemoryConfig),
-        );
-        frame = this.stateStack.topMemoryFrame();
-      }
+    let frame = this.stateStack.activeMemoryFrame();
+    if (!frame && this.jsonMemoryConfig && !this.stateStack.hasMemoryFrameStack()) {
+      // Old-checkpoint back-compat: stateStack restored from a
+      // pre-memoryFrames snapshot (the array key isn't present at
+      // all). Re-seed the JSON bottom frame so resume behaves like
+      // a fresh run. An empty-array stack (user explicitly called
+      // `disableMemory()`) is NOT re-seeded — that would silently
+      // resurrect what the user asked to turn off.
+      this.stateStack.pushMemoryFrame(new MemoryFrame(this.jsonMemoryConfig));
+      frame = this.stateStack.activeMemoryFrame();
     }
     if (!frame) return undefined;
 

--- a/packages/agency-lang/lib/runtime/state/stateStack.test.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.test.ts
@@ -703,3 +703,63 @@ describe("StateStack.rehydrateInheritedGuardsFrom", () => {
     expect(child.inheritedGuardCount).toBe(0);
   });
 });
+
+describe("StateStack memory frames", () => {
+  const frameA = { configKey: "/abs/dirA", config: { dir: "/abs/dirA" } };
+  const frameAOther = { configKey: "/abs/dirA", config: { dir: "/abs/dirA", model: "different" } };
+  const frameB = { configKey: "/abs/dirB", config: { dir: "/abs/dirB" } };
+
+  it("topMemoryFrame returns undefined on a fresh stack", () => {
+    const s = new StateStack();
+    expect(s.topMemoryFrame()).toBeUndefined();
+  });
+
+  it("pushMemoryFrame then topMemoryFrame returns the frame", () => {
+    const s = new StateStack();
+    s.pushMemoryFrame(frameA);
+    expect(s.topMemoryFrame()).toEqual(frameA);
+  });
+
+  it("same-dir push is a no-op (does not stack)", () => {
+    const s = new StateStack();
+    s.pushMemoryFrame(frameA);
+    s.pushMemoryFrame(frameAOther);
+    expect(s.topMemoryFrame()).toEqual(frameA);
+    // pop once should leave the stack empty
+    s.popMemoryFrame();
+    expect(s.topMemoryFrame()).toBeUndefined();
+  });
+
+  it("different-dir push stacks on top, pop returns to previous", () => {
+    const s = new StateStack();
+    s.pushMemoryFrame(frameA);
+    s.pushMemoryFrame(frameB);
+    expect(s.topMemoryFrame()).toEqual(frameB);
+    s.popMemoryFrame();
+    expect(s.topMemoryFrame()).toEqual(frameA);
+  });
+
+  it("popMemoryFrame on empty returns undefined and leaves stack empty", () => {
+    const s = new StateStack();
+    expect(s.popMemoryFrame()).toBeUndefined();
+    expect(s.topMemoryFrame()).toBeUndefined();
+  });
+
+  it("frames survive a serialize/deserialize roundtrip with nested config", () => {
+    const richFrame = {
+      configKey: "/abs/rich",
+      config: {
+        dir: "/abs/rich",
+        model: "gpt-4o",
+        autoExtract: { interval: 7 },
+        compaction: { trigger: "messages" as const, threshold: 100 },
+        embeddings: { model: "text-embedding-3-small" },
+      },
+    };
+    const s = new StateStack();
+    s.pushMemoryFrame(richFrame);
+    const json = s.toJSON();
+    const restored = StateStack.fromJSON(json);
+    expect(restored.topMemoryFrame()).toEqual(richFrame);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/stateStack.test.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.test.ts
@@ -709,40 +709,50 @@ describe("StateStack memory frames", () => {
   const frameAOther = { configKey: "/abs/dirA", config: { dir: "/abs/dirA", model: "different" } };
   const frameB = { configKey: "/abs/dirB", config: { dir: "/abs/dirB" } };
 
-  it("topMemoryFrame returns undefined on a fresh stack", () => {
+  it("activeMemoryFrame returns undefined on a fresh stack", () => {
     const s = new StateStack();
-    expect(s.topMemoryFrame()).toBeUndefined();
+    expect(s.activeMemoryFrame()).toBeUndefined();
   });
 
-  it("pushMemoryFrame then topMemoryFrame returns the frame", () => {
+  it("hasMemoryFrameStack is false on a fresh stack, true after first push (even on dedup)", () => {
     const s = new StateStack();
+    expect(s.hasMemoryFrameStack()).toBe(false);
     s.pushMemoryFrame(frameA);
-    expect(s.topMemoryFrame()).toEqual(frameA);
+    expect(s.hasMemoryFrameStack()).toBe(true);
+    // pop to empty — flag stays true (distinguishes "user emptied" from "never set")
+    s.popMemoryFrame();
+    expect(s.hasMemoryFrameStack()).toBe(true);
   });
 
-  it("same-dir push is a no-op (does not stack)", () => {
+  it("pushMemoryFrame then activeMemoryFrame returns the frame", () => {
     const s = new StateStack();
-    s.pushMemoryFrame(frameA);
-    s.pushMemoryFrame(frameAOther);
-    expect(s.topMemoryFrame()).toEqual(frameA);
+    expect(s.pushMemoryFrame(frameA)).toBe(true);
+    expect(s.activeMemoryFrame()).toEqual(frameA);
+  });
+
+  it("same-dir push is a no-op (returns false, does not stack)", () => {
+    const s = new StateStack();
+    expect(s.pushMemoryFrame(frameA)).toBe(true);
+    expect(s.pushMemoryFrame(frameAOther)).toBe(false);
+    expect(s.activeMemoryFrame()).toEqual(frameA);
     // pop once should leave the stack empty
     s.popMemoryFrame();
-    expect(s.topMemoryFrame()).toBeUndefined();
+    expect(s.activeMemoryFrame()).toBeUndefined();
   });
 
   it("different-dir push stacks on top, pop returns to previous", () => {
     const s = new StateStack();
     s.pushMemoryFrame(frameA);
     s.pushMemoryFrame(frameB);
-    expect(s.topMemoryFrame()).toEqual(frameB);
+    expect(s.activeMemoryFrame()).toEqual(frameB);
     s.popMemoryFrame();
-    expect(s.topMemoryFrame()).toEqual(frameA);
+    expect(s.activeMemoryFrame()).toEqual(frameA);
   });
 
   it("popMemoryFrame on empty returns undefined and leaves stack empty", () => {
     const s = new StateStack();
     expect(s.popMemoryFrame()).toBeUndefined();
-    expect(s.topMemoryFrame()).toBeUndefined();
+    expect(s.activeMemoryFrame()).toBeUndefined();
   });
 
   it("frames survive a serialize/deserialize roundtrip with nested config", () => {
@@ -760,6 +770,6 @@ describe("StateStack memory frames", () => {
     s.pushMemoryFrame(richFrame);
     const json = s.toJSON();
     const restored = StateStack.fromJSON(json);
-    expect(restored.topMemoryFrame()).toEqual(richFrame);
+    expect(restored.activeMemoryFrame()).toEqual(richFrame);
   });
 });

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -1,6 +1,7 @@
 import type { Guard, GuardJSON } from "../guard.js";
 import { guardFromJSON } from "../guard.js";
 import { Checkpoint } from "../index.js";
+import type { MemoryFrame } from "../memory/frame.js";
 import { deepClone } from "../utils.js";
 import { ThreadStoreJSON } from "./threadStore.js";
 
@@ -328,6 +329,49 @@ export class StateStack {
   // double-serializing shared state.
   guards: Guard[] = [];
   inheritedGuardCount: number = 0;
+
+  /**
+   * Push a memory frame onto this stack. Frames live in `other.memoryFrames`
+   * so they serialize and fork-clone for free via the existing
+   * `other` deepClone path. Callers MUST NOT touch the underlying
+   * array directly — go through these three methods.
+   *
+   * Same-`configKey` as top is a no-op so the common pattern
+   * `static const _ = enableMemory(...)` + an `enableMemory(...)`
+   * in `main()` doesn't double-stack the same frame. Different-dir
+   * pushes stack on top; pop with `popMemoryFrame()` or use the
+   * `memory(){}` block for lexical scoping.
+   */
+  pushMemoryFrame(frame: MemoryFrame): void {
+    const top = this.topMemoryFrame();
+    if (top?.configKey === frame.configKey) return;
+    const existing = (this.other.memoryFrames as MemoryFrame[] | undefined) ?? [];
+    this.other.memoryFrames = [...existing, frame];
+  }
+
+  /** Pop the top memory frame, including the JSON-seeded bottom frame.
+   *  Returns the popped frame or `undefined` if the stack is already
+   *  empty.
+   *
+   *  When the last frame is popped the array stays present (but
+   *  empty) so `topMemoryFrame()` returns `undefined` and the
+   *  old-checkpoint re-seed in `getActiveMemoryManager()` knows the
+   *  user explicitly disabled memory rather than restored an
+   *  ancient snapshot. */
+  popMemoryFrame(): MemoryFrame | undefined {
+    const existing = this.other.memoryFrames as MemoryFrame[] | undefined;
+    if (!existing || existing.length === 0) return undefined;
+    const popped = existing[existing.length - 1];
+    this.other.memoryFrames = existing.slice(0, -1);
+    return popped;
+  }
+
+  /** The active memory frame, or `undefined` if memory is currently off. */
+  topMemoryFrame(): MemoryFrame | undefined {
+    const frames = this.other.memoryFrames as MemoryFrame[] | undefined;
+    if (!frames || frames.length === 0) return undefined;
+    return frames[frames.length - 1];
+  }
 
   pushGuard(guard: Guard): void {
     guard.install(this);

--- a/packages/agency-lang/lib/runtime/state/stateStack.ts
+++ b/packages/agency-lang/lib/runtime/state/stateStack.ts
@@ -1,7 +1,7 @@
 import type { Guard, GuardJSON } from "../guard.js";
 import { guardFromJSON } from "../guard.js";
 import { Checkpoint } from "../index.js";
-import type { MemoryFrame } from "../memory/frame.js";
+import { MemoryFrame } from "../memory/frame.js";
 import { deepClone } from "../utils.js";
 import { ThreadStoreJSON } from "./threadStore.js";
 
@@ -330,23 +330,56 @@ export class StateStack {
   guards: Guard[] = [];
   inheritedGuardCount: number = 0;
 
+  /** Lazy accessor for the frame array, creating it on first push.
+   *  Created with sentinel-marking semantics: once the array exists
+   *  (even if popped to empty), `hasMemoryFrameStack()` returns true,
+   *  which distinguishes "user explicitly disabled memory" from
+   *  "stack restored from a pre-memoryFrames checkpoint". */
+  private memoryFramesArr(): MemoryFrame[] | undefined {
+    return this.other.memoryFrames as MemoryFrame[] | undefined;
+  }
+
+  /** True iff the memory-frame stack has been touched on this
+   *  StateStack (push or pop has run at least once). Returns false
+   *  for stacks restored from pre-memoryFrames checkpoints, which is
+   *  the only legitimate trigger for the JSON-config re-seed back
+   *  in `getActiveMemoryManager`. */
+  hasMemoryFrameStack(): boolean {
+    return this.memoryFramesArr() !== undefined;
+  }
+
   /**
    * Push a memory frame onto this stack. Frames live in `other.memoryFrames`
    * so they serialize and fork-clone for free via the existing
    * `other` deepClone path. Callers MUST NOT touch the underlying
-   * array directly — go through these three methods.
+   * array directly — go through these methods.
    *
-   * Same-`configKey` as top is a no-op so the common pattern
-   * `static const _ = enableMemory(...)` + an `enableMemory(...)`
-   * in `main()` doesn't double-stack the same frame. Different-dir
-   * pushes stack on top; pop with `popMemoryFrame()` or use the
-   * `memory(){}` block for lexical scoping.
+   * Same-`configKey` as the active frame is a no-op so the common
+   * pattern `static const _ = enableMemory(...)` + an
+   * `enableMemory(...)` in `main()` doesn't double-stack the same
+   * frame. Different-dir pushes stack on top; pop with
+   * `popMemoryFrame()` or use the `memory(){}` block for lexical
+   * scoping.
+   *
+   * Returns `true` if the frame was actually pushed, `false` if
+   * deduped. The block form (`memory(){}` in stdlib/memory.agency)
+   * pairs this with `popMemoryFrame()` so a no-op push doesn't
+   * unbalance the pop. ALWAYS materializes `other.memoryFrames` (even
+   * on dedup) so `hasMemoryFrameStack()` flips true on first push —
+   * checkpoints from this point on are recognised as "memory-aware".
    */
-  pushMemoryFrame(frame: MemoryFrame): void {
-    const top = this.topMemoryFrame();
-    if (top?.configKey === frame.configKey) return;
-    const existing = (this.other.memoryFrames as MemoryFrame[] | undefined) ?? [];
-    this.other.memoryFrames = [...existing, frame];
+  pushMemoryFrame(frame: MemoryFrame): boolean {
+    const existing = this.memoryFramesArr() ?? [];
+    if (this.memoryFramesArr() === undefined) {
+      // Materialize so hasMemoryFrameStack() flips true; protects
+      // against the dedup-no-push case looking identical to a fresh
+      // stack on a future resume.
+      this.other.memoryFrames = existing;
+    }
+    const top = this.activeMemoryFrame();
+    if (top && MemoryFrame.equals(top, frame)) return false;
+    existing.push(frame);
+    return true;
   }
 
   /** Pop the top memory frame, including the JSON-seeded bottom frame.
@@ -354,23 +387,17 @@ export class StateStack {
    *  empty.
    *
    *  When the last frame is popped the array stays present (but
-   *  empty) so `topMemoryFrame()` returns `undefined` and the
+   *  empty) so `activeMemoryFrame()` returns `undefined` and the
    *  old-checkpoint re-seed in `getActiveMemoryManager()` knows the
    *  user explicitly disabled memory rather than restored an
    *  ancient snapshot. */
   popMemoryFrame(): MemoryFrame | undefined {
-    const existing = this.other.memoryFrames as MemoryFrame[] | undefined;
-    if (!existing || existing.length === 0) return undefined;
-    const popped = existing[existing.length - 1];
-    this.other.memoryFrames = existing.slice(0, -1);
-    return popped;
+    return this.memoryFramesArr()?.pop();
   }
 
   /** The active memory frame, or `undefined` if memory is currently off. */
-  topMemoryFrame(): MemoryFrame | undefined {
-    const frames = this.other.memoryFrames as MemoryFrame[] | undefined;
-    if (!frames || frames.length === 0) return undefined;
-    return frames[frames.length - 1];
+  activeMemoryFrame(): MemoryFrame | undefined {
+    return this.memoryFramesArr()?.at(-1);
   }
 
   pushGuard(guard: Guard): void {

--- a/packages/agency-lang/lib/stdlib/memory.test.ts
+++ b/packages/agency-lang/lib/stdlib/memory.test.ts
@@ -36,7 +36,10 @@ function makeFakeCtx(): { ctx: any; manager: FakeManager } {
       this.setMemoryIdCalls.push(id);
     },
   };
-  return { ctx: { memoryManager: manager }, manager };
+  return {
+    ctx: { getActiveMemoryManager: () => manager },
+    manager,
+  };
 }
 
 describe("std::memory ctx-passing concurrency", () => {
@@ -76,5 +79,134 @@ describe("std::memory ctx-passing concurrency", () => {
     expect(__internal_shouldRunMemory(a.ctx, null as any, null as any)).toBe(true);
     expect(__internal_shouldRunMemory({} as any, null as any, null as any)).toBe(false);
     expect(__internal_shouldRunMemory(null as any, null as any, null as any)).toBe(false);
+  });
+});
+
+import {
+  _enableMemory,
+  _disableMemory,
+} from "./memory.js";
+import {
+  _resetStoreRegistry,
+} from "../runtime/memory/index.js";
+import { runInTestContext } from "../runtime/asyncContext.js";
+import { RuntimeContext } from "../runtime/state/context.js";
+import { StateStack } from "../runtime/state/stateStack.js";
+import { ThreadStore } from "../runtime/state/threadStore.js";
+import { beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+describe("std::memory enable/disable/block", () => {
+  let tmpRoot: string;
+  let dirA: string;
+  let dirB: string;
+
+  function makeCtx(memory?: { dir: string }) {
+    return new RuntimeContext({
+      statelogConfig: {
+        host: "https://example.com",
+        apiKey: "test-api-key",
+        projectId: "test-project",
+        debugMode: false,
+      },
+      smoltalkDefaults: {},
+      dirname: tmpRoot,
+      memory,
+    });
+  }
+
+  async function withCtx(ctx: RuntimeContext<any>, fn: () => Promise<void>): Promise<void> {
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), fn);
+  }
+
+  beforeEach(() => {
+    _resetStoreRegistry();
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "stdmem-"));
+    dirA = path.join(tmpRoot, "a");
+    dirB = path.join(tmpRoot, "b");
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    _resetStoreRegistry();
+  });
+
+  it("_enableMemory pushes a frame on top of nothing", async () => {
+    const ctx = makeCtx();
+    await withCtx(ctx, async () => {
+      await _enableMemory({ dir: dirA });
+    });
+  });
+
+  it("_enableMemory is a no-op when pushing the same dir as the top frame", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      await _enableMemory({ dir: dirA });
+      const beforeFrames = (execCtx.stateStack.other.memoryFrames as any[]).length;
+      await _enableMemory({ dir: dirA });
+      const afterFrames = (execCtx.stateStack.other.memoryFrames as any[]).length;
+      expect(afterFrames).toBe(beforeFrames);
+    });
+  });
+
+  it("_enableMemory with a different dir stacks on top", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      await _enableMemory({ dir: dirA });
+      await _enableMemory({ dir: dirB });
+      const frames = execCtx.stateStack.other.memoryFrames as any[];
+      expect(frames.length).toBe(2);
+      expect(frames[1].configKey).toBe(fs.realpathSync(dirB));
+    });
+  });
+
+  it("_disableMemory pops one frame", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      await _enableMemory({ dir: dirA });
+      await _enableMemory({ dir: dirB });
+      _disableMemory();
+      const frames = execCtx.stateStack.other.memoryFrames as any[];
+      expect(frames.length).toBe(1);
+      expect(frames[0].configKey).toBe(fs.realpathSync(dirA));
+    });
+  });
+
+  it("frames survive serialize/deserialize with nested config intact", async () => {
+    const ctx = makeCtx();
+    const execCtx = await ctx.createExecutionContext("r1");
+    const richConfig = {
+      dir: dirA,
+      model: "gpt-4o",
+      autoExtract: { interval: 3 },
+      compaction: { trigger: "messages" as const, threshold: 12 },
+      embeddings: { model: "emb-1" },
+    };
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      await _enableMemory(richConfig);
+    });
+    const json = execCtx.stateStack.toJSON();
+    const restored = StateStack.fromJSON(json);
+    const top = restored.topMemoryFrame();
+    expect(top?.configKey).toBe(fs.realpathSync(dirA));
+    expect(top?.config).toEqual(richConfig);
+  });
+
+  it("_disableMemory against the JSON-seeded bottom frame turns memory off", async () => {
+    const dirJson = path.join(tmpRoot, "json");
+    fs.mkdirSync(dirJson);
+    const ctx = makeCtx({ dir: dirJson });
+    const execCtx = await ctx.createExecutionContext("r1");
+    expect(execCtx.getActiveMemoryManager()).toBeDefined();
+    await runInTestContext(execCtx, execCtx.stateStack, new ThreadStore(), async () => {
+      _disableMemory();
+    });
+    expect(execCtx.getActiveMemoryManager()).toBeUndefined();
   });
 });

--- a/packages/agency-lang/lib/stdlib/memory.test.ts
+++ b/packages/agency-lang/lib/stdlib/memory.test.ts
@@ -193,7 +193,7 @@ describe("std::memory enable/disable/block", () => {
     });
     const json = execCtx.stateStack.toJSON();
     const restored = StateStack.fromJSON(json);
-    const top = restored.topMemoryFrame();
+    const top = restored.activeMemoryFrame();
     expect(top?.configKey).toBe(fs.realpathSync(dirA));
     expect(top?.config).toEqual(richConfig);
   });

--- a/packages/agency-lang/lib/stdlib/memory.ts
+++ b/packages/agency-lang/lib/stdlib/memory.ts
@@ -1,11 +1,10 @@
 import { getRuntimeContext } from "../runtime/asyncContext.js";
-import { AgencyFunction } from "../runtime/agencyFunction.js";
 import type { RuntimeContext } from "../runtime/state/context.js";
 import type {
   ExtractionResult,
   ForgetResult,
 } from "../runtime/memory/index.js";
-import { normalizeMemoryFrame } from "../runtime/memory/frame.js";
+import { MemoryFrame } from "../runtime/memory/frame.js";
 import type { MemoryConfig } from "../runtime/memory/types.js";
 import type { StateStack } from "../runtime/state/stateStack.js";
 import type { ThreadStore } from "../runtime/state/threadStore.js";
@@ -192,8 +191,8 @@ export async function _forget(query: string): Promise<void> {
 
 // ── New: enable / disable / block ──
 //
-// "What" lives here. "How" lives in normalizeMemoryFrame +
-// StateStack.{push,pop,top}MemoryFrame.
+// "What" lives here. "How" lives in MemoryFrame's constructor +
+// StateStack.{push,pop,active}MemoryFrame.
 
 /**
  * Push a memory frame onto the current branch's stateStack.
@@ -212,7 +211,7 @@ export async function _forget(query: string): Promise<void> {
 export async function _enableMemory(config: MemoryConfig): Promise<void> {
   const { stack } = getRuntimeContext();
   if (!stack) return;
-  stack.pushMemoryFrame(normalizeMemoryFrame(config));
+  stack.pushMemoryFrame(new MemoryFrame(config));
 }
 
 /** Pop the top memory frame from the current branch's stateStack.
@@ -225,35 +224,27 @@ export function _disableMemory(): void {
 }
 
 /**
- * Run `block` with `config` pushed as the active memory frame; pop
- * on exit (including on throw). The block-form sibling of
- * `enableMemory` / `disableMemory` for lexical scoping.
+ * Push a memory frame, returning whether the push actually happened
+ * (false on same-dir dedup). The Agency-side `memory({...}) as { ... }`
+ * block pairs this with `_popMemoryFrame()` so a no-op push doesn't
+ * unbalance the pop — mirrors the `_pushGuard`/`_popGuard` count
+ * pattern in std::thread. Returns `false` and is a no-op outside any
+ * runtime frame (consistent with `_enableMemory`).
  *
- * The push/pop is implemented in TS rather than Agency `try/finally`
- * because Agency has no `finally`; an explicit TS wrapper is the
- * smallest correct construct. `block` is the AgencyFunction the
- * compiler synthesises for `memory({...}) as { ... }` — invoke it
- * through `AgencyFunction.invoke` so its frame, callsite, and
- * interrupt machinery hook up correctly.
+ * Lives in TS rather than as a thin wrapper around `_enableMemory`
+ * because Agency callers need the boolean to decide whether to pop.
  */
-export async function _memoryBlock(
-  config: MemoryConfig,
-  block: AgencyFunction | (() => unknown),
-): Promise<unknown> {
-  const callBlock = (): Promise<unknown> => {
-    if (AgencyFunction.isAgencyFunction(block)) {
-      return Promise.resolve(
-        (block as AgencyFunction).invoke({ type: "positional", args: [] }),
-      );
-    }
-    return Promise.resolve((block as () => unknown)());
-  };
+export function _pushMemoryFrame(config: MemoryConfig): boolean {
   const { stack } = getRuntimeContext();
-  if (!stack) return await callBlock();
-  stack.pushMemoryFrame(normalizeMemoryFrame(config));
-  try {
-    return await callBlock();
-  } finally {
-    stack.popMemoryFrame();
-  }
+  if (!stack) return false;
+  return stack.pushMemoryFrame(new MemoryFrame(config));
+}
+
+/** Pop the top memory frame. Counterpart to `_pushMemoryFrame`; the
+ *  Agency-side `memory(){}` block calls this only when `_pushMemoryFrame`
+ *  returned true so dedup-no-op pushes don't accidentally pop the
+ *  caller's frame. */
+export function _popMemoryFrame(): void {
+  const { stack } = getRuntimeContext();
+  stack?.popMemoryFrame();
 }

--- a/packages/agency-lang/lib/stdlib/memory.ts
+++ b/packages/agency-lang/lib/stdlib/memory.ts
@@ -1,9 +1,12 @@
 import { getRuntimeContext } from "../runtime/asyncContext.js";
+import { AgencyFunction } from "../runtime/agencyFunction.js";
 import type { RuntimeContext } from "../runtime/state/context.js";
 import type {
   ExtractionResult,
   ForgetResult,
 } from "../runtime/memory/index.js";
+import { normalizeMemoryFrame } from "../runtime/memory/frame.js";
+import type { MemoryConfig } from "../runtime/memory/types.js";
 import type { StateStack } from "../runtime/state/stateStack.js";
 import type { ThreadStore } from "../runtime/state/threadStore.js";
 
@@ -18,11 +21,14 @@ import type { ThreadStore } from "../runtime/state/threadStore.js";
  * the TypeScript builder prepends `__ctx`, `__stateStack`, and
  * `__threads` at every context-injected call site.
  *
- * If memory isn't configured in `agency.json`, every function is a
- * no-op: side-effecting helpers resolve to `undefined`,
+ * If no memory frame is active (neither `agency.json` nor a code-side
+ * `enableMemory(...)` has set one), every function is a no-op:
+ * side-effecting helpers resolve to `undefined`,
  * `__internal_recall` to `""`, and the prompt-build helpers return
  * `""` so the agency-side guard short-circuits.
  */
+
+// ---- ctx-passing variants (kept for the context-injected builtin migration) ----
 
 export async function __internal_setMemoryId(
   ctx: RuntimeContext<any>,
@@ -30,8 +36,9 @@ export async function __internal_setMemoryId(
   _threads: ThreadStore,
   id: string,
 ): Promise<void> {
-  if (!ctx?.memoryManager) return;
-  ctx.memoryManager.setMemoryId(id);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return;
+  manager.setMemoryId(id);
 }
 
 export function __internal_shouldRunMemory(
@@ -39,7 +46,7 @@ export function __internal_shouldRunMemory(
   _stack: StateStack,
   _threads: ThreadStore,
 ): boolean {
-  return ctx?.memoryManager !== undefined;
+  return ctx?.getActiveMemoryManager?.() !== undefined;
 }
 
 export async function __internal_buildExtractionPrompt(
@@ -48,8 +55,9 @@ export async function __internal_buildExtractionPrompt(
   _threads: ThreadStore,
   content: string,
 ): Promise<string> {
-  if (!ctx?.memoryManager) return "";
-  return ctx.memoryManager.buildExtractionPromptFor(content);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return "";
+  return manager.buildExtractionPromptFor(content);
 }
 
 export async function __internal_applyExtractionResult(
@@ -58,8 +66,9 @@ export async function __internal_applyExtractionResult(
   _threads: ThreadStore,
   result: ExtractionResult,
 ): Promise<void> {
-  if (!ctx?.memoryManager) return;
-  await ctx.memoryManager.applyExtractionFromLLM(result);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return;
+  await manager.applyExtractionFromLLM(result);
 }
 
 export async function __internal_buildForgetPrompt(
@@ -68,8 +77,9 @@ export async function __internal_buildForgetPrompt(
   _threads: ThreadStore,
   query: string,
 ): Promise<string> {
-  if (!ctx?.memoryManager) return "";
-  return ctx.memoryManager.buildForgetPromptFor(query);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return "";
+  return manager.buildForgetPromptFor(query);
 }
 
 export async function __internal_applyForgetResult(
@@ -78,8 +88,9 @@ export async function __internal_applyForgetResult(
   _threads: ThreadStore,
   result: ForgetResult,
 ): Promise<void> {
-  if (!ctx?.memoryManager) return;
-  await ctx.memoryManager.applyForgetFromLLM(result);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return;
+  await manager.applyForgetFromLLM(result);
 }
 
 export async function __internal_remember(
@@ -88,8 +99,9 @@ export async function __internal_remember(
   _threads: ThreadStore,
   content: string,
 ): Promise<void> {
-  if (!ctx?.memoryManager) return;
-  await ctx.memoryManager.remember(content);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return;
+  await manager.remember(content);
 }
 
 export async function __internal_recall(
@@ -98,8 +110,9 @@ export async function __internal_recall(
   _threads: ThreadStore,
   query: string,
 ): Promise<string> {
-  if (!ctx?.memoryManager) return "";
-  return ctx.memoryManager.recall(query);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return "";
+  return manager.recall(query);
 }
 
 export async function __internal_forget(
@@ -108,8 +121,9 @@ export async function __internal_forget(
   _threads: ThreadStore,
   query: string,
 ): Promise<void> {
-  if (!ctx?.memoryManager) return;
-  await ctx.memoryManager.forget(query);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return;
+  await manager.forget(query);
 }
 
 // ── ALS-reading replacements for the `__internal_*` exports above ──
@@ -117,53 +131,129 @@ export async function __internal_forget(
 
 export async function _setMemoryId(id: string): Promise<void> {
   const { ctx } = getRuntimeContext();
-  if (!ctx?.memoryManager) return;
-  ctx.memoryManager.setMemoryId(id);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return;
+  manager.setMemoryId(id);
 }
 
 export function _shouldRunMemory(): boolean {
   const { ctx } = getRuntimeContext();
-  return ctx?.memoryManager !== undefined;
+  return ctx?.getActiveMemoryManager?.() !== undefined;
 }
 
 export async function _buildExtractionPrompt(content: string): Promise<string> {
   const { ctx } = getRuntimeContext();
-  if (!ctx?.memoryManager) return "";
-  return ctx.memoryManager.buildExtractionPromptFor(content);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return "";
+  return manager.buildExtractionPromptFor(content);
 }
 
 export async function _applyExtractionResult(result: ExtractionResult): Promise<void> {
   const { ctx } = getRuntimeContext();
-  if (!ctx?.memoryManager) return;
-  await ctx.memoryManager.applyExtractionFromLLM(result);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return;
+  await manager.applyExtractionFromLLM(result);
 }
 
 export async function _buildForgetPrompt(query: string): Promise<string> {
   const { ctx } = getRuntimeContext();
-  if (!ctx?.memoryManager) return "";
-  return ctx.memoryManager.buildForgetPromptFor(query);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return "";
+  return manager.buildForgetPromptFor(query);
 }
 
 export async function _applyForgetResult(result: ForgetResult): Promise<void> {
   const { ctx } = getRuntimeContext();
-  if (!ctx?.memoryManager) return;
-  await ctx.memoryManager.applyForgetFromLLM(result);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return;
+  await manager.applyForgetFromLLM(result);
 }
 
 export async function _remember(content: string): Promise<void> {
   const { ctx } = getRuntimeContext();
-  if (!ctx?.memoryManager) return;
-  await ctx.memoryManager.remember(content);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return;
+  await manager.remember(content);
 }
 
 export async function _recall(query: string): Promise<string> {
   const { ctx } = getRuntimeContext();
-  if (!ctx?.memoryManager) return "";
-  return ctx.memoryManager.recall(query);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return "";
+  return manager.recall(query);
 }
 
 export async function _forget(query: string): Promise<void> {
   const { ctx } = getRuntimeContext();
-  if (!ctx?.memoryManager) return;
-  await ctx.memoryManager.forget(query);
+  const manager = ctx?.getActiveMemoryManager?.();
+  if (!manager) return;
+  await manager.forget(query);
+}
+
+// ── New: enable / disable / block ──
+//
+// "What" lives here. "How" lives in normalizeMemoryFrame +
+// StateStack.{push,pop,top}MemoryFrame.
+
+/**
+ * Push a memory frame onto the current branch's stateStack.
+ *
+ * Process-wide stores are cached by absolute realpath'd dir, so
+ * multiple calls with the same dir share one underlying store.
+ * Repeating the same dir as the current top frame is a no-op (so the
+ * common `static const _ = enableMemory(...)` plus an
+ * `enableMemory(...)` in `main()` is safe). Pushing a different dir
+ * stacks the new frame on top — pop it with `disableMemory()`.
+ *
+ * Auto-creates the dir if missing. Resolves `dir` against
+ * `process.cwd()` (deliberately the same as `agency.json`'s
+ * `memory.dir`, NOT the module dir like `read`/`write`).
+ */
+export async function _enableMemory(config: MemoryConfig): Promise<void> {
+  const { stack } = getRuntimeContext();
+  if (!stack) return;
+  stack.pushMemoryFrame(normalizeMemoryFrame(config));
+}
+
+/** Pop the top memory frame from the current branch's stateStack.
+ *  Frame-scoped: a `disableMemory()` inside a fork branch only
+ *  affects that branch. Pops the JSON-seeded bottom frame too —
+ *  library authors should avoid calling this casually. */
+export function _disableMemory(): void {
+  const { stack } = getRuntimeContext();
+  stack?.popMemoryFrame();
+}
+
+/**
+ * Run `block` with `config` pushed as the active memory frame; pop
+ * on exit (including on throw). The block-form sibling of
+ * `enableMemory` / `disableMemory` for lexical scoping.
+ *
+ * The push/pop is implemented in TS rather than Agency `try/finally`
+ * because Agency has no `finally`; an explicit TS wrapper is the
+ * smallest correct construct. `block` is the AgencyFunction the
+ * compiler synthesises for `memory({...}) as { ... }` — invoke it
+ * through `AgencyFunction.invoke` so its frame, callsite, and
+ * interrupt machinery hook up correctly.
+ */
+export async function _memoryBlock(
+  config: MemoryConfig,
+  block: AgencyFunction | (() => unknown),
+): Promise<unknown> {
+  const callBlock = (): Promise<unknown> => {
+    if (AgencyFunction.isAgencyFunction(block)) {
+      return Promise.resolve(
+        (block as AgencyFunction).invoke({ type: "positional", args: [] }),
+      );
+    }
+    return Promise.resolve((block as () => unknown)());
+  };
+  const { stack } = getRuntimeContext();
+  if (!stack) return await callBlock();
+  stack.pushMemoryFrame(normalizeMemoryFrame(config));
+  try {
+    return await callBlock();
+  } finally {
+    stack.popMemoryFrame();
+  }
 }

--- a/packages/agency-lang/stdlib/memory.agency
+++ b/packages/agency-lang/stdlib/memory.agency
@@ -14,6 +14,17 @@ type ForgetResult = {
   relations: { fromName: string, toName: string, type: string }[]
 }
 
+// User-facing memory config shape. Mirrors the `memory:` block in
+// `agency.json` so the same fields work whether you configure memory
+// declaratively or in code.
+export type MemoryConfig = {
+  dir: string,
+  model?: string,
+  autoExtract?: { interval: number },
+  compaction?: { trigger: string, threshold: number },
+  embeddings?: { model: string }
+}
+
 // `_*` exports read ctx from AsyncLocalStorage (see
 // `lib/runtime/asyncContext.ts`); no `__ctx` arg is plumbed at the
 // call site. The deprecated `__internal_*` exports remain in
@@ -26,6 +37,9 @@ import {
   _buildForgetPrompt,
   _applyForgetResult,
   _recall,
+  _enableMemory,
+  _disableMemory,
+  _memoryBlock,
 } from "agency-lang/stdlib-lib/memory.js"
 
 export def setMemoryId(id: string) {
@@ -34,12 +48,80 @@ export def setMemoryId(id: string) {
   memory operations to scope reads and writes to a specific user,
   thread, or workspace. If never called, the scope defaults to "default".
 
-  Memory must be enabled in agency.json for this to do anything; without
-  configuration this is a no-op.
+  Memory must be enabled (either via `agency.json` or via
+  `enableMemory(...)`) for this to do anything; without configuration
+  this is a no-op.
+
+  The id is orthogonal to which memory frame is active — it persists
+  across `enableMemory` / `disableMemory` calls. If you want a fresh
+  scope when switching stores, call `setMemoryId(...)` explicitly.
 
   @param id - A unique identifier for the memory scope (e.g. user ID)
   """
   _setMemoryId(id)
+}
+
+export def enableMemory(config: MemoryConfig) {
+  """
+  Turn memory on for the current execution branch using `config`.
+
+  Pushes a new memory frame onto the active stateStack. Storage is
+  shared process-wide by absolute directory, so multiple calls
+  (across runs, forks, or modules) that point at the same dir share
+  one underlying store.
+
+  Same-dir push is a no-op — the common pattern of declaring
+  `static const _ = enableMemory({...})` AND calling
+  `enableMemory({...})` from `main()` is safe. Pushing a different
+  dir stacks the new frame on top; pop with `disableMemory()` or
+  use the block form `memory({...}) as { ... }` for lexical scoping.
+
+  `config.dir` is resolved against `process.cwd()` (NOT the module
+  dir, deliberately — mirrors how `agency.json`'s `memory.dir` is
+  resolved so the same string in JSON and in code points at the same
+  place). The directory is auto-created if missing.
+
+  Per-fork: each fork branch has its own frame stack, so an
+  `enableMemory` in one branch does not affect siblings.
+
+  @param config - Memory configuration with `dir` required
+  """
+  _enableMemory(config)
+}
+
+export def disableMemory() {
+  """
+  Pop the top memory frame from the current branch's stateStack.
+
+  Frame-scoped: a `disableMemory()` inside a fork branch only
+  affects that branch.
+
+  WARNING: this pops whatever is on top, including the JSON-seeded
+  bottom frame from `agency.json`. Library authors should not call
+  this casually — they will shadow the caller's configured memory.
+  Prefer the block form `memory({...}) as { ... }` for lexical
+  scoping, which restores the previous frame on exit.
+  """
+  _disableMemory()
+}
+
+export def memory(config: MemoryConfig, block: () => any): any {
+  """
+  Run `block` with `config` pushed as the active memory frame; pop
+  the frame when the block returns (or throws).
+
+  The block form of `enableMemory` / `disableMemory`. Prefer this
+  whenever the memory frame should be lexically scoped.
+
+  Example:
+    memory({ dir: "./mem-user-a" }) as {
+      remember("alice's favorite color is blue")
+    }
+
+  @param config - Memory configuration with `dir` required
+  @param block - The code to run with the frame active
+  """
+  return _memoryBlock(config, block)
 }
 
 export def remember(content: string) {

--- a/packages/agency-lang/stdlib/memory.agency
+++ b/packages/agency-lang/stdlib/memory.agency
@@ -16,13 +16,15 @@ type ForgetResult = {
 
 // User-facing memory config shape. Mirrors the `memory:` block in
 // `agency.json` so the same fields work whether you configure memory
-// declaratively or in code.
+// declaratively or in code. Every nested field is optional because
+// the runtime provides defaults for each one (matching the shape of
+// `MemoryConfig` in `lib/runtime/memory/types.ts`).
 export type MemoryConfig = {
   dir: string,
   model?: string,
-  autoExtract?: { interval: number },
-  compaction?: { trigger: string, threshold: number },
-  embeddings?: { model: string }
+  autoExtract?: { interval?: number },
+  compaction?: { trigger?: "token" | "messages", threshold?: number },
+  embeddings?: { model?: string }
 }
 
 // `_*` exports read ctx from AsyncLocalStorage (see
@@ -39,8 +41,24 @@ import {
   _recall,
   _enableMemory,
   _disableMemory,
-  _memoryBlock,
+  _pushMemoryFrame,
+  _popMemoryFrame,
 } from "agency-lang/stdlib-lib/memory.js"
+
+export def isMemoryActive(): boolean {
+  """
+  Return `true` iff there is an active memory frame on the current
+  branch's stateStack — i.e. memory is on and `remember`/`recall` will
+  reach a real store. Returns `false` when memory was never enabled,
+  was explicitly turned off via `disableMemory()`, or the call is
+  outside any runtime frame.
+
+  Useful for branching in user code (`if (isMemoryActive()) { ... }`)
+  and for integration tests that want to verify push/pop semantics
+  without poking at the stateStack directly.
+  """
+  return _shouldRunMemory()
+}
 
 export def setMemoryId(id: string) {
   """
@@ -105,23 +123,37 @@ export def disableMemory() {
   _disableMemory()
 }
 
-export def memory(config: MemoryConfig, block: () => any): any {
+export def memory(config: MemoryConfig, block: () => any = null): Result {
   """
   Run `block` with `config` pushed as the active memory frame; pop
-  the frame when the block returns (or throws).
+  the frame when the block returns (or fails). Mirrors the `guard()`
+  pattern in `std::thread` so push/pop balancing flows through the
+  same `try` expression — Agency has no `finally`, so the agency-side
+  body uses `try block()` to capture the result and runs `pop` after.
 
-  The block form of `enableMemory` / `disableMemory`. Prefer this
-  whenever the memory frame should be lexically scoped.
+  The pop only fires when the push actually happened: `_pushMemoryFrame`
+  returns `false` if the new frame's dir matches the current top
+  (dedup), and the matching no-pop preserves the caller's frame
+  instead of unbalancing it. This fixes the prior `_memoryBlock`
+  unbalanced-pop bug.
+
+  Returns a `Result` (success holds the block's return value, failure
+  holds an error from inside the block). Same convention as `guard()`.
 
   Example:
-    memory({ dir: "./mem-user-a" }) as {
+    const r = memory({ dir: "./mem-user-a" }) as {
       remember("alice's favorite color is blue")
     }
 
   @param config - Memory configuration with `dir` required
   @param block - The code to run with the frame active
   """
-  return _memoryBlock(config, block)
+  const pushed = _pushMemoryFrame(config)
+  const result = try block()
+  if (pushed) {
+    _popMemoryFrame()
+  }
+  return result
 }
 
 export def remember(content: string) {

--- a/packages/agency-lang/tests/agency/memory-code/block.agency
+++ b/packages/agency-lang/tests/agency/memory-code/block.agency
@@ -1,0 +1,18 @@
+import { memory, recall } from "std::memory"
+
+// Block form: `memory({...}) as { ... }` pushes a frame on entry
+// and pops on exit. Inside the block, `recall` reaches the active
+// store (empty graph -> "") so the call returns "". Outside the
+// block, no frame is active so `recall` short-circuits and also
+// returns "". The point of this test is that the block body
+// executes and returns without throwing, and that the pop happens
+// on normal exit (so a follow-up recall outside still works).
+node main(): boolean {
+  let inside: string = "unset"
+  memory({ dir: ".agency-tmp/memory-code-block-test" }) as {
+    inside = recall("anything")
+  }
+  // After block exit, memory frame is popped — recall is a no-op.
+  const outside: string = recall("anything")
+  return inside == "" && outside == ""
+}

--- a/packages/agency-lang/tests/agency/memory-code/block.agency
+++ b/packages/agency-lang/tests/agency/memory-code/block.agency
@@ -1,18 +1,22 @@
-import { memory, recall } from "std::memory"
+import { memory, recall, isMemoryActive } from "std::memory"
 
 // Block form: `memory({...}) as { ... }` pushes a frame on entry
-// and pops on exit. Inside the block, `recall` reaches the active
-// store (empty graph -> "") so the call returns "". Outside the
-// block, no frame is active so `recall` short-circuits and also
-// returns "". The point of this test is that the block body
-// executes and returns without throwing, and that the pop happens
-// on normal exit (so a follow-up recall outside still works).
+// and pops on exit. We verify push/pop semantics directly via
+// `isMemoryActive()` (introspects the active frame) rather than
+// indirectly via recall — the recall-returns-"" trick from the old
+// version of this test would pass even if push and pop both no-op'd,
+// which defeats the purpose.
 node main(): boolean {
-  let inside: string = "unset"
+  // Before the block: no frame active.
+  const before: boolean = isMemoryActive()
+  let inside: boolean = false
+  let recallInside: string = "unset"
   memory({ dir: ".agency-tmp/memory-code-block-test" }) as {
-    inside = recall("anything")
+    inside = isMemoryActive()
+    // recall on a fresh, empty graph returns "" without an LLM call.
+    recallInside = recall("anything")
   }
-  // After block exit, memory frame is popped — recall is a no-op.
-  const outside: string = recall("anything")
-  return inside == "" && outside == ""
+  // After the block: frame popped, memory off again.
+  const after: boolean = isMemoryActive()
+  return before == false && inside == true && after == false && recallInside == ""
 }

--- a/packages/agency-lang/tests/agency/memory-code/block.test.json
+++ b/packages/agency-lang/tests/agency/memory-code/block.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/memory-code/enable.agency
+++ b/packages/agency-lang/tests/agency/memory-code/enable.agency
@@ -1,14 +1,20 @@
-import { enableMemory, recall, setMemoryId } from "std::memory"
+import { enableMemory, disableMemory, recall, setMemoryId, isMemoryActive } from "std::memory"
 
-// Exercises the new code-side memory configuration. enableMemory
-// pushes a frame onto the stateStack; setMemoryId scopes it.
-// Recall on a fresh, empty graph returns the empty string without
-// any LLM call (the manager short-circuits on graph.entities=0),
-// which lets this test prove the new wiring works end-to-end without
-// requiring mocks.
+// Exercises the code-side memory configuration end-to-end:
+//   - `enableMemory` flips memory on (isMemoryActive becomes true)
+//   - `recall` on a fresh, empty graph returns "" without any LLM
+//     call (the manager short-circuits on graph.entities=0), proving
+//     the manager actually got wired up.
+//   - `disableMemory` pops the frame, flipping isMemoryActive back
+//     off — verifying the push and pop are balanced rather than
+//     trusting that both silently no-op'd.
 node main(): boolean {
+  const before: boolean = isMemoryActive()
   enableMemory({ dir: ".agency-tmp/memory-code-enable-test" })
   setMemoryId("enable-test")
+  const active: boolean = isMemoryActive()
   const r: string = recall("anything")
-  return r == ""
+  disableMemory()
+  const after: boolean = isMemoryActive()
+  return before == false && active == true && r == "" && after == false
 }

--- a/packages/agency-lang/tests/agency/memory-code/enable.agency
+++ b/packages/agency-lang/tests/agency/memory-code/enable.agency
@@ -1,0 +1,14 @@
+import { enableMemory, recall, setMemoryId } from "std::memory"
+
+// Exercises the new code-side memory configuration. enableMemory
+// pushes a frame onto the stateStack; setMemoryId scopes it.
+// Recall on a fresh, empty graph returns the empty string without
+// any LLM call (the manager short-circuits on graph.entities=0),
+// which lets this test prove the new wiring works end-to-end without
+// requiring mocks.
+node main(): boolean {
+  enableMemory({ dir: ".agency-tmp/memory-code-enable-test" })
+  setMemoryId("enable-test")
+  const r: string = recall("anything")
+  return r == ""
+}

--- a/packages/agency-lang/tests/agency/memory-code/enable.test.json
+++ b/packages/agency-lang/tests/agency/memory-code/enable.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "true",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Add memory configuration in Agency code

Lets Agency code enable, configure, and disable memory directly,
without requiring a `memory` block in `agency.json`. Supports per-thread
/ per-fork memory by moving memory configuration onto the stateStack.

New stdlib API in `stdlib/memory.agency`:

  enableMemory({ dir, model?, autoExtract?, compaction?, embeddings? })
  disableMemory()
  memory({ ... }) as { ... }

All three are also valid tools an LLM can be passed.

Architecture:

- `StateStack` carries a stack of memory frames, hidden behind
  `pushMemoryFrame` / `popMemoryFrame` / `topMemoryFrame`. No caller
  touches the array. Lives in `stack.other` so it serializes for free
  and forks correctly.
- Single source of truth: JSON config is just the bottom frame. At
  `createExecutionContext`, the JSON config is pushed onto the new
  execCtx's stateStack. After that, the stack is the only thing
  anyone consults. "Code wins over JSON" is structural, not coded.
- Process-wide store registry in `lib/runtime/memory/registry.ts`,
  keyed by absolute realpath'd dir. Multiple call sites with the
  same dir share storage.
- Active manager resolved via single
  `ctx.getActiveMemoryManager()` — top of stack or undefined, no
  fallback branch.

`agency.memory.*` namespace added for TS helpers so they have
symmetric access to what Agency code can do.

Dir resolution mirrors `agency.json`: relative `dir` resolves against
`process.cwd()`. `~` expansion lands separately in
docs/superpowers/plans/2026-05-29-tilde-expansion-in-stdlib.md.

Plan: docs/superpowers/plans/2026-05-29-memory-config-in-code.md
