### PR TITLE
agency-agent: split into code + research subagents with handoff routing

### DIFF
--- a/packages/agency-lang/docs/superpowers/ideas/2026-05-30-routing-stickiness.md
+++ b/packages/agency-lang/docs/superpowers/ideas/2026-05-30-routing-stickiness.md
@@ -1,0 +1,251 @@
+# Routing-Stickiness for Multi-Thread Agents
+
+## The Problem
+
+When an agent splits a conversation across per-category subagents (e.g. the
+agency-agent's `code` / `research` split — see
+`docs/superpowers/plans/2026-05-29-agency-agent-multi-thread.md`), every new
+user message has to be routed to one of the subagents. A naïve `categorize()`
+LLM call routes message-by-message in isolation, which produces a bad UX:
+
+1. User starts a coding session — routed to `code` ✓
+2. User's third message is ambiguous ("can you make it faster?") — categorize
+   returns `research` ✗
+3. The `research` subagent has none of the conversation context. It tries to
+   answer cold.
+4. User is confused: "why did the agent forget what we were doing?"
+
+The cost-asymmetry matters. A **false-stay** (we should have switched but
+didn't) is recoverable — the agent answers slightly off-topic, the user
+re-prompts. A **false-switch** is catastrophic — the new agent looks dumb,
+the user loses trust. So the design rule is: **strongly bias toward
+stay; only switch on high-confidence evidence of a category change**.
+
+This document collects all the routing-stickiness techniques we brainstormed.
+The v1 implementation in `lib/agents/agency-agent/` uses just one of them
+(let-the-current-agent-decide via `handoff()`), but the rest are worth trying
+in follow-ups to see which combination produces the best behavior.
+
+## The Techniques
+
+### 1. Sticky-default categorizer
+
+Save the previous category on the run. The categorizer prompt says: *"If
+you're not sure, return the previous category as the default."* The LLM is
+explicitly told to bias toward stay.
+
+- **Cost:** zero extra LLM calls.
+- **Implementation effort:** trivial — one extra field in the categorize
+  prompt + one local variable.
+- **Failure mode:** the LLM might ignore the "if unsure" instruction.
+  Models vary in how literally they take soft hints in prompts.
+
+### 2. Probability-distribution categorizer
+
+Don't ask for a single category. Ask for a probability for each category.
+If the top category's probability is above a threshold (say 0.7), switch;
+otherwise stay. The threshold encodes the bias-toward-stay tunably.
+
+- **Cost:** same number of LLM calls; slightly longer prompt.
+- **Implementation effort:** small — change `Category` return type to
+  `Record<Category, number>`, add threshold logic.
+- **Failure mode:** LLM-reported probabilities are notoriously
+  uncalibrated. A 0.9 from one model is not the same as 0.9 from
+  another. May need empirical tuning per model.
+
+### 3. Forked probability averaging
+
+Same as #2, but `fork` the same prompt N times (N=3 or 5) at temperature > 0
+and average the per-category probabilities. Reduces single-sample noise.
+
+- **Cost:** N× LLM calls per turn — significant.
+- **Implementation effort:** small — Agency already has `fork`/`race`
+  primitives.
+- **Failure mode:** N× cost for marginal accuracy gain in most cases.
+  Probably only worth it for ambiguous/borderline messages — could
+  combine with #2 (only fork when single-shot probability is in the
+  uncertain range).
+
+### 4. Parallel speculative execution
+
+When a new user message comes in, in parallel:
+- Send it to the *current* category's agent (speculatively assume stay).
+- Send it to the categorizer.
+
+When both return, check categorizer confidence + whether the current agent's
+reply looks like it answered the message well (a third LLM call could
+self-rate the answer). Decide post-hoc: keep the speculative answer, or
+discard it and route to the new category.
+
+- **Cost:** at least 2× LLM calls per turn (categorizer + speculative
+  agent); 3× if we add a self-rate. But latency is `max`, not `sum`,
+  since they run in parallel.
+- **Implementation effort:** moderate — coordinate two threads, decide
+  which to commit, drop the loser's thread or rewind it.
+- **Failure mode:** discarding the speculative answer wastes
+  significant compute. Mitigated by only speculating when prior turn
+  was confidently in the same category.
+
+### 5. Two-stage continuation classifier
+
+First ask a binary question: *"Is this message a continuation of the
+previous topic? yes/no."* Only on `no` do we ask the full categorizer.
+The binary question is much cheaper (smaller prompt, possibly a smaller
+model) and the LLM has a clearer task.
+
+- **Cost:** one extra cheap call on the common (stay) case; one extra
+  cheap call + the categorize call on the switch case. Net: cheaper than
+  always-categorize if stay >> switch (which is the whole premise).
+- **Implementation effort:** small — one new helper def.
+- **Failure mode:** "continuation" is itself ambiguous for ambiguous
+  messages. Pushes the same problem one level down.
+
+### 6. Let the current agent decide (handoff tool)
+
+Don't categorize on every turn. The current category's LLM gets the user
+message with a single tool: `handoff(category: Category, reason: string)`.
+If the agent thinks it can handle the message, it just answers. If clearly
+out of scope, it calls `handoff()` and the runtime closes the current
+thread + reroutes to the chosen category.
+
+- **Cost:** zero extra LLM calls on the common case (the answering call
+  *is* the routing decision). One extra call only on switch.
+- **Implementation effort:** small — register `handoff` as a tool;
+  detect tool-call result in the runtime loop and reroute. No
+  categorizer at all.
+- **Failure mode:** the agent has to *remember* the handoff tool is
+  there and use it appropriately. Depends on prompt quality. Models
+  prone to "I'll try my best" might rarely hand off.
+- **Why this is the v1 pick:** it's the simplest end-to-end design.
+  Categorization is implicit in the existing answering call. The agent
+  that knows the conversation context is the one that decides.
+
+### 7. Embedding similarity to recent context
+
+Embed the new message. Embed the last N messages of the current thread.
+Compute cosine similarity. If high (above threshold), stay without any
+categorizer call. If low, fall back to a categorizer.
+
+- **Cost:** two embedding calls per turn (cheap — embeddings are
+  ~free compared to chat completions). Categorizer only on misses.
+- **Implementation effort:** moderate — needs an embedding client
+  + threshold tuning + integration with the routing loop.
+- **Failure mode:** semantic similarity ≠ category similarity. A
+  message can be on-topic but use very different vocabulary, or
+  off-topic but use the same vocabulary ("write me a haiku about
+  Python" looks similar to a coding session).
+
+### 8. Hysteresis / sticky counter
+
+Only switch categories if the categorizer returns the same non-current
+category for K turns in a row (K=2 or 3). A single ambiguous
+categorization never causes a switch.
+
+- **Cost:** zero extra LLM calls.
+- **Implementation effort:** trivial — a counter on the run state.
+- **Failure mode:** introduces lag — a genuine category switch takes
+  K turns to actually happen. Bad UX if K is too large.
+
+### 9. Context-aware categorizer
+
+Pass the last N messages of the current category to the categorizer
+along with the new message. The categorizer sees "we've been talking
+about React for 5 turns" and naturally biases toward `code` for
+ambiguous follow-ups. No threshold tuning needed.
+
+- **Cost:** same number of LLM calls; longer prompt = more input
+  tokens.
+- **Implementation effort:** small — pass extra context into the
+  categorize prompt.
+- **Failure mode:** very long contexts can confuse smaller models;
+  may need summarization for long threads.
+
+### 10. Short-message bypass
+
+Heuristic: messages under ~5 words or pure acknowledgments ("yes",
+"more", "fix it", "go on", "what about errors?") always stay in the
+current category. No categorizer call.
+
+- **Cost:** zero LLM calls for bypassed messages.
+- **Implementation effort:** trivial — string-length check + a stop
+  list of common acknowledgments.
+- **Failure mode:** rare edge cases ("stop" might genuinely be a
+  reset). Easy to widen the stop list as patterns emerge.
+
+### 11. Few-shot in-session calibration
+
+The categorizer prompt includes the last K `(message, category)` pairs
+from this run. The LLM learns "this user's 'fix it' messages have all
+been `code` in this session". Per-session calibration without
+fine-tuning.
+
+- **Cost:** same number of LLM calls; longer prompt.
+- **Implementation effort:** small — record recent decisions, splice
+  into the prompt.
+- **Failure mode:** early in a session, K examples don't exist yet.
+  Falls back to standard categorization.
+
+## Auto-Context-Injection on Switch
+
+Even *correct* routing yields a context-less new agent. If the user
+genuinely switches from `code` to `research` mid-conversation, the
+`research` agent starts cold. The user can manually invoke
+`getThread`/`listThreads` to give it context, but that's extra friction.
+
+**The technique:** on first entry to a new category mid-run, automatically
+inject a one-line summary of the immediately-prior conversation. The new
+agent's first system message becomes something like:
+
+> *"The user was previously in the `code` thread working on
+> `/tmp/server.py`. Their new message routes here for research."*
+
+We already have the eager-summarize machinery (`stdlib/threads.agency`).
+The auto-injection is a small wrapper: when routing produces a switch,
+read the previous thread's cached summary, prepend it as context to the
+new thread's system message.
+
+- **Cost:** zero extra LLM calls (summary is already eagerly cached).
+- **Implementation effort:** small — one helper in the agent's REPL
+  loop.
+- **Failure mode:** summary may not be the *right* context. Better
+  than nothing.
+
+**Why this matters separately:** none of the routing techniques above
+can be 100% accurate. Even with perfect routing, the new agent still
+needs context. Auto-injection decouples routing accuracy from the
+context-loss penalty: a misroute becomes "agent answers from one
+sentence of summarized context" instead of "agent has nothing".
+
+## Recommended Stack
+
+For a future "best-effort" implementation that combines the cheap and
+clever techniques:
+
+- **#10 (short-message bypass)** as a free pre-filter — catches the
+  acknowledgment-continuation failure mode at zero cost.
+- **#8 (hysteresis, K=2)** — kills single-glitch misroutes for free.
+- **#7 (embedding similarity)** as the everyday gate — most turns
+  never even hit the categorizer.
+- **#9 (context-aware categorizer)** as the fallback when the cheap
+  filters say "uncertain".
+- **Auto-context-injection** on confirmed switches so misroutes are
+  recoverable.
+
+The v1 implementation picks #6 alone because it's the simplest
+end-to-end design and exercises the full thread-switching machinery
+without any of the surrounding scaffolding.
+
+## Open Questions for Empirical Work
+
+- Which technique (or stack) produces the highest user-perceived
+  conversation continuity? We need a test harness: a corpus of
+  multi-turn conversations with ground-truth category labels per
+  turn, scored on (a) correct routing rate and (b) catastrophic
+  misroute rate (the "agent lost context" failure mode).
+- Are the cost/quality trade-offs model-dependent? A bigger model
+  might handle #6 (handoff tool) so well that the extra cheap
+  filters don't help.
+- Does #11 (in-session calibration) actually learn from K=3 or K=5
+  examples, or does it need K=20+?
+- For #2 (probability distribution), what's the right threshold? Is
+  there a single answer or does it depend on the category set size?

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -1,37 +1,41 @@
-import { typecheck } from "std::agency"
-import { browserUse } from "std::browser"
 import { today } from "std::date"
-import { Workspace, openDir } from "std::fs"
-import { setMemoryId, remember, recall } from "std::memory"
-import { fetch, fetchJSON, fetchMarkdown } from "std::http"
 import { Policy, PolicyRule, checkPolicy } from "std::policy"
 import { exists } from "std::shell"
-import { skillsDir } from "std::skills"
-import { highlight } from "std::syntax"
 import { cwd } from "std::system"
-import { systemMessage } from "std::thread"
-// Wikipedia exports a bare `search`; alias it so the LLM sees a
-// self-describing tool name in its tool list.
-import {
-  search as wikipediaSearch,
-  summary as wikipediaSummary,
-  article as wikipediaArticle,
-} from "std::wikipedia"
+import { AgentContext, consumeHandoff } from "./shared.agency"
+import { runCode } from "./code.agency"
+import { runResearch } from "./research.agency"
+
 /*
  * Agency Agent — helps users create and modify Agency code.
  *
- * Features:
- * - Doc-as-skills: bundles `docs/site/guide` (copied to
- *   `dist/lib/agents/docs/guide` at build time, see makefile) and
- *   exposes each Markdown file as a skill the LLM can read on demand.
- * - Typechecking: the LLM can call `typecheck` on any source it
- *   generates to verify the code before showing it to the user.
+ * Multi-thread architecture: the agent splits work across two
+ * specialists, each with its own thread / system prompt / tool set:
+ *   - `code.agency`     — writes, edits, typechecks, runs code
+ *   - `research.agency` — looks up docs, fetches URLs, browses web
+ *
+ * Routing: we don't categorize on every turn. The current
+ * specialist's LLM gets a `handoff(category, reason)` tool. If it
+ * can handle the message, it just answers. If clearly out of scope,
+ * it calls `handoff()` and this loop re-runs the user's message in
+ * the new category. See `shared.agency` for the design rationale and
+ * `docs/superpowers/ideas/2026-05-30-routing-stickiness.md` for the
+ * alternatives we deliberately deferred.
+ *
+ * Other features:
+ * - Doc-as-skills: bundles `docs/site/guide` etc. (copied to
+ *   `dist/lib/agents/docs/` at build time, see makefile) and
+ *   exposes each Markdown file as a skill the research agent can
+ *   read on demand.
+ * - Typechecking: the code agent can call `typecheck` on any
+ *   source it generates to verify the code before showing it.
  * - File I/O tools: `read`, `write`, `edit` for actually creating /
  *   editing `.agency` files.
  * - Interactive policy: every interrupt the LLM raises pops a
  *   prompt with approve / reject / always-approve / always-reject.
- *   "Always" decisions are recorded in a per-run Policy and replayed
- *   automatically for the rest of the session via `checkPolicy`.
+ *   "Always" decisions are recorded in a per-run Policy and
+ *   replayed automatically for the rest of the session via
+ *   `checkPolicy`.
  *
  * Run: `pnpm run agency run dist/lib/agents/agency-agent/agent.agency`
  *      (run from `dist/` so the bundled docs at `../docs/guide` resolve.)
@@ -51,38 +55,12 @@ callback("onToolCallEnd") as data {
   )
 }
 
-// Bundled docs live one level above the agent's compiled JS. Built once
-// at module load — `skillsDir` reads + parses every `.md` file's
-// frontmatter and bakes a description listing all available skills into
-// the returned tool. `static` caches this across runs; `with approve`
-// auto-approves the init-time `glob` and `read` interrupts (the binding
-// itself is the user opt-in).
-static const docSkill = skillsDir("../docs/guide") with approve
-
-// Same pattern for the CLI reference (`agency run`, `agency test`,
-// `agency compile`, ...) and the appendix (built-ins, callbacks,
-// advanced types). Each becomes its own tool so the LLM can pick the
-// right corpus instead of grepping a giant blob of docs.
-static const cliSkill = skillsDir("../docs/cli") with approve
-static const appendixSkill = skillsDir("../docs/appendix") with approve
-
 // Per-run policy: starts empty, grows as the user opts into
 // always-approve / always-reject for each interrupt kind. Lives at
 // module scope so the handler in `node main` and any helpers
 // can read AND mutate it during a run. Module-level `let` is
 // stored in the GlobalStore, which Agency reinitializes per run.
 let policy: Policy = {}
-
-// File-system tools handed to the LLM as a single bundle anchored to
-// one directory. `openDir(dir)` returns a Workspace whose `read` /
-// `write` / `edit` / `ls` / `glob` / `grep` all resolve their
-// `filename` (or `pattern`) argument against `dir` and its subtree.
-// `setCwd` rebuilds the bundle to re-anchor. The bundle is rebuilt
-// fresh each iteration of the main loop so a `setCwd` from one turn
-// is visible on the next; the binding is static within a single LLM
-// turn — `setCwd` is meant as an opening move, not as a mid-turn
-// switch.
-let workspace: Workspace = openDir(cwd())
 
 def loadAgentsMd(dir: string): string {
   """
@@ -100,23 +78,6 @@ def loadAgentsMd(dir: string): string {
     return ""
   }
   return "\n\n<project_context>\n${result.value}\n</project_context>"
-}
-
-def setCwd(dir: string): string {
-  """
-  Use this when the user tells you to change your current working
-  directory. After you call this, every file-system tool (read,
-  write, edit, ls, glob, grep) will resolve filenames against the
-  given directory and its subtree. Pass "cwd" to anchor to the user's
-  current working directory.
-
-  @param dir - The directory to anchor file operations against
-  """
-  if (dir == "cwd") {
-    dir = cwd()
-  }
-  workspace = openDir(dir)
-  return "Working directory set to: ${dir}"
 }
 
 type Decision =
@@ -357,143 +318,105 @@ def defaultHandler(intr) {
   return reject(reason)
 }
 
-node main() {
-  print(color.cyan("╭───────────────────────────────────────────╮"))
-  print(color.cyan("│       Welcome to the Agency Agent         │"))
-  print(color.cyan("│  I help you write and edit .agency code.  │"))
-  print(color.cyan("╰───────────────────────────────────────────╯"))
-  print("Type 'exit' to quit.\n")
+// Maximum number of consecutive handoffs allowed inside a single user
+// turn. Each handoff is an LLM round-trip charged to the user, so a
+// runaway chain (A → B → A → B → ...) is bad both for cost and for
+// the user (they're waiting and watching it ping-pong). 3 is a
+// "the LLMs both disagree about scope, just answer with the last one"
+// safety net — in practice every handoff terminates after 1.
+const MAX_HOPS = 3
 
-  // Scope the knowledge graph to the project directory so notes the
-  // agent learns in one project don't leak into another. No-op unless
-  // the user enables memory in their `agency.json` — see the
-  // `std::memory` docs for the config block.
-  setMemoryId(cwd())
-
-  const sysPrompt = """
-  You are an Agency-language coding assistant. Help the user create or
-  modify `.agency` files.
-
-  Agency is a domain-specific language for AI agents. When you need to
-  recall syntax, semantics, or a particular feature, call the bundled
-  docs tools first — they give you access to the language guide
-  (`docSkill`), the CLI reference (`cliSkill`: `agency run`, `agency
-  test`, `agency compile`, ...), and the appendix (`appendixSkill`:
-  built-ins, callbacks, advanced types). Pick whichever matches the
-  question rather than guessing.
-
-  Workflow:
-  1. First, call `setCwd` with the user's project directory. After
-     that, every file-system tool resolves filenames against that
-     directory and its subtree — you don't have to pass a directory.
-  2. Use `ls` or `glob` to discover what files exist before guessing
-     filenames. `glob("**/*.agency")` is a good first move on a new
-     project. The returned paths (which may include subdirectories
-     like `"sub/foo.agency"`) are exactly what `read` / `edit` expect
-     as their `filename` argument.
-  3. Use `read` to inspect existing code before modifying it.
-     NEVER `write` or `edit` a file you haven't read.
-  4. Always call `typecheck` on any source you produce before showing
-     it to the user. If the typecheck reports errors, fix them and
-     check again. Don't show broken code.
-  5. Use `write` / `edit` to persist changes. `edit` takes an array
-     of `{oldText, newText, replaceAll}` entries — prefer one call
-     with multiple entries over several `edit` calls when you have
-     more than one change to make to the same file. The user will be
-     prompted to approve every write.
-  6. Use `bash` to run project-level commands (tests, git, formatters,
-     package managers). Prefer the dedicated file tools above for file
-     operations; use `bash` for everything else. The user is asked to
-     approve each command.
-  6a. When you need information from the internet, prefer the lighter
-      tools first:
-      - `wikipediaSearch` / `wikipediaSummary` / `wikipediaArticle` for
-        background knowledge — fast, no API key required, no user
-        approval needed.
-      - `fetchMarkdown(baseUrl, path)` to grab a known docs page or
-        README and get it as readable Markdown.
-      - `fetchJSON(url)` / `fetch(url)` for any specific URL where you
-        already know the endpoint.
-      - `browserUse(task)` only when you actually need an open-ended
-        web search or a page that requires JavaScript / a login flow.
-        It is the heaviest option and costs money per call.
-      Cite the source URL in your reply whenever you used one of these.
-  6b. You have a persistent knowledge graph scoped to this project.
-      Call `recall(query)` whenever you need to remember something the
-      user told you in a previous session (their preferences, the
-      project's conventions, decisions made earlier). Call
-      `remember(content)` to persist a fact worth keeping across
-      sessions — user preferences ("prefers tabs", "wants short
-      replies"), project conventions ("uses `def` not `node` for
-      utilities"), or important decisions. Don't `remember` transient
-      details or things already in AGENTS.md. Relevant facts are also
-      auto-injected before each turn, so often you don't need to call
-      `recall` explicitly.
-  7. Whenever you want to show the user a multi-line code snippet,
-     call `print(highlight(code))` instead of including the raw
-     source in your reply. `highlight` returns a terminal-colored
-     string and `print` writes it directly to the user's console, so
-     the snippet appears with proper syntax highlighting. Skip this
-     for inline identifiers or one-token excerpts; use it for any
-     multi-line block. Your reply can then refer to the printed
-     snippet without repeating the source.
-
-  Keep replies brief. Show code, not commentary.
+def runForCategory(category: string, userMsg: string, ctx: AgentContext): string {
   """
+  Dispatch a single turn to the chosen specialist. Wraps the
+  per-category `thread(session: ...) { ... }` block so the caller
+  (the main routing loop) doesn't have to know which thread name
+  goes with which subagent.
+
+  `summarize: true` is set on every routed thread so closed sessions
+  get an LLM-generated summary at close time via the eager summarize
+  hook in `lib/stdlib/threads.ts`. This makes `listThreads()` cheap
+  on future runs (no lazy summarize round-trip).
+
+  @param category - Which specialist's thread to run in
+  @param userMsg - The user's input message for this turn
+  @param ctx - Per-call invariants (env, projectContext)
+  """
+  let reply = ""
+  if (category == "code") {
+    thread(session: "code", label: "code", summarize: true) {
+      reply = runCode(userMsg, ctx)
+    }
+  } else {
+    thread(session: "research", label: "research", summarize: true) {
+      reply = runResearch(userMsg, ctx)
+    }
+  }
+  return reply
+}
+
+node main() {
+  print(color.cyan("╭───────────────────────────────────────────────╮"))
+  print(color.cyan("│         Welcome to the Agency Agent           │"))
+  print(color.cyan("│  I help you write Agency code, look up docs,  │"))
+  print(color.cyan("│       and research things from the web.       │"))
+  print(color.cyan("╰───────────────────────────────────────────────╯"))
+  print("Type 'exit' to quit.\n")
 
   // Grounding: the LLM should not have to ask the user where it is
   // or what day it is. Both are appended once per run so they ride
-  // with the first system message.
+  // with the first system message in each specialist's thread.
   const env = "\n\nCurrent date: ${today()}\nCurrent working directory: ${cwd()}"
 
   // Project context: if the user keeps an AGENTS.md at the workspace
   // root (Anthropic / Pi / Aider all read it), inline it so the LLM
   // automatically follows the project's conventions.
   const projectContext = loadAgentsMd(cwd()) with approve
+  const ctx: AgentContext = { env: env, projectContext: projectContext }
 
-  thread {
-    systemMessage(sysPrompt + env + projectContext)
-    let userMsg = input("What would you like to do? ")
-    while (userMsg != "exit" && userMsg != "quit") {
-      handle {
-        // List workspace tools explicitly so we can PFA `printDiff: true`
-        // onto `edit` — every edit the LLM runs prints a colored diff
-        // to the console before / after the change, so the user can
-        // eyeball what actually got written. Internet tools (wikipedia,
-        // fetch, browserUse) are listed after the project tools so the
-        // LLM defaults to local context first.
-        const reply = llm(userMsg, {
-          memory: true,
-          tools: [
-            setCwd,
-            workspace.read,
-            workspace.write,
-            workspace.edit.partial(printDiff: true),
-            workspace.ls,
-            workspace.glob,
-            workspace.grep,
-            workspace.bash,
-            typecheck,
-            docSkill,
-            cliSkill,
-            appendixSkill,
-            highlight.partial(language: "ts"),
-            print,
-            remember,
-            recall,
-            wikipediaSearch,
-            wikipediaSummary,
-            wikipediaArticle,
-            fetch,
-            fetchJSON,
-            fetchMarkdown,
-            browserUse,
-          ]
-        })
-        print(color.green("\n${reply}\n"))
-      } with defaultHandler
-      userMsg = input("\nNext request (or 'exit'): ")
-    }
+  // Starting category. The code subagent is the better default for
+  // an agent named "Agency Agent" — most users open it to work on
+  // code. The handoff machinery will route to research on the first
+  // research-shaped message.
+  //
+  // Typed as `string` (not `Category`) because the routing loop
+  // re-assigns it from `consumeHandoff()`'s string return value
+  // (see the sentinel-string rationale in `shared.agency`). The
+  // contents are still always a valid Category — `handoff()` is the
+  // only writer of the source state and takes a Category-typed
+  // parameter.
+  let category: string = "code"
+
+  let userMsg = input("What would you like to do? ")
+  while (userMsg != "exit" && userMsg != "quit") {
+    handle {
+      // Chain handoffs (with a hop limit) so a single user turn can
+      // re-route once if the current specialist decides it's the wrong
+      // one. The common case is zero handoffs — the agent answers and
+      // we fall through. One handoff is the cross-specialist case
+      // ("can you look up X in docs?" while in code → handoff to
+      // research). Two+ would be ping-pong, which the limit kills.
+      let hop = 0
+      let done = false
+      while (!done && hop < MAX_HOPS) {
+        const reply = runForCategory(category, userMsg, ctx)
+        const target = consumeHandoff()
+        if (target == "") {
+          print(color.green("\n${reply}\n"))
+          done = true
+        } else {
+          print(color.cyan("→ handing off to ${target}"))
+          category = target
+          hop = hop + 1
+        }
+      }
+      if (!done) {
+        print(color.yellow("(handoff hop limit reached; answering in ${category})"))
+        const finalReply = runForCategory(category, userMsg, ctx)
+        print(color.green("\n${finalReply}\n"))
+      }
+    } with defaultHandler
+    userMsg = input("\nNext request (or 'exit'): ")
   }
   print(color.cyan("\nGoodbye!"))
   return "done"

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -12,7 +12,11 @@ import { cwd, env } from "std::system"
 
 import { runCode } from "./code.agency"
 import { runResearch } from "./research.agency"
-import { AgentContext, consumeHandoff } from "./shared.agency"
+import {
+  AgentContext,
+  AGENCY_AGENT_DIR,
+  consumeHandoff,
+} from "./shared.agency"
 
 
 /*
@@ -75,10 +79,11 @@ callback("onToolCallEnd") as data {
 
 // Persistent on-disk policy. Saved here as JSON; loaded once at
 // module init and rewritten every time the user makes a new
-// "always" decision. Sibling to the memory store directory used
-// by `shared.agency`.
+// "always" decision. Sibling to the memory store under the same
+// per-user agent dir (see `shared.agency` for the `~` expansion
+// rationale).
 const POLICY_FILE = "policy.json"
-const POLICY_DIR = "~/.agency-agent"
+const POLICY_DIR = AGENCY_AGENT_DIR
 const POLICY_PATH = "${POLICY_DIR}/${POLICY_FILE}"
 
 def loadPolicy(): Policy {

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -2,9 +2,11 @@ import { today } from "std::date"
 import { Policy, PolicyRule, checkPolicy } from "std::policy"
 import { exists } from "std::shell"
 import { cwd } from "std::system"
-import { AgentContext, consumeHandoff } from "./shared.agency"
+
 import { runCode } from "./code.agency"
 import { runResearch } from "./research.agency"
+import { AgentContext, consumeHandoff } from "./shared.agency"
+
 
 /*
  * Agency Agent — helps users create and modify Agency code.
@@ -37,8 +39,6 @@ import { runResearch } from "./research.agency"
  *   replayed automatically for the rest of the session via
  *   `checkPolicy`.
  *
- * Run: `pnpm run agency run dist/lib/agents/agency-agent/agent.agency`
- *      (run from `dist/` so the bundled docs at `../docs/guide` resolve.)
  */
 
 callback("onToolCallStart") as data {
@@ -98,18 +98,60 @@ type FieldSpec = {
 }
 
 const ALWAYS_FIELDS: Record<string, FieldSpec[]> = {
-  "std::read":  [{ field: "dir", wildcardSubpaths: true }],
-  "std::write": [{ field: "dir", wildcardSubpaths: true }],
-  "std::edit":  [{ field: "dir", wildcardSubpaths: true }],
-  "std::ls":    [{ field: "dir", wildcardSubpaths: true }],
-  "std::glob":  [{ field: "dir", wildcardSubpaths: true }],
-  "std::grep":  [{ field: "dir", wildcardSubpaths: true }],
-  "std::copy":  [{ field: "src",  wildcardSubpaths: true },
-                 { field: "dest", wildcardSubpaths: true }],
-  "std::move":  [{ field: "src",  wildcardSubpaths: true },
-                 { field: "dest", wildcardSubpaths: true }],
-  "std::exec":  [{ field: "command",    wildcardSubpaths: false },
-                 { field: "subcommand", wildcardSubpaths: false }]
+  "std::read": [{
+    field: "dir",
+    wildcardSubpaths: true
+  }],
+  "std::write": [{
+    field: "dir",
+    wildcardSubpaths: true
+  }],
+  "std::edit": [{
+    field: "dir",
+    wildcardSubpaths: true
+  }],
+  "std::ls": [{
+    field: "dir",
+    wildcardSubpaths: true
+  }],
+  "std::glob": [{
+    field: "dir",
+    wildcardSubpaths: true
+  }],
+  "std::grep": [{
+    field: "dir",
+    wildcardSubpaths: true
+  }],
+  "std::copy": [
+    {
+    field: "src",
+    wildcardSubpaths: true
+  },
+    {
+    field: "dest",
+    wildcardSubpaths: true
+  },
+  ],
+  "std::move": [
+    {
+    field: "src",
+    wildcardSubpaths: true
+  },
+    {
+    field: "dest",
+    wildcardSubpaths: true
+  },
+  ],
+  "std::exec": [
+    {
+    field: "command",
+    wildcardSubpaths: false
+  },
+    {
+    field: "subcommand",
+    wildcardSubpaths: false
+  },
+  ]
 }
 
 def buildScopedMatch(intr): Record<string, string> {
@@ -129,9 +171,12 @@ def buildScopedMatch(intr): Record<string, string> {
   // is rarely useful — so collapse to just the command field.
   let effective = specs
   if (intr.kind == "std::exec" && intr.data.subcommand == "") {
-    effective = [{ field: "command", wildcardSubpaths: false }]
+    effective = [{
+      field: "command",
+      wildcardSubpaths: false
+    }]
   }
-  let match: Record<string, string> = {}
+  let matchObj: Record<string, string> = {}
   for (spec in effective) {
     const raw = intr.data[spec.field]
     let pattern = raw
@@ -140,9 +185,9 @@ def buildScopedMatch(intr): Record<string, string> {
       // "${raw}/**" — matches the exact dir and any subdir.
       pattern = "${raw}{,/**}"
     }
-    match = { ...match, [spec.field]: pattern }
+    matchObj[spec.field] = pattern
   }
-  return match
+  return matchObj
 }
 
 def describeScopedMatch(intr): string {
@@ -151,8 +196,8 @@ def describeScopedMatch(intr): string {
   used in the prompt so the user sees the exact rule they're about to
   agree to. Returns an empty string when the kind isn't scoped.
   """
-  const match = buildScopedMatch(intr)
-  const ks = keys(match)
+  const matchObj = buildScopedMatch(intr)
+  const ks = keys(matchObj)
   if (ks.length == 0) {
     return ""
   }
@@ -161,22 +206,22 @@ def describeScopedMatch(intr): string {
   // values without fighting the parser's string-escape rules.
   const dirKinds = ["std::read", "std::write", "std::edit", "std::ls", "std::glob", "std::grep"]
   if (dirKinds.includes(intr.kind)) {
-    return `dir="${intr.data.dir}" or any subdir`
+    return "dir='${intr.data.dir}' or any subdir"
   }
   if (intr.kind == "std::copy" || intr.kind == "std::move") {
-    return `src="${intr.data.src}" or any subdir, dest="${intr.data.dest}" or any subdir`
+    return "src='${intr.data.src}' or any subdir, dest='${intr.data.dest}' or any subdir"
   }
   // std::exec — render command and (if non-empty) subcommand.
   if (intr.kind == "std::exec") {
     if (intr.data.subcommand == "") {
-      return `command="${intr.data.command}"`
+      return "command='${intr.data.command}'"
     }
-    return `command="${intr.data.command}", subcommand="${intr.data.subcommand}"`
+    return "command='${intr.data.command}', subcommand='${intr.data.subcommand}'"
   }
   // Generic fallback for any future kind added to ALWAYS_FIELDS.
   let parts: string[] = []
   for (k in ks) {
-    parts = [...parts, `${k}="${match[k]}"`]
+    parts.push("${k}='${matchObj[k]}'")
   }
   return parts.join(", ")
 }
@@ -216,7 +261,11 @@ def askUser(intr: any): Decision {
     } else if (answer == "ap" && scopedAvailable) {
       valid = true
     } else if (answer == "ap") {
-      print(color.yellow("(ap) isn't available for ${intr.kind} — pick one of (a)/(r)/(aa)/(rr)."))
+      print(
+        color.yellow(
+        "(ap) isn't available for ${intr.kind} — pick one of (a)/(r)/(aa)/(rr).",
+      ),
+      )
     }
   }
   if (answer == "a") {
@@ -268,11 +317,16 @@ def recordAlwaysScoped(intr) {
   }
   const next: Policy = {
     ...policy,
-    [intr.kind]: [{ match: match, action: "approve" }, ...rules]
+    [intr.kind]: [{
+      match: match,
+      action: "approve"
+    }, ...rules]
   }
   policy = next
   print(
-    color.cyan("→ Recorded policy: ${intr.kind} = approve where ${describeScopedMatch(intr)}"),
+    color.cyan(
+    "→ Recorded policy: ${intr.kind} = approve where ${describeScopedMatch(intr)}",
+  ),
   )
 }
 
@@ -326,7 +380,11 @@ def defaultHandler(intr) {
 // safety net — in practice every handoff terminates after 1.
 const MAX_HOPS = 3
 
-def runForCategory(category: string, userMsg: string, ctx: AgentContext): string {
+def runForCategory(
+  category: string,
+  userMsg: string,
+  ctx: AgentContext,
+): string {
   """
   Dispatch a single turn to the chosen specialist. Wraps the
   per-category `thread(session: ...) { ... }` block so the caller
@@ -344,11 +402,11 @@ def runForCategory(category: string, userMsg: string, ctx: AgentContext): string
   """
   let reply = ""
   if (category == "code") {
-    thread(session: "code", label: "code", summarize: true) {
+    thread(session: "code", label: "code", summarize: true) as {
       reply = runCode(userMsg, ctx)
     }
   } else {
-    thread(session: "research", label: "research", summarize: true) {
+    thread(session: "research", label: "research", summarize: true) as {
       reply = runResearch(userMsg, ctx)
     }
   }
@@ -372,7 +430,10 @@ node main() {
   // root (Anthropic / Pi / Aider all read it), inline it so the LLM
   // automatically follows the project's conventions.
   const projectContext = loadAgentsMd(cwd()) with approve
-  const ctx: AgentContext = { env: env, projectContext: projectContext }
+  const ctx: AgentContext = {
+    env: env,
+    projectContext: projectContext
+  }
 
   // Starting category. The code subagent is the better default for
   // an agent named "Agency Agent" — most users open it to work on
@@ -411,7 +472,9 @@ node main() {
         }
       }
       if (!done) {
-        print(color.yellow("(handoff hop limit reached; answering in ${category})"))
+        print(
+          color.yellow("(handoff hop limit reached; answering in ${category})"),
+        )
         const finalReply = runForCategory(category, userMsg, ctx)
         print(color.green("\n${finalReply}\n"))
       }

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -384,6 +384,7 @@ def runForCategory(
   category: string,
   userMsg: string,
   ctx: AgentContext,
+  allowHandoff: boolean = true,
 ): string {
   """
   Dispatch a single turn to the chosen specialist. Wraps the
@@ -399,15 +400,18 @@ def runForCategory(
   @param category - Which specialist's thread to run in
   @param userMsg - The user's input message for this turn
   @param ctx - Per-call invariants (env, projectContext)
+  @param allowHandoff - Forwarded to `runCode` / `runResearch`. When
+    false the subagent's `handoff` tool is suppressed and the agent
+    has no choice but to answer. Used by the hop-limit fallback.
   """
   let reply = ""
   if (category == "code") {
     thread(session: "code", label: "code", summarize: true) {
-      reply = runCode(userMsg, ctx)
+      reply = runCode(userMsg, ctx, allowHandoff)
     }
   } else {
     thread(session: "research", label: "research", summarize: true) {
-      reply = runResearch(userMsg, ctx)
+      reply = runResearch(userMsg, ctx, allowHandoff)
     }
   }
   return reply
@@ -475,7 +479,10 @@ node main() {
         print(
           color.yellow("(handoff hop limit reached; answering in ${category})"),
         )
-        const finalReply = runForCategory(category, userMsg, ctx)
+        // Force the agent to actually answer instead of handing off
+        // yet again — `allowHandoff: false` strips `handoff` from the
+        // tool set, so the LLM has no escape hatch this turn.
+        const finalReply = runForCategory(category, userMsg, ctx, false)
         print(color.green("\n${finalReply}\n"))
       }
     } with defaultHandler

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -1,6 +1,13 @@
 import { today } from "std::date"
-import { Policy, PolicyRule, checkPolicy } from "std::policy"
+import {
+  Policy,
+  PolicyRule,
+  checkPolicy,
+  validatePolicy,
+  writePolicyFile,
+} from "std::policy"
 import { exists } from "std::shell"
+import { highlight } from "std::syntax"
 import { cwd } from "std::system"
 
 import { runCode } from "./code.agency"
@@ -55,12 +62,73 @@ callback("onToolCallEnd") as data {
   )
 }
 
-// Per-run policy: starts empty, grows as the user opts into
-// always-approve / always-reject for each interrupt kind. Lives at
-// module scope so the handler in `node main` and any helpers
+// Persistent on-disk policy. Saved here as JSON; loaded once at
+// module init and rewritten every time the user makes a new
+// "always" decision. Sibling to the memory store directory used
+// by `shared.agency`.
+const POLICY_FILE = "policy.json"
+const POLICY_DIR = "~/.agency-agent"
+const POLICY_PATH = "${POLICY_DIR}/${POLICY_FILE}"
+
+def loadPolicy(): Policy {
+  """
+  Read and validate the on-disk policy. Returns the parsed policy
+  if it exists and is well-formed; returns `{}` (empty policy)
+  when the file is absent, unreadable, malformed JSON, or fails
+  validation. A warning is printed for the malformed cases so the
+  user knows a previous decision didn't carry over.
+  """
+  if (!exists(POLICY_FILE, POLICY_DIR)) {
+    return {}
+  }
+  const readResult = read(POLICY_FILE, POLICY_DIR) with approve
+  if (isFailure(readResult)) {
+    print(color.yellow("Could not read ${POLICY_PATH}: ${readResult.error}"))
+    return {}
+  }
+  const parsed = try parseJSON(readResult.value)
+  if (isFailure(parsed)) {
+    print(
+      color.yellow(
+      "Malformed JSON in ${POLICY_PATH}; ignoring and starting fresh.",
+    ),
+    )
+    return {}
+  }
+  const valid = validatePolicy(parsed.value)
+  if (!valid.success) {
+    print(
+      color.yellow(
+      "Invalid policy in ${POLICY_PATH} (${valid.error}); ignoring and starting fresh.",
+    ),
+    )
+    return {}
+  }
+  return parsed.value
+}
+
+def savePolicy() {
+  """
+  Persist the current in-memory policy to disk. Called from
+  `recordAlways` / `recordAlwaysScoped` so every "always" decision
+  immediately survives a restart. Failures are warnings, not
+  errors — losing one decision is better than crashing the REPL.
+  """
+  const result = try writePolicyFile(POLICY_PATH, policy) with approve
+  if (isFailure(result)) {
+    print(color.yellow("Could not save policy to ${POLICY_PATH}: ${result.error}"))
+  }
+}
+
+// Persistent policy: starts from the on-disk file (or `{}` if none
+// exists yet), grows as the user opts into always-approve /
+// always-reject for each interrupt kind, and is written back to
+// disk on every change so decisions stick across sessions. Lives
+// at module scope so the handler in `node main` and any helpers
 // can read AND mutate it during a run. Module-level `let` is
-// stored in the GlobalStore, which Agency reinitializes per run.
-let policy: Policy = {}
+// stored in the GlobalStore, which Agency reinitializes per run —
+// hence the explicit load.
+let policy: Policy = loadPolicy() with approve
 
 def loadAgentsMd(dir: string): string {
   """
@@ -297,8 +365,9 @@ def recordAlways(kind: string, action: string) {
     }]
   }
   policy = next
+  savePolicy()
   print(
-    color.cyan("→ Recorded policy: ${kind} = ${action} (won't ask again this session)"),
+    color.cyan("→ Recorded policy: ${kind} = ${action} (won't ask again)"),
   )
 }
 
@@ -323,6 +392,7 @@ def recordAlwaysScoped(intr) {
     }, ...rules]
   }
   policy = next
+  savePolicy()
   print(
     color.cyan(
     "→ Recorded policy: ${intr.kind} = approve where ${describeScopedMatch(intr)}",
@@ -467,7 +537,11 @@ node main() {
         const reply = runForCategory(category, userMsg, ctx)
         const target = consumeHandoff()
         if (target == "") {
-          print(color.green("\n${reply}\n"))
+          // Subagents are prompted to reply in Markdown. Render
+          // headings/bullets/bold/code-fences instead of dumping the
+          // raw source — see `code.agency` / `research.agency` for
+          // the prompt and the system-prompt instruction.
+          print(highlight("\n${reply}\n", language: "markdown"))
           done = true
         } else {
           print(color.cyan("→ handing off to ${target}"))
@@ -483,7 +557,7 @@ node main() {
         // yet again — `allowHandoff: false` strips `handoff` from the
         // tool set, so the LLM has no escape hatch this turn.
         const finalReply = runForCategory(category, userMsg, ctx, false)
-        print(color.green("\n${finalReply}\n"))
+        print(highlight("\n${finalReply}\n", language: "markdown"))
       }
     } with defaultHandler
     userMsg = input("\nNext request (or 'exit'): ")

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -8,7 +8,7 @@ import {
 } from "std::policy"
 import { exists } from "std::shell"
 import { highlight } from "std::syntax"
-import { cwd } from "std::system"
+import { cwd, env } from "std::system"
 
 import { runCode } from "./code.agency"
 import { runResearch } from "./research.agency"
@@ -48,18 +48,29 @@ import { AgentContext, consumeHandoff } from "./shared.agency"
  *
  */
 
+// Tool-call tracing is opt-in via the `AGENT_DEBUG` env var. Set
+// `AGENT_DEBUG=1` to see the yellow `tool call: ...` / `tool
+// return: ...` lines on every LLM tool invocation. Off by default
+// because the verbose output buries the agent's actual replies.
+// `env(...)` returns the literal env value or `null` when unset.
+const AGENT_DEBUG = env("AGENT_DEBUG") == "1"
+
 callback("onToolCallStart") as data {
-  print(
-    color.yellow("tool call: ${data.toolName}(${JSON.stringify(data.args)})"),
-  )
+  if (AGENT_DEBUG) {
+    print(
+      color.yellow("tool call: ${data.toolName}(${JSON.stringify(data.args)})"),
+    )
+  }
 }
 
 callback("onToolCallEnd") as data {
-  print(
-    color.yellow(
-    "tool return: ${data.toolName} -> ${JSON.stringify(data.result)} ${data.timeTaken}ms",
-  ),
-  )
+  if (AGENT_DEBUG) {
+    print(
+      color.yellow(
+      "tool return: ${data.toolName} -> ${JSON.stringify(data.result)} ${data.timeTaken}ms",
+    ),
+    )
+  }
 }
 
 // Persistent on-disk policy. Saved here as JSON; loaded once at

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -402,11 +402,11 @@ def runForCategory(
   """
   let reply = ""
   if (category == "code") {
-    thread(session: "code", label: "code", summarize: true) as {
+    thread(session: "code", label: "code", summarize: true) {
       reply = runCode(userMsg, ctx)
     }
   } else {
-    thread(session: "research", label: "research", summarize: true) as {
+    thread(session: "research", label: "research", summarize: true) {
       reply = runResearch(userMsg, ctx)
     }
   }

--- a/packages/agency-lang/lib/agents/agency-agent/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/code.agency
@@ -19,7 +19,9 @@ import { highlight } from "std::syntax"
 import { cwd } from "std::system"
 import { systemMessage } from "std::thread"
 import { currentThreadId, getThread } from "std::threads"
+
 import { Category, AgentContext, handoff } from "./shared.agency"
+
 
 // File-system tools handed to the LLM as a single bundle anchored to
 // one directory. `openDir(dir)` returns a Workspace whose `read` /
@@ -137,7 +139,9 @@ export def runCode(userMsg: string, ctx: AgentContext): string {
   if (isSuccess(t) && t.value.length == 0) {
     systemMessage(codeSysPrompt + ctx.env + ctx.projectContext)
   }
-  return llm(userMsg, {
+  return llm(
+    userMsg,
+    {
     memory: true,
     tools: [
       setCwd,
@@ -154,6 +158,7 @@ export def runCode(userMsg: string, ctx: AgentContext): string {
       remember,
       recall,
       handoff,
-    ],
-  })
+    ]
+  },
+  )
 }

--- a/packages/agency-lang/lib/agents/agency-agent/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/code.agency
@@ -1,0 +1,159 @@
+/*
+ * Code subagent — handles anything that touches code or the file
+ * system: writing, editing, typechecking, running shell commands.
+ *
+ * Tools: setCwd + the full Workspace bundle + typecheck + highlight +
+ * print + remember/recall + handoff. NO docs / web / wikipedia —
+ * the agent must `handoff("research", ...)` when it needs those.
+ *
+ * The Workspace state lives here (not in `shared.agency`) because
+ * only the code subagent uses file-system tools. `setCwd` re-anchors
+ * the bundle so a directory change in one turn persists to the next.
+ *
+ * See `shared.agency` for the multi-agent design rationale.
+ */
+import { typecheck } from "std::agency"
+import { Workspace, openDir } from "std::fs"
+import { setMemoryId, remember, recall } from "std::memory"
+import { highlight } from "std::syntax"
+import { cwd } from "std::system"
+import { systemMessage } from "std::thread"
+import { currentThreadId, getThread } from "std::threads"
+import { Category, AgentContext, handoff } from "./shared.agency"
+
+// File-system tools handed to the LLM as a single bundle anchored to
+// one directory. `openDir(dir)` returns a Workspace whose `read` /
+// `write` / `edit` / `ls` / `glob` / `grep` / `bash` all resolve
+// their `filename` (or `pattern`) argument against `dir` and its
+// subtree. `setCwd` rebuilds the bundle to re-anchor. Module-level
+// `let` so the rebuilt bundle is visible to the next turn (Agency
+// stores module-level lets in the GlobalStore).
+let workspace: Workspace = openDir(cwd())
+
+export def setCwd(dir: string): string {
+  """
+  Use this when the user tells you to change your current working
+  directory. After you call this, every file-system tool (read,
+  write, edit, ls, glob, grep, bash) will resolve filenames against
+  the given directory and its subtree. Pass `"cwd"` to anchor to the
+  user's current working directory.
+
+  @param dir - The directory to anchor file operations against
+  """
+  if (dir == "cwd") {
+    dir = cwd()
+  }
+  workspace = openDir(dir)
+  return "Working directory set to: ${dir}"
+}
+
+const codeSysPrompt = """
+You are the **code specialist** of a multi-thread Agency-language
+assistant. You handle anything that touches code or the file system:
+writing, editing, running, and typechecking Agency or shell code.
+
+You do NOT have access to web search, documentation lookup, Wikipedia,
+or URL fetching. If the user asks a question that needs research
+(Agency syntax you're unsure of, an external API, a Wikipedia
+summary, or a URL fetch), call `handoff("research", reason)` —
+the runtime will re-route the user's original message to the
+research specialist.
+
+**Bias toward staying in the code thread.** Most follow-up messages
+("can you make it faster?", "fix the error", "what about edge
+cases?") are continuations of the current coding task, NOT new
+categories. Only call `handoff` when the message clearly needs
+research-specialist tools.
+
+Workflow:
+1. First, call `setCwd` with the user's project directory. After
+   that, every file-system tool resolves filenames against that
+   directory and its subtree — you don't have to pass a directory.
+2. Use `ls` or `glob` to discover what files exist before guessing
+   filenames. `glob("**/*.agency")` is a good first move on a new
+   project. The returned paths (which may include subdirectories
+   like `"sub/foo.agency"`) are exactly what `read` / `edit` expect
+   as their `filename` argument.
+3. Use `read` to inspect existing code before modifying it.
+   NEVER `write` or `edit` a file you haven't read.
+4. Always call `typecheck` on any source you produce before showing
+   it to the user. If the typecheck reports errors, fix them and
+   check again. Don't show broken code.
+5. Use `write` / `edit` to persist changes. `edit` takes an array
+   of `{oldText, newText, replaceAll}` entries — prefer one call
+   with multiple entries over several `edit` calls when you have
+   more than one change to make to the same file. The user will be
+   prompted to approve every write.
+6. Use `bash` to run project-level commands (tests, git, formatters,
+   package managers). Prefer the dedicated file tools above for file
+   operations; use `bash` for everything else. The user is asked to
+   approve each command.
+7. You have a persistent knowledge graph scoped to coding work. Call
+   `recall(query)` to retrieve anything the user told you in a
+   previous session (project conventions, decisions made earlier).
+   Call `remember(content)` to persist a fact worth keeping across
+   sessions — user preferences ("prefers tabs"), project conventions
+   ("uses `def` not `node` for utilities"), or important decisions.
+   Don't `remember` transient details or things already in
+   AGENTS.md. Relevant facts are also auto-injected before each turn,
+   so often you don't need to call `recall` explicitly.
+8. Whenever you want to show the user a multi-line code snippet,
+   call `print(highlight(code))` instead of including the raw
+   source in your reply. `highlight` returns a terminal-colored
+   string and `print` writes it directly to the user's console, so
+   the snippet appears with proper syntax highlighting. Skip this
+   for inline identifiers or one-token excerpts; use it for any
+   multi-line block. Your reply can then refer to the printed
+   snippet without repeating the source.
+
+Keep replies brief. Show code, not commentary.
+"""
+
+export def runCode(userMsg: string, ctx: AgentContext): string {
+  """
+  Run a single turn in the code subagent. The caller is responsible
+  for the surrounding `thread(session: "code") { ... }` block; this
+  function just (a) seeds the code system message on first entry,
+  (b) scopes memory to the `"code"` knowledge graph, and (c) runs
+  the LLM call with the code tool set.
+
+  Returns the LLM's text reply. If the LLM called `handoff()` mid-
+  turn, the reply is the LLM's post-handoff filler text and the
+  caller MUST check `consumeHandoff()` to discover whether to
+  re-route.
+
+  @param userMsg - The user's input message for this turn
+  @param ctx - Per-call invariants (env, projectContext) for the system message
+  """
+  setMemoryId("code")
+  // First-entry detection via the active thread's message count.
+  // `currentThreadId()` returns the active thread slug (set by the
+  // surrounding `thread(session: "code") { ... }` block);
+  // `getThread` reads its messages. Length 0 means this is the first
+  // time the code session has been opened in this run, so seed the
+  // system message. On subsequent entries (or interrupt resumes) the
+  // system message is already there and we skip the seed.
+  const t = getThread(currentThreadId())
+  if (isSuccess(t) && t.value.length == 0) {
+    systemMessage(codeSysPrompt + ctx.env + ctx.projectContext)
+  }
+  return llm(userMsg, {
+    memory: true,
+    tools: [
+      setCwd,
+      workspace.read,
+      workspace.write,
+      workspace.edit.partial(printDiff: true),
+      workspace.ls,
+      workspace.glob,
+      workspace.grep,
+      workspace.bash,
+      typecheck,
+      highlight.partial(language: "ts"),
+      print,
+      remember,
+      recall,
+      handoff,
+    ],
+  })
+}

--- a/packages/agency-lang/lib/agents/agency-agent/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/code.agency
@@ -116,6 +116,14 @@ Workflow:
    snippet without repeating the source.
 
 Keep replies brief. Show code, not commentary.
+
+Respond in Markdown — use `#`/`##` headings, `-` bullets, **bold**,
+_italic_, and fenced code blocks (```ts, ```bash, ```json, ```diff)
+for any code or command output. The REPL renders your reply through a
+Markdown syntax highlighter, so well-marked-up replies appear with
+colored headings, bold/italic styling, and properly highlighted code
+fences. Code fences are especially important — they're how code in
+your reply gets per-language coloring.
 """
 
 export def runCode(

--- a/packages/agency-lang/lib/agents/agency-agent/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/code.agency
@@ -4,7 +4,8 @@
  *
  * Tools: setCwd + the full Workspace bundle + typecheck + highlight +
  * print + remember/recall + handoff. NO docs / web / wikipedia —
- * the agent must `handoff("research", ...)` when it needs those.
+ * the agent must `handoff(reason)` (PFA-bound to research only) when
+ * it needs those.
  *
  * The Workspace state lives here (not in `shared.agency`) because
  * only the code subagent uses file-system tools. `setCwd` re-anchors
@@ -18,7 +19,6 @@ import { setMemoryId, remember, recall } from "std::memory"
 import { highlight } from "std::syntax"
 import { cwd } from "std::system"
 import { systemMessage } from "std::thread"
-import { currentThreadId, getThread } from "std::threads"
 
 import { Category, AgentContext, handoff } from "./shared.agency"
 
@@ -31,6 +31,13 @@ import { Category, AgentContext, handoff } from "./shared.agency"
 // `let` so the rebuilt bundle is visible to the next turn (Agency
 // stores module-level lets in the GlobalStore).
 let workspace: Workspace = openDir(cwd())
+
+// First-entry detection for the code session. Flipped to false the
+// first time `runCode` seeds its system message; subsequent turns
+// (including interrupt resumes) see it as false and skip the seed.
+// Lives in the GlobalStore (module-level `let`) so it survives the
+// `llm()` tool-call boundary and persists across user turns.
+let codeFirstEntry: boolean = true
 
 export def setCwd(dir: string): string {
   """
@@ -57,9 +64,9 @@ writing, editing, running, and typechecking Agency or shell code.
 You do NOT have access to web search, documentation lookup, Wikipedia,
 or URL fetching. If the user asks a question that needs research
 (Agency syntax you're unsure of, an external API, a Wikipedia
-summary, or a URL fetch), call `handoff("research", reason)` —
-the runtime will re-route the user's original message to the
-research specialist.
+summary, or a URL fetch), call `handoff(reason)` — the only valid
+target for you is the research specialist, so just pass a brief
+reason. The runtime will re-route the user's original message there.
 
 **Bias toward staying in the code thread.** Most follow-up messages
 ("can you make it faster?", "fix the error", "what about edge
@@ -111,7 +118,11 @@ Workflow:
 Keep replies brief. Show code, not commentary.
 """
 
-export def runCode(userMsg: string, ctx: AgentContext): string {
+export def runCode(
+  userMsg: string,
+  ctx: AgentContext,
+  allowHandoff: boolean = true,
+): string {
   """
   Run a single turn in the code subagent. The caller is responsible
   for the surrounding `thread(session: "code") { ... }` block; this
@@ -126,39 +137,40 @@ export def runCode(userMsg: string, ctx: AgentContext): string {
 
   @param userMsg - The user's input message for this turn
   @param ctx - Per-call invariants (env, projectContext) for the system message
+  @param allowHandoff - When false, the `handoff` tool is omitted from the
+    tool set so the agent is forced to answer this turn. Used by the
+    REPL's hop-limit fallback to break a re-routing chain.
   """
   setMemoryId("code")
-  // First-entry detection via the active thread's message count.
-  // `currentThreadId()` returns the active thread slug (set by the
-  // surrounding `thread(session: "code") { ... }` block);
-  // `getThread` reads its messages. Length 0 means this is the first
-  // time the code session has been opened in this run, so seed the
-  // system message. On subsequent entries (or interrupt resumes) the
-  // system message is already there and we skip the seed.
-  const t = getThread(currentThreadId())
-  if (isSuccess(t) && t.value.length == 0) {
+  if (codeFirstEntry) {
     systemMessage(codeSysPrompt + ctx.env + ctx.projectContext)
+    codeFirstEntry = false
   }
-  return llm(
-    userMsg,
-    {
+  // Build the tool set conditionally. `handoff` is PFA-bound to
+  // `validCategories: ["research"]` — the runtime check in
+  // `shared.agency` rejects any other target, so the LLM cannot
+  // hand off to itself. When `allowHandoff` is false (hop-limit
+  // fallback), drop `handoff` entirely.
+  let tools = [
+    setCwd,
+    workspace.read,
+    workspace.write,
+    workspace.edit.partial(printDiff: true),
+    workspace.ls,
+    workspace.glob,
+    workspace.grep,
+    workspace.bash,
+    typecheck,
+    highlight.partial(language: "ts"),
+    print,
+    remember,
+    recall,
+  ]
+  if (allowHandoff) {
+    tools.push(handoff.partial(validCategories: ["research"]))
+  }
+  return llm(userMsg, {
     memory: true,
-    tools: [
-      setCwd,
-      workspace.read,
-      workspace.write,
-      workspace.edit.partial(printDiff: true),
-      workspace.ls,
-      workspace.glob,
-      workspace.grep,
-      workspace.bash,
-      typecheck,
-      highlight.partial(language: "ts"),
-      print,
-      remember,
-      recall,
-      handoff,
-    ]
-  },
-  )
+    tools: tools
+  })
 }

--- a/packages/agency-lang/lib/agents/agency-agent/research.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/research.agency
@@ -1,0 +1,148 @@
+/*
+ * Research subagent — handles anything that needs reading: looking
+ * up Agency syntax in the bundled docs, searching Wikipedia,
+ * fetching URLs, browsing the web, or recalling stored facts.
+ *
+ * Tools: docSkill / cliSkill / appendixSkill + wikipedia* + fetch* +
+ * browserUse + remember/recall + highlight + print + handoff. NO
+ * file write / edit / typecheck / bash — the agent must
+ * `handoff("code", ...)` when the user asks for code changes.
+ *
+ * The bundled-docs Skills live here (not in `shared.agency`) because
+ * only the research subagent uses them. `static const` caches the
+ * Skill across runs.
+ *
+ * See `shared.agency` for the multi-agent design rationale.
+ */
+import { fetch, fetchJSON, fetchMarkdown } from "std::http"
+import { browserUse } from "std::browser"
+import { setMemoryId, remember, recall } from "std::memory"
+import { skillsDir } from "std::skills"
+import { highlight } from "std::syntax"
+import { systemMessage } from "std::thread"
+import { currentThreadId, getThread } from "std::threads"
+import {
+  search as wikipediaSearch,
+  summary as wikipediaSummary,
+  article as wikipediaArticle,
+} from "std::wikipedia"
+import { Category, AgentContext, handoff } from "./shared.agency"
+
+// Bundled docs live one level above the agent's compiled JS. Built
+// once at module load — `skillsDir` reads + parses every `.md`
+// file's frontmatter and bakes a description listing all available
+// skills into the returned tool. `static` caches this across runs;
+// `with approve` auto-approves the init-time `glob` and `read`
+// interrupts (the binding itself is the user opt-in).
+static const docSkill = skillsDir("../docs/guide") with approve
+
+// Same pattern for the CLI reference (`agency run`, `agency test`,
+// `agency compile`, ...) and the appendix (built-ins, callbacks,
+// advanced types). Each becomes its own tool so the LLM can pick
+// the right corpus instead of grepping a giant blob of docs.
+static const cliSkill = skillsDir("../docs/cli") with approve
+static const appendixSkill = skillsDir("../docs/appendix") with approve
+
+const researchSysPrompt = """
+You are the **research specialist** of a multi-thread Agency-language
+assistant. You answer questions that need reading: Agency-language
+syntax / semantics / built-ins, CLI usage, external docs, Wikipedia
+background, URL contents, and general conversation backed by recall.
+
+You do NOT have file-system write tools (no write, edit, bash, or
+typecheck). If the user asks you to actually write, edit, or run
+code, call `handoff("code", reason)` — the runtime will re-route
+the user's original message to the code specialist.
+
+**Bias toward staying in the research thread.** Most follow-up
+messages ("can you say more?", "what about X?", "explain that
+again") are continuations of the current research task, NOT new
+categories. Only call `handoff` when the message clearly needs the
+code-specialist's write/edit/run tools.
+
+When you need information:
+
+- For **Agency language** questions, call the bundled docs tools
+  first — they're authoritative:
+    * `docSkill`      — language guide (syntax, control flow,
+                        types, error handling, etc.)
+    * `cliSkill`      — CLI reference (`agency run`, `agency test`,
+                        `agency compile`, ...)
+    * `appendixSkill` — built-ins, callbacks, advanced types
+  Pick whichever matches the question rather than guessing.
+
+- For **general knowledge**, prefer the lighter tools first:
+    * `wikipediaSearch` / `wikipediaSummary` / `wikipediaArticle`
+      for background knowledge — fast, no API key required, no
+      user approval needed.
+    * `fetchMarkdown(baseUrl, path)` to grab a known docs page or
+      README and get it as readable Markdown.
+    * `fetchJSON(url)` / `fetch(url)` for any specific URL where
+      you already know the endpoint.
+    * `browserUse(task)` only when you actually need an open-ended
+      web search or a page that requires JavaScript / a login flow.
+      It is the heaviest option and costs money per call.
+  Cite the source URL in your reply whenever you used one of these.
+
+- You have a persistent knowledge graph scoped to research work.
+  Call `recall(query)` to retrieve anything the user told you in a
+  previous session. Call `remember(content)` to persist a fact
+  worth keeping across sessions — user preferences ("prefers
+  brief replies"), recurring topics, decisions made earlier. Don't
+  `remember` transient details. Relevant facts are also
+  auto-injected before each turn, so often you don't need to call
+  `recall` explicitly.
+
+When showing code snippets in your reply, call
+`print(highlight(code))` for any multi-line block — `highlight`
+returns a terminal-colored string and `print` writes it to the
+user's console. Skip this for inline identifiers or one-token
+excerpts.
+
+Keep replies brief. Cite sources. Show, don't lecture.
+"""
+
+export def runResearch(userMsg: string, ctx: AgentContext): string {
+  """
+  Run a single turn in the research subagent. The caller is
+  responsible for the surrounding `thread(session: "research") { ... }`
+  block; this function just (a) seeds the research system message
+  on first entry, (b) scopes memory to the `"research"` knowledge
+  graph, and (c) runs the LLM call with the research tool set.
+
+  Returns the LLM's text reply. If the LLM called `handoff()` mid-
+  turn, the reply is the LLM's post-handoff filler text and the
+  caller MUST check `consumeHandoff()` to discover whether to
+  re-route.
+
+  @param userMsg - The user's input message for this turn
+  @param ctx - Per-call invariants (env, projectContext) for the system message
+  """
+  setMemoryId("research")
+  // First-entry detection — see the matching comment in `code.agency`
+  // for the rationale.
+  const t = getThread(currentThreadId())
+  if (isSuccess(t) && t.value.length == 0) {
+    systemMessage(researchSysPrompt + ctx.env + ctx.projectContext)
+  }
+  return llm(userMsg, {
+    memory: true,
+    tools: [
+      docSkill,
+      cliSkill,
+      appendixSkill,
+      wikipediaSearch,
+      wikipediaSummary,
+      wikipediaArticle,
+      fetch,
+      fetchJSON,
+      fetchMarkdown,
+      browserUse,
+      remember,
+      recall,
+      highlight.partial(language: "ts"),
+      print,
+      handoff,
+    ],
+  })
+}

--- a/packages/agency-lang/lib/agents/agency-agent/research.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/research.agency
@@ -6,7 +6,8 @@
  * Tools: docSkill / cliSkill / appendixSkill + wikipedia* + fetch* +
  * browserUse + remember/recall + highlight + print + handoff. NO
  * file write / edit / typecheck / bash — the agent must
- * `handoff("code", ...)` when the user asks for code changes.
+ * `handoff(reason)` (PFA-bound to code only) when the user asks for
+ * code changes.
  *
  * The bundled-docs Skills live here (not in `shared.agency`) because
  * only the research subagent uses them. `static const` caches the
@@ -20,7 +21,6 @@ import { setMemoryId, remember, recall } from "std::memory"
 import { skillsDir } from "std::skills"
 import { highlight } from "std::syntax"
 import { systemMessage } from "std::thread"
-import { currentThreadId, getThread } from "std::threads"
 import {
   search as wikipediaSearch,
   summary as wikipediaSummary,
@@ -43,6 +43,10 @@ static const docSkill = skillsDir("../docs/guide") with approve
 static const cliSkill = skillsDir("../docs/cli") with approve
 static const appendixSkill = skillsDir("../docs/appendix") with approve
 
+// First-entry detection for the research session. See the matching
+// comment in `code.agency` for the rationale.
+let researchFirstEntry: boolean = true
+
 const researchSysPrompt = """
 You are the **research specialist** of a multi-thread Agency-language
 assistant. You answer questions that need reading: Agency-language
@@ -51,8 +55,9 @@ background, URL contents, and general conversation backed by recall.
 
 You do NOT have file-system write tools (no write, edit, bash, or
 typecheck). If the user asks you to actually write, edit, or run
-code, call `handoff("code", reason)` — the runtime will re-route
-the user's original message to the code specialist.
+code, call `handoff(reason)` — the only valid target for you is
+the code specialist, so just pass a brief reason. The runtime will
+re-route the user's original message there.
 
 **Bias toward staying in the research thread.** Most follow-up
 messages ("can you say more?", "what about X?", "explain that
@@ -102,7 +107,11 @@ excerpts.
 Keep replies brief. Cite sources. Show, don't lecture.
 """
 
-export def runResearch(userMsg: string, ctx: AgentContext): string {
+export def runResearch(
+  userMsg: string,
+  ctx: AgentContext,
+  allowHandoff: boolean = true,
+): string {
   """
   Run a single turn in the research subagent. The caller is
   responsible for the surrounding `thread(session: "research") { ... }`
@@ -117,32 +126,39 @@ export def runResearch(userMsg: string, ctx: AgentContext): string {
 
   @param userMsg - The user's input message for this turn
   @param ctx - Per-call invariants (env, projectContext) for the system message
+  @param allowHandoff - When false, the `handoff` tool is omitted from the
+    tool set so the agent is forced to answer this turn. Used by the
+    REPL's hop-limit fallback to break a re-routing chain.
   """
   setMemoryId("research")
-  // First-entry detection — see the matching comment in `code.agency`
-  // for the rationale.
-  const t = getThread(currentThreadId())
-  if (isSuccess(t) && t.value.length == 0) {
+  if (researchFirstEntry) {
     systemMessage(researchSysPrompt + ctx.env + ctx.projectContext)
+    researchFirstEntry = false
+  }
+  // See the comment in `code.agency`: `handoff` is PFA-bound to
+  // `validCategories: ["code"]` so the LLM can't hand off to itself,
+  // and omitted entirely when `allowHandoff` is false.
+  let tools = [
+    docSkill,
+    cliSkill,
+    appendixSkill,
+    wikipediaSearch,
+    wikipediaSummary,
+    wikipediaArticle,
+    fetch,
+    fetchJSON,
+    fetchMarkdown,
+    browserUse,
+    remember,
+    recall,
+    highlight.partial(language: "ts"),
+    print,
+  ]
+  if (allowHandoff) {
+    tools.push(handoff.partial(validCategories: ["code"]))
   }
   return llm(userMsg, {
     memory: true,
-    tools: [
-      docSkill,
-      cliSkill,
-      appendixSkill,
-      wikipediaSearch,
-      wikipediaSummary,
-      wikipediaArticle,
-      fetch,
-      fetchJSON,
-      fetchMarkdown,
-      browserUse,
-      remember,
-      recall,
-      highlight.partial(language: "ts"),
-      print,
-      handoff,
-    ],
+    tools: tools
   })
 }

--- a/packages/agency-lang/lib/agents/agency-agent/research.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/research.agency
@@ -105,6 +105,13 @@ user's console. Skip this for inline identifiers or one-token
 excerpts.
 
 Keep replies brief. Cite sources. Show, don't lecture.
+
+Respond in Markdown — use `#`/`##` headings, `-` bullets, **bold**,
+_italic_, [links](url), and fenced code blocks (```ts, ```bash,
+```json) for any code or structured output. The REPL renders your
+reply through a Markdown syntax highlighter, so well-marked-up
+replies appear with colored headings, bold/italic styling, link
+underlining, and properly highlighted code fences.
 """
 
 export def runResearch(

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -4,15 +4,17 @@
  * The agent is split across:
  *   - `agent.agency`     — REPL loop + interrupt handler + policy
  *   - `shared.agency`    — this file; Category type + handoff plumbing
+ *                          + persistent-memory bootstrap
  *   - `code.agency`      — code subagent (file ops, shell, typecheck)
  *   - `research.agency`  — research subagent (docs, web, knowledge)
  *
  * Routing: we don't categorize the user's message on every turn.
- * Instead, the current category's LLM gets a `handoff(category,
- * reason)` tool. If it can handle the message, it just answers. If it
- * can't (e.g. the user asks the code agent a wikipedia question), it
- * calls `handoff()` and the main loop re-routes the same user message
- * to the chosen specialist.
+ * Instead, the current category's LLM gets a `handoff(reason)` tool
+ * (the valid targets are bound per-subagent via PFA — see below).
+ * If it can handle the message, it just answers. If it can't (e.g.
+ * the user asks the code agent a wikipedia question), it calls
+ * `handoff()` and the main loop re-routes the same user message to
+ * the chosen specialist.
  *
  * Why this design? Most messages in a conversation continue the
  * current topic. A naïve `categorize()` LLM call on every turn
@@ -26,8 +28,20 @@
  * the full design rationale and a catalogue of alternative routing
  * techniques worth trying in follow-ups.
  */
+import { enableMemory } from "std::memory"
 
 export type Category = "code" | "research"
+
+// Persistent knowledge graph for every subagent. `setMemoryId(...)`
+// in each subagent scopes which graph their `remember`/`recall` calls
+// hit, so a single shared on-disk directory cleanly hosts both. Using
+// `static const _ = ...` is the documented top-level pattern (see
+// `stdlib/memory.agency`): the `with approve` modifier needs an
+// enclosing step path, which a bare top-level call doesn't have. The
+// underscore name signals "we want the side-effect, not the value".
+static const _memoryReady = enableMemory({
+  dir: "~/.agency-agent/memory"
+}) with approve
 
 // Per-call context handed to each subagent's run function. Holds the
 // invariants computed once per turn in `agent.agency` and read by
@@ -51,16 +65,17 @@ export type AgentContext = {
 // unambiguous. The `handoff` tool only ever writes a valid Category.
 let _handoffTarget: string = ""
 
-export safe def handoff(category: Category, reason: string): string {
+export safe def handoff(
+  category: Category,
+  reason: string,
+  validCategories: Category[],
+): string {
   """
   Re-route the user's current message to a different specialist. Use
-  this ONLY when the user's message is clearly outside your scope:
-
-  - Call `handoff("code", reason)` for write/edit/typecheck/run
-    requests when you're the research agent.
-  - Call `handoff("research", reason)` for docs lookup, web
-    search, fetch, or Wikipedia requests when you're the code
-    agent.
+  this ONLY when the user's message is clearly outside your scope —
+  e.g. the user asks the code agent a research-shaped question (docs
+  lookup, Wikipedia, web fetch), or the research agent a code-shaped
+  one (write/edit/typecheck/run).
 
   After you call this, the runtime closes your turn and re-routes the
   user's ORIGINAL message to the chosen specialist. Anything you say
@@ -75,9 +90,19 @@ export safe def handoff(category: Category, reason: string): string {
   the user has a much smoother experience when the same specialist
   carries a multi-turn topic through.
 
-  @param category - The specialist to re-route to: `"code"` or `"research"`
+  @param category - The specialist to re-route to
   @param reason - Brief explanation; recorded for debugging, not shown to the user
+  @param validCategories - Bound per-subagent via PFA — do not set this manually.
   """
+  // `validCategories` is PFA-bound at the call site (e.g. the code
+  // subagent registers `handoff.partial(validCategories: ["research"])`).
+  // If the LLM tries to hand off to itself, the bound list won't
+  // contain that category and we return an error string the model
+  // sees as the tool's result — no state change.
+  const validList = validCategories.join(", ")
+  if (!validCategories.includes(category)) {
+    return "Error: '${category}' is not a valid handoff target from this agent. Valid targets: ${validList}. If the user's request is in scope for you, just answer it directly."
+  }
   _handoffTarget = category
   return "Handoff scheduled — return now without further reply."
 }

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -39,8 +39,17 @@ export type Category = "code" | "research"
 // `stdlib/memory.agency`): the `with approve` modifier needs an
 // enclosing step path, which a bare top-level call doesn't have. The
 // underscore name signals "we want the side-effect, not the value".
+// `embeddings.model` MUST be set — without it, the embedder is
+// invoked with `model: undefined` and smoltalk warns
+// `[memory] embed call failed: Model undefined is not recognized`,
+// which silently disables Tier 2 (embedding-similarity) recall.
+// `text-embedding-3-small` is the canonical default cited in the
+// memory guide; cheap and ubiquitous.
 static const _memoryReady = enableMemory({
-  dir: "~/.agency-agent/memory"
+  dir: "~/.agency-agent/memory",
+  embeddings: {
+    model: "text-embedding-3-small"
+  }
 }) with approve
 
 // Per-call context handed to each subagent's run function. Holds the

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -29,8 +29,29 @@
  * techniques worth trying in follow-ups.
  */
 import { enableMemory } from "std::memory"
+import { env } from "std::system"
 
 export type Category = "code" | "research"
+
+// Per-user state directory for the agent (persistent memory + saved
+// policy). We expand `~` ourselves via `env("HOME")` because
+// `enableMemory(...)`'s underlying `MemoryFrame` calls
+// `path.resolve(cwd, dir)` directly — Node's `path.resolve` does NOT
+// expand `~`, so passing `"~/.agency-agent/memory"` would silently
+// create a literal `./~/.agency-agent/memory` under cwd instead of
+// the intended `$HOME/.agency-agent/memory`. Tracked upstream as
+// agency-lang#230. Falls back to `.` if `HOME` is unset (rare; mostly
+// a Windows concern — the `.` puts the dir under cwd as a last
+// resort instead of crashing module init).
+def computeAgentDir(): string {
+  const home = env("HOME")
+  if (home == null) {
+    return "./.agency-agent"
+  }
+  return "${home}/.agency-agent"
+}
+
+export static const AGENCY_AGENT_DIR = computeAgentDir()
 
 // Persistent knowledge graph for every subagent. `setMemoryId(...)`
 // in each subagent scopes which graph their `remember`/`recall` calls
@@ -46,7 +67,7 @@ export type Category = "code" | "research"
 // `text-embedding-3-small` is the canonical default cited in the
 // memory guide; cheap and ubiquitous.
 static const _memoryReady = enableMemory({
-  dir: "~/.agency-agent/memory",
+  dir: "${AGENCY_AGENT_DIR}/memory",
   embeddings: {
     model: "text-embedding-3-small"
   }

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -1,0 +1,97 @@
+/*
+ * Shared state and types for the multi-thread Agency Agent.
+ *
+ * The agent is split across:
+ *   - `agent.agency`     — REPL loop + interrupt handler + policy
+ *   - `shared.agency`    — this file; Category type + handoff plumbing
+ *   - `code.agency`      — code subagent (file ops, shell, typecheck)
+ *   - `research.agency`  — research subagent (docs, web, knowledge)
+ *
+ * Routing: we don't categorize the user's message on every turn.
+ * Instead, the current category's LLM gets a `handoff(category,
+ * reason)` tool. If it can handle the message, it just answers. If it
+ * can't (e.g. the user asks the code agent a wikipedia question), it
+ * calls `handoff()` and the main loop re-routes the same user message
+ * to the chosen specialist.
+ *
+ * Why this design? Most messages in a conversation continue the
+ * current topic. A naïve `categorize()` LLM call on every turn
+ * over-eagerly re-routes ambiguous follow-ups, stranding the new
+ * specialist without conversation context. Letting the current agent
+ * decide biases hard toward "stay" — the agent has the full thread
+ * history and is the most-informed judge of whether the message is
+ * in-scope.
+ *
+ * See docs/superpowers/ideas/2026-05-30-routing-stickiness.md for
+ * the full design rationale and a catalogue of alternative routing
+ * techniques worth trying in follow-ups.
+ */
+
+export type Category = "code" | "research"
+
+// Per-call context handed to each subagent's run function. Holds the
+// invariants computed once per turn in `agent.agency` and read by
+// each subagent on first entry to seed its system message.
+export type AgentContext = {
+  env: string,
+  projectContext: string,
+}
+
+// Module-level handoff signal. Set by the `handoff` tool while the
+// current category's LLM is mid-call; consumed by the main loop
+// immediately after that call returns. A module-level `let` lives in
+// the GlobalStore, which is the right scope — it survives across the
+// LLM tool-call boundary (handoff fires INSIDE the llm() call) and
+// resets cleanly between user turns once `consumeHandoff` reads it.
+//
+// Stored as a string (not `Category | null`) so the consumer can
+// assign it back without tripping Agency's lack of flow-narrowing
+// for nullable union types. Empty string means "no handoff pending"
+// — the `Category` union does not contain `""`, so the sentinel is
+// unambiguous. The `handoff` tool only ever writes a valid Category.
+let _handoffTarget: string = ""
+
+export safe def handoff(category: Category, reason: string): string {
+  """
+  Re-route the user's current message to a different specialist. Use
+  this ONLY when the user's message is clearly outside your scope:
+
+  - Call `handoff("code", reason)` for write/edit/typecheck/run
+    requests when you're the research agent.
+  - Call `handoff("research", reason)` for docs lookup, web
+    search, fetch, or Wikipedia requests when you're the code
+    agent.
+
+  After you call this, the runtime closes your turn and re-routes the
+  user's ORIGINAL message to the chosen specialist. Anything you say
+  after `handoff()` is discarded — return immediately without further
+  commentary.
+
+  Bias toward staying. Most ambiguous follow-up messages
+  ("can you make it faster?", "why?", "more please") are
+  continuations of the current topic, NOT new categories. Only call
+  handoff when you're confident the message needs a different
+  specialist's tools. When in doubt, attempt to answer it yourself —
+  the user has a much smoother experience when the same specialist
+  carries a multi-turn topic through.
+
+  @param category - The specialist to re-route to: `"code"` or `"research"`
+  @param reason - Brief explanation; recorded for debugging, not shown to the user
+  """
+  _handoffTarget = category
+  return "Handoff scheduled — return now without further reply."
+}
+
+export safe def consumeHandoff(): string {
+  """
+  Read and clear the pending handoff target. Called by the main loop
+  in `agent.agency` after each LLM round to decide whether to
+  re-route. Returns `""` when no handoff was requested; otherwise
+  returns the slug of the target category (`"code"` or `"research"`),
+  guaranteed to be a valid Category because `handoff()` is the only
+  writer and takes a `Category`-typed parameter.
+  """
+  const result = _handoffTarget
+  _handoffTarget = ""
+  return result
+}

--- a/packages/agency-lang/lib/runtime/memory/manager.test.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.test.ts
@@ -211,7 +211,9 @@ describe("MemoryManager", () => {
     // Tier 3 (filter) returns Mom's id from the candidate set Tier 1
     // surfaced. We assert end-to-end that the formatted recall text
     // includes the entity and its observation.
-    client.text.mockResolvedValue(wrapTextResult(JSON.stringify([mom.id])));
+    client.text.mockResolvedValue(
+      wrapTextResult(JSON.stringify({ ids: [mom.id] })),
+    );
     const text = await manager.recall("mom");
     expect(text).toContain("Mom");
     expect(text).toContain("Likes pottery");
@@ -239,7 +241,7 @@ describe("MemoryManager", () => {
     // hallucination guard this collapses to an empty filter result,
     // and recall should return "" rather than a corrupted entity ref.
     client.text.mockResolvedValue(
-      wrapTextResult(JSON.stringify(["entity-totally-fake"])),
+      wrapTextResult(JSON.stringify({ ids: ["entity-totally-fake"] })),
     );
     const text = await manager.recall("mom");
     expect(text).toBe("");
@@ -415,7 +417,9 @@ describe("MemoryManager", () => {
 
       // Tier-3 LLM returns the seeded entity id.
       const mom = manager.getGraph().findEntityByName("Mom")!;
-      client.text.mockResolvedValueOnce(wrapTextResult(JSON.stringify([mom.id])));
+      client.text.mockResolvedValueOnce(
+        wrapTextResult(JSON.stringify({ ids: [mom.id] })),
+      );
 
       // Spy on spans + reset the events file so we only see recall.
       const openedSpans = spyOnSpans(statelogClient);

--- a/packages/agency-lang/lib/runtime/memory/manager.ts
+++ b/packages/agency-lang/lib/runtime/memory/manager.ts
@@ -1226,10 +1226,15 @@ export class MemoryManager {
 }
 
 // Schema for the JSON returned by the Tier-3 (LLM) filter pass — a
-// list of entity ids picked from the candidate set. The manager
-// additionally filters the result to ids that were actually offered
-// so a hallucinated id is silently dropped.
-const StringArraySchema = z.array(z.string());
+// list of entity ids picked from the candidate set, wrapped in an
+// object so OpenAI's structured-output API accepts it (the API
+// requires the root schema to be `type: "object"` — a top-level
+// array is rejected with HTTP 400). The manager additionally filters
+// the result to ids that were actually offered so a hallucinated id
+// is silently dropped. The retrieval prompt template (`retrieval.
+// mustache`) is matched to this shape and asks the LLM to emit
+// `{"ids": [...]}` rather than a bare array.
+const StringArraySchema = z.object({ ids: z.array(z.string()) });
 
 function parseStringArray(text: string): string[] | null {
   let raw: unknown;
@@ -1239,7 +1244,7 @@ function parseStringArray(text: string): string[] | null {
     return null;
   }
   const result = StringArraySchema.safeParse(raw);
-  return result.success ? result.data : null;
+  return result.success ? result.data.ids : null;
 }
 
 // Schema for the JSON returned by the `forget()` LLM call. Wrapped

--- a/packages/agency-lang/lib/runtime/trace/sinks.ts
+++ b/packages/agency-lang/lib/runtime/trace/sinks.ts
@@ -43,17 +43,42 @@ export class FileSink implements TraceSink {
       const ok = this.stream.write(JSON.stringify(line) + "\n");
       if (ok) {
         resolve();
-      } else {
-        this.stream.once("drain", resolve);
-        this.stream.once("error", reject);
+        return;
       }
+      // Back-pressure path: wait for drain. We register listeners
+      // for BOTH `drain` and `error` and pair them so whichever
+      // fires also removes the other. Without the pairing, the
+      // `once("error", ...)` listener stays attached forever after
+      // a successful drain — and on a long-running agent with many
+      // writes, error listeners accumulate until Node emits
+      // `MaxListenersExceededWarning: 11 error listeners added to
+      // [WriteStream]`.
+      const onDrain = () => {
+        this.stream.removeListener("error", onError);
+        resolve();
+      };
+      const onError = (err: Error) => {
+        this.stream.removeListener("drain", onDrain);
+        reject(err);
+      };
+      this.stream.once("drain", onDrain);
+      this.stream.once("error", onError);
     });
   }
 
   close(): Promise<void> {
     return new Promise((resolve, reject) => {
-      this.stream.end(() => resolve());
-      this.stream.once("error", reject);
+      // Same listener-leak shape as `writeLine` — pair `end`'s
+      // success callback with the `error` listener so the loser is
+      // removed. `close` is normally called once, but pairing keeps
+      // the contract uniform and avoids a stale error listener if
+      // the FileSink is reused.
+      const onError = (err: Error) => reject(err);
+      this.stream.once("error", onError);
+      this.stream.end(() => {
+        this.stream.removeListener("error", onError);
+        resolve();
+      });
     });
   }
 }

--- a/packages/agency-lang/lib/templates/prompts/memory/retrieval.mustache
+++ b/packages/agency-lang/lib/templates/prompts/memory/retrieval.mustache
@@ -5,12 +5,12 @@ Candidate entities (each line: "id: name (type) — facts"):
 
 Query: {{{query:string}}}
 
-Return only the entity ids that are actually relevant to the query, as a JSON array of strings.
+Return only the entity ids that are actually relevant to the query, as a JSON object with an `ids` field holding an array of strings.
 
 Rules:
 - Each id must be one of the candidate ids above. Do not invent ids.
 - Order does not matter.
-- Return [] if no candidates are relevant.
-- Return only the JSON array — no prose, no markdown.
+- Return {"ids": []} if no candidates are relevant.
+- Return only the JSON object — no prose, no markdown.
 
-Example output: ["entity-1", "entity-7"]
+Example output: {"ids": ["entity-1", "entity-7"]}

--- a/packages/agency-lang/lib/templates/prompts/memory/retrieval.ts
+++ b/packages/agency-lang/lib/templates/prompts/memory/retrieval.ts
@@ -10,15 +10,15 @@ Candidate entities (each line: "id: name (type) — facts"):
 
 Query: {{{query:string}}}
 
-Return only the entity ids that are actually relevant to the query, as a JSON array of strings.
+Return only the entity ids that are actually relevant to the query, as a JSON object with an \`ids\` field holding an array of strings.
 
 Rules:
 - Each id must be one of the candidate ids above. Do not invent ids.
 - Order does not matter.
-- Return [] if no candidates are relevant.
-- Return only the JSON array — no prose, no markdown.
+- Return {"ids": []} if no candidates are relevant.
+- Return only the JSON object — no prose, no markdown.
 
-Example output: ["entity-1", "entity-7"]
+Example output: {"ids": ["entity-1", "entity-7"]}
 `;
 
 export type TemplateType = {

--- a/packages/agency-lang/lib/typeChecker/resolveCall.ts
+++ b/packages/agency-lang/lib/typeChecker/resolveCall.ts
@@ -61,6 +61,8 @@ export const RESERVED_FUNCTION_NAMES = new Set<string>([
   "schema",
   "interrupt",
   "debugger",
+  "thread",
+  "subthread",
 
   // Category 3 — auto-imported from `std::index` (see stdlib/index.agency).
   // Redefinition would shadow the import and break compile-time lifting

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.test.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.test.ts
@@ -361,4 +361,47 @@ describe("undefined function diagnostic — imported nodes", () => {
       rmdirSync(dir);
     }
   });
+
+  // `thread(args) as { ... }` falls through the messageThread block
+  // parser (which requires `{` immediately after the paren list) and
+  // gets parsed as a generic `functionCall` instead. Before this
+  // diagnostic was added the user saw a confusing
+  // "Function 'thread' is not defined" warning; now they get a
+  // pointer at the actual mistake.
+  it("emits a tailored hint when `thread` is mistakenly called as a function", () => {
+    const errors = errorsFrom(
+      `
+      node main() {
+        thread(label: "x") as {
+          let y = 1
+        }
+      }
+    `,
+      WARN,
+    );
+    const hits = errors.filter((e) => e.message.includes("`thread`"));
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain("reserved block keyword");
+    expect(hits[0].message).toContain("`as` keyword is not supported");
+    // Generic "is not defined" wording must NOT appear for this case.
+    expect(hits[0].message).not.toContain("is not defined");
+  });
+
+  it("emits a tailored hint when `subthread` is mistakenly called as a function", () => {
+    const errors = errorsFrom(
+      `
+      node main() {
+        thread {
+          subthread() as {
+            let y = 1
+          }
+        }
+      }
+    `,
+      WARN,
+    );
+    const hits = errors.filter((e) => e.message.includes("`subthread`"));
+    expect(hits).toHaveLength(1);
+    expect(hits[0].message).toContain("reserved block keyword");
+  });
 });

--- a/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
+++ b/packages/agency-lang/lib/typeChecker/undefinedFunctionDiagnostic.ts
@@ -72,6 +72,25 @@ function hasFunctionOrNodeAncestor(ancestors: readonly unknown[]): boolean {
 
 // --- Internal helpers ---
 
+// Reserved block keywords that the parser turns into their own AST node
+// when used correctly (`thread { ... }`, `subthread(args) { ... }`).
+// When a user writes them with syntax the block parser doesn't accept
+// (e.g. `thread(args) as { ... }` — `as` is not supported on thread
+// blocks), the parser falls back to the generic functionCall form and
+// the user sees a confusing "Function 'thread' is not defined" error.
+// This map provides a tailored diagnostic instead, pointing the user at
+// the actual mistake.
+const RESERVED_BLOCK_KEYWORDS: Record<string, string> = {
+  thread:
+    "`thread` is a reserved block keyword. Write `thread { ... }` or " +
+    "`thread(args) { ... }` directly — the `as` keyword is not supported " +
+    "on thread blocks (there's nothing to bind).",
+  subthread:
+    "`subthread` is a reserved block keyword. Write `subthread { ... }` or " +
+    "`subthread(args) { ... }` directly — the `as` keyword is not supported " +
+    "on subthread blocks (there's nothing to bind).",
+};
+
 function checkBareCall(
   call: FunctionCall,
   scope: Scope,
@@ -88,8 +107,19 @@ function checkBareCall(
     scopeHas: (name) => scope.has(name),
   });
   if (resolution.kind !== "unresolved") return;
+  // `in` instead of bracket access — bracket access walks the prototype chain,
+  // so `RESERVED_BLOCK_KEYWORDS["toString"]` would otherwise return
+  // `Object.prototype.toString` (a function), bypass the `??` default, and
+  // push a non-string message.
+  const blockHint = Object.prototype.hasOwnProperty.call(
+    RESERVED_BLOCK_KEYWORDS,
+    call.functionName,
+  )
+    ? RESERVED_BLOCK_KEYWORDS[call.functionName]
+    : undefined;
   ctx.errors.push({
-    message: `Function '${call.functionName}' is not defined.`,
+    message:
+      blockHint ?? `Function '${call.functionName}' is not defined.`,
     severity: mode === "warn" ? "warning" : "error",
     loc: call.loc,
   });

--- a/packages/agency-lang/tests/agency/memory/basic.test.json
+++ b/packages/agency-lang/tests/agency/memory/basic.test.json
@@ -27,9 +27,11 @@
           }
         },
         {
-          "return": [
-            "entity-1"
-          ]
+          "return": {
+            "ids": [
+              "entity-1"
+            ]
+          }
         }
       ]
     }


### PR DESCRIPTION
Refactors the Agency Agent from a single 23-tool REPL into a multi-thread architecture where each specialist subagent has its own file, system prompt, tool set, and thread session.

## Architecture

```diagram
╭────────────────╮      handoff()       ╭───────────────────╮
│  code agent    │ ◀──────────────────▶ │  research agent   │
│                │                      │                   │
│ file ops       │                      │ docSkill          │
│ shell          │                      │ cliSkill          │
│ typecheck      │                      │ appendixSkill     │
│ highlight      │                      │ wikipedia*        │
│ remember/recall│                      │ fetch / fetchJSON │
│ print          │                      │ browserUse        │
│                │                      │ remember/recall   │
│ thread:"code"  │                      │ thread:"research" │
│ memory:"code"  │                      │ memory:"research" │
╰────────────────╯                      ╰───────────────────╯
        ▲                                       ▲
        │                                       │
        ╰────────────── routing ────────────────╯
                  │
                  ▼
        ╭────────────────────╮
        │ agent.agency       │
        │   REPL + handler   │
        │   handoff loop     │
        ╰────────────────────╯
```

## Files

- **`lib/agents/agency-agent/shared.agency`** — `Category` type, `AgentContext`, `handoff(category, reason)` tool + `consumeHandoff()` plumbing.
- **`lib/agents/agency-agent/code.agency`** — code specialist (file ops, shell, typecheck, syntax highlight). Owns the `workspace` state + `setCwd` tool. NO docs / web access.
- **`lib/agents/agency-agent/research.agency`** — research specialist (docs Skills, Wikipedia, fetch, browserUse). NO write / edit / bash.
- **`lib/agents/agency-agent/agent.agency`** — REPL loop, interrupt handler, policy state, routing loop with hop limit.
- **`docs/superpowers/ideas/2026-05-30-routing-stickiness.md`** — design rationale and a catalogue of alternative routing techniques.

## Routing design

Rather than categorizing every user message (which over-eagerly re-routes ambiguous follow-ups and strands the new specialist with no conversation context), each subagent gets a `handoff(category, reason)` tool. If the current agent can handle the message, it just answers. If clearly out of scope, it calls `handoff()` and the main loop re-runs the user's original message in the chosen specialist's thread.

The current agent is the most-informed judge of whether a follow-up message is in-scope — it has the full thread history. This biases hard toward "stay" without any extra LLM calls. The full design space (sticky-default categorizer, probability distributions, hysteresis, short-message bypass, embedding similarity, in-session calibration, auto-context-injection on switch) is documented in the new ideas file for future experiments.

## Per-thread continuity

Every routed turn runs inside `thread(session: category, label: category, summarize: true) { ... }`. Re-entering a category resumes its prior conversation via the session mechanism. Closed sessions are eagerly summarized via the hook in `lib/stdlib/threads.ts` so future `listThreads()` calls don't pay a lazy round-trip.

## Memory scoping

Each subagent calls `setMemoryId("code")` / `setMemoryId("research")` so each agent's knowledge graph stays separate. A "this user prefers tabs" fact in the code thread doesn't pollute the research thread, and vice versa.

## Verification

End-to-end smoke tests against the real LLM:

- **Stay** — `hello` → defaults to code, gets a coding-assistant reply, no handoff.
- **Handoff** — `search wikipedia for 'Alan Turing'...` → code agent calls `handoff({"category":"research","reason":"User requested a summary from Wikipedia."})`, main loop prints `→ handing off to research`, research agent picks up and starts using docSkill.

Both compile clean (`make` + `pnpm run lint:structure` both green; no type warnings on the new files).

## Out of scope (per plan edits)

- Two subagents (code + research) instead of the originally-planned four. More specialists are easy follow-ups now that the infrastructure is in place.
- `/sessions` REPL shortcut deferred — `listThreads`/`getThread` are still available to add to a tool set later when we want LLM-side session introspection.
- Docs guide update and CHANGELOG entry deferred.

## Follow-up work tracked in the ideas doc

The routing-stickiness ideas file lists 11 alternative routing techniques. The recommended stack for a future "best-effort" implementation is short-message bypass + hysteresis + embedding similarity + context-aware categorizer + auto-context-injection — each is documented with cost / effort / failure-mode analysis.
