### PR TITLE
Cross-Thread Context Sharing: std::threads registry + resumable thread blocks

### DIFF
--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -1,3 +1,23 @@
+## Unreleased
+
+### Cross-Thread Context Sharing
+
+- New `std::threads` stdlib module: `listThreads()`, `getThread(id, offset, limit)`, `currentThreadId()`. Inspect every thread in the run (active + closed) and paginated-read any thread's messages. The marquee use case is the categorize-and-route pattern (one router, many specialized agent nodes, per-category thread continuity).
+- `agency.threads.{list, get, current}` TS namespace mirrors the stdlib surface for TypeScript helpers and external integrations.
+- New `onThreadStart` / `onThreadEnd` lifecycle hooks, alongside the existing `onNodeStart/End`. Payloads carry slug-form thread ids, `label`, `isResumption`, and the final message snapshot at close.
+- `thread {}` block grows four optional named args: `thread(label, summarize, continue, session) { ... }`.
+  - `label` — template-level intent ("coding task"); surfaces on `ThreadInfo`.
+  - `summarize` — opt-in eager summarization hook payload.
+  - `continue: id` — resume a previously-closed thread; new messages append.
+  - `session: "name"` — runtime-owned name → id map; first entry creates, subsequent entries resume. Sugar over `continue` that erases the "did I save the id?" footgun.
+- `ThreadStore.resumeExisting()` and `ThreadStore.openSession()` runtime primitives; both reject subthreads (a subthread's identity is tied to its parent's context at the time it was created).
+- `MessageThread.parentId` round-trips through JSON, so the registry surfaces parent-child linkage on `ThreadInfo` and the resume guards can recognize subthreads after an interrupt resume.
+- **Cross-node persistence required no production code.** The existing `state.messages` mechanism (`runNode` creates one `ThreadStore` per agent run; `setupNode` reuses it on every node hop) already does the right thing. We added a unit test (`lib/runtime/__tests__/node.test.ts`) pinning the contract so future refactors of `setupNode` can't silently break the registry.
+
+See [`docs/site/guide/cross-thread-context.md`](docs/site/guide/cross-thread-context.md) for the full guide and the categorize-and-route worked example.
+
+---
+
 ## May 28 2026 — v0.3
 
 ### Language

--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -1,23 +1,3 @@
-## Unreleased
-
-### Cross-Thread Context Sharing
-
-- New `std::threads` stdlib module: `listThreads()`, `getThread(id, offset, limit)`, `currentThreadId()`. Inspect every thread in the run (active + closed) and paginated-read any thread's messages. The marquee use case is the categorize-and-route pattern (one router, many specialized agent nodes, per-category thread continuity).
-- `agency.threads.{list, get, current}` TS namespace mirrors the stdlib surface for TypeScript helpers and external integrations.
-- New `onThreadStart` / `onThreadEnd` lifecycle hooks, alongside the existing `onNodeStart/End`. Payloads carry slug-form thread ids, `label`, `isResumption`, and the final message snapshot at close.
-- `thread {}` block grows four optional named args: `thread(label, summarize, continue, session) { ... }`.
-  - `label` — template-level intent ("coding task"); surfaces on `ThreadInfo`.
-  - `summarize` — opt-in eager summarization hook payload.
-  - `continue: id` — resume a previously-closed thread; new messages append.
-  - `session: "name"` — runtime-owned name → id map; first entry creates, subsequent entries resume. Sugar over `continue` that erases the "did I save the id?" footgun.
-- `ThreadStore.resumeExisting()` and `ThreadStore.openSession()` runtime primitives; both reject subthreads (a subthread's identity is tied to its parent's context at the time it was created).
-- `MessageThread.parentId` round-trips through JSON, so the registry surfaces parent-child linkage on `ThreadInfo` and the resume guards can recognize subthreads after an interrupt resume.
-- **Cross-node persistence required no production code.** The existing `state.messages` mechanism (`runNode` creates one `ThreadStore` per agent run; `setupNode` reuses it on every node hop) already does the right thing. We added a unit test (`lib/runtime/__tests__/node.test.ts`) pinning the contract so future refactors of `setupNode` can't silently break the registry.
-
-See [`docs/site/guide/cross-thread-context.md`](docs/site/guide/cross-thread-context.md) for the full guide and the categorize-and-route worked example.
-
----
-
 ## May 28 2026 — v0.3
 
 ### Language

--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -47,10 +47,6 @@ export default defineConfig({
               text: "Message History and Threads",
               link: "/guide/message-history-and-threads",
             },
-            {
-              text: "Cross-Thread Context Sharing",
-              link: "/guide/cross-thread-context",
-            },
             { text: "Error Handling", link: "/guide/error-handling" },
             { text: "Blocks", link: "/guide/blocks" },
             { text: "Execution Model", link: "/guide/execution-model" },
@@ -67,6 +63,10 @@ export default defineConfig({
             { text: "Type Validation", link: "/guide/type-validation" },
             { text: "Checkpointing", link: "/guide/checkpointing" },
             { text: "Memory", link: "/guide/memory" },
+            {
+              text: "Cross-Thread Context Sharing",
+              link: "/guide/cross-thread-context",
+            },
             { text: "MCP", link: "/guide/mcp" },
           ],
         },
@@ -116,10 +116,6 @@ export default defineConfig({
             {
               text: "Message History and Threads",
               link: "/guide/message-history-and-threads",
-            },
-            {
-              text: "Cross-Thread Context Sharing",
-              link: "/guide/cross-thread-context",
             },
             { text: "Error Handling", link: "/guide/error-handling" },
             { text: "Debugger", link: "/guide/debugger" },

--- a/packages/agency-lang/docs/site/.vitepress/config.mts
+++ b/packages/agency-lang/docs/site/.vitepress/config.mts
@@ -47,6 +47,10 @@ export default defineConfig({
               text: "Message History and Threads",
               link: "/guide/message-history-and-threads",
             },
+            {
+              text: "Cross-Thread Context Sharing",
+              link: "/guide/cross-thread-context",
+            },
             { text: "Error Handling", link: "/guide/error-handling" },
             { text: "Blocks", link: "/guide/blocks" },
             { text: "Execution Model", link: "/guide/execution-model" },
@@ -112,6 +116,10 @@ export default defineConfig({
             {
               text: "Message History and Threads",
               link: "/guide/message-history-and-threads",
+            },
+            {
+              text: "Cross-Thread Context Sharing",
+              link: "/guide/cross-thread-context",
             },
             { text: "Error Handling", link: "/guide/error-handling" },
             { text: "Debugger", link: "/guide/debugger" },

--- a/packages/agency-lang/docs/site/guide/cross-thread-context.md
+++ b/packages/agency-lang/docs/site/guide/cross-thread-context.md
@@ -1,0 +1,166 @@
+# Cross-Thread Context Sharing
+
+The cross-thread context-sharing feature lets one agent inspect, read, and resume **sibling `thread {}` blocks** in the same run. The marquee use case is the *categorize-and-route* pattern: a top-level router sends each user message to a specialized agent node, each agent owns its own thread for isolation, and when the user returns to an earlier topic the router resumes the *original* thread instead of starting fresh.
+
+```agency
+import { listThreads, getThread, currentThreadId } from "std::threads"
+```
+
+Three exports cover the user-facing API:
+
+- `listThreads(): ThreadInfo[]` — every thread in the run (active + closed) with optional `label` and lazily-generated `summary`.
+- `getThread(id, offset, limit): ThreadMessage[]` — paginated read of any thread's messages.
+- `currentThreadId(): string` — slug of the active thread, useful when you want to capture an id at the moment it was active so you can `thread(continue: id)` later.
+
+And the `thread {}` block grows four optional named arguments:
+
+```agency
+thread(label: "coding task", summarize: true) { /* ... */ }
+thread(continue: priorId) { /* ... */ }
+thread(session: "coding", label: "coding") { /* ... */ }
+```
+
+`continue` and `session` are mutually exclusive — pick one. `session` is sugar over `continue` plus a runtime-owned name → id map.
+
+---
+
+## Why `label` *and* `summary`?
+
+A `thread {}` block inside a loop runs many times with very different content. The user-supplied `label` captures the *template intent* ("this is a coding task"). The auto-generated `summary` captures *what actually happened in this instance* ("refactored auth, added JWT validation"). `listThreads()` returns both so an LLM searching for "the auth one" can match on summary while one looking for "any coding task" can match on label.
+
+## Slug ids (`t1`, `t2`, ...) vs. nanoids
+
+`ThreadStore` uses a per-store integer counter internally; the registry exposes it as a slug (`t${counter}`). LLMs handle short ordinal strings far better than random nanoids, and the wrong-but-valid-integer risk is bounded by `listThreads()` returning the summaries — the LLM picks by reading the list, not by guessing an integer.
+
+---
+
+## Resuming a thread (`continue`)
+
+`thread(continue: id)` re-enters a previously-closed thread. New messages append to its existing history rather than starting fresh:
+
+```agency
+import { getThread, currentThreadId } from "std::threads"
+import { userMessage } from "std::thread"
+
+node main() {
+  let codingId: string = ""
+  thread(label: "coding") {
+    userMessage("first coding turn")
+    codingId = currentThreadId()
+  }
+  // ... work on something else ...
+  thread(continue: codingId) {
+    userMessage("back to coding")
+  }
+  // The coding thread now holds BOTH messages, in order.
+}
+```
+
+**v1 limitation: subthreads cannot be resumed.** A subthread inherits its parent's message history at the moment it was created; resuming one outside that context would surface confusing ordering. If you need to continue work inside a subthread, resume the parent thread and open a fresh `subthread {}` block.
+
+---
+
+## Routing with sessions
+
+`thread(session: "name")` is the bread-and-butter primitive for routers. The runtime owns a `session-name → thread-id` map; first entry creates a thread, subsequent entries auto-resume it — no id bookkeeping at the call site:
+
+```agency
+import { listThreads } from "std::threads"
+import { userMessage } from "std::thread"
+
+node main() {
+  // First "coding" entry creates a new thread.
+  thread(session: "coding", label: "coding") {
+    userMessage("first coding")
+  }
+  // Distinct session — new thread.
+  thread(session: "weather", label: "weather") {
+    userMessage("weather request")
+  }
+  // Second "coding" entry RESUMES the original — message
+  // history persists across the weather hop.
+  thread(session: "coding", label: "coding") {
+    userMessage("back to coding")
+  }
+}
+```
+
+Sessions are always **top-level threads** — they cannot map to subthreads. (If you want a subthread inside a session, open the session normally and put a `subthread {}` block inside.)
+
+---
+
+## Memory scoping for routed agents
+
+When a router fans messages out to per-category agents, each agent should have its own *memory* scope so the coding agent's facts don't bleed into the weather agent. `setMemoryId(category)` from `std::memory` is already per-branch — call it at the top of each routed node:
+
+```agency
+import { setMemoryId } from "std::memory"
+
+node coding() {
+  setMemoryId("coding")
+  // ... coding-specific recall() and remember() calls ...
+}
+
+node weather() {
+  setMemoryId("weather")
+  // ... weather-specific recall() and remember() calls ...
+}
+```
+
+If you have facts that everyone should read — a workspace overview, the user's name — keep one well-known id and switch to it for cross-cutting writes:
+
+```agency
+node coding() {
+  setMemoryId("workspace")
+  remember("the user prefers Rust")
+  setMemoryId("coding")
+  // ... back to per-category scope ...
+}
+```
+
+This pairs with `thread(session: category)` to give each routed agent its own thread *and* its own memory scope:
+
+```agency
+import { listThreads } from "std::threads"
+import { setMemoryId } from "std::memory"
+
+node routedAgent(category: string, message: string) {
+  setMemoryId(category)
+  thread(session: category, label: category) {
+    // ... category-specific work ...
+  }
+}
+```
+
+---
+
+## Cross-node persistence
+
+The thread registry persists across node transitions automatically. Internally a single `ThreadStore` is created once per `runNode` call and threaded through `state.messages` to every step — so threads created in node `a` remain queryable from node `b`. Subthreads are normal entries in the same registry with `parentId` set.
+
+On interrupt resume the store is rebuilt from `stack.threads` (checkpoint serialization). The registry survives the interrupt and in-flight `thread {}` blocks resume mid-flight via the existing substep mechanism. See `docs/dev/threads.md` for the underlying mechanism.
+
+---
+
+## How this is built
+
+The whole feature is six small primitives plus a stdlib module:
+
+1. `agency.threads.{list, get, current}` — TS namespace, parallel to `agency.memory.*`.
+2. `onThreadStart` / `onThreadEnd` lifecycle hooks, in the same `CallbackMap` as `onNodeStart`/`onNodeEnd`.
+3. `thread(label, summarize)` named args.
+4. Cross-node persistence (no new code — `ThreadStore` already flows through `state.messages` on every node transition).
+5. `thread(continue: id)` — `ThreadStore.resumeExisting()`, rejects subthreads.
+6. `thread(session: "name")` — `ThreadStore.openSession()`, sugar over `continue`.
+
+The `stdlib/threads.agency` module is *the same code a user could write* on top of those primitives. If you want to ship a "tag threads by topic" feature, or a "diff two threads" inspector, or any other variant, the same surface is open to you — `agency.threads.*` plus the lifecycle hooks plus `thread(label / summarize / continue / session)` cover the whole feature set.
+
+---
+
+## Out of scope for v1
+
+- **Auto-context injection by label.** Users can replicate it in three lines with `listThreads().filter(...)`.
+- **Cross-run persistence.** The registry is run-scoped — restarting the agent starts fresh.
+- **Filtering / search in `listThreads`.** Returns everything; the LLM filters.
+- **Summary regeneration.** Once cached, a summary is final. Eager summarize on close (`thread(summarize: true)`) is not yet wired through the v1 stdlib hook — it remains on the wire for users who register their own `callback("onThreadEnd")`.
+- **A router primitive.** User-space already expresses categorize-and-route in three lines (see `tests/agency/categorize.agency`); adding `route { ... }` would be redundant complexity.

--- a/packages/agency-lang/docs/site/guide/cross-thread-context.md
+++ b/packages/agency-lang/docs/site/guide/cross-thread-context.md
@@ -18,10 +18,11 @@ The `std::threads` module gives you both:
 import { listThreads, getThread, currentThreadId } from "std::threads"
 ```
 
-And the `thread {}` block grows four optional named arguments:
+And the `thread {}` block grows five optional named arguments:
 
 ```ts
 thread(label: "coding") { /* ... */ }                        // tag it
+thread(summarize: true) { /* ... */ }                         // pre-mark for eager summary
 thread(continue: priorId) { /* ... */ }                       // resume by id
 thread(session: "coding") { /* ... */ }                       // resume by name (sugar)
 thread(label: "coding", hidden: true) { /* ... */ }           // exclude from listThreads()

--- a/packages/agency-lang/docs/site/guide/cross-thread-context.md
+++ b/packages/agency-lang/docs/site/guide/cross-thread-context.md
@@ -1,44 +1,87 @@
-# Cross-Thread Context Sharing
+---
+title: Cross-thread context sharing
+description: Inspect, read, and resume sibling `thread {}` blocks in the same run. Covers `listThreads()`, `getThread()`, and the `thread(label, summarize, continue, session)` named arguments, plus the categorize-and-route worked example.
+---
 
-The cross-thread context-sharing feature lets one agent inspect, read, and resume **sibling `thread {}` blocks** in the same run. The marquee use case is the *categorize-and-route* pattern: a top-level router sends each user message to a specialized agent node, each agent owns its own thread for isolation, and when the user returns to an earlier topic the router resumes the *original* thread instead of starting fresh.
+# Cross-thread context sharing
 
-```agency
+Here's the problem. You've built a router: a top-level node reads each user message, picks a category, and dispatches to one of several specialized agents. Each agent runs in its own `thread {}` block so its context stays clean. Great — until the user comes back to a topic they were discussing five minutes ago, and the agent has no memory of it. Each `thread {}` block starts fresh, so "back to coding" walks into a `coding` thread with no prior turns.
+
+You need two things to fix this:
+
+1. A way to *see* the other threads in the run.
+2. A way to *resume* one when the user circles back.
+
+The `std::threads` module gives you both:
+
+```ts
 import { listThreads, getThread, currentThreadId } from "std::threads"
 ```
 
-Three exports cover the user-facing API:
-
-- `listThreads(): ThreadInfo[]` — every thread in the run (active + closed) with optional `label` and lazily-generated `summary`.
-- `getThread(id, offset, limit): ThreadMessage[]` — paginated read of any thread's messages.
-- `currentThreadId(): string` — slug of the active thread, useful when you want to capture an id at the moment it was active so you can `thread(continue: id)` later.
-
 And the `thread {}` block grows four optional named arguments:
 
-```agency
-thread(label: "coding task", summarize: true) { /* ... */ }
-thread(continue: priorId) { /* ... */ }
-thread(session: "coding", label: "coding") { /* ... */ }
+```ts
+thread(label: "coding") { /* ... */ }                        // tag it
+thread(continue: priorId) { /* ... */ }                       // resume by id
+thread(session: "coding") { /* ... */ }                       // resume by name (sugar)
+thread(label: "coding", hidden: true) { /* ... */ }           // exclude from listThreads()
 ```
 
-`continue` and `session` are mutually exclusive — pick one. `session` is sugar over `continue` plus a runtime-owned name → id map.
+`continue` and `session` are mutually exclusive — pick one. We'll cover each below.
 
----
+## Listing threads
 
-## Why `label` *and* `summary`?
+`listThreads()` returns every thread in the run, including the active one. It returns a `Result` (see [error handling](./error-handling)) — success holds a `ThreadInfo[]`, failure holds an error message (e.g. when called from outside a node body).
 
-A `thread {}` block inside a loop runs many times with very different content. The user-supplied `label` captures the *template intent* ("this is a coding task"). The auto-generated `summary` captures *what actually happened in this instance* ("refactored auth, added JWT validation"). `listThreads()` returns both so an LLM searching for "the auth one" can match on summary while one looking for "any coding task" can match on label.
+```ts
+const all = listThreads()
+if (isSuccess(all)) {
+  for (t in all.value) {
+    print("[" + t.id + "] " + t.label + " — " + t.summary)
+  }
+}
+```
 
-## Slug ids (`t1`, `t2`, ...) vs. nanoids
+Each `ThreadInfo` has:
 
-`ThreadStore` uses a per-store integer counter internally; the registry exposes it as a slug (`t${counter}`). LLMs handle short ordinal strings far better than random nanoids, and the wrong-but-valid-integer risk is bounded by `listThreads()` returning the summaries — the LLM picks by reading the list, not by guessing an integer.
+```ts
+type ThreadInfo = {
+  id: string             // slug form: "t0", "t1", ...
+  label?: string         // from thread(label: "...") { }
+  summary?: string       // LLM-generated, lazily on first listThreads() call
+  parentId?: string      // set when this is a subthread
+  threadType: string     // "thread" | "subthread"
+  messageCount: number
+  isActive: boolean
+}
+```
 
----
+A few things worth knowing:
 
-## Resuming a thread (`continue`)
+- **Slug ids (`t1`, `t2`, ...) instead of nanoids.** LLMs handle short ordinal strings far better than random ids. When the LLM picks a thread to resume, it picks by reading `listThreads()` and matching on the summary — not by guessing an integer.
+- **Summaries are lazy.** The first time `listThreads()` runs against a closed thread without a cached summary, it makes one LLM call to summarize and stashes the result on the thread itself. Subsequent calls read the cache. Active threads are skipped so we don't summarize a half-finished conversation.
+- **`label` vs `summary`.** A `thread {}` block inside a loop runs many times with very different content. `label` captures the *template intent* ("coding task"). `summary` captures *what actually happened this time* ("refactored auth, added JWT validation"). An LLM searching for "the auth one" can match on summary; one searching for "any coding task" can match on label.
 
-`thread(continue: id)` re-enters a previously-closed thread. New messages append to its existing history rather than starting fresh:
+## Reading a thread's messages
 
-```agency
+`getThread(id, offset, limit)` returns a slice of a thread's history. Also a `Result`:
+
+```ts
+const msgs = getThread("t1", 0, 20)
+if (isSuccess(msgs)) {
+  for (m in msgs.value) {
+    print("[" + m.role + "] " + m.content)
+  }
+}
+```
+
+`offset` is 0-indexed; `limit` defaults to 50. Pass larger limits for a full-thread read.
+
+## Resuming a thread by id
+
+`thread(continue: id)` re-enters a previously-closed thread. New messages append to its history rather than starting fresh:
+
+```ts
 import { getThread, currentThreadId } from "std::threads"
 import { userMessage } from "std::thread"
 
@@ -56,16 +99,15 @@ node main() {
 }
 ```
 
-**v1 limitation: subthreads cannot be resumed.** A subthread inherits its parent's message history at the moment it was created; resuming one outside that context would surface confusing ordering. If you need to continue work inside a subthread, resume the parent thread and open a fresh `subthread {}` block.
+You'll want `currentThreadId()` to capture the id at the moment the thread is active. Storing it in a parent-scope variable like the example does is the simplest pattern.
 
----
+One v1 limitation: **subthreads cannot be resumed.** A subthread inherits its parent's message history at the moment it was created; resuming one outside that context would surface confusing ordering. If you need to continue work that was inside a subthread, resume the parent thread and open a fresh `subthread {}` block.
 
-## Routing with sessions
+## Resuming a thread by name (sessions)
 
-`thread(session: "name")` is the bread-and-butter primitive for routers. The runtime owns a `session-name → thread-id` map; first entry creates a thread, subsequent entries auto-resume it — no id bookkeeping at the call site:
+Saving and reaching back for ids gets old fast. `thread(session: "name")` does the bookkeeping for you — the runtime owns a `session-name → thread-id` map; first entry creates a thread, subsequent entries auto-resume:
 
-```agency
-import { listThreads } from "std::threads"
+```ts
 import { userMessage } from "std::thread"
 
 node main() {
@@ -85,31 +127,43 @@ node main() {
 }
 ```
 
-Sessions are always **top-level threads** — they cannot map to subthreads. (If you want a subthread inside a session, open the session normally and put a `subthread {}` block inside.)
+Sessions are always **top-level threads** — they cannot map to subthreads. If you want a subthread inside a session, open the session normally and put a `subthread {}` block inside.
 
----
+## The marquee example: categorize and route
 
-## Memory scoping for routed agents
+Putting the pieces together — here's a router that classifies each user message, then dispatches to a per-category thread that auto-resumes if the user circles back:
 
-When a router fans messages out to per-category agents, each agent should have its own *memory* scope so the coding agent's facts don't bleed into the weather agent. `setMemoryId(category)` from `std::memory` is already per-branch — call it at the top of each routed node:
-
-```agency
+```ts
+import { listThreads } from "std::threads"
+import { userMessage, llm } from "std::thread"
 import { setMemoryId } from "std::memory"
 
-node coding() {
-  setMemoryId("coding")
-  // ... coding-specific recall() and remember() calls ...
+node routedAgent(category: string, message: string) {
+  setMemoryId(category)
+  thread(session: category, label: category) {
+    userMessage(message)
+    const reply = llm("Reply to the user.")
+    print(reply)
+  }
 }
 
-node weather() {
-  setMemoryId("weather")
-  // ... weather-specific recall() and remember() calls ...
+node main(message: string) {
+  // Classify the message however you like — LLM, rule, regex.
+  // The string we get back becomes the session name.
+  const category = llm("Classify the message as one of: coding, weather, smalltalk. Message: " + message)
+  routedAgent(category, message)
 }
 ```
 
-If you have facts that everyone should read — a workspace overview, the user's name — keep one well-known id and switch to it for cross-cutting writes:
+That's it. The first time the user asks a coding question, a new `coding` thread opens. The next time, the existing one resumes. Weather questions get their own thread. Coding's history isn't polluted by weather, and the user can flip between topics without losing context.
 
-```agency
+The companion call is `setMemoryId(category)`: it gives each routed agent its own [memory](./memory) scope so facts don't bleed across categories. The coding agent's recall of "the user prefers tabs" doesn't surface in a weather conversation.
+
+If you have facts everyone should read — a workspace overview, the user's name — keep one well-known id and switch to it for cross-cutting writes:
+
+```ts
+import { setMemoryId, remember } from "std::memory"
+
 node coding() {
   setMemoryId("workspace")
   remember("the user prefers Rust")
@@ -118,49 +172,28 @@ node coding() {
 }
 ```
 
-This pairs with `thread(session: category)` to give each routed agent its own thread *and* its own memory scope:
+## Hiding internal threads
 
-```agency
-import { listThreads } from "std::threads"
-import { setMemoryId } from "std::memory"
+If a library opens its own `thread {}` block to run a side-conversation (a summarizer, a classifier, a code analyzer), you usually don't want it showing up in user-facing `listThreads()` output:
 
-node routedAgent(category: string, message: string) {
-  setMemoryId(category)
-  thread(session: category, label: category) {
-    // ... category-specific work ...
-  }
+```ts
+thread(hidden: true) {
+  // Library-internal scaffolding the user shouldn't see.
 }
 ```
 
----
+The `std::threads` module's own `summarize()` helper uses exactly this pattern when it generates the lazy thread summaries.
 
 ## Cross-node persistence
 
-The thread registry persists across node transitions automatically. Internally a single `ThreadStore` is created once per `runNode` call and threaded through `state.messages` to every step — so threads created in node `a` remain queryable from node `b`. Subthreads are normal entries in the same registry with `parentId` set.
+Threads created in one node remain queryable from another. Internally a single `ThreadStore` is created once per `runNode` call and reused across every node hop, so threads survive node transitions for free. Subthreads are normal entries in the same registry with `parentId` set. On interrupt resume the store is rebuilt from the checkpoint, so an in-flight `thread {}` block resumes mid-flight via the existing substep mechanism. See `docs/dev/threads.md` for the underlying mechanism.
 
-On interrupt resume the store is rebuilt from `stack.threads` (checkpoint serialization). The registry survives the interrupt and in-flight `thread {}` blocks resume mid-flight via the existing substep mechanism. See `docs/dev/threads.md` for the underlying mechanism.
+## What's out of scope for v1
 
----
+A few things we deliberately left out:
 
-## How this is built
-
-The whole feature is six small primitives plus a stdlib module:
-
-1. `agency.threads.{list, get, current}` — TS namespace, parallel to `agency.memory.*`.
-2. `onThreadStart` / `onThreadEnd` lifecycle hooks, in the same `CallbackMap` as `onNodeStart`/`onNodeEnd`.
-3. `thread(label, summarize)` named args.
-4. Cross-node persistence (no new code — `ThreadStore` already flows through `state.messages` on every node transition).
-5. `thread(continue: id)` — `ThreadStore.resumeExisting()`, rejects subthreads.
-6. `thread(session: "name")` — `ThreadStore.openSession()`, sugar over `continue`.
-
-The `stdlib/threads.agency` module is *the same code a user could write* on top of those primitives. If you want to ship a "tag threads by topic" feature, or a "diff two threads" inspector, or any other variant, the same surface is open to you — `agency.threads.*` plus the lifecycle hooks plus `thread(label / summarize / continue / session)` cover the whole feature set.
-
----
-
-## Out of scope for v1
-
-- **Auto-context injection by label.** Users can replicate it in three lines with `listThreads().filter(...)`.
+- **Auto-context injection by label.** Users can replicate it in three lines with `listThreads()` plus a filter.
 - **Cross-run persistence.** The registry is run-scoped — restarting the agent starts fresh.
-- **Filtering / search in `listThreads`.** Returns everything; the LLM filters.
-- **Summary regeneration.** Once cached, a summary is final. Eager summarize on close (`thread(summarize: true)`) is not yet wired through the v1 stdlib hook — it remains on the wire for users who register their own `callback("onThreadEnd")`.
-- **A router primitive.** User-space already expresses categorize-and-route in three lines (see `tests/agency/categorize.agency`); adding `route { ... }` would be redundant complexity.
+- **Filtering / search in `listThreads()`.** Returns everything; the LLM filters.
+- **Eager summarization at close.** `thread(summarize: true)` is parsed and forwarded to the `onThreadEnd` hook payload, but the v1 stdlib doesn't act on it yet — summaries are computed lazily on the next `listThreads()` call. Wiring TS-side hooks to call an Agency function cleanly is a follow-up.
+- **A router primitive.** User-space already expresses categorize-and-route in three lines (see the example above); adding a `route { ... }` builtin would be redundant.

--- a/packages/agency-lang/docs/site/guide/message-history-and-threads.md
+++ b/packages/agency-lang/docs/site/guide/message-history-and-threads.md
@@ -82,3 +82,7 @@ They do **not** work in these "bootstrap" scopes:
 If you call a thread builtin from one of these scopes — `systemMessage`, `userMessage`, `llm`, `thread { ... }`, `subthread { ... }` — you'll get a runtime error like *"Message threads are not available in this scope."* with a pointer to this guide. Move the code inside a `node` or `def` body to fix it.
 
 `onAgentEnd` is the exception: it fires *after* the run completes, so it has access to the final conversation. You can inspect or log the thread state from there.
+
+## See also
+
+- [Cross-Thread Context Sharing](./cross-thread-context.md) — `listThreads()`, `getThread()`, and the `thread(label, summarize, continue, session)` named arguments for inspecting and resuming sibling threads. The marquee use case is the categorize-and-route pattern (one router, many specialized agents, per-category thread continuity).

--- a/packages/agency-lang/docs/site/guide/message-history-and-threads.md
+++ b/packages/agency-lang/docs/site/guide/message-history-and-threads.md
@@ -85,4 +85,4 @@ If you call a thread builtin from one of these scopes — `systemMessage`, `user
 
 ## See also
 
-- [Cross-Thread Context Sharing](./cross-thread-context.md) — `listThreads()`, `getThread()`, and the `thread(label, summarize, continue, session)` named arguments for inspecting and resuming sibling threads. The marquee use case is the categorize-and-route pattern (one router, many specialized agents, per-category thread continuity).
+- [Cross-Thread Context Sharing](./cross-thread-context) — `listThreads()`, `getThread()`, and the `thread(label, summarize, continue, session)` named arguments for inspecting and resuming sibling threads. The marquee use case is the categorize-and-route pattern (one router, many specialized agents, per-category thread continuity).

--- a/packages/agency-lang/docs/site/stdlib/memory.md
+++ b/packages/agency-lang/docs/site/stdlib/memory.md
@@ -41,6 +41,26 @@ export type MemoryConfig = {
 
 ## Functions
 
+### isMemoryActive
+
+```ts
+isMemoryActive(): boolean
+```
+
+Return `true` iff there is an active memory frame on the current
+  branch's stateStack — i.e. memory is on and `remember`/`recall` will
+  reach a real store. Returns `false` when memory was never enabled,
+  was explicitly turned off via `disableMemory()`, or the call is
+  outside any runtime frame.
+
+  Useful for branching in user code (`if (isMemoryActive()) { ... }`)
+  and for integration tests that want to verify push/pop semantics
+  without poking at the stateStack directly.
+
+**Returns:** `boolean`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L48))
+
 ### setMemoryId
 
 ```ts
@@ -67,7 +87,7 @@ Set the memory scope for this agent run. Call this before other
 |---|---|---|
 | id | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L48))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L63))
 
 ### enableMemory
 
@@ -104,7 +124,7 @@ Turn memory on for the current execution branch using `config`.
 |---|---|---|
 | config | [MemoryConfig](#memoryconfig) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L67))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L82))
 
 ### disableMemory
 
@@ -123,7 +143,7 @@ Pop the top memory frame from the current branch's stateStack.
   Prefer the block form `memory({...}) as { ... }` for lexical
   scoping, which restores the previous frame on exit.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L95))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L110))
 
 ### memory
 
@@ -163,7 +183,7 @@ Run `block` with `config` pushed as the active memory frame; pop
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L111))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L126))
 
 ### remember
 
@@ -188,7 +208,7 @@ Extract and store structured facts from the given text into the
 |---|---|---|
 | content | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L144))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L159))
 
 ### recall
 
@@ -213,7 +233,7 @@ Retrieve relevant facts from the knowledge graph as a formatted
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L166))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L181))
 
 ### forget
 
@@ -237,4 +257,4 @@ Soft-delete facts matching the query from the knowledge graph.
 |---|---|---|
 | query | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L180))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/memory.agency#L195))

--- a/packages/agency-lang/docs/site/stdlib/threads.md
+++ b/packages/agency-lang/docs/site/stdlib/threads.md
@@ -83,7 +83,7 @@ Return every thread in the current run, including the active one.
 
 **Returns:** `ThreadInfo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L87))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L91))
 
 ### currentThreadId
 
@@ -98,7 +98,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L126))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L130))
 
 ### getThread
 
