### PR TITLE
typechecker: error when a handler body may raise an interrupt

### DIFF
--- a/packages/agency-lang/docs/site/guide/handlers.md
+++ b/packages/agency-lang/docs/site/guide/handlers.md
@@ -139,6 +139,145 @@ The rules of handlers are thus:
 3. Otherwise, if a handler approves, the interrupt is approved.
 4. Of course, a handler doesn't need to approve, reject, or propagate. It can simply choose to log the interrupt data, print out the lyrics to "A Day in the Life," or whatever. If no handler approves, rejects, or propagates, by default, the interrupt propagates up to the user for a decision.
 
+## Handlers can't raise interrupts
+
+A handler's body — whether inline `with (data) { ... }` or a referenced
+function `with myHandler` — is not allowed to raise an interrupt
+(directly or transitively, through any function it calls). The
+typechecker errors at compile time if it might.
+
+### Why
+
+The previous section explained that every handler up the chain runs on
+every interrupt, even after one approves. That is what makes handlers
+a safety primitive: an outer reject always wins, so wrapping someone
+else's code in a `handle { } with reject` actually rejects.
+
+But it also means a handler whose body raises an interrupt re-enters
+the chain — including itself. Without a guard you get unbounded
+recursion. The runtime caps nested dispatch at
+`MAX_HANDLER_CHAIN_DEPTH` and throws `HandlerRecursionError`, which
+fires *after* a deep stack has already grown. The typechecker catches
+the structural problem at compile time instead.
+
+You might wonder if the runtime could just skip handlers already on
+the stack. It can't — that would silently disable a handler in
+exactly the situation it was written to catch. Suppose a handler
+rejects reads of `/private` and consults a policy file for everything
+else:
+
+```ts
+handle { ... } with (data) {
+  if (data.kind == "std::read" && data.params.dir == "/private") {
+    return reject()
+  }
+  return consultPolicy()
+}
+```
+
+If `consultPolicy()` reads `~/.policy.json` via `with approve`, the
+chain re-enters the handler. If we skipped it, fine. But now an
+attacker edits `consultPolicy()` to also read `/private` under `with
+approve` — and because the handler is on the skip list, the
+rejection never fires. Preventing the recursion at compile time
+keeps the "every handler always runs" guarantee intact.
+
+### The diagnostic
+
+The error names the handler and the interrupt kinds:
+
+```
+Handler 'defaultHandler' may raise interrupts [std::read]. That would
+re-enter the handler chain (the dispatcher visits every handler,
+even the one currently running) and recurse until
+HandlerRecursionError fires at runtime. Restructure so the handler
+doesn't call interrupt-raising code (e.g. hoist file I/O out of the
+handler), or suppress this error with `// @tc-ignore` on the line
+above the `handle` block.
+```
+
+### Fixing it
+
+Two patterns cover almost every real case.
+
+**Pattern 1: hoist the interrupt-raising work out of the handler.** If
+the handler needs a value it can compute once at startup, do the
+compute *before* installing the handler:
+
+```ts
+// Before — handler reads the policy file every time, which itself
+// raises a std::read interrupt the chain wants to dispatch.
+def myHandler(data) {
+  const policy = read("policy.json") with approve   // ← re-enters
+  return checkPolicy(policy, data)
+}
+node main() {
+  handle { ... } with myHandler
+}
+```
+
+```ts
+// After — read once outside the handler, close over the value.
+let policy: Policy = {}
+node main() {
+  policy = read("policy.json") with approve
+  handle { ... } with myHandler   // myHandler now just reads `policy`
+}
+```
+
+**Pattern 2: flip a sentinel flag *before* the interrupting call, not
+after.** If the handler genuinely has to do something once that may
+itself interrupt — say, lazy-load on first use — guard the re-entry
+explicitly:
+
+```ts
+let loaded: boolean = false
+def ensureLoaded() {
+  if (!loaded) {
+    loaded = true                              // ← flip FIRST
+    policy = read("policy.json") with approve  // re-enters, but the
+                                               // guard short-circuits
+  }
+}
+def myHandler(data) {
+  ensureLoaded()
+  return checkPolicy(policy, data)
+}
+```
+
+The order matters: if you flip `loaded` *after* the read, the
+re-entered call sees `loaded == false`, raises another interrupt, and
+recurses. Flipping first makes the re-entry a no-op.
+
+### The escape hatch
+
+If neither pattern fits — e.g. you're forwarding the interrupt to a
+remote process and the network call genuinely has to happen inside
+the handler — add `// @tc-ignore` on the line directly above the
+`handle` block to silence this one error:
+
+```ts
+node main() {
+  // @tc-ignore
+  handle { ... } with myUnavoidableHandler
+}
+```
+
+A few things to know:
+
+- `@tc-ignore` only suppresses errors whose source location is on the
+  *very next line*. It only silences the handler-recursion error at
+  this `handle` site. Errors inside the handle body or the handler
+  function continue to fire normally.
+- The suppression has to live at the `handle` call site, not at the
+  handler function's definition. If `myUnavoidableHandler` is defined
+  in another file, the comment still goes above the `handle` that
+  references it. The error names the handler, so search for the
+  definition from there.
+- The whole-file `// @tc-nocheck` directive also turns this rule off
+  along with everything else, but prefer the per-site `@tc-ignore` so
+  you don't lose unrelated diagnostics.
+
 ## Handler shorthand
 
 Specifically for the keywords `approve`, `reject`, and `propagate`, there is a shorthand syntax you can use:

