### PR TITLE
Add `agency literate weave` command

### DIFF
--- a/packages/agency-lang/lib/backends/agencyGenerator.test.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.test.ts
@@ -552,3 +552,30 @@ describe("AgencyGenerator - Result Patterns", () => {
   });
 });
 
+describe("AgencyGenerator - preserveOrder mode", () => {
+  function formatPreserveOrder(input: string): string {
+    const parseResult = parseAgency(input, {}, false);
+    expect(parseResult.success).toBe(true);
+    if (!parseResult.success) return "";
+    const generator = new AgencyGenerator({ preserveOrder: true });
+    return generator.generate(parseResult.result).output.trim();
+  }
+
+  it("does not sort imports alphabetically", () => {
+    const input = `import { zebra } from "z"\nimport { apple } from "a"\n`;
+    const output = formatPreserveOrder(input);
+    expect(output.indexOf("zebra")).toBeLessThan(output.indexOf("apple"));
+  });
+
+  it("does not hoist mid-file imports to the top", () => {
+    const input = `def first(): number { return 1 }\n\nimport { later } from "wherever"\n\ndef second(): number { return 2 }\n`;
+    const output = formatPreserveOrder(input);
+    const firstIdx = output.indexOf("def first");
+    const importIdx = output.indexOf('import { later }');
+    const secondIdx = output.indexOf("def second");
+    expect(firstIdx).toBeGreaterThanOrEqual(0);
+    expect(importIdx).toBeGreaterThan(firstIdx);
+    expect(secondIdx).toBeGreaterThan(importIdx);
+  });
+});
+