@@ -125,4 +125,4 @@ Read a slice of a thread's messages. Returns `[]` for an unknown id.
 
 **Returns:** `ThreadMessage[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L136))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L140))

--- a/packages/agency-lang/docs/site/stdlib/threads.md
+++ b/packages/agency-lang/docs/site/stdlib/threads.md
@@ -1,0 +1,113 @@
+# threads
+
+## Types
+
+### ThreadMessage
+
+```ts
+export type ThreadMessage = {
+  role: string;
+  content: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L31))
+
+### ThreadInfo
+
+```ts
+export type ThreadInfo = {
+  id: string;
+  label?: string;
+  summary?: string;
+  parentId?: string;
+  threadType: string;
+  messageCount: number;
+  isActive: boolean
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L36))
+
+## Functions
+
+### summarize
+
+```ts
+summarize(messages: ThreadMessage[]): string
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| messages | `ThreadMessage[]` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L49))
+
+### summaryFor
+
+```ts
+summaryFor(id: string, messages: ThreadMessage[] | null): string | null
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `string` |  |
+| messages | `ThreadMessage[] \| null` | null |
+
+**Returns:** `string | null`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L64))
+
+### listThreads
+
+```ts
+listThreads(): ThreadInfo[]
+```
+
+Return every thread in the current run, including the active one.
+
+  Lazy summary generation: a thread that doesn't yet have a cached
+  summary triggers exactly one LLM round-trip the first time
+  `listThreads()` is called on it. Active threads are skipped so the
+  in-flight conversation is not summarized mid-stream.
+
+  Eager summarization (one summary call per `thread {}` close instead
+  of all-at-once on first `listThreads()`) is opt-in:
+  `thread(summarize: true) { ... }`.
+
+**Returns:** `ThreadInfo[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L86))
+
+### getThread
+
+```ts
+getThread(id: string, offset: number, limit: number): ThreadMessage[]
+```
+
+Read a slice of a thread's messages. Returns `[]` for an unknown id.
+
+  Pagination: `offset` is 0-indexed; `limit` defaults to 50. Pass
+  larger explicit values for full-thread reads.
+
+  @param id - Thread slug (e.g. "t1") from `listThreads()`
+  @param offset - 0-indexed start of the message slice
+  @param limit - Maximum number of messages to return
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| id | `string` |  |
+| offset | `number` | 0 |
+| limit | `number` | 50 |
+
+**Returns:** `ThreadMessage[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L125))

--- a/packages/agency-lang/docs/site/stdlib/threads.md
+++ b/packages/agency-lang/docs/site/stdlib/threads.md
@@ -1,5 +1,35 @@
 # threads
 
+Cross-thread context sharing: `listThreads()` enumerates
+every thread in the current run (active + closed), `getThread(id,
+offset, limit)` reads a slice of a thread's messages. The registry is
+built on the public `agency.threads.*` primitives — the same surface
+you'd reach for to build your own variants (tag-threads, thread-diff,
+etc.) in user space.
+
+  ```ts
+  import { listThreads, getThread } from "std::threads"
+
+  // Inspect the run's other threads:
+  const info = listThreads()
+
+  // Read a slice of a prior thread's messages:
+  const lines = getThread("t1", 0, 20)
+  ```
+
+`label` is set at `thread {}` create time (template-level intent set
+via `thread(label: "...") { ... }`); `summary` is per-instance and
+generated lazily on first `listThreads()` call against a closed
+thread. Both fields live directly on the underlying `MessageThread`
+so the registry is per-run and survives interrupt-resume via the
+existing checkpoint serialization.
+
+The eager-summarize flag (`thread(summarize: true) { ... }`) is
+parsed and forwarded to the `onThreadEnd` hook payload as
+`eagerSummarize: true`, but the v1 stdlib does not yet act on it —
+summaries are computed lazily on the next `listThreads()` call. See
+the TODO in `lib/runtime/runner.ts::thread` for the deferral.
+
 ## Types
 
 ### ThreadMessage
@@ -11,7 +41,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L32))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L39))
 
 ### ThreadInfo
 
@@ -27,7 +57,17 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L44))
+
+### SummaryResult
+
+```ts
+type SummaryResult = {
+  summary: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L54))
 
 ## Functions
 
@@ -37,6 +77,14 @@ export type ThreadInfo = {
 summarize(messages: ThreadMessage[]): string
 ```
 
+One-shot LLM summarization used by the lazy summarize path.
+  Wrapped in a `thread {}` block so the summarizer prompt runs on
+  an isolated message history and doesn't pollute the agent's main
+  conversation. Uses structured output so the returned text comes
+  back on a known field instead of free-form completion text.
+
+  @param messages - The thread's messages to summarize
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -45,12 +93,12 @@ summarize(messages: ThreadMessage[]): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L50))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L58))
 
 ### summaryFor
 
 ```ts
-summaryFor(id: string, messages: ThreadMessage[] | null): string | null
+summaryFor(id: string, existing: string | null, messages: ThreadMessage[] | null): string | null
 ```
 
 **Parameters:**
@@ -58,16 +106,17 @@ summaryFor(id: string, messages: ThreadMessage[] | null): string | null
 | Name | Type | Default |
 |---|---|---|
 | id | `string` |  |
+| existing | `string \| null` |  |
 | messages | `ThreadMessage[] \| null` | null |
 
 **Returns:** `string | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L65))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L82))
 
 ### listThreads
 
 ```ts
-listThreads(): ThreadInfo[]
+listThreads(): Result
 ```
 
 Return every thread in the current run, including the active one.
@@ -75,15 +124,17 @@ Return every thread in the current run, including the active one.
   Lazy summary generation: a thread that doesn't yet have a cached
   summary triggers exactly one LLM round-trip the first time
   `listThreads()` is called on it. Active threads are skipped so the
-  in-flight conversation is not summarized mid-stream.
+  in-flight conversation is not summarized mid-stream. The computed
+  summary is stashed on the underlying `MessageThread` so subsequent
+  calls read it back without re-prompting.
 
-  Eager summarization (one summary call per `thread {}` close instead
-  of all-at-once on first `listThreads()`) is opt-in:
-  `thread(summarize: true) { ... }`.
+  Returns a `Result` — success holds `ThreadInfo[]`, failure holds
+  the error (e.g. called outside an Agency frame). See
+  [error handling](https://agency-lang.com/guide/error-handling).
 
-**Returns:** `ThreadInfo[]`
+**Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L91))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L98))
 
 ### currentThreadId
 
@@ -98,18 +149,23 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L130))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L137))
 
 ### getThread
 
 ```ts
-getThread(id: string, offset: number, limit: number): ThreadMessage[]
+getThread(id: string, offset: number, limit: number): Result
 ```
 
-Read a slice of a thread's messages. Returns `[]` for an unknown id.
+Read a slice of a thread's messages. Returns success holding `[]`
+  for an unknown id; returns failure when called outside an Agency
+  frame.
 
   Pagination: `offset` is 0-indexed; `limit` defaults to 50. Pass
   larger explicit values for full-thread reads.
+
+  Returns a `Result` — success holds `ThreadMessage[]`. See
+  [error handling](https://agency-lang.com/guide/error-handling).
 
   @param id - Thread slug (e.g. "t1") from `listThreads()`
   @param offset - 0-indexed start of the message slice
@@ -123,6 +179,6 @@ Read a slice of a thread's messages. Returns `[]` for an unknown id.
 | offset | `number` | 0 |
 | limit | `number` | 50 |
 
-**Returns:** `ThreadMessage[]`
+**Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L140))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L147))

--- a/packages/agency-lang/docs/site/stdlib/threads.md
+++ b/packages/agency-lang/docs/site/stdlib/threads.md
@@ -11,7 +11,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L31))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L32))
 
 ### ThreadInfo
 
@@ -27,7 +27,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L36))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L37))
 
 ## Functions
 
@@ -45,7 +45,7 @@ summarize(messages: ThreadMessage[]): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L49))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L50))
 
 ### summaryFor
 
@@ -62,7 +62,7 @@ summaryFor(id: string, messages: ThreadMessage[] | null): string | null
 
 **Returns:** `string | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L64))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L65))
 
 ### listThreads
 
@@ -83,7 +83,22 @@ Return every thread in the current run, including the active one.
 
 **Returns:** `ThreadInfo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L86))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L87))
+
+### currentThreadId
+
+```ts
+currentThreadId(): string
+```
+
+Slug-form id of the active thread (e.g. "t3"), or `""` outside any
+  runtime frame. Useful with `thread(continue: id)` when you want to
+  capture a thread's id at the moment it was active so you can
+  resume it later.
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L126))
 
 ### getThread
 
@@ -110,4 +125,4 @@ Read a slice of a thread's messages. Returns `[]` for an unknown id.
 
 **Returns:** `ThreadMessage[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L125))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L136))

--- a/packages/agency-lang/docs/site/stdlib/threads.md
+++ b/packages/agency-lang/docs/site/stdlib/threads.md
@@ -111,7 +111,7 @@ summaryFor(id: string, existing: string | null, messages: ThreadMessage[] | null
 
 **Returns:** `string | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L82))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L83))
 
 ### listThreads
 
@@ -134,7 +134,7 @@ Return every thread in the current run, including the active one.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L98))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L99))
 
 ### currentThreadId
 
@@ -149,7 +149,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L137))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L138))
 
 ### getThread
 
@@ -181,4 +181,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L148))

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-29-thread-registry.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-29-thread-registry.md
@@ -104,7 +104,9 @@ Internal storage keeps the existing counter-string ID; the slug is a pure presen
 │  1. agency.threads.{list, get, current}            │
 │  2. thread(label?, summarize?) named args          │
 │  3. onThreadStart / onThreadEnd lifecycle hooks    │
-│  4. ThreadStore persists across node transitions   │
+│  4. (No new code — ThreadStore already persists    │
+│     across nodes via state.messages; verify +      │
+│     document.)                                     │
 │  5. thread(continue: id) — resume a closed thread  │
 │  6. thread(session: "name") — runtime-owned        │
 │     session→id map, sugar over (5)                 │
@@ -152,9 +154,25 @@ Build strategy: each primitive lands in its own task, the stdlib module is the l
 
 ## Task 1 — `agency.threads.*` TS-helper namespace
 
-**Goal:** Expose `ThreadStore` read methods via the canonical `agency` namespace, parallel to `agency.memory.*`. Pure read-side; no behavior change yet.
+**Goal:** Expose `ThreadStore` read methods via the canonical `agency` namespace, parallel to `agency.memory.*`. Pure read-side; one small data-model change (`parentId` on `MessageThread`) that downstream tasks depend on.
 
-- [ ] **Step 1: Add `agency.threads` to `lib/runtime/agency.ts`**
+- [ ] **Step 1: Track parent-id on `MessageThread`**
+
+  `MessageThread` (in `lib/runtime/state/messageThread.ts`) doesn't know whether it was created as a subthread today — only the `StatelogClient.threadCreated` event carries `parentThreadId`. Add an explicit field so `listThreads()` can return `parentId` and Task 6 can reject subthread continuation:
+
+  ```ts
+  export class MessageThread {
+    messages: smoltalk.Message[] = [];
+    id: string;
+    parentId: string | null = null;  // set by ThreadStore.createSubthread
+  }
+  ```
+
+  Update `MessageThreadJSON` (`parentId?: string | null`), `toJSON`, `fromJSON` to round-trip. Set it in `ThreadStore.createSubthread()` after `newSubthreadChild()`. `newChild()` and the plain `new MessageThread()` path leave it `null` (top-level).
+
+  Add a unit test: `createSubthread()` returns a thread whose `parentId === parentActiveId`; `create()` returns one whose `parentId === null`; both survive a JSON round-trip.
+
+- [ ] **Step 2: Add `agency.threads` to `lib/runtime/agency.ts`**
 
   Add a `threads` sub-namespace alongside `agency.memory`:
 
@@ -177,11 +195,11 @@ Build strategy: each primitive lands in its own task, the stdlib module is the l
 
   Both `ThreadInfoTS` and `ThreadMessageTS` are pure-TS types; the Agency-side analogs live in `stdlib/threads.agency` and structurally match.
 
-- [ ] **Step 2: Add `agency.threads` unit tests**
+- [ ] **Step 3: Add `agency.threads` unit tests**
 
   In `lib/runtime/agency.test.ts`, mirror the `agency.memory.*` test pattern: construct a `RuntimeContext`, run something that creates two threads, assert `agency.threads.list()` returns both with stable order and `isActive` set correctly on the right one, assert `agency.threads.get("t0", 0, 1)` returns just the first message.
 
-- [ ] **Step 3: Verify**
+- [ ] **Step 4: Verify**
 
   ```bash
   pnpm vitest run lib/runtime/agency.test.ts 2>&1 | tee /tmp/task1.log
@@ -264,69 +282,58 @@ Build strategy: each primitive lands in its own task, the stdlib module is the l
 
 ---
 
-## Task 4 — `ThreadStore` persists across node transitions
+## Task 4 — Verify cross-node persistence (no code change)
 
-**Goal:** Today, every fresh node calls `ThreadStore.withDefaultActive(...)` (see `setupNode` in `lib/runtime/node.ts`), which throws away the registry. Make the registry survive node boundaries while still resetting the *active* thread.
+**Goal:** Confirm the registry already persists across node transitions today, then write an integration test that pins the behavior so future refactors of `setupNode` can't silently break it. **No production code changes** — this task exists to lock in the contract Tasks 1, 5, 6, 7 depend on.
 
-- [ ] **Step 1: Decide the persistence vehicle**
+**Background — why this is doc-and-test instead of refactor:**
 
-  Options:
-  - **A.** Stash the `ThreadStore` on `RuntimeContext` as a run-scoped field; `setupNode` looks there first before falling back to `withDefaultActive`.
-  - **B.** Move the `threads` field off `StateStack` (per-branch) and onto the run-level context (cross-node).
+Initial draft of this plan called for adding `RuntimeContext.runThreadStore` and a `ThreadStore.beginNode()` reset method, under the assumption that each node started with a fresh `ThreadStore` and discarded prior threads. That's wrong. The actual flow:
 
-  Go with **A**. `StateStack` per-branch isolation is correct for the *active* thread; the cross-node *registry* is the new concept. Adding a `RuntimeContext.runThreadStore?: ThreadStore` field is the smallest correct change.
+- [`runNode` line 229](../../../lib/runtime/node.ts) creates **one** `ThreadStore` per agent run (`ThreadStore.withDefaultActive(...)`).
+- That same store is passed as `state.messages` to `graph.run` on every node transition (line 247).
+- [`setupNode` lines 42–54](../../../lib/runtime/node.ts) reuses it via the `state.messages instanceof ThreadStore` branch.
+- Across interrupts, the store is serialized to `stack.threads` and rebuilt via `ThreadStore.fromJSON`.
 
-- [ ] **Step 2: Add `ThreadStore.beginNode()` so `setupNode` doesn't have to know how**
+So both the `threads` registry *and* the `activeStack` carry across nodes today. The implicit root thread persisting across nodes is the desired behavior (it's where the running agent's conversation lives). `thread {}` blocks push/pop within a single node and don't leak. We have exactly the semantics we want — we just need to make it explicit and tested.
 
-  In `lib/runtime/state/threadStore.ts`, add:
+- [ ] **Step 1: Read the existing flow and confirm the contract**
 
-  ```ts
-  /** Reset the active-thread stack for a new node boundary while
-   *  keeping the registry of all prior threads. The single owner of
-   *  "what 'enter a fresh node' means for a thread store." */
-  beginNode(): void {
-    this.activeStack = [];
-    this.getOrCreateActive();
-  }
-  ```
+  Skim `lib/runtime/node.ts::runNode` (the outer loop) and `setupNode`. Confirm: one `ThreadStore` per `runNode` call, threaded through `state.messages` to every `graph.run` step. Note the three setup branches (checkpoint restore / reuse `state.messages` / `withDefaultActive` fallback) and which one fires in normal cross-node transitions (it's the middle one).
 
-- [ ] **Step 3: Wire `setupNode`**
+- [ ] **Step 2: Add an integration test pinning the behavior**
 
-  In `lib/runtime/node.ts::setupNode`, the new branch is a one-line idempotent assignment plus a call to `beginNode()`. No mutation of `activeStack`, no manual `getOrCreateActive`, no order-sensitive "set, then store on ctx" pair:
+  Add `tests/agency/threads-registry/persists-across-nodes.test.json` + `.agency`:
 
-  ```ts
-  let threads: ThreadStore;
-  if (stack?.threads) {
-    threads = ThreadStore.fromJSON(stack.threads);
-  } else if (state.messages instanceof ThreadStore) {
-    threads = state.messages;
-  } else {
-    // Idempotent: first node creates it, every subsequent node reuses it.
-    ctx.runThreadStore ??= ThreadStore.withDefaultActive(ctx.statelogClient);
-    threads = ctx.runThreadStore;
-    threads.beginNode();
-  }
-  ```
-
-  `setupNode` now says *what* it wants ("a thread store, starting a new node"); `beginNode` owns *how*.
-
-- [ ] **Step 4: Make sure `beginNode` doesn't lose the registry**
-
-  Add a `ThreadStore` test: create two threads, call `beginNode()`, assert the two pre-existing threads are still in `threads.threads` and `counter` advanced past them (so the new active thread doesn't collide with their IDs).
-
-- [ ] **Step 5: Integration test**
-
-  Add a new agency test under `tests/agency/threads-registry/`:
   ```agency
   import { listThreads } from "std::threads"
