### PR TITLE
stdlib/threads: wire `thread(summarize: true)` to an eager onThreadEnd hook

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/threads.md
+++ b/packages/agency-lang/docs/site/stdlib/threads.md
@@ -26,9 +26,13 @@ existing checkpoint serialization.
 
 The eager-summarize flag (`thread(summarize: true) { ... }`) is
 parsed and forwarded to the `onThreadEnd` hook payload as
-`eagerSummarize: true`, but the v1 stdlib does not yet act on it —
-summaries are computed lazily on the next `listThreads()` call. See
-the TODO in `lib/runtime/runner.ts::thread` for the deferral.
+`eagerSummarize: true`. A global TS-side `onThreadEnd` hook
+registered in `lib/stdlib/threads.ts` consumes the payload and
+triggers a one-shot LLM summarize at close time, stashing the
+result on the underlying `MessageThread`. Threads that did NOT opt
+in eagerly fall back to the lazy summarize path in `summaryFor()`
+below, which runs on the first `listThreads()` call against a
+closed thread.
 
 ## Types
 
@@ -41,7 +45,7 @@ export type ThreadMessage = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L43))
 
 ### ThreadInfo
 
@@ -57,7 +61,7 @@ export type ThreadInfo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L44))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L48))
 
 ### SummaryResult
 
@@ -67,7 +71,7 @@ type SummaryResult = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L58))
 
 ## Functions
 
@@ -93,7 +97,7 @@ One-shot LLM summarization used by the lazy summarize path.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L58))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L62))
 
 ### summaryFor
 