--- a/packages/agency-lang/lib/backends/agencyGenerator.ts
+++ b/packages/agency-lang/lib/backends/agencyGenerator.ts
@@ -102,8 +102,19 @@ export class AgencyGenerator {
   private indentSize: number = 2;
   private debug: boolean = !!process.env.AGENCY_DEBUG;
 
-  constructor(args: { config?: AgencyConfig } = {}) {
+  /**
+   * When true, imports render in-place (in their original source position)
+   * rather than being hoisted to the top of the file and sorted. Used by
+   * `agency literate weave`, which needs to render the file in source
+   * order so the prose / code alternation matches what the author wrote.
+   */
+  protected preserveOrder: boolean = false;
+
+  constructor(
+    args: { config?: AgencyConfig; preserveOrder?: boolean } = {},
+  ) {
     this.agencyConfig = mergeDeep(this.configDefaults(), args.config || {});
+    this.preserveOrder = args.preserveOrder ?? false;
     if (this.agencyConfig.verbose) {
       console.log("Generator config:", this.agencyConfig);
     }
@@ -140,7 +151,11 @@ export class AgencyGenerator {
     // comments/blanks) and each import statement (with any comments
     // directly attached to it). This lets the imports block be sorted
     // while preserving `// @tc-ignore` / `// @tc-nocheck` placement.
-    program.nodes = this.partitionImports(program.nodes);
+    // Skipped in preserveOrder mode (literate weave) because the whole
+    // point there is to leave nodes exactly where the author put them.
+    if (!this.preserveOrder) {
+      program.nodes = this.partitionImports(program.nodes);
+    }
 
     // Pass 3: Collect all node imports
     for (const node of program.nodes) {
@@ -195,8 +210,13 @@ export class AgencyGenerator {
 
     const output: string[] = [];
 
-    this.addIfNonEmpty(this.renderImportHeader(), output);
-    this.addIfNonEmpty(this.sortAndRenderImports(), output);
+    // In preserveOrder mode, imports already rendered in-place via
+    // processNodeInner, so we skip both the top-of-file header reflow
+    // and the sorted import block.
+    if (!this.preserveOrder) {
+      this.addIfNonEmpty(this.renderImportHeader(), output);
+      this.addIfNonEmpty(this.sortAndRenderImports(), output);
+    }
     this.addIfNonEmpty(this.generatedTypeAliases.join("\n"), output);
     this.addIfNonEmpty(stmtLines.join("\n"), output);
 
@@ -394,9 +414,11 @@ export class AgencyGenerator {
       case "graphNode":
         return this.processGraphNode(node);
       case "importStatement":
+        if (this.preserveOrder) return this.processImportStatement(node);
         this.importNodes.push(node);
         return "";
       case "importNodeStatement":
+        if (this.preserveOrder) return this.processImportNodeStatement(node);
         this.importedNodes.push(node);
         return "";
       case "exportFromStatement":
@@ -1471,8 +1493,11 @@ export class AgencyGenerator {
   }
 }
 
-export function generateAgency(program: AgencyProgram): string {
-  const generator = new AgencyGenerator();
+export function generateAgency(
+  program: AgencyProgram,
+  opts: { preserveOrder?: boolean } = {},
+): string {
+  const generator = new AgencyGenerator({ preserveOrder: opts.preserveOrder });
   return (
     generator
       .generate(program)

--- a/packages/agency-lang/lib/cli/literate.test.ts
+++ b/packages/agency-lang/lib/cli/literate.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { generateLiterate } from "./literate.js";
+import * as fs from "fs";
+import * as path from "path";
+
+const tmpDir = path.join(process.env.TMPDIR || "/tmp", "agency-literate-test");
+
+beforeEach(() => {
+  fs.mkdirSync(tmpDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function writeInput(name: string, contents: string): string {
+  const inputDir = path.join(tmpDir, "in");
+  fs.mkdirSync(inputDir, { recursive: true });
+  const inputPath = path.join(inputDir, name);
+  fs.writeFileSync(inputPath, contents);
+  return inputPath;
+}
+
+function weaveAndRead(
+  name: string,
+  contents: string,
+  opts: { lang?: string } = {},
+): string {
+  const inputPath = writeInput(name, contents);
+  const outputDir = path.join(tmpDir, "out");
+  generateLiterate(
+    {},
+    inputPath,
+    outputDir,
+    [],
+    opts.lang ?? "agency",
+  );
+  const outName = name.replace(/\.agency$/, ".md");
+  return fs.readFileSync(path.join(outputDir, outName), "utf-8");
+}
+
+describe("generateLiterate (weave)", () => {
+  it("turns a block comment into prose and code into a fence", () => {
+    const md = weaveAndRead(
+      "test.agency",
+      `/* hello */
+
+def foo(): number {
+  return 1
+}
+`,
+    );
+
+    // prose is plain text
+    expect(md).toContain("hello");
+
+    // code goes in an agency fence
+    expect(md).toContain("```agency");
+    expect(md).toContain("def foo");
+
+    // prose appears BEFORE the fence (positional check)
+    const proseIdx = md.indexOf("hello");
+    const fenceIdx = md.indexOf("```agency");
+    expect(proseIdx).toBeGreaterThanOrEqual(0);
+    expect(fenceIdx).toBeGreaterThan(proseIdx);
+
+    // and "hello" must not be inside the fence
+    const fenceEndIdx = md.indexOf("```", fenceIdx + 3);
+    expect(md.substring(fenceIdx, fenceEndIdx)).not.toContain("hello");
+  });
+
+  it("turns a doc comment (/** */) into prose, not into a fence", () => {
+    const md = weaveAndRead(
+      "test.agency",
+      `/** docs */
+
+def foo(): number {
+  return 1
+}
+`,
+    );
+
+    // The "docs" string must appear outside any fence.
+    const fenceIdx = md.indexOf("```agency");
+    expect(fenceIdx).toBeGreaterThan(0);
+    const fenceEndIdx = md.indexOf("```", fenceIdx + 3);
+    const fenceContent = md.substring(fenceIdx, fenceEndIdx + 3);
+    expect(fenceContent).not.toContain("docs");
+
+    // And it must appear before the fence as prose.
+    const docsIdx = md.indexOf("docs");
+    expect(docsIdx).toBeGreaterThanOrEqual(0);
+    expect(docsIdx).toBeLessThan(fenceIdx);
+  });
+
+  it("module-level doc comment appears once as the first prose paragraph", () => {
+    const md = weaveAndRead(
+      "test.agency",
+      `/** module docs */
+
+def foo(): number {
+  return 1
+}
+`,
+    );
+
+    // Exactly one occurrence (regression guard against double-emitting from
+    // program.docComment AND the multiLineComment node).
+    const occurrences = md.split("module docs").length - 1;
+    expect(occurrences).toBe(1);
+
+    // And it must be the first thing in the output (no fence before it).
+    const firstFenceIdx = md.indexOf("```");
+    const docsIdx = md.indexOf("module docs");
+    expect(docsIdx).toBeGreaterThanOrEqual(0);
+    expect(docsIdx).toBeLessThan(firstFenceIdx);
+  });
+
+  it("line comments stay inside the code fence", () => {
+    const md = weaveAndRead(
+      "test.agency",
+      `def foo(): number {
+  // inline comment here
+  return 1
+}
+`,
+    );
+
+    const fenceIdx = md.indexOf("```agency");
+    const fenceEndIdx = md.indexOf("```", fenceIdx + 3);
+    const fenceContent = md.substring(fenceIdx, fenceEndIdx + 3);
+    expect(fenceContent).toContain("// inline comment here");
+  });
+
+  it("adjacent block comments merge with a paragraph break", () => {
+    const md = weaveAndRead(
+      "test.agency",
+      `/* a */
+
+/* b */
+`,
+    );
+
+    // No fence at all — only prose.
+    expect(md).not.toContain("```");
+
+    // The two prose chunks are joined by "\n\n".
+    const aIdx = md.indexOf("a");
+    const bIdx = md.indexOf("b");
+    expect(aIdx).toBeGreaterThanOrEqual(0);
+    expect(bIdx).toBeGreaterThan(aIdx);
+    expect(md.substring(aIdx, bIdx + 1)).toContain("\n\n");
+  });
+
+  it("--lang flag flows through to the fence language tag", () => {
+    const md = weaveAndRead(
+      "test.agency",
+      `def foo(): number { return 1 }
+`,
+      { lang: "typescript" },
+    );
+
+    expect(md).toContain("```typescript");
+    expect(md).not.toContain("```agency");
+  });
+
+  it("mirrors the tree for directory input", () => {
+    const inputDir = path.join(tmpDir, "src");
+    const nestedDir = path.join(inputDir, "nested");
+    fs.mkdirSync(nestedDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(inputDir, "a.agency"),
+      `def a(): number { return 1 }\n`,
+    );
+    fs.writeFileSync(
+      path.join(nestedDir, "b.agency"),
+      `def b(): number { return 2 }\n`,
+    );
+
+    const outputDir = path.join(tmpDir, "out");
+    generateLiterate({}, inputDir, outputDir, [], "agency");
+
+    expect(fs.existsSync(path.join(outputDir, "a.md"))).toBe(true);
+    expect(fs.existsSync(path.join(outputDir, "nested", "b.md"))).toBe(true);
+  });
+
+  it("produces an empty .md for an empty input file", () => {
+    const md = weaveAndRead("empty.agency", "");
+    expect(md).toBe("");
+  });
+
+  it("escalates the fence delimiter when the code contains triple backticks", () => {
+    // Block comment containing ``` ends up as prose, not code — so to
+    // exercise escalation through codeFence we need backticks inside a
+    // CODE node. A doc-string is the simplest way to get a string with
+    // backticks into the code segment.
+    const md = weaveAndRead(
+      "test.agency",
+      "def foo(): string {\n" +
+        '  """contains ``` triple backticks"""\n' +
+        '  return "x"\n' +
+        "}\n",
+    );
+
+    // The surrounding fence must be at least 4 backticks so the inner
+    // ``` doesn't terminate it prematurely.
+    expect(md).toMatch(/^````+agency\n/m);
+    expect(md).toMatch(/\n````+\n?$/);
+  });
+
+  it("escalates the fence delimiter to 5 backticks when content has 4", () => {
+    const md = weaveAndRead(
+      "test.agency",
+      "def foo(): string {\n" +
+        '  """contains ```` four backticks"""\n' +
+        '  return "x"\n' +
+        "}\n",
+    );
+
+    expect(md).toMatch(/^`````+agency\n/m);
+  });
+
+  it("strips JSDoc-style leading `*` from multi-line block comments", () => {
+    const md = weaveAndRead(
+      "test.agency",
+      `/**
+ * Line one
+ *
+ * Line two
+ */
+
+def foo(): number { return 1 }
+`,
+    );
+
+    // The leading " * " on each line is gone; paragraphs are preserved.
+    expect(md).toContain("Line one");
+    expect(md).toContain("Line two");
+    expect(md).not.toMatch(/^\s*\*\s+Line/m);
+
+    // The two paragraphs are separated by a blank line.
+    const oneIdx = md.indexOf("Line one");
+    const twoIdx = md.indexOf("Line two");
+    expect(md.substring(oneIdx, twoIdx)).toContain("\n\n");
+  });
+
+  it("preserves markdown bullets (leading `*` after the JSDoc decoration)", () => {
+    const md = weaveAndRead(
+      "test.agency",
+      `/**
+ * Items:
+ * * one
+ * * two
+ */
+`,
+    );
+
+    // After stripping the JSDoc decoration, the inner "* one" / "* two"
+    // markdown bullets remain.
+    expect(md).toContain("Items:");
+    expect(md).toContain("* one");
+    expect(md).toContain("* two");
+  });
+
+  it("leaves single-line block comments alone", () => {
+    const md = weaveAndRead("test.agency", `/* a * b */\n`);
+    // The internal "*" is untouched.
+    expect(md).toContain("a * b");
+  });
+
+  it("smoke-tests against stdlib/markdown.agency (real-world AST)", () => {
+    const repoRoot = path.resolve(__dirname, "..", "..");
+    const input = path.join(repoRoot, "stdlib", "markdown.agency");
+    // Sanity: only run if the fixture exists in this checkout.
+    if (!fs.existsSync(input)) return;
+
+    const outputDir = path.join(tmpDir, "out");
+    generateLiterate({}, input, outputDir, [], "agency");
+
+    const md = fs.readFileSync(path.join(outputDir, "markdown.md"), "utf-8");
+    expect(md.length).toBeGreaterThan(0);
+    expect(md).toContain("```agency");
+  });
+});

--- a/packages/agency-lang/lib/cli/literate.test.ts
+++ b/packages/agency-lang/lib/cli/literate.test.ts
@@ -269,6 +269,47 @@ def foo(): number { return 1 }
     expect(md).toContain("a * b");
   });
 
+  it("preserves source order of imports (no hoisting, no alphabetical sort)", () => {
+    const md = weaveAndRead(
+      "test.agency",
+      `import { zebra } from "z"
+import { apple } from "a"
+
+def hello(): string {
+  return "world"
+}
+`,
+    );
+
+    // Without preserveOrder, AgencyGenerator would alphabetize these
+    // imports — "apple" would come before "zebra". Pin source order.
+    const zebraIdx = md.indexOf("zebra");
+    const appleIdx = md.indexOf("apple");
+    expect(zebraIdx).toBeGreaterThan(0);
+    expect(appleIdx).toBeGreaterThan(0);
+    expect(zebraIdx).toBeLessThan(appleIdx);
+  });
+
+  it("preserves imports placed mid-file (no hoisting)", () => {
+    const md = weaveAndRead(
+      "test.agency",
+      `def first(): number { return 1 }
+
+import { later } from "wherever"
+
+def second(): number { return 2 }
+`,
+    );
+
+    // The mid-file import must appear AFTER first() and BEFORE second().
+    const firstIdx = md.indexOf("def first");
+    const importIdx = md.indexOf("import { later }");
+    const secondIdx = md.indexOf("def second");
+    expect(firstIdx).toBeGreaterThanOrEqual(0);
+    expect(importIdx).toBeGreaterThan(firstIdx);
+    expect(secondIdx).toBeGreaterThan(importIdx);
+  });
+
   it("smoke-tests against stdlib/markdown.agency (real-world AST)", () => {
     const repoRoot = path.resolve(__dirname, "..", "..");
     const input = path.join(repoRoot, "stdlib", "markdown.agency");

--- a/packages/agency-lang/lib/cli/literate.ts
+++ b/packages/agency-lang/lib/cli/literate.ts
@@ -113,7 +113,14 @@ function classify(program: AgencyProgram): Segment[] {
 
 function renderSegment(seg: Segment, lang: string): string {
   if (seg.kind === "prose") return seg.text;
-  const code = generateAgency({ type: "agencyProgram", nodes: seg.nodes });
+  // `preserveOrder: true` keeps imports in their source position rather
+  // than hoisting them to the top of the segment and sorting them. We
+  // need this for literate output to faithfully reproduce the file in
+  // source order.
+  const code = generateAgency(
+    { type: "agencyProgram", nodes: seg.nodes },
+    { preserveOrder: true },
+  );
   return codeFence(code, lang); // codeFence handles trimEnd + fence escalation
 }
 

--- a/packages/agency-lang/lib/cli/literate.ts
+++ b/packages/agency-lang/lib/cli/literate.ts
@@ -1,0 +1,165 @@
+import { AgencyConfig } from "@/config.js";
+import { generateAgency } from "@/backends/agencyGenerator.js";
+import { parse, readFile } from "./commands.js";
+import { findRecursively } from "./util.js";
+import { AgencyNode, AgencyProgram, AgencyMultiLineComment } from "@/types.js";
+import { codeFence } from "@/utils/markdown.js";
+import * as fs from "fs";
+import * as path from "path";
+
+type Kind = "prose" | "empty" | "code";
+type Tagged = { kind: "prose" | "code"; node: AgencyNode };
+type Segment =
+  | { kind: "prose"; text: string }
+  | { kind: "code"; nodes: AgencyNode[] };
+
+// --- classification pipeline (declarative) -------------------------------
+
+/** Base kind of a single node, ignoring context. */
+function kindOf(node: AgencyNode): Kind {
+  if (node.type === "multiLineComment") return "prose"; // /* */ and /** */
+  if (node.type === "newLine") return "empty";
+  return "code";
+}
+
+/** Nearest non-empty neighbor in `dir` direction. */
+function neighbor(
+  nodes: AgencyNode[],
+  from: number,
+  dir: 1 | -1,
+): AgencyNode | undefined {
+  for (let i = from + dir; i >= 0 && i < nodes.length; i += dir) {
+    if (kindOf(nodes[i]) !== "empty") return nodes[i];
+  }
+  return undefined;
+}
+
+/**
+ * Promote `empty` nodes to `code` when both neighbors are code (blank lines
+ * inside a code run are preserved). Drop empty nodes everywhere else.
+ */
+function resolveEmpty(nodes: AgencyNode[]): Tagged[] {
+  return nodes.flatMap((node, i): Tagged[] => {
+    const k = kindOf(node);
+    if (k === "prose" || k === "code") return [{ kind: k, node }];
+    const prev = neighbor(nodes, i, -1);
+    const next = neighbor(nodes, i, +1);
+    const sandwichedByCode =
+      !!prev && !!next && kindOf(prev) === "code" && kindOf(next) === "code";
+    return sandwichedByCode ? [{ kind: "code", node }] : [];
+  });
+}
+
+/** Collapse consecutive same-kind items into runs. */
+function groupRuns(
+  items: Tagged[],
+): { kind: "prose" | "code"; items: Tagged[] }[] {
+  return items.reduce<{ kind: "prose" | "code"; items: Tagged[] }[]>(
+    (runs, item) => {
+      const last = runs[runs.length - 1];
+      if (last && last.kind === item.kind) last.items.push(item);
+      else runs.push({ kind: item.kind, items: [item] });
+      return runs;
+    },
+    [],
+  );
+}
+
+/**
+ * Strip the JSDoc-style ` * ` decoration that prefixes each line of a
+ * multi-line block comment. Single-line comments are returned unchanged.
+ *
+ *   /**
+ *    * Line one
+ *    *
+ *    * Line two
+ *    *\/
+ *
+ * has raw content `"\n * Line one\n *\n * Line two\n "` which we want to
+ * render as the prose `"Line one\n\nLine two"`.
+ */
+function stripJsdocStars(content: string): string {
+  if (!content.includes("\n")) return content;
+  return content
+    .split("\n")
+    .map((line) => line.replace(/^\s*\*\s?/, ""))
+    .join("\n");
+}
+
+function classify(program: AgencyProgram): Segment[] {
+  // NOTE: program.docComment is only populated by TypescriptPreprocessor,
+  // which we deliberately skip. A module-level `/** */` is present as an
+  // ordinary `multiLineComment` node in `program.nodes` and flows through
+  // the prose branch below. Do NOT consult program.docComment — doing so
+  // would double-emit the module doc.
+  return groupRuns(resolveEmpty(program.nodes)).map((run): Segment => {
+    if (run.kind === "prose") {
+      return {
+        kind: "prose",
+        text: run.items
+          .map((it) =>
+            stripJsdocStars(
+              (it.node as AgencyMultiLineComment).content,
+            ).trim(),
+          )
+          .join("\n\n"),
+      };
+    }
+    return { kind: "code", nodes: run.items.map((it) => it.node) };
+  });
+}
+
+// --- rendering ------------------------------------------------------------
+
+function renderSegment(seg: Segment, lang: string): string {
+  if (seg.kind === "prose") return seg.text;
+  const code = generateAgency({ type: "agencyProgram", nodes: seg.nodes });
+  return codeFence(code, lang); // codeFence handles trimEnd + fence escalation
+}
+
+function render(segments: Segment[], lang: string): string {
+  if (segments.length === 0) return "";
+  return segments.map((s) => renderSegment(s, lang)).join("\n\n") + "\n";
+}
+
+// --- I/O ------------------------------------------------------------------
+
+function weaveFile(
+  inputPath: string,
+  outputPath: string,
+  config: AgencyConfig,
+  lang: string,
+): void {
+  // `applyTemplate: false` skips the implicit `import { ... } from "std::index"`
+  // prelude that the parser normally injects. For literate output we want to
+  // render exactly what the user wrote, nothing more.
+  const program = parse(readFile(inputPath), config, false);
+  const md = render(classify(program), lang);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, md);
+}
+
+export function generateLiterate(
+  config: AgencyConfig,
+  inputPath: string,
+  outputDir: string,
+  ignoreDirs: string[] = [],
+  lang: string = "agency",
+): void {
+  if (fs.statSync(inputPath).isDirectory()) {
+    for (const { path: filePath } of findRecursively(
+      inputPath,
+      ".agency",
+      [],
+      ignoreDirs,
+    )) {
+      const rel = path
+        .relative(inputPath, filePath)
+        .replace(/\.agency$/, ".md");
+      weaveFile(filePath, path.join(outputDir, rel), config, lang);
+    }
+  } else {
+    const base = path.basename(inputPath).replace(/\.agency$/, ".md");
+    weaveFile(inputPath, path.join(outputDir, base), config, lang);
+  }
+}

--- a/packages/agency-lang/lib/utils/markdown.test.ts
+++ b/packages/agency-lang/lib/utils/markdown.test.ts
@@ -1,5 +1,25 @@
 import { describe, it, expect } from "vitest";
-import { escapeTableCell, markdownTable } from "./markdown.js";
+import { codeFence, escapeTableCell, markdownTable } from "./markdown.js";
+
+describe("codeFence", () => {
+  it("uses a 3-backtick fence by default", () => {
+    expect(codeFence("hello", "ts")).toBe("```ts\nhello\n```");
+  });
+
+  it("escalates to 4 backticks when content contains triple backticks", () => {
+    expect(codeFence("see ```js\nfoo\n```", "md")).toBe(
+      "````md\nsee ```js\nfoo\n```\n````",
+    );
+  });
+
+  it("escalates to 5 backticks when content contains quadruple backticks", () => {
+    expect(codeFence("a ```` b", "md")).toBe("`````md\na ```` b\n`````");
+  });
+
+  it("trims trailing whitespace from the code", () => {
+    expect(codeFence("hello\n\n", "ts")).toBe("```ts\nhello\n```");
+  });
+});
 
 describe("escapeTableCell", () => {
   it("escapes pipe characters", () => {

--- a/packages/agency-lang/lib/utils/markdown.ts
+++ b/packages/agency-lang/lib/utils/markdown.ts
@@ -3,7 +3,10 @@ export function heading(level: number, text: string): string {
 }
 
 export function codeFence(code: string, lang: string = "ts"): string {
-  return `\`\`\`${lang}\n${code.trimEnd()}\n\`\`\``;
+  const matches = code.match(/`+/g) ?? [];
+  const longest = matches.reduce((m, s) => Math.max(m, s.length), 0);
+  const fence = "`".repeat(Math.max(3, longest + 1));
+  return `${fence}${lang}\n${code.trimEnd()}\n${fence}`;
 }
 
 export function bold(text: string): string {

--- a/packages/agency-lang/scripts/agency.ts
+++ b/packages/agency-lang/scripts/agency.ts
@@ -49,6 +49,7 @@ import { scheduleTest } from "@/cli/schedule/test.js";
 import { loadEnv } from "@/utils/envfile.js";
 import { debug } from "@/cli/debug.js";
 import { generateDoc } from "@/cli/doc.js";
+import { generateLiterate } from "@/cli/literate.js";
 import { optimize } from "@/cli/optimize.js";
 import { watchAndCompile } from "@/cli/watch.js";
 import {
@@ -678,6 +679,36 @@ export function createProgram(deps: CliDependencies = {}): Command {
       const outputDir = opts.output || config.doc?.outDir || "docs";
       generateDoc(config, input, outputDir, opts.ignore || [], opts.baseUrl);
     });
+
+  const literate = program
+    .command("literate")
+    .description("Render Agency code as literate-programming markdown");
+
+  literate
+    .command("weave")
+    .description("Render .agency file(s) as markdown")
+    .argument("<input>", "Path to .agency file or directory")
+    .option("-o, --output <dir>", "Output directory", "literate")
+    .option(
+      "--ignore <dirs...>",
+      "Directory names to ignore when scanning recursively",
+    )
+    .option("--lang <name>", "Code-fence language tag", "agency")
+    .action(
+      (
+        input: string,
+        opts: { output: string; ignore?: string[]; lang: string },
+      ) => {
+        const config = getConfig();
+        generateLiterate(
+          config,
+          input,
+          opts.output,
+          opts.ignore || [],
+          opts.lang,
+        );
+      },
+    );
 
   program
     .command("optimize")

--- a/packages/agency-lang/tests/integration/cli/test.mjs
+++ b/packages/agency-lang/tests/integration/cli/test.mjs
@@ -1,7 +1,8 @@
 // CLI end-to-end tests: compile+run, stdlib imports, interrupts/handlers, test runner.
 // All tests avoid LLM calls.
 
-import { resolve } from "node:path";
+import { resolve, join } from "node:path";
+import { readFileSync } from "node:fs";
 import {
   createTempProject, initProject, installTarball,
   writeFile, run, assertIncludes, cleanup, getTarballPath,
@@ -105,6 +106,27 @@ node main() {
   }, null, 2));
   run(dir, "npx agency test testable.agency");
   console.log("Test 4 passed");
+
+  // --- Test 5: Literate weave ---
+  console.log("--- Test 5: Literate weave ---");
+  writeFile(dir, "literate-input.agency", `/* hello literate world */
+
+def add(a: number, b: number): number {
+  // sum
+  return a + b
+}
+`);
+  run(dir, "npx agency literate weave literate-input.agency -o literate-out");
+  const literateOutput = readFileSync(
+    join(dir, "literate-out", "literate-input.md"),
+    "utf-8",
+  );
+  assertIncludes(literateOutput, "hello literate world");
+  assertIncludes(literateOutput, "```agency");
+  assertIncludes(literateOutput, "def add");
+  // line comment stays inside the fence (i.e. not lost)
+  assertIncludes(literateOutput, "// sum");
+  console.log("Test 5 passed");
 
   console.log("=== All CLI tests passed ===");
   cleanup(dir);


### PR DESCRIPTION
## Summary

Adds a new `agency literate weave` command that renders Agency source as
literate-programming markdown. Block comments (`/* */` and `/** */`)
become prose; everything else stays in a code fence.

```
agency literate weave <input> [-o <outputDir>] [--ignore <dirs...>] [--lang <name>]
```

- `<input>` is a file or directory. Directory input mirrors the relative
  tree under `outputDir`.
- Output dir defaults to `literate`.
- Code-fence language tag defaults to `agency`; pass `--lang typescript`
  for syntax highlighting on renderers that do not yet know `agency`.

This is intentionally distinct from `agency doc`, which produces API
reference output reorganized by symbol kind. `literate` is a narrative
reproduction of the file in source order.

## Design notes

- **Declarative classifier.** `lib/cli/literate.ts` is built as a
  three-stage pipeline (`kindOf` -> `resolveEmpty` -> `groupRuns`) and
  then mapped to segments. No mutable scratch state, no order-dependent
  flush callbacks.
- **Skip the preprocessor.** The literate weaver calls `parse()` only;
  running `TypescriptPreprocessor` would mutate the AST (attach doc
  comments to declarations, etc.) and break source-order rendering.
- **Skip the parser template.** `applyTemplate: false` is passed to
  `parse()` so the implicit `import { ... } from "std::index"` prelude
  does not show up in every weaved file.
- **JSDoc star-stripping.** Multi-line block comments have their
  leading ` * ` decoration removed so prose renders cleanly. Single-line
  comments and inner `*` characters are untouched, so markdown bullets
  and arithmetic survive.

## Side-improvement: `codeFence` auto-escalation

`lib/utils/markdown.ts:codeFence` now picks the fence delimiter as
`max(3, longest backtick run in code + 1)` instead of hardcoding three
backticks. Backward-compatible; every existing caller becomes correct
for inputs that happen to contain triple-backticks.

## Tests

- `lib/cli/literate.test.ts` (14 cases): block/doc/line comments,
  adjacent block merging, `--lang` flow-through, directory tree mirror,
  empty input, fence escalation (3-, 4-, 5-backtick), JSDoc star
  stripping, markdown-bullet preservation, single-line passthrough, and
  a real-file smoke test against `stdlib/markdown.agency`.
- `lib/utils/markdown.test.ts` (4 new cases): default + escalation +
  trim behavior for `codeFence`.
- `tests/integration/cli/test.mjs` (Test 5): end-to-end smoke through
  the published CLI.

## Out of scope

- `agency literate tangle` (markdown -> agency).
- Round-trip / idempotency.
- Local-import linking.
- A `literate?` config key in `agency.json` (defaults are inline on the
  commander options; YAGNI for now).