-  node a() { thread { /* something */ } -> b }
-  node b(): number { return listThreads().length }   // expect 2 (a's thread + b's active)
+
+  node a() {
+    thread { /* anything that opens and closes a thread */ }
+    return ""
+  }
+
+  node b(): number {
+    // Expected: prior thread from `a` + the active thread for `b`.
+    return listThreads().length
+  }
   ```
-  (Requires Task 5 to compile; commit this test alongside.)
 
-- [ ] **Step 6: Checkpoint compatibility**
+  Wire it into the chain so `a -> b` runs end-to-end. Assert the message count survives the node hop. Requires Task 5 to compile; commit this test alongside Task 5.
 
-  Old checkpoints don't have `runThreadStore` serialized. Confirm the back-compat path is just the existing `withDefaultActive` fallback — i.e. on resume, the registry restarts empty. Document this in the new module's docstring.
+- [ ] **Step 3: Add a runtime unit test (no Agency layer) that pins the mechanism directly**
+
+  In `lib/runtime/node.test.ts` (create if absent): construct a `ThreadStore`, populate two threads, pass it as `state.messages` to a `setupNode`-driven test, assert the resulting `threads.threads` record still has both ids and `counter` advanced past them. This is the fail-fast guard for anyone who refactors `setupNode` later.
+
+- [ ] **Step 4: Document the existing mechanism**
+
+  Add a short "Cross-node persistence" section to `docs/site/guide/cross-thread-context.md` (created in Task 5/9). Cover:
+  - One `ThreadStore` per run, shared via `state.messages`.
+  - Subthreads are normal entries in the same registry with `parentId` set.
+  - `thread {}` blocks push/pop within a node — no cross-node leakage by design.
+  - On interrupt resume, the store is rebuilt from `stack.threads` (checkpoint serialization). The registry survives the interrupt; in-flight `thread {}` blocks resume mid-flight via the existing substep mechanism.
+
+  Link from this section to `docs/dev/threads.md` for runtime internals.
 
 ---
 
@@ -444,10 +451,23 @@ Build strategy: each primitive lands in its own task, the stdlib module is the l
    *  `activeStack` (same path as `pushActive`) without creating a new
    *  MessageThread. Throws if `id` is unknown — silent fallback to
    *  create-new would mask a real bug (typo, hallucinated id) at the
-   *  call site. */
+   *  call site.
+   *
+   *  v1: rejects subthreads. A subthread's identity is tied to its
+   *  parent's context at the time it was created; resuming one outside
+   *  that context could surface confusing message ordering. If a user
+   *  wants to continue inside a subthread, they should resume the
+   *  parent and open a fresh `subthread {}` block. */
   resumeExisting(id: MessageThreadID): void {
-    if (!this.threads[id]) {
+    const thread = this.threads[id];
+    if (!thread) {
       throw new Error(`Cannot resume unknown thread id: ${id}`);
+    }
+    if (thread.isSubthread) {
+      throw new Error(
+        `Cannot resume subthread ${id}. Resume the parent thread and open ` +
+          `a fresh subthread block instead.`,
+      );
     }
     this.activeStack.push(id);
     this.statelogClient?.threadResumed?.({ threadId: id });
@@ -471,6 +491,7 @@ Build strategy: each primitive lands in its own task, the stdlib module is the l
 - [ ] **Step 5: Tests**
 
   - Unit test in `lib/runtime/state/threadStore.test.ts`: create a thread, close it, `resumeExisting(id)`, assert `activeId()` matches and `threads[id]` is unchanged.
+  - Subthread-rejection unit test: open a thread, create a subthread inside it, close both, attempt `resumeExisting(subthreadId)` — assert it throws the "Cannot resume subthread" error and `activeId()` is unchanged.
   - Agency integration test under `tests/agency/threads-registry/continue.agency`: open a thread, send a user message, close, `thread(continue: id) { ... }`, send another message, assert the active thread's message count is 2 (not 1).
   - Negative test: `thread(continue: "tDoesNotExist") { ... }` raises a clear runtime error mentioning the id.
 
@@ -503,19 +524,21 @@ Build strategy: each primitive lands in its own task, the stdlib module is the l
 
 - [ ] **Step 2: Add `ThreadStore.openSession(name)`**
 
-  Single owner of the "create if absent, resume if present" rule, so codegen stays dumb:
+  Single owner of the "create if absent, resume if present" rule, so codegen stays dumb. Always creates a **top-level** thread (never a subthread) — a session is "step into a named context," not "branch off the current one." If a user writes `thread(session: "x") { subthread { ... } }`, the subthread becomes a child of session "x"'s thread, which is the intuitive shape:
 
   ```ts
   /** Open a named session. Returns the thread id (whether newly
    *  created or resumed). Always leaves the session's thread on top
-   *  of `activeStack`. */
+   *  of `activeStack`. First entry creates a top-level thread; later
+   *  entries resume via `resumeExisting` (which already rejects
+   *  subthreads — sessions can only map to top-level threads). */
   openSession(name: string): MessageThreadID {
     const existing = this.sessions[name];
     if (existing) {
       this.resumeExisting(existing);
       return existing;
     }
-    const id = this.create();
+    const id = this.create();          // top-level, never subthread
     this.sessions[name] = id;
     this.activeStack.push(id);
     return id;

--- a/packages/agency-lang/docs/superpowers/plans/2026-05-29-thread-registry.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-29-thread-registry.md
@@ -1,0 +1,601 @@
+# Cross-Thread Context Sharing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an agent discover, read, and *continue* sibling `thread {}` blocks within the same run, so "separate but related" tasks can share context without dissolving thread isolation. Persists across node transitions; no interaction with the long-term memory layer.
+
+**Primary use case:** the categorize-and-route pattern. A top-level categorizer (see `tests/agency/categorize.agency` for the three-line LLM form) sends each user message to a specialized agent node. Each agent has its own thread. The registry + continuation primitives let the third user message that re-visits a category (e.g., "back to the coding task") resume the *original* thread, not start fresh.
+
+**Core design bet:** Instead of building the registry as a black-box feature, ship it as four small **extensibility primitives** plus a **stdlib module** that uses them. The stdlib module is *the same code a user would write themselves* given those primitives — so the same APIs that ship the feature also unlock users building "tag threads by topic", "diff two threads", and similar variants in user space.
+
+---
+
+## User-visible API (final)
+
+Three new exports added to a new module `stdlib/threads.agency` (separate from `std::thread`, which today only handles cost/tokens/messages within the active thread):
+
+```agency
+import { listThreads, getThread } from "std::threads"
+
+type ThreadInfo = {
+  id: string,                          // ordinal slug — "t1", "t2", ...
+  label?: string,                      // user-supplied (thread template purpose)
+  summary?: string,                    // auto-generated (per-instance content)
+  parentId?: string,                   // for subthreads
+  threadType: "thread" | "subthread",
+  messageCount: number,
+  isActive: boolean,                   // true iff this is the currently active thread
+}
+
+// Returns all threads in the registry. If a thread has no cached
+// summary yet, generates one lazily on first call (one LLM round-trip
+// per thread that needs it). `label` is returned as-is.
+def listThreads(): ThreadInfo[]
+
+type ThreadMessage = {
+  role: "system" | "user" | "assistant" | "tool",
+  content: string,
+}
+
+// Paginated read of a closed thread's messages. `offset` defaults to
+// 0, `limit` defaults to 50. Returns the active thread's messages
+// too, so an agent can introspect itself.
+def getThread(id: string, offset: number = 0, limit: number = 50): ThreadMessage[]
+```
+
+The `thread { }` block gains four optional named args:
+
+```agency
+// label:     template-level purpose. Same string across repeated
+//            invocations of the same `thread` block.
+// summarize: if true, eagerly summarize at thread close (instead of
+//            lazily on first listThreads() call). Default false.
+// continue:  resume a previously-closed thread by id. Existing
+//            messages stay intact; new messages append. Errors if
+//            the id is unknown.
+// session:   sugar over `continue`. The runtime keeps a
+//            session-name → thread-id map; first entry with a given
+//            session name creates a thread, subsequent entries
+//            resume it. The router pattern's bread-and-butter.
+thread(label: "coding task", summarize: true) { /* ... */ }
+thread(continue: priorId) { /* ... */ }                  // explicit resume
+thread(session: "coding", label: "coding task") { /* ... */ }  // declarative resume
+```
+
+`continue` and `session` are mutually exclusive. `session` is just `continue` with a runtime-owned id map — picking one or the other is a style choice; both compile to the same `pushExistingActive` machinery.
+
+### Why both `label` and `summary`?
+
+A `thread {}` block in a loop runs many times with very different content. The user-supplied `label` captures the *template intent* ("this is a coding task"); the auto-`summary` captures *what actually happened in this instance* ("refactored auth, added JWT validation"). `listThreads()` returns both so an LLM filtering by "I want the auth one" can match on summary, while one looking for "any coding task" can match on label.
+
+### Why ordinal slug IDs (`t1`, `t2`...) instead of nanoid?
+
+`ThreadStore.create()` already uses a per-store integer counter, so we just expose it as a slug (`t${counter}`). Two reasons:
+
+1. **LLMs handle short ordinal strings well.** A random nanoid like `V1StGXR8_Z5jdHi6B-myT` is easy for an LLM to mis-type or hallucinate.
+2. **The "wrong but valid integer" risk is bounded** by `listThreads()` returning the slug → summary mapping. The LLM picks by reading the summary list, not by guessing an integer.
+
+Internal storage keeps the existing counter-string ID; the slug is a pure presentation concern in the registry wrapper.
+
+---
+
+## Architecture
+
+```diagram
+╭────────────────────────────────────────────────────╮
+│  stdlib/threads.agency  (user-buildable layer)     │
+│                                                    │
+│   def listThreads(): ThreadInfo[]                  │
+│   def getThread(id, offset, limit)                 │
+│                                                    │
+│   summaries: Record<id, string>  ← agency global   │
+│   labels:    Record<id, string>  ← agency global   │
+│                                                    │
+│   On import:                                       │
+│     agency.threads.onThreadClose(t => {            │
+│       if (t.label) labels[t.id] = t.label          │
+│       if (t.eagerSummarize) summarize(t) → cache   │
+│     })                                             │
+╰────────────┬───────────────────────────────────────╯
+             │ uses
+             ▼
+╭────────────────────────────────────────────────────╮
+│  Primitives (added to core)                        │
+│  1. agency.threads.{list, get, current}            │
+│  2. thread(label?, summarize?) named args          │
+│  3. onThreadStart / onThreadEnd lifecycle hooks    │
+│  4. ThreadStore persists across node transitions   │
+│  5. thread(continue: id) — resume a closed thread  │
+│  6. thread(session: "name") — runtime-owned        │
+│     session→id map, sugar over (5)                 │
+╰────────────────────────────────────────────────────╯
+```
+
+Build strategy: each primitive lands in its own task, the stdlib module is the last task on top. Every primitive is independently useful — a user could ignore the stdlib module and write their own (`tagged-threads`, `thread-diff`, etc.) on the same surface.
+
+---
+
+## Open questions resolved
+
+| Question | Decision |
+|---|---|
+| Eager vs. lazy summarization? | Both. Lazy is default; `thread(summarize: true)` opts into eager-at-close so users with many threads don't hit the "first `listThreads()` is slow" cliff. |
+| Same thread block repeated → which summary wins? | Keep both. `label` is template-level (user-supplied), `summary` is per-instance (auto). Both surface in `ThreadInfo`. |
+| ID format? | Ordinal slug (`t1`, `t2`...) wrapping the existing counter. LLM-friendly; the wrong-ID risk is bounded by `listThreads()` returning summaries to disambiguate. |
+| Active conversation across nodes? | **No.** Only the registry persists; the active thread still resets per node. |
+| Long-term memory layer interaction? | **No direct coupling.** The recommended router pattern is `setMemoryId(category)` at the top of each routed node so the knowledge graph is per-agent. Existing primitive, doc-only. |
+| Read-only or read-write? | **Read + resume.** `getThread(id)` is read; `thread(continue: id)` and `thread(session: "name")` are resume. The router-back-to-coding scenario needs resume — reading-only forces every re-entry to re-pay the entire prior context. |
+| Categorize-and-route — should the runtime own routing? | **No.** User-space code already expresses it in three lines (see `tests/agency/categorize.agency`); a router primitive would be redundant. |
+
+---
+
+## Pre-flight
+
+- [ ] **Sanity check the current tree is green**
+
+  ```bash
+  pnpm test:run 2>&1 | tee /tmp/preflight-test.log
+  ```
+
+  If any failures exist that are unrelated to this work, surface them before continuing.
+
+- [ ] **Read the existing thread infrastructure**
+
+  Skim, in this order:
+  - `lib/runtime/state/threadStore.ts` — `ThreadStore`, the counter, `withDefaultActive`, `setupNode`'s wiping behavior.
+  - `lib/runtime/state/messageThread.ts` — `MessageThread` shape and `MessageThreadJSON`.
+  - `lib/runtime/hooks.ts` — `CallbackMap` and the `onAgent*`, `onNode*`, `onFunction*` patterns to mirror.
+  - `lib/runtime/node.ts::setupNode` — the line that calls `ThreadStore.withDefaultActive(...)` on every fresh node. This is what Task 4 changes.
+  - `stdlib/memory.agency` and `lib/runtime/agency.ts::agency.memory.*` — the analog we mirror in Tasks 1 + 5.
+
+---
+
+## Task 1 — `agency.threads.*` TS-helper namespace
+
+**Goal:** Expose `ThreadStore` read methods via the canonical `agency` namespace, parallel to `agency.memory.*`. Pure read-side; no behavior change yet.
+
+- [ ] **Step 1: Add `agency.threads` to `lib/runtime/agency.ts`**
+
+  Add a `threads` sub-namespace alongside `agency.memory`:
+
+  ```ts
+  threads: {
+    /** All threads in the run's registry. Returns plain records, not
+     *  live `MessageThread` instances — safe to serialize / pass to
+     *  LLMs. Includes the currently active thread (with `isActive: true`). */
+    list(): ThreadInfoTS[],
+    /** Read a slice of a thread's messages. Returns `[]` if the id is
+     *  unknown. */
+    get(id: string, offset?: number, limit?: number): ThreadMessageTS[],
+    /** ID of the currently active thread, or `undefined` outside a
+     *  runtime frame. */
+    current(): string | undefined,
+  }
+  ```
+
+  Implementation reads `getRuntimeContext().ctx?.stateStack.threads` (the `ThreadStore`). For `list()`, iterate `threads.threads`, map each `MessageThread` to a `ThreadInfoTS` (id-slugged via `t${id}`, `messageCount = thread.messages.length`, `isActive = id === activeId`). `get()` slices `thread.messages` and maps each to `{ role, content }`.
+
+  Both `ThreadInfoTS` and `ThreadMessageTS` are pure-TS types; the Agency-side analogs live in `stdlib/threads.agency` and structurally match.
+
+- [ ] **Step 2: Add `agency.threads` unit tests**
+
+  In `lib/runtime/agency.test.ts`, mirror the `agency.memory.*` test pattern: construct a `RuntimeContext`, run something that creates two threads, assert `agency.threads.list()` returns both with stable order and `isActive` set correctly on the right one, assert `agency.threads.get("t0", 0, 1)` returns just the first message.
+
+- [ ] **Step 3: Verify**
+
+  ```bash
+  pnpm vitest run lib/runtime/agency.test.ts 2>&1 | tee /tmp/task1.log
+  ```
+
+---
+
+## Task 2 — `onThreadStart` / `onThreadEnd` lifecycle hooks
+
+**Goal:** Fire callbacks when a `thread {}` block opens and when it closes. Mirrors the existing `onNodeStart`/`onNodeEnd` pattern in `lib/runtime/hooks.ts`.
+
+- [ ] **Step 1: Extend `CallbackMap`**
+
+  In `lib/runtime/hooks.ts`, add two entries:
+
+  ```ts
+  onThreadStart: {
+    threadId: string;             // slug form, e.g. "t3"
+    threadType: "thread" | "subthread";
+    parentThreadId?: string;
+    label?: string;               // from thread(label: "...") {} — see Task 3
+  };
+  onThreadEnd: {
+    threadId: string;
+    label?: string;
+    eagerSummarize: boolean;      // from thread(summarize: true) — Task 3
+    messages: MessageJSON[];      // snapshot at close — registry uses this
+  };
+  ```
+
+  Append `"onThreadStart"` and `"onThreadEnd"` to `VALID_CALLBACK_NAMES` so the compile-time guard stays green.
+
+- [ ] **Step 2: Fire the events**
+
+  `ThreadStore` already emits `threadCreated` to `StatelogClient`. Find the `thread {}` block's TS emitter (look in `lib/backends/typescriptGenerator/` for "thread" or in the runtime helpers it calls — likely `pushActiveThread` / `popActiveThread` on `ThreadStore`). At those two sites, add:
+
+  ```ts
+  await callHook({ ctx, name: "onThreadStart", payload: {...} });
+  // ...block runs...
+  await callHook({ ctx, name: "onThreadEnd",   payload: {...} });
+  ```
+
+  The `messages` snapshot in the End payload is `thread.messages.map(m => m.toJSON())`.
+
+- [ ] **Step 3: Add a unit test**
+
+  In `lib/runtime/hooks.test.ts` (or wherever `onNodeStart` is tested), register a TS callback for `onThreadStart`/`onThreadEnd`, run an Agency program with one `thread {}` block, assert both callbacks fire with the right `threadId` and that the End payload contains the message snapshot.
+
+---
+
+## Task 3 — `thread(label, summarize)` named args
+
+**Goal:** Let users tag a `thread {}` block with a template-level label and opt into eager summarization at close.
+
+- [ ] **Step 1: Parser**
+
+  `thread {}` is currently a block-form keyword (see `lib/parsers/`). Find the parser and accept an optional named-arg list:
+
+  ```agency
+  thread(label: "coding task", summarize: true) { ... }
+  ```
+
+  Both args are optional; the no-arg form `thread { ... }` keeps working unchanged. The AST node for `thread` gains two optional fields `label: Expression | null` and `summarize: Expression | null`.
+
+- [ ] **Step 2: Codegen**
+
+  In `lib/backends/typescriptGenerator/`, find the thread emitter and forward the new args to the runtime helper that opens the thread. Plumb them through to the `onThreadStart` payload (label) and `onThreadEnd` payload (label + eagerSummarize).
+
+- [ ] **Step 3: Type checker**
+
+  Both args have known types (`string` and `boolean`). Add the entry to whatever named-args validator the typechecker uses for keyword forms. Reject unknown arg names.
+
+- [ ] **Step 4: Parser + typechecker tests**
+
+  Add fixtures under `tests/parser/` and `tests/typeChecker/` covering: no-args, label-only, summarize-only, both, unknown arg (should error), wrong type (should error).
+
+- [ ] **Step 5: Update the language guide**
+
+  Append a short section to `docs/site/guide/threads.md` documenting the two args, what they're for, and noting that without them `thread {}` behaves exactly as before.
+
+---
+
+## Task 4 — `ThreadStore` persists across node transitions
+
+**Goal:** Today, every fresh node calls `ThreadStore.withDefaultActive(...)` (see `setupNode` in `lib/runtime/node.ts`), which throws away the registry. Make the registry survive node boundaries while still resetting the *active* thread.
+
+- [ ] **Step 1: Decide the persistence vehicle**
+
+  Options:
+  - **A.** Stash the `ThreadStore` on `RuntimeContext` as a run-scoped field; `setupNode` looks there first before falling back to `withDefaultActive`.
+  - **B.** Move the `threads` field off `StateStack` (per-branch) and onto the run-level context (cross-node).
+
+  Go with **A**. `StateStack` per-branch isolation is correct for the *active* thread; the cross-node *registry* is the new concept. Adding a `RuntimeContext.runThreadStore?: ThreadStore` field is the smallest correct change.
+
+- [ ] **Step 2: Add `ThreadStore.beginNode()` so `setupNode` doesn't have to know how**
+
+  In `lib/runtime/state/threadStore.ts`, add:
+
+  ```ts
+  /** Reset the active-thread stack for a new node boundary while
+   *  keeping the registry of all prior threads. The single owner of
+   *  "what 'enter a fresh node' means for a thread store." */
+  beginNode(): void {
+    this.activeStack = [];
+    this.getOrCreateActive();
+  }
+  ```
+
+- [ ] **Step 3: Wire `setupNode`**
+
+  In `lib/runtime/node.ts::setupNode`, the new branch is a one-line idempotent assignment plus a call to `beginNode()`. No mutation of `activeStack`, no manual `getOrCreateActive`, no order-sensitive "set, then store on ctx" pair:
+
+  ```ts
+  let threads: ThreadStore;
+  if (stack?.threads) {
+    threads = ThreadStore.fromJSON(stack.threads);
+  } else if (state.messages instanceof ThreadStore) {
+    threads = state.messages;
+  } else {
+    // Idempotent: first node creates it, every subsequent node reuses it.
+    ctx.runThreadStore ??= ThreadStore.withDefaultActive(ctx.statelogClient);
+    threads = ctx.runThreadStore;
+    threads.beginNode();
+  }
+  ```
+
+  `setupNode` now says *what* it wants ("a thread store, starting a new node"); `beginNode` owns *how*.
+
+- [ ] **Step 4: Make sure `beginNode` doesn't lose the registry**
+
+  Add a `ThreadStore` test: create two threads, call `beginNode()`, assert the two pre-existing threads are still in `threads.threads` and `counter` advanced past them (so the new active thread doesn't collide with their IDs).
+
+- [ ] **Step 5: Integration test**
+
+  Add a new agency test under `tests/agency/threads-registry/`:
+  ```agency
+  import { listThreads } from "std::threads"
+  node a() { thread { /* something */ } -> b }
+  node b(): number { return listThreads().length }   // expect 2 (a's thread + b's active)
+  ```
+  (Requires Task 5 to compile; commit this test alongside.)
+
+- [ ] **Step 6: Checkpoint compatibility**
+
+  Old checkpoints don't have `runThreadStore` serialized. Confirm the back-compat path is just the existing `withDefaultActive` fallback — i.e. on resume, the registry restarts empty. Document this in the new module's docstring.
+
+---
+
+## Task 5 — `stdlib/threads.agency` module
+
+**Goal:** Build the user-facing API entirely on top of the four primitives from Tasks 1–4. The TS side adds no new behavior; it's all wiring.
+
+**Design principle:** *one* cache keyed by thread id, *one* accessor that owns get-or-compute. The "what" — a thread has an optional label and an optional summary — lives in a single type. The "how" — when to read from cache vs. when to LLM-summarize — lives in one place. No parallel maps to keep in sync, no order-sensitive mutations in callbacks.
+
+- [ ] **Step 1: Create the module with a single-cache shape**
+
+  Create `stdlib/threads.agency` with the three exports (`listThreads`, `getThread`, types). Internal state is a single `static const` map keyed by thread id, persisted across nodes via the global-store layer:
+
+  ```agency
+  type Cached = { label?: string, summary?: string }
+
+  static const cache: Record<string, Cached> = {}
+
+  // Single owner of the cache-write rule: a patch shallow-merges into
+  // the entry for `id`. Callers never index into `cache` directly.
+  def remember(id: string, patch: Cached) {
+    cache[id] = { ...cache[id], ...patch }
+  }
+
+  // Single owner of the "return cached summary, else LLM-summarize and
+  // cache" rule. Active threads pass `null` so the LLM call is skipped
+  // while the conversation is still in flight.
+  def summaryFor(id: string, messages: (ThreadMessage[] | null) = null): (string | null) {
+    if (cache[id]?.summary) { return cache[id].summary }
+    if (messages == null) { return null }
+    const s = summarize(messages)
+    remember(id, { summary: s })
+    return s
+  }
+  ```
+
+  `summarize(messages)` is a one-shot LLM call internal to this module; pin its model with the runtime default so it doesn't blow up costs.
+
+- [ ] **Step 2: Lifecycle hook — one writer, one rule**
+
+  Module-load registers the `onThreadEnd` hook, which only ever writes through `remember`:
+
+  ```agency
+  static const _ = agency.threads.onThreadEnd((evt) => {
+    remember(evt.threadId, { label: evt.label })
+    if (evt.eagerSummarize) {
+      remember(evt.threadId, { summary: summarize(evt.messages) })
+    }
+  })
+  ```
+
+  Both writes go through `remember`, so the merge rule (spread over the existing entry, partial patches compose) lives in one place. The callback is *order-independent within `remember` calls* — re-arranging the two statements produces the same final cache state. That eliminates the "if label, set labels[id]; if summarize, set summaries[id]" ladder that the parallel-maps version invited.
+
+- [ ] **Step 3: `listThreads()` — one declarative map**
+
+  No imperative for-loop, no per-iteration mutation:
+
+  ```agency
+  def listThreads(): ThreadInfo[] {
+    return agency.threads.list().map((t) => {
+      // Active threads pass `null` for messages so summaryFor skips
+      // the LLM call while the conversation is still in flight.
+      let messages: (ThreadMessage[] | null) = null
+      if (t.isActive == false) { messages = t.messages }
+      return {
+        ...t,
+        label: cache[t.id]?.label,
+        summary: summaryFor(t.id, messages)
+      }
+    })
+  }
+  ```
+
+  The "what" (every ThreadInfo has an optional label and an optional summary) is the type; the "how" (cache lookup, lazy LLM call, active-thread skip) is one call to `summaryFor`. Adding behavior — e.g. "regenerate stale summaries" or "summarize subthreads inline" — changes one accessor, not the loop.
+
+- [ ] **Step 4: `getThread(id, offset, limit)`**
+
+  Thin pass-through to `agency.threads.get` — that primitive already returns `[]` for unknown ids (see Task 1 contract), so no extra logic here:
+
+  ```agency
+  def getThread(id: string, offset: number = 0, limit: number = 50): ThreadMessage[] {
+    return agency.threads.get(id, offset, limit)
+  }
+  ```
+
+- [ ] **Step 5: Tests**
+
+  Under `tests/agency/threads-registry/`:
+  - `basic.agency` — create two threads via `thread {}`, assert `listThreads().length == 2` and that summaries are non-empty.
+  - `label.agency` — `thread(label: "x") { ... }`, assert the returned `ThreadInfo` carries `label: "x"` without an LLM call (label alone shouldn't trigger summarize).
+  - `pagination.agency` — create a thread with 60 messages (use `__internal_userMessage` etc.), assert `getThread(id, 0, 10).length == 10` and `getThread(id, 50, 50).length == 10`.
+  - `eager-vs-lazy.agency` — `thread(summarize: true) {...}` vs `thread {...}`. Use a deterministic-LLM-client agency-js test that counts summarize calls.
+
+  Run via `pnpm run agency test tests/agency/threads-registry/<name>.test.json`. Save output to `/tmp/task5.log` per the project's "save test output" rule.
+
+- [ ] **Step 6: Documentation**
+
+  - Add `docs/site/guide/cross-thread-context.md` covering the user model (listThreads, getThread, label vs summary).
+  - Append a short "How this is built" section pointing at `agency.threads.*` and `onThreadEnd`, with the message: *"these primitives are public — you can build your own variants (tag threads by topic, diff two threads, etc.) the same way `std::threads` does."*
+
+---
+
+## Task 6 — `thread(continue: id)` — explicit thread continuation
+
+**Goal:** Re-enter a previously-closed thread. New messages append to its existing history instead of starting fresh.
+
+**Why it's a runtime feature, not user-space:** the thread's message history lives inside `ThreadStore`, which is not on the public Agency surface. The minimal primitive that unlocks resumption is "push an existing thread id back onto `activeStack`" — that's a one-method addition to `ThreadStore`.
+
+- [ ] **Step 1: Add `ThreadStore.resumeExisting(id)`**
+
+  In `lib/runtime/state/threadStore.ts`:
+
+  ```ts
+  /** Re-activate a previously-closed thread. Pushes `id` onto
+   *  `activeStack` (same path as `pushActive`) without creating a new
+   *  MessageThread. Throws if `id` is unknown — silent fallback to
+   *  create-new would mask a real bug (typo, hallucinated id) at the
+   *  call site. */
+  resumeExisting(id: MessageThreadID): void {
+    if (!this.threads[id]) {
+      throw new Error(`Cannot resume unknown thread id: ${id}`);
+    }
+    this.activeStack.push(id);
+    this.statelogClient?.threadResumed?.({ threadId: id });
+  }
+  ```
+
+  Add a matching `threadResumed` event to `StatelogClient` (optional method, mirrors `threadCreated`). The block closer is the existing `popActive` — no change needed there.
+
+- [ ] **Step 2: Parser + AST**
+
+  Extend the `thread {}` parser (already touched by Task 3 for `label` / `summarize`) to accept `continue: <expr>`. AST gains `continueExpr: Expression | null`. `continue` and `session` (Task 7) are mutually exclusive — reject at parse time.
+
+- [ ] **Step 3: Codegen**
+
+  In the thread-block emitter, if `continueExpr` is set, evaluate the expression to a string, **slug-strip** the leading `t` (the public form is `t1`, the storage form is `1`), and call `threads.resumeExisting(rawId)` instead of `threads.create()`. The rest of the block (push handlers, run body, pop) stays identical.
+
+- [ ] **Step 4: `onThreadStart` payload**
+
+  When `continue` was used, fire `onThreadStart` with a new field `isResumption: true` and the original `threadId`. This matters for `stdlib/threads.agency` — the resumed thread shouldn't double-count toward `messageCount` baselines, and a future "this thread was resumed N times" stat is then free.
+
+- [ ] **Step 5: Tests**
+
+  - Unit test in `lib/runtime/state/threadStore.test.ts`: create a thread, close it, `resumeExisting(id)`, assert `activeId()` matches and `threads[id]` is unchanged.
+  - Agency integration test under `tests/agency/threads-registry/continue.agency`: open a thread, send a user message, close, `thread(continue: id) { ... }`, send another message, assert the active thread's message count is 2 (not 1).
+  - Negative test: `thread(continue: "tDoesNotExist") { ... }` raises a clear runtime error mentioning the id.
+
+- [ ] **Step 6: Doc**
+
+  Add a "Resuming a thread" section to `docs/site/guide/cross-thread-context.md`. Show the router-back-to-coding example end-to-end. Call out the slug → raw-id translation as an internal detail users don't see.
+
+---
+
+## Task 7 — `thread(session: "name")` — session-keyed continuation
+
+**Goal:** The runtime owns a `session-name → thread-id` map keyed per run. First entry with a given session name creates a thread; subsequent entries auto-resume it. Sugar over Task 6 — same machinery underneath, but the user never has to track ids manually.
+
+**Why this is the router pattern's bread-and-butter:** A categorize-and-route loop where each routed agent does `thread(session: category, label: category) { ... }` gets per-category continuity *for free*. The router stays three lines (`categorize.agency` style) — no `Record<string, string>` to maintain, no "did I save the id?" footgun.
+
+- [ ] **Step 1: Add `sessions` to `ThreadStore`**
+
+  In `lib/runtime/state/threadStore.ts`:
+
+  ```ts
+  /** session-name → thread-id. Populated by `thread(session: ...)` on
+   *  first entry; subsequent entries with the same name resume via
+   *  `resumeExisting`. Serialized as part of `ThreadStoreJSON` so it
+   *  survives interrupts and node transitions (lives on the same
+   *  cross-node `runThreadStore` as Task 4's registry). */
+  sessions: Record<string, MessageThreadID> = {};
+  ```
+
+  Extend `ThreadStoreJSON`, `toJSON`, and `fromJSON` to round-trip `sessions`. Default to `{}` when restoring older snapshots.
+
+- [ ] **Step 2: Add `ThreadStore.openSession(name)`**
+
+  Single owner of the "create if absent, resume if present" rule, so codegen stays dumb:
+
+  ```ts
+  /** Open a named session. Returns the thread id (whether newly
+   *  created or resumed). Always leaves the session's thread on top
+   *  of `activeStack`. */
+  openSession(name: string): MessageThreadID {
+    const existing = this.sessions[name];
+    if (existing) {
+      this.resumeExisting(existing);
+      return existing;
+    }
+    const id = this.create();
+    this.sessions[name] = id;
+    this.activeStack.push(id);
+    return id;
+  }
+  ```
+
+- [ ] **Step 3: Parser + AST**
+
+  Extend the `thread {}` parser to accept `session: <expr>`. AST gains `sessionExpr: Expression | null`. Enforce the `continue` ⊕ `session` mutual exclusion from Task 6.
+
+- [ ] **Step 4: Codegen**
+
+  In the thread emitter, if `sessionExpr` is set, emit `threads.openSession(name)` and skip the `threads.create()` / `pushActive` path. `onThreadStart` payload carries `isResumption: existed_before` so `stdlib/threads.agency` can tell first-entry from re-entry without keeping its own bookkeeping.
+
+- [ ] **Step 5: Tests**
+
+  - Unit test on `ThreadStore.openSession`: first call creates + pushes; second call with same name resumes the same id (assert `Object.keys(threads).length` stays at 1, `activeId() === firstId` both times).
+  - Agency integration test `tests/agency/threads-registry/session.agency`: open `thread(session: "coding") { msg("a") }`, then `thread(session: "weather") { msg("b") }`, then `thread(session: "coding") { msg("c") }`. Assert the coding thread has messages `["a", "c"]` and the weather thread has `["b"]`. This is the user's three-message router scenario in test form.
+  - Verify that an `onThreadStart` callback receives `isResumption: true` on the third entry.
+
+- [ ] **Step 6: Doc + worked example**
+
+  Append a "Routing with sessions" subsection to `docs/site/guide/cross-thread-context.md`. Show a complete categorize-and-route loop that uses `categorize.agency`-style routing + `thread(session: category, label: category) { ... }`. This is the canonical example we point users at when they ask "how do I build a multi-agent assistant?"
+
+---
+
+## Task 8 — Memory-per-agent: document the existing pattern
+
+**Goal:** No new feature — `setMemoryId(category)` from `std::memory` is already per-branch (stored on `stateStack.other.memoryId`) and is exactly what the router pattern needs. We just need to *document* it as the recommended companion to `thread(session: ...)`, with a worked example, so users don't end up cross-polluting their agents' knowledge graphs by default.
+
+- [ ] **Step 1: Confirm the per-branch semantics still hold**
+
+  Quick sanity check: in a routed-node setup, calling `setMemoryId("coding")` at the top of the coding agent's node should not affect the weather agent's `recall()` in a parallel branch. If it does, that's a separate bug to surface — but per `lib/runtime/memory/manager.ts:78-91`, the id lives on `stateStack.other.memoryId` and is per-branch by construction.
+
+  ```bash
+  pnpm vitest run lib/runtime/memory 2>&1 | tee /tmp/task8-sanity.log
+  ```
+
+  Optional: add a focused test that two sibling branches with different `setMemoryId` calls produce disjoint `recall()` results.
+
+- [ ] **Step 2: Doc — "Memory scoping for routed agents"**
+
+  Append to `docs/site/guide/cross-thread-context.md`. Concretely:
+
+  - Lead with the problem ("the coding agent's facts shouldn't bleed into the weather agent").
+  - Show the pattern: each routed node opens with `setMemoryId(category)`.
+  - Show the optional **shared** layer: leave one well-known id ("workspace") for facts everyone reads — agents `setMemoryId("workspace")` for cross-cutting writes, then switch back.
+  - Tiny worked example combining Task 7's `thread(session: category)` with this `setMemoryId(category)` pattern, so the router doc has one canonical complete sample.
+
+- [ ] **Step 3: Update the agency-agent example**
+
+  In `lib/agents/agency-agent/agent.agency`, the current `setMemoryId(cwd())` line is fine for a single-purpose agent. Add a short comment pointing readers to the new guide for the multi-agent / router pattern, but don't change behavior. (This is a doc-pointer, not a refactor.)
+
+---
+
+## Task 9 — End-to-end polish
+
+- [ ] **Step 1: Documentation cross-links**
+
+  - Link the new guide page from `docs/site/guide/threads.md`.
+  - Add `cross-thread-context.md` to the site nav (wherever the guide TOC lives).
+
+- [ ] **Step 2: Verify full unit + lint pipeline**
+
+  ```bash
+  make 2>&1 | tee /tmp/final-build.log
+  pnpm test:run 2>&1 | tee /tmp/final-unit.log
+  pnpm run lint:structure
+  ```
+
+- [ ] **Step 3: Update changelog**
+
+  Add a `CHANGELOG.md` entry under the next release: short note about the registry feature, the six new primitives (`agency.threads.*`, `onThreadStart/End`, `thread(label/summarize/continue/session)`, cross-node `ThreadStore`, `resumeExisting`/`openSession`), and the "you can build this yourself" angle. Call out the categorize-and-route worked example as the marquee use case.
+
+---
+
+## Out of scope for v1
+
+- **Auto-context injection by label.** `thread(label: "coding", includePriorSummaries: true) { ... }` was discussed — held off because users can replicate it in three lines with `listThreads().filter(...)` once Tasks 1+5 ship.
+- **Cross-run persistence.** The registry is run-scoped — restarting the agent starts fresh. (A future task could store the registry under the memory layer's `dir` if users ask for it.)
+- **Filtering / search in `listThreads`.** Return everything; let the LLM filter. If the registry grows past ~hundreds of threads in real-world use we add server-side filtering later.
+- **Summary regeneration.** Once cached, a summary is final. If users want fresh ones they can ignore the cached value in their own listThreads wrapper.
+- **A router primitive.** User-space already expresses categorize-and-route in three lines (see `tests/agency/categorize.agency`); adding `route { ... }` would be redundant complexity. Documented as a deliberate non-goal in Task 8's guide so future contributors don't re-propose it.

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-30-thread-as-agency-function.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-30-thread-as-agency-function.md
@@ -10,15 +10,15 @@
 
 ## Problem
 
-The current `thread {}` block is parsed by a hand-rolled parser ([`_threadNamedArgsParser` in `lib/parsers/parsers.ts:3103`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/parsers/parsers.ts#L3103)) and lowered through a bespoke pipeline. As a result:
+The current `thread {}` block is parsed by a hand-rolled parser ([`_threadNamedArgsParser` in `lib/parsers/parsers.ts`](../../../lib/parsers/parsers.ts)) and lowered through a bespoke pipeline. As a result:
 
 - Bad argument names produce a parse-time error message that lives inside the parser ("Unknown thread argument: foo. Allowed: label, summarize, ..."). That string is awkward to maintain and drifts every time the allowed-arg list changes.
-- The AST node ([`MessageThread` in `lib/types/messageThread.ts`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/types/messageThread.ts)) carries five+ optional `Expression` fields (`label`, `summarize`, `continueExpr`, `sessionExpr`, and — as of PR #225 — `hidden`) that have to be plumbed through:
+- The AST node ([`MessageThread` in `lib/types/messageThread.ts`](../../../lib/types/messageThread.ts)) carries five+ optional `Expression` fields (`label`, `summarize`, `continueExpr`, `sessionExpr`, and — as of PR #225 — `hidden`) that have to be plumbed through:
   1. the parser (`_threadNamedArgsParser`),
   2. the AST type (`MessageThread`),
   3. the IR (`TsRunnerThread`),
-  4. the codegen emitter ([`processMessageThread` in `lib/backends/typescriptBuilder.ts:2767`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/backends/typescriptBuilder.ts#L2767)),
-  5. the IR pretty-printer ([`prettyPrint.ts:300`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/backends/prettyPrint.ts#L300)), and
+  4. the codegen emitter ([`processMessageThread` in `lib/backends/typescriptBuilder.ts`](../../../lib/backends/typescriptBuilder.ts)),
+  5. the IR pretty-printer ([`lib/ir/prettyPrint.ts`](../../../lib/ir/prettyPrint.ts)), and
   6. the `Runner.thread` runtime entry.
 
 So every new named argument is a five-file edit. **Concrete example: the `hidden` arg added in PR #225** required touching exactly that fan-out — the most recent demonstration of the cost.
@@ -27,10 +27,10 @@ So every new named argument is a five-file edit. **Concrete example: the `hidden
 
 ## Proposal
 
-`thread {}` becomes pure syntactic sugar for a stdlib function call. The source:
+`thread {}` becomes pure syntactic sugar for a stdlib function call. The source (current syntax — unchanged):
 
 ```agency
-thread label="x", hidden=true {
+thread(label: "x", hidden: true) {
   // body
 }
 ```
@@ -62,7 +62,7 @@ __internal_thread({ label: "x", hidden: true }, () => {
 
 - The `_threadNamedArgsParser` parser and its "unknown thread argument" error (becomes a normal "no such field on `ThreadOpts`" type error).
 - The `MessageThread` AST node's optional argument fields. The AST node itself may remain for the source-to-source rewriter to attach a marker, but the named-arg slots become dead weight.
-- The codegen branch in [`processMessageThread` in `lib/backends/typescriptBuilder.ts`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/backends/typescriptBuilder.ts#L2767) that processes `label` / `summarize` / `hidden` / etc. into `TsNode`s.
+- The codegen branch in [`processMessageThread` in `lib/backends/typescriptBuilder.ts`](../../../lib/backends/typescriptBuilder.ts#L2767) that processes `label` / `summarize` / `hidden` / etc. into `TsNode`s.
 - The IR `TsRunnerThread`'s optional fields (`label`, `summarize`, `continueExpr`, `sessionExpr`, `hidden`) — they become regular function-call arguments handled by the existing call pipeline.
 - The codegen-time mutual-exclusion check between `continue` / `session`, and the codegen-time rejection of `subthread(continue/session)` — both become **type errors** on the `ThreadOpts` / `SubthreadOpts` types (e.g. discriminated unions or distinct opts types per construct).
 

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-30-thread-as-agency-function.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-30-thread-as-agency-function.md
@@ -1,0 +1,109 @@
+# `thread {}` as an Agency stdlib function
+
+**One-line summary:** Replace the hand-rolled `thread {}` parser + bespoke AST/IR/codegen path with a desugaring into a stdlib function call (`__internal_thread(opts, block)`), so adding a new named argument becomes a one-line stdlib change instead of a fan-out across five files.
+
+**Status:** Proposed (follow-up to PR #225). NOT part of PR #225.
+
+> ⚠️ This document is a **follow-up proposal** captured during PR #225 review. It is intentionally out of scope for that PR. Filing it here so the idea isn't lost.
+
+---
+
+## Problem
+
+The current `thread {}` block is parsed by a hand-rolled parser ([`_threadNamedArgsParser` in `lib/parsers/parsers.ts:3103`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/parsers/parsers.ts#L3103)) and lowered through a bespoke pipeline. As a result:
+
+- Bad argument names produce a parse-time error message that lives inside the parser ("Unknown thread argument: foo. Allowed: label, summarize, ..."). That string is awkward to maintain and drifts every time the allowed-arg list changes.
+- The AST node ([`MessageThread` in `lib/types/messageThread.ts`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/types/messageThread.ts)) carries five+ optional `Expression` fields (`label`, `summarize`, `continueExpr`, `sessionExpr`, and — as of PR #225 — `hidden`) that have to be plumbed through:
+  1. the parser (`_threadNamedArgsParser`),
+  2. the AST type (`MessageThread`),
+  3. the IR (`TsRunnerThread`),
+  4. the codegen emitter ([`processMessageThread` in `lib/backends/typescriptBuilder.ts:2767`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/backends/typescriptBuilder.ts#L2767)),
+  5. the IR pretty-printer ([`prettyPrint.ts:300`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/backends/prettyPrint.ts#L300)), and
+  6. the `Runner.thread` runtime entry.
+
+So every new named argument is a five-file edit. **Concrete example: the `hidden` arg added in PR #225** required touching exactly that fan-out — the most recent demonstration of the cost.
+
+---
+
+## Proposal
+
+`thread {}` becomes pure syntactic sugar for a stdlib function call. The source:
+
+```agency
+thread label="x", hidden=true {
+  // body
+}
+```
+
+is rewritten by the parser into:
+
+```agency
+__internal_thread({ label: "x", hidden: true }, () => {
+  // body
+})
+```
+
+- `__internal_thread` is a stdlib `def` declared in `stdlib/threads.agency` (or similar), with a typed `opts: ThreadOpts` parameter and a block parameter. See the [block-arg semantics](https://agency-lang.com/guide/blocks.html) for the existing block-parameter calling convention.
+- The parser does ONE thing: rewrite `thread <args> { body }` into a function-call AST. After that the **existing function-call pipeline** handles type checking, codegen, and runtime dispatch — no `thread`-specific code paths.
+
+`subthread {}` follows the same pattern via a separate `__internal_subthread(opts, block)`.
+
+---
+
+## What survives
+
+- `Runner.thread(id, method, opts, callback)` — still the runtime primitive that pushes/pops the active stack, fires `onThreadStart` / `onThreadEnd`, and tracks the per-call substep counter.
+- The `ThreadStepOpts` type — same shape, just consumed by `__internal_thread` instead of by codegen.
+- All existing tests for thread isolation, messaging, `continue`, `session`, and `hidden`.
+
+---
+
+## What goes away
+
+- The `_threadNamedArgsParser` parser and its "unknown thread argument" error (becomes a normal "no such field on `ThreadOpts`" type error).
+- The `MessageThread` AST node's optional argument fields. The AST node itself may remain for the source-to-source rewriter to attach a marker, but the named-arg slots become dead weight.
+- The codegen branch in [`processMessageThread` in `lib/backends/typescriptBuilder.ts`](file:///Users/adityabhargava/agency-lang/packages/agency-lang/lib/backends/typescriptBuilder.ts#L2767) that processes `label` / `summarize` / `hidden` / etc. into `TsNode`s.
+- The IR `TsRunnerThread`'s optional fields (`label`, `summarize`, `continueExpr`, `sessionExpr`, `hidden`) — they become regular function-call arguments handled by the existing call pipeline.
+- The codegen-time mutual-exclusion check between `continue` / `session`, and the codegen-time rejection of `subthread(continue/session)` — both become **type errors** on the `ThreadOpts` / `SubthreadOpts` types (e.g. discriminated unions or distinct opts types per construct).
+
+---
+
+## Migration
+
+Three focused PRs:
+
+1. **Ship `__internal_thread`** in stdlib alongside the current parser-level form. Parser still emits the existing AST node; nothing user-visible changes. This proves the runtime + block-arg plumbing works.
+2. **Flip the parser** to emit a function-call AST node calling `__internal_thread`. Keep the old `MessageThread` AST node as an alias for one release so any external tooling that introspects the AST has a deprecation window.
+3. **Delete** the old AST node fields, parser branch, IR fields, codegen branch, and pretty-printer branch.
+
+Each step is independently testable and revertable.
+
+---
+
+## Tradeoffs
+
+**Pros**
+
+- Future named args are **zero-code-change** in the parser/codegen — just add a field to the `ThreadOpts` type in `stdlib/threads.agency`.
+- Errors become idiomatic type-system errors handled by the existing type checker.
+- Removes ~200 lines across 5 files.
+- Documentation can describe `thread {}` as "sugar for `__internal_thread(opts, block)`" with a one-page redirect to the function reference.
+
+**Cons**
+
+- Existing parse error messages ("Unknown thread argument: foo. Allowed: label, summarize, ...") become slightly less direct (the type-checker will say something like "Type `{foo: string}` is not assignable to type `ThreadOpts`"). Solvable with a custom type-checker rule if it matters.
+- Any tooling that introspects the AST for `messageThread` nodes (doc generators, the AST dump) needs to update. Likely small surface area.
+- Requires resolving the open question of how the `thread {}` block scope (lexical scope = caller's scope) maps to a block-arg function parameter. Per the existing [block-arg semantics](https://agency-lang.com/guide/blocks.html), this should already match how block-arg calls work — but worth confirming in step 1.
+
+---
+
+## Effort estimate
+
+Roughly **3–4 developer-days** end-to-end including tests and fixture regeneration. Sliceable into the three PRs above (parallel codepath → flip → delete) so no single PR is large.
+
+---
+
+## Out of scope for this spec
+
+- The per-feature work to add new named args (those become trivial once the refactor lands).
+- Any user-facing language changes; this is a pure refactor of the implementation strategy. The surface syntax of `thread {}` and `subthread {}` does not change.

--- a/packages/agency-lang/lib/backends/typescriptBuilder.integration.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.integration.test.ts
@@ -231,6 +231,37 @@ node main() {
   });
 });
 
+describe("subthread rejects continue/session at codegen", () => {
+  // `subthread` is identity-bound to its parent's context; resuming
+  // via `continue` or `session` would be ambiguous, so the builder
+  // throws. See `lib/backends/typescriptBuilder.ts` (subthread continue/session check).
+  it("throws when subthread() uses `continue`", () => {
+    expect(() =>
+      generateWithBuilder(`
+node main() {
+  thread {
+    subthread(continue: "t1") {
+    }
+  }
+}
+`),
+    ).toThrow(/subthread.*continue.*session/i);
+  });
+
+  it("throws when subthread() uses `session`", () => {
+    expect(() =>
+      generateWithBuilder(`
+node main() {
+  thread {
+    subthread(session: "my-session") {
+    }
+  }
+}
+`),
+    ).toThrow(/subthread.*continue.*session/i);
+  });
+});
+
 import { mapTypeToValidationSchema } from "./typescriptGenerator/typeToZodSchema.js";
 
 describe("mapTypeToValidationSchema", () => {

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2791,13 +2791,30 @@ export class TypeScriptBuilder {
       );
     }
 
-    // Optional named args: thread(label, summarize, continue, session).
+    // Optional named args: thread(label, summarize, continue, session, hidden).
     // Each is an Expression in the AST — process to TsNode so codegen
     // can splice it into the opts arg. Codegen-time mutual exclusion
     // check defends parse-time guard.
     if (node.continueExpr && node.sessionExpr) {
       throw new Error(
         "thread() cannot use both `continue` and `session` — they are mutually exclusive",
+      );
+    }
+    // `subthread` is identity-bound to its parent's context at create
+    // time; resuming via `continue` or `session` would either need to
+    // re-derive that parent (ambiguous) or strip the subthread linkage
+    // (silently lossy). Reject at codegen so users see a clear error
+    // instead of confusing runtime behaviour. (Parse-time rejection
+    // would be nicer but the shared parser doesn't know which variant
+    // we're in.)
+    if (
+      node.threadType === "subthread" &&
+      (node.continueExpr || node.sessionExpr)
+    ) {
+      throw new Error(
+        "subthread() does not support `continue` or `session` — those modes " +
+          "resume a top-level thread. Use `thread(continue: ...)` or " +
+          "`thread(session: ...)` instead.",
       );
     }
     const label = node.label ? this.processNode(node.label) : null;
@@ -2808,6 +2825,7 @@ export class TypeScriptBuilder {
     const sessionExpr = node.sessionExpr
       ? this.processNode(node.sessionExpr)
       : null;
+    const hidden = node.hidden ? this.processNode(node.hidden) : null;
 
     return ts.runnerThread({
       id,
@@ -2817,6 +2835,7 @@ export class TypeScriptBuilder {
       summarize,
       continueExpr,
       sessionExpr,
+      hidden,
     });
   }
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2791,7 +2791,33 @@ export class TypeScriptBuilder {
       );
     }
 
-    return ts.runnerThread({ id, method, body: bodyNodes });
+    // Optional named args: thread(label, summarize, continue, session).
+    // Each is an Expression in the AST — process to TsNode so codegen
+    // can splice it into the opts arg. Codegen-time mutual exclusion
+    // check defends parse-time guard.
+    if (node.continueExpr && node.sessionExpr) {
+      throw new Error(
+        "thread() cannot use both `continue` and `session` — they are mutually exclusive",
+      );
+    }
+    const label = node.label ? this.processNode(node.label) : null;
+    const summarize = node.summarize ? this.processNode(node.summarize) : null;
+    const continueExpr = node.continueExpr
+      ? this.processNode(node.continueExpr)
+      : null;
+    const sessionExpr = node.sessionExpr
+      ? this.processNode(node.sessionExpr)
+      : null;
+
+    return ts.runnerThread({
+      id,
+      method,
+      body: bodyNodes,
+      label,
+      summarize,
+      continueExpr,
+      sessionExpr,
+    });
   }
 
   private processBlockPlain(

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2764,6 +2764,10 @@ export class TypeScriptBuilder {
     });
   }
 
+  // TODO(follow-up): `thread {}` should desugar into a call to a stdlib
+  // `__internal_thread(opts, block)` function so future named args don't
+  // require parser+IR+codegen+runtime edits in five files. See
+  // `docs/superpowers/specs/2026-05-30-thread-as-agency-function.md`.
   private processMessageThread(
     node: MessageThread,
     assignTo?: Assignment,

--- a/packages/agency-lang/lib/ir/builders.ts
+++ b/packages/agency-lang/lib/ir/builders.ts
@@ -441,7 +441,15 @@ export const ts = {
     return { kind: "runnerStep", ...opts };
   },
 
-  runnerThread(opts: { id: number; method: "create" | "createSubthread"; body: TsNode[] }): TsRunnerThread {
+  runnerThread(opts: {
+    id: number;
+    method: "create" | "createSubthread";
+    body: TsNode[];
+    label?: TsNode | null;
+    summarize?: TsNode | null;
+    continueExpr?: TsNode | null;
+    sessionExpr?: TsNode | null;
+  }): TsRunnerThread {
     const res = { kind: "runnerThread" as const, ...opts };
     return res;
   },

--- a/packages/agency-lang/lib/ir/builders.ts
+++ b/packages/agency-lang/lib/ir/builders.ts
@@ -449,6 +449,7 @@ export const ts = {
     summarize?: TsNode | null;
     continueExpr?: TsNode | null;
     sessionExpr?: TsNode | null;
+    hidden?: TsNode | null;
   }): TsRunnerThread {
     const res = { kind: "runnerThread" as const, ...opts };
     return res;

--- a/packages/agency-lang/lib/ir/prettyPrint.ts
+++ b/packages/agency-lang/lib/ir/prettyPrint.ts
@@ -299,7 +299,16 @@ export function printTs(node: TsNode, indent = 0): string {
 
     case "runnerThread": {
       const body = node.body.map((n) => printTs(n, indent + 1)).join("\n");
-      return `await runner.thread(${node.id}, "${node.method}", async (runner) => {\n${body}\n${ind(indent)}});`;
+      const optsParts: string[] = [];
+      if (node.label) optsParts.push(`label: ${printTs(node.label, indent)}`);
+      if (node.summarize) optsParts.push(`summarize: ${printTs(node.summarize, indent)}`);
+      if (node.continueExpr) optsParts.push(`continueId: ${printTs(node.continueExpr, indent)}`);
+      if (node.sessionExpr) optsParts.push(`session: ${printTs(node.sessionExpr, indent)}`);
+      // Always pass an opts object so Runner.thread has a single,
+      // uniform signature: legacy callers see `{}` and the
+      // hook-firing path can treat opts as required.
+      const optsArg = optsParts.length === 0 ? "{}" : `{ ${optsParts.join(", ")} }`;
+      return `await runner.thread(${node.id}, "${node.method}", ${optsArg}, async (runner) => {\n${body}\n${ind(indent)}});`;
     }
 
     case "runnerHandle": {

--- a/packages/agency-lang/lib/ir/prettyPrint.ts
+++ b/packages/agency-lang/lib/ir/prettyPrint.ts
@@ -304,6 +304,7 @@ export function printTs(node: TsNode, indent = 0): string {
       if (node.summarize) optsParts.push(`summarize: ${printTs(node.summarize, indent)}`);
       if (node.continueExpr) optsParts.push(`continueId: ${printTs(node.continueExpr, indent)}`);
       if (node.sessionExpr) optsParts.push(`session: ${printTs(node.sessionExpr, indent)}`);
+      if (node.hidden) optsParts.push(`hidden: ${printTs(node.hidden, indent)}`);
       // Always pass an opts object so Runner.thread has a single,
       // uniform signature: legacy callers see `{}` and the
       // hook-firing path can treat opts as required.

--- a/packages/agency-lang/lib/ir/tsIR.ts
+++ b/packages/agency-lang/lib/ir/tsIR.ts
@@ -320,12 +320,20 @@ export interface TsRunnerStep {
   body: TsNode[];
 }
 
-/** runner.thread(id, method, async (runner) => { body }) */
+/** runner.thread(id, method, opts, async (runner) => { body }).
+ *  `label`, `summarize`, `continueExpr`, `sessionExpr` are optional
+ *  expressions plumbed in by Tasks 3 / 6 / 7. When all are absent the
+ *  emitter elides the opts arg and falls back to the legacy
+ *  `runner.thread(id, method, async ...)` shape. */
 export interface TsRunnerThread {
   kind: "runnerThread";
   id: number;
   method: "create" | "createSubthread";
   body: TsNode[];
+  label?: TsNode | null;
+  summarize?: TsNode | null;
+  continueExpr?: TsNode | null;
+  sessionExpr?: TsNode | null;
 }
 
 /** runner.handle(id, handlerFn, async (runner) => { body }) */

--- a/packages/agency-lang/lib/ir/tsIR.ts
+++ b/packages/agency-lang/lib/ir/tsIR.ts
@@ -334,6 +334,7 @@ export interface TsRunnerThread {
   summarize?: TsNode | null;
   continueExpr?: TsNode | null;
   sessionExpr?: TsNode | null;
+  hidden?: TsNode | null;
 }
 
 /** runner.handle(id, handlerFn, async (runner) => { body }) */

--- a/packages/agency-lang/lib/ir/tsIR.ts
+++ b/packages/agency-lang/lib/ir/tsIR.ts
@@ -321,10 +321,10 @@ export interface TsRunnerStep {
 }
 
 /** runner.thread(id, method, opts, async (runner) => { body }).
- *  `label`, `summarize`, `continueExpr`, `sessionExpr` are optional
- *  expressions plumbed in by Tasks 3 / 6 / 7. When all are absent the
- *  emitter elides the opts arg and falls back to the legacy
- *  `runner.thread(id, method, async ...)` shape. */
+ *  `label`, `summarize`, `continueExpr`, `sessionExpr`, `hidden` are
+ *  optional expressions; the emitter always emits an opts object
+ *  (`{}` when every field is absent) so `Runner.thread` can rely on
+ *  the uniform 4-arg signature. */
 export interface TsRunnerThread {
   kind: "runnerThread";
   id: number;

--- a/packages/agency-lang/lib/parsers/messageThread.test.ts
+++ b/packages/agency-lang/lib/parsers/messageThread.test.ts
@@ -14,6 +14,38 @@ describe("messageThreadParser", () => {
       expect(r.result.summarize).toBeNull();
       expect(r.result.continueExpr).toBeNull();
       expect(r.result.sessionExpr).toBeNull();
+      expect(r.result.hidden).toBeNull();
+    }
+  });
+
+  it("parses thread(hidden: true) { ... }", () => {
+    const input = "thread(hidden: true) {\n  foo()\n}";
+    const r = messageThreadParser(normalizeCode(input));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.result.hidden).not.toBeNull();
+      expect(r.result.label).toBeNull();
+      expect(r.result.summarize).toBeNull();
+    }
+  });
+
+  it("parses thread(label, hidden) combined", () => {
+    const input = 'thread(label: "shh", hidden: true) {\n  foo()\n}';
+    const r = messageThreadParser(normalizeCode(input));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.result.label).not.toBeNull();
+      expect(r.result.hidden).not.toBeNull();
+    }
+  });
+
+  it("parses subthread(hidden: true) { ... }", () => {
+    const input = "subthread(hidden: true) {\n  foo()\n}";
+    const r = messageThreadParser(normalizeCode(input));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.result.threadType).toBe("subthread");
+      expect(r.result.hidden).not.toBeNull();
     }
   });
 

--- a/packages/agency-lang/lib/parsers/messageThread.test.ts
+++ b/packages/agency-lang/lib/parsers/messageThread.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { messageThreadParser } from "./parsers.js";
+import { normalizeCode } from "@/index.js";
+
+describe("messageThreadParser", () => {
+  it("parses thread { ... } with no args", () => {
+    const input = "thread {\n  foo()\n}";
+    const r = messageThreadParser(normalizeCode(input));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.result.type).toBe("messageThread");
+      expect(r.result.threadType).toBe("thread");
+      expect(r.result.label).toBeNull();
+      expect(r.result.summarize).toBeNull();
+      expect(r.result.continueExpr).toBeNull();
+      expect(r.result.sessionExpr).toBeNull();
+    }
+  });
+
+  it("parses thread(label: \"x\") { ... }", () => {
+    const input = 'thread(label: "coding task") {\n  foo()\n}';
+    const r = messageThreadParser(normalizeCode(input));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.result.label).not.toBeNull();
+      expect(r.result.summarize).toBeNull();
+    }
+  });
+
+  it("parses thread(label, summarize) { ... }", () => {
+    const input = 'thread(label: "x", summarize: true) {\n  foo()\n}';
+    const r = messageThreadParser(normalizeCode(input));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.result.label).not.toBeNull();
+      expect(r.result.summarize).not.toBeNull();
+    }
+  });
+
+  it("parses thread(continue: priorId) { ... }", () => {
+    const input = "thread(continue: priorId) {\n  foo()\n}";
+    const r = messageThreadParser(normalizeCode(input));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.result.continueExpr).not.toBeNull();
+      expect(r.result.sessionExpr).toBeNull();
+    }
+  });
+
+  it("parses thread(session: \"coding\") { ... }", () => {
+    const input = 'thread(session: "coding") {\n  foo()\n}';
+    const r = messageThreadParser(normalizeCode(input));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.result.sessionExpr).not.toBeNull();
+      expect(r.result.continueExpr).toBeNull();
+    }
+  });
+
+  it("rejects unknown arg names", () => {
+    const input = 'thread(bogus: "x") {\n  foo()\n}';
+    const r = messageThreadParser(normalizeCode(input));
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects continue + session combined", () => {
+    const input = 'thread(continue: priorId, session: "x") {\n  foo()\n}';
+    const r = messageThreadParser(normalizeCode(input));
+    expect(r.success).toBe(false);
+  });
+
+  it("parses subthread(label: \"x\") { ... }", () => {
+    const input = 'subthread(label: "child") {\n  foo()\n}';
+    const r = messageThreadParser(normalizeCode(input));
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.result.threadType).toBe("subthread");
+      expect(r.result.label).not.toBeNull();
+    }
+  });
+});

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -3098,6 +3098,7 @@ type ThreadNamedArgs = {
   summarize: Expression | null;
   continueExpr: Expression | null;
   sessionExpr: Expression | null;
+  hidden: Expression | null;
 };
 
 const _threadNamedArgsParser: Parser<ThreadNamedArgs> = (
@@ -3119,12 +3120,12 @@ const _threadNamedArgsParser: Parser<ThreadNamedArgs> = (
   const r = inner(input);
   if (!r.success) return r as ParserResult<ThreadNamedArgs>;
   const args: NamedArgument[] = r.result.arguments;
-  const allowed = ["label", "summarize", "continue", "session"];
+  const allowed = ["label", "summarize", "continue", "session", "hidden"];
   const seen: Record<string, Expression> = {};
   for (const arg of args) {
     if (!allowed.includes(arg.name)) {
       return failure(
-        `Unknown thread argument: ${arg.name}. Allowed: label, summarize, continue, session`,
+        `Unknown thread argument: ${arg.name}. Allowed: label, summarize, continue, session, hidden`,
         input,
       );
     }
@@ -3145,6 +3146,7 @@ const _threadNamedArgsParser: Parser<ThreadNamedArgs> = (
       summarize: seen.summarize ?? null,
       continueExpr: seen.continue ?? null,
       sessionExpr: seen.session ?? null,
+      hidden: seen.hidden ?? null,
     },
     r.rest,
   );
@@ -3208,6 +3210,7 @@ const liftThreadArgs = (parsed: any): MessageThread => {
         summarize: Expression | null;
         continueExpr: Expression | null;
         sessionExpr: Expression | null;
+        hidden: Expression | null;
       }
     | null
     | undefined;
@@ -3218,11 +3221,13 @@ const liftThreadArgs = (parsed: any): MessageThread => {
     out.summarize = args.summarize;
     out.continueExpr = args.continueExpr;
     out.sessionExpr = args.sessionExpr;
+    out.hidden = args.hidden;
   } else {
     out.label = null;
     out.summarize = null;
     out.continueExpr = null;
     out.sessionExpr = null;
+    out.hidden = null;
   }
   return out as MessageThread;
 };

--- a/packages/agency-lang/lib/parsers/parsers.ts
+++ b/packages/agency-lang/lib/parsers/parsers.ts
@@ -3089,12 +3089,77 @@ export const bodyParser = (input: string): ParserResult<AgencyNode[]> => {
   return parser(input);
 };
 
+/** Parse optional `(label: ..., summarize: ..., continue: ..., session: ...)`
+ *  before the `{` of a `thread` / `subthread` block. Accepts zero args
+ *  via `()` as well as no parens at all. Unknown keys produce a parse
+ *  error; `continue` and `session` are mutually exclusive. */
+type ThreadNamedArgs = {
+  label: Expression | null;
+  summarize: Expression | null;
+  continueExpr: Expression | null;
+  sessionExpr: Expression | null;
+};
+
+const _threadNamedArgsParser: Parser<ThreadNamedArgs> = (
+  input: string,
+): ParserResult<ThreadNamedArgs> => {
+  // Reuse the canonical NamedArgument parser shape used by function
+  // calls so users get identical syntax / error messages.
+  const inner: Parser<any> = seqC(
+    char("("),
+    optionalSpacesOrNewline,
+    capture(
+      sepBy(commaWithNewline, namedArgumentParser),
+      "arguments",
+    ),
+    optional(comma),
+    optionalSpacesOrNewline,
+    char(")"),
+  );
+  const r = inner(input);
+  if (!r.success) return r as ParserResult<ThreadNamedArgs>;
+  const args: NamedArgument[] = r.result.arguments;
+  const allowed = ["label", "summarize", "continue", "session"];
+  const seen: Record<string, Expression> = {};
+  for (const arg of args) {
+    if (!allowed.includes(arg.name)) {
+      return failure(
+        `Unknown thread argument: ${arg.name}. Allowed: label, summarize, continue, session`,
+        input,
+      );
+    }
+    if (seen[arg.name]) {
+      return failure(`Duplicate thread argument: ${arg.name}`, input);
+    }
+    seen[arg.name] = arg.value as Expression;
+  }
+  if (seen.continue && seen.session) {
+    return failure(
+      "thread() cannot use both `continue` and `session` — they are mutually exclusive",
+      input,
+    );
+  }
+  return success(
+    {
+      label: seen.label ?? null,
+      summarize: seen.summarize ?? null,
+      continueExpr: seen.continue ?? null,
+      sessionExpr: seen.session ?? null,
+    },
+    r.rest,
+  );
+};
+
 export const _messageThreadParser: Parser<MessageThread> = trace(
   "_messageThreadParser",
   seqC(
     set("type", "messageThread"),
     str("thread"),
     set("threadType", "thread"),
+    capture(
+      optional(_threadNamedArgsParser),
+      "_args",
+    ),
     optionalSpaces,
     char("{"),
     captureCaptures(
@@ -3115,6 +3180,10 @@ export const _submessageThreadParser: Parser<MessageThread> = trace(
     set("type", "messageThread"),
     str("subthread"),
     set("threadType", "subthread"),
+    capture(
+      optional(_threadNamedArgsParser),
+      "_args",
+    ),
     optionalSpaces,
     char("{"),
     captureCaptures(
@@ -3129,10 +3198,38 @@ export const _submessageThreadParser: Parser<MessageThread> = trace(
     ),
   ),
 );
-export const messageThreadParser: Parser<MessageThread> = withLoc(or(
-  _messageThreadParser,
-  _submessageThreadParser,
-));
+
+/** Lift `_args` (the optional named-args object) to top-level fields on
+ *  the MessageThread node. */
+const liftThreadArgs = (parsed: any): MessageThread => {
+  const args = parsed._args as
+    | {
+        label: Expression | null;
+        summarize: Expression | null;
+        continueExpr: Expression | null;
+        sessionExpr: Expression | null;
+      }
+    | null
+    | undefined;
+  const out: any = { ...parsed };
+  delete out._args;
+  if (args) {
+    out.label = args.label;
+    out.summarize = args.summarize;
+    out.continueExpr = args.continueExpr;
+    out.sessionExpr = args.sessionExpr;
+  } else {
+    out.label = null;
+    out.summarize = null;
+    out.continueExpr = null;
+    out.sessionExpr = null;
+  }
+  return out as MessageThread;
+};
+
+export const messageThreadParser: Parser<MessageThread> = withLoc(
+  map(or(_messageThreadParser, _submessageThreadParser), liftThreadArgs),
+);
 
 const inlineHandlerParser: Parser<HandleBlock["handler"]> = (input) => {
   const parser = seqC(

--- a/packages/agency-lang/lib/runtime/__tests__/node.test.ts
+++ b/packages/agency-lang/lib/runtime/__tests__/node.test.ts
@@ -56,4 +56,30 @@ describe("setupNode", () => {
     expect(result.threads).toBeInstanceOf(ThreadStore);
     expect(result.threads.activeId()).toBeDefined();
   });
+
+  // Task 4: pin the cross-node persistence contract that the thread
+  // registry depends on. setupNode reuses the ThreadStore passed via
+  // state.messages on every node transition, so any threads created
+  // inside an earlier node remain queryable from a later one. If a
+  // future refactor of setupNode breaks this branch the registry
+  // breaks silently — this test fails fast.
+  it("pins the cross-node ThreadStore registry contract", () => {
+    const threadStore = new ThreadStore();
+    threadStore.getOrCreateActive();           // raw id "0"
+    const extraId = threadStore.create();      // raw id "1" — closed thread
+
+    const ctx = { stateStack: new StateStack() } as any;
+    const state = { messages: threadStore, ctx, data: {} } as any;
+
+    const result = runInTestContext(ctx, ctx.stateStack, threadStore, () =>
+      setupNode({ state }),
+    );
+
+    // setupNode must hand back the SAME store, with both threads
+    // intact and the counter past them — i.e. nothing has been wiped
+    // or rebuilt.
+    expect(result.threads).toBe(threadStore);
+    expect(Object.keys(result.threads.threads).sort()).toEqual(["0", extraId]);
+    expect(result.threads.counter).toBeGreaterThan(Number(extraId));
+  });
 });

--- a/packages/agency-lang/lib/runtime/__tests__/testHelpers.ts
+++ b/packages/agency-lang/lib/runtime/__tests__/testHelpers.ts
@@ -50,6 +50,10 @@ export function makeMockCtx(opts: {
       createSubthread: () => "tid-sub-1",
       pushActive: () => {},
       popActive: () => {},
+      activeId: () => undefined,
+      get: () => ({ messages: [], parentId: null }),
+      resumeExisting: () => {},
+      openSession: (_name: string) => ({ id: "tid-1", existed: false }),
     },
     // Minimal statelogClient stub. runBatch (used by Runner.hook's
     // per-callback machinery) needs `snapshotStack` and

--- a/packages/agency-lang/lib/runtime/agency.test.ts
+++ b/packages/agency-lang/lib/runtime/agency.test.ts
@@ -160,8 +160,12 @@ describe("agency.thread (subnamespace)", () => {
 });
 
 describe("agency.threads (registry subnamespace)", () => {
-  it("list returns [] outside a frame", () => {
-    expect(agency.threads.list()).toEqual([]);
+  it("list throws outside a frame (silent [] would mask misuse)", () => {
+    expect(() => agency.threads.list()).toThrow(/outside an Agency frame/);
+  });
+
+  it("get throws outside a frame", () => {
+    expect(() => agency.threads.get("t0")).toThrow(/outside an Agency frame/);
   });
 
   it("current returns undefined outside a frame", () => {

--- a/packages/agency-lang/lib/runtime/agency.test.ts
+++ b/packages/agency-lang/lib/runtime/agency.test.ts
@@ -159,6 +159,76 @@ describe("agency.thread (subnamespace)", () => {
   });
 });
 
+describe("agency.threads (registry subnamespace)", () => {
+  it("list returns [] outside a frame", () => {
+    expect(agency.threads.list()).toEqual([]);
+  });
+
+  it("current returns undefined outside a frame", () => {
+    expect(agency.threads.current()).toBeUndefined();
+  });
+
+  it("get returns [] for an unknown id", () => {
+    const env = setup();
+    agency.withTestContext(env, () => {
+      expect(agency.threads.get("tDoesNotExist")).toEqual([]);
+    });
+  });
+
+  it("list returns every thread with slug ids and correct isActive flag", () => {
+    const env = setup();
+    // Seed an active root thread, then create a second thread.
+    env.threads.getOrCreateActive();           // raw id "0", pushed active
+    env.threads.create();                       // raw id "1", not active
+    agency.withTestContext(env, () => {
+      const list = agency.threads.list();
+      expect(list.map((t) => t.id)).toEqual(["t0", "t1"]);
+      expect(list[0].isActive).toBe(true);
+      expect(list[1].isActive).toBe(false);
+      expect(list[0].threadType).toBe("thread");
+      expect(list[0].parentId).toBeNull();
+    });
+  });
+
+  it("subthreads surface threadType and parentId", () => {
+    const env = setup();
+    const parentId = env.threads.create();
+    env.threads.pushActive(parentId);
+    const childId = env.threads.createSubthread();
+    agency.withTestContext(env, () => {
+      const list = agency.threads.list();
+      const child = list.find((t) => t.id === `t${childId}`);
+      expect(child).toBeDefined();
+      expect(child!.threadType).toBe("subthread");
+      expect(child!.parentId).toBe(`t${parentId}`);
+    });
+  });
+
+  it("get returns a sliced view of messages", async () => {
+    const env = setup();
+    env.threads.getOrCreateActive();
+    await agency.withTestContext(env, async () => {
+      agency.thread.user("hello");
+      agency.thread.assistant("hi there");
+      const all = agency.threads.get("t0", 0, 10);
+      expect(all.length).toBe(2);
+      expect(all[0]).toEqual({ role: "user", content: "hello" });
+      expect(all[1]).toEqual({ role: "assistant", content: "hi there" });
+      const first = agency.threads.get("t0", 0, 1);
+      expect(first.length).toBe(1);
+      expect(first[0].role).toBe("user");
+    });
+  });
+
+  it("current returns the active id in slug form", () => {
+    const env = setup();
+    env.threads.getOrCreateActive();
+    agency.withTestContext(env, () => {
+      expect(agency.threads.current()).toBe("t0");
+    });
+  });
+});
+
 describe("agency.checkpoint / getCheckpoint / restore", () => {
   // Checkpoint creation requires a node id on the state stack;
   // `makeMockCtx()` pre-seeds one ("process"), matching what

--- a/packages/agency-lang/lib/runtime/agency.ts
+++ b/packages/agency-lang/lib/runtime/agency.ts
@@ -177,14 +177,27 @@ const messageToThreadMessage = (m: smoltalk.Message): ThreadMessageTS => {
   return { role: json.role as ThreadMessageTS["role"], content };
 };
 
-/** Return every thread in the run's registry as plain records. The
- *  currently active thread is included with `isActive: true`. */
+/** Return every thread in the run's registry as plain records.
+ *  Threads created with `thread(hidden: true) { ... }` are filtered
+ *  out so library-internal LLM scaffolding (e.g. summarizer prompts)
+ *  doesn't show up in user-facing thread enumerations.
+ *
+ *  Throws when called outside any Agency frame — silently returning
+ *  `[]` would mask a misuse (TS helper called from non-Agency code)
+ *  that the user would otherwise debug as a confusing empty list. */
 const threadsList = (): ThreadInfoTS[] => {
   const store = threadStoreMaybe();
-  if (!store) return [];
+  if (!store) {
+    throw new Error(
+      "agency.threads.list() called outside an Agency frame. " +
+        "It must run inside `agencyStore.run(...)` / a node body — " +
+        "wrap test calls with `agency.withTestContext({ctx,stack,threads}, ...)`.",
+    );
+  }
   const activeId = store.activeId();
   const out: ThreadInfoTS[] = [];
   for (const [rawId, thread] of Object.entries(store.threads)) {
+    if (thread.hidden) continue;
     out.push({
       id: toSlug(rawId),
       parentId: thread.parentId ? toSlug(thread.parentId) : null,
@@ -199,14 +212,22 @@ const threadsList = (): ThreadInfoTS[] => {
 
 /** Read a slice of a thread's messages. Returns `[]` for unknown ids
  *  (silent — callers can probe). `offset` and `limit` default to 0 and
- *  50, matching the Agency-side `getThread` signature. */
+ *  50, matching the Agency-side `getThread` signature.
+ *
+ *  Throws when called outside any Agency frame. */
 const threadsGet = (
   id: string,
   offset = 0,
   limit = 50,
 ): ThreadMessageTS[] => {
   const store = threadStoreMaybe();
-  if (!store) return [];
+  if (!store) {
+    throw new Error(
+      "agency.threads.get() called outside an Agency frame. " +
+        "It must run inside `agencyStore.run(...)` / a node body — " +
+        "wrap test calls with `agency.withTestContext({ctx,stack,threads}, ...)`.",
+    );
+  }
   const rawId = fromSlug(id);
   const thread = store.threads[rawId];
   if (!thread) return [];

--- a/packages/agency-lang/lib/runtime/agency.ts
+++ b/packages/agency-lang/lib/runtime/agency.ts
@@ -136,20 +136,27 @@ const threadWith = async <T>(
 
 /** Plain record describing a thread in the run's registry. Slug-ified
  *  ids (`t0`, `t1`, ...) wrap the internal counter strings so LLMs see
- *  short, easy-to-quote identifiers. */
+ *  short, easy-to-quote identifiers. `label` and `summary` are
+ *  surfaced directly from the underlying `MessageThread` (post-Commit-B:
+ *  no more module-level TS cache). */
 export type ThreadInfoTS = {
   id: string;
   parentId: string | null;
   threadType: "thread" | "subthread";
   messageCount: number;
   isActive: boolean;
-  messages: ThreadMessageTS[];
-};
-
-/** Plain record describing a single message inside a thread. */
-export type ThreadMessageTS = {
-  role: "system" | "user" | "assistant" | "tool";
-  content: string;
+  /** Snapshot of the thread's messages in smoltalk's wire format.
+   *  Consumers that need flat `{role, content}` records can call
+   *  `m.role` / `m.content` directly; tool-call / structured-content
+   *  variants land here untouched (no lossy coercion). */
+  messages: smoltalk.MessageJSON[];
+  /** Optional user-supplied label from `thread(label: "...") { ... }`.
+   *  `null` when no label was given. */
+  label: string | null;
+  /** Cached summary written by the stdlib's `summaryFor()` helper.
+   *  `null` until the summary is computed (lazy on first
+   *  `listThreads()`). */
+  summary: string | null;
 };
 
 /** Convert an internal counter string id (`"0"`, `"1"`, ...) to the
@@ -162,20 +169,6 @@ const toSlug = (rawId: string): string => `t${rawId}`;
  *  form. */
 const fromSlug = (slug: string): string =>
   slug.startsWith("t") ? slug.slice(1) : slug;
-
-const messageToThreadMessage = (m: smoltalk.Message): ThreadMessageTS => {
-  const json = m.toJSON();
-  // smoltalk.MessageJSON has a `role` field of the union we care about
-  // and a `content` field that may be string | structured. Coerce
-  // non-string content to a JSON string so the LLM-facing API stays
-  // flat. (Tool messages keep their stringified content; assistant
-  // tool-call messages serialize their tool calls.)
-  const content =
-    typeof json.content === "string"
-      ? json.content
-      : JSON.stringify(json.content ?? "");
-  return { role: json.role as ThreadMessageTS["role"], content };
-};
 
 /** Return every thread in the run's registry as plain records.
  *  Threads created with `thread(hidden: true) { ... }` are filtered
@@ -204,7 +197,9 @@ const threadsList = (): ThreadInfoTS[] => {
       threadType: thread.parentId ? "subthread" : "thread",
       messageCount: thread.messages.length,
       isActive: rawId === activeId,
-      messages: thread.messages.map(messageToThreadMessage),
+      messages: thread.messages.map((m) => m.toJSON()),
+      label: thread.label,
+      summary: thread.summary,
     });
   }
   return out;
@@ -219,7 +214,7 @@ const threadsGet = (
   id: string,
   offset = 0,
   limit = 50,
-): ThreadMessageTS[] => {
+): smoltalk.MessageJSON[] => {
   const store = threadStoreMaybe();
   if (!store) {
     throw new Error(
@@ -233,7 +228,7 @@ const threadsGet = (
   if (!thread) return [];
   return thread.messages
     .slice(offset, offset + limit)
-    .map(messageToThreadMessage);
+    .map((m) => m.toJSON());
 };
 
 /** Slug form of the currently active thread id, or `undefined` outside

--- a/packages/agency-lang/lib/runtime/agency.ts
+++ b/packages/agency-lang/lib/runtime/agency.ts
@@ -164,11 +164,13 @@ export type ThreadInfoTS = {
 const toSlug = (rawId: string): string => `t${rawId}`;
 
 /** Strip the leading `t` from a public slug to get the internal
- *  counter string id. Returns the input unchanged if it does not
- *  start with `t` — defensive only; codegen always emits the slug
- *  form. */
+ *  counter string id. Only strips when the input matches the
+ *  canonical `t<digits>` shape — non-numeric ids (test mocks, ids
+ *  that happen to start with `t`) pass through unchanged. Mirrors
+ *  `stripSlug` in runner.ts so both call sites treat slugs the
+ *  same way. */
 const fromSlug = (slug: string): string =>
-  slug.startsWith("t") ? slug.slice(1) : slug;
+  /^t\d+$/.test(slug) ? slug.slice(1) : slug;
 
 /** Return every thread in the run's registry as plain records.
  *  Threads created with `thread(hidden: true) { ... }` are filtered

--- a/packages/agency-lang/lib/runtime/agency.ts
+++ b/packages/agency-lang/lib/runtime/agency.ts
@@ -132,6 +132,97 @@ const threadWith = async <T>(
   }
 };
 
+// ---- Threads (registry) subnamespace ----------------------------------
+
+/** Plain record describing a thread in the run's registry. Slug-ified
+ *  ids (`t0`, `t1`, ...) wrap the internal counter strings so LLMs see
+ *  short, easy-to-quote identifiers. */
+export type ThreadInfoTS = {
+  id: string;
+  parentId: string | null;
+  threadType: "thread" | "subthread";
+  messageCount: number;
+  isActive: boolean;
+  messages: ThreadMessageTS[];
+};
+
+/** Plain record describing a single message inside a thread. */
+export type ThreadMessageTS = {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+};
+
+/** Convert an internal counter string id (`"0"`, `"1"`, ...) to the
+ *  public slug form (`"t0"`, `"t1"`, ...). */
+const toSlug = (rawId: string): string => `t${rawId}`;
+
+/** Strip the leading `t` from a public slug to get the internal
+ *  counter string id. Returns the input unchanged if it does not
+ *  start with `t` — defensive only; codegen always emits the slug
+ *  form. */
+const fromSlug = (slug: string): string =>
+  slug.startsWith("t") ? slug.slice(1) : slug;
+
+const messageToThreadMessage = (m: smoltalk.Message): ThreadMessageTS => {
+  const json = m.toJSON();
+  // smoltalk.MessageJSON has a `role` field of the union we care about
+  // and a `content` field that may be string | structured. Coerce
+  // non-string content to a JSON string so the LLM-facing API stays
+  // flat. (Tool messages keep their stringified content; assistant
+  // tool-call messages serialize their tool calls.)
+  const content =
+    typeof json.content === "string"
+      ? json.content
+      : JSON.stringify(json.content ?? "");
+  return { role: json.role as ThreadMessageTS["role"], content };
+};
+
+/** Return every thread in the run's registry as plain records. The
+ *  currently active thread is included with `isActive: true`. */
+const threadsList = (): ThreadInfoTS[] => {
+  const store = threadStoreMaybe();
+  if (!store) return [];
+  const activeId = store.activeId();
+  const out: ThreadInfoTS[] = [];
+  for (const [rawId, thread] of Object.entries(store.threads)) {
+    out.push({
+      id: toSlug(rawId),
+      parentId: thread.parentId ? toSlug(thread.parentId) : null,
+      threadType: thread.parentId ? "subthread" : "thread",
+      messageCount: thread.messages.length,
+      isActive: rawId === activeId,
+      messages: thread.messages.map(messageToThreadMessage),
+    });
+  }
+  return out;
+};
+
+/** Read a slice of a thread's messages. Returns `[]` for unknown ids
+ *  (silent — callers can probe). `offset` and `limit` default to 0 and
+ *  50, matching the Agency-side `getThread` signature. */
+const threadsGet = (
+  id: string,
+  offset = 0,
+  limit = 50,
+): ThreadMessageTS[] => {
+  const store = threadStoreMaybe();
+  if (!store) return [];
+  const rawId = fromSlug(id);
+  const thread = store.threads[rawId];
+  if (!thread) return [];
+  return thread.messages
+    .slice(offset, offset + limit)
+    .map(messageToThreadMessage);
+};
+
+/** Slug form of the currently active thread id, or `undefined` outside
+ *  any runtime frame / when no thread is active. */
+const threadsCurrent = (): string | undefined => {
+  const store = threadStoreMaybe();
+  const id = store?.activeId();
+  return id !== undefined ? toSlug(id) : undefined;
+};
+
 // ---- Checkpoints -------------------------------------------------------
 
 /** Capture a checkpoint of the current execution state. The recorded
@@ -325,6 +416,12 @@ export const agency = {
     remember: memoryRemember,
     recall: memoryRecall,
     forget: memoryForget,
+  },
+
+  threads: {
+    list: threadsList,
+    get: threadsGet,
+    current: threadsCurrent,
   },
 
   withTestContext,

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -62,6 +62,19 @@ export type CallbackMap = {
     cancel: () => void;
   };
   onEmit: unknown;
+  onThreadStart: {
+    threadId: string;                          // slug form ("t3")
+    threadType: "thread" | "subthread";
+    parentThreadId?: string;                   // slug form when present
+    label?: string;                            // from thread(label: "...") {}
+    isResumption?: boolean;                    // true when entered via continue/session
+  };
+  onThreadEnd: {
+    threadId: string;                          // slug form
+    label?: string;
+    eagerSummarize: boolean;                   // from thread(summarize: true)
+    messages: MessageJSON[];                   // snapshot at close
+  };
 };
 
 // Compile-time guard: ensures VALID_CALLBACK_NAMES stays in sync with CallbackMap.

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -146,24 +146,6 @@ export function registerGlobalHook<K extends keyof CallbackMap>(
   _globalHooks[name]!.push(fn);
 }
 
-/** Cheap pre-check: returns `true` iff at least one callback is
- *  registered for `name` (global, top-level, or TS-passed). Used by
- *  hot-path call sites that want to skip the `await invokeCallbacks(...)`
- *  microtask boundary in the common no-listeners case. Scoped
- *  callbacks (registered via `callback()` inside a function/node body)
- *  are intentionally NOT checked here — a `false` result is a fast-path
- *  optimisation only; callers may still safely call invokeCallbacks. */
-export function hasHook<K extends keyof CallbackMap>(
-  ctx: RuntimeContext<any>,
-  name: K,
-): boolean {
-  if ((_globalHooks[name] ?? []).length > 0) return true;
-  if (ctx.callbacks && ctx.callbacks[name]) return true;
-  const topLevel = ctx.topLevelCallbacks ?? [];
-  for (const cb of topLevel) if (cb.name === name) return true;
-  return false;
-}
-
 async function invokeCallback(
   fn: any,
   data: unknown,

--- a/packages/agency-lang/lib/runtime/hooks.ts
+++ b/packages/agency-lang/lib/runtime/hooks.ts
@@ -146,6 +146,24 @@ export function registerGlobalHook<K extends keyof CallbackMap>(
   _globalHooks[name]!.push(fn);
 }
 
+/** Cheap pre-check: returns `true` iff at least one callback is
+ *  registered for `name` (global, top-level, or TS-passed). Used by
+ *  hot-path call sites that want to skip the `await invokeCallbacks(...)`
+ *  microtask boundary in the common no-listeners case. Scoped
+ *  callbacks (registered via `callback()` inside a function/node body)
+ *  are intentionally NOT checked here — a `false` result is a fast-path
+ *  optimisation only; callers may still safely call invokeCallbacks. */
+export function hasHook<K extends keyof CallbackMap>(
+  ctx: RuntimeContext<any>,
+  name: K,
+): boolean {
+  if ((_globalHooks[name] ?? []).length > 0) return true;
+  if (ctx.callbacks && ctx.callbacks[name]) return true;
+  const topLevel = ctx.topLevelCallbacks ?? [];
+  for (const cb of topLevel) if (cb.name === name) return true;
+  return false;
+}
+
 async function invokeCallback(
   fn: any,
   data: unknown,

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -501,6 +501,45 @@ describe("Runner", () => {
       expect(popped).toBe(true);
       expect(runner.halted).toBe(true);
     });
+
+    it("fires onThreadStart and onThreadEnd with slug ids and label", async () => {
+      const frame = makeFrame();
+      const ctx = makeMockCtx();
+      const events: Array<{ kind: string; data: any }> = [];
+      ctx.callbacks = {
+        onThreadStart: (data: any) => { events.push({ kind: "start", data }); },
+        onThreadEnd: (data: any) => { events.push({ kind: "end", data }); },
+      };
+      // makeMockCtx returns "tid-1" from create(). Override get() to
+      // surface a non-empty message list so we can assert the snapshot.
+      ctx.threads.get = () => ({
+        messages: [{ toJSON: () => ({ role: "user", content: "hi" }) }],
+        parentId: null,
+      });
+
+      const runner = new Runner(ctx, frame, { threads: ctx.threads });
+
+      await runner.thread(
+        0,
+        "create",
+        { label: "coding task", summarize: true },
+        async () => {
+          /* body */
+        },
+      );
+
+      expect(events.length).toBe(2);
+      expect(events[0].kind).toBe("start");
+      expect(events[0].data.threadId).toBe("ttid-1");
+      expect(events[0].data.label).toBe("coding task");
+      expect(events[0].data.threadType).toBe("thread");
+      expect(events[0].data.isResumption).toBe(false);
+      expect(events[1].kind).toBe("end");
+      expect(events[1].data.threadId).toBe("ttid-1");
+      expect(events[1].data.label).toBe("coding task");
+      expect(events[1].data.eagerSummarize).toBe(true);
+      expect(events[1].data.messages).toEqual([{ role: "user", content: "hi" }]);
+    });
   });
 
   describe("handle()", () => {

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Runner } from "./runner.js";
+import { Runner, stripSlug } from "./runner.js";
 import { State, StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
 import { getRuntimeContext } from "./asyncContext.js";
@@ -726,5 +726,21 @@ describe("Runner", () => {
       expect(paths[0]).toBe("0");
       expect(paths[paths.length - 1]).toContain("0.0");
     });
+  });
+});
+
+describe("stripSlug", () => {
+  it("strips the leading t from canonical slugs", () => {
+    expect(stripSlug("t1")).toBe("1");
+    expect(stripSlug("t42")).toBe("42");
+  });
+
+  it("leaves non-slug strings untouched", () => {
+    expect(stripSlug("hello")).toBe("hello");
+    // Regression: prior to the tightened regex this returned "hello".
+    expect(stripSlug("thello")).toBe("thello");
+    expect(stripSlug("t")).toBe("t");
+    expect(stripSlug("t1a")).toBe("t1a");
+    expect(stripSlug("")).toBe("");
   });
 });

--- a/packages/agency-lang/lib/runtime/runner.test.ts
+++ b/packages/agency-lang/lib/runtime/runner.test.ts
@@ -477,7 +477,7 @@ describe("Runner", () => {
 
       const runner = new Runner(ctx, frame, { threads: ctx.threads });
 
-      await runner.thread(0, "create", async () => {
+      await runner.thread(0, "create", {}, async () => {
         calls.push("body");
       });
 
@@ -494,7 +494,7 @@ describe("Runner", () => {
 
       const runner = new Runner(ctx, frame, { threads: ctx.threads });
 
-      await runner.thread(0, "create", async (runner) => {
+      await runner.thread(0, "create", {}, async (runner) => {
         runner.halt("interrupt");
       });
 

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -3,7 +3,7 @@ import { agencyStore } from "./asyncContext.js";
 import { debugStep } from "./debugger.js";
 import { RestoreSignal } from "./errors.js";
 import { HaltSignal } from "./haltSignal.js";
-import { invokeCallbacks } from "./hooks.js";
+import { hasHook, invokeCallbacks } from "./hooks.js";
 import { hasInterrupts } from "./interrupts.js";
 import { __pipeBind } from "./result.js";
 import { runBatch } from "./runBatch.js";
@@ -569,22 +569,27 @@ export class Runner {
       threads.pushActive(tid);
     }
 
-    // Fire onThreadStart. Slug the id for the public payload.
+    // Fire onThreadStart. Slug the id for the public payload. Skip
+    // the await entirely when no callbacks are registered for this
+    // hook (the common case) so we don't introduce an extra
+    // microtask boundary that perturbs debugger checkpoint timing.
     const slug = `t${tid}`;
     const threadType: "thread" | "subthread" =
       method === "createSubthread" ? "subthread" : "thread";
     const parentRaw = threads.get(tid)?.parentId ?? undefined;
-    await invokeCallbacks({
-      ctx: this.ctx,
-      name: "onThreadStart",
-      data: {
-        threadId: slug,
-        threadType: parentRaw ? "subthread" : threadType,
-        parentThreadId: parentRaw ? `t${parentRaw}` : undefined,
-        label: opts.label,
-        isResumption,
-      },
-    });
+    if (hasHook(this.ctx, "onThreadStart")) {
+      await invokeCallbacks({
+        ctx: this.ctx,
+        name: "onThreadStart",
+        data: {
+          threadId: slug,
+          threadType: parentRaw ? "subthread" : threadType,
+          parentThreadId: parentRaw ? `t${parentRaw}` : undefined,
+          label: opts.label,
+          isResumption,
+        },
+      });
+    }
 
     this.path.push(id);
     try {
@@ -607,20 +612,24 @@ export class Runner {
         // statements see the prior active thread.
         threads.popActive();
       }
-      // Fire onThreadEnd unconditionally so the registry stdlib hook
-      // sees the close. We fire from `finally` so exceptions thrown
-      // inside the body still record a close event.
+      // Fire onThreadEnd so the registry stdlib hook sees the
+      // close. We fire from `finally` so exceptions thrown inside
+      // the body still record a close event. Same as onThreadStart,
+      // skip the await when no callbacks are registered to avoid a
+      // spurious microtask boundary.
       try {
-        await invokeCallbacks({
-          ctx: this.ctx,
-          name: "onThreadEnd",
-          data: {
-            threadId: slug,
-            label: opts.label,
-            eagerSummarize: opts.summarize === true,
-            messages: messagesSnapshot,
-          },
-        });
+        if (hasHook(this.ctx, "onThreadEnd")) {
+          await invokeCallbacks({
+            ctx: this.ctx,
+            name: "onThreadEnd",
+            data: {
+              threadId: slug,
+              label: opts.label,
+              eagerSummarize: opts.summarize === true,
+              messages: messagesSnapshot,
+            },
+          });
+        }
       } catch (e) {
         // Swallow hook errors in finally to avoid masking the
         // primary exception. `fireWithGuard` inside invokeCallbacks

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -33,7 +33,7 @@ export type ThreadStepOpts = {
  *  canonical `t<digits>` shape so user-chosen ids that happen to
  *  begin with `t` (e.g. session names like `"telephone"`) are not
  *  silently mangled. */
-function stripSlug(slug: string): string {
+export function stripSlug(slug: string): string {
   return /^t\d+$/.test(slug) ? slug.slice(1) : slug;
 }
 

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -1,7 +1,9 @@
 import { nanoid } from "nanoid";
 import { agencyStore } from "./asyncContext.js";
 import { debugStep } from "./debugger.js";
+import { RestoreSignal } from "./errors.js";
 import { HaltSignal } from "./haltSignal.js";
+import { invokeCallbacks } from "./hooks.js";
 import { hasInterrupts } from "./interrupts.js";
 import { __pipeBind } from "./result.js";
 import { runBatch } from "./runBatch.js";
@@ -11,6 +13,24 @@ import type { BranchState, State } from "./state/stateStack.js";
 import { StateStack } from "./state/stateStack.js";
 import type { ThreadStore } from "./state/threadStore.js";
 import type { HandlerFn } from "./types.js";
+
+/** Options bag for the new `Runner.thread(id, method, opts, callback)`
+ *  signature. All fields are optional; emitter passes only the ones
+ *  the user supplied via `thread(label: ..., summarize: ..., continue: ..., session: ...) { ... }`. */
+export type ThreadStepOpts = {
+  label?: string;
+  summarize?: boolean;
+  /** Slug form (e.g. "t3"). Stripped to raw counter id internally. */
+  continueId?: string;
+  /** Session name; runtime maps it to a thread id via openSession. */
+  session?: string;
+};
+
+/** Strip the leading `t` from a public thread slug to recover the
+ *  internal counter-string id. Defensive: accepts a raw id unchanged. */
+function stripSlug(slug: string): string {
+  return slug.startsWith("t") ? slug.slice(1) : slug;
+}
 
 /**
  * Runner centralizes step execution logic for generated Agency code.
@@ -466,8 +486,21 @@ export class Runner {
   async thread(
     id: number,
     method: "create" | "createSubthread",
-    callback: (runner: Runner) => Promise<void>,
+    optsOrCallback:
+      | ThreadStepOpts
+      | ((runner: Runner) => Promise<void>),
+    maybeCallback?: (runner: Runner) => Promise<void>,
   ): Promise<void> {
+    // Two-form signature so legacy call sites
+    // (`runner.thread(id, method, async (runner) => ...)`, used by
+    // `lib/runtime/runner.test.ts` and any old fixtures) keep working
+    // alongside the new opts-bearing form
+    // (`runner.thread(id, method, opts, async (runner) => ...)`).
+    const opts: ThreadStepOpts =
+      typeof optsOrCallback === "function" ? {} : optsOrCallback;
+    const callback =
+      typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback!;
+
     this.beforeStep();
     if (this.shouldSkip()) return;
     if (this.getCounter() > id) return;
@@ -491,27 +524,112 @@ export class Runner {
       );
     }
 
-    // Guard thread creation so it only happens once. On resume from a
-    // debug pause inside the callback, the entire thread() method
-    // re-executes (the step counter only advances after the callback
-    // completes). Without this guard, threads.create() would run again
-    // on every resume, creating duplicate threads.
+    // Guard thread creation/resumption so it only happens once. On
+    // resume from a debug pause inside the callback, the entire
+    // thread() method re-executes (the step counter only advances
+    // after the callback completes). Without this guard, the side
+    // effect (create/resumeExisting/openSession) would run again on
+    // every resume, corrupting the registry.
     const threadKey = `__thread_${this.stepPath(id)}`;
+    const resumptionKey = `__thread_resumed_${this.stepPath(id)}`;
     let tid: string;
+    let isResumption = false;
     if (this.frame.locals[threadKey] !== undefined) {
       tid = this.frame.locals[threadKey];
+      isResumption = this.frame.locals[resumptionKey] === true;
     } else {
-      tid = threads[method]();
+      // Resolve the entry mode: continueId > session > default
+      // create/createSubthread. continue + session are mutually
+      // exclusive (rejected at parse time, but defended again here).
+      if (opts.continueId !== undefined && opts.session !== undefined) {
+        throw new Error(
+          "thread() received both `continue` and `session` options; " +
+            "they are mutually exclusive.",
+        );
+      }
+      if (opts.continueId !== undefined) {
+        const rawId = stripSlug(opts.continueId);
+        threads.resumeExisting(rawId);
+        tid = rawId;
+        isResumption = true;
+      } else if (opts.session !== undefined) {
+        const { id: openedId, existed } = threads.openSession(opts.session);
+        tid = openedId;
+        isResumption = existed;
+      } else {
+        tid = threads[method]();
+      }
       this.frame.locals[threadKey] = tid;
+      this.frame.locals[resumptionKey] = isResumption;
     }
-    threads.pushActive(tid);
+    // For `continueId` / `session`, openSession / resumeExisting
+    // already push the active stack. Avoid a double-push.
+    const alreadyActive = threads.activeId() === tid;
+    if (!alreadyActive) {
+      threads.pushActive(tid);
+    }
+
+    // Fire onThreadStart. Slug the id for the public payload.
+    const slug = `t${tid}`;
+    const threadType: "thread" | "subthread" =
+      method === "createSubthread" ? "subthread" : "thread";
+    const parentRaw = threads.get(tid)?.parentId ?? undefined;
+    await invokeCallbacks({
+      ctx: this.ctx,
+      name: "onThreadStart",
+      data: {
+        threadId: slug,
+        threadType: parentRaw ? "subthread" : threadType,
+        parentThreadId: parentRaw ? `t${parentRaw}` : undefined,
+        label: opts.label,
+        isResumption,
+      },
+    });
 
     this.path.push(id);
     try {
       await this.runInScope(() => callback(this));
     } finally {
       this.path.pop();
-      threads.popActive();
+      // Snapshot messages BEFORE popping the active stack so the
+      // onThreadEnd payload sees the just-closed thread's final
+      // message list. Use the active id (which is `tid`) to look it
+      // up regardless of double-push avoidance.
+      const closingThread = threads.get(tid);
+      const messagesSnapshot = closingThread
+        ? closingThread.messages.map((m) => m.toJSON())
+        : [];
+      if (!alreadyActive) {
+        threads.popActive();
+      } else {
+        // We did not push, but the user's perception is that the
+        // thread is "closing" — pop the resumed entry so subsequent
+        // statements see the prior active thread.
+        threads.popActive();
+      }
+      // Fire onThreadEnd unconditionally so the registry stdlib hook
+      // sees the close. We fire from `finally` so exceptions thrown
+      // inside the body still record a close event.
+      try {
+        await invokeCallbacks({
+          ctx: this.ctx,
+          name: "onThreadEnd",
+          data: {
+            threadId: slug,
+            label: opts.label,
+            eagerSummarize: opts.summarize === true,
+            messages: messagesSnapshot,
+          },
+        });
+      } catch (e) {
+        // Swallow hook errors in finally to avoid masking the
+        // primary exception. `fireWithGuard` inside invokeCallbacks
+        // already logs JS errors; this catch is belt-and-braces for
+        // unexpected throws from the dispatcher itself.
+        if (e instanceof RestoreSignal) throw e;
+        // eslint-disable-next-line no-console
+        console.error("[agency] onThreadEnd dispatcher error:", e);
+      }
     }
 
     if (this.halted) return;

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -582,7 +582,13 @@ export class Runner {
     const slug = `t${tid}`;
     const threadType: "thread" | "subthread" =
       method === "createSubthread" ? "subthread" : "thread";
-    const parentRaw = threads.get(tid)?.parentId ?? undefined;
+    // Prefer the persisted label on the MessageThread so resumed
+    // threads (continue/session) emit the original label even when
+    // the resumption call site omits it. Fall back to opts.label
+    // for fresh threads where MessageThread.label is still null.
+    const startedThread = threads.get(tid);
+    const parentRaw = startedThread?.parentId ?? undefined;
+    const startedLabel = startedThread?.label ?? opts.label;
     await invokeCallbacks({
       ctx: this.ctx,
       name: "onThreadStart",
@@ -590,7 +596,7 @@ export class Runner {
         threadId: slug,
         threadType: parentRaw ? "subthread" : threadType,
         parentThreadId: parentRaw ? `t${parentRaw}` : undefined,
-        label: opts.label,
+        label: startedLabel ?? undefined,
         isResumption,
       },
     });
@@ -622,7 +628,10 @@ export class Runner {
           name: "onThreadEnd",
           data: {
             threadId: slug,
-            label: opts.label,
+            // Prefer persisted label so resumed threads emit the
+            // original label even when the resumption call site
+            // omits it (mirrors onThreadStart above).
+            label: closingThread?.label ?? opts.label ?? undefined,
             eagerSummarize: opts.summarize === true,
             messages: messagesSnapshot,
           },

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -491,21 +491,13 @@ export class Runner {
   async thread(
     id: number,
     method: "create" | "createSubthread",
-    optsOrCallback:
-      | ThreadStepOpts
-      | ((runner: Runner) => Promise<void>),
-    maybeCallback?: (runner: Runner) => Promise<void>,
+    opts: ThreadStepOpts,
+    callback: (runner: Runner) => Promise<void>,
   ): Promise<void> {
-    // Two-form signature so legacy call sites
-    // (`runner.thread(id, method, async (runner) => ...)`, used by
-    // `lib/runtime/runner.test.ts` and any old fixtures) keep working
-    // alongside the new opts-bearing form
-    // (`runner.thread(id, method, opts, async (runner) => ...)`).
-    const opts: ThreadStepOpts =
-      typeof optsOrCallback === "function" ? {} : optsOrCallback;
-    const callback =
-      typeof optsOrCallback === "function" ? optsOrCallback : maybeCallback!;
-
+    // Single canonical signature; `prettyPrint.ts` always emits an
+    // opts object (possibly empty) so there is no dual-form path to
+    // support. Test harnesses pass `{}` explicitly when they don't
+    // need named-args behaviour.
     this.beforeStep();
     if (this.shouldSkip()) return;
     if (this.getCounter() > id) return;
@@ -564,14 +556,17 @@ export class Runner {
       } else {
         tid = threads[method]();
       }
-      // `hidden` is set only on the brand-new code paths
+      // `hidden` and `label` are set only on the brand-new code paths
       // (`create` / `createSubthread` / first-time `openSession`).
       // For `resumeExisting` and existing sessions we leave whatever
-      // value is already on the MessageThread — hidden is decided at
+      // value is already on the MessageThread — both are decided at
       // first-create time, not on every re-entry.
-      if (opts.hidden === true && !isResumption) {
+      if (!isResumption) {
         const created = threads.get(tid);
-        if (created) created.hidden = true;
+        if (created) {
+          if (opts.hidden === true) created.hidden = true;
+          if (opts.label !== undefined) created.label = opts.label;
+        }
       }
       this.frame.locals[threadKey] = tid;
       this.frame.locals[resumptionKey] = isResumption;
@@ -638,8 +633,14 @@ export class Runner {
         // already logs JS errors; this catch is belt-and-braces for
         // unexpected throws from the dispatcher itself.
         if (e instanceof RestoreSignal) throw e;
-        // eslint-disable-next-line no-console
-        console.error("[agency] onThreadEnd dispatcher error:", e);
+        // Surface the failure as a structured statelog event so it
+        // shows up in traces (replaces the prior bare console.error).
+        // Optional chaining: older test contexts may construct a
+        // statelogClient without the threadEndHookError method.
+        this.ctx.statelogClient?.threadEndHookError?.({
+          threadId: slug,
+          error: e instanceof Error ? e.message : String(e),
+        });
       }
     }
 

--- a/packages/agency-lang/lib/runtime/runner.ts
+++ b/packages/agency-lang/lib/runtime/runner.ts
@@ -3,7 +3,7 @@ import { agencyStore } from "./asyncContext.js";
 import { debugStep } from "./debugger.js";
 import { RestoreSignal } from "./errors.js";
 import { HaltSignal } from "./haltSignal.js";
-import { hasHook, invokeCallbacks } from "./hooks.js";
+import { invokeCallbacks } from "./hooks.js";
 import { hasInterrupts } from "./interrupts.js";
 import { __pipeBind } from "./result.js";
 import { runBatch } from "./runBatch.js";
@@ -24,12 +24,17 @@ export type ThreadStepOpts = {
   continueId?: string;
   /** Session name; runtime maps it to a thread id via openSession. */
   session?: string;
+  /** When true, the created thread is excluded from `listThreads()`. */
+  hidden?: boolean;
 };
 
 /** Strip the leading `t` from a public thread slug to recover the
- *  internal counter-string id. Defensive: accepts a raw id unchanged. */
+ *  internal counter-string id. Only strips when the slug matches the
+ *  canonical `t<digits>` shape so user-chosen ids that happen to
+ *  begin with `t` (e.g. session names like `"telephone"`) are not
+ *  silently mangled. */
 function stripSlug(slug: string): string {
-  return slug.startsWith("t") ? slug.slice(1) : slug;
+  return /^t\d+$/.test(slug) ? slug.slice(1) : slug;
 }
 
 /**
@@ -559,6 +564,15 @@ export class Runner {
       } else {
         tid = threads[method]();
       }
+      // `hidden` is set only on the brand-new code paths
+      // (`create` / `createSubthread` / first-time `openSession`).
+      // For `resumeExisting` and existing sessions we leave whatever
+      // value is already on the MessageThread — hidden is decided at
+      // first-create time, not on every re-entry.
+      if (opts.hidden === true && !isResumption) {
+        const created = threads.get(tid);
+        if (created) created.hidden = true;
+      }
       this.frame.locals[threadKey] = tid;
       this.frame.locals[resumptionKey] = isResumption;
     }
@@ -569,27 +583,22 @@ export class Runner {
       threads.pushActive(tid);
     }
 
-    // Fire onThreadStart. Slug the id for the public payload. Skip
-    // the await entirely when no callbacks are registered for this
-    // hook (the common case) so we don't introduce an extra
-    // microtask boundary that perturbs debugger checkpoint timing.
+    // Fire onThreadStart. Slug the id for the public payload.
     const slug = `t${tid}`;
     const threadType: "thread" | "subthread" =
       method === "createSubthread" ? "subthread" : "thread";
     const parentRaw = threads.get(tid)?.parentId ?? undefined;
-    if (hasHook(this.ctx, "onThreadStart")) {
-      await invokeCallbacks({
-        ctx: this.ctx,
-        name: "onThreadStart",
-        data: {
-          threadId: slug,
-          threadType: parentRaw ? "subthread" : threadType,
-          parentThreadId: parentRaw ? `t${parentRaw}` : undefined,
-          label: opts.label,
-          isResumption,
-        },
-      });
-    }
+    await invokeCallbacks({
+      ctx: this.ctx,
+      name: "onThreadStart",
+      data: {
+        threadId: slug,
+        threadType: parentRaw ? "subthread" : threadType,
+        parentThreadId: parentRaw ? `t${parentRaw}` : undefined,
+        label: opts.label,
+        isResumption,
+      },
+    });
 
     this.path.push(id);
     try {
@@ -604,32 +613,25 @@ export class Runner {
       const messagesSnapshot = closingThread
         ? closingThread.messages.map((m) => m.toJSON())
         : [];
-      if (!alreadyActive) {
-        threads.popActive();
-      } else {
-        // We did not push, but the user's perception is that the
-        // thread is "closing" — pop the resumed entry so subsequent
-        // statements see the prior active thread.
-        threads.popActive();
-      }
+      // Always pop one entry: when we pushed above, this balances
+      // that push; when openSession/resumeExisting pushed (so we
+      // didn't double-push), this pops the resumed entry the user
+      // is "closing".
+      threads.popActive();
       // Fire onThreadEnd so the registry stdlib hook sees the
       // close. We fire from `finally` so exceptions thrown inside
-      // the body still record a close event. Same as onThreadStart,
-      // skip the await when no callbacks are registered to avoid a
-      // spurious microtask boundary.
+      // the body still record a close event.
       try {
-        if (hasHook(this.ctx, "onThreadEnd")) {
-          await invokeCallbacks({
-            ctx: this.ctx,
-            name: "onThreadEnd",
-            data: {
-              threadId: slug,
-              label: opts.label,
-              eagerSummarize: opts.summarize === true,
-              messages: messagesSnapshot,
-            },
-          });
-        }
+        await invokeCallbacks({
+          ctx: this.ctx,
+          name: "onThreadEnd",
+          data: {
+            threadId: slug,
+            label: opts.label,
+            eagerSummarize: opts.summarize === true,
+            messages: messagesSnapshot,
+          },
+        });
       } catch (e) {
         // Swallow hook errors in finally to avoid masking the
         // primary exception. `fireWithGuard` inside invokeCallbacks

--- a/packages/agency-lang/lib/runtime/state/messageThread.test.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { MessageThread } from "./messageThread.js";
+
+describe("MessageThread defaults", () => {
+  it("has hidden=false, label=null, summary=null, parentId=null by default", () => {
+    const t = new MessageThread();
+    expect(t.hidden).toBe(false);
+    expect(t.label).toBeNull();
+    expect(t.summary).toBeNull();
+    expect(t.parentId).toBeNull();
+    expect(t.messages).toEqual([]);
+  });
+});
+
+describe("MessageThread JSON round-trip", () => {
+  it("preserves hidden / label / summary / parentId / messages", () => {
+    const t = new MessageThread();
+    t.hidden = true;
+    t.label = "my-label";
+    t.summary = "my-summary";
+    t.parentId = "42";
+    const restored = MessageThread.fromJSON(t.toJSON());
+    expect(restored.hidden).toBe(true);
+    expect(restored.label).toBe("my-label");
+    expect(restored.summary).toBe("my-summary");
+    expect(restored.parentId).toBe("42");
+  });
+
+  it("preserves default values across round-trip", () => {
+    const t = new MessageThread();
+    const restored = MessageThread.fromJSON(t.toJSON());
+    expect(restored.hidden).toBe(false);
+    expect(restored.label).toBeNull();
+    expect(restored.summary).toBeNull();
+    expect(restored.parentId).toBeNull();
+  });
+
+  it("defaults missing back-compat fields when reading old-shape JSON", () => {
+    // Simulate a JSON blob produced by an older runtime that didn't
+    // emit the `hidden` / `label` / `summary` fields at all.
+    const oldShape = { messages: [] };
+    const restored = MessageThread.fromJSON(oldShape as any);
+    expect(restored.hidden).toBe(false);
+    expect(restored.label).toBeNull();
+    expect(restored.summary).toBeNull();
+    expect(restored.parentId).toBeNull();
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/messageThread.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.ts
@@ -4,6 +4,7 @@ import { nanoid } from "nanoid";
 export type MessageThreadJSON = {
   messages: smoltalk.MessageJSON[];
   parentId?: string | null;
+  hidden?: boolean;
 };
 
 export class MessageThread {
@@ -16,6 +17,12 @@ export class MessageThread {
    *  ThreadInfo, and by `ThreadStore.resumeExisting()` to reject
    *  resuming a subthread outside its parent's context. */
   parentId: string | null = null;
+  /** When `true`, this thread is excluded from `agency.threads.list()`
+   *  (and therefore the stdlib `listThreads()` user-facing surface).
+   *  Set by `Runner.thread` at first-create time when the user opts
+   *  in via `thread(hidden: true) { ... }`. Round-tripped through
+   *  `toJSON`/`fromJSON` so the flag survives interrupt resume. */
+  hidden: boolean = false;
 
   constructor(messages: smoltalk.Message[] = []) {
     this.messages = messages;
@@ -58,6 +65,7 @@ export class MessageThread {
     return {
       messages: this.messages.map((m) => m.toJSON()),
       parentId: this.parentId,
+      hidden: this.hidden,
     };
   }
 
@@ -73,12 +81,16 @@ export class MessageThread {
 
     let _messages: any[] = [];
     let _parentId: string | null = null;
+    let _hidden = false;
     if (Array.isArray(json)) {
       _messages = json;
     } else if ("messages" in json) {
       _messages = json.messages;
       if ("parentId" in json && json.parentId !== undefined) {
         _parentId = json.parentId;
+      }
+      if ("hidden" in json && json.hidden === true) {
+        _hidden = true;
       }
     } else {
       throw new Error("Invalid input for MessageThread.fromJSON");
@@ -95,6 +107,7 @@ export class MessageThread {
 
     thread.setMessages(smoltalkMessages);
     thread.parentId = _parentId;
+    thread.hidden = _hidden;
 
     return thread;
   }

--- a/packages/agency-lang/lib/runtime/state/messageThread.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.ts
@@ -5,6 +5,8 @@ export type MessageThreadJSON = {
   messages: smoltalk.MessageJSON[];
   parentId?: string | null;
   hidden?: boolean;
+  label?: string | null;
+  summary?: string | null;
 };
 
 export class MessageThread {
@@ -23,6 +25,20 @@ export class MessageThread {
    *  in via `thread(hidden: true) { ... }`. Round-tripped through
    *  `toJSON`/`fromJSON` so the flag survives interrupt resume. */
   hidden: boolean = false;
+  /** Optional user-supplied label from `thread(label: "...") { ... }`.
+   *  Set by `Runner.thread` at first-create time. `null` for threads
+   *  created without a label or via `subthread {}` without one.
+   *  Surfaces on `agency.threads.list()` so the stdlib `listThreads()`
+   *  can attach it to `ThreadInfo`. Round-tripped through
+   *  `toJSON`/`fromJSON` so the value survives interrupt resume. */
+  label: string | null = null;
+  /** Cached summary produced by the stdlib `summaryFor()` helper on
+   *  first `listThreads()` call after the thread closes. Written via
+   *  the TS-side `_setThreadSummary` shim so the cache lives on the
+   *  per-run `MessageThread` and gets GC'd with the run — no
+   *  module-level state in TS. `null` until the summary is computed.
+   *  Round-tripped through `toJSON`/`fromJSON`. */
+  summary: string | null = null;
 
   constructor(messages: smoltalk.Message[] = []) {
     this.messages = messages;
@@ -66,6 +82,8 @@ export class MessageThread {
       messages: this.messages.map((m) => m.toJSON()),
       parentId: this.parentId,
       hidden: this.hidden,
+      label: this.label,
+      summary: this.summary,
     };
   }
 
@@ -82,6 +100,8 @@ export class MessageThread {
     let _messages: any[] = [];
     let _parentId: string | null = null;
     let _hidden = false;
+    let _label: string | null = null;
+    let _summary: string | null = null;
     if (Array.isArray(json)) {
       _messages = json;
     } else if ("messages" in json) {
@@ -91,6 +111,12 @@ export class MessageThread {
       }
       if ("hidden" in json && json.hidden === true) {
         _hidden = true;
+      }
+      if ("label" in json && json.label !== undefined) {
+        _label = json.label;
+      }
+      if ("summary" in json && json.summary !== undefined) {
+        _summary = json.summary;
       }
     } else {
       throw new Error("Invalid input for MessageThread.fromJSON");
@@ -108,6 +134,8 @@ export class MessageThread {
     thread.setMessages(smoltalkMessages);
     thread.parentId = _parentId;
     thread.hidden = _hidden;
+    thread.label = _label;
+    thread.summary = _summary;
 
     return thread;
   }

--- a/packages/agency-lang/lib/runtime/state/messageThread.ts
+++ b/packages/agency-lang/lib/runtime/state/messageThread.ts
@@ -3,11 +3,19 @@ import { nanoid } from "nanoid";
 
 export type MessageThreadJSON = {
   messages: smoltalk.MessageJSON[];
+  parentId?: string | null;
 };
 
 export class MessageThread {
   messages: smoltalk.Message[] = [];
   id: string;
+  /** ID of the parent thread when this thread was created via
+   *  `ThreadStore.createSubthread()`. `null` for top-level threads
+   *  (the default `MessageThread` constructor leaves it null). Used by
+   *  `agency.threads.list()` to surface the parent linkage in
+   *  ThreadInfo, and by `ThreadStore.resumeExisting()` to reject
+   *  resuming a subthread outside its parent's context. */
+  parentId: string | null = null;
 
   constructor(messages: smoltalk.Message[] = []) {
     this.messages = messages;
@@ -49,6 +57,7 @@ export class MessageThread {
   toJSON(): MessageThreadJSON {
     return {
       messages: this.messages.map((m) => m.toJSON()),
+      parentId: this.parentId,
     };
   }
 
@@ -63,10 +72,14 @@ export class MessageThread {
     const thread = new MessageThread();
 
     let _messages: any[] = [];
+    let _parentId: string | null = null;
     if (Array.isArray(json)) {
       _messages = json;
     } else if ("messages" in json) {
       _messages = json.messages;
+      if ("parentId" in json && json.parentId !== undefined) {
+        _parentId = json.parentId;
+      }
     } else {
       throw new Error("Invalid input for MessageThread.fromJSON");
     }
@@ -81,6 +94,7 @@ export class MessageThread {
     );
 
     thread.setMessages(smoltalkMessages);
+    thread.parentId = _parentId;
 
     return thread;
   }

--- a/packages/agency-lang/lib/runtime/state/threadStore.test.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { ThreadStore } from "./threadStore.js";
+import { MessageThread } from "./messageThread.js";
+
+describe("ThreadStore parentId tracking", () => {
+  it("create() returns a top-level thread with parentId null", () => {
+    const store = new ThreadStore();
+    const id = store.create();
+    expect(store.get(id).parentId).toBeNull();
+  });
+
+  it("createSubthread() sets parentId to the active thread id", () => {
+    const store = new ThreadStore();
+    const parentId = store.create();
+    store.pushActive(parentId);
+    const childId = store.createSubthread();
+    expect(store.get(childId).parentId).toBe(parentId);
+  });
+
+  it("parentId survives JSON round-trip", () => {
+    const store = new ThreadStore();
+    const parentId = store.create();
+    store.pushActive(parentId);
+    const childId = store.createSubthread();
+    const json = store.toJSON();
+    const restored = ThreadStore.fromJSON(json);
+    expect(restored.get(parentId).parentId).toBeNull();
+    expect(restored.get(childId).parentId).toBe(parentId);
+  });
+
+  it("MessageThread JSON round-trip preserves parentId", () => {
+    const mt = new MessageThread();
+    mt.parentId = "42";
+    const restored = MessageThread.fromJSON(mt.toJSON());
+    expect(restored.parentId).toBe("42");
+  });
+
+  it("MessageThread JSON round-trip preserves null parentId", () => {
+    const mt = new MessageThread();
+    const restored = MessageThread.fromJSON(mt.toJSON());
+    expect(restored.parentId).toBeNull();
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/threadStore.test.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.test.ts
@@ -56,6 +56,16 @@ describe("ThreadStore.resumeExisting", () => {
     expect(() => store.resumeExisting("999")).toThrow(/unknown thread/);
   });
 
+  it("formats numeric ids with a t-prefix in the error message", () => {
+    const store = new ThreadStore();
+    expect(() => store.resumeExisting("42")).toThrow(/t42/);
+  });
+
+  it("leaves non-numeric ids unchanged in the error message (no `tt1` double-prefix)", () => {
+    const store = new ThreadStore();
+    expect(() => store.resumeExisting("t1")).toThrow(/Cannot resume unknown thread id: t1$/m);
+  });
+
   it("rejects subthreads", () => {
     const store = new ThreadStore();
     const parentId = store.create();

--- a/packages/agency-lang/lib/runtime/state/threadStore.test.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.test.ts
@@ -41,3 +41,62 @@ describe("ThreadStore parentId tracking", () => {
     expect(restored.parentId).toBeNull();
   });
 });
+
+describe("ThreadStore.resumeExisting", () => {
+  it("re-activates a known top-level thread", () => {
+    const store = new ThreadStore();
+    const id = store.create();
+    // simulate close by leaving activeStack empty
+    store.resumeExisting(id);
+    expect(store.activeId()).toBe(id);
+  });
+
+  it("throws for unknown ids", () => {
+    const store = new ThreadStore();
+    expect(() => store.resumeExisting("999")).toThrow(/unknown thread/);
+  });
+
+  it("rejects subthreads", () => {
+    const store = new ThreadStore();
+    const parentId = store.create();
+    store.pushActive(parentId);
+    const childId = store.createSubthread();
+    store.popActive();
+    store.popActive();
+    expect(() => store.resumeExisting(childId)).toThrow(/Cannot resume subthread/);
+    expect(store.activeId()).toBeUndefined();
+  });
+});
+
+describe("ThreadStore.openSession", () => {
+  it("first entry creates and pushes; second entry resumes the same id", () => {
+    const store = new ThreadStore();
+    const a = store.openSession("coding");
+    expect(a.existed).toBe(false);
+    expect(store.activeId()).toBe(a.id);
+    // simulate block-close
+    store.popActive();
+    const b = store.openSession("coding");
+    expect(b.existed).toBe(true);
+    expect(b.id).toBe(a.id);
+    expect(store.activeId()).toBe(a.id);
+    // only one thread exists
+    expect(Object.keys(store.threads).length).toBe(1);
+  });
+
+  it("different session names create distinct threads", () => {
+    const store = new ThreadStore();
+    const a = store.openSession("coding");
+    store.popActive();
+    const b = store.openSession("weather");
+    expect(b.id).not.toBe(a.id);
+    expect(Object.keys(store.threads).length).toBe(2);
+  });
+
+  it("sessions survive JSON round-trip", () => {
+    const store = new ThreadStore();
+    store.openSession("coding");
+    const restored = ThreadStore.fromJSON(store.toJSON());
+    expect(restored.sessions.coding).toBe(store.sessions.coding);
+  });
+});

--- a/packages/agency-lang/lib/runtime/state/threadStore.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.ts
@@ -135,12 +135,17 @@ export class ThreadStore {
    */
   resumeExisting(id: MessageThreadID): void {
     const thread = this.threads[id];
+    // Display id: only prepend `t` when `id` is a numeric counter
+    // string. Callers that accidentally pass a slug (`"t1"`) or a
+    // non-numeric id (test mocks, ids that already look slug-shaped)
+    // would otherwise show up as `tt1` in the error message.
+    const displayId = /^\d+$/.test(id) ? `t${id}` : id;
     if (!thread) {
-      throw new Error(`Cannot resume unknown thread id: t${id}`);
+      throw new Error(`Cannot resume unknown thread id: ${displayId}`);
     }
     if (thread.parentId !== null) {
       throw new Error(
-        `Cannot resume subthread t${id}. Resume the parent thread and open ` +
+        `Cannot resume subthread ${displayId}. Resume the parent thread and open ` +
           `a fresh subthread block instead.`,
       );
     }

--- a/packages/agency-lang/lib/runtime/state/threadStore.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.ts
@@ -58,7 +58,9 @@ export class ThreadStore {
   createSubthread(): MessageThreadID {
     const parentId = this.activeId();
     const id = (this.counter++).toString();
-    this.threads[id] = this.threads[parentId!].newSubthreadChild();
+    const child = this.threads[parentId!].newSubthreadChild();
+    child.parentId = parentId ?? null;
+    this.threads[id] = child;
     this.statelogClient?.threadCreated({
       threadId: id,
       threadType: "subthread",

--- a/packages/agency-lang/lib/runtime/state/threadStore.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.ts
@@ -5,6 +5,11 @@ export type ThreadStoreJSON = {
   threads: Record<string, MessageThreadJSON>;
   counter: number;
   activeStack: string[];
+  /** session-name → thread-id map. Populated by openSession on first
+   *  entry; subsequent entries with the same name resume the recorded
+   *  thread via resumeExisting. Round-tripped so sessions survive
+   *  interrupt resume / cross-node hops. */
+  sessions?: Record<string, string>;
 };
 
 export type MessageThreadID = string;
@@ -13,12 +18,15 @@ export class ThreadStore {
   threads: Record<MessageThreadID, MessageThread> = {};
   counter: number = 0;
   activeStack: MessageThreadID[] = [];
+  /** session-name → thread-id. See ThreadStoreJSON.sessions for docs. */
+  sessions: Record<string, MessageThreadID> = {};
   private statelogClient?: StatelogClient;
 
   constructor() {
     this.threads = {};
     this.counter = 0;
     this.activeStack = [];
+    this.sessions = {};
   }
 
   // Set after construction. Most callers should pass the client to
@@ -110,6 +118,51 @@ export class ThreadStore {
     return this.threads[id];
   }
 
+  /** Re-activate a previously-closed thread. Pushes `id` onto the
+   *  active stack (same path as pushActive) without creating a new
+   *  MessageThread. Throws if `id` is unknown — a silent fallback to
+   *  create-new would mask a real bug (typo, hallucinated id) at the
+   *  call site.
+   *
+   *  v1: rejects subthreads. A subthread's identity is tied to its
+   *  parent's context at the time it was created; resuming one
+   *  outside that context could surface confusing message ordering.
+   *  If a user wants to continue inside a subthread, they should
+   *  resume the parent thread and open a fresh `subthread {}` block.
+   */
+  resumeExisting(id: MessageThreadID): void {
+    const thread = this.threads[id];
+    if (!thread) {
+      throw new Error(`Cannot resume unknown thread id: t${id}`);
+    }
+    if (thread.parentId !== null) {
+      throw new Error(
+        `Cannot resume subthread t${id}. Resume the parent thread and open ` +
+          `a fresh subthread block instead.`,
+      );
+    }
+    this.activeStack.push(id);
+    this.statelogClient?.threadResumed?.({ threadId: id });
+  }
+
+  /** Open a named session. Returns `{id, existed}` — `existed` is
+   *  `true` when this name already mapped to a thread. Always leaves
+   *  the session's thread on top of `activeStack`. First entry
+   *  creates a top-level thread (never a subthread); later entries
+   *  resume via `resumeExisting` (which already rejects subthreads —
+   *  sessions can only map to top-level threads). */
+  openSession(name: string): { id: MessageThreadID; existed: boolean } {
+    const existing = this.sessions[name];
+    if (existing !== undefined) {
+      this.resumeExisting(existing);
+      return { id: existing, existed: true };
+    }
+    const id = this.create();
+    this.sessions[name] = id;
+    this.activeStack.push(id);
+    return { id, existed: false };
+  }
+
   // Serialize all threads for interrupt handling / state return
   toJSON(): ThreadStoreJSON {
     const threadsJson: Record<MessageThreadID, MessageThreadJSON> = {};
@@ -120,6 +173,7 @@ export class ThreadStore {
       threads: threadsJson,
       counter: this.counter,
       activeStack: [...this.activeStack],
+      sessions: { ...this.sessions },
     };
   }
 
@@ -133,6 +187,7 @@ export class ThreadStore {
     }
     store.counter = json.counter || 0;
     store.activeStack = json.activeStack || [];
+    store.sessions = json.sessions ?? {};
     return store;
   }
 }

--- a/packages/agency-lang/lib/runtime/state/threadStore.ts
+++ b/packages/agency-lang/lib/runtime/state/threadStore.ts
@@ -18,15 +18,18 @@ export class ThreadStore {
   threads: Record<MessageThreadID, MessageThread> = {};
   counter: number = 0;
   activeStack: MessageThreadID[] = [];
-  /** session-name → thread-id. See ThreadStoreJSON.sessions for docs. */
-  sessions: Record<string, MessageThreadID> = {};
+  /** session-name → thread-id. See ThreadStoreJSON.sessions for docs.
+   *  Backed by `Object.create(null)` so user-supplied session names
+   *  like `"__proto__"` or `"constructor"` cannot mutate the
+   *  Object prototype (prototype pollution). */
+  sessions: Record<string, MessageThreadID> = Object.create(null);
   private statelogClient?: StatelogClient;
 
   constructor() {
     this.threads = {};
     this.counter = 0;
     this.activeStack = [];
-    this.sessions = {};
+    this.sessions = Object.create(null);
   }
 
   // Set after construction. Most callers should pass the client to
@@ -187,7 +190,16 @@ export class ThreadStore {
     }
     store.counter = json.counter || 0;
     store.activeStack = json.activeStack || [];
-    store.sessions = json.sessions ?? {};
+    // Rebuild sessions on a null-prototype object so deserialized
+    // snapshots with reserved keys (e.g. `__proto__`) cannot
+    // pollute the Object prototype.
+    const sessions: Record<string, MessageThreadID> = Object.create(null);
+    if (json.sessions) {
+      for (const [k, v] of Object.entries(json.sessions)) {
+        sessions[k] = v;
+      }
+    }
+    store.sessions = sessions;
     return store;
   }
 }

--- a/packages/agency-lang/lib/statelogClient.test.ts
+++ b/packages/agency-lang/lib/statelogClient.test.ts
@@ -666,6 +666,19 @@ describe("StatelogClient", () => {
       expect(events[1].parentThreadId).toBe("0");
     });
 
+    it("threadEndHookError emits threadId + error", async () => {
+      const file = newLogFile("thread-end-hook-err");
+      const client = fileClient(file);
+      await client.threadEndHookError({
+        threadId: "t1",
+        error: "boom from onThreadEnd dispatcher",
+      });
+      const [evt] = readEvents(file);
+      expect(evt.data.type).toBe("threadEndHookError");
+      expect(evt.data.threadId).toBe("t1");
+      expect(evt.data.error).toBe("boom from onThreadEnd dispatcher");
+    });
+
     it("error emits errorType + retryable", async () => {
       const file = newLogFile("error");
       const client = fileClient(file);

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -850,6 +850,22 @@ export class StatelogClient {
     });
   }
 
+  /** Fired when a previously-closed thread is re-activated via
+   *  `ThreadStore.resumeExisting()` (i.e. by `thread(continue: id)`
+   *  or `thread(session: name)` on second+ entry). Mirrors
+   *  `threadCreated` so trace consumers can distinguish first-entry
+   *  from resumption. */
+  async threadResumed({
+    threadId,
+  }: {
+    threadId: string;
+  }): Promise<void> {
+    await this.post({
+      type: "threadResumed",
+      threadId,
+    });
+  }
+
   // --- Structured errors ---
 
   async error({

--- a/packages/agency-lang/lib/statelogClient.ts
+++ b/packages/agency-lang/lib/statelogClient.ts
@@ -866,6 +866,27 @@ export class StatelogClient {
     });
   }
 
+  /** Fired when the `onThreadEnd` callback dispatcher itself throws
+   *  inside the `Runner.thread` finally block. Individual callback
+   *  errors are caught and logged by `fireWithGuard`; this event
+   *  covers the rarer case where the dispatcher loop itself blew up
+   *  (e.g. a malformed registration). Emitted in lieu of the
+   *  previous `console.error` so the failure is observable in
+   *  traces. */
+  async threadEndHookError({
+    threadId,
+    error,
+  }: {
+    threadId: string;
+    error: string;
+  }): Promise<void> {
+    await this.post({
+      type: "threadEndHookError",
+      threadId,
+      error,
+    });
+  }
+
   // --- Structured errors ---
 
   async error({

--- a/packages/agency-lang/lib/stdlib/threads.ts
+++ b/packages/agency-lang/lib/stdlib/threads.ts
@@ -37,10 +37,16 @@ export function _getThread(
   const raw = agency.threads.get(id, offset, limit);
   return raw.map((m) => ({
     role: String(m.role),
+    // Coerce non-string content to a flat string for the Agency
+    // surface. Nullish content (common on tool-call assistant
+    // messages where the LLM emitted tool calls but no text) maps
+    // to "" instead of the literal JSON-encoded `'""'`.
     content:
       typeof m.content === "string"
         ? m.content
-        : JSON.stringify(m.content ?? ""),
+        : m.content == null
+          ? ""
+          : JSON.stringify(m.content),
   }));
 }
 
@@ -57,7 +63,10 @@ export function _currentThreadId(): string {
 export function _setThreadSummary(id: string, summary: string): void {
   const store = agency.thread.storeMaybe();
   if (!store) return;
-  const rawId = id.startsWith("t") ? id.slice(1) : id;
+  // Only strip canonical `t<digits>` slugs — non-slug ids pass
+  // through unchanged (matches stripSlug in runner.ts and fromSlug
+  // in agency.ts).
+  const rawId = /^t\d+$/.test(id) ? id.slice(1) : id;
   const thread = store.threads[rawId];
   if (!thread) return;
   thread.summary = summary;

--- a/packages/agency-lang/lib/stdlib/threads.ts
+++ b/packages/agency-lang/lib/stdlib/threads.ts
@@ -1,92 +1,64 @@
 /**
  * TS-side helpers for `stdlib/threads.agency` — the user-facing
  * cross-thread registry module. Wraps the `agency.threads.*` primitives
- * from Task 1 and owns a per-run cache of labels and summaries keyed
- * by thread id.
+ * from Task 1.
  *
- * Cache placement rationale: Agency-side `static const` maps are
- * immutable after initialization, so the registry cache has to live in
- * TS. Keeping it here also keeps the Agency module tiny and lets the
- * cache survive interrupt-resume cleanly (it is rebuilt the same way
- * the rest of the registry is — from the run's onThreadEnd events).
+ * Post-Commit-B cleanup: there is no module-level cache here anymore.
+ * `label` and `summary` live directly on the per-run `MessageThread`
+ * (see `lib/runtime/state/messageThread.ts`), so per-run isolation
+ * comes for free and the cache survives interrupt-resume via the
+ * existing `toJSON`/`fromJSON` round-trip. `_setThreadSummary` is the
+ * single TS-side writer Agency uses to record a freshly-computed
+ * summary; the rest is read-through from `agency.threads.list()`.
  *
  * Naming follows stdlib conventions: every export is `_`-prefixed and
  * reads its runtime context from AsyncLocalStorage via `agency.*`.
  */
-import { agency, type ThreadInfoTS, type ThreadMessageTS } from "../runtime/agency.js";
-import { registerGlobalHook } from "../runtime/hooks.js";
-
-export type _Cached = { label?: string; summary?: string };
-
-/** Per-run cache of thread metadata keyed by slug id. Single owner:
- *  `_remember()`. Single reader: the Agency `listThreads()` and
- *  `summaryFor()` helpers. */
-const _cache: Record<string, _Cached> = {};
-
-// Module-load: register a global hook that snapshots a thread's
-// `label` on close. Mirrors what an Agency-side
-// `callback("onThreadEnd") as evt { ... }` at the top level of
-// `stdlib/threads.agency` would do — but verified empirically
-// (tests/agency-js/threads-fix-callback-propagation): a top-level
-// Agency callback only fires when its OWNING module is imported
-// AS THE ENTRY POINT of the run. Imported modules' top-level
-// callbacks are compiled in but never wired to `ctx.topLevelCallbacks`
-// because `__registerTopLevelCallbacks` is per-entry. A global
-// JS-side hook here side-steps that limitation so the registry
-// works transparently for any program that imports `std::threads`,
-// with no boilerplate at the call site.
-//
-// Eager summarization (`thread(summarize: true)`) is intentionally
-// NOT handled here: summarize() needs to make an LLM call, and
-// firing an LLM call from a TS-side hook on every thread close
-// would surprise users who only wanted to register the registry.
-// Eager summarize remains an opt-in agency hook that users can add
-// themselves; the v1 stdlib does lazy summarization at
-// `listThreads()` call time instead (one call per thread that
-// doesn't have a cached summary yet).
-registerGlobalHook("onThreadEnd", (evt: any) => {
-  if (evt && typeof evt.label === "string") {
-    _remember(evt.threadId, { label: evt.label });
-  }
-});
-
-/** Single owner of the cache-write rule. Shallow-merges `patch` into
- *  the entry for `id`. Agency-side callers go through this so the
- *  "label set → object updated, summary set → object updated"
- *  composition lives in one place. */
-export function _remember(id: string, patch: _Cached): void {
-  const existing = _cache[id];
-  _cache[id] = existing ? { ...existing, ...patch } : patch;
-}
-
-/** Read the cached entry for `id`, or `null` if absent. Used by the
- *  Agency listThreads() implementation to attach label + summary to
- *  each raw ThreadInfo. */
-export function _getCached(id: string): _Cached | null {
-  return _cache[id] ?? null;
-}
-
-/** Test/cleanup hook: empties the cache. Exposed for unit tests that
- *  reuse the module across cases. Not used at runtime. */
-export function _resetCache(): void {
-  for (const k of Object.keys(_cache)) delete _cache[k];
-}
+import { agency, type ThreadInfoTS } from "../runtime/agency.js";
 
 /** Pass-through to `agency.threads.list()`. */
 export function _listThreadsRaw(): ThreadInfoTS[] {
   return agency.threads.list();
 }
 
-/** Pass-through to `agency.threads.get(id, offset, limit)`. */
+/** Read a slice of a thread's messages, coerced to the
+ *  `{ role: string, content: string }` shape Agency's
+ *  `ThreadMessage` declares. Non-string `content` values
+ *  (tool-call / structured) are JSON-stringified at the boundary so
+ *  the Agency caller's `m.content` field is always a string — the
+ *  TS-internal `agency.threads.get` returns the raw
+ *  `smoltalk.MessageJSON` shape for callers that need full structure.
+ */
 export function _getThread(
   id: string,
   offset: number = 0,
   limit: number = 50,
-): ThreadMessageTS[] {
-  return agency.threads.get(id, offset, limit);
+): Array<{ role: string; content: string }> {
+  const raw = agency.threads.get(id, offset, limit);
+  return raw.map((m) => ({
+    role: String(m.role),
+    content:
+      typeof m.content === "string"
+        ? m.content
+        : JSON.stringify(m.content ?? ""),
+  }));
 }
 
 /** Slug form of the active thread, or `""` (Agency has no undefined). */
 export function _currentThreadId(): string {
   return agency.threads.current() ?? "";
+}
+
+/** Stash a freshly-computed summary on the underlying `MessageThread`
+ *  so subsequent `listThreads()` calls read it back without
+ *  re-prompting. Called by the Agency-side `summaryFor()` helper after
+ *  the lazy summarize round-trip. No-op when the id is unknown or
+ *  there is no active store (e.g. called from non-Agency code). */
+export function _setThreadSummary(id: string, summary: string): void {
+  const store = agency.thread.storeMaybe();
+  if (!store) return;
+  const rawId = id.startsWith("t") ? id.slice(1) : id;
+  const thread = store.threads[rawId];
+  if (!thread) return;
+  thread.summary = summary;
 }

--- a/packages/agency-lang/lib/stdlib/threads.ts
+++ b/packages/agency-lang/lib/stdlib/threads.ts
@@ -25,11 +25,16 @@ const _cache: Record<string, _Cached> = {};
 
 // Module-load: register a global hook that snapshots a thread's
 // `label` on close. Mirrors what an Agency-side
-// `callback("onThreadEnd") as evt { ... }` would do, but a top-level
-// Agency callback only fires when the OWNING module is imported as
-// the entry point — it does not propagate cross-module. A global
-// hook here makes the registry work transparently for any program
-// that imports `std::threads`, with no boilerplate at the call site.
+// `callback("onThreadEnd") as evt { ... }` at the top level of
+// `stdlib/threads.agency` would do — but verified empirically
+// (tests/agency-js/threads-fix-callback-propagation): a top-level
+// Agency callback only fires when its OWNING module is imported
+// AS THE ENTRY POINT of the run. Imported modules' top-level
+// callbacks are compiled in but never wired to `ctx.topLevelCallbacks`
+// because `__registerTopLevelCallbacks` is per-entry. A global
+// JS-side hook here side-steps that limitation so the registry
+// works transparently for any program that imports `std::threads`,
+// with no boilerplate at the call site.
 //
 // Eager summarization (`thread(summarize: true)`) is intentionally
 // NOT handled here: summarize() needs to make an LLM call, and

--- a/packages/agency-lang/lib/stdlib/threads.ts
+++ b/packages/agency-lang/lib/stdlib/threads.ts
@@ -1,0 +1,87 @@
+/**
+ * TS-side helpers for `stdlib/threads.agency` — the user-facing
+ * cross-thread registry module. Wraps the `agency.threads.*` primitives
+ * from Task 1 and owns a per-run cache of labels and summaries keyed
+ * by thread id.
+ *
+ * Cache placement rationale: Agency-side `static const` maps are
+ * immutable after initialization, so the registry cache has to live in
+ * TS. Keeping it here also keeps the Agency module tiny and lets the
+ * cache survive interrupt-resume cleanly (it is rebuilt the same way
+ * the rest of the registry is — from the run's onThreadEnd events).
+ *
+ * Naming follows stdlib conventions: every export is `_`-prefixed and
+ * reads its runtime context from AsyncLocalStorage via `agency.*`.
+ */
+import { agency, type ThreadInfoTS, type ThreadMessageTS } from "../runtime/agency.js";
+import { registerGlobalHook } from "../runtime/hooks.js";
+
+export type _Cached = { label?: string; summary?: string };
+
+/** Per-run cache of thread metadata keyed by slug id. Single owner:
+ *  `_remember()`. Single reader: the Agency `listThreads()` and
+ *  `summaryFor()` helpers. */
+const _cache: Record<string, _Cached> = {};
+
+// Module-load: register a global hook that snapshots a thread's
+// `label` on close. Mirrors what an Agency-side
+// `callback("onThreadEnd") as evt { ... }` would do, but a top-level
+// Agency callback only fires when the OWNING module is imported as
+// the entry point — it does not propagate cross-module. A global
+// hook here makes the registry work transparently for any program
+// that imports `std::threads`, with no boilerplate at the call site.
+//
+// Eager summarization (`thread(summarize: true)`) is intentionally
+// NOT handled here: summarize() needs to make an LLM call, and
+// firing an LLM call from a TS-side hook on every thread close
+// would surprise users who only wanted to register the registry.
+// Eager summarize remains an opt-in agency hook that users can add
+// themselves; the v1 stdlib does lazy summarization at
+// `listThreads()` call time instead (one call per thread that
+// doesn't have a cached summary yet).
+registerGlobalHook("onThreadEnd", (evt: any) => {
+  if (evt && typeof evt.label === "string") {
+    _remember(evt.threadId, { label: evt.label });
+  }
+});
+
+/** Single owner of the cache-write rule. Shallow-merges `patch` into
+ *  the entry for `id`. Agency-side callers go through this so the
+ *  "label set → object updated, summary set → object updated"
+ *  composition lives in one place. */
+export function _remember(id: string, patch: _Cached): void {
+  const existing = _cache[id];
+  _cache[id] = existing ? { ...existing, ...patch } : patch;
+}
+
+/** Read the cached entry for `id`, or `null` if absent. Used by the
+ *  Agency listThreads() implementation to attach label + summary to
+ *  each raw ThreadInfo. */
+export function _getCached(id: string): _Cached | null {
+  return _cache[id] ?? null;
+}
+
+/** Test/cleanup hook: empties the cache. Exposed for unit tests that
+ *  reuse the module across cases. Not used at runtime. */
+export function _resetCache(): void {
+  for (const k of Object.keys(_cache)) delete _cache[k];
+}
+
+/** Pass-through to `agency.threads.list()`. */
+export function _listThreadsRaw(): ThreadInfoTS[] {
+  return agency.threads.list();
+}
+
+/** Pass-through to `agency.threads.get(id, offset, limit)`. */
+export function _getThread(
+  id: string,
+  offset: number = 0,
+  limit: number = 50,
+): ThreadMessageTS[] {
+  return agency.threads.get(id, offset, limit);
+}
+
+/** Slug form of the active thread, or `""` (Agency has no undefined). */
+export function _currentThreadId(): string {
+  return agency.threads.current() ?? "";
+}

--- a/packages/agency-lang/lib/types/function.ts
+++ b/packages/agency-lang/lib/types/function.ts
@@ -36,6 +36,8 @@ export const VALID_CALLBACK_NAMES = [
   "onTrace",
   "onOAuthRequired",
   "onEmit",
+  "onThreadStart",
+  "onThreadEnd",
 ] as const;
 
 export type CallbackName = (typeof VALID_CALLBACK_NAMES)[number];

--- a/packages/agency-lang/lib/types/messageThread.ts
+++ b/packages/agency-lang/lib/types/messageThread.ts
@@ -15,4 +15,6 @@ export type MessageThread = BaseNode & {
   continueExpr?: Expression | null;
   /** Optional `thread(session: "name") { }` — sugar over continue. */
   sessionExpr?: Expression | null;
+  /** Optional `thread(hidden: true) { }` — exclude from `listThreads()`. */
+  hidden?: Expression | null;
 };

--- a/packages/agency-lang/lib/types/messageThread.ts
+++ b/packages/agency-lang/lib/types/messageThread.ts
@@ -1,4 +1,4 @@
-import { AgencyNode } from "@/types.js";
+import { AgencyNode, Expression } from "@/types.js";
 import { BaseNode } from "./base.js";
 
 type ThreadType = "thread" | "subthread";
@@ -7,4 +7,12 @@ export type MessageThread = BaseNode & {
   type: "messageThread";
   threadType: ThreadType;
   body: AgencyNode[];
+  /** Optional template-level label from `thread(label: "...") { }`. */
+  label?: Expression | null;
+  /** Optional eager-summarize flag from `thread(summarize: true) { }`. */
+  summarize?: Expression | null;
+  /** Optional `thread(continue: <id>) { }` — resume a prior thread. */
+  continueExpr?: Expression | null;
+  /** Optional `thread(session: "name") { }` — sugar over continue. */
+  sessionExpr?: Expression | null;
 };

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -328,16 +328,17 @@ export function* walkNodes(
       node.type === "seqBlock"
     ) {
       // messageThread carries optional named-arg expressions
-      // (`label`, `summarize`, `continue`, `session`) from
-      // Task 3 / 6 / 7. They must be walked so the symbol-table
-      // resolver populates the `scope` field on any variable
-      // references inside them — otherwise codegen emits bare
-      // identifiers instead of `__stack.locals.foo`.
+      // (`label`, `summarize`, `continue`, `session`, `hidden`).
+      // They must be walked so the symbol-table resolver populates
+      // the `scope` field on any variable references inside them —
+      // otherwise codegen emits bare identifiers instead of
+      // `__stack.locals.foo`.
       if (node.type === "messageThread") {
         if (node.label) yield* walkNodes([node.label as AgencyNode], [...ancestors, node], scopes);
         if (node.summarize) yield* walkNodes([node.summarize as AgencyNode], [...ancestors, node], scopes);
         if (node.continueExpr) yield* walkNodes([node.continueExpr as AgencyNode], [...ancestors, node], scopes);
         if (node.sessionExpr) yield* walkNodes([node.sessionExpr as AgencyNode], [...ancestors, node], scopes);
+        if (node.hidden) yield* walkNodes([node.hidden as AgencyNode], [...ancestors, node], scopes);
       }
       yield* walkNodes(node.body, [...ancestors, node], scopes);
     } else if (node.type === "handleBlock") {

--- a/packages/agency-lang/lib/utils/node.ts
+++ b/packages/agency-lang/lib/utils/node.ts
@@ -327,6 +327,18 @@ export function* walkNodes(
       node.type === "parallelBlock" ||
       node.type === "seqBlock"
     ) {
+      // messageThread carries optional named-arg expressions
+      // (`label`, `summarize`, `continue`, `session`) from
+      // Task 3 / 6 / 7. They must be walked so the symbol-table
+      // resolver populates the `scope` field on any variable
+      // references inside them — otherwise codegen emits bare
+      // identifiers instead of `__stack.locals.foo`.
+      if (node.type === "messageThread") {
+        if (node.label) yield* walkNodes([node.label as AgencyNode], [...ancestors, node], scopes);
+        if (node.summarize) yield* walkNodes([node.summarize as AgencyNode], [...ancestors, node], scopes);
+        if (node.continueExpr) yield* walkNodes([node.continueExpr as AgencyNode], [...ancestors, node], scopes);
+        if (node.sessionExpr) yield* walkNodes([node.sessionExpr as AgencyNode], [...ancestors, node], scopes);
+      }
       yield* walkNodes(node.body, [...ancestors, node], scopes);
     } else if (node.type === "handleBlock") {
       yield* walkNodes(node.body, [...ancestors, node], scopes);

--- a/packages/agency-lang/stdlib/threads.agency
+++ b/packages/agency-lang/stdlib/threads.agency
@@ -72,7 +72,11 @@ def summaryFor(id: string, messages: (ThreadMessage[] | null) = null): (string |
   if (messages == null) {
     return null
   }
-  const s = summarize(messages)
+  // Narrow: messages is non-null at this point. Re-bind via a
+  // `const` of the non-null variant so the typechecker's flow
+  // analysis sees a `ThreadMessage[]` for the summarize() call.
+  const concrete: ThreadMessage[] = messages
+  const s = summarize(concrete)
   _remember(id, { summary: s })
   return s
 }

--- a/packages/agency-lang/stdlib/threads.agency
+++ b/packages/agency-lang/stdlib/threads.agency
@@ -84,9 +84,10 @@ def summaryFor(id: string, messages: (ThreadMessage[] | null) = null): (string |
 // Lifecycle hook is registered TS-side in lib/stdlib/threads.ts via
 // `registerGlobalHook("onThreadEnd", ...)`. A top-level Agency-side
 // `callback(...)` only fires when its module is the entry point of
-// the run, which would defeat the "import std::threads and it just
-// works" experience. The TS-side hook snapshots `label` to the
-// shared cache; summary generation stays lazy (see `summaryFor`).
+// the run (verified by tests/agency-js/threads-fix-callback-propagation);
+// it does not fire from imported modules. The TS-side hook snapshots
+// `label` to the shared cache; summary generation stays lazy
+// (see `summaryFor`).
 
 export def listThreads(): ThreadInfo[] {
   """

--- a/packages/agency-lang/stdlib/threads.agency
+++ b/packages/agency-lang/stdlib/threads.agency
@@ -1,10 +1,9 @@
-/**
-Cross-thread context sharing: `listThreads()` enumerates every thread
-in the current run (active + closed), `getThread(id, offset, limit)`
-reads a slice of a thread's messages. The registry is built on the
-public `agency.threads.*` primitives plus the `onThreadEnd` lifecycle
-hook — the same surface you'd reach for to build your own variants
-(tag-threads, thread-diff, etc.) in user space.
+/** @module Cross-thread context sharing: `listThreads()` enumerates
+every thread in the current run (active + closed), `getThread(id,
+offset, limit)` reads a slice of a thread's messages. The registry is
+built on the public `agency.threads.*` primitives — the same surface
+you'd reach for to build your own variants (tag-threads, thread-diff,
+etc.) in user space.
 
   ```ts
   import { listThreads, getThread } from "std::threads"
@@ -16,16 +15,24 @@ hook — the same surface you'd reach for to build your own variants
   const lines = getThread("t1", 0, 20)
   ```
 
-`label` is template-level (set via `thread(label: "...") { ... }`);
-`summary` is per-instance and generated lazily on first `listThreads()`
-call unless the user opts into `thread(summarize: true) { ... }`.
+`label` is set at `thread {}` create time (template-level intent set
+via `thread(label: "...") { ... }`); `summary` is per-instance and
+generated lazily on first `listThreads()` call against a closed
+thread. Both fields live directly on the underlying `MessageThread`
+so the registry is per-run and survives interrupt-resume via the
+existing checkpoint serialization.
+
+The eager-summarize flag (`thread(summarize: true) { ... }`) is
+parsed and forwarded to the `onThreadEnd` hook payload as
+`eagerSummarize: true`, but the v1 stdlib does not yet act on it —
+summaries are computed lazily on the next `listThreads()` call. See
+the TODO in `lib/runtime/runner.ts::thread` for the deferral.
 */
 
 import {
   _listThreadsRaw,
   _getThread,
-  _remember,
-  _getCached,
+  _setThreadSummary,
   _currentThreadId,
 } from "agency-lang/stdlib-lib/threads.js"
 
@@ -44,30 +51,38 @@ export type ThreadInfo = {
   isActive: boolean,
 }
 
-// One-shot LLM summarization used by the lazy + eager paths. Wrapped
-// in a `thread {}` block so the summarizer prompt runs on an isolated
-// message history and doesn't pollute the agent's main conversation.
+type SummaryResult = {
+  summary: string,
+}
+
 def summarize(messages: ThreadMessage[]): string {
+  """
+  One-shot LLM summarization used by the lazy summarize path.
+  Wrapped in a `thread {}` block so the summarizer prompt runs on
+  an isolated message history and doesn't pollute the agent's main
+  conversation. Uses structured output so the returned text comes
+  back on a known field instead of free-form completion text.
+
+  @param messages - The thread's messages to summarize
+  """
   let transcript = ""
   for (m in messages) {
     transcript = transcript + "[" + m.role + "] " + m.content + "\n"
   }
-  let result = ""
+  let summary = ""
   thread {
-    result = llm("Summarize this conversation in 1-2 sentences:\n" + transcript)
+    const r: SummaryResult = llm("Summarize this conversation in 1-2 sentences:\n" + transcript)
+    summary = r.summary
   }
-  return result
+  return summary
 }
 
 // Single owner of the "return cached summary, else LLM-summarize and
 // cache" rule. Active threads pass `null` so the LLM call is skipped
 // while the conversation is still in flight.
-def summaryFor(id: string, messages: (ThreadMessage[] | null) = null): (string | null) {
-  const c = _getCached(id)
-  if (c != null) {
-    if (c.summary != null) {
-      return c.summary
-    }
+def summaryFor(id: string, existing: (string | null), messages: (ThreadMessage[] | null) = null): (string | null) {
+  if (existing != null) {
+    return existing
   }
   if (messages == null) {
     return null
@@ -77,47 +92,39 @@ def summaryFor(id: string, messages: (ThreadMessage[] | null) = null): (string |
   // analysis sees a `ThreadMessage[]` for the summarize() call.
   const concrete: ThreadMessage[] = messages
   const s = summarize(concrete)
-  _remember(id, { summary: s })
+  _setThreadSummary(id, s)
   return s
 }
 
-// Lifecycle hook is registered TS-side in lib/stdlib/threads.ts via
-// `registerGlobalHook("onThreadEnd", ...)`. A top-level Agency-side
-// `callback(...)` only fires when its module is the entry point of
-// the run (verified by tests/agency-js/threads-fix-callback-propagation);
-// it does not fire from imported modules. The TS-side hook snapshots
-// `label` to the shared cache; summary generation stays lazy
-// (see `summaryFor`).
-
-export def listThreads(): ThreadInfo[] {
+export def listThreads(): Result {
   """
   Return every thread in the current run, including the active one.
 
   Lazy summary generation: a thread that doesn't yet have a cached
   summary triggers exactly one LLM round-trip the first time
   `listThreads()` is called on it. Active threads are skipped so the
-  in-flight conversation is not summarized mid-stream.
+  in-flight conversation is not summarized mid-stream. The computed
+  summary is stashed on the underlying `MessageThread` so subsequent
+  calls read it back without re-prompting.
 
-  Eager summarization (one summary call per `thread {}` close instead
-  of all-at-once on first `listThreads()`) is opt-in:
-  `thread(summarize: true) { ... }`.
+  Returns a `Result` — success holds `ThreadInfo[]`, failure holds
+  the error (e.g. called outside an Agency frame). See
+  [error handling](https://agency-lang.com/guide/error-handling).
   """
-  const raw = _listThreadsRaw()
+  const raw = try _listThreadsRaw()
+  if (isFailure(raw)) {
+    return raw
+  }
   const out: ThreadInfo[] = []
-  for (t in raw) {
-    const c = _getCached(t.id)
-    let label: (string | null) = null
-    if (c != null) {
-      if (c.label != null) { label = c.label }
-    }
+  for (t in raw.value) {
     let messages: (ThreadMessage[] | null) = null
     if (t.isActive == false) {
       messages = t.messages
     }
-    const summary = summaryFor(t.id, messages)
+    const summary = summaryFor(t.id, t.summary, messages)
     out.push({
       id: t.id,
-      label: label,
+      label: t.label,
       summary: summary,
       parentId: t.parentId,
       threadType: t.threadType,
@@ -125,7 +132,7 @@ export def listThreads(): ThreadInfo[] {
       isActive: t.isActive
     })
   }
-  return out
+  return success(out)
 }
 
 export safe def currentThreadId(): string {
@@ -138,16 +145,21 @@ export safe def currentThreadId(): string {
   return _currentThreadId()
 }
 
-export safe def getThread(id: string, offset: number = 0, limit: number = 50): ThreadMessage[] {
+export def getThread(id: string, offset: number = 0, limit: number = 50): Result {
   """
-  Read a slice of a thread's messages. Returns `[]` for an unknown id.
+  Read a slice of a thread's messages. Returns success holding `[]`
+  for an unknown id; returns failure when called outside an Agency
+  frame.
 
   Pagination: `offset` is 0-indexed; `limit` defaults to 50. Pass
   larger explicit values for full-thread reads.
+
+  Returns a `Result` — success holds `ThreadMessage[]`. See
+  [error handling](https://agency-lang.com/guide/error-handling).
 
   @param id - Thread slug (e.g. "t1") from `listThreads()`
   @param offset - 0-indexed start of the message slice
   @param limit - Maximum number of messages to return
   """
-  return _getThread(id, offset, limit)
+  return try _getThread(id, offset, limit)
 }

--- a/packages/agency-lang/stdlib/threads.agency
+++ b/packages/agency-lang/stdlib/threads.agency
@@ -70,7 +70,7 @@ def summarize(messages: ThreadMessage[]): string {
     transcript = transcript + "[" + m.role + "] " + m.content + "\n"
   }
   let summary = ""
-  thread {
+  thread(hidden: true) {
     const r: SummaryResult = llm("Summarize this conversation in 1-2 sentences:\n" + transcript)
     summary = r.summary
   }

--- a/packages/agency-lang/stdlib/threads.agency
+++ b/packages/agency-lang/stdlib/threads.agency
@@ -1,0 +1,137 @@
+/**
+Cross-thread context sharing: `listThreads()` enumerates every thread
+in the current run (active + closed), `getThread(id, offset, limit)`
+reads a slice of a thread's messages. The registry is built on the
+public `agency.threads.*` primitives plus the `onThreadEnd` lifecycle
+hook — the same surface you'd reach for to build your own variants
+(tag-threads, thread-diff, etc.) in user space.
+
+  ```ts
+  import { listThreads, getThread } from "std::threads"
+
+  // Inspect the run's other threads:
+  const info = listThreads()
+
+  // Read a slice of a prior thread's messages:
+  const lines = getThread("t1", 0, 20)
+  ```
+
+`label` is template-level (set via `thread(label: "...") { ... }`);
+`summary` is per-instance and generated lazily on first `listThreads()`
+call unless the user opts into `thread(summarize: true) { ... }`.
+*/
+
+import {
+  _listThreadsRaw,
+  _getThread,
+  _remember,
+  _getCached,
+} from "agency-lang/stdlib-lib/threads.js"
+
+export type ThreadMessage = {
+  role: string,
+  content: string,
+}
+
+export type ThreadInfo = {
+  id: string,
+  label?: string,
+  summary?: string,
+  parentId?: string,
+  threadType: string,
+  messageCount: number,
+  isActive: boolean,
+}
+
+// One-shot LLM summarization used by the lazy + eager paths. Wrapped
+// in a `thread {}` block so the summarizer prompt runs on an isolated
+// message history and doesn't pollute the agent's main conversation.
+def summarize(messages: ThreadMessage[]): string {
+  let transcript = ""
+  for (m in messages) {
+    transcript = transcript + "[" + m.role + "] " + m.content + "\n"
+  }
+  let result = ""
+  thread {
+    result = llm("Summarize this conversation in 1-2 sentences:\n" + transcript)
+  }
+  return result
+}
+
+// Single owner of the "return cached summary, else LLM-summarize and
+// cache" rule. Active threads pass `null` so the LLM call is skipped
+// while the conversation is still in flight.
+def summaryFor(id: string, messages: (ThreadMessage[] | null) = null): (string | null) {
+  const c = _getCached(id)
+  if (c != null) {
+    if (c.summary != null) {
+      return c.summary
+    }
+  }
+  if (messages == null) {
+    return null
+  }
+  const s = summarize(messages)
+  _remember(id, { summary: s })
+  return s
+}
+
+// Lifecycle hook is registered TS-side in lib/stdlib/threads.ts via
+// `registerGlobalHook("onThreadEnd", ...)`. A top-level Agency-side
+// `callback(...)` only fires when its module is the entry point of
+// the run, which would defeat the "import std::threads and it just
+// works" experience. The TS-side hook snapshots `label` to the
+// shared cache; summary generation stays lazy (see `summaryFor`).
+
+export def listThreads(): ThreadInfo[] {
+  """
+  Return every thread in the current run, including the active one.
+
+  Lazy summary generation: a thread that doesn't yet have a cached
+  summary triggers exactly one LLM round-trip the first time
+  `listThreads()` is called on it. Active threads are skipped so the
+  in-flight conversation is not summarized mid-stream.
+
+  Eager summarization (one summary call per `thread {}` close instead
+  of all-at-once on first `listThreads()`) is opt-in:
+  `thread(summarize: true) { ... }`.
+  """
+  const raw = _listThreadsRaw()
+  const out: ThreadInfo[] = []
+  for (t in raw) {
+    const c = _getCached(t.id)
+    let label: (string | null) = null
+    if (c != null) {
+      if (c.label != null) { label = c.label }
+    }
+    let messages: (ThreadMessage[] | null) = null
+    if (t.isActive == false) {
+      messages = t.messages
+    }
+    const summary = summaryFor(t.id, messages)
+    out.push({
+      id: t.id,
+      label: label,
+      summary: summary,
+      parentId: t.parentId,
+      threadType: t.threadType,
+      messageCount: t.messageCount,
+      isActive: t.isActive
+    })
+  }
+  return out
+}
+
+export safe def getThread(id: string, offset: number = 0, limit: number = 50): ThreadMessage[] {
+  """
+  Read a slice of a thread's messages. Returns `[]` for an unknown id.
+
+  Pagination: `offset` is 0-indexed; `limit` defaults to 50. Pass
+  larger explicit values for full-thread reads.
+
+  @param id - Thread slug (e.g. "t1") from `listThreads()`
+  @param offset - 0-indexed start of the message slice
+  @param limit - Maximum number of messages to return
+  """
+  return _getThread(id, offset, limit)
+}

--- a/packages/agency-lang/stdlib/threads.agency
+++ b/packages/agency-lang/stdlib/threads.agency
@@ -26,6 +26,7 @@ import {
   _getThread,
   _remember,
   _getCached,
+  _currentThreadId,
 } from "agency-lang/stdlib-lib/threads.js"
 
 export type ThreadMessage = {
@@ -120,6 +121,16 @@ export def listThreads(): ThreadInfo[] {
     })
   }
   return out
+}
+
+export safe def currentThreadId(): string {
+  """
+  Slug-form id of the active thread (e.g. "t3"), or `""` outside any
+  runtime frame. Useful with `thread(continue: id)` when you want to
+  capture a thread's id at the moment it was active so you can
+  resume it later.
+  """
+  return _currentThreadId()
 }
 
 export safe def getThread(id: string, offset: number = 0, limit: number = 50): ThreadMessage[] {

--- a/packages/agency-lang/tests/agency-js/entry-module-callback-fires/agent.agency
+++ b/packages/agency-lang/tests/agency-js/entry-module-callback-fires/agent.agency
@@ -1,0 +1,20 @@
+// Positive baseline counterpart to
+// `tests/agency-js/threads-fix-callback-propagation/`. That fixture
+// pins the negative: a top-level `callback("onThreadEnd")` defined in
+// an IMPORTED module does NOT fire when the entry-point opens a
+// `thread { }`. This fixture pins the positive: a top-level
+// `callback("onThreadEnd")` defined in the ENTRY module DOES fire.
+// Combined, the two tests cover both directions and would break
+// loudly if the propagation rule changed in either direction.
+import { setMutable } from "../../helpers/mutableVar.js"
+
+callback("onThreadEnd") as evt {
+  setMutable("entry-onThreadEnd-fired", true)
+  setMutable("entry-onThreadEnd-thread-id", evt.threadId)
+}
+
+node main() {
+  thread {
+    // Empty body — close immediately so onThreadEnd fires.
+  }
+}

--- a/packages/agency-lang/tests/agency-js/entry-module-callback-fires/fixture.json
+++ b/packages/agency-lang/tests/agency-js/entry-module-callback-fires/fixture.json
@@ -1,0 +1,4 @@
+{
+  "entryCallbackFired": true,
+  "threadId": "t1"
+}

--- a/packages/agency-lang/tests/agency-js/entry-module-callback-fires/test.js
+++ b/packages/agency-lang/tests/agency-js/entry-module-callback-fires/test.js
@@ -1,0 +1,18 @@
+import { writeFileSync } from "fs";
+import { main } from "./agent.js";
+import { getMutable, resetMutable } from "../../helpers/mutableVar.js";
+
+resetMutable();
+await main();
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      entryCallbackFired: getMutable("entry-onThreadEnd-fired", false) === true,
+      threadId: getMutable("entry-onThreadEnd-thread-id", null),
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency-js/threads-fix-callback-propagation/agent.agency
+++ b/packages/agency-lang/tests/agency-js/threads-fix-callback-propagation/agent.agency
@@ -1,0 +1,12 @@
+import { noop } from "./mod.agency"
+
+// Entry: opens a `thread { }` so onThreadEnd has something to fire on.
+// If the imported module's top-level callback propagates, the JS-side
+// `getMutable("imported-onThreadEnd-fired")` in test.js will be true.
+node main() {
+  // Reference imported symbol so the module is loaded.
+  const _ = noop()
+  thread {
+    // Empty body — close immediately.
+  }
+}

--- a/packages/agency-lang/tests/agency-js/threads-fix-callback-propagation/fixture.json
+++ b/packages/agency-lang/tests/agency-js/threads-fix-callback-propagation/fixture.json
@@ -1,0 +1,4 @@
+{
+  "importedCallbackFired": false,
+  "threadId": null
+}

--- a/packages/agency-lang/tests/agency-js/threads-fix-callback-propagation/mod.agency
+++ b/packages/agency-lang/tests/agency-js/threads-fix-callback-propagation/mod.agency
@@ -1,0 +1,19 @@
+// Documents PR #225 fix #8 finding: a top-level
+// `callback("onThreadEnd")` defined in an IMPORTED module does NOT
+// fire when the entry-point module opens `thread { }` blocks. This
+// is why `lib/stdlib/threads.ts` registers the registry's
+// onThreadEnd snapshotter via `registerGlobalHook(...)` instead of
+// a top-level Agency-side `callback(...)`. Fixture asserts the
+// negative behaviour so a future change that makes imported
+// modules' callbacks fire will trip this test and prompt the
+// stdlib hook migration described in PR #225.
+import { setMutable } from "../../helpers/mutableVar.js"
+
+callback("onThreadEnd") as evt {
+  setMutable("imported-onThreadEnd-fired", true)
+  setMutable("imported-onThreadEnd-thread-id", evt.threadId)
+}
+
+export def noop(): number {
+  return 1
+}

--- a/packages/agency-lang/tests/agency-js/threads-fix-callback-propagation/test.js
+++ b/packages/agency-lang/tests/agency-js/threads-fix-callback-propagation/test.js
@@ -1,0 +1,18 @@
+import { writeFileSync } from "fs";
+import { main } from "./agent.js";
+import { getMutable, resetMutable } from "../../helpers/mutableVar.js";
+
+resetMutable();
+await main();
+
+writeFileSync(
+  "__result.json",
+  JSON.stringify(
+    {
+      importedCallbackFired: getMutable("imported-onThreadEnd-fired", false) === true,
+      threadId: getMutable("imported-onThreadEnd-thread-id", null),
+    },
+    null,
+    2,
+  ),
+);

--- a/packages/agency-lang/tests/agency/threads-registry/basic.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/basic.agency
@@ -2,10 +2,8 @@ import { listThreads, getThread } from "std::threads"
 import { userMessage } from "std::thread"
 
 // Verifies the registry observes threads created via `thread {}`
-// blocks. Uses `thread(label, summarize)` to opt into eager
-// summarization so each closed thread's summary is cached at close
-// time (one LLM call per thread), and listThreads() then reads from
-// cache without triggering additional LLM round-trips.
+// blocks. Lazy summaries are cached on the underlying MessageThread
+// at the first listThreads() call after a thread closes.
 node main() {
   thread(label: "first") {
     userMessage("hello from first")
@@ -14,13 +12,13 @@ node main() {
     userMessage("hello from second")
   }
   const all = listThreads()
-  // Return the labels for closed threads only; the active root
-  // thread (t0) has no label. Labels are populated by the
-  // onThreadEnd callback registered in stdlib/threads.agency.
+  // listThreads() now returns Result — unwrap before iterating.
   const labels: string[] = []
-  for (t in all) {
-    if (t.label != null) {
-      labels.push(t.label)
+  if (isSuccess(all)) {
+    for (t in all.value) {
+      if (t.label != null) {
+        labels.push(t.label)
+      }
     }
   }
   return labels

--- a/packages/agency-lang/tests/agency/threads-registry/basic.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/basic.agency
@@ -1,0 +1,27 @@
+import { listThreads, getThread } from "std::threads"
+import { userMessage } from "std::thread"
+
+// Verifies the registry observes threads created via `thread {}`
+// blocks. Uses `thread(label, summarize)` to opt into eager
+// summarization so each closed thread's summary is cached at close
+// time (one LLM call per thread), and listThreads() then reads from
+// cache without triggering additional LLM round-trips.
+node main() {
+  thread(label: "first") {
+    userMessage("hello from first")
+  }
+  thread(label: "second") {
+    userMessage("hello from second")
+  }
+  const all = listThreads()
+  // Return the labels for closed threads only; the active root
+  // thread (t0) has no label. Labels are populated by the
+  // onThreadEnd callback registered in stdlib/threads.agency.
+  const labels: string[] = []
+  for (t in all) {
+    if (t.label != null) {
+      labels.push(t.label)
+    }
+  }
+  return labels
+}

--- a/packages/agency-lang/tests/agency/threads-registry/basic.test.json
+++ b/packages/agency-lang/tests/agency/threads-registry/basic.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[\"first\",\"second\"]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "stdlib/threads listThreads() surfaces labels from thread(label) blocks; eager summaries are cached at close.",
+      "llmMocks": [
+        { "return": "summary-of-first" },
+        { "return": "summary-of-second" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/threads-registry/basic.test.json
+++ b/packages/agency-lang/tests/agency/threads-registry/basic.test.json
@@ -5,10 +5,10 @@
       "input": "",
       "expectedOutput": "[\"first\",\"second\"]",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "stdlib/threads listThreads() surfaces labels from thread(label) blocks; eager summaries are cached at close.",
+      "description": "stdlib/threads listThreads() surfaces labels from thread(label) blocks; summaries are computed lazily on the first listThreads() call after each thread closes.",
       "llmMocks": [
-        { "return": "summary-of-first" },
-        { "return": "summary-of-second" }
+        { "return": { "summary": "summary-of-first" } },
+        { "return": { "summary": "summary-of-second" } }
       ]
     }
   ]

--- a/packages/agency-lang/tests/agency/threads-registry/continue.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/continue.agency
@@ -1,0 +1,23 @@
+import { getThread, currentThreadId } from "std::threads"
+import { userMessage } from "std::thread"
+
+// Verify thread(continue: id) resumes a previously-closed thread:
+// new messages append to its existing history instead of starting a
+// fresh thread. Captures the id of the first thread, then continues
+// it. Expected: the resumed thread holds BOTH messages in order.
+node main() {
+  let firstId: string = ""
+  thread(label: "a") {
+    userMessage("first")
+    firstId = currentThreadId()
+  }
+  thread(continue: firstId) {
+    userMessage("second")
+  }
+  const messages = getThread(firstId, 0, 50)
+  const contents: string[] = []
+  for (m in messages) {
+    contents.push(m.content)
+  }
+  return contents
+}

--- a/packages/agency-lang/tests/agency/threads-registry/continue.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/continue.agency
@@ -16,8 +16,10 @@ node main() {
   }
   const messages = getThread(firstId, 0, 50)
   const contents: string[] = []
-  for (m in messages) {
-    contents.push(m.content)
+  if (isSuccess(messages)) {
+    for (m in messages.value) {
+      contents.push(m.content)
+    }
   }
   return contents
 }

--- a/packages/agency-lang/tests/agency/threads-registry/continue.test.json
+++ b/packages/agency-lang/tests/agency/threads-registry/continue.test.json
@@ -1,0 +1,12 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[\"first\",\"second\"]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "thread(continue: id) appends to the resumed thread's history; the resumed thread holds both messages in order.",
+      "llmMocks": []
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/threads-registry/hidden-arg-variable.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/hidden-arg-variable.agency
@@ -1,0 +1,29 @@
+import { listThreads } from "std::threads"
+import { userMessage } from "std::thread"
+
+// Regression: `thread(hidden: <varRef>) { ... }` must walk the
+// `hidden` expression during symbol-table resolution so codegen
+// emits `__stack.locals.shouldHide` instead of a bare identifier.
+// Before the walker fix, this test would crash at runtime with
+// "shouldHide is not defined".
+node main() {
+  const shouldHide: boolean = true
+  const shouldShow: boolean = false
+
+  thread(label: "kept-visible", hidden: shouldShow) {
+    userMessage("kept body")
+  }
+  thread(label: "filtered-out", hidden: shouldHide) {
+    userMessage("hidden body")
+  }
+  const all = listThreads()
+  const labels: string[] = []
+  if (isSuccess(all)) {
+    for (t in all.value) {
+      if (t.label != null) {
+        labels.push(t.label)
+      }
+    }
+  }
+  return labels
+}

--- a/packages/agency-lang/tests/agency/threads-registry/hidden-arg-variable.test.json
+++ b/packages/agency-lang/tests/agency/threads-registry/hidden-arg-variable.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[\"kept-visible\"]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "thread(hidden: <varRef>) resolves the variable reference and filters by its value (regression for the walker fix that previously skipped the hidden expression).",
+      "llmMocks": [
+        { "return": { "summary": "kept-summary" } }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/threads-registry/hidden-arg.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/hidden-arg.agency
@@ -1,0 +1,22 @@
+import { listThreads } from "std::threads"
+import { userMessage } from "std::thread"
+
+// Verifies `thread(hidden: true) { ... }` excludes the created
+// thread from `listThreads()`. The visible thread should appear;
+// the hidden one should not.
+node main() {
+  thread(label: "visible") {
+    userMessage("visible body")
+  }
+  thread(label: "shh", hidden: true) {
+    userMessage("hidden body")
+  }
+  const all = listThreads()
+  const labels: string[] = []
+  for (t in all) {
+    if (t.label != null) {
+      labels.push(t.label)
+    }
+  }
+  return labels
+}

--- a/packages/agency-lang/tests/agency/threads-registry/hidden-arg.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/hidden-arg.agency
@@ -13,9 +13,11 @@ node main() {
   }
   const all = listThreads()
   const labels: string[] = []
-  for (t in all) {
-    if (t.label != null) {
-      labels.push(t.label)
+  if (isSuccess(all)) {
+    for (t in all.value) {
+      if (t.label != null) {
+        labels.push(t.label)
+      }
     }
   }
   return labels

--- a/packages/agency-lang/tests/agency/threads-registry/hidden-arg.test.json
+++ b/packages/agency-lang/tests/agency/threads-registry/hidden-arg.test.json
@@ -5,7 +5,10 @@
       "input": "",
       "expectedOutput": "[\"visible\"]",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "thread(hidden: true) excludes the thread from listThreads()."
+      "description": "thread(hidden: true) excludes the thread from listThreads().",
+      "llmMocks": [
+        { "return": { "summary": "visible-summary" } }
+      ]
     }
   ]
 }

--- a/packages/agency-lang/tests/agency/threads-registry/hidden-arg.test.json
+++ b/packages/agency-lang/tests/agency/threads-registry/hidden-arg.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[\"visible\"]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "thread(hidden: true) excludes the thread from listThreads()."
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/threads-registry/hidden-interrupt.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/hidden-interrupt.agency
@@ -1,0 +1,26 @@
+import { listThreads } from "std::threads"
+import { userMessage } from "std::thread"
+
+// Verifies the `hidden` flag survives an interrupt/resume cycle.
+// Opens a hidden thread, then a visible thread, then forces a
+// serialize/deserialize boundary via interrupt. After resume,
+// `listThreads()` should still hide the hidden thread.
+node main() {
+  thread(label: "secret", hidden: true) {
+    userMessage("hidden body")
+  }
+  thread(label: "after") {
+    userMessage("after body")
+  }
+  const _ = interrupt("checkpoint here")
+  const all = listThreads()
+  const labels: string[] = []
+  if (isSuccess(all)) {
+    for (t in all.value) {
+      if (t.label != null) {
+        labels.push(t.label)
+      }
+    }
+  }
+  return labels
+}

--- a/packages/agency-lang/tests/agency/threads-registry/hidden-interrupt.test.json
+++ b/packages/agency-lang/tests/agency/threads-registry/hidden-interrupt.test.json
@@ -1,0 +1,21 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[\"after\"]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "hidden flag round-trips through interrupt serialize/deserialize.",
+      "interruptHandlers": [
+        {
+          "action": "resolve",
+          "expectedMessage": "checkpoint here",
+          "resolvedValue": "ok"
+        }
+      ],
+      "llmMocks": [
+        { "return": { "summary": "after-summary" } }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/threads-registry/hidden-subthread.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/hidden-subthread.agency
@@ -1,0 +1,28 @@
+import { listThreads } from "std::threads"
+import { userMessage } from "std::thread"
+
+// Verifies `subthread(hidden: true) { ... }` excludes the created
+// subthread from `listThreads()`. Mirrors `hidden-arg.agency` but
+// exercises the `subthread` block instead of the top-level `thread`
+// block so the `hidden` named-arg coverage spans both forms.
+node main() {
+  thread(label: "parent") {
+    userMessage("parent body")
+    subthread(label: "sub-visible") {
+      userMessage("visible-sub")
+    }
+    subthread(label: "sub-hidden", hidden: true) {
+      userMessage("hidden-sub")
+    }
+  }
+  const all = listThreads()
+  const labels: string[] = []
+  if (isSuccess(all)) {
+    for (t in all.value) {
+      if (t.label != null) {
+        labels.push(t.label)
+      }
+    }
+  }
+  return labels
+}

--- a/packages/agency-lang/tests/agency/threads-registry/hidden-subthread.test.json
+++ b/packages/agency-lang/tests/agency/threads-registry/hidden-subthread.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[\"parent\",\"sub-visible\"]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "subthread(hidden: true) excludes the subthread from listThreads().",
+      "llmMocks": [
+        { "return": { "summary": "parent-summary" } },
+        { "return": { "summary": "sub-visible-summary" } }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/threads-registry/session.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/session.agency
@@ -18,12 +18,15 @@ node main() {
     userMessage("back to coding")
   }
   const all = listThreads()
+  // listThreads() now returns Result; unwrap before iterating.
   // Build a name → message-count map for the labelled (non-active)
   // threads so the assertion is order-independent.
   const result: any = {}
-  for (t in all) {
-    if (t.label != null) {
-      result[t.label] = t.messageCount
+  if (isSuccess(all)) {
+    for (t in all.value) {
+      if (t.label != null) {
+        result[t.label] = t.messageCount
+      }
     }
   }
   return result

--- a/packages/agency-lang/tests/agency/threads-registry/session.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/session.agency
@@ -1,0 +1,30 @@
+import { listThreads } from "std::threads"
+import { userMessage } from "std::thread"
+
+// Three-message router scenario from the plan: coding → weather →
+// back to coding. Sessions are keyed by name; first entry creates,
+// second entry resumes. After the run, the coding thread should
+// contain BOTH "first coding" and "back to coding", and the weather
+// thread should contain only "weather request" — proving that
+// thread(session: "name") preserves history across re-entries.
+node main() {
+  thread(session: "coding", label: "coding") {
+    userMessage("first coding")
+  }
+  thread(session: "weather", label: "weather") {
+    userMessage("weather request")
+  }
+  thread(session: "coding", label: "coding") {
+    userMessage("back to coding")
+  }
+  const all = listThreads()
+  // Build a name → message-count map for the labelled (non-active)
+  // threads so the assertion is order-independent.
+  const result: any = {}
+  for (t in all) {
+    if (t.label != null) {
+      result[t.label] = t.messageCount
+    }
+  }
+  return result
+}

--- a/packages/agency-lang/tests/agency/threads-registry/session.test.json
+++ b/packages/agency-lang/tests/agency/threads-registry/session.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"coding\":2,\"weather\":1}",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "thread(session: name) resumes the same thread on re-entry: coding history persists across the weather hop.",
+      "llmMocks": [
+        { "return": "coding-summary" },
+        { "return": "weather-summary" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/threads-registry/session.test.json
+++ b/packages/agency-lang/tests/agency/threads-registry/session.test.json
@@ -7,8 +7,8 @@
       "evaluationCriteria": [{ "type": "exact" }],
       "description": "thread(session: name) resumes the same thread on re-entry: coding history persists across the weather hop.",
       "llmMocks": [
-        { "return": "coding-summary" },
-        { "return": "weather-summary" }
+        { "return": { "summary": "coding-summary" } },
+        { "return": { "summary": "weather-summary" } }
       ]
     }
   ]

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -181,7 +181,7 @@ await callHook({
           }
         })
       });
-      await runner.thread(1, "create", async (runner) => {
+      await runner.thread(1, "create", {}, async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res1 = await runPrompt({
@@ -202,7 +202,7 @@ if (hasInterrupts(__stack.locals.res1)) {
             return;
           }
         });
-await runner.thread(1, "createSubthread", async (runner) => {
+await runner.thread(1, "createSubthread", {}, async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res2 = await runPrompt({
@@ -223,7 +223,7 @@ if (hasInterrupts(__stack.locals.res2)) {
               return;
             }
           });
-await runner.thread(1, "createSubthread", async (runner) => {
+await runner.thread(1, "createSubthread", {}, async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res3 = await runPrompt({
@@ -245,7 +245,7 @@ if (hasInterrupts(__stack.locals.res3)) {
               }
             });
           });
-await runner.thread(2, "create", async (runner) => {
+await runner.thread(2, "create", {}, async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res5 = await runPrompt({
@@ -268,7 +268,7 @@ if (hasInterrupts(__stack.locals.res5)) {
             });
           });
         });
-await runner.thread(2, "createSubthread", async (runner) => {
+await runner.thread(2, "createSubthread", {}, async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res4 = await runPrompt({
@@ -422,7 +422,7 @@ await callHook({
           }
         })
       });
-      await runner.thread(1, "create", async (runner) => {
+      await runner.thread(1, "create", {}, async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res1 = await runPrompt({
@@ -446,7 +446,7 @@ if (hasInterrupts(__stack.locals.res1)) {
             return;
           }
         });
-await runner.thread(1, "createSubthread", async (runner) => {
+await runner.thread(1, "createSubthread", {}, async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res2 = await runPrompt({
@@ -470,7 +470,7 @@ if (hasInterrupts(__stack.locals.res2)) {
               return;
             }
           });
-await runner.thread(1, "createSubthread", async (runner) => {
+await runner.thread(1, "createSubthread", {}, async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res3 = await runPrompt({
@@ -495,7 +495,7 @@ if (hasInterrupts(__stack.locals.res3)) {
               }
             });
           });
-await runner.thread(2, "create", async (runner) => {
+await runner.thread(2, "create", {}, async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res5 = await runPrompt({
@@ -521,7 +521,7 @@ if (hasInterrupts(__stack.locals.res5)) {
             });
           });
         });
-await runner.thread(2, "createSubthread", async (runner) => {
+await runner.thread(2, "createSubthread", {}, async (runner) => {
 await runner.step(0, async (runner) => {
 __self.__removedTools = __self.__removedTools || [];
 __stack.locals.res4 = await runPrompt({

--- a/packages/agency-lang/tests/typescriptPreprocessor/threads.json
+++ b/packages/agency-lang/tests/typescriptPreprocessor/threads.json
@@ -92,6 +92,7 @@
           "summarize": null,
           "continueExpr": null,
           "sessionExpr": null,
+          "hidden": null,
           "loc": {
             "line": 1,
             "col": 2,

--- a/packages/agency-lang/tests/typescriptPreprocessor/threads.json
+++ b/packages/agency-lang/tests/typescriptPreprocessor/threads.json
@@ -88,6 +88,10 @@
               "scope": "local"
             }
           ],
+          "label": null,
+          "summarize": null,
+          "continueExpr": null,
+          "sessionExpr": null,
           "loc": {
             "line": 1,
             "col": 2,


### PR DESCRIPTION
## Cross-Thread Context Sharing — `std::threads` registry + resumable `thread {}` blocks

Implements the plan in `docs/superpowers/plans/2026-05-29-thread-registry.md`. The marquee use case is the **categorize-and-route** pattern: a router node sends each user message to a specialized agent node, and the third message that re-visits a category (e.g. "back to the coding task") resumes the *original* thread instead of starting fresh.

### User-visible API

New stdlib module `std::threads`:

```agency
import { listThreads, getThread, currentThreadId } from "std::threads"

listThreads()                       // ThreadInfo[]  (id, label, summary, parentId, messageCount, isActive, ...)
getThread(id, offset?, limit?)      // ThreadMessage[]
currentThreadId()                   // slug-form id of the active thread, or ""
```

`thread {}` gains four optional named args:

```agency
thread(label: "coding task", summarize: true) { ... }      // tag + opt-in eager summary
thread(continue: priorId) { ... }                          // resume a closed thread
thread(session: "coding", label: "coding task") { ... }    // session-keyed auto-resume
```

`continue` and `session` are mutually exclusive (parser-rejected). `session` is sugar over `continue` with a runtime-owned name→id map; first entry creates, subsequent entries resume.

### Architecture

Shipped as **six small extensibility primitives + one stdlib module**, so any user can replicate (or extend) the registry without touching core:

1. `agency.threads.{list, get, current}` — TS namespace mirroring the stdlib surface.
2. `onThreadStart` / `onThreadEnd` lifecycle hooks (slug ids, label, isResumption, message snapshot on End).
3. `thread(label, summarize, continue, session)` named-arg syntax.
4. Cross-node `ThreadStore` persistence — required zero production code; added pinning test (`lib/runtime/__tests__/node.test.ts`).
5. `ThreadStore.resumeExisting(id)` — explicit continuation primitive.
6. `ThreadStore.openSession(name)` — single owner of the "create if absent, resume if present" rule.

The stdlib module is *the same code a user would write themselves* given those primitives. The thread metadata cache lives in `lib/stdlib/threads.ts` because Agency `static const` variables are immutable.

### Implementation notes

- **Subthreads cannot be resumed.** Both `resumeExisting` and `openSession` reject subthreads — a subthread's identity is tied to its parent's context at the time of creation, so resuming one out of context would be misleading.
- **`MessageThread.parentId`** now round-trips through JSON so `ThreadInfo` surfaces parent-child linkage and the resume guards survive interrupt resume.
- **`hasHook(ctx, name)`** fast-path: `Runner.thread` skips the `await invokeCallbacks(...)` microtask boundary when no listeners are registered, preserving debugger checkpoint timing in the common case. Scoped callbacks are intentionally not consulted (false is a fast-path hint only; callers are always safe to call invokeCallbacks anyway).
- **Slug ids** (`t1`, `t2`, ...) wrap the existing per-store counter. LLM-friendly; the "wrong but valid integer" risk is bounded by `listThreads()` returning the slug→summary mapping for disambiguation.

### Out of scope (v1)

- Auto-context injection by label (`thread(label: ..., includePriorSummaries: true)`).
- Cross-run persistence (registry is run-scoped; future work could fold this into the memory layer).

### Tests

- Agency integration: `tests/agency/threads-registry/{basic,label,pagination,eager-vs-lazy,continue,session}.agency`.
- Unit: `ThreadStore.resumeExisting` / `openSession` in `lib/runtime/state/threadStore.test.ts`.
- Cross-node persistence pinning test in `lib/runtime/__tests__/node.test.ts`.
- Hook firing tests in the existing hooks test suite.

### Local validation

- `pnpm run lint:structure` — clean.
- `make fixtures` — regenerated (`tests/typescriptPreprocessor/threads.json` includes the four new optional named-arg fields).

Full unit + agency suites will run in CI per repo policy.

### Docs

- New guide: `docs/site/guide/cross-thread-context.md` (full API + categorize-and-route worked example + memory-scoping-for-routed-agents section + sessions subsection).
- Linked from `docs/site/guide/message-history-and-threads.md` and from the site nav (`docs/site/.vitepress/config.mts`).
- CHANGELOG entry under `## Unreleased`.

### Plan + history

- Plan: `docs/superpowers/plans/2026-05-29-thread-registry.md`
- Six commits, one per task:
  - `766d33c8` Task 1: `agency.threads.*` namespace + `parentId` on MessageThread
  - `f23cd3d3` Task 2: `onThreadStart`/`onThreadEnd` hooks + `ThreadStore.resumeExisting`/`openSession`
  - `f2071aef` Task 3: `thread(label, summarize, continue, session)` parser + codegen
  - `260bd4c7` Tasks 4-5: `stdlib/threads.agency` module + cross-node persistence test
  - `0a515c7b` Tasks 6+7: `thread(continue)` + `thread(session)` integration tests
  - `0d6806a2` Task 9: docs + changelog + lint cleanup + hasHook fast path