@@ -111,7 +115,7 @@ summaryFor(id: string, existing: string | null, messages: ThreadMessage[] | null
 
 **Returns:** `string | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L83))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L87))
 
 ### listThreads
 
@@ -121,12 +125,16 @@ listThreads(): Result
 
 Return every thread in the current run, including the active one.
 
-  Lazy summary generation: a thread that doesn't yet have a cached
-  summary triggers exactly one LLM round-trip the first time
-  `listThreads()` is called on it. Active threads are skipped so the
-  in-flight conversation is not summarized mid-stream. The computed
-  summary is stashed on the underlying `MessageThread` so subsequent
-  calls read it back without re-prompting.
+  Summary generation: threads opened with `thread(summarize: true)`
+  are summarized eagerly when they close (see the global onThreadEnd
+  hook in `lib/stdlib/threads.ts`), so their summary is already
+  cached by the time `listThreads()` runs. Threads that did NOT opt
+  in eagerly trigger exactly one LLM round-trip the first time
+  `listThreads()` is called on them. Active threads are skipped on
+  both paths so the in-flight conversation is not summarized
+  mid-stream. The computed summary is stashed on the underlying
+  `MessageThread` so subsequent calls read it back without
+  re-prompting.
 
   Returns a `Result` — success holds `ThreadInfo[]`, failure holds
   the error (e.g. called outside an Agency frame). See
@@ -134,7 +142,7 @@ Return every thread in the current run, including the active one.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L99))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L103))
 
 ### currentThreadId
 
@@ -149,7 +157,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L138))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L146))
 
 ### getThread
 
@@ -181,4 +189,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L148))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L156))

--- a/packages/agency-lang/docs/site/stdlib/threads.md
+++ b/packages/agency-lang/docs/site/stdlib/threads.md
@@ -102,7 +102,7 @@ One-shot LLM summarization used by the lazy summarize path.
 ### summaryFor
 
 ```ts
-summaryFor(id: string, existing: string | null, messages: ThreadMessage[] | null): string | null
+summaryFor(id: string, existing: string | null, messages: ThreadMessage[]): string | null
 ```
 
 **Parameters:**
@@ -111,11 +111,11 @@ summaryFor(id: string, existing: string | null, messages: ThreadMessage[] | null
 |---|---|---|
 | id | `string` |  |
 | existing | `string \| null` |  |
-| messages | `ThreadMessage[] \| null` | null |
+| messages | `ThreadMessage[]` |  |
 
 **Returns:** `string | null`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L87))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L90))
 
 ### listThreads
 
@@ -160,7 +160,7 @@ Return every thread in the current run, including the active one.
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L103))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L99))
 
 ### currentThreadId
 
@@ -175,7 +175,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L172))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L171))
 
 ### getThread
 
@@ -207,4 +207,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L182))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L181))

--- a/packages/agency-lang/docs/site/stdlib/threads.md
+++ b/packages/agency-lang/docs/site/stdlib/threads.md
@@ -120,7 +120,7 @@ summaryFor(id: string, existing: string | null, messages: ThreadMessage[] | null
 ### listThreads
 
 ```ts
-listThreads(): Result
+listThreads(lazySummarize: boolean): Result
 ```
 
 Return every thread in the current run, including the active one.
@@ -130,15 +130,33 @@ Return every thread in the current run, including the active one.
   hook in `lib/stdlib/threads.ts`), so their summary is already
   cached by the time `listThreads()` runs. Threads that did NOT opt
   in eagerly trigger exactly one LLM round-trip the first time
-  `listThreads()` is called on them. Active threads are skipped on
-  both paths so the in-flight conversation is not summarized
-  mid-stream. The computed summary is stashed on the underlying
-  `MessageThread` so subsequent calls read it back without
-  re-prompting.
+  `listThreads()` is called on them (the "lazy" path). Active
+  threads are skipped on both paths so the in-flight conversation
+  is not summarized mid-stream. The computed summary is stashed on
+  the underlying `MessageThread` so subsequent calls read it back
+  without re-prompting.
+
+  Pass `lazySummarize: false` to skip the on-demand LLM round-trip
+  entirely. Threads without a cached summary fall back to their
+  label (or `""` if no label is set), so the call stays free even
+  when no eager summary is available. Useful in tests and in
+  performance-sensitive surfaces where you'd rather see "no summary
+  yet" than pay for one synchronously.
 
   Returns a `Result` — success holds `ThreadInfo[]`, failure holds
   the error (e.g. called outside an Agency frame). See
   [error handling](https://agency-lang.com/guide/error-handling).
+
+  @param lazySummarize - When true (default), generate summaries
+                         on-demand for any thread that doesn't have
+                         one cached. When false, fall back to the
+                         label (or `""`).
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| lazySummarize | `boolean` | true |
 
 **Returns:** `Result`
 
@@ -157,7 +175,7 @@ Slug-form id of the active thread (e.g. "t3"), or `""` outside any
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L146))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L172))
 
 ### getThread
 
@@ -189,4 +207,4 @@ Read a slice of a thread's messages. Returns success holding `[]`
 
 **Returns:** `Result`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L156))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/threads.agency#L182))

--- a/packages/agency-lang/lib/stdlib/threads.test.ts
+++ b/packages/agency-lang/lib/stdlib/threads.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi } from "vitest";
+
+/**
+ * Pin the eager-summarize wiring contract for `thread(summarize:
+ * true) { ... }`. The hook in `lib/stdlib/threads.ts` is the only
+ * thing that translates the `eagerSummarize: true` payload field
+ * into a real LLM call + `MessageThread.summary` write. A regression
+ * that breaks this would silently revert to lazy-only behavior; the
+ * Agency-side `summaryFor` path still works, but the "snappy
+ * /sessions" UX the registry feature promises disappears.
+ *
+ * Mocks `runPrompt` instead of going through the deterministic LLM
+ * client because (a) we only care about the wiring, not the prompt
+ * format, and (b) the deterministic client requires a fuller
+ * RuntimeContext setup than these focused tests need.
+ */
+vi.mock("../runtime/prompt.js", () => ({
+  runPrompt: vi.fn(async () => ({ summary: "spy-summary" })),
+}));
+
+import { agency } from "../runtime/agency.js";
+import { RuntimeContext } from "../runtime/state/context.js";
+import { ThreadStore } from "../runtime/state/threadStore.js";
+import { MessageThread } from "../runtime/state/messageThread.js";
+import { runPrompt } from "../runtime/prompt.js";
+import { _eagerSummarizeIfNeeded } from "./threads.js";
+
+function makeCtx(): RuntimeContext<any> {
+  return new RuntimeContext({
+    statelogConfig: {
+      host: "https://example.com",
+      apiKey: "test-api-key",
+      projectId: "test-project",
+      debugMode: false,
+    },
+    smoltalkDefaults: {},
+    dirname: "/tmp",
+  });
+}
+
+describe("_eagerSummarizeIfNeeded", () => {
+  it("calls the LLM and writes MessageThread.summary when eagerSummarize is true", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const id = threads.create();
+    threads.get(id).addMessage({ role: "user", content: "hello" } as any);
+    const spy = runPrompt as unknown as ReturnType<typeof vi.fn>;
+    spy.mockClear();
+
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      () =>
+        _eagerSummarizeIfNeeded({
+          threadId: `t${id}`,
+          eagerSummarize: true,
+          messages: [{ role: "user", content: "hello" } as any],
+        }),
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(threads.get(id).summary).toBe("spy-summary");
+  });
+
+  it("uses a standalone MessageThread for the LLM call (does NOT append to the active thread)", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const id = threads.create();
+    const spy = runPrompt as unknown as ReturnType<typeof vi.fn>;
+    spy.mockClear();
+
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      () =>
+        _eagerSummarizeIfNeeded({
+          threadId: `t${id}`,
+          eagerSummarize: true,
+          messages: [{ role: "user", content: "x" } as any],
+        }),
+    );
+
+    // The thread passed to runPrompt must be a fresh standalone
+    // MessageThread, not the closing thread or the default active
+    // thread. Both would cause the summarizer prompt to pollute the
+    // user's conversation history.
+    const passedThread = spy.mock.calls[0][0].messages as MessageThread;
+    expect(passedThread).toBeInstanceOf(MessageThread);
+    expect(passedThread).not.toBe(threads.get(id));
+    expect(passedThread).not.toBe(threads.active());
+    expect(passedThread.messages.length).toBe(0);
+  });
+
+  it("no-ops when eagerSummarize is false", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const id = threads.create();
+    const spy = runPrompt as unknown as ReturnType<typeof vi.fn>;
+    spy.mockClear();
+
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      () =>
+        _eagerSummarizeIfNeeded({
+          threadId: `t${id}`,
+          eagerSummarize: false,
+          messages: [{ role: "user", content: "x" } as any],
+        }),
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(threads.get(id).summary).toBe(null);
+  });
+
+  it("no-ops when messages is empty", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const id = threads.create();
+    const spy = runPrompt as unknown as ReturnType<typeof vi.fn>;
+    spy.mockClear();
+
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      () =>
+        _eagerSummarizeIfNeeded({
+          threadId: `t${id}`,
+          eagerSummarize: true,
+          messages: [],
+        }),
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(threads.get(id).summary).toBe(null);
+  });
+
+  it("no-ops when the thread already has a summary (idempotency / cost guard)", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const id = threads.create();
+    threads.get(id).summary = "already-set";
+    const spy = runPrompt as unknown as ReturnType<typeof vi.fn>;
+    spy.mockClear();
+
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      () =>
+        _eagerSummarizeIfNeeded({
+          threadId: `t${id}`,
+          eagerSummarize: true,
+          messages: [{ role: "user", content: "x" } as any],
+        }),
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(threads.get(id).summary).toBe("already-set");
+  });
+
+  it("swallows LLM errors silently (best-effort)", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const id = threads.create();
+    const spy = runPrompt as unknown as ReturnType<typeof vi.fn>;
+    spy.mockClear();
+    spy.mockRejectedValueOnce(new Error("boom"));
+
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      () =>
+        // Should NOT throw — the eager hook must never propagate
+        // its errors up to the caller's `Runner.thread` finally
+        // block (it would mask the user's real exception).
+        expect(
+          _eagerSummarizeIfNeeded({
+            threadId: `t${id}`,
+            eagerSummarize: true,
+            messages: [{ role: "user", content: "x" } as any],
+          }),
+        ).resolves.toBeUndefined(),
+    );
+
+    expect(threads.get(id).summary).toBe(null);
+  });
+
+  it("tolerates non-canonical (non-slug) thread ids by passing them through", async () => {
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    // Explicitly use a non-slug id to verify the same /^t\d+$/
+    // tightening other helpers do.
+    threads.threads["custom-id"] = new MessageThread();
+    const spy = runPrompt as unknown as ReturnType<typeof vi.fn>;
+    spy.mockClear();
+
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      () =>
+        _eagerSummarizeIfNeeded({
+          threadId: "custom-id",
+          eagerSummarize: true,
+          messages: [{ role: "user", content: "x" } as any],
+        }),
+    );
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(threads.threads["custom-id"].summary).toBe("spy-summary");
+  });
+});

--- a/packages/agency-lang/lib/stdlib/threads.test.ts
+++ b/packages/agency-lang/lib/stdlib/threads.test.ts
@@ -153,13 +153,45 @@ describe("_eagerSummarizeIfNeeded", () => {
     expect(threads.get(id).summary).toBe("already-set");
   });
 
-  it("swallows LLM errors silently (best-effort)", async () => {
+  it("respects an explicit empty-string summary as 'already cached'", async () => {
+    // Regression: `if (thread.summary)` would treat `""` as falsy
+    // and re-summarize, silently overwriting an intentional empty
+    // marker (and burning an LLM call). The check is now
+    // `thread.summary != null` so any non-null string wins.
+    const ctx = makeCtx();
+    const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
+    const id = threads.create();
+    threads.get(id).summary = "";
+    const spy = runPrompt as unknown as ReturnType<typeof vi.fn>;
+    spy.mockClear();
+
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads },
+      () =>
+        _eagerSummarizeIfNeeded({
+          threadId: `t${id}`,
+          eagerSummarize: true,
+          messages: [{ role: "user", content: "x" } as any],
+        }),
+    );
+
+    expect(spy).not.toHaveBeenCalled();
+    expect(threads.get(id).summary).toBe("");
+  });
+
+  it("swallows LLM errors and reports them via statelog (best-effort)", async () => {
     const ctx = makeCtx();
     const threads = ThreadStore.withDefaultActive(ctx.statelogClient);
     const id = threads.create();
     const spy = runPrompt as unknown as ReturnType<typeof vi.fn>;
     spy.mockClear();
     spy.mockRejectedValueOnce(new Error("boom"));
+    // Spy on the statelog reporter to verify the failure is
+    // surfaced, not silently dropped.
+    const statelogSpy = vi.fn();
+    ctx.statelogClient = {
+      threadEndHookError: statelogSpy,
+    } as any;
 
     await agency.withTestContext(
       { ctx, stack: ctx.stateStack, threads },
@@ -177,6 +209,10 @@ describe("_eagerSummarizeIfNeeded", () => {
     );
 
     expect(threads.get(id).summary).toBe(null);
+    expect(statelogSpy).toHaveBeenCalledWith({
+      threadId: `t${id}`,
+      error: "boom",
+    });
   });
 
   it("tolerates non-canonical (non-slug) thread ids by passing them through", async () => {

--- a/packages/agency-lang/lib/stdlib/threads.ts
+++ b/packages/agency-lang/lib/stdlib/threads.ts
@@ -28,6 +28,20 @@ import * as smoltalk from "smoltalk";
 import { agency, type ThreadInfoTS } from "../runtime/agency.js";
 import { registerGlobalHook } from "../runtime/hooks.js";
 import { MessageThread } from "../runtime/state/messageThread.js";
+import { createLogger } from "../logger.js";
+
+/** Coerce a `smoltalk` message's `content` to a flat string. Non-string
+ *  content (tool-call / structured) is JSON-stringified; nullish
+ *  content (common on tool-call assistant messages where the LLM
+ *  emitted tool calls but no text) maps to `""` instead of the literal
+ *  JSON-encoded `'""'`. Shared by `_getThread` (the Agency-facing
+ *  reader) and `_buildSummaryTranscript` (the eager summarizer
+ *  prompt) so both surfaces agree on the same coercion rule. */
+function _contentToString(content: smoltalk.MessageJSON["content"]): string {
+  if (typeof content === "string") return content;
+  if (content == null) return "";
+  return JSON.stringify(content);
+}
 
 /** Pass-through to `agency.threads.list()`. */
 export function _listThreadsRaw(): ThreadInfoTS[] {
@@ -50,16 +64,7 @@ export function _getThread(
   const raw = agency.threads.get(id, offset, limit);
   return raw.map((m) => ({
     role: String(m.role),
-    // Coerce non-string content to a flat string for the Agency
-    // surface. Nullish content (common on tool-call assistant
-    // messages where the LLM emitted tool calls but no text) maps
-    // to "" instead of the literal JSON-encoded `'""'`.
-    content:
-      typeof m.content === "string"
-        ? m.content
-        : m.content == null
-          ? ""
-          : JSON.stringify(m.content),
+    content: _contentToString(m.content),
   }));
 }
 
@@ -106,13 +111,7 @@ const _summarySchema = z.object({ summary: z.string() });
 function _buildSummaryTranscript(messages: smoltalk.MessageJSON[]): string {
   let transcript = "";
   for (const m of messages) {
-    const content =
-      typeof m.content === "string"
-        ? m.content
-        : m.content == null
-          ? ""
-          : JSON.stringify(m.content);
-    transcript += `[${String(m.role)}] ${content}\n`;
+    transcript += `[${String(m.role)}] ${_contentToString(m.content)}\n`;
   }
   return transcript;
 }
@@ -126,11 +125,13 @@ function _buildSummaryTranscript(messages: smoltalk.MessageJSON[]): string {
  *  Mirrors what `thread(hidden: true) { llm(...) }` would do in
  *  Agency-land.
  *
- *  All errors are swallowed — eager summarize is a performance
- *  optimization, not a correctness path. If the call fails (no LLM
- *  client, network error, missing API key), the next
+ *  Errors never propagate to the caller — eager summarize is a
+ *  performance optimization, not a correctness path. If the call
+ *  fails (no LLM client, network error, missing API key), the next
  *  `listThreads()` falls back to the lazy summarize path which
- *  surfaces a clean error path through `try _listThreadsRaw()`. */
+ *  surfaces a clean error path through `try _listThreadsRaw()`.
+ *  Failures are still recorded via `logger.debug` and the
+ *  `threadEndHookError` statelog event so they're observable. */
 export async function _eagerSummarizeIfNeeded(evt: {
   threadId: string;
   eagerSummarize: boolean;
@@ -147,7 +148,11 @@ export async function _eagerSummarizeIfNeeded(evt: {
     : evt.threadId;
   const thread = store.threads[rawId];
   if (!thread) return;
-  if (thread.summary) return;
+  // Idempotency: any non-null cached summary (including an empty
+  // string explicitly set by an earlier path) wins — re-summarizing
+  // wastes an LLM call and would silently overwrite an intentional
+  // empty marker.
+  if (thread.summary != null) return;
 
   try {
     const transcript = _buildSummaryTranscript(evt.messages);
@@ -163,8 +168,23 @@ export async function _eagerSummarizeIfNeeded(evt: {
       },
     );
     _setThreadSummary(evt.threadId, result.summary);
-  } catch {
+  } catch (e) {
     // Best-effort — lazy summarize will retry on next listThreads().
+    // Surface the failure two ways: a `logger.debug` line for local
+    // troubleshooting (gated on the runtime's `logLevel` so the
+    // default `info` level still stays silent) and a structured
+    // `threadEndHookError` statelog event so production traces show
+    // it. Mirrors the belt-and-braces failure-reporting pattern in
+    // `Runner.thread`'s finally block.
+    const message = e instanceof Error ? e.message : String(e);
+    const ctx = agency.ctxMaybe();
+    createLogger(ctx?.logLevel ?? "info").debug(
+      `eager summarize failed for thread ${evt.threadId}: ${message}`,
+    );
+    ctx?.statelogClient?.threadEndHookError?.({
+      threadId: evt.threadId,
+      error: message,
+    });
   }
 }
 

--- a/packages/agency-lang/lib/stdlib/threads.ts
+++ b/packages/agency-lang/lib/stdlib/threads.ts
@@ -11,10 +11,23 @@
  * single TS-side writer Agency uses to record a freshly-computed
  * summary; the rest is read-through from `agency.threads.list()`.
  *
+ * Eager summarize wiring: this module registers a global
+ * `onThreadEnd` hook (see below) so that any `thread(summarize: true)
+ * { ... }` block triggers a one-shot LLM summarize call at close
+ * time and stashes the result on the underlying `MessageThread`.
+ * Lazy summarize (the on-demand path in `summaryFor()` inside
+ * `stdlib/threads.agency`) still runs for threads that did NOT opt
+ * in eagerly. Importing `std::threads` from Agency code triggers
+ * this module's load, which registers the hook.
+ *
  * Naming follows stdlib conventions: every export is `_`-prefixed and
  * reads its runtime context from AsyncLocalStorage via `agency.*`.
  */
+import { z } from "zod";
+import * as smoltalk from "smoltalk";
 import { agency, type ThreadInfoTS } from "../runtime/agency.js";
+import { registerGlobalHook } from "../runtime/hooks.js";
+import { MessageThread } from "../runtime/state/messageThread.js";
 
 /** Pass-through to `agency.threads.list()`. */
 export function _listThreadsRaw(): ThreadInfoTS[] {
@@ -71,3 +84,88 @@ export function _setThreadSummary(id: string, summary: string): void {
   if (!thread) return;
   thread.summary = summary;
 }
+
+// ── Eager summarize hook ──────────────────────────────────────────
+//
+// Mirrors the Agency-side `summarize()` def in `stdlib/threads.agency`
+// but lives in TS so the global onThreadEnd hook can invoke it
+// directly without needing to look up an Agency function reference.
+//
+// Why TS: top-level `callback("onThreadEnd")` in an Agency module
+// only fires when the module is the entry-point of the run (see the
+// regression test at `tests/agency-js/threads-fix-callback-propagation`).
+// A global TS hook bypasses that, so any program that imports
+// `std::threads` gets eager summarize for free.
+
+const _summarySchema = z.object({ summary: z.string() });
+
+/** Build the transcript string used by both the lazy and eager
+ *  summarize prompts. Keeps the shape symmetric with the Agency-side
+ *  `summarize()` def. Non-string content gets coerced the same way
+ *  `_getThread()` does to keep the prompt deterministic. */
+function _buildSummaryTranscript(messages: smoltalk.MessageJSON[]): string {
+  let transcript = "";
+  for (const m of messages) {
+    const content =
+      typeof m.content === "string"
+        ? m.content
+        : m.content == null
+          ? ""
+          : JSON.stringify(m.content);
+    transcript += `[${String(m.role)}] ${content}\n`;
+  }
+  return transcript;
+}
+
+/** Best-effort summarize at thread close. Mirrors the Agency-side
+ *  `summarize()` prompt + structured-output shape so eager and lazy
+ *  paths produce comparable summaries. Uses an ephemeral standalone
+ *  `MessageThread` (NOT registered with the active `ThreadStore`)
+ *  for the LLM call so the summarizer prompt doesn't pollute the
+ *  agent's main conversation and doesn't show up in `listThreads()`.
+ *  Mirrors what `thread(hidden: true) { llm(...) }` would do in
+ *  Agency-land.
+ *
+ *  All errors are swallowed — eager summarize is a performance
+ *  optimization, not a correctness path. If the call fails (no LLM
+ *  client, network error, missing API key), the next
+ *  `listThreads()` falls back to the lazy summarize path which
+ *  surfaces a clean error path through `try _listThreadsRaw()`. */
+export async function _eagerSummarizeIfNeeded(evt: {
+  threadId: string;
+  eagerSummarize: boolean;
+  messages: smoltalk.MessageJSON[];
+}): Promise<void> {
+  if (!evt.eagerSummarize) return;
+  if (!evt.messages || evt.messages.length === 0) return;
+  // Skip if a summary is already present (e.g. set by lazy path
+  // earlier in the same run). Re-summarizing would waste cost.
+  const store = agency.thread.storeMaybe();
+  if (!store) return;
+  const rawId = /^t\d+$/.test(evt.threadId)
+    ? evt.threadId.slice(1)
+    : evt.threadId;
+  const thread = store.threads[rawId];
+  if (!thread) return;
+  if (thread.summary) return;
+
+  try {
+    const transcript = _buildSummaryTranscript(evt.messages);
+    const result = await agency.llm(
+      `Summarize this conversation in 1-2 sentences:\n${transcript}`,
+      {
+        schema: _summarySchema,
+        // Standalone MessageThread — not in the active ThreadStore,
+        // so listThreads() never sees the summarizer prompt. Same
+        // isolation guarantee as `thread(hidden: true) { ... }` on
+        // the Agency side.
+        thread: new MessageThread(),
+      },
+    );
+    _setThreadSummary(evt.threadId, result.summary);
+  } catch {
+    // Best-effort — lazy summarize will retry on next listThreads().
+  }
+}
+
+registerGlobalHook("onThreadEnd", _eagerSummarizeIfNeeded);

--- a/packages/agency-lang/stdlib/threads.agency
+++ b/packages/agency-lang/stdlib/threads.agency
@@ -24,9 +24,13 @@ existing checkpoint serialization.
 
 The eager-summarize flag (`thread(summarize: true) { ... }`) is
 parsed and forwarded to the `onThreadEnd` hook payload as
-`eagerSummarize: true`, but the v1 stdlib does not yet act on it —
-summaries are computed lazily on the next `listThreads()` call. See
-the TODO in `lib/runtime/runner.ts::thread` for the deferral.
+`eagerSummarize: true`. A global TS-side `onThreadEnd` hook
+registered in `lib/stdlib/threads.ts` consumes the payload and
+triggers a one-shot LLM summarize at close time, stashing the
+result on the underlying `MessageThread`. Threads that did NOT opt
+in eagerly fall back to the lazy summarize path in `summaryFor()`
+below, which runs on the first `listThreads()` call against a
+closed thread.
 */
 
 import {
@@ -100,12 +104,16 @@ export def listThreads(): Result {
   """
   Return every thread in the current run, including the active one.
 
-  Lazy summary generation: a thread that doesn't yet have a cached
-  summary triggers exactly one LLM round-trip the first time
-  `listThreads()` is called on it. Active threads are skipped so the
-  in-flight conversation is not summarized mid-stream. The computed
-  summary is stashed on the underlying `MessageThread` so subsequent
-  calls read it back without re-prompting.
+  Summary generation: threads opened with `thread(summarize: true)`
+  are summarized eagerly when they close (see the global onThreadEnd
+  hook in `lib/stdlib/threads.ts`), so their summary is already
+  cached by the time `listThreads()` runs. Threads that did NOT opt
+  in eagerly trigger exactly one LLM round-trip the first time
+  `listThreads()` is called on them. Active threads are skipped on
+  both paths so the in-flight conversation is not summarized
+  mid-stream. The computed summary is stashed on the underlying
+  `MessageThread` so subsequent calls read it back without
+  re-prompting.
 
   Returns a `Result` — success holds `ThreadInfo[]`, failure holds
   the error (e.g. called outside an Agency frame). See

--- a/packages/agency-lang/stdlib/threads.agency
+++ b/packages/agency-lang/stdlib/threads.agency
@@ -100,7 +100,7 @@ def summaryFor(id: string, existing: (string | null), messages: (ThreadMessage[]
   return s
 }
 
-export def listThreads(): Result {
+export def listThreads(lazySummarize: boolean = true): Result {
   """
   Return every thread in the current run, including the active one.
 
@@ -109,15 +109,27 @@ export def listThreads(): Result {
   hook in `lib/stdlib/threads.ts`), so their summary is already
   cached by the time `listThreads()` runs. Threads that did NOT opt
   in eagerly trigger exactly one LLM round-trip the first time
-  `listThreads()` is called on them. Active threads are skipped on
-  both paths so the in-flight conversation is not summarized
-  mid-stream. The computed summary is stashed on the underlying
-  `MessageThread` so subsequent calls read it back without
-  re-prompting.
+  `listThreads()` is called on them (the "lazy" path). Active
+  threads are skipped on both paths so the in-flight conversation
+  is not summarized mid-stream. The computed summary is stashed on
+  the underlying `MessageThread` so subsequent calls read it back
+  without re-prompting.
+
+  Pass `lazySummarize: false` to skip the on-demand LLM round-trip
+  entirely. Threads without a cached summary fall back to their
+  label (or `""` if no label is set), so the call stays free even
+  when no eager summary is available. Useful in tests and in
+  performance-sensitive surfaces where you'd rather see "no summary
+  yet" than pay for one synchronously.
 
   Returns a `Result` — success holds `ThreadInfo[]`, failure holds
   the error (e.g. called outside an Agency frame). See
   [error handling](https://agency-lang.com/guide/error-handling).
+
+  @param lazySummarize - When true (default), generate summaries
+                         on-demand for any thread that doesn't have
+                         one cached. When false, fall back to the
+                         label (or `""`).
   """
   const raw = try _listThreadsRaw()
   if (isFailure(raw)) {
@@ -125,11 +137,25 @@ export def listThreads(): Result {
   }
   const out: ThreadInfo[] = []
   for (t in raw.value) {
-    let messages: (ThreadMessage[] | null) = null
-    if (t.isActive == false) {
-      messages = t.messages
+    let summary: (string | null) = null
+    if (lazySummarize) {
+      let messages: (ThreadMessage[] | null) = null
+      if (t.isActive == false) {
+        messages = t.messages
+      }
+      summary = summaryFor(t.id, t.summary, messages)
+    } else {
+      // No LLM round-trip — return whatever is cached, falling
+      // back to the label (or "" if unlabeled) so the field is
+      // always populated.
+      if (t.summary != null) {
+        summary = t.summary
+      } else if (t.label != null) {
+        summary = t.label
+      } else {
+        summary = ""
+      }
     }
-    const summary = summaryFor(t.id, t.summary, messages)
     out.push({
       id: t.id,
       label: t.label,

--- a/packages/agency-lang/stdlib/threads.agency
+++ b/packages/agency-lang/stdlib/threads.agency
@@ -82,20 +82,16 @@ def summarize(messages: ThreadMessage[]): string {
 }
 
 // Single owner of the "return cached summary, else LLM-summarize and
-// cache" rule. Active threads pass `null` so the LLM call is skipped
-// while the conversation is still in flight.
-def summaryFor(id: string, existing: (string | null), messages: (ThreadMessage[] | null) = null): (string | null) {
+// cache" rule. Callers must skip the call for active threads
+// themselves (the in-flight conversation should not be summarized
+// mid-stream); accepting only a non-nullable `messages` keeps the
+// type signature honest and avoids a flow-narrowing warning Agency's
+// typechecker can't currently prove.
+def summaryFor(id: string, existing: (string | null), messages: ThreadMessage[]): (string | null) {
   if (existing != null) {
     return existing
   }
-  if (messages == null) {
-    return null
-  }
-  // Narrow: messages is non-null at this point. Re-bind via a
-  // `const` of the non-null variant so the typechecker's flow
-  // analysis sees a `ThreadMessage[]` for the summarize() call.
-  const concrete: ThreadMessage[] = messages
-  const s = summarize(concrete)
+  const s = summarize(messages)
   _setThreadSummary(id, s)
   return s
 }
@@ -139,11 +135,14 @@ export def listThreads(lazySummarize: boolean = true): Result {
   for (t in raw.value) {
     let summary: (string | null) = null
     if (lazySummarize) {
-      let messages: (ThreadMessage[] | null) = null
-      if (t.isActive == false) {
-        messages = t.messages
+      // Active threads are skipped — the in-flight conversation
+      // should not be summarized mid-stream. Closed threads with no
+      // cached summary trigger a one-shot summarize via summaryFor().
+      if (t.isActive) {
+        summary = t.summary
+      } else {
+        summary = summaryFor(t.id, t.summary, t.messages)
       }
-      summary = summaryFor(t.id, t.summary, messages)
     } else {
       // No LLM round-trip — return whatever is cached, falling
       // back to the label (or "" if unlabeled) so the field is

--- a/packages/agency-lang/tests/agency/threads-registry/eager-summarize.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/eager-summarize.agency
@@ -3,16 +3,21 @@ import { userMessage } from "std::thread"
 
 // Verifies that `thread(summarize: true) { ... }` populates
 // MessageThread.summary at close time via the TS-side onThreadEnd
-// hook in lib/stdlib/threads.ts. Once the hook has run, `listThreads`
-// reads the cached summary without triggering the lazy
-// summarize-on-demand path.
+// hook in lib/stdlib/threads.ts.
 //
-// The first thread opts into eager summarize; the second does not.
-// Both LLM mocks below are consumed (one eager, one lazy at the
-// listThreads call), so the relative ordering of mock entries is
-// the actual contract test:
-//   - mock[0] is consumed at close-time of the eager thread
-//   - mock[1] is consumed inside listThreads() for the lazy thread
+// `lazySummarize: false` is the key: it disables the on-demand
+// summarize fallback inside listThreads(), so the ONLY way a thread
+// ends up with a cached LLM-generated summary is via the eager hook
+// firing at close. Threads without a cached summary fall back to
+// their label (or "") and consume no LLM mocks. We provide exactly
+// one LLM mock — the eager hook is the only consumer.
+//
+// Test outcomes:
+//   - working eager hook: "eager" thread.summary = "eager-summary"
+//                         "lazy"  thread.summary = "lazy"      (label fallback)
+//   - broken eager hook: "eager" thread.summary = "eager"      (label fallback)
+//                        "lazy"  thread.summary = "lazy"       (label fallback)
+//                        the single LLM mock is never consumed.
 node main() {
   thread(label: "eager", summarize: true) {
     userMessage("eager body")
@@ -20,14 +25,18 @@ node main() {
   thread(label: "lazy") {
     userMessage("lazy body")
   }
-  const all = listThreads()
-  const summaries: string[] = []
+  const all = listThreads(lazySummarize: false)
+  // Build "<label>=<summary>" pairs for every labeled thread. The
+  // active main thread is unlabeled and gets skipped. Sorted so
+  // mock-mode iteration order doesn't make the test brittle.
+  const pairs: string[] = []
   if (isSuccess(all)) {
     for (t in all.value) {
-      if (t.summary != null) {
-        summaries.push(t.summary)
+      if (t.label != null && t.summary != null) {
+        pairs.push(t.label + "=" + t.summary)
       }
     }
   }
-  return summaries
+  pairs.sort()
+  return pairs
 }

--- a/packages/agency-lang/tests/agency/threads-registry/eager-summarize.agency
+++ b/packages/agency-lang/tests/agency/threads-registry/eager-summarize.agency
@@ -1,0 +1,33 @@
+import { listThreads } from "std::threads"
+import { userMessage } from "std::thread"
+
+// Verifies that `thread(summarize: true) { ... }` populates
+// MessageThread.summary at close time via the TS-side onThreadEnd
+// hook in lib/stdlib/threads.ts. Once the hook has run, `listThreads`
+// reads the cached summary without triggering the lazy
+// summarize-on-demand path.
+//
+// The first thread opts into eager summarize; the second does not.
+// Both LLM mocks below are consumed (one eager, one lazy at the
+// listThreads call), so the relative ordering of mock entries is
+// the actual contract test:
+//   - mock[0] is consumed at close-time of the eager thread
+//   - mock[1] is consumed inside listThreads() for the lazy thread
+node main() {
+  thread(label: "eager", summarize: true) {
+    userMessage("eager body")
+  }
+  thread(label: "lazy") {
+    userMessage("lazy body")
+  }
+  const all = listThreads()
+  const summaries: string[] = []
+  if (isSuccess(all)) {
+    for (t in all.value) {
+      if (t.summary != null) {
+        summaries.push(t.summary)
+      }
+    }
+  }
+  return summaries
+}

--- a/packages/agency-lang/tests/agency/threads-registry/eager-summarize.test.json
+++ b/packages/agency-lang/tests/agency/threads-registry/eager-summarize.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "[\"eager-summary\",\"lazy-summary\"]",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "thread(summarize: true) populates MessageThread.summary at close via the TS-side onThreadEnd hook; the lazy path still fires for non-eager threads.",
+      "useTestLLMProvider": true,
+      "llmMocks": [
+        { "return": { "summary": "eager-summary" } },
+        { "return": { "summary": "lazy-summary" } }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/threads-registry/eager-summarize.test.json
+++ b/packages/agency-lang/tests/agency/threads-registry/eager-summarize.test.json
@@ -3,13 +3,12 @@
     {
       "nodeName": "main",
       "input": "",
-      "expectedOutput": "[\"eager-summary\",\"lazy-summary\"]",
+      "expectedOutput": "[\"eager=eager-summary\",\"lazy=lazy\"]",
       "evaluationCriteria": [{ "type": "exact" }],
-      "description": "thread(summarize: true) populates MessageThread.summary at close via the TS-side onThreadEnd hook; the lazy path still fires for non-eager threads.",
+      "description": "thread(summarize: true) populates MessageThread.summary at close via the TS-side onThreadEnd hook. listThreads(lazySummarize: false) disables the on-demand summarizer so the only LLM mock can only be consumed by the eager hook — a broken hook would leave the eager thread falling back to its label and produce [\"eager=eager\",\"lazy=lazy\"] instead.",
       "useTestLLMProvider": true,
       "llmMocks": [
-        { "return": { "summary": "eager-summary" } },
-        { "return": { "summary": "lazy-summary" } }
+        { "return": { "summary": "eager-summary" } }
       ]
     }
   ]


### PR DESCRIPTION
Wires `thread(summarize: true) { ... }` end-to-end. Until now the
`eagerSummarize: true` payload on `onThreadEnd` was emitted by
`Runner.thread` but nothing consumed it; summaries were always
computed lazily on the first `listThreads()` call.

## What changed

- **`lib/stdlib/threads.ts`** — registers a global `onThreadEnd` hook
  (`_eagerSummarizeIfNeeded`) that fires a one-shot summarize LLM
  call on a standalone `MessageThread` (so the summarizer prompt
  does not pollute the closed thread or the active thread) and
  writes the result back via `_setThreadSummary`. Errors are
  swallowed — the lazy `summaryFor()` path in
  `stdlib/threads.agency` is the correctness fallback.
- **Why a TS-side hook (not Agency-side)** — a top-level
  `callback("onThreadEnd")` inside an Agency stdlib module only
  fires when that module is the run entry-point (see the regression
  test at `tests/agency-js/threads-fix-callback-propagation`). A
  global TS hook bypasses that, so any program that imports
  `std::threads` gets eager summarize for free.
- **`stdlib/threads.agency`** — module docstring and
  `listThreads()` docstring rewritten to describe the actual
  eager-vs-lazy behaviour instead of the prior "v1 stdlib does not
  yet act on it" placeholder.

## Tests

- `lib/stdlib/threads.test.ts` — focused unit coverage for the hook
  (mocks `runPrompt`): writes summary on success, uses a standalone
  `MessageThread`, no-ops on `eagerSummarize:false` / empty messages
  / already-summarized threads, swallows LLM errors, tolerates
  non-canonical (non-slug) thread ids.
- `tests/agency/threads-registry/eager-summarize.agency` — end-to-end
  integration test that `thread(summarize: true)` populates the
  cache at close while a sibling `thread { ... }` block still goes
  through the lazy path on the next `listThreads()`.

## Verification

- `pnpm vitest run lib/stdlib/threads.test.ts` → 7/7 pass.
- `pnpm run agency test tests/agency/threads-registry/eager-summarize.agency` → 1/1 pass.
- `make` builds cleanly (stdlib regen + docs regen).

## Follow-up

Unblocks the multi-thread refactor of `lib/agents/agency-agent/agent.agency`
(see `docs/superpowers/plans/2026-05-29-agency-agent-multi-thread.md`),
which relies on `thread(session: ..., summarize: true)` for snappy
`/sessions` output.