--- a/packages/agency-lang/lib/typeChecker/handlerBodyInterrupts.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerBodyInterrupts.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, unlinkSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { liftCallbackBlocks } from "../preprocessors/liftCallbacks.js";
+import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
+
+// Errors when a `handle { } with X` handler can transitively raise an
+// interrupt — that would re-enter the handler chain and recurse. See
+// the rationale at `checkHandlerBodyInterrupts` in interruptAnalysis.ts.
+
+function errorsFrom(source: string): TypeCheckError[] {
+  const file = path.join(
+    os.tmpdir(),
+    `tc-handler-body-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`,
+  );
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath);
+    const parseResult = parseAgency(source, {});
+    if (!parseResult.success) throw new Error("Parse failed");
+    const lifted = liftCallbackBlocks(parseResult.result);
+    const info = buildCompilationUnit(lifted, symbolTable, absPath, source);
+    const { errors } = typeCheck(lifted, {}, info);
+    return errors.filter((e) => e.severity === "error");
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+describe("checkHandlerBodyInterrupts", () => {
+  it("errors when an inline handler directly raises an interrupt", () => {
+    const errors = errorsFrom(`
+      node main() {
+        handle {
+          let _x: number = 1
+        } with (_data) {
+          interrupt myapp::pause("nope")
+        }
+        return 1
+      }
+    `);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("(inline)");
+    expect(errors[0].message).toContain("myapp::pause");
+    expect(errors[0].message).toContain("re-enter the handler chain");
+  });
+
+  it("errors when an inline handler transitively raises via a called function", () => {
+    const errors = errorsFrom(`
+      def maybeFail() {
+        interrupt myapp::transitive("nope")
+      }
+      node main() {
+        handle {
+          let _x: number = 1
+        } with (_data) {
+          maybeFail()
+        }
+        return 1
+      }
+    `);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("(inline)");
+    expect(errors[0].message).toContain("myapp::transitive");
+  });
+
+  it("errors when a functionRef handler may raise an interrupt", () => {
+    const errors = errorsFrom(`
+      def myHandler(_intr) {
+        interrupt myapp::nested("nope")
+      }
+      node main() {
+        handle {
+          let _x: number = 1
+        } with myHandler
+        return 1
+      }
+    `);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("'myHandler'");
+    expect(errors[0].message).toContain("myapp::nested");
+  });
+
+  it("errors when a functionRef handler transitively interrupts", () => {
+    const errors = errorsFrom(`
+      def innerCall() {
+        interrupt myapp::deep("nope")
+      }
+      def myHandler(_intr) {
+        innerCall()
+      }
+      node main() {
+        handle {
+          let _x: number = 1
+        } with myHandler
+        return 1
+      }
+    `);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("'myHandler'");
+    expect(errors[0].message).toContain("myapp::deep");
+  });
+
+  it("does NOT error when the handler is interrupt-free", () => {
+    const errors = errorsFrom(`
+      def myHandler(_intr) {
+        print("just logging")
+      }
+      node main() {
+        handle {
+          let _x: number = 1
+        } with myHandler
+        handle {
+          let _y: number = 2
+        } with (_data) {
+          print("inline but safe")
+        }
+        return 1
+      }
+    `);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("does NOT error for `with approve` / `with reject` modifiers", () => {
+    // The built-in approve/reject handlers don't run user code.
+    const errors = errorsFrom(`
+      def needsApproval() {
+        interrupt std::read("ignored")
+      }
+      node main() {
+        needsApproval() with approve
+        return 1
+      }
+    `);
+    expect(errors).toHaveLength(0);
+  });
+
+  it("is suppressible with @tc-ignore on the line above the handle block", () => {
+    const errors = errorsFrom(`
+      def myHandler(_intr) {
+        interrupt myapp::escape("intentional")
+      }
+      node main() {
+        // @tc-ignore
+        handle {
+          let _x: number = 1
+        } with myHandler
+        return 1
+      }
+    `);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/handlerBodyInterrupts.test.ts
+++ b/packages/agency-lang/lib/typeChecker/handlerBodyInterrupts.test.ts
@@ -107,6 +107,30 @@ describe("checkHandlerBodyInterrupts", () => {
     expect(errors[0].message).toContain("myapp::deep");
   });
 
+  it("catches interrupts via function refs passed as arguments (e.g. tools)", () => {
+    // Mirrors the analyzeInterruptsFromScopes treatment of
+    // `functionRefsInArgs`: handing an interrupt-raising function as a
+    // value (tool, callback, strategy, etc.) to another call inside the
+    // handler still risks re-entering the chain when that callee invokes
+    // it. Catches the gap Copilot flagged on the original PR.
+    const errors = errorsFrom(`
+      def deploy() {
+        interrupt myapp::deploy("nope")
+      }
+      node main() {
+        handle {
+          let _x: number = 1
+        } with (_data) {
+          llm("do it", { tools: [deploy] })
+        }
+        return 1
+      }
+    `);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("(inline)");
+    expect(errors[0].message).toContain("myapp::deploy");
+  });
+
   it("does NOT error when the handler is interrupt-free", () => {
     const errors = errorsFrom(`
       def myHandler(_intr) {

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -36,6 +36,7 @@ import {
   analyzeInterruptsFromScopes,
   checkUnhandledInterruptWarnings,
   checkCallbackBodyInterrupts,
+  checkHandlerBodyInterrupts,
 } from "./interruptAnalysis.js";
 import { checkUndefinedFunctions } from "./undefinedFunctionDiagnostic.js";
 import { checkUndefinedVariables } from "./undefinedVariableDiagnostic.js";
@@ -290,6 +291,10 @@ export class TypeChecker {
     // 6a. Reject `interrupt` inside any callback body. Callbacks fire as
     // side effects; their body cannot pause execution.
     checkCallbackBodyInterrupts(scopes, interruptKindsByFunction, ctx);
+
+    // 6b. Reject handlers whose body may itself raise an interrupt — that
+    // re-enters the handler chain and recurses (see HandlerRecursionError).
+    checkHandlerBodyInterrupts(scopes, interruptKindsByFunction, ctx);
 
     // 7. Check for undefined function calls (config-controlled severity).
     checkUndefinedFunctions(scopes, ctx);

--- a/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
@@ -2,7 +2,7 @@ import type { InterruptKind } from "../symbolTable.js";
 import type { TypeCheckerContext, ScopeInfo } from "./types.js";
 import { synthType } from "./synthesizer.js";
 import { walkNodes } from "../utils/node.js";
-import type { Expression, VariableType } from "../types.js";
+import type { AgencyNode, Expression, VariableType } from "../types.js";
 import type { SplatExpression, NamedArgument } from "../types/dataStructures.js";
 import type { Scope } from "./scope.js";
 import { isInsideHandler } from "./checker.js";
@@ -49,26 +49,41 @@ function collectProfiles(
 }
 
 function collectFromScope(info: ScopeInfo, ctx: TypeCheckerContext): FunctionProfile {
-  const kinds: string[] = [];
-  const callees: string[] = [];
-
   // Set the typechecker's current scope so synthType (called via
   // functionRefsInArgs) can resolve scope-local type aliases.
+  let profile: FunctionProfile = { kinds: [], callees: [] };
   ctx.withScope(info.scopeKey, () => {
-    for (const { node } of walkNodes(info.body)) {
-      if (node.type === "interruptStatement") {
-        addUnique(kinds, node.kind);
-      } else if (node.type === "functionCall") {
-        addUnique(callees, node.functionName);
-        for (const name of functionRefsInArgs(node.arguments, info.scope, ctx)) {
-          addUnique(callees, name);
-        }
-      } else if (node.type === "gotoStatement") {
-        addUnique(callees, node.nodeCall.functionName);
-      }
-    }
+    profile = collectFromBody(info.body, info.scope, ctx);
   });
+  return profile;
+}
 
+/** Walk one AST body and produce a `FunctionProfile`: direct interrupt
+ *  kinds plus the names of every callee — including function references
+ *  passed as arguments (e.g. `llm(..., { tools: [deploy] })`) and `goto`
+ *  targets. Shared between Phase 1 scope analysis and the handler-body
+ *  diagnostic so any future analyzer change applies to both. The caller
+ *  is responsible for setting `ctx.withScope` if the body's
+ *  `functionRefsInArgs` resolution needs scope-local type aliases. */
+function collectFromBody(
+  body: AgencyNode[],
+  scope: Scope,
+  ctx: TypeCheckerContext,
+): FunctionProfile {
+  const kinds: string[] = [];
+  const callees: string[] = [];
+  for (const { node } of walkNodes(body)) {
+    if (node.type === "interruptStatement") {
+      addUnique(kinds, node.kind);
+    } else if (node.type === "functionCall") {
+      addUnique(callees, node.functionName);
+      for (const name of functionRefsInArgs(node.arguments, scope, ctx)) {
+        addUnique(callees, name);
+      }
+    } else if (node.type === "gotoStatement") {
+      addUnique(callees, node.nodeCall.functionName);
+    }
+  }
   return { kinds, callees };
 }
 
@@ -250,49 +265,29 @@ export function checkHandlerBodyInterrupts(
 
 /** Collect every interrupt kind a handle block's handler may raise,
  *  transitively. For a `functionRef` handler we read the already-propagated
- *  kinds directly. For an inline handler we mirror `collectFromScope`:
- *  direct `interruptStatement`s contribute their kind, and every callee —
- *  including function references passed as arguments (e.g. tools handed to
- *  `llm(..., tools: [deploy])`) — is resolved through
- *  `interruptKindsByFunction` so transitive interrupts via tool calls or
- *  callback handoffs are caught. */
+ *  kinds directly. For an inline handler we reuse `collectFromBody` (the
+ *  same walker Phase 1 uses for every scope) and then resolve its callees
+ *  through `interruptKindsByFunction`, so transitive interrupts via tool
+ *  calls, function refs in args, or `goto` targets are caught with no
+ *  duplicated walker logic. */
 function collectHandlerOffenderKinds(
   node: { handler: { kind: string; functionName?: string; body?: any[] } },
   info: ScopeInfo,
   interruptKindsByFunction: Record<string, InterruptKind[]>,
   ctx: TypeCheckerContext,
 ): string[] {
-  const kinds: string[] = [];
   if (node.handler.kind === "functionRef") {
     const ks = interruptKindsByFunction[node.handler.functionName!] ?? [];
-    for (const k of ks) addUnique(kinds, k.kind);
-    return kinds;
+    return ks.map((k) => k.kind);
   }
-  // inline handler — mirror collectFromScope's callee discovery
-  for (const { node: inner } of walkNodes(node.handler.body ?? [])) {
-    if (inner.type === "interruptStatement") {
-      addUnique(kinds, inner.kind);
-      continue;
-    }
-    if (inner.type === "functionCall") {
-      addKindsFor(inner.functionName, interruptKindsByFunction, kinds);
-      for (const refName of functionRefsInArgs(inner.arguments, info.scope, ctx)) {
-        addKindsFor(refName, interruptKindsByFunction, kinds);
-      }
-    } else if (inner.type === "gotoStatement") {
-      addKindsFor(inner.nodeCall.functionName, interruptKindsByFunction, kinds);
+  const profile = collectFromBody(node.handler.body ?? [], info.scope, ctx);
+  const kinds = [...profile.kinds];
+  for (const callee of profile.callees) {
+    for (const k of interruptKindsByFunction[callee] ?? []) {
+      addUnique(kinds, k.kind);
     }
   }
   return kinds;
-}
-
-function addKindsFor(
-  name: string,
-  interruptKindsByFunction: Record<string, InterruptKind[]>,
-  out: string[],
-): void {
-  const ks = interruptKindsByFunction[name] ?? [];
-  for (const k of ks) addUnique(out, k.kind);
 }
 
 /** Narrow a call-argument slot (which may be a positional Expression,

--- a/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
@@ -216,57 +216,83 @@ export function checkHandlerBodyInterrupts(
   ctx: TypeCheckerContext,
 ): void {
   for (const info of scopes) {
-    for (const { node } of walkNodes(info.body)) {
-      if (node.type !== "handleBlock") continue;
-      const offenders = collectHandlerOffenders(node, interruptKindsByFunction);
-      if (offenders.kinds.length === 0) continue;
-      const kindList = offenders.kinds.join(", ");
-      const handlerLabel =
-        node.handler.kind === "functionRef"
-          ? `'${node.handler.functionName}'`
-          : "(inline)";
-      ctx.errors.push({
-        message:
-          `Handler ${handlerLabel} may raise interrupts [${kindList}]. ` +
-          `That would re-enter the handler chain (the dispatcher visits ` +
-          `every handler, even the one currently running) and recurse ` +
-          `until \`HandlerRecursionError\` fires at runtime. ` +
-          `Restructure so the handler doesn't call interrupt-raising ` +
-          `code (e.g. hoist file I/O out of the handler), or suppress ` +
-          `this error with \`// @tc-ignore\` on the line above the ` +
-          `\`handle\` block.`,
-        severity: "error",
-        loc: node.loc,
-      });
-    }
+    ctx.withScope(info.scopeKey, () => {
+      for (const { node } of walkNodes(info.body)) {
+        if (node.type !== "handleBlock") continue;
+        const kinds = collectHandlerOffenderKinds(
+          node,
+          info,
+          interruptKindsByFunction,
+          ctx,
+        );
+        if (kinds.length === 0) continue;
+        const handlerLabel =
+          node.handler.kind === "functionRef"
+            ? `'${node.handler.functionName}'`
+            : "(inline)";
+        ctx.errors.push({
+          message:
+            `Handler ${handlerLabel} may raise interrupts [${kinds.join(", ")}]. ` +
+            `That would re-enter the handler chain (the dispatcher visits ` +
+            `every handler, even the one currently running) and recurse ` +
+            `until \`HandlerRecursionError\` fires at runtime. ` +
+            `Restructure so the handler doesn't call interrupt-raising ` +
+            `code (e.g. hoist file I/O out of the handler), or suppress ` +
+            `this error with \`// @tc-ignore\` on the line above the ` +
+            `\`handle\` block.`,
+          severity: "error",
+          loc: node.loc,
+        });
+      }
+    });
   }
 }
 
-/** Collect every interrupt kind that this handle block's handler may raise,
- *  transitively. For a functionRef handler we read the propagated kinds
- *  directly; for an inline handler we walk its body for direct
- *  `interruptStatement`s and for `functionCall`s whose target was already
- *  flagged in `interruptKindsByFunction`. */
-function collectHandlerOffenders(
+/** Collect every interrupt kind a handle block's handler may raise,
+ *  transitively. For a `functionRef` handler we read the already-propagated
+ *  kinds directly. For an inline handler we mirror `collectFromScope`:
+ *  direct `interruptStatement`s contribute their kind, and every callee —
+ *  including function references passed as arguments (e.g. tools handed to
+ *  `llm(..., tools: [deploy])`) — is resolved through
+ *  `interruptKindsByFunction` so transitive interrupts via tool calls or
+ *  callback handoffs are caught. */
+function collectHandlerOffenderKinds(
   node: { handler: { kind: string; functionName?: string; body?: any[] } },
+  info: ScopeInfo,
   interruptKindsByFunction: Record<string, InterruptKind[]>,
-): { kinds: string[] } {
+  ctx: TypeCheckerContext,
+): string[] {
   const kinds: string[] = [];
   if (node.handler.kind === "functionRef") {
     const ks = interruptKindsByFunction[node.handler.functionName!] ?? [];
     for (const k of ks) addUnique(kinds, k.kind);
-    return { kinds };
+    return kinds;
   }
-  // inline handler
+  // inline handler — mirror collectFromScope's callee discovery
   for (const { node: inner } of walkNodes(node.handler.body ?? [])) {
     if (inner.type === "interruptStatement") {
       addUnique(kinds, inner.kind);
-    } else if (inner.type === "functionCall") {
-      const ks = interruptKindsByFunction[inner.functionName] ?? [];
-      for (const k of ks) addUnique(kinds, k.kind);
+      continue;
+    }
+    if (inner.type === "functionCall") {
+      addKindsFor(inner.functionName, interruptKindsByFunction, kinds);
+      for (const refName of functionRefsInArgs(inner.arguments, info.scope, ctx)) {
+        addKindsFor(refName, interruptKindsByFunction, kinds);
+      }
+    } else if (inner.type === "gotoStatement") {
+      addKindsFor(inner.nodeCall.functionName, interruptKindsByFunction, kinds);
     }
   }
-  return { kinds };
+  return kinds;
+}
+
+function addKindsFor(
+  name: string,
+  interruptKindsByFunction: Record<string, InterruptKind[]>,
+  out: string[],
+): void {
+  const ks = interruptKindsByFunction[name] ?? [];
+  for (const k of ks) addUnique(out, k.kind);
 }
 
 /** Narrow a call-argument slot (which may be a positional Expression,

--- a/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
+++ b/packages/agency-lang/lib/typeChecker/interruptAnalysis.ts
@@ -194,6 +194,81 @@ export function checkUnhandledInterruptWarnings(
   }
 }
 
+/**
+ * A handler whose body can itself raise an interrupt creates a
+ * dispatch-recursion loop: the inner interrupt re-enters the handler
+ * chain, which visits every handler (including the one currently
+ * running), which raises another interrupt, etc. The runtime now
+ * bounds this at `MAX_HANDLER_CHAIN_DEPTH` and throws
+ * `HandlerRecursionError`, but catching it at compile time is better.
+ *
+ * Restructure the code so the handler doesn't call interrupt-raising
+ * functions — e.g. hoist a `read("policy.json") with approve` out of
+ * the handler and into `node main()` (see `ensurePolicyLoaded` in
+ * `lib/agents/agency-agent/agent.agency` for the canonical fix).
+ *
+ * If the call really is unavoidable, suppress this error with a
+ * `// @tc-ignore` comment on the line above the `handle` block.
+ */
+export function checkHandlerBodyInterrupts(
+  scopes: ScopeInfo[],
+  interruptKindsByFunction: Record<string, InterruptKind[]>,
+  ctx: TypeCheckerContext,
+): void {
+  for (const info of scopes) {
+    for (const { node } of walkNodes(info.body)) {
+      if (node.type !== "handleBlock") continue;
+      const offenders = collectHandlerOffenders(node, interruptKindsByFunction);
+      if (offenders.kinds.length === 0) continue;
+      const kindList = offenders.kinds.join(", ");
+      const handlerLabel =
+        node.handler.kind === "functionRef"
+          ? `'${node.handler.functionName}'`
+          : "(inline)";
+      ctx.errors.push({
+        message:
+          `Handler ${handlerLabel} may raise interrupts [${kindList}]. ` +
+          `That would re-enter the handler chain (the dispatcher visits ` +
+          `every handler, even the one currently running) and recurse ` +
+          `until \`HandlerRecursionError\` fires at runtime. ` +
+          `Restructure so the handler doesn't call interrupt-raising ` +
+          `code (e.g. hoist file I/O out of the handler), or suppress ` +
+          `this error with \`// @tc-ignore\` on the line above the ` +
+          `\`handle\` block.`,
+        severity: "error",
+        loc: node.loc,
+      });
+    }
+  }
+}
+
+/** Collect every interrupt kind that this handle block's handler may raise,
+ *  transitively. For a functionRef handler we read the propagated kinds
+ *  directly; for an inline handler we walk its body for direct
+ *  `interruptStatement`s and for `functionCall`s whose target was already
+ *  flagged in `interruptKindsByFunction`. */
+function collectHandlerOffenders(
+  node: { handler: { kind: string; functionName?: string; body?: any[] } },
+  interruptKindsByFunction: Record<string, InterruptKind[]>,
+): { kinds: string[] } {
+  const kinds: string[] = [];
+  if (node.handler.kind === "functionRef") {
+    const ks = interruptKindsByFunction[node.handler.functionName!] ?? [];
+    for (const k of ks) addUnique(kinds, k.kind);
+    return { kinds };
+  }
+  // inline handler
+  for (const { node: inner } of walkNodes(node.handler.body ?? [])) {
+    if (inner.type === "interruptStatement") {
+      addUnique(kinds, inner.kind);
+    } else if (inner.type === "functionCall") {
+      const ks = interruptKindsByFunction[inner.functionName] ?? [];
+      for (const k of ks) addUnique(kinds, k.kind);
+    }
+  }
+  return { kinds };
+}
+
 /** Narrow a call-argument slot (which may be a positional Expression,
  *  a SplatExpression, or a NamedArgument) to a positional Expression.
  *  Returns null for splat / named arguments — we only act on the


### PR DESCRIPTION
## What

Adds a typechecker error when a `handle { } with X` handler can transitively raise an interrupt — the situation that caused the handler-recursion bug in https://ampcode.com/threads/T-019e7a80-0a51-75ce-840e-89b5f595da5c.

The runtime fix (`HandlerRecursionError` at `MAX_HANDLER_CHAIN_DEPTH=10`) catches the loop *after* it spirals. This catches it at compile time so users see the structural mistake instead of a runtime stack trace.

## Why not "skip handlers already on the stack"?

That was the first idea, and it's an authorization-bypass waiting to happen. Example: a handler rejects reads of `/private` and consults a policy file for everything else.

```
handle { ... } with (data) {
  if (data.kind == "std::read" && data.params.dir == "/private") {
    return reject()
  }
  return consultPolicy()
}
```

If `consultPolicy()` reads `~/.policy.json` via `with approve`, the chain re-enters the handler — fine if we skip it. But if an attacker edits `consultPolicy()` to also read `/private` under `with approve`, the skip rule means the rejection handler never sees that read. Skipping handlers breaks the core safety guarantee. So the recursion has to be prevented at compile time, not papered over at runtime.

## Design

Modeled on the existing `checkCallbackBodyInterrupts`:
- For `handle { } with myHandler`, look up `myHandler` in the transitive `interruptKindsByFunction` map (already built by `analyzeInterruptsFromScopes`).
- For `handle { } with (data) { ... }`, walk the inline body for direct `interruptStatement`s and `functionCall`s into functions with kinds.
- Severity: `error`.

`with approve` / `with reject` modifiers are not checked — their handler is the built-in `approve`/`reject`/`propagate` trio (see `lib/types/withModifier.ts`), which never runs user code.

## Escape hatch

The existing `// @tc-ignore` directive (one line above the `handle` block) suppresses this error at a single site. I deliberately did **not** add an `agency.json` kill switch — it would encourage disabling the check globally instead of locally, the opposite of what a safety check needs.

## Tests

`lib/typeChecker/handlerBodyInterrupts.test.ts` — 7 tests covering:
- inline handler with direct `interrupt`
- inline handler with transitive interrupt
- `functionRef` handler with direct interrupt
- `functionRef` handler with transitive interrupt
- interrupt-free handler (no false positives)
- `with approve` modifier on interrupt-raising code (correctly skipped)
- `// @tc-ignore` suppression

All 504 typechecker tests pass.

## Files changed

- `lib/typeChecker/interruptAnalysis.ts` — `checkHandlerBodyInterrupts` + helper
- `lib/typeChecker/index.ts` — wired in as pipeline step 6b
- `lib/typeChecker/handlerBodyInterrupts.test.ts` — new test file
