### PR TITLE
tests: fix CI debugger test + stale agency-js fixtures after thread-registry merge

### DIFF
--- a/packages/agency-lang/tests/agency-js/default-messages/with-thread/no-root-messages/fixture.json
+++ b/packages/agency-lang/tests/agency-js/default-messages/with-thread/no-root-messages/fixture.json
@@ -2,7 +2,11 @@
   "messages": {
     "threads": {
       "0": {
-        "messages": []
+        "messages": [],
+        "parentId": null,
+        "hidden": false,
+        "label": null,
+        "summary": null
       },
       "1": {
         "messages": [
@@ -22,12 +26,17 @@
             "role": "assistant",
             "content": "{\"response\":[13,17]}"
           }
-        ]
+        ],
+        "parentId": null,
+        "hidden": false,
+        "label": null,
+        "summary": null
       }
     },
     "counter": 2,
     "activeStack": [
       "0"
-    ]
+    ],
+    "sessions": {}
   }
 }

--- a/packages/agency-lang/tests/agency-js/default-messages/with-thread/with-root-messages/fixture.json
+++ b/packages/agency-lang/tests/agency-js/default-messages/with-thread/with-root-messages/fixture.json
@@ -19,7 +19,11 @@
             "role": "assistant",
             "content": "{\"response\":6}"
           }
-        ]
+        ],
+        "parentId": null,
+        "hidden": false,
+        "label": null,
+        "summary": null
       },
       "1": {
         "messages": [
@@ -39,12 +43,17 @@
             "role": "assistant",
             "content": "{\"response\":[13,17]}"
           }
-        ]
+        ],
+        "parentId": null,
+        "hidden": false,
+        "label": null,
+        "summary": null
       }
     },
     "counter": 2,
     "activeStack": [
       "0"
-    ]
+    ],
+    "sessions": {}
   }
 }

--- a/packages/agency-lang/tests/agency-js/stdlib-thread-messages/fixture.json
+++ b/packages/agency-lang/tests/agency-js/stdlib-thread-messages/fixture.json
@@ -32,12 +32,17 @@
             "role": "assistant",
             "content": "second-answer"
           }
-        ]
+        ],
+        "parentId": null,
+        "hidden": false,
+        "label": null,
+        "summary": null
       }
     },
     "counter": 1,
     "activeStack": [
       "0"
-    ]
+    ],
+    "sessions": {}
   }
 }

--- a/packages/agency-lang/tests/debugger/thread-test.agency
+++ b/packages/agency-lang/tests/debugger/thread-test.agency
@@ -2,10 +2,13 @@ node main() {
   thread {
     capital = llm("What is the capital of France?")
     population: { capital: string; pop: number } = llm("And what is its population?")
+    // Trailing no-op step INSIDE the thread block so the debugger
+    // renders one more checkpoint while the thread is still active
+    // (with 4 messages from both llm calls). Without this, the next
+    // checkpoint after the second llm fires is at `done = true`
+    // outside the thread block, where popActive has already
+    // swapped the active thread back to the outer one — and the
+    // "4 messages" state is never observable from a render call.
+    done = true
   }
-  // Trailing step so the debugger renders one more checkpoint after the
-  // second llm call completes — without it, the thread state with 4
-  // messages is never observable from a render call (debug steps fire
-  // before the callback executes).
-  done = true
 }


### PR DESCRIPTION
Fixes the two CI failures on `main` that surfaced after the thread-registry merge (the typechecker warning was fixed in #226):

## 1. `lib/debugger/thread.test.ts` — "shows thread messages after each LLM call"

The test asserts that some debugger render captures the active thread holding 4 messages (after both `llm()` calls inside the `thread { ... }` block). The trailing `done = true` step was placed *outside* the thread block, but by the time the debugger fires that checkpoint `Runner.thread`'s `finally` block has already called `popActive()` — so the active thread has reverted to the outer one and the "4 messages" state was never observable from any render.

**Fix:** moved `done = true` inside the thread block. The trailing-step checkpoint now fires while the just-completed thread is still active. Reproduced + verified locally:

```
✓ lib/debugger/thread.test.ts (1 test) 534ms
    ✓ shows thread messages after each LLM call  473ms
```

### Why this only started failing now

I checked the same test at `fc852f76^` (pre-merge) and it also failed — but at the *first* assertion (`twoMessages`), because pre-merge the debugger never even stepped *into* the thread block (the locations stayed at `main#1` for all 21 commands). The thread-registry merge fixed the stepping behaviour for thread bodies and brought the test closer to passing, but exposed the always-broken second assertion. Moving `done = true` inside the block is the minimal fix.

## 2. Three `tests/agency-js/*` fixture mismatches

The thread-registry merge added new fields to `MessageThread.toJSON()` (`parentId`, `hidden`, `label`, `summary`) and `ThreadStore.toJSON()` (`sessions`). The serialization is what the agency-js fixtures pin, but three fixtures were never regenerated:

- [tests/agency-js/default-messages/with-thread/no-root-messages/fixture.json](file:///Users/adityabhargava/agency-lang/packages/agency-lang/tests/agency-js/default-messages/with-thread/no-root-messages/fixture.json)
- [tests/agency-js/default-messages/with-thread/with-root-messages/fixture.json](file:///Users/adityabhargava/agency-lang/packages/agency-lang/tests/agency-js/default-messages/with-thread/with-root-messages/fixture.json)
- [tests/agency-js/stdlib-thread-messages/fixture.json](file:///Users/adityabhargava/agency-lang/packages/agency-lang/tests/agency-js/stdlib-thread-messages/fixture.json)

**Fix:** copied each test's `__result.json` (the actual run output that the gitignored runner already wrote on the failing run) onto `fixture.json`. The diff is purely the new default values:

```diff
-        ]
+        ],
+        "parentId": null,
+        "hidden": false,
+        "label": null,
+        "summary": null
       }
     },
     "counter": 1,
     "activeStack": ["0"],
+    "sessions": {}
   }
```

No user-visible behaviour change — these fixtures just pin the new serialization shape so future regressions catch accidental field-removal.

## Verification

```
✓ lib/debugger/thread.test.ts (1 test) — passing
✓ tests/agency-js/default-messages/with-thread/no-root-messages — passing
✓ tests/agency-js/default-messages/with-thread/with-root-messages — passing
✓ tests/agency-js/stdlib-thread-messages — passing
```
