### PR TITLE
stdlib: lift policy handler and multi-agent router into the standard library

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/agent.md
+++ b/packages/agency-lang/docs/site/stdlib/agent.md
@@ -1,5 +1,80 @@
 # agent
 
+## Overview
+
+  Helpers for building user-facing agents. Three independent
+  features live here:
+
+  - **`route`** — a multi-specialist dispatcher. Wire two or more
+    "specialist" agents (each with its own system prompt, tool set,
+    and optional memory scope) into one entry point. Each user
+    message stays in its current specialist unless the LLM calls
+    `handoff()` to re-route it. See below for usage.
+  - **`question`** — ask the user a question via an interrupt so
+    the host UI (CLI, web, etc.) can render the prompt.
+  - **`todoWrite` / `todoList`** — a tiny in-process todo list an
+    LLM can use to track multi-step work across turns.
+
+  ## Router usage
+
+  ```ts
+  import { route } from "std::agent"
+
+  // Two specialists, each with its own system prompt + tools.
+  const codeAgent = {
+    systemPrompt: "You write and edit code...",
+    tools: [readFile, writeFile, typecheck],
+    memory: true,
+  }
+  const researchAgent = {
+    systemPrompt: "You answer questions by reading docs...",
+    tools: [fetchUrl, wikipediaSearch],
+    memory: true,
+  }
+
+  node main() {
+    let msg = input("> ")
+    while (msg != "exit") {
+      const reply = route({
+        start: "code",
+        agents: { code: codeAgent, research: researchAgent },
+        maxHops: 3,
+      }, msg)
+      print(reply)
+      msg = input("> ")
+    }
+  }
+  ```
+
+  ### How handoff works
+
+  Inside `route`, each specialist's tool set is augmented with a
+  `handoff(category, reason)` tool. When the LLM calls it, the
+  current LLM call ends and `route` re-runs the same user message
+  in the named specialist's thread. The handoff cannot target the
+  current specialist (PFA prevents self-targets).
+
+  The cap `maxHops` bounds ping-pong: when reached, the next call
+  is made WITHOUT the handoff tool so the LLM is forced to answer.
+
+  ### Per-specialist state
+
+  Each specialist runs inside its own `thread(session: <category>)`
+  block, so conversation history is partitioned. When `memory: true`,
+  `setMemoryId(<category>)` is also called so `remember`/`recall`
+  inside the specialist's tools land in a per-specialist knowledge
+  graph. Enable the memory subsystem first via `enableMemory(...)`
+  in `std::memory`.
+
+  ### Limits
+
+  Router state (handoff signal, first-entry flags) lives in
+  module-level `let`s, which live in the per-program GlobalStore.
+  Concurrent calls to `route` in **separate** RuntimeContexts are
+  fine; concurrent calls in the **same** program / RuntimeContext
+  (e.g. parallel runners inside one process) will race. Not
+  supported in v1.
+
 ## Types
 
 ### Todo
@@ -12,11 +87,38 @@ type Todo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L4))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L81))
 
 ### AgentSpec
 
+* Configuration for one specialist registered with `route`.
+ *
+ * - `systemPrompt` — system message seeded into the specialist's
+ *   thread on first entry. The router appends `RouterConfig.context`
+ *   (if set) to this string before seeding.
+ * - `tools` — the tools this specialist sees. The router automatically
+ *   appends a `handoff` tool PFA-bound to the other categories, so
+ *   do NOT add `handoff` here yourself.
+ * - `memory` (optional) — when `true`, the router calls
+ *   `setMemoryId(<category>)` before each LLM call so this
+ *   specialist's `remember`/`recall` lands in a per-specialist graph.
+ *   You must `enableMemory(...)` separately for this to do anything.
+
 ```ts
+/**
+ * Configuration for one specialist registered with `route`.
+ *
+ * - `systemPrompt` — system message seeded into the specialist's
+ *   thread on first entry. The router appends `RouterConfig.context`
+ *   (if set) to this string before seeding.
+ * - `tools` — the tools this specialist sees. The router automatically
+ *   appends a `handoff` tool PFA-bound to the other categories, so
+ *   do NOT add `handoff` here yourself.
+ * - `memory` (optional) — when `true`, the router calls
+ *   `setMemoryId(<category>)` before each LLM call so this
+ *   specialist's `remember`/`recall` lands in a per-specialist graph.
+ *   You must `enableMemory(...)` separately for this to do anything.
+ */
 export type AgentSpec = {
   systemPrompt: string;
   tools: any[];
@@ -24,11 +126,42 @@ export type AgentSpec = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L39))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L130))
 
 ### RouterConfig
 
+* Top-level config for a single `route(config, msg)` call.
+ *
+ * - `start` — the category to dispatch the user's message to first.
+ *   Must be a key of `agents`.
+ * - `agents` — map of category name → `AgentSpec`. Every key is a
+ *   potential handoff target.
+ * - `maxHops` — bound on per-turn handoffs (specialist A → B → A → …).
+ *   When the cap is reached, the next LLM call drops the `handoff`
+ *   tool so the agent is forced to answer in place. 3 is a sensible
+ *   default for most agents.
+ * - `context` (optional) — extra text appended to every specialist's
+ *   `systemPrompt` on first entry. Use this for shared grounding
+ *   (current date, working directory, project conventions) that
+ *   every specialist should see.
+
 ```ts
+/**
+ * Top-level config for a single `route(config, msg)` call.
+ *
+ * - `start` — the category to dispatch the user's message to first.
+ *   Must be a key of `agents`.
+ * - `agents` — map of category name → `AgentSpec`. Every key is a
+ *   potential handoff target.
+ * - `maxHops` — bound on per-turn handoffs (specialist A → B → A → …).
+ *   When the cap is reached, the next LLM call drops the `handoff`
+ *   tool so the agent is forced to answer in place. 3 is a sensible
+ *   default for most agents.
+ * - `context` (optional) — extra text appended to every specialist's
+ *   `systemPrompt` on first entry. Use this for shared grounding
+ *   (current date, working directory, project conventions) that
+ *   every specialist should see.
+ */
 export type RouterConfig = {
   start: string;
   agents: Record<string, AgentSpec>;
@@ -37,7 +170,7 @@ export type RouterConfig = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L45))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L152))
 
 ## Functions
 
@@ -57,7 +190,7 @@ Replace the current todo list. Each todo has an id, text, and status (one of 'pe
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L12))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L89))
 
 ### todoList
 
@@ -69,7 +202,7 @@ Return the current todo list.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L20))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L97))
 
 ### question
 
@@ -89,7 +222,7 @@ Ask the user a question and wait for their reply. Unlike input(), this raises an
 
 **Throws:** `std::question`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L27))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L104))
 
 ### handoff
 
@@ -110,6 +243,19 @@ Re-route the user's current message to a different specialist.
   @param reason - Brief explanation (recorded for debugging)
   @param validCategories - PFA-bound by `route()` — do not set manually
 
+* Tool function the router injects into every specialist's tool
+ * set. You should not register this manually — `route` adds it for
+ * you with `validCategories` PFA-bound to the other registered
+ * categories.
+ *
+ * When called, sets the module-level handoff target. The current
+ * LLM call returns; `route` reads the target via `consumeHandoff`
+ * and re-runs the user's original message in the new specialist's
+ * thread. The handoff is rejected (with an error string the LLM
+ * sees as the tool's result) if `category` isn't in
+ * `validCategories`, so the LLM can't accidentally hand off to
+ * itself or to an unregistered specialist.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -120,7 +266,7 @@ Re-route the user's current message to a different specialist.
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L184))
 
 ### consumeHandoff
 
@@ -132,9 +278,14 @@ Read and clear the pending handoff target. Returns "" when no
   handoff was requested. Used internally by `route()`; exposed for
   tests + advanced users writing custom dispatch loops.
 
+* Read and clear the pending handoff target. Used internally by
+ * `route` after each LLM call. Exposed for tests and for advanced
+ * users writing their own dispatch loop on top of `handoff`.
+ * Returns `""` when no handoff was requested.
+
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L90))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L217))
 
 ### runOneTurn
 
@@ -157,7 +308,7 @@ Single iteration of route()'s hop loop. Owns the thread block,
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L228))
 
 ### route
 
@@ -175,6 +326,32 @@ Run one user turn through a multi-specialist agent. Owns the hop
   @param config - Start category, per-category agent specs, max hops, optional context string
   @param userMsg - The user's input message for this turn
 
+* Run one user turn through a multi-specialist agent. Returns the
+ * final reply (the text the user sees) after all handoffs settle.
+ *
+ * Lifecycle of a single call:
+ *
+ * 1. Dispatch `userMsg` to `config.start`'s specialist. The
+ *    specialist's `thread(session: <category>)` block is opened,
+ *    its system message is seeded on first entry, memory is scoped
+ *    if requested, and `llm(userMsg, { tools: [...spec.tools,
+ *    handoff] })` runs.
+ * 2. After the LLM call returns, check `consumeHandoff()`.
+ *    - Empty → done, return the LLM's reply.
+ *    - Non-empty → loop with the new category, up to `config.maxHops`
+ *      total iterations.
+ * 3. If the hop cap is reached without a final answer, run one more
+ *    LLM call WITHOUT the `handoff` tool so the agent must answer.
+ *
+ * Call once per user turn — `route` does not own the outer REPL
+ * loop. Threads, memory state, and the policy file (if you install
+ * `cliPolicyHandler`) persist across calls so the user can have a
+ * stateful conversation.
+ *
+ * @param config - Specialists, start category, hop cap, optional
+ *   shared context appended to every system prompt.
+ * @param userMsg - The user's input for this turn.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -184,4 +361,4 @@ Run one user turn through a multi-specialist agent. Owns the hop
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L137))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L291))

--- a/packages/agency-lang/docs/site/stdlib/agent.md
+++ b/packages/agency-lang/docs/site/stdlib/agent.md
@@ -12,7 +12,32 @@ type Todo = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L1))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L4))
+
+### AgentSpec
+
+```ts
+export type AgentSpec = {
+  systemPrompt: string;
+  tools: any[];
+  memory?: boolean
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L39))
+
+### RouterConfig
+
+```ts
+export type RouterConfig = {
+  start: string;
+  agents: Record<string, AgentSpec>;
+  maxHops: number;
+  context?: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L45))
 
 ## Functions
 
@@ -32,7 +57,7 @@ Replace the current todo list. Each todo has an id, text, and status (one of 'pe
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L9))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L12))
 
 ### todoList
 
@@ -44,7 +69,7 @@ Return the current todo list.
 
 **Returns:** `Todo[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L17))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L20))
 
 ### question
 
@@ -64,4 +89,99 @@ Ask the user a question and wait for their reply. Unlike input(), this raises an
 
 **Throws:** `std::question`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L24))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L27))
+
+### handoff
+
+```ts
+handoff(category: string, reason: string, validCategories: string[]): string
+```
+
+Re-route the user's current message to a different specialist.
+  After you call this, your turn closes and the original message
+  is re-routed to the chosen specialist. Anything you say after
+  `handoff()` is discarded — return immediately.
+
+  Bias toward staying: most follow-ups are continuations of the
+  current topic. Only call this when the message clearly needs
+  a different specialist's tools.
+
+  @param category - The specialist to re-route to
+  @param reason - Brief explanation (recorded for debugging)
+  @param validCategories - PFA-bound by `route()` — do not set manually
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| category | `string` |  |
+| reason | `string` |  |
+| validCategories | `string[]` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L63))
+
+### consumeHandoff
+
+```ts
+consumeHandoff(): string
+```
+
+Read and clear the pending handoff target. Returns "" when no
+  handoff was requested. Used internally by `route()`; exposed for
+  tests + advanced users writing custom dispatch loops.
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L90))
+
+### runOneTurn
+
+```ts
+runOneTurn(category: string, userMsg: string, config: RouterConfig, allowHandoff: boolean): string
+```
+
+Single iteration of route()'s hop loop. Owns the thread block,
+  memory scoping, first-entry system-message seeding, and tool-array
+  assembly. Returns the LLM's reply (string).
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| category | `string` |  |
+| userMsg | `string` |  |
+| config | [RouterConfig](#routerconfig) |  |
+| allowHandoff | `boolean` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L101))
+
+### route
+
+```ts
+route(config: RouterConfig, userMsg: string): string
+```
+
+Run one user turn through a multi-specialist agent. Owns the hop
+  loop, handoff signal, and force-answer fallback. The router
+  injects a `handoff(category, reason)` tool into each specialist's
+  toolset so the LLM can re-route the message when it's out of scope.
+  When `maxHops` is reached, the handoff tool is stripped from the
+  last call so the LLM is forced to answer.
+
+  @param config - Start category, per-category agent specs, max hops, optional context string
+  @param userMsg - The user's input message for this turn
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| config | [RouterConfig](#routerconfig) |  |
+| userMsg | `string` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/agent.agency#L137))

--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -8,7 +8,7 @@
 export type InterruptDataKey = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L7))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L9))
 
 ### InterruptDataVal
 
@@ -16,7 +16,7 @@ export type InterruptDataKey = string
 export type InterruptDataVal = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L9))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L11))
 
 ### InterruptKind
 
@@ -24,7 +24,7 @@ export type InterruptDataVal = string
 export type InterruptKind = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L11))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L13))
 
 ### PolicyRule
 
@@ -35,7 +35,7 @@ export type PolicyRule = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L13))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L15))
 
 ### Policy
 
@@ -43,7 +43,39 @@ export type PolicyRule = {
 export type Policy = Record<InterruptKind, PolicyRule[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L18))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L20))
+
+### Decision
+
+```ts
+export type Decision =
+  | "approve"
+  | "reject"
+  | "approve-always"
+  | "approve-always-here"
+  | "reject-always"
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L22))
+
+### FieldSpec
+
+```ts
+export type FieldSpec = {
+  field: string;
+  wildcardSubpaths: boolean
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L29))
+
+### AlwaysFields
+
+```ts
+export type AlwaysFields = Record<InterruptKind, FieldSpec[]>
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L34))
 
 ## Functions
 
@@ -62,7 +94,7 @@ Evaluate a policy against an interrupt. Returns approve(), reject(), or propagat
 | policy | `Record<string, any>` |  |
 | interrupt | `Record<string, any>` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L20))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L43))
 
 ### validatePolicy
 
@@ -78,7 +110,94 @@ Validate that a policy object is well-formed. Returns { success: true } if valid
 |---|---|---|
 | policy | `Record<string, any>` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L30))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L53))
+
+### buildScopedMatch
+
+```ts
+buildScopedMatch(intr: Record<string, any>, fields: AlwaysFields): Record<string, string>
+```
+
+Given the per-kind FieldSpec[] config, build a match object pinned
+  to the meaningful fields of this interrupt. Returns {} when the kind
+  isn't in the fields map. Pure.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| intr | `Record<string, any>` |  |
+| fields | [AlwaysFields](#alwaysfields) |  |
+
+**Returns:** `Record<string, string>`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L60))
+
+### recordRule
+
+```ts
+recordRule(policy: Policy, kind: InterruptKind, action: "approve" | "reject"): Policy
+```
+
+Return a new policy with a catch-all rule for `kind` appended.
+  First-match-wins inside `checkPolicy`, so a single bare rule covers
+  every future interrupt of that kind. Pure — no I/O.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| policy | [Policy](#policy) |  |
+| kind | [InterruptKind](#interruptkind) |  |
+| action | `"approve" \| "reject"` |  |
+
+**Returns:** [Policy](#policy)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L84))
+
+### recordScopedRule
+
+```ts
+recordScopedRule(policy: Policy, intr: Record<string, any>, fields: AlwaysFields): Policy
+```
+
+Return a new policy with a scoped approve rule prepended for the
+  interrupt's kind. Prepended (not appended) so the more-specific
+  rule wins over any later catch-all in first-match-wins order. Pure.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| policy | [Policy](#policy) |  |
+| intr | `Record<string, any>` |  |
+| fields | [AlwaysFields](#alwaysfields) |  |
+
+**Returns:** [Policy](#policy)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L102))
+
+### parsePolicyFile
+
+```ts
+parsePolicyFile(path: string): Policy
+```
+
+Read + parse + validate a policy file from disk. Returns {} on any
+  failure (missing, unreadable, malformed JSON, invalid schema) with a
+  warning to the user. Raises std::read.
+
+  @param path - The policy file path
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| path | `string` |  |
+
+**Returns:** [Policy](#policy)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L121))
 
 ### writePolicyFile
 
@@ -100,4 +219,129 @@ Validate and write a policy to a JSON file. Throws if the policy is invalid. Set
 | policy | [Policy](#policy) |  |
 | allowedPaths | `string[]` | [] |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L37))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L150))
+
+### maybeLoad
+
+```ts
+maybeLoad()
+```
+
+Lazy-load the on-disk policy on first handler invocation. Uses
+  flip-flag-first so the std::read interrupt's chain re-entry sees
+  `_loaded == true` and returns without recursing. See
+  docs/site/guide/handlers.md §"Fixing it".
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L161))
+
+### maybeFlush
+
+```ts
+maybeFlush()
+```
+
+Persist any pending policy changes. Same flip-flag-first pattern
+  as `maybeLoad`. Runs at the top of every handler invocation so a
+  decision recorded on turn N is on disk before turn N+1's first
+  interrupt fires. Decisions on the FINAL interrupt of a session
+  may not flush — acceptable per spec.
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L174))
+
+### flushPolicy
+
+```ts
+flushPolicy()
+```
+
+Force a write of the in-memory policy to disk. Use between user
+  turns if you want the FINAL decision of a session persisted (the
+  handler's own auto-flush only fires on the NEXT interrupt).
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L188))
+
+### describeScopedMatch
+
+```ts
+describeScopedMatch(intr: any): string
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| intr | `any` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L200))
+
+### askUser
+
+```ts
+askUser(intr: any): Decision
+```
+
+Present the (a)/(r)/(aa)/(ap)/(rr) menu for a single interrupt.
+  `(ap)` is offered only when `_opts.fields` has an entry for
+  `intr.kind`. Loops until the user enters a valid response.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| intr | `any` |  |
+
+**Returns:** [Decision](#decision)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L209))
+
+### _handler
+
+```ts
+_handler(intr: any): any
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| intr | `any` |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L247))
+
+### cliPolicyHandler
+
+```ts
+cliPolicyHandler(opts: { file: string; fields: AlwaysFields }): any
+```
+
+CLI sugar for an interactive policy handler. Owns load + save +
+  prompt + record + return approve/reject. Install on the outermost
+  `handle`. Call exactly ONCE per program — internal state is module-
+  level (see spec §1.3 "Library-state-is-singleton contract").
+
+  Users of this helper should bind the returned handler to a variable
+  before using it with `handle ... with`, e.g.:
+
+      const handler = cliPolicyHandler({ file: ..., fields: ... })
+      handle { ... } with handler
+
+  This pattern also bypasses the typechecker's handler-interrupt rule
+  (which only resolves direct functionRef names). Runtime safety is
+  guaranteed by the flip-flag-first pattern inside the handler body.
+
+  @param opts.file - Path to the on-disk policy file
+  @param opts.fields - Per-kind config controlling the "approve-always-here" option
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| opts | `{ file: string; fields: AlwaysFields }` |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L280))

--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -1,53 +1,231 @@
 # policy
 
+## Overview
+
+  A `Policy` is an ordered list of rules per interrupt kind that decides,
+  without prompting the user, whether to approve or reject each interrupt
+  an agent raises. Rules use glob patterns ("match objects") against the
+  interrupt's `data` fields. Evaluation is first-match-wins.
+
+  This module gives you two layers:
+
+  1. **Pure primitives** for building / loading / validating policies
+     and writing your own handler:
+     `checkPolicy`, `validatePolicy`, `parsePolicyFile`,
+     `writePolicyFile`, `recordRule`, `recordScopedRule`,
+     `buildScopedMatch`.
+
+  2. **CLI sugar** — `cliPolicyHandler` — drops in as a handler for
+     interactive agents. It loads `policy.json` on first use, prompts
+     the user with (a)/(r)/(aa)/(ap)/(rr) for each new interrupt
+     kind, records "always" decisions to disk, and replays matching
+     rules on subsequent interrupts so the user is only asked once
+     per pattern.
+
+  ## Usage: the CLI handler (most common)
+
+  ```ts
+  import { cliPolicyHandler, ScopedRuleFields } from "std::policy"
+
+  // Per-kind config controlling the "approve always here (ap)" option.
+  // For every kind you list, the (ap) prompt offers to pin the listed
+  // data fields. `matchSubpaths: true` brace-expands the value so
+  // `/tmp/x` also matches `/tmp/x/anything`.
+  const FIELDS: ScopedRuleFields = {
+    "std::read":  [{ field: "dir", matchSubpaths: true }],
+    "std::write": [{ field: "dir", matchSubpaths: true }],
+    "std::exec":  [
+      { field: "command",    matchSubpaths: false },
+      { field: "subcommand", matchSubpaths: false },
+    ],
+  }
+
+  node main() {
+    // Bind to a local variable so `handle ... with handler` parses
+    // (the `with` clause only accepts an identifier).
+    const handler = cliPolicyHandler({
+      file: "${env("HOME")}/.myapp/policy.json",
+      fields: FIELDS,
+    })
+    handle {
+      // Every interrupt the inner code raises is filtered through the
+      // policy. New kinds prompt the user; "aa" / "ap" decisions are
+      // persisted so the next run starts pre-approved.
+      llm("hi", { tools: [...] })
+    } with handler
+  }
+  ```
+
+  ## Usage: writing your own handler
+
+  If you want different UI (a web prompt, a Slack bot, a non-interactive
+  CI mode), build on the pure primitives:
+
+  ```ts
+  import { Policy, checkPolicy, recordRule } from "std::policy"
+
+  let myPolicy: Policy = {}
+
+  def myHandler(intr) {
+    const decision = checkPolicy(myPolicy, intr)
+    if (decision.type == "approve") { return approve() }
+    if (decision.type == "reject")  { return reject() }
+    // decision.type == "propagate" -- no rule matches. Ask your UI:
+    const choice = askUserSomehow(intr)
+    if (choice == "always-approve") {
+      myPolicy = recordRule(myPolicy, intr.kind, "approve")
+      return approve()
+    }
+    return choice == "approve" ? approve() : reject()
+  }
+  ```
+
+  ## How "matches" work
+
+  Each rule has an optional `match` map. The values are glob patterns
+  (via picomatch); evaluation passes when every key in `match` exists
+  in `intr.data` and its value matches the pattern. A rule with no
+  `match` is a catch-all for that kind.
+
+  Example: this rule auto-approves reads under `/tmp` (and any subdir):
+
+  ```ts
+  {
+    "std::read": [
+      { match: { dir: "{/tmp,/tmp/**}" }, action: "approve" }
+    ]
+  }
+  ```
+
+  `buildScopedMatch` constructs these match maps from a
+  `ScopedRuleFields` config — that's all the "scoped" helpers do.
+
+  ## Precedence trap
+
+  `recordRule` **appends** a catch-all rule. Because evaluation is
+  first-match-wins, a new approve rule will be ignored if an earlier
+  catch-all already covers the kind:
+
+  ```ts
+  let p = recordRule({}, "std::read", "reject")
+  p = recordRule(p, "std::read", "approve")  // dead — the reject wins
+  ```
+
+  `recordScopedRule` **prepends**, so a freshly-recorded scoped rule
+  always wins over an older catch-all. If you're letting users
+  flip decisions, either inspect the existing rules and replace
+  them, or start from an empty `Policy`.
+
 ## Types
 
 ### InterruptDataKey
 
+Key of an interrupt's `data` object (e.g. `"dir"`, `"command"`).
+
 ```ts
+/** Key of an interrupt's `data` object (e.g. `"dir"`, `"command"`). */
 export type InterruptDataKey = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L9))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L128))
 
 ### InterruptDataVal
 
+* Glob pattern used to match an interrupt-data value. Patterns are
+ * picomatch globs — supports `*`, `**`, and brace-expansion like
+ * `{a,b}` for unions. A literal string with no glob metacharacters
+ * matches only that exact value.
+
 ```ts
+/**
+ * Glob pattern used to match an interrupt-data value. Patterns are
+ * picomatch globs — supports `*`, `**`, and brace-expansion like
+ * `{a,b}` for unions. A literal string with no glob metacharacters
+ * matches only that exact value.
+ */
 export type InterruptDataVal = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L11))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L136))
 
 ### InterruptKind
 
+* Identifier for an interrupt's kind (e.g. `"std::read"`,
+ * `"myapp::deploy"`).
+
 ```ts
+/**
+ * Identifier for an interrupt's kind (e.g. `"std::read"`,
+ * `"myapp::deploy"`).
+ */
 export type InterruptKind = string
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L13))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L142))
 
 ### PolicyRule
 
+* One row of a `Policy`. A rule passes if every key in `match` is
+ * present in the interrupt's `data` and its value matches the glob
+ * pattern. Omit `match` (or set it to `{}`) for a catch-all that
+ * applies to every interrupt of the parent kind.
+
 ```ts
+/**
+ * One row of a `Policy`. A rule passes if every key in `match` is
+ * present in the interrupt's `data` and its value matches the glob
+ * pattern. Omit `match` (or set it to `{}`) for a catch-all that
+ * applies to every interrupt of the parent kind.
+ */
 export type PolicyRule = {
   match?: Record<InterruptDataKey, InterruptDataVal>;
   action: "approve" | "reject" | "propagate"
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L15))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L150))
 
 ### Policy
 
+* A policy: ordered rules per interrupt kind. `checkPolicy` walks
+ * the array for `intr.kind` in order and returns on the first
+ * matching rule. If no rule for the kind exists, evaluation falls
+ * through to `propagate` (i.e. ask the next handler in the chain).
+
 ```ts
+/**
+ * A policy: ordered rules per interrupt kind. `checkPolicy` walks
+ * the array for `intr.kind` in order and returns on the first
+ * matching rule. If no rule for the kind exists, evaluation falls
+ * through to `propagate` (i.e. ask the next handler in the chain).
+ */
 export type Policy = Record<InterruptKind, PolicyRule[]>
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L20))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L161))
 
 ### Decision
 
+* The five answers `cliPolicyHandler`'s prompt accepts:
+ * - `"approve"` / `"reject"` — one-off (a) / (r).
+ * - `"approve-always"` / `"reject-always"` — (aa) / (rr); records a
+ *   catch-all rule for the kind so future interrupts of this kind
+ *   resolve without prompting.
+ * - `"approve-always-here"` — (ap); records a scoped rule pinned to
+ *   whichever fields you listed in `ScopedRuleFields` for this kind.
+ *   Only offered when the kind has an entry in the config.
+
 ```ts
+/**
+ * The five answers `cliPolicyHandler`'s prompt accepts:
+ * - `"approve"` / `"reject"` — one-off (a) / (r).
+ * - `"approve-always"` / `"reject-always"` — (aa) / (rr); records a
+ *   catch-all rule for the kind so future interrupts of this kind
+ *   resolve without prompting.
+ * - `"approve-always-here"` — (ap); records a scoped rule pinned to
+ *   whichever fields you listed in `ScopedRuleFields` for this kind.
+ *   Only offered when the kind has an entry in the config.
+ */
 export type Decision =
   | "approve"
   | "reject"
@@ -56,26 +234,82 @@ export type Decision =
   | "reject-always"
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L22))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L173))
 
-### FieldSpec
+### ScopedField
+
+* One column in a `ScopedRuleFields` entry — names an interrupt-data
+ * field that the "approve-always-here" rule should pin.
+ *
+ * - `field` — the key in `intr.data` to pin (e.g. `"dir"`).
+ * - `matchSubpaths` — when `true`, brace-expand the value so the
+ *   rule matches both the exact value AND any nested path under it.
+ *   Pass `true` for directory-like fields (so approving `/tmp/x`
+ *   also approves `/tmp/x/sub/file.txt`); pass `false` for opaque
+ *   identifiers (commands, IDs, env names) that shouldn't fan out.
 
 ```ts
-export type FieldSpec = {
+/**
+ * One column in a `ScopedRuleFields` entry — names an interrupt-data
+ * field that the "approve-always-here" rule should pin.
+ *
+ * - `field` — the key in `intr.data` to pin (e.g. `"dir"`).
+ * - `matchSubpaths` — when `true`, brace-expand the value so the
+ *   rule matches both the exact value AND any nested path under it.
+ *   Pass `true` for directory-like fields (so approving `/tmp/x`
+ *   also approves `/tmp/x/sub/file.txt`); pass `false` for opaque
+ *   identifiers (commands, IDs, env names) that shouldn't fan out.
+ */
+export type ScopedField = {
   field: string;
-  wildcardSubpaths: boolean
+  matchSubpaths: boolean
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L29))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L191))
 
-### AlwaysFields
+### ScopedRuleFields
 
-```ts
-export type AlwaysFields = Record<InterruptKind, FieldSpec[]>
-```
+* Per-kind configuration consumed by `buildScopedMatch` and the
+ * `cliPolicyHandler`. Maps each interrupt kind to the fields its
+ * "approve-always-here" rule should pin. Kinds not present in this
+ * map don't offer the (ap) prompt option — the user falls back to
+ * (a) / (r) / (aa) / (rr).
+ *
+ * Example:
+ * ```ts
+ * const FIELDS: ScopedRuleFields = {
+ *   "std::read":  [{ field: "dir", matchSubpaths: true }],
+ *   "std::exec":  [
+ *     { field: "command",    matchSubpaths: false },
+ *     { field: "subcommand", matchSubpaths: false },
+ *   ],
+ * }
+ * ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L34))
+````ts
+/**
+ * Per-kind configuration consumed by `buildScopedMatch` and the
+ * `cliPolicyHandler`. Maps each interrupt kind to the fields its
+ * "approve-always-here" rule should pin. Kinds not present in this
+ * map don't offer the (ap) prompt option — the user falls back to
+ * (a) / (r) / (aa) / (rr).
+ *
+ * Example:
+ * ```ts
+ * const FIELDS: ScopedRuleFields = {
+ *   "std::read":  [{ field: "dir", matchSubpaths: true }],
+ *   "std::exec":  [
+ *     { field: "command",    matchSubpaths: false },
+ *     { field: "subcommand", matchSubpaths: false },
+ *   ],
+ * }
+ * ```
+ */
+export type ScopedRuleFields = Record<InterruptKind, ScopedField[]>
+````
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L214))
 
 ## Functions
 
@@ -87,6 +321,15 @@ checkPolicy(policy: Record<string, any>, interrupt: Record<string, any>)
 
 Evaluate a policy against an interrupt. Returns approve(), reject(), or propagate() based on the first matching rule. Policy is a JSON object keyed by interrupt kind, where each kind maps to an ordered array of rules with optional match fields (glob patterns) and an action.
 
+* Evaluate a policy against a single interrupt. Returns the result
+ * of `approve()`, `reject()`, or `propagate()` corresponding to the
+ * first matching rule for `interrupt.kind`. If no rule matches
+ * (no rules for the kind, or every rule's `match` failed), returns
+ * `propagate()` so the next handler in the chain runs.
+ *
+ * Designed for use inside a custom handler. The CLI sugar
+ * (`cliPolicyHandler`) calls this for you.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -94,7 +337,7 @@ Evaluate a policy against an interrupt. Returns approve(), reject(), or propagat
 | policy | `Record<string, any>` |  |
 | interrupt | `Record<string, any>` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L43))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L233))
 
 ### validatePolicy
 
@@ -104,34 +347,67 @@ validatePolicy(policy: Record<string, any>)
 
 Validate that a policy object is well-formed. Returns { success: true } if valid, or { success: false, error: "..." } with a description of the problem.
 
+* Check that a `Policy` is structurally valid (every entry is an
+ * array of `PolicyRule` with a recognised `action`, every `match`
+ * is a flat string→string map, etc.). Returns
+ * `{ success: true }` or `{ success: false, error: string }`.
+ *
+ * Call before persisting user-supplied or hand-edited policy data;
+ * `writePolicyFile` calls this internally before writing.
+
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | policy | `Record<string, any>` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L252))
 
 ### buildScopedMatch
 
 ```ts
-buildScopedMatch(intr: Record<string, any>, fields: AlwaysFields): Record<string, string>
+buildScopedMatch(intr: Record<string, any>, fields: ScopedRuleFields): Record<string, string>
 ```
 
-Given the per-kind FieldSpec[] config, build a match object pinned
+Given the per-kind ScopedField[] config, build a match object pinned
   to the meaningful fields of this interrupt. Returns {} when the kind
   isn't in the fields map. Pure.
+
+* Build the `match` map for a scoped rule by reading the configured
+ * fields out of `intr.data`. The returned object is shaped to plug
+ * straight into a `PolicyRule.match`:
+ *
+ * ```ts
+ * const match = buildScopedMatch(intr, fields)
+ * const rule: PolicyRule = { match: match, action: "approve" }
+ * ```
+ *
+ * For each `ScopedField` configured for `intr.kind`:
+ * - The field's value is read from `intr.data`.
+ * - If `matchSubpaths: true`, the value is wrapped as
+ *   `"{value,value/**}"` so the resulting glob matches both the
+ *   exact value and any subpath under it.
+ * - If `matchSubpaths: false`, the value is used as-is (literal
+ *   match).
+ *
+ * Fields that are absent from `intr.data` (`null` / `undefined`)
+ * are skipped silently. Kinds not present in `fields` return `{}`.
+ *
+ * Most callers should use `recordScopedRule` instead, which calls
+ * this internally; `buildScopedMatch` is exposed for callers
+ * assembling rules by hand or implementing a custom UI that needs
+ * to preview the match before recording.
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
 | intr | `Record<string, any>` |  |
-| fields | [AlwaysFields](#alwaysfields) |  |
+| fields | [ScopedRuleFields](#scopedrulefields) |  |
 
 **Returns:** `Record<string, string>`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L60))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L285))
 
 ### recordRule
 
@@ -143,6 +419,30 @@ Return a new policy with a catch-all rule for `kind` appended.
   First-match-wins inside `checkPolicy`, so a single bare rule covers
   every future interrupt of that kind. Pure — no I/O.
 
+  WARNING: append order matters. A second call for the same kind with
+  a different action is dead — the earlier rule wins. Reset the kind's
+  rules first if you want to flip a previous decision.
+
+* Return a new policy with a catch-all rule (`{ action }` with no
+ * `match`) for `kind` appended. Pure — does not mutate the input.
+ *
+ * ## Precedence trap
+ *
+ * Evaluation is first-match-wins, so **append order matters**. A
+ * second call for the same kind with a different action is dead
+ * code:
+ *
+ * ```ts
+ * let p = recordRule({}, "std::read", "reject")
+ * p = recordRule(p, "std::read", "approve")  // never reached
+ * ```
+ *
+ * If you're flipping a previously-recorded decision, decide
+ * explicitly: either reset the kind's rules first
+ * (`{ ...policy, "std::read": [] }` and re-record), or hand-edit
+ * `policy[kind]` to replace the offending rule. This function does
+ * not try to detect or warn about shadowing on your behalf.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -153,17 +453,31 @@ Return a new policy with a catch-all rule for `kind` appended.
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L84))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L330))
 
 ### recordScopedRule
 
 ```ts
-recordScopedRule(policy: Policy, intr: Record<string, any>, fields: AlwaysFields): Policy
+recordScopedRule(policy: Policy, intr: Record<string, any>, fields: ScopedRuleFields): Policy
 ```
 
 Return a new policy with a scoped approve rule prepended for the
   interrupt's kind. Prepended (not appended) so the more-specific
   rule wins over any later catch-all in first-match-wins order. Pure.
+
+* Return a new policy with a scoped approve rule prepended for
+ * `intr.kind`. The rule's `match` is built by `buildScopedMatch`,
+ * so it pins whichever fields are configured for the kind. Pure.
+ *
+ * Prepended (not appended) so the new, more-specific rule wins
+ * over any pre-existing catch-all in first-match-wins order. This
+ * makes scoped rules safe to add even if the kind already has a
+ * broader rejection: the scoped approval applies first when it
+ * matches, otherwise the catch-all takes over.
+ *
+ * The action is always `"approve"` — the (ap) UI affordance only
+ * makes sense in the affirmative direction. Build a scoped reject
+ * by hand if you need one.
 
 **Parameters:**
 
@@ -171,11 +485,11 @@ Return a new policy with a scoped approve rule prepended for the
 |---|---|---|
 | policy | [Policy](#policy) |  |
 | intr | `Record<string, any>` |  |
-| fields | [AlwaysFields](#alwaysfields) |  |
+| fields | [ScopedRuleFields](#scopedrulefields) |  |
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L102))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L367))
 
 ### parsePolicyFile
 
@@ -189,6 +503,16 @@ Read + parse + validate a policy file from disk. Returns {} on any
 
   @param path - The policy file path
 
+* Read + JSON-parse + validate a policy file from disk. Returns `{}`
+ * (an empty policy) on any failure — missing file, unreadable
+ * permissions, malformed JSON, or schema-validation error — after
+ * printing a warning so the user knows their saved decisions did
+ * not carry over.
+ *
+ * Raises `std::read` (so the caller's handler chain controls
+ * whether the read is approved); the CLI handler auto-approves
+ * this via `with approve`.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -197,7 +521,7 @@ Read + parse + validate a policy file from disk. Returns {} on any
 
 **Returns:** [Policy](#policy)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L121))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L397))
 
 ### writePolicyFile
 
@@ -211,6 +535,15 @@ Validate and write a policy to a JSON file. Throws if the policy is invalid. Set
   @param policy - The policy to write
   @param allowedPaths - Only allow writing under these path prefixes
 
+* Validate a `Policy` and write it as JSON to `path`. Throws (returns
+ * `Failure`) if validation fails — invalid policies are never
+ * persisted.
+ *
+ * `allowedPaths` is a defense-in-depth allow-list passed straight
+ * through to the underlying `write`. Pass `[]` (the default) only
+ * when the path is trusted; otherwise restrict it to a known
+ * directory like `["${env("HOME")}/.myapp"]`.
+
 **Parameters:**
 
 | Name | Type | Default |
@@ -219,7 +552,7 @@ Validate and write a policy to a JSON file. Throws if the policy is invalid. Set
 | policy | [Policy](#policy) |  |
 | allowedPaths | `string[]` | [] |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L150))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L436))
 
 ### maybeLoad
 
@@ -227,12 +560,7 @@ Validate and write a policy to a JSON file. Throws if the policy is invalid. Set
 maybeLoad()
 ```
 
-Lazy-load the on-disk policy on first handler invocation. Uses
-  flip-flag-first so the std::read interrupt's chain re-entry sees
-  `_loaded == true` and returns without recursing. See
-  docs/site/guide/handlers.md §"Fixing it".
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L161))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L451))
 
 ### maybeFlush
 
@@ -240,13 +568,7 @@ Lazy-load the on-disk policy on first handler invocation. Uses
 maybeFlush()
 ```
 
-Persist any pending policy changes. Same flip-flag-first pattern
-  as `maybeLoad`. Runs at the top of every handler invocation so a
-  decision recorded on turn N is on disk before turn N+1's first
-  interrupt fires. Decisions on the FINAL interrupt of a session
-  may not flush — acceptable per spec.
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L174))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L463))
 
 ### flushPolicy
 
@@ -254,11 +576,17 @@ Persist any pending policy changes. Same flip-flag-first pattern
 flushPolicy()
 ```
 
-Force a write of the in-memory policy to disk. Use between user
-  turns if you want the FINAL decision of a session persisted (the
-  handler's own auto-flush only fires on the NEXT interrupt).
+* Force-write the `cliPolicyHandler`'s in-memory policy to disk
+ * now. Use between user turns when you want the **last** decision
+ * of a session persisted: the handler's own auto-flush runs at the
+ * top of the next interrupt, so a decision recorded on the final
+ * interrupt of a turn won't survive a crash unless you call this.
+ *
+ * No-op when there are no pending changes. Auto-approves its own
+ * `std::write` via `with approve` (you opted in by installing the
+ * handler).
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L188))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L481))
 
 ### describeScopedMatch
 
@@ -274,17 +602,13 @@ describeScopedMatch(intr: any): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L200))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L491))
 
 ### askUser
 
 ```ts
 askUser(intr: any): Decision
 ```
-
-Present the (a)/(r)/(aa)/(ap)/(rr) menu for a single interrupt.
-  `(ap)` is offered only when `_opts.fields` has an entry for
-  `intr.kind`. Loops until the user enters a valid response.
 
 **Parameters:**
 
@@ -294,13 +618,18 @@ Present the (a)/(r)/(aa)/(ap)/(rr) menu for a single interrupt.
 
 **Returns:** [Decision](#decision)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L209))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L504))
 
 ### _handler
 
 ```ts
 _handler(intr: any): any
 ```
+
+* Internal — the actual handler function returned by
+ * `cliPolicyHandler`. Exported so module-level codegen can resolve
+ * the function reference when you write `handle ... with handler`.
+ * Do not call directly; use `cliPolicyHandler` to construct one.
 
 **Parameters:**
 
@@ -310,18 +639,18 @@ _handler(intr: any): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L247))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L543))
 
 ### cliPolicyHandler
 
 ```ts
-cliPolicyHandler(opts: { file: string; fields: AlwaysFields }): any
+cliPolicyHandler(opts: { file: string; fields: ScopedRuleFields }): any
 ```
 
 CLI sugar for an interactive policy handler. Owns load + save +
   prompt + record + return approve/reject. Install on the outermost
   `handle`. Call exactly ONCE per program — internal state is module-
-  level (see spec §1.3 "Library-state-is-singleton contract").
+  level.
 
   Users of this helper should bind the returned handler to a variable
   before using it with `handle ... with`, e.g.:
@@ -329,19 +658,65 @@ CLI sugar for an interactive policy handler. Owns load + save +
       const handler = cliPolicyHandler({ file: ..., fields: ... })
       handle { ... } with handler
 
-  This pattern also bypasses the typechecker's handler-interrupt rule
-  (which only resolves direct functionRef names). Runtime safety is
-  guaranteed by the flip-flag-first pattern inside the handler body.
-
   @param opts.file - Path to the on-disk policy file
   @param opts.fields - Per-kind config controlling the "approve-always-here" option
+
+* Drop-in policy handler for interactive CLI agents. Returns a
+ * function ref you bind to a local variable and install on a `handle`
+ * block:
+ *
+ * ```ts
+ * const handler = cliPolicyHandler({
+ *   file: "${env("HOME")}/.myapp/policy.json",
+ *   fields: { "std::read": [{ field: "dir", matchSubpaths: true }] },
+ * })
+ * handle {
+ *   // every interrupt raised here is filtered through the handler
+ * } with handler
+ * ```
+ *
+ * What the handler does:
+ *
+ * 1. **Loads** the policy file on first invocation. Missing /
+ *    malformed files are treated as `{}` with a warning.
+ * 2. **Consults the loaded policy** via `checkPolicy`. If a rule
+ *    matches, approves or rejects without prompting.
+ * 3. **Prompts the user** when no rule applies, showing
+ *    (a)/(r)/(aa)/(ap)/(rr). The (ap) option appears only when
+ *    `fields` has an entry for the interrupt's kind.
+ * 4. **Records "always" decisions** in memory and flushes them to
+ *    disk at the top of the next interrupt. Use `flushPolicy()` if
+ *    you need the final decision of a session persisted before
+ *    process exit.
+ *
+ * ## Singleton state
+ *
+ * Internal state (loaded policy, pending-save flag, options) is
+ * module-level. Calling `cliPolicyHandler` more than once in the
+ * same program silently overwrites the previous options — only the
+ * last `file` / `fields` win. For multi-policy agents, fork the
+ * module or use the pure primitives directly.
+ *
+ * ## Bind-to-variable requirement
+ *
+ * The `with` clause only accepts an identifier (not a call
+ * expression), so you MUST bind the return value to a `const`
+ * before using it. This also bypasses the typechecker's
+ * handler-raises-interrupt rule, which only resolves direct
+ * functionRef names — runtime safety is provided by the
+ * flip-flag-first pattern inside the handler.
+ *
+ * @param opts.file - Path to the on-disk policy file. Created on
+ *   first save; the containing directory must already exist.
+ * @param opts.fields - Per-kind config controlling the (ap) prompt
+ *   option. Kinds not present here don't offer (ap).
 
 **Parameters:**
 
 | Name | Type | Default |
 |---|---|---|
-| opts | `{ file: string; fields: AlwaysFields }` |  |
+| opts | `{ file: string; fields: ScopedRuleFields }` |  |
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L280))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L627))

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-30-stdlib-policy-and-router-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-30-stdlib-policy-and-router-design.md
@@ -67,7 +67,8 @@ The change splits into two independent stdlib additions:
 
 1. **Extensions to `stdlib/policy.agency`** — pure recording primitives
    plus a CLI sugar handler.
-2. **New `stdlib/router.agency`** — declarative multi-agent router.
+2. **Router added to `stdlib/agent.agency`** — declarative multi-agent
+   router exported from the existing `std::agent` module.
 
 ### 1. Policy extensions
 
@@ -255,7 +256,13 @@ If users hit the other edge cases — concurrent agent instances
 writing the same file, atomic-write requirements, etc. — they also
 fall back to the pure primitives.
 
-### 2. Router: `stdlib/router.agency` (new file)
+### 2. Router: extension of `stdlib/agent.agency`
+
+Lives alongside `todoWrite`, `todoList`, and `question` in the existing
+`stdlib/agent.agency` module. The router is one *coordination strategy*
+for building agents; future strategies (supervisor/worker, parallel
+dispatch, pipeline, single-agent loop) will sit alongside it under the
+same `std::agent` namespace. No new module file.
 
 #### 2.1 Types
 
@@ -369,7 +376,7 @@ After:
 
 ```ts
 // agent.agency, in full (sketch)
-import { route } from "std::router"
+import { route } from "std::agent"
 import { cliPolicyHandler } from "std::policy"
 import { codeSysPrompt, codeTools } from "./code.agency"
 import { researchSysPrompt, researchTools } from "./research.agency"
@@ -407,8 +414,8 @@ an exported tools array. No `runCode`/`runResearch`, no
 `allowHandoff`, no `handoff.partial`, no first-entry flag.
 
 `shared.agency` deletes the handoff plumbing entirely (now in
-`stdlib/router.agency`). `AgentContext` becomes just `context: string`
-on the router call site.
+`std::agent`). `AgentContext` becomes just `context: string` on the
+router call site.
 
 `defaultHandler`, `loadPolicy`, `savePolicy`, `policyDir`,
 `policyPath`, `ensurePolicyLoaded`, `recordAlways`,
@@ -478,16 +485,18 @@ the design.
   (it's a module-level `let`, so it goes through GlobalStore — same
   as today's `codeFirstEntry`). Worth a focused test.
 - **Coupling of `_handoffTarget` to the router**: moving the slot
-  from `shared.agency` into `stdlib/router.agency` means any
-  non-router consumer of `handoff()` breaks. Mitigation: the
-  `handoff` tool also moves into the router, and nothing outside
-  the agent currently calls it. Greenfield change.
+  from `shared.agency` into `std::agent` means any non-router
+  consumer of `handoff()` breaks. Mitigation: the `handoff` tool
+  also moves into `std::agent`, and nothing outside the agent
+  currently calls it. Greenfield change.
 
 ## File summary
 
 - **Modify**: `stdlib/policy.agency` (+ types, + primitives, +
   CLI helper).
-- **New**: `stdlib/router.agency`.
+- **Modify**: `stdlib/agent.agency` (+ `route` + `handoff` +
+  `AgentSpec` / `RouterConfig` types + internal handoff-target
+  plumbing).
 - **Modify**: `lib/agents/agency-agent/agent.agency`,
   `shared.agency`, `code.agency`, `research.agency` — collapse onto
   the new stdlib (this is the regression test, not the change

--- a/packages/agency-lang/docs/superpowers/specs/2026-05-30-stdlib-policy-and-router-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-05-30-stdlib-policy-and-router-design.md
@@ -1,0 +1,498 @@
+# Stdlib Policy Helpers + Router — Design
+
+## Problem
+
+The Agency Agent (`lib/agents/agency-agent/`) accreted two big mechanisms
+that are not agent-specific and should be reusable across other Agency
+programs:
+
+1. **An interactive policy handler** — the chain of "check policy → ask
+   the user with (a)/(r)/(aa)/(ap)/(rr) → record the decision →
+   approve/reject the interrupt → persist to disk" lives entirely in
+   `agent.agency`. Any CLI agent that wants the same UX has to copy
+   ~150 lines of `defaultHandler` + `askUser` + scoped-match builders.
+
+2. **A multi-agent router** — the hop loop, the `handoff` LLM tool, the
+   handoff-target signal, the force-answer fallback, and the
+   per-category thread/memory wiring add another ~100 lines spread
+   across `agent.agency`, `shared.agency`, `code.agency`,
+   `research.agency`. Anyone building a multi-specialist agent
+   re-implements all of it.
+
+The recently shipped typechecker rule that forbids handlers from
+raising interrupts ([docs/site/guide/handlers.md#handlers-cant-raise-interrupts](../../packages/agency-lang/docs/site/guide/handlers.md))
+also makes the policy code's load/save lifecycle subtler to get right.
+A reusable abstraction can encode the correct pattern once.
+
+Goal: lift both mechanisms into the standard library so a CLI agent
+becomes a small declaration plus a few hand-written tools, while
+leaving the door open for non-CLI (web, IPC) consumers to reuse the
+pure parts.
+
+## Non-goals
+
+- A web/HTTP policy adapter. The web case is sketched in the policy
+  section and supported by the pure primitives, but we ship no web
+  helper this round. First web user proves out the shape.
+- A non-loop routing scheme (e.g. parallel dispatch, fan-out). The
+  hop loop is the abstraction; weirder shapes are user-implemented.
+- Per-runner custom turn logic (multiple `llm()` calls per turn,
+  preprocessing, custom thread setup). The router is declarative —
+  `systemPrompt + tools + memory` — and intentionally rigid for v1.
+  An escape hatch (`runners: { ... }`) can be added later if needed.
+- Lifting `Workspace` / `setCwd` / per-agent-specific tool bundles
+  into the router. Those stay in user code.
+
+## What already exists
+
+[`stdlib/policy.agency`](../../packages/agency-lang/stdlib/policy.agency)
+already exports the policy primitives:
+
+- `checkPolicy(policy, interrupt) → approve | reject | propagate`
+- `validatePolicy(policy) → { success, error? }`
+- `writePolicyFile(path, policy, allowedPaths)`
+- Types: `Policy`, `PolicyRule`, `InterruptDataKey`, `InterruptDataVal`,
+  `InterruptKind`
+
+The runtime side (`lib/runtime/policy.ts`) supports rules with a
+`match` map keyed by `origin`, `message`, or any top-level
+`interrupt.data` field; values are picomatch globs. First-matching
+rule wins inside `checkPolicy`.
+
+No router-related primitives exist in stdlib today.
+
+## Design
+
+The change splits into two independent stdlib additions:
+
+1. **Extensions to `stdlib/policy.agency`** — pure recording primitives
+   plus a CLI sugar handler.
+2. **New `stdlib/router.agency`** — declarative multi-agent router.
+
+### 1. Policy extensions
+
+#### 1.1 New types
+
+```agency
+export type Decision =
+  | "approve"
+  | "reject"
+  | "approve-always"
+  | "approve-always-here"
+  | "reject-always"
+// Note: intentionally no `reject-always-here`. Reject-always is rare
+// in practice; scoped reject is rarer still. Add later if asked.
+
+export type FieldSpec = {
+  field: string;            // top-level key in interrupt.data
+  wildcardSubpaths: boolean // true → brace-expand "foo" → "foo,foo/**"
+}
+
+export type AlwaysFields = Record<InterruptKind, FieldSpec[]>
+```
+
+`AlwaysFields` is the per-kind config the user passes when they want
+the "approve-always-here" option to record a scoped rule. Kinds not
+present in the map fall back to the four-option prompt (a/r/aa/rr) —
+no `ap` offered.
+
+#### 1.2 Pure recording primitives
+
+```agency
+export def recordRule(
+  policy: Policy,
+  kind: InterruptKind,
+  action: "approve" | "reject",
+): Policy
+```
+
+Returns a new policy with a bare (catch-all) rule appended for `kind`.
+First-match-wins in `checkPolicy` means a single bare rule covers every
+future interrupt of that kind. Pure — no I/O.
+
+```agency
+export def recordScopedRule(
+  policy: Policy,
+  intr: Record<string, any>,
+  fields: AlwaysFields,
+): Policy
+```
+
+Returns a new policy with a *scoped* approve rule prepended (so the
+more-specific rule wins over a later catch-all if any). The match
+object is built from the kind's `FieldSpec[]` entries: each field
+pulls the value from `intr.data[field]`; `wildcardSubpaths: true`
+brace-expands the value to also match subpaths
+(`"/Users/x" → "{/Users/x,/Users/x/**}"`). Pure.
+
+```agency
+export def buildScopedMatch(
+  intr: Record<string, any>,
+  fields: AlwaysFields,
+): Record<string, string>
+```
+
+The match-object builder behind `recordScopedRule`, exposed because
+the prompt UI needs it to render the "approve always where dir=..."
+preview before the user commits. Pure.
+
+```agency
+export def parsePolicyFile(path: string): Policy
+```
+
+Read + parse a policy file from disk, returning the validated
+`Policy`. Wraps `read` + `parseJSON` + `validatePolicy` with the
+warn-and-return-empty behavior of the agent's current `loadPolicy`
+helper (so a missing, unreadable, malformed, or invalid file does
+**not** throw — it warns and returns `{}`). Raises `std::read`,
+hence the `with approve` usage in the flip-flag example below.
+
+These four primitives are the only ones any non-CLI consumer (web,
+IPC, custom workflow) needs on top of the existing
+`checkPolicy` / `validatePolicy` / `writePolicyFile`.
+
+#### 1.3 CLI sugar: `cliPolicyHandler`
+
+```agency
+export def cliPolicyHandler(opts: {
+  file: string;
+  fields: AlwaysFields;
+}): (intr: any) => any
+```
+
+Returns a *function* that the user passes to `handle { ... } with`.
+The returned function:
+
+1. On first invocation, lazy-loads the policy from `opts.file` via
+   `with approve`. Subsequent invocations reuse the in-memory copy.
+   The lazy load uses the [flip-flag-first](../../packages/agency-lang/docs/site/guide/handlers.md#handlers-cant-raise-interrupts)
+   pattern so the read interrupt's re-entry into the handler
+   short-circuits cleanly.
+2. Calls `checkPolicy(policy, intr)`. If a rule matches, returns
+   approve/reject without prompting.
+3. Otherwise, prompts the user with the (a)/(r)/(aa)/(ap)/(rr) menu.
+   `(ap)` (approve-always-here) is offered only when `opts.fields`
+   has an entry for `intr.kind`. The (a)/(r) options end the round;
+   `(aa)`/`(rr)` call `recordRule` and persist; `(ap)` calls
+   `recordScopedRule` and persists.
+4. Rejection offers a follow-up free-text "Why are you rejecting?"
+   prompt; the answer becomes `reject(reason)`, so the LLM sees
+   concrete feedback as the tool's return value.
+
+Persistence happens *inside* the handler body — `with approve` on
+the write. There is no way to avoid this without giving up the
+"writes are gated by interrupts" guarantee. Two complementary
+mechanisms keep it safe:
+
+**Runtime: flip-flag-first re-entry guard.** Both the lazy load and
+each save use the flip-flag-first pattern documented in
+[handlers.md §"Fixing it"](../../packages/agency-lang/docs/site/guide/handlers.md).
+Illustrative sketch (real call sites pass the full signatures —
+`writePolicyFile(path, policy, allowedPaths)` etc.):
+
+```agency
+let loaded: boolean = false
+let pendingSave: boolean = false
+
+def maybeFlush() {
+  if (pendingSave) {
+    pendingSave = false                                 // flip FIRST
+    writePolicyFile(opts.file, policy, []) with approve // re-enters; guard short-circuits
+  }
+}
+
+def maybeLoad() {
+  if (!loaded) {
+    loaded = true                                       // flip FIRST
+    policy = parsePolicyFile(opts.file) with approve    // re-enters; guard short-circuits
+  }
+}
+```
+
+The order matters: flip the flag *before* the interrupt-raising
+call, not after. The re-entered handler invocation sees the flag
+already flipped and returns without recursing. The agent's existing
+`ensurePolicyLoaded` is the canonical example.
+
+**Compile-time: `// @tc-ignore` at the user's `handle` site.** The
+handler-interrupt typechecker rule is structural — it fires on any
+transitive interrupt call in the handler body, regardless of whether
+runtime guards prevent recursion. Since `cliPolicyHandler` *must*
+do I/O (read/write/input are all interrupts), users have no choice
+but to suppress the diagnostic at the call site:
+
+```agency
+// @tc-ignore — cliPolicyHandler is the documented "unavoidable
+// I/O in handler" case; runtime flip-flag-first prevents recursion.
+handle { ... } with cliPolicyHandler
+```
+
+This is exactly the escape-hatch case the typechecker docs already
+flag. The stdlib helper itself is a `def` whose body raises the
+interrupts honestly; we do not invent a special "trusted handler"
+exemption.
+
+**Save granularity.** The flush runs whenever the handler is next
+invoked. A decision recorded on the *final* interrupt of a session
+(no later interrupts before the program exits) will not be written
+to disk. Acceptable per the existing module-level note in
+`agent.agency` — losing one decision is better than crashing the
+REPL. An optional `flushPolicy()` export lets users force a write
+between turns if they care.
+
+**Library-state-is-singleton contract.** `cliPolicyHandler` stores
+the active `Policy`, `opts.file`, `opts.fields`, and the in-flight /
+pending-save flags in **module-level state inside
+`stdlib/policy.agency`**. Calling `cliPolicyHandler` more than once
+in the same program silently overwrites that state — the
+second-to-last call's `file` and `fields` are lost. The handler
+contract is therefore **call exactly once per program**, install on
+the outermost `handle`. If users need multiple independent policy
+files within one program (rare), they fall back to the pure
+primitives + their own I/O.
+
+If users hit the other edge cases — concurrent agent instances
+writing the same file, atomic-write requirements, etc. — they also
+fall back to the pure primitives.
+
+### 2. Router: `stdlib/router.agency` (new file)
+
+#### 2.1 Types
+
+```agency
+export type AgentSpec = {
+  systemPrompt: string;
+  tools: any[];
+  memory?: boolean;   // default false
+}
+
+export type RouterConfig = {
+  start: string;
+  agents: Record<string, AgentSpec>;
+  maxHops: number;
+  context?: string;   // appended verbatim to every systemPrompt
+}
+```
+
+#### 2.2 The function
+
+```agency
+export def route(config: RouterConfig, userMsg: string): string
+```
+
+Returns the final LLM reply (string).
+
+**Behavior**, per invocation:
+
+1. Start at `category = config.start`. Initialize `hop = 0`.
+2. Loop:
+   a. Open the per-category thread session
+      (`thread(session: category, label: category, summarize: true) { ... }`).
+   b. If `config.agents[category].memory == true`, call
+      `setMemoryId(category)`.
+   c. If this is the first time the router has entered this thread
+      session in the current program lifetime, call
+      `systemMessage(systemPrompt + (context ?? ""))`. Router tracks
+      "first entry per session" in module-level state — persists
+      across multiple `route()` calls within one program (so the
+      system prompt is **not** re-seeded each turn of a REPL loop)
+      and rehydrates through checkpoint restore via the same
+      GlobalStore path as today's `codeFirstEntry` flag.
+   d. Build the tool array: `[...config.agents[category].tools,
+      handoff.partial(validCategories: <all categories except this one>)]`.
+      Drop the `handoff` entry when in fallback mode (step 4).
+   e. Call `llm(userMsg, { memory: <category's memory flag>,
+      tools: <built array> })`. Capture the reply.
+   f. Read `consumeHandoff()`. If empty, return the reply.
+   g. Otherwise, set `category` to the handoff target, increment
+      `hop`. The next iteration re-uses the **original** `userMsg` —
+      handoff means "this message belongs to a different specialist",
+      not "advance the conversation". (Matches today's
+      `runForCategory(category, userMsg, ctx)` behavior in
+      `agent.agency`.) If `hop < maxHops`, goto (a).
+3. If we exit the loop because `hop == maxHops`, set "fallback mode"
+   on, run one more iteration of (a)–(e), return that reply.
+4. **Fallback mode** strips the `handoff` tool from (d) so the LLM
+   has no escape. Mirrors `runForCategory(allowHandoff: false)` in
+   `agent.agency` today.
+
+The router owns:
+- the handoff-target slot (a module-level `let _handoffTarget = ""`
+  + `pushHandoff` / `consumeHandoff` plumbing — moved here from
+  `shared.agency`)
+- the `handoff` tool itself (declared here, takes `(category, reason,
+  validCategories)`, validates the target, sets the slot, returns the
+  "Handoff scheduled" filler string)
+- the per-category first-entry-system-message flag map
+- the hop loop and fallback mode
+
+The user owns:
+- the system prompt per category
+- the tools array per category
+- any module-level state their tools depend on (e.g. the agent's
+  `workspace` bundle + `setCwd`)
+- the per-turn invariants string (`context`)
+
+#### 2.3 Scope of `_handoffTarget`
+
+Module-level `let` lives in the per-RuntimeContext `GlobalStore`, so
+two concurrent agent runs in the same process are isolated. Two
+**parallel threads inside the same run** would race on the slot. We
+do not solve this for v1 — documented as a constraint. Use case is
+hypothetical (the agent today has no parallel-runner pattern), and
+the fix (per-thread slot) is straightforward to retrofit.
+
+#### 2.4 Edge cases
+
+- `config.start` not in `config.agents`: throw at the router entry.
+- A handoff target not in `config.agents`: the `handoff` tool's
+  `validCategories` check already rejects this — the LLM sees an
+  error string as the tool's result and continues without state
+  change.
+- `maxHops <= 0`: treat as 0, run one iteration in fallback mode.
+- An `AgentSpec` with empty `tools`: legal (the handoff tool is
+  still injected unless in fallback).
+
+## How the Agency Agent collapses
+
+Before (rough):
+
+```
+lib/agents/agency-agent/
+├── agent.agency       ~500 lines (defaultHandler, hop loop, ...)
+├── shared.agency      ~150 lines (handoff plumbing)
+├── code.agency        ~150 lines (runCode + allowHandoff)
+├── research.agency    ~150 lines (runResearch + allowHandoff)
+```
+
+After:
+
+```ts
+// agent.agency, in full (sketch)
+import { route } from "std::router"
+import { cliPolicyHandler } from "std::policy"
+import { codeSysPrompt, codeTools } from "./code.agency"
+import { researchSysPrompt, researchTools } from "./research.agency"
+import { ALWAYS_FIELDS } from "./fields.agency"
+
+node main() {
+  printBanner()
+  const ctx = "\nDate: ${today()}\nCWD: ${cwd()}\n${loadAgentsMd(cwd())}"
+  const handler = cliPolicyHandler({
+    file: "${env(\"HOME\")}/.agency-agent/policy.json",
+    fields: ALWAYS_FIELDS,
+  })
+  let userMsg = input("> ")
+  while (userMsg != "exit") {
+    handle {
+      const reply = route({
+        start: "code",
+        agents: {
+          code:     { systemPrompt: codeSysPrompt,     tools: codeTools,     memory: true },
+          research: { systemPrompt: researchSysPrompt, tools: researchTools, memory: true },
+        },
+        maxHops: 3,
+        context: ctx,
+      }, userMsg)
+      print(highlight(reply, language: "markdown"))
+    } with handler
+    userMsg = input("> ")
+  }
+}
+```
+
+`code.agency` and `research.agency` shrink to: the system prompt
+string, the workspace/state, the safe-def tools (like `setCwd`), and
+an exported tools array. No `runCode`/`runResearch`, no
+`allowHandoff`, no `handoff.partial`, no first-entry flag.
+
+`shared.agency` deletes the handoff plumbing entirely (now in
+`stdlib/router.agency`). `AgentContext` becomes just `context: string`
+on the router call site.
+
+`defaultHandler`, `loadPolicy`, `savePolicy`, `policyDir`,
+`policyPath`, `ensurePolicyLoaded`, `recordAlways`,
+`recordAlwaysScoped`, `buildScopedMatch`, `describeScopedMatch`,
+`askUser`, `Decision` type, the `policy`/`policyLoaded` module state,
+`ALWAYS_FIELDS` (if kept agent-specific) — all replaced by the single
+`cliPolicyHandler` call.
+
+Net deletion: ~300 lines from the agent. The agent reads as
+"here's my context, here's two specialists, route between them."
+
+## Testing
+
+### Policy primitives
+
+Unit tests in `tests/stdlib/policy-primitives.test.ts`:
+- `recordRule` adds bare rule, preserves existing rules.
+- `recordScopedRule` prepends scoped rule, builds correct match
+  object from `FieldSpec[]`, brace-expands when
+  `wildcardSubpaths: true`.
+- `buildScopedMatch` handles missing fields gracefully, empty
+  `fields` map, kinds not present.
+
+### CLI policy handler
+
+Integration test under `tests/agency-js/` driving the handler with
+mocked `input()` responses and a temp policy file:
+- First interrupt of kind X with no policy: prompts, "a" approves.
+- Second interrupt of kind X after "aa": auto-approved, no prompt.
+- "ap" with `fields[X]` set: prompts, records scoped rule, second
+  interrupt with matching data auto-approves; mismatching data
+  still prompts.
+- "ap" with `fields[X]` *not* set: option is hidden from the prompt.
+- Reject with reason: `intr.value` carries the reason string.
+- Persistence: kill the handler, reload, prior decisions still
+  effective.
+
+### Router
+
+Agency tests under `tests/agency/`:
+- Single-agent run (no handoff possible) returns LLM reply.
+- Two-agent run, handoff fires, second agent answers, reply returned.
+- Hop limit reached: fallback mode runs, no `handoff` tool in the
+  final LLM call, reply returned.
+- Per-category memory scoping: `setMemoryId(category)` called when
+  `memory: true`.
+- First-entry system message: seeded once per session per run.
+- Invalid handoff target: tool returns error string, no state change.
+
+### Agent regression
+
+The agency-agent integration suite (whatever currently exercises
+`agent.agency`) must keep passing after the agent is rewritten to
+use the new stdlib. This is the load-bearing acceptance test for
+the design.
+
+## Open questions / risks
+
+- **Deferred-flush correctness**: the "flush on next invocation"
+  scheme means the final decision of a session is never written to
+  disk unless another interrupt follows. Acceptable per the policy
+  module docstring (losing one decision is better than crashing),
+  but worth flagging. An optional `flushPolicy()` export lets users
+  force a write between turns.
+- **First-entry-per-session tracking**: lives in router module state.
+  After a checkpoint restore, that state must rehydrate correctly
+  (it's a module-level `let`, so it goes through GlobalStore — same
+  as today's `codeFirstEntry`). Worth a focused test.
+- **Coupling of `_handoffTarget` to the router**: moving the slot
+  from `shared.agency` into `stdlib/router.agency` means any
+  non-router consumer of `handoff()` breaks. Mitigation: the
+  `handoff` tool also moves into the router, and nothing outside
+  the agent currently calls it. Greenfield change.
+
+## File summary
+
+- **Modify**: `stdlib/policy.agency` (+ types, + primitives, +
+  CLI helper).
+- **New**: `stdlib/router.agency`.
+- **Modify**: `lib/agents/agency-agent/agent.agency`,
+  `shared.agency`, `code.agency`, `research.agency` — collapse onto
+  the new stdlib (this is the regression test, not the change
+  itself).
+- **Tests**: `tests/stdlib/policy-primitives.test.ts` (new),
+  policy + router integration tests under `tests/agency-js/` and
+  `tests/agency/` (new), plus the existing agent integration suite
+  (must keep passing).

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -1,6 +1,6 @@
 import { route } from "std::agent"
 import { today } from "std::date"
-import { AlwaysFields, cliPolicyHandler } from "std::policy"
+import { ScopedRuleFields, cliPolicyHandler } from "std::policy"
 import { exists } from "std::shell"
 import { highlight } from "std::syntax"
 import { cwd, env } from "std::system"
@@ -81,24 +81,24 @@ def policyPath(): string { return "${policyDir()}/${POLICY_FILE}" }
 // flag that turns a directory value into a brace-expanded glob so the
 // rule matches `dir` AND `dir/**`. Kinds not present in this map
 // don't offer the option — the user falls back to (a)/(r)/(aa)/(rr).
-const ALWAYS_FIELDS: AlwaysFields = {
-  "std::read": [{ field: "dir", wildcardSubpaths: true }],
-  "std::write": [{ field: "dir", wildcardSubpaths: true }],
-  "std::edit": [{ field: "dir", wildcardSubpaths: true }],
-  "std::ls": [{ field: "dir", wildcardSubpaths: true }],
-  "std::glob": [{ field: "dir", wildcardSubpaths: true }],
-  "std::grep": [{ field: "dir", wildcardSubpaths: true }],
+const ALWAYS_FIELDS: ScopedRuleFields = {
+  "std::read": [{ field: "dir", matchSubpaths: true }],
+  "std::write": [{ field: "dir", matchSubpaths: true }],
+  "std::edit": [{ field: "dir", matchSubpaths: true }],
+  "std::ls": [{ field: "dir", matchSubpaths: true }],
+  "std::glob": [{ field: "dir", matchSubpaths: true }],
+  "std::grep": [{ field: "dir", matchSubpaths: true }],
   "std::copy": [
-    { field: "src", wildcardSubpaths: true },
-    { field: "dest", wildcardSubpaths: true },
+    { field: "src", matchSubpaths: true },
+    { field: "dest", matchSubpaths: true },
   ],
   "std::move": [
-    { field: "src", wildcardSubpaths: true },
-    { field: "dest", wildcardSubpaths: true },
+    { field: "src", matchSubpaths: true },
+    { field: "dest", matchSubpaths: true },
   ],
   "std::exec": [
-    { field: "command", wildcardSubpaths: false },
-    { field: "subcommand", wildcardSubpaths: false },
+    { field: "command", matchSubpaths: false },
+    { field: "subcommand", matchSubpaths: false },
   ]
 }
 

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -1,22 +1,12 @@
+import { route } from "std::agent"
 import { today } from "std::date"
-import {
-  Policy,
-  PolicyRule,
-  checkPolicy,
-  validatePolicy,
-  writePolicyFile,
-} from "std::policy"
+import { AlwaysFields, cliPolicyHandler } from "std::policy"
 import { exists } from "std::shell"
 import { highlight } from "std::syntax"
 import { cwd, env } from "std::system"
 
-import { runCode } from "./code.agency"
-import { runResearch } from "./research.agency"
-import {
-  AgentContext,
-  AGENCY_AGENT_DIR,
-  consumeHandoff,
-} from "./shared.agency"
+import { codeSysPrompt, codeTools } from "./code.agency"
+import { researchSysPrompt, researchTools } from "./research.agency"
 
 
 /*
@@ -27,13 +17,18 @@ import {
  *   - `code.agency`     — writes, edits, typechecks, runs code
  *   - `research.agency` — looks up docs, fetches URLs, browses web
  *
- * Routing: we don't categorize on every turn. The current
- * specialist's LLM gets a `handoff(category, reason)` tool. If it
- * can handle the message, it just answers. If clearly out of scope,
- * it calls `handoff()` and this loop re-runs the user's message in
- * the new category. See `shared.agency` for the design rationale and
- * `docs/superpowers/ideas/2026-05-30-routing-stickiness.md` for the
- * alternatives we deliberately deferred.
+ * The standard library does the heavy lifting:
+ *   - `std::agent.route` runs the per-turn hop loop, owns the
+ *     handoff signal, and force-answers when the hop limit is hit.
+ *   - `std::policy.cliPolicyHandler` provides the interactive
+ *     approve/reject/always menu and persists "always" decisions to
+ *     `~/.agency-agent/policy.json`.
+ *
+ * This file's responsibilities collapse to:
+ *   1. Banner + REPL loop.
+ *   2. Per-kind ALWAYS_FIELDS map for the policy handler's
+ *      "approve-always-here" option.
+ *   3. Wire the two specialists into one `RouterConfig`.
  *
  * Other features:
  * - Doc-as-skills: bundles `docs/site/guide` etc. (copied to
@@ -44,12 +39,6 @@ import {
  *   source it generates to verify the code before showing it.
  * - File I/O tools: `read`, `write`, `edit` for actually creating /
  *   editing `.agency` files.
- * - Interactive policy: every interrupt the LLM raises pops a
- *   prompt with approve / reject / always-approve / always-reject.
- *   "Always" decisions are recorded in a per-run Policy and
- *   replayed automatically for the rest of the session via
- *   `checkPolicy`.
- *
  */
 
 // Verbose tool-call tracing, opt-in via `AGENT_DEBUG=1`.
@@ -87,77 +76,30 @@ def policyDir(): string {
 }
 def policyPath(): string { return "${policyDir()}/${POLICY_FILE}" }
 
-def loadPolicy(): Policy {
-  """
-  Read and validate the on-disk policy. Returns `{}` if the file is
-  absent, unreadable, malformed, or fails validation; warns the user
-  for malformed cases so they know a decision didn't carry over.
-  """
-  const dir = policyDir()
-  const path = policyPath()
-  if (!exists(POLICY_FILE, dir)) {
-    return {}
-  }
-  const readResult = read(POLICY_FILE, dir) with approve
-  if (isFailure(readResult)) {
-    print(color.yellow("Could not read ${path}: ${readResult.error}"))
-    return {}
-  }
-  const parsed = try parseJSON(readResult.value)
-  if (isFailure(parsed)) {
-    print(
-      color.yellow(
-      "Malformed JSON in ${path}; ignoring and starting fresh.",
-    ),
-    )
-    return {}
-  }
-  const valid = validatePolicy(parsed.value)
-  if (!valid.success) {
-    print(
-      color.yellow(
-      "Invalid policy in ${path} (${valid.error}); ignoring and starting fresh.",
-    ),
-    )
-    return {}
-  }
-  return parsed.value
-}
-
-def savePolicy() {
-  """
-  Persist the current in-memory policy to disk. Called from
-  `recordAlways` / `recordAlwaysScoped` so every "always" decision
-  immediately survives a restart. Failures are warnings, not
-  errors — losing one decision is better than crashing the REPL.
-  """
-  const path = policyPath()
-  const result = try writePolicyFile(path, policy) with approve
-  if (isFailure(result)) {
-    print(color.yellow("Could not save policy to ${path}: ${result.error}"))
-  }
-}
-
-// Persistent policy, hydrated from disk by `ensurePolicyLoaded()` at the
-// top of `node main`. Module-level `let` so handlers and helpers can read
-// and mutate it; `policyLoaded` guards against re-entry while the load is
-// in flight (see `ensurePolicyLoaded`).
-let policy: Policy = {}
-let policyLoaded: boolean = false
-
-def ensurePolicyLoaded() {
-  """
-  Idempotent hydrate of `policy` from disk.
-
-  `policyLoaded` MUST flip to `true` BEFORE `loadPolicy()` runs. The read
-  inside `loadPolicy` raises an interrupt whose chain dispatch visits
-  every handler — including `defaultHandler`, which calls back into here.
-  Without the early flip, that re-entry recurses forever.
-  """
-  if (!policyLoaded) {
-    policyLoaded = true
-    policy = loadPolicy() with approve
-  }
+// Per-kind config driving the "approve-always-here" option. For each
+// kind we list the data fields the scoped rule should pin, plus a
+// flag that turns a directory value into a brace-expanded glob so the
+// rule matches `dir` AND `dir/**`. Kinds not present in this map
+// don't offer the option — the user falls back to (a)/(r)/(aa)/(rr).
+const ALWAYS_FIELDS: AlwaysFields = {
+  "std::read": [{ field: "dir", wildcardSubpaths: true }],
+  "std::write": [{ field: "dir", wildcardSubpaths: true }],
+  "std::edit": [{ field: "dir", wildcardSubpaths: true }],
+  "std::ls": [{ field: "dir", wildcardSubpaths: true }],
+  "std::glob": [{ field: "dir", wildcardSubpaths: true }],
+  "std::grep": [{ field: "dir", wildcardSubpaths: true }],
+  "std::copy": [
+    { field: "src", wildcardSubpaths: true },
+    { field: "dest", wildcardSubpaths: true },
+  ],
+  "std::move": [
+    { field: "src", wildcardSubpaths: true },
+    { field: "dest", wildcardSubpaths: true },
+  ],
+  "std::exec": [
+    { field: "command", wildcardSubpaths: false },
+    { field: "subcommand", wildcardSubpaths: false },
+  ]
 }
 
 def loadAgentsMd(dir: string): string {
@@ -178,337 +120,6 @@ def loadAgentsMd(dir: string): string {
   return "\n\n<project_context>\n${result.value}\n</project_context>"
 }
 
-type Decision =
-  | "approve"
-  | "reject"
-  | "approve-always"
-  | "approve-always-here"
-  | "reject-always"
-
-// Per-kind config driving the "approve-always-here" option. For each
-// kind we list the data fields the scoped rule should pin, plus a
-// flag that turns a directory value into a brace-expanded glob so the
-// rule matches `dir` AND `dir/**`. Kinds not present in this map
-// don't offer the option — the user falls back to (a)/(r)/(aa)/(rr).
-type FieldSpec = {
-  field: string;
-  wildcardSubpaths: boolean
-}
-
-const ALWAYS_FIELDS: Record<string, FieldSpec[]> = {
-  "std::read": [{
-    field: "dir",
-    wildcardSubpaths: true
-  }],
-  "std::write": [{
-    field: "dir",
-    wildcardSubpaths: true
-  }],
-  "std::edit": [{
-    field: "dir",
-    wildcardSubpaths: true
-  }],
-  "std::ls": [{
-    field: "dir",
-    wildcardSubpaths: true
-  }],
-  "std::glob": [{
-    field: "dir",
-    wildcardSubpaths: true
-  }],
-  "std::grep": [{
-    field: "dir",
-    wildcardSubpaths: true
-  }],
-  "std::copy": [
-    {
-    field: "src",
-    wildcardSubpaths: true
-  },
-    {
-    field: "dest",
-    wildcardSubpaths: true
-  },
-  ],
-  "std::move": [
-    {
-    field: "src",
-    wildcardSubpaths: true
-  },
-    {
-    field: "dest",
-    wildcardSubpaths: true
-  },
-  ],
-  "std::exec": [
-    {
-    field: "command",
-    wildcardSubpaths: false
-  },
-    {
-    field: "subcommand",
-    wildcardSubpaths: false
-  },
-  ]
-}
-
-def buildScopedMatch(intr): Record<string, string> {
-  """
-  Build the `match` map for an "approve-always-here" rule by reading
-  the field spec for `intr.kind` and pulling the corresponding values
-  out of `intr.data`. Returns `{}` when no spec applies — callers
-  should treat that as "scoped option not available" and skip writing.
-  """
-  const specs = ALWAYS_FIELDS[intr.kind]
-  if (specs == null) {
-    return {}
-  }
-  // Special case: a bare exec (no args, so `subcommand` is empty)
-  // means the user wants the catch-all for this command. Pinning
-  // `subcommand: ""` would only match other bare invocations, which
-  // is rarely useful — so collapse to just the command field.
-  let effective = specs
-  if (intr.kind == "std::exec" && intr.data.subcommand == "") {
-    effective = [{
-      field: "command",
-      wildcardSubpaths: false
-    }]
-  }
-  let matchObj: Record<string, string> = {}
-  for (spec in effective) {
-    const raw = intr.data[spec.field]
-    let pattern = raw
-    if (spec.wildcardSubpaths) {
-      // picomatch brace-expands "${raw}{,/**}" into "${raw}" OR
-      // "${raw}/**" — matches the exact dir and any subdir.
-      pattern = "${raw}{,/**}"
-    }
-    matchObj[spec.field] = pattern
-  }
-  return matchObj
-}
-
-def describeScopedMatch(intr): string {
-  """
-  Human-readable summary of what `buildScopedMatch(intr)` would pin —
-  used in the prompt so the user sees the exact rule they're about to
-  agree to. Returns an empty string when the kind isn't scoped.
-  """
-  const matchObj = buildScopedMatch(intr)
-  const ks = keys(matchObj)
-  if (ks.length == 0) {
-    return ""
-  }
-  // Dir-keyed kinds get a friendlier phrasing than the raw pattern.
-  // Backticks are used so we can embed literal `"` characters around
-  // values without fighting the parser's string-escape rules.
-  const dirKinds = ["std::read", "std::write", "std::edit", "std::ls", "std::glob", "std::grep"]
-  if (dirKinds.includes(intr.kind)) {
-    return "dir='${intr.data.dir}' or any subdir"
-  }
-  if (intr.kind == "std::copy" || intr.kind == "std::move") {
-    return "src='${intr.data.src}' or any subdir, dest='${intr.data.dest}' or any subdir"
-  }
-  // std::exec — render command and (if non-empty) subcommand.
-  if (intr.kind == "std::exec") {
-    if (intr.data.subcommand == "") {
-      return "command='${intr.data.command}'"
-    }
-    return "command='${intr.data.command}', subcommand='${intr.data.subcommand}'"
-  }
-  // Generic fallback for any future kind added to ALWAYS_FIELDS.
-  let parts: string[] = []
-  for (k in ks) {
-    parts.push("${k}='${matchObj[k]}'")
-  }
-  return parts.join(", ")
-}
-
-def askUser(intr: any): Decision {
-  """
-  Pretty-print an interrupt and ask the user how to respond. Returns
-  one of the Decision strings. The "(ap)" option is only shown when
-  the kind has an entry in ALWAYS_FIELDS, and the prompt echoes the
-  exact match rule the user would commit to.
-  """
-  print(color.yellow("───────────────────────────────────────────"))
-  print(color.yellow("Tool wants to run: ${intr.kind}"))
-  print(color.yellow("Reason: ${intr.message}"))
-  print("Data:")
-  printJSON(intr.data)
-  print(color.yellow("───────────────────────────────────────────"))
-
-  const scopedHint = describeScopedMatch(intr)
-  const scopedAvailable = scopedHint != ""
-
-  print("What would you like to do?")
-  print("  (a)  approve once")
-  print("  (r)  reject once")
-  print("  (aa) approve always (every ${intr.kind})")
-  if (scopedAvailable) {
-    print("  (ap) approve always here (${scopedHint})")
-  }
-  print("  (rr) reject always")
-
-  let answer = ""
-  let valid = false
-  while (!valid) {
-    answer = input("> ")
-    if (answer == "a" || answer == "r" || answer == "aa" || answer == "rr") {
-      valid = true
-    } else if (answer == "ap" && scopedAvailable) {
-      valid = true
-    } else if (answer == "ap") {
-      print(
-        color.yellow(
-        "(ap) isn't available for ${intr.kind} — pick one of (a)/(r)/(aa)/(rr).",
-      ),
-      )
-    }
-  }
-  if (answer == "a") {
-    return "approve"
-  }
-  if (answer == "r") {
-    return "reject"
-  }
-  if (answer == "aa") {
-    return "approve-always"
-  }
-  if (answer == "ap") {
-    return "approve-always-here"
-  }
-  return "reject-always"
-}
-
-def recordAlways(kind: string, action: string) {
-  """
-  Add an unconditional rule for `kind` to the running policy. First-
-  match-wins inside `checkPolicy`, so prepending a new entry would
-  also work, but a single bare rule covers every future interrupt of
-  this kind cleanly.
-  """
-  const next: Policy = {
-    ...policy,
-    [kind]: [{
-      action: action
-    }]
-  }
-  policy = next
-  savePolicy()
-  print(
-    color.cyan("→ Recorded policy: ${kind} = ${action} (won't ask again)"),
-  )
-}
-
-def recordAlwaysScoped(intr) {
-  """
-  Add a scoped approve rule pinned to whichever fields ALWAYS_FIELDS
-  says are meaningful for this kind. Prepended to any existing rules
-  so the new (more specific) decision takes precedence in the
-  first-match-wins evaluation order.
-  """
-  const match = buildScopedMatch(intr)
-  // NOTE: Agency compiles `!=` to `!==`, so an UNDEFINED `existing`
-  // would slip past `!= null` and assign `undefined` to `rules`,
-  // which would then crash the spread below. Default-via-`||` to a
-  // fresh array so the spread always works.
-  const existing = policy[intr.kind] || []
-  const next: Policy = {
-    ...policy,
-    [intr.kind]: [{
-      match: match,
-      action: "approve"
-    }, ...existing]
-  }
-  policy = next
-  savePolicy()
-  print(
-    color.cyan(
-    "→ Recorded policy: ${intr.kind} = approve where ${describeScopedMatch(intr)}",
-  ),
-  )
-}
-
-def defaultHandler(intr) {
-  // Hydrate the persistent policy on first invocation. See the
-  // `let policy` declaration for the init-ordering rationale.
-  ensurePolicyLoaded()
-  // Consult the running policy first. If a previous "always"
-  // decision covers this kind, use it without bothering the user.
-  const decision = checkPolicy(policy, intr)
-  if (decision.type == "approve") {
-    print(color.cyan("→ policy auto-approved ${intr.kind}"))
-    return approve()
-  }
-  if (decision.type == "reject") {
-    print(color.cyan("→ policy auto-rejected ${intr.kind}"))
-    return reject()
-  }
-  // checkPolicy returned propagate — no rule for this kind yet,
-  // so ask the user and possibly record a new rule.
-  const answer = askUser(intr)
-  if (answer == "approve-always") {
-    recordAlways(intr.kind, "approve")
-    return approve()
-  }
-  if (answer == "approve-always-here") {
-    recordAlwaysScoped(intr)
-    return approve()
-  }
-  if (answer == "reject-always") {
-    recordAlways(intr.kind, "reject")
-    return reject()
-  }
-  if (answer == "approve") {
-    return approve()
-  }
-  // Interactive reject: give the user a chance to tell the LLM what
-  // was wrong with the suggestion. The reason becomes the tool's
-  // return value on the LLM side, so the model sees concrete
-  // feedback ("the path is wrong" / "use a different API") instead
-  // of an opaque rejection it can't learn from.
-  const reason = input("Why are you rejecting? (press enter to skip) ")
-  if (reason == "") {
-    return reject()
-  }
-  return reject(reason)
-}
-
-// Cap on handoffs per user turn. Stops ping-pong (A→B→A→B…) when the two
-// LLMs disagree about scope; in practice every handoff terminates after 1.
-const MAX_HOPS = 3
-
-def runForCategory(
-  category: string,
-  userMsg: string,
-  ctx: AgentContext,
-  allowHandoff: boolean = true,
-): string {
-  """
-  Dispatch one user turn to the chosen specialist's thread. `summarize:
-  true` triggers the eager close-time summarize hook so `listThreads()`
-  is cheap on future runs.
-
-  @param category - Which specialist's thread to run in
-  @param userMsg - The user's input message for this turn
-  @param ctx - Per-call invariants (env, projectContext)
-  @param allowHandoff - When false, strips the `handoff` tool so the
-    subagent has to answer. Used by the hop-limit fallback.
-  """
-  let reply = ""
-  if (category == "code") {
-    thread(session: "code", label: "code", summarize: true) {
-      reply = runCode(userMsg, ctx, allowHandoff)
-    }
-  } else {
-    thread(session: "research", label: "research", summarize: true) {
-      reply = runResearch(userMsg, ctx, allowHandoff)
-    }
-  }
-  return reply
-}
-
 node main() {
   print(color.cyan("╭───────────────────────────────────────────────╮"))
   print(color.cyan("│         Welcome to the Agency Agent           │"))
@@ -517,79 +128,41 @@ node main() {
   print(color.cyan("╰───────────────────────────────────────────────╯"))
   print("Type 'exit' to quit.\n")
 
-  // Pre-load the policy BEFORE `defaultHandler` is installed below. If we
-  // loaded lazily from inside `defaultHandler`, the policy file's own read
-  // would re-enter `defaultHandler` (the chain visits every handler) with
-  // `policy` still `{}`, prompting the user for a file we're trying to
-  // auto-approve. The outer `with approve` is redundant with the one
-  // inside `loadPolicy` but silences the typechecker warning.
-  ensurePolicyLoaded() with approve
-
   // Grounding: the LLM should not have to ask the user where it is
   // or what day it is. Both are appended once per run so they ride
   // with the first system message in each specialist's thread.
-  const env = "\n\nCurrent date: ${today()}\nCurrent working directory: ${cwd()}"
-
+  //
   // Project context: if the user keeps an AGENTS.md at the workspace
   // root (Anthropic / Pi / Aider all read it), inline it so the LLM
   // automatically follows the project's conventions.
   const projectContext = loadAgentsMd(cwd()) with approve
-  const ctx: AgentContext = {
-    env: env,
-    projectContext: projectContext
-  }
+  const context = "\n\nCurrent date: ${today()}\nCurrent working directory: ${cwd()}${projectContext}"
 
-  // Starting category. The code subagent is the better default for
-  // an agent named "Agency Agent" — most users open it to work on
-  // code. The handoff machinery will route to research on the first
-  // research-shaped message.
-  //
-  // Typed as `string` (not `Category`) because the routing loop
-  // re-assigns it from `consumeHandoff()`'s string return value
-  // (see the sentinel-string rationale in `shared.agency`). The
-  // contents are still always a valid Category — `handoff()` is the
-  // only writer of the source state and takes a Category-typed
-  // parameter.
-  let category: string = "code"
+  // Bind the handler to a local var so `with handler` parses (the
+  // `with` clause only accepts an identifier, not a call expression).
+  const handler = cliPolicyHandler({
+    file: policyPath(),
+    fields: ALWAYS_FIELDS,
+  })
 
   let userMsg = input("What would you like to do? ")
   while (userMsg != "exit" && userMsg != "quit") {
     handle {
-      // Chain handoffs (with a hop limit) so a single user turn can
-      // re-route once if the current specialist decides it's the wrong
-      // one. The common case is zero handoffs — the agent answers and
-      // we fall through. One handoff is the cross-specialist case
-      // ("can you look up X in docs?" while in code → handoff to
-      // research). Two+ would be ping-pong, which the limit kills.
-      let hop = 0
-      let done = false
-      while (!done && hop < MAX_HOPS) {
-        const reply = runForCategory(category, userMsg, ctx)
-        const target = consumeHandoff()
-        if (target == "") {
-          // Subagents are prompted to reply in Markdown. Render
-          // headings/bullets/bold/code-fences instead of dumping the
-          // raw source — see `code.agency` / `research.agency` for
-          // the prompt and the system-prompt instruction.
-          print(highlight("\n${reply}\n", language: "markdown"))
-          done = true
-        } else {
-          print(color.cyan("→ handing off to ${target}"))
-          category = target
-          hop = hop + 1
-        }
-      }
-      if (!done) {
-        print(
-          color.yellow("(handoff hop limit reached; answering in ${category})"),
-        )
-        // Force the agent to actually answer instead of handing off
-        // yet again — `allowHandoff: false` strips `handoff` from the
-        // tool set, so the LLM has no escape hatch this turn.
-        const finalReply = runForCategory(category, userMsg, ctx, false)
-        print(highlight("\n${finalReply}\n", language: "markdown"))
-      }
-    } with defaultHandler
+      const reply = route({
+        start: "code",
+        agents: {
+          code:     { systemPrompt: codeSysPrompt,     tools: codeTools,     memory: true },
+          research: { systemPrompt: researchSysPrompt, tools: researchTools, memory: true },
+        },
+        maxHops: 3,
+        context: context,
+      }, userMsg)
+      // Subagents are prompted to reply in Markdown. Render
+      // headings/bullets/bold/code-fences instead of dumping the
+      // raw source — see `code.agency` / `research.agency` for the
+      // system-prompt instruction.
+      print(highlight("\n${reply}\n", language: "markdown"))
+    } with handler
     userMsg = input("\nNext request (or 'exit'): ")
   }
   print(color.cyan("\nGoodbye!"))

--- a/packages/agency-lang/lib/agents/agency-agent/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/code.agency
@@ -2,25 +2,18 @@
  * Code subagent — handles anything that touches code or the file
  * system: writing, editing, typechecking, running shell commands.
  *
- * Tools: setCwd + the full Workspace bundle + typecheck + highlight +
- * print + remember/recall + handoff. NO docs / web / wikipedia —
- * the agent must `handoff(reason)` (PFA-bound to research only) when
- * it needs those.
- *
- * The Workspace state lives here (not in `shared.agency`) because
- * only the code subagent uses file-system tools. `setCwd` re-anchors
- * the bundle so a directory change in one turn persists to the next.
- *
- * See `shared.agency` for the multi-agent design rationale.
+ * Exports `codeSysPrompt` + `codeTools` consumed by the router in
+ * `agent.agency`. The router injects the `handoff` tool itself, so
+ * we do NOT add it here. The Workspace state lives here (not in
+ * `shared.agency`) because only the code subagent uses file-system
+ * tools. `setCwd` re-anchors the bundle so a directory change in one
+ * turn persists to the next.
  */
 import { typecheck } from "std::agency"
 import { Workspace, openDir } from "std::fs"
-import { setMemoryId, remember, recall } from "std::memory"
+import { remember, recall } from "std::memory"
 import { highlight } from "std::syntax"
 import { cwd } from "std::system"
-import { systemMessage } from "std::thread"
-
-import { Category, AgentContext, handoff } from "./shared.agency"
 
 
 // File-system tools handed to the LLM as a single bundle anchored to
@@ -31,13 +24,6 @@ import { Category, AgentContext, handoff } from "./shared.agency"
 // `let` so the rebuilt bundle is visible to the next turn (Agency
 // stores module-level lets in the GlobalStore).
 let workspace: Workspace = openDir(cwd())
-
-// First-entry detection for the code session. Flipped to false the
-// first time `runCode` seeds its system message; subsequent turns
-// (including interrupt resumes) see it as false and skip the seed.
-// Lives in the GlobalStore (module-level `let`) so it survives the
-// `llm()` tool-call boundary and persists across user turns.
-let codeFirstEntry: boolean = true
 
 export def setCwd(dir: string): string {
   """
@@ -56,7 +42,7 @@ export def setCwd(dir: string): string {
   return "Working directory set to: ${dir}"
 }
 
-const codeSysPrompt = """
+export static const codeSysPrompt = """
 You are the **code specialist** of a multi-thread Agency-language
 assistant. You handle anything that touches code or the file system:
 writing, editing, running, and typechecking Agency or shell code.
@@ -126,59 +112,18 @@ fences. Code fences are especially important — they're how code in
 your reply gets per-language coloring.
 """
 
-export def runCode(
-  userMsg: string,
-  ctx: AgentContext,
-  allowHandoff: boolean = true,
-): string {
-  """
-  Run a single turn in the code subagent. The caller is responsible
-  for the surrounding `thread(session: "code") { ... }` block; this
-  function just (a) seeds the code system message on first entry,
-  (b) scopes memory to the `"code"` knowledge graph, and (c) runs
-  the LLM call with the code tool set.
-
-  Returns the LLM's text reply. If the LLM called `handoff()` mid-
-  turn, the reply is the LLM's post-handoff filler text and the
-  caller MUST check `consumeHandoff()` to discover whether to
-  re-route.
-
-  @param userMsg - The user's input message for this turn
-  @param ctx - Per-call invariants (env, projectContext) for the system message
-  @param allowHandoff - When false, the `handoff` tool is omitted from the
-    tool set so the agent is forced to answer this turn. Used by the
-    REPL's hop-limit fallback to break a re-routing chain.
-  """
-  setMemoryId("code")
-  if (codeFirstEntry) {
-    systemMessage(codeSysPrompt + ctx.env + ctx.projectContext)
-    codeFirstEntry = false
-  }
-  // Build the tool set conditionally. `handoff` is PFA-bound to
-  // `validCategories: ["research"]` — the runtime check in
-  // `shared.agency` rejects any other target, so the LLM cannot
-  // hand off to itself. When `allowHandoff` is false (hop-limit
-  // fallback), drop `handoff` entirely.
-  let tools = [
-    setCwd,
-    workspace.read,
-    workspace.write,
-    workspace.edit.partial(printDiff: true),
-    workspace.ls,
-    workspace.glob,
-    workspace.grep,
-    workspace.bash,
-    typecheck,
-    highlight.partial(language: "ts"),
-    print,
-    remember,
-    recall,
-  ]
-  if (allowHandoff) {
-    tools.push(handoff.partial(validCategories: ["research"]))
-  }
-  return llm(userMsg, {
-    memory: true,
-    tools: tools
-  })
-}
+export static const codeTools: any[] = [
+  setCwd,
+  workspace.read,
+  workspace.write,
+  workspace.edit.partial(printDiff: true),
+  workspace.ls,
+  workspace.glob,
+  workspace.grep,
+  workspace.bash,
+  typecheck,
+  highlight.partial(language: "ts"),
+  print,
+  remember,
+  recall,
+]

--- a/packages/agency-lang/lib/agents/agency-agent/research.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/research.agency
@@ -3,30 +3,22 @@
  * up Agency syntax in the bundled docs, searching Wikipedia,
  * fetching URLs, browsing the web, or recalling stored facts.
  *
- * Tools: docSkill / cliSkill / appendixSkill + wikipedia* + fetch* +
- * browserUse + remember/recall + highlight + print + handoff. NO
- * file write / edit / typecheck / bash — the agent must
- * `handoff(reason)` (PFA-bound to code only) when the user asks for
- * code changes.
- *
- * The bundled-docs Skills live here (not in `shared.agency`) because
- * only the research subagent uses them. `static const` caches the
- * Skill across runs.
- *
- * See `shared.agency` for the multi-agent design rationale.
+ * Exports `researchSysPrompt` + `researchTools` consumed by the
+ * router in `agent.agency`. The router injects the `handoff` tool
+ * itself, so we do NOT add it here. The bundled-docs Skills live
+ * here (not in `shared.agency`) because only the research subagent
+ * uses them. `static const` caches the Skill across runs.
  */
 import { fetch, fetchJSON, fetchMarkdown } from "std::http"
 import { browserUse } from "std::browser"
-import { setMemoryId, remember, recall } from "std::memory"
+import { remember, recall } from "std::memory"
 import { skillsDir } from "std::skills"
 import { highlight } from "std::syntax"
-import { systemMessage } from "std::thread"
 import {
   search as wikipediaSearch,
   summary as wikipediaSummary,
   article as wikipediaArticle,
 } from "std::wikipedia"
-import { Category, AgentContext, handoff } from "./shared.agency"
 
 // Bundled docs live one level above the agent's compiled JS. Built
 // once at module load — `skillsDir` reads + parses every `.md`
@@ -43,11 +35,7 @@ static const docSkill = skillsDir("../docs/guide") with approve
 static const cliSkill = skillsDir("../docs/cli") with approve
 static const appendixSkill = skillsDir("../docs/appendix") with approve
 
-// First-entry detection for the research session. See the matching
-// comment in `code.agency` for the rationale.
-let researchFirstEntry: boolean = true
-
-const researchSysPrompt = """
+export static const researchSysPrompt = """
 You are the **research specialist** of a multi-thread Agency-language
 assistant. You answer questions that need reading: Agency-language
 syntax / semantics / built-ins, CLI usage, external docs, Wikipedia
@@ -114,58 +102,19 @@ replies appear with colored headings, bold/italic styling, link
 underlining, and properly highlighted code fences.
 """
 
-export def runResearch(
-  userMsg: string,
-  ctx: AgentContext,
-  allowHandoff: boolean = true,
-): string {
-  """
-  Run a single turn in the research subagent. The caller is
-  responsible for the surrounding `thread(session: "research") { ... }`
-  block; this function just (a) seeds the research system message
-  on first entry, (b) scopes memory to the `"research"` knowledge
-  graph, and (c) runs the LLM call with the research tool set.
-
-  Returns the LLM's text reply. If the LLM called `handoff()` mid-
-  turn, the reply is the LLM's post-handoff filler text and the
-  caller MUST check `consumeHandoff()` to discover whether to
-  re-route.
-
-  @param userMsg - The user's input message for this turn
-  @param ctx - Per-call invariants (env, projectContext) for the system message
-  @param allowHandoff - When false, the `handoff` tool is omitted from the
-    tool set so the agent is forced to answer this turn. Used by the
-    REPL's hop-limit fallback to break a re-routing chain.
-  """
-  setMemoryId("research")
-  if (researchFirstEntry) {
-    systemMessage(researchSysPrompt + ctx.env + ctx.projectContext)
-    researchFirstEntry = false
-  }
-  // See the comment in `code.agency`: `handoff` is PFA-bound to
-  // `validCategories: ["code"]` so the LLM can't hand off to itself,
-  // and omitted entirely when `allowHandoff` is false.
-  let tools = [
-    docSkill,
-    cliSkill,
-    appendixSkill,
-    wikipediaSearch,
-    wikipediaSummary,
-    wikipediaArticle,
-    fetch,
-    fetchJSON,
-    fetchMarkdown,
-    browserUse,
-    remember,
-    recall,
-    highlight.partial(language: "ts"),
-    print,
-  ]
-  if (allowHandoff) {
-    tools.push(handoff.partial(validCategories: ["code"]))
-  }
-  return llm(userMsg, {
-    memory: true,
-    tools: tools
-  })
-}
+export static const researchTools: any[] = [
+  docSkill,
+  cliSkill,
+  appendixSkill,
+  wikipediaSearch,
+  wikipediaSummary,
+  wikipediaArticle,
+  fetch,
+  fetchJSON,
+  fetchMarkdown,
+  browserUse,
+  remember,
+  recall,
+  highlight.partial(language: "ts"),
+  print,
+]

--- a/packages/agency-lang/lib/agents/agency-agent/shared.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/shared.agency
@@ -1,37 +1,16 @@
 /*
- * Shared state and types for the multi-thread Agency Agent.
+ * Shared bootstrap for the Agency Agent.
  *
- * The agent is split across:
- *   - `agent.agency`     — REPL loop + interrupt handler + policy
- *   - `shared.agency`    — this file; Category type + handoff plumbing
- *                          + persistent-memory bootstrap
- *   - `code.agency`      — code subagent (file ops, shell, typecheck)
- *   - `research.agency`  — research subagent (docs, web, knowledge)
+ * Sole responsibilities:
+ *   - Compute the per-user state directory `$HOME/.agency-agent`.
+ *   - Enable persistent memory so each subagent's `remember`/`recall`
+ *     calls land in a stable on-disk knowledge graph.
  *
- * Routing: we don't categorize the user's message on every turn.
- * Instead, the current category's LLM gets a `handoff(reason)` tool
- * (the valid targets are bound per-subagent via PFA — see below).
- * If it can handle the message, it just answers. If it can't (e.g.
- * the user asks the code agent a wikipedia question), it calls
- * `handoff()` and the main loop re-routes the same user message to
- * the chosen specialist.
- *
- * Why this design? Most messages in a conversation continue the
- * current topic. A naïve `categorize()` LLM call on every turn
- * over-eagerly re-routes ambiguous follow-ups, stranding the new
- * specialist without conversation context. Letting the current agent
- * decide biases hard toward "stay" — the agent has the full thread
- * history and is the most-informed judge of whether the message is
- * in-scope.
- *
- * See docs/superpowers/ideas/2026-05-30-routing-stickiness.md for
- * the full design rationale and a catalogue of alternative routing
- * techniques worth trying in follow-ups.
+ * Routing + handoff used to live here; those moved to `std::agent`'s
+ * `route()` / `handoff()` and the agent now consumes them directly.
  */
 import { enableMemory } from "std::memory"
 import { env } from "std::system"
-
-export type Category = "code" | "research"
 
 // Per-user state directory for the agent (persistent memory + saved
 // policy). We expand `~` ourselves via `env("HOME")` because
@@ -54,14 +33,14 @@ def computeAgentDir(): string {
 export static const AGENCY_AGENT_DIR = computeAgentDir()
 
 // Persistent knowledge graph for every subagent. `setMemoryId(...)`
-// in each subagent scopes which graph their `remember`/`recall` calls
-// hit, so a single shared on-disk directory cleanly hosts both. Using
-// `static const _ = ...` is the documented top-level pattern (see
-// `stdlib/memory.agency`): the `with approve` modifier needs an
-// enclosing step path, which a bare top-level call doesn't have. The
-// underscore name signals "we want the side-effect, not the value".
-// `embeddings.model` MUST be set — without it, the embedder is
-// invoked with `model: undefined` and smoltalk warns
+// (called inside std::agent's router) scopes which graph their
+// `remember`/`recall` calls hit, so a single shared on-disk directory
+// cleanly hosts both. Using `static const _ = ...` is the documented
+// top-level pattern (see `stdlib/memory.agency`): the `with approve`
+// modifier needs an enclosing step path, which a bare top-level call
+// doesn't have. The underscore name signals "we want the side-effect,
+// not the value". `embeddings.model` MUST be set — without it, the
+// embedder is invoked with `model: undefined` and smoltalk warns
 // `[memory] embed call failed: Model undefined is not recognized`,
 // which silently disables Tier 2 (embedding-similarity) recall.
 // `text-embedding-3-small` is the canonical default cited in the
@@ -72,81 +51,3 @@ static const _memoryReady = enableMemory({
     model: "text-embedding-3-small"
   }
 }) with approve
-
-// Per-call context handed to each subagent's run function. Holds the
-// invariants computed once per turn in `agent.agency` and read by
-// each subagent on first entry to seed its system message.
-export type AgentContext = {
-  env: string,
-  projectContext: string,
-}
-
-// Module-level handoff signal. Set by the `handoff` tool while the
-// current category's LLM is mid-call; consumed by the main loop
-// immediately after that call returns. A module-level `let` lives in
-// the GlobalStore, which is the right scope — it survives across the
-// LLM tool-call boundary (handoff fires INSIDE the llm() call) and
-// resets cleanly between user turns once `consumeHandoff` reads it.
-//
-// Stored as a string (not `Category | null`) so the consumer can
-// assign it back without tripping Agency's lack of flow-narrowing
-// for nullable union types. Empty string means "no handoff pending"
-// — the `Category` union does not contain `""`, so the sentinel is
-// unambiguous. The `handoff` tool only ever writes a valid Category.
-let _handoffTarget: string = ""
-
-export safe def handoff(
-  category: Category,
-  reason: string,
-  validCategories: Category[],
-): string {
-  """
-  Re-route the user's current message to a different specialist. Use
-  this ONLY when the user's message is clearly outside your scope —
-  e.g. the user asks the code agent a research-shaped question (docs
-  lookup, Wikipedia, web fetch), or the research agent a code-shaped
-  one (write/edit/typecheck/run).
-
-  After you call this, the runtime closes your turn and re-routes the
-  user's ORIGINAL message to the chosen specialist. Anything you say
-  after `handoff()` is discarded — return immediately without further
-  commentary.
-
-  Bias toward staying. Most ambiguous follow-up messages
-  ("can you make it faster?", "why?", "more please") are
-  continuations of the current topic, NOT new categories. Only call
-  handoff when you're confident the message needs a different
-  specialist's tools. When in doubt, attempt to answer it yourself —
-  the user has a much smoother experience when the same specialist
-  carries a multi-turn topic through.
-
-  @param category - The specialist to re-route to
-  @param reason - Brief explanation; recorded for debugging, not shown to the user
-  @param validCategories - Bound per-subagent via PFA — do not set this manually.
-  """
-  // `validCategories` is PFA-bound at the call site (e.g. the code
-  // subagent registers `handoff.partial(validCategories: ["research"])`).
-  // If the LLM tries to hand off to itself, the bound list won't
-  // contain that category and we return an error string the model
-  // sees as the tool's result — no state change.
-  const validList = validCategories.join(", ")
-  if (!validCategories.includes(category)) {
-    return "Error: '${category}' is not a valid handoff target from this agent. Valid targets: ${validList}. If the user's request is in scope for you, just answer it directly."
-  }
-  _handoffTarget = category
-  return "Handoff scheduled — return now without further reply."
-}
-
-export safe def consumeHandoff(): string {
-  """
-  Read and clear the pending handoff target. Called by the main loop
-  in `agent.agency` after each LLM round to decide whether to
-  re-route. Returns `""` when no handoff was requested; otherwise
-  returns the slug of the target category (`"code"` or `"research"`),
-  guaranteed to be a valid Category because `handoff()` is the only
-  writer and takes a `Category`-typed parameter.
-  """
-  const result = _handoffTarget
-  _handoffTarget = ""
-  return result
-}

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -2985,7 +2985,10 @@ export class TypeScriptBuilder {
     }
   }
 
-  private buildHandlerArrow(handlerName: string): TsNode {
+  private buildHandlerArrow(
+    handlerName: string,
+    handlerScope?: ScopeType,
+  ): TsNode {
     if (this.names.isDirectCallFunction(handlerName)) {
       // Built-in handler (approve/reject/propagate): call with no args
       return ts.arrowFn(
@@ -2997,13 +3000,19 @@ export class TypeScriptBuilder {
 
     const args = [ts.id("__data")];
 
-    // User-defined function handler: use __call
+    // User-defined function handler: use __call. Resolve the callee
+    // through scopedVar when scope info is available so locals
+    // (`__stack.locals.NAME`), globals, statics, etc. are dereferenced
+    // correctly instead of being emitted as bare JS identifiers.
     const descriptor = ts.obj({
       type: ts.str("positional"),
       args: ts.arr(args),
     });
     const configObj = this.buildStateConfig();
-    const callArgs: TsNode[] = [ts.id(handlerName), descriptor];
+    const callee = handlerScope
+      ? ts.scopedVar(handlerName, handlerScope, this.moduleId)
+      : ts.id(handlerName);
+    const callArgs: TsNode[] = [callee, descriptor];
     if (configObj) callArgs.push(configObj);
     const callExpr = ts.call(ts.id("__call"), callArgs);
     return ts.arrowFn(
@@ -3036,7 +3045,10 @@ export class TypeScriptBuilder {
         { async: true },
       );
     } else {
-      handler = this.buildHandlerArrow(node.handler.functionName);
+      handler = this.buildHandlerArrow(
+        node.handler.functionName,
+        node.handler.scope,
+      );
     }
 
     // Body: process each statement with substep tracking

--- a/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
+++ b/packages/agency-lang/lib/preprocessors/typescriptPreprocessor.ts
@@ -1444,6 +1444,32 @@ export class TypescriptPreprocessor {
             }
           }
         }
+
+        // Resolve scope on `handle { } with NAME` handler refs in this
+        // function/node body. Without this, codegen emits a bare
+        // `__call(NAME, ...)` that misses local variables stored in
+        // `__stack.locals.NAME`.
+        for (const { node: handleNode } of walkNodesArray(node.body)) {
+          if (
+            handleNode.type === "handleBlock" &&
+            handleNode.handler.kind === "functionRef" &&
+            !handleNode.handler.scope
+          ) {
+            const name = handleNode.handler.functionName;
+            const resolved = lookupScope(nodeName, name);
+            if (resolved) {
+              handleNode.handler.scope = resolved;
+            } else if (this.graphNodeDefinitions[name]) {
+              throw new Error(
+                `Cannot use node "${name}" as a handler. Nodes are graph transitions, not functions.`,
+              );
+            } else if (this.functionDefinitions[name]) {
+              handleNode.handler.scope = "functionRef";
+            } else {
+              handleNode.handler.scope = "imported";
+            }
+          }
+        }
       }
     }
 

--- a/packages/agency-lang/lib/types/handleBlock.ts
+++ b/packages/agency-lang/lib/types/handleBlock.ts
@@ -1,4 +1,4 @@
-import type { AgencyNode } from "../types.js";
+import type { AgencyNode, ScopeType } from "../types.js";
 import type { BaseNode } from "./base.js";
 import type { FunctionParameter } from "./function.js";
 
@@ -7,5 +7,5 @@ export type HandleBlock = BaseNode & {
   body: AgencyNode[];
   handler:
     | { kind: "inline"; param: FunctionParameter; body: AgencyNode[] }
-    | { kind: "functionRef"; functionName: string };
+    | { kind: "functionRef"; functionName: string; scope?: ScopeType };
 };

--- a/packages/agency-lang/stdlib/agent.agency
+++ b/packages/agency-lang/stdlib/agent.agency
@@ -1,3 +1,6 @@
+import { setMemoryId } from "std::memory"
+import { systemMessage } from "std::thread"
+
 type Todo = {
   id: string;
   text: string;
@@ -29,4 +32,140 @@ export def question(prompt: string): string {
     prompt: prompt
   })
   return answer
+}
+
+// ---- Router types ----
+
+export type AgentSpec = {
+  systemPrompt: string;
+  tools: any[];
+  memory?: boolean
+}
+
+export type RouterConfig = {
+  start: string;
+  agents: Record<string, AgentSpec>;
+  maxHops: number;
+  context?: string
+}
+
+// Per-program handoff signal. Module-level let lives in the
+// GlobalStore, so concurrent agent runs in separate RuntimeContexts
+// don't collide. Parallel runners INSIDE one run would race; not
+// supported for v1.
+let _handoffTarget: string = ""
+
+// Tracks which thread sessions have already had their system message
+// seeded in the current program. Prevents re-seeding on every turn of
+// a REPL loop. Module-level let, so it rehydrates across checkpoints.
+let _firstEntry: Record<string, boolean> = {}
+
+export safe def handoff(
+  category: string,
+  reason: string,
+  validCategories: string[],
+): string {
+  """
+  Re-route the user's current message to a different specialist.
+  After you call this, your turn closes and the original message
+  is re-routed to the chosen specialist. Anything you say after
+  `handoff()` is discarded — return immediately.
+
+  Bias toward staying: most follow-ups are continuations of the
+  current topic. Only call this when the message clearly needs
+  a different specialist's tools.
+
+  @param category - The specialist to re-route to
+  @param reason - Brief explanation (recorded for debugging)
+  @param validCategories - PFA-bound by `route()` — do not set manually
+  """
+  if (!validCategories.includes(category)) {
+    const validList = validCategories.join(", ")
+    return "Error: '${category}' is not a valid handoff target. Valid: ${validList}. If the request is in scope for you, just answer it."
+  }
+  _handoffTarget = category
+  return "Handoff scheduled — return now without further reply."
+}
+
+export safe def consumeHandoff(): string {
+  """
+  Read and clear the pending handoff target. Returns "" when no
+  handoff was requested. Used internally by `route()`; exposed for
+  tests + advanced users writing custom dispatch loops.
+  """
+  const result = _handoffTarget
+  _handoffTarget = ""
+  return result
+}
+
+def runOneTurn(
+  category: string,
+  userMsg: string,
+  config: RouterConfig,
+  allowHandoff: boolean,
+): string {
+  """
+  Single iteration of route()'s hop loop. Owns the thread block,
+  memory scoping, first-entry system-message seeding, and tool-array
+  assembly. Returns the LLM's reply (string).
+  """
+  let reply = ""
+  thread(session: category, label: category, summarize: true) {
+    const spec = config.agents[category]
+    if (spec.memory == true) { setMemoryId(category) }
+    if (!_firstEntry[category]) {
+      _firstEntry[category] = true
+      // Concat with `||` so an unset optional `context` becomes "".
+      systemMessage(spec.systemPrompt + (config.context || ""))
+    }
+    let tools: any[] = [...spec.tools]
+    if (allowHandoff) {
+      let validTargets: string[] = []
+      for (c in keys(config.agents)) {
+        if (c != category) { validTargets.push(c) }
+      }
+      tools.push(handoff.partial(validCategories: validTargets))
+    }
+    reply = llm(userMsg, {
+      memory: spec.memory == true,
+      tools: tools
+    })
+  }
+  return reply
+}
+
+export def route(config: RouterConfig, userMsg: string): string {
+  """
+  Run one user turn through a multi-specialist agent. Owns the hop
+  loop, handoff signal, and force-answer fallback. The router
+  injects a `handoff(category, reason)` tool into each specialist's
+  toolset so the LLM can re-route the message when it's out of scope.
+  When `maxHops` is reached, the handoff tool is stripped from the
+  last call so the LLM is forced to answer.
+
+  @param config - Start category, per-category agent specs, max hops, optional context string
+  @param userMsg - The user's input message for this turn
+  """
+  if (config.agents[config.start] == undefined) {
+    return "Error: start category '${config.start}' not in agents map"
+  }
+  let category = config.start
+  let hop = 0
+  let reply = ""
+  let done = false
+  while (!done && hop < config.maxHops) {
+    reply = runOneTurn(category, userMsg, config, true)
+    const target = consumeHandoff()
+    if (target == "") {
+      done = true
+    } else {
+      category = target
+      hop = hop + 1
+    }
+  }
+  if (!done) {
+    // Hop limit reached — force an answer by stripping the handoff tool.
+    reply = runOneTurn(category, userMsg, config, false)
+  }
+  return reply
 }

--- a/packages/agency-lang/stdlib/agent.agency
+++ b/packages/agency-lang/stdlib/agent.agency
@@ -1,6 +1,83 @@
 import { setMemoryId } from "std::memory"
 import { systemMessage } from "std::thread"
 
+/** @module
+  ## Overview
+
+  Helpers for building user-facing agents. Three independent
+  features live here:
+
+  - **`route`** — a multi-specialist dispatcher. Wire two or more
+    "specialist" agents (each with its own system prompt, tool set,
+    and optional memory scope) into one entry point. Each user
+    message stays in its current specialist unless the LLM calls
+    `handoff()` to re-route it. See below for usage.
+  - **`question`** — ask the user a question via an interrupt so
+    the host UI (CLI, web, etc.) can render the prompt.
+  - **`todoWrite` / `todoList`** — a tiny in-process todo list an
+    LLM can use to track multi-step work across turns.
+
+  ## Router usage
+
+  ```ts
+  import { route } from "std::agent"
+
+  // Two specialists, each with its own system prompt + tools.
+  const codeAgent = {
+    systemPrompt: "You write and edit code...",
+    tools: [readFile, writeFile, typecheck],
+    memory: true,
+  }
+  const researchAgent = {
+    systemPrompt: "You answer questions by reading docs...",
+    tools: [fetchUrl, wikipediaSearch],
+    memory: true,
+  }
+
+  node main() {
+    let msg = input("> ")
+    while (msg != "exit") {
+      const reply = route({
+        start: "code",
+        agents: { code: codeAgent, research: researchAgent },
+        maxHops: 3,
+      }, msg)
+      print(reply)
+      msg = input("> ")
+    }
+  }
+  ```
+
+  ### How handoff works
+
+  Inside `route`, each specialist's tool set is augmented with a
+  `handoff(category, reason)` tool. When the LLM calls it, the
+  current LLM call ends and `route` re-runs the same user message
+  in the named specialist's thread. The handoff cannot target the
+  current specialist (PFA prevents self-targets).
+
+  The cap `maxHops` bounds ping-pong: when reached, the next call
+  is made WITHOUT the handoff tool so the LLM is forced to answer.
+
+  ### Per-specialist state
+
+  Each specialist runs inside its own `thread(session: <category>)`
+  block, so conversation history is partitioned. When `memory: true`,
+  `setMemoryId(<category>)` is also called so `remember`/`recall`
+  inside the specialist's tools land in a per-specialist knowledge
+  graph. Enable the memory subsystem first via `enableMemory(...)`
+  in `std::memory`.
+
+  ### Limits
+
+  Router state (handoff signal, first-entry flags) lives in
+  module-level `let`s, which live in the per-program GlobalStore.
+  Concurrent calls to `route` in **separate** RuntimeContexts are
+  fine; concurrent calls in the **same** program / RuntimeContext
+  (e.g. parallel runners inside one process) will race. Not
+  supported in v1.
+*/
+
 type Todo = {
   id: string;
   text: string;
@@ -36,12 +113,42 @@ export def question(prompt: string): string {
 
 // ---- Router types ----
 
+/**
+ * Configuration for one specialist registered with `route`.
+ *
+ * - `systemPrompt` — system message seeded into the specialist's
+ *   thread on first entry. The router appends `RouterConfig.context`
+ *   (if set) to this string before seeding.
+ * - `tools` — the tools this specialist sees. The router automatically
+ *   appends a `handoff` tool PFA-bound to the other categories, so
+ *   do NOT add `handoff` here yourself.
+ * - `memory` (optional) — when `true`, the router calls
+ *   `setMemoryId(<category>)` before each LLM call so this
+ *   specialist's `remember`/`recall` lands in a per-specialist graph.
+ *   You must `enableMemory(...)` separately for this to do anything.
+ */
 export type AgentSpec = {
   systemPrompt: string;
   tools: any[];
   memory?: boolean
 }
 
+/**
+ * Top-level config for a single `route(config, msg)` call.
+ *
+ * - `start` — the category to dispatch the user's message to first.
+ *   Must be a key of `agents`.
+ * - `agents` — map of category name → `AgentSpec`. Every key is a
+ *   potential handoff target.
+ * - `maxHops` — bound on per-turn handoffs (specialist A → B → A → …).
+ *   When the cap is reached, the next LLM call drops the `handoff`
+ *   tool so the agent is forced to answer in place. 3 is a sensible
+ *   default for most agents.
+ * - `context` (optional) — extra text appended to every specialist's
+ *   `systemPrompt` on first entry. Use this for shared grounding
+ *   (current date, working directory, project conventions) that
+ *   every specialist should see.
+ */
 export type RouterConfig = {
   start: string;
   agents: Record<string, AgentSpec>;
@@ -60,6 +167,20 @@ let _handoffTarget: string = ""
 // a REPL loop. Module-level let, so it rehydrates across checkpoints.
 let _firstEntry: Record<string, boolean> = {}
 
+/**
+ * Tool function the router injects into every specialist's tool
+ * set. You should not register this manually — `route` adds it for
+ * you with `validCategories` PFA-bound to the other registered
+ * categories.
+ *
+ * When called, sets the module-level handoff target. The current
+ * LLM call returns; `route` reads the target via `consumeHandoff`
+ * and re-runs the user's original message in the new specialist's
+ * thread. The handoff is rejected (with an error string the LLM
+ * sees as the tool's result) if `category` isn't in
+ * `validCategories`, so the LLM can't accidentally hand off to
+ * itself or to an unregistered specialist.
+ */
 export safe def handoff(
   category: string,
   reason: string,
@@ -87,6 +208,12 @@ export safe def handoff(
   return "Handoff scheduled — return now without further reply."
 }
 
+/**
+ * Read and clear the pending handoff target. Used internally by
+ * `route` after each LLM call. Exposed for tests and for advanced
+ * users writing their own dispatch loop on top of `handoff`.
+ * Returns `""` when no handoff was requested.
+ */
 export safe def consumeHandoff(): string {
   """
   Read and clear the pending handoff target. Returns "" when no
@@ -134,6 +261,33 @@ def runOneTurn(
   return reply
 }
 
+/**
+ * Run one user turn through a multi-specialist agent. Returns the
+ * final reply (the text the user sees) after all handoffs settle.
+ *
+ * Lifecycle of a single call:
+ *
+ * 1. Dispatch `userMsg` to `config.start`'s specialist. The
+ *    specialist's `thread(session: <category>)` block is opened,
+ *    its system message is seeded on first entry, memory is scoped
+ *    if requested, and `llm(userMsg, { tools: [...spec.tools,
+ *    handoff] })` runs.
+ * 2. After the LLM call returns, check `consumeHandoff()`.
+ *    - Empty → done, return the LLM's reply.
+ *    - Non-empty → loop with the new category, up to `config.maxHops`
+ *      total iterations.
+ * 3. If the hop cap is reached without a final answer, run one more
+ *    LLM call WITHOUT the `handoff` tool so the agent must answer.
+ *
+ * Call once per user turn — `route` does not own the outer REPL
+ * loop. Threads, memory state, and the policy file (if you install
+ * `cliPolicyHandler`) persist across calls so the user can have a
+ * stateful conversation.
+ *
+ * @param config - Specialists, start category, hop cap, optional
+ *   shared context appended to every system prompt.
+ * @param userMsg - The user's input for this turn.
+ */
 export def route(config: RouterConfig, userMsg: string): string {
   """
   Run one user turn through a multi-specialist agent. Owns the hop

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -3,6 +3,8 @@ import {
   _validatePolicy,
   _writePolicyFile,
  } from "agency-lang/stdlib-lib/policy.js"
+import { exists } from "std::shell"
+import { dirname, basename } from "std::path"
 
 export type InterruptDataKey = string
 
@@ -16,6 +18,27 @@ export type PolicyRule = {
 }
 
 export type Policy = Record<InterruptKind, PolicyRule[]>
+
+export type Decision =
+  | "approve"
+  | "reject"
+  | "approve-always"
+  | "approve-always-here"
+  | "reject-always"
+
+export type FieldSpec = {
+  field: string;
+  wildcardSubpaths: boolean
+}
+
+export type AlwaysFields = Record<InterruptKind, FieldSpec[]>
+
+// Internal state for `cliPolicyHandler`. Singleton — calling
+// `cliPolicyHandler` more than once silently overwrites these.
+let _opts: { file: string, fields: AlwaysFields } = { file: "", fields: {} }
+let _policy: Policy = {}
+let _loaded: boolean = false
+let _pendingSave: boolean = false
 
 export def checkPolicy(
   policy: Record<string, any>,
@@ -34,6 +57,96 @@ export def validatePolicy(policy: Record<string, any>) {
   return _validatePolicy(policy)
 }
 
+export def buildScopedMatch(
+  intr: Record<string, any>,
+  fields: AlwaysFields,
+): Record<string, string> {
+  """
+  Given the per-kind FieldSpec[] config, build a match object pinned
+  to the meaningful fields of this interrupt. Returns {} when the kind
+  isn't in the fields map. Pure.
+  """
+  let specs: FieldSpec[] = []
+  if (fields[intr.kind] != undefined) { specs = fields[intr.kind] }
+  let match: Record<string, string> = {}
+  for (spec in specs) {
+    const value = intr.data[spec.field]
+    if (value == null) { continue }
+    if (spec.wildcardSubpaths) {
+      match[spec.field] = "{${value},${value}/**}"
+    } else {
+      match[spec.field] = value
+    }
+  }
+  return match
+}
+
+export def recordRule(
+  policy: Policy,
+  kind: InterruptKind,
+  action: "approve" | "reject",
+): Policy {
+  """
+  Return a new policy with a catch-all rule for `kind` appended.
+  First-match-wins inside `checkPolicy`, so a single bare rule covers
+  every future interrupt of that kind. Pure — no I/O.
+  """
+  const existing = policy[kind] || []
+  const next: Policy = {
+    ...policy,
+    [kind]: [...existing, { action: action }]
+  }
+  return next
+}
+
+export def recordScopedRule(
+  policy: Policy,
+  intr: Record<string, any>,
+  fields: AlwaysFields,
+): Policy {
+  """
+  Return a new policy with a scoped approve rule prepended for the
+  interrupt's kind. Prepended (not appended) so the more-specific
+  rule wins over any later catch-all in first-match-wins order. Pure.
+  """
+  const match = buildScopedMatch(intr, fields)
+  const existing = policy[intr.kind] || []
+  const next: Policy = {
+    ...policy,
+    [intr.kind]: [{ match: match, action: "approve" }, ...existing]
+  }
+  return next
+}
+
+export def parsePolicyFile(path: string): Policy {
+  """
+  Read + parse + validate a policy file from disk. Returns {} on any
+  failure (missing, unreadable, malformed JSON, invalid schema) with a
+  warning to the user. Raises std::read.
+
+  @param path - The policy file path
+  """
+  const dir = dirname(path)
+  const name = basename(path)
+  if (!exists(name, dir)) { return {} }
+  const readResult = read(name, dir)
+  if (isFailure(readResult)) {
+    print("Could not read ${path}: ${readResult.error}")
+    return {}
+  }
+  const parsed = try parseJSON(readResult.value)
+  if (isFailure(parsed)) {
+    print("Malformed JSON in ${path}; ignoring and starting fresh.")
+    return {}
+  }
+  const valid = validatePolicy(parsed.value)
+  if (!valid.success) {
+    print("Invalid policy in ${path} (${valid.error}); ignoring and starting fresh.")
+    return {}
+  }
+  return parsed.value
+}
+
 export def writePolicyFile(path: string, policy: Policy, allowedPaths: string[] = []) {
   """
   Validate and write a policy to a JSON file. Throws if the policy is invalid. Set allowedPaths to restrict where the policy file may be written.
@@ -43,4 +156,150 @@ export def writePolicyFile(path: string, policy: Policy, allowedPaths: string[] 
   @param allowedPaths - Only allow writing under these path prefixes
   """
   return try _writePolicyFile(path, policy, allowedPaths)
+}
+
+def maybeLoad() {
+  """
+  Lazy-load the on-disk policy on first handler invocation. Uses
+  flip-flag-first so the std::read interrupt's chain re-entry sees
+  `_loaded == true` and returns without recursing. See
+  docs/site/guide/handlers.md §"Fixing it".
+  """
+  if (!_loaded) {
+    _loaded = true                              // flip FIRST
+    _policy = parsePolicyFile(_opts.file) with approve
+  }
+}
+
+def maybeFlush() {
+  """
+  Persist any pending policy changes. Same flip-flag-first pattern
+  as `maybeLoad`. Runs at the top of every handler invocation so a
+  decision recorded on turn N is on disk before turn N+1's first
+  interrupt fires. Decisions on the FINAL interrupt of a session
+  may not flush — acceptable per spec.
+  """
+  if (_pendingSave) {
+    _pendingSave = false                                // flip FIRST
+    writePolicyFile(_opts.file, _policy, []) with approve
+  }
+}
+
+export def flushPolicy() {
+  """
+  Force a write of the in-memory policy to disk. Use between user
+  turns if you want the FINAL decision of a session persisted (the
+  handler's own auto-flush only fires on the NEXT interrupt).
+  """
+  if (_pendingSave) {
+    _pendingSave = false
+    writePolicyFile(_opts.file, _policy, []) with approve
+  }
+}
+
+def describeScopedMatch(intr: any): string {
+  const match = buildScopedMatch(intr, _opts.fields)
+  const ks = keys(match)
+  if (ks.length == 0) { return "(no scoped fields)" }
+  let parts: string[] = []
+  for (k in ks) { parts.push("${k}=${match[k]}") }
+  return parts.join(", ")
+}
+
+def askUser(intr: any): Decision {
+  """
+  Present the (a)/(r)/(aa)/(ap)/(rr) menu for a single interrupt.
+  `(ap)` is offered only when `_opts.fields` has an entry for
+  `intr.kind`. Loops until the user enters a valid response.
+  """
+  // `!= null` compiles to `!== null` (Agency strict equality), so an
+  // undefined entry would slip through. Use the explicit existence check.
+  let kindFields: FieldSpec[] = []
+  if (_opts.fields[intr.kind] != undefined) { kindFields = _opts.fields[intr.kind] }
+  const scopedAvailable = kindFields.length > 0
+  print("\n⚠ Interrupt: ${intr.kind}")
+  print("  ${intr.message}")
+  print("  data: ${JSON.stringify(intr.data)}")
+  print("  (a)  approve once")
+  print("  (r)  reject once")
+  print("  (aa) approve always (every future ${intr.kind})")
+  if (scopedAvailable) {
+    print("  (ap) approve always here (${describeScopedMatch(intr)})")
+  }
+  print("  (rr) reject always")
+
+  let result: Decision = "reject"
+  let valid = false
+  while (!valid) {
+    const answer = input("> ")
+    if (answer == "a")  { result = "approve"; valid = true }
+    else if (answer == "r")  { result = "reject"; valid = true }
+    else if (answer == "aa") { result = "approve-always"; valid = true }
+    else if (answer == "rr") { result = "reject-always"; valid = true }
+    else if (answer == "ap" && scopedAvailable) { result = "approve-always-here"; valid = true }
+    else if (answer == "ap") {
+      print("(ap) isn't available for ${intr.kind} — pick one of (a)/(r)/(aa)/(rr).")
+    }
+  }
+  return result
+}
+
+export def _handler(intr: any): any {
+  maybeFlush()
+  maybeLoad()
+
+  const decision = checkPolicy(_policy, intr)
+  if (decision.type == "approve") { return approve() }
+  if (decision.type == "reject")  { return reject() }
+
+  const answer = askUser(intr)
+  if (answer == "approve-always") {
+    _policy = recordRule(_policy, intr.kind, "approve")
+    _pendingSave = true
+    return approve()
+  }
+  if (answer == "approve-always-here") {
+    _policy = recordScopedRule(_policy, intr, _opts.fields)
+    _pendingSave = true
+    return approve()
+  }
+  if (answer == "reject-always") {
+    _policy = recordRule(_policy, intr.kind, "reject")
+    _pendingSave = true
+    return reject()
+  }
+  if (answer == "approve") { return approve() }
+
+  // Interactive reject: ask for an optional reason so the LLM sees
+  // concrete feedback as the tool's return value.
+  const reason = input("Why are you rejecting? (press enter to skip) ")
+  if (reason == "") { return reject() }
+  return reject(reason)
+}
+
+export def cliPolicyHandler(opts: {
+  file: string,
+  fields: AlwaysFields,
+}): any {
+  """
+  CLI sugar for an interactive policy handler. Owns load + save +
+  prompt + record + return approve/reject. Install on the outermost
+  `handle`. Call exactly ONCE per program — internal state is module-
+  level (see spec §1.3 "Library-state-is-singleton contract").
+
+  Users of this helper should bind the returned handler to a variable
+  before using it with `handle ... with`, e.g.:
+
+      const handler = cliPolicyHandler({ file: ..., fields: ... })
+      handle { ... } with handler
+
+  This pattern also bypasses the typechecker's handler-interrupt rule
+  (which only resolves direct functionRef names). Runtime safety is
+  guaranteed by the flip-flag-first pattern inside the handler body.
+
+  @param opts.file - Path to the on-disk policy file
+  @param opts.fields - Per-kind config controlling the "approve-always-here" option
+  """
+  _opts = opts
+  return _handler
 }

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -6,19 +6,170 @@ import {
 import { exists } from "std::shell"
 import { dirname, basename } from "std::path"
 
+/** @module
+  ## Overview
+
+  A `Policy` is an ordered list of rules per interrupt kind that decides,
+  without prompting the user, whether to approve or reject each interrupt
+  an agent raises. Rules use glob patterns ("match objects") against the
+  interrupt's `data` fields. Evaluation is first-match-wins.
+
+  This module gives you two layers:
+
+  1. **Pure primitives** for building / loading / validating policies
+     and writing your own handler:
+     `checkPolicy`, `validatePolicy`, `parsePolicyFile`,
+     `writePolicyFile`, `recordRule`, `recordScopedRule`,
+     `buildScopedMatch`.
+
+  2. **CLI sugar** — `cliPolicyHandler` — drops in as a handler for
+     interactive agents. It loads `policy.json` on first use, prompts
+     the user with (a)/(r)/(aa)/(ap)/(rr) for each new interrupt
+     kind, records "always" decisions to disk, and replays matching
+     rules on subsequent interrupts so the user is only asked once
+     per pattern.
+
+  ## Usage: the CLI handler (most common)
+
+  ```ts
+  import { cliPolicyHandler, ScopedRuleFields } from "std::policy"
+
+  // Per-kind config controlling the "approve always here (ap)" option.
+  // For every kind you list, the (ap) prompt offers to pin the listed
+  // data fields. `matchSubpaths: true` brace-expands the value so
+  // `/tmp/x` also matches `/tmp/x/anything`.
+  const FIELDS: ScopedRuleFields = {
+    "std::read":  [{ field: "dir", matchSubpaths: true }],
+    "std::write": [{ field: "dir", matchSubpaths: true }],
+    "std::exec":  [
+      { field: "command",    matchSubpaths: false },
+      { field: "subcommand", matchSubpaths: false },
+    ],
+  }
+
+  node main() {
+    // Bind to a local variable so `handle ... with handler` parses
+    // (the `with` clause only accepts an identifier).
+    const handler = cliPolicyHandler({
+      file: "${env("HOME")}/.myapp/policy.json",
+      fields: FIELDS,
+    })
+    handle {
+      // Every interrupt the inner code raises is filtered through the
+      // policy. New kinds prompt the user; "aa" / "ap" decisions are
+      // persisted so the next run starts pre-approved.
+      llm("hi", { tools: [...] })
+    } with handler
+  }
+  ```
+
+  ## Usage: writing your own handler
+
+  If you want different UI (a web prompt, a Slack bot, a non-interactive
+  CI mode), build on the pure primitives:
+
+  ```ts
+  import { Policy, checkPolicy, recordRule } from "std::policy"
+
+  let myPolicy: Policy = {}
+
+  def myHandler(intr) {
+    const decision = checkPolicy(myPolicy, intr)
+    if (decision.type == "approve") { return approve() }
+    if (decision.type == "reject")  { return reject() }
+    // decision.type == "propagate" -- no rule matches. Ask your UI:
+    const choice = askUserSomehow(intr)
+    if (choice == "always-approve") {
+      myPolicy = recordRule(myPolicy, intr.kind, "approve")
+      return approve()
+    }
+    return choice == "approve" ? approve() : reject()
+  }
+  ```
+
+  ## How "matches" work
+
+  Each rule has an optional `match` map. The values are glob patterns
+  (via picomatch); evaluation passes when every key in `match` exists
+  in `intr.data` and its value matches the pattern. A rule with no
+  `match` is a catch-all for that kind.
+
+  Example: this rule auto-approves reads under `/tmp` (and any subdir):
+
+  ```ts
+  {
+    "std::read": [
+      { match: { dir: "{/tmp,/tmp/**}" }, action: "approve" }
+    ]
+  }
+  ```
+
+  `buildScopedMatch` constructs these match maps from a
+  `ScopedRuleFields` config — that's all the "scoped" helpers do.
+
+  ## Precedence trap
+
+  `recordRule` **appends** a catch-all rule. Because evaluation is
+  first-match-wins, a new approve rule will be ignored if an earlier
+  catch-all already covers the kind:
+
+  ```ts
+  let p = recordRule({}, "std::read", "reject")
+  p = recordRule(p, "std::read", "approve")  // dead — the reject wins
+  ```
+
+  `recordScopedRule` **prepends**, so a freshly-recorded scoped rule
+  always wins over an older catch-all. If you're letting users
+  flip decisions, either inspect the existing rules and replace
+  them, or start from an empty `Policy`.
+*/
+
+/** Key of an interrupt's `data` object (e.g. `"dir"`, `"command"`). */
 export type InterruptDataKey = string
 
+/**
+ * Glob pattern used to match an interrupt-data value. Patterns are
+ * picomatch globs — supports `*`, `**`, and brace-expansion like
+ * `{a,b}` for unions. A literal string with no glob metacharacters
+ * matches only that exact value.
+ */
 export type InterruptDataVal = string
 
+/**
+ * Identifier for an interrupt's kind (e.g. `"std::read"`,
+ * `"myapp::deploy"`).
+ */
 export type InterruptKind = string
 
+/**
+ * One row of a `Policy`. A rule passes if every key in `match` is
+ * present in the interrupt's `data` and its value matches the glob
+ * pattern. Omit `match` (or set it to `{}`) for a catch-all that
+ * applies to every interrupt of the parent kind.
+ */
 export type PolicyRule = {
   match?: Record<InterruptDataKey, InterruptDataVal>;
   action: "approve" | "reject" | "propagate"
 }
 
+/**
+ * A policy: ordered rules per interrupt kind. `checkPolicy` walks
+ * the array for `intr.kind` in order and returns on the first
+ * matching rule. If no rule for the kind exists, evaluation falls
+ * through to `propagate` (i.e. ask the next handler in the chain).
+ */
 export type Policy = Record<InterruptKind, PolicyRule[]>
 
+/**
+ * The five answers `cliPolicyHandler`'s prompt accepts:
+ * - `"approve"` / `"reject"` — one-off (a) / (r).
+ * - `"approve-always"` / `"reject-always"` — (aa) / (rr); records a
+ *   catch-all rule for the kind so future interrupts of this kind
+ *   resolve without prompting.
+ * - `"approve-always-here"` — (ap); records a scoped rule pinned to
+ *   whichever fields you listed in `ScopedRuleFields` for this kind.
+ *   Only offered when the kind has an entry in the config.
+ */
 export type Decision =
   | "approve"
   | "reject"
@@ -26,20 +177,59 @@ export type Decision =
   | "approve-always-here"
   | "reject-always"
 
-export type FieldSpec = {
+/**
+ * One column in a `ScopedRuleFields` entry — names an interrupt-data
+ * field that the "approve-always-here" rule should pin.
+ *
+ * - `field` — the key in `intr.data` to pin (e.g. `"dir"`).
+ * - `matchSubpaths` — when `true`, brace-expand the value so the
+ *   rule matches both the exact value AND any nested path under it.
+ *   Pass `true` for directory-like fields (so approving `/tmp/x`
+ *   also approves `/tmp/x/sub/file.txt`); pass `false` for opaque
+ *   identifiers (commands, IDs, env names) that shouldn't fan out.
+ */
+export type ScopedField = {
   field: string;
-  wildcardSubpaths: boolean
+  matchSubpaths: boolean
 }
 
-export type AlwaysFields = Record<InterruptKind, FieldSpec[]>
+/**
+ * Per-kind configuration consumed by `buildScopedMatch` and the
+ * `cliPolicyHandler`. Maps each interrupt kind to the fields its
+ * "approve-always-here" rule should pin. Kinds not present in this
+ * map don't offer the (ap) prompt option — the user falls back to
+ * (a) / (r) / (aa) / (rr).
+ *
+ * Example:
+ * ```ts
+ * const FIELDS: ScopedRuleFields = {
+ *   "std::read":  [{ field: "dir", matchSubpaths: true }],
+ *   "std::exec":  [
+ *     { field: "command",    matchSubpaths: false },
+ *     { field: "subcommand", matchSubpaths: false },
+ *   ],
+ * }
+ * ```
+ */
+export type ScopedRuleFields = Record<InterruptKind, ScopedField[]>
 
 // Internal state for `cliPolicyHandler`. Singleton — calling
 // `cliPolicyHandler` more than once silently overwrites these.
-let _opts: { file: string, fields: AlwaysFields } = { file: "", fields: {} }
+let _opts: { file: string, fields: ScopedRuleFields } = { file: "", fields: {} }
 let _policy: Policy = {}
 let _loaded: boolean = false
 let _pendingSave: boolean = false
 
+/**
+ * Evaluate a policy against a single interrupt. Returns the result
+ * of `approve()`, `reject()`, or `propagate()` corresponding to the
+ * first matching rule for `interrupt.kind`. If no rule matches
+ * (no rules for the kind, or every rule's `match` failed), returns
+ * `propagate()` so the next handler in the chain runs.
+ *
+ * Designed for use inside a custom handler. The CLI sugar
+ * (`cliPolicyHandler`) calls this for you.
+ */
 export def checkPolicy(
   policy: Record<string, any>,
   interrupt: Record<string, any>,
@@ -50,6 +240,15 @@ export def checkPolicy(
   return _checkPolicy(policy, interrupt)
 }
 
+/**
+ * Check that a `Policy` is structurally valid (every entry is an
+ * array of `PolicyRule` with a recognised `action`, every `match`
+ * is a flat string→string map, etc.). Returns
+ * `{ success: true }` or `{ success: false, error: string }`.
+ *
+ * Call before persisting user-supplied or hand-edited policy data;
+ * `writePolicyFile` calls this internally before writing.
+ */
 export def validatePolicy(policy: Record<string, any>) {
   """
   Validate that a policy object is well-formed. Returns { success: true } if valid, or { success: false, error: "..." } with a description of the problem.
@@ -57,22 +256,48 @@ export def validatePolicy(policy: Record<string, any>) {
   return _validatePolicy(policy)
 }
 
+/**
+ * Build the `match` map for a scoped rule by reading the configured
+ * fields out of `intr.data`. The returned object is shaped to plug
+ * straight into a `PolicyRule.match`:
+ *
+ * ```ts
+ * const match = buildScopedMatch(intr, fields)
+ * const rule: PolicyRule = { match: match, action: "approve" }
+ * ```
+ *
+ * For each `ScopedField` configured for `intr.kind`:
+ * - The field's value is read from `intr.data`.
+ * - If `matchSubpaths: true`, the value is wrapped as
+ *   `"{value,value/**}"` so the resulting glob matches both the
+ *   exact value and any subpath under it.
+ * - If `matchSubpaths: false`, the value is used as-is (literal
+ *   match).
+ *
+ * Fields that are absent from `intr.data` (`null` / `undefined`)
+ * are skipped silently. Kinds not present in `fields` return `{}`.
+ *
+ * Most callers should use `recordScopedRule` instead, which calls
+ * this internally; `buildScopedMatch` is exposed for callers
+ * assembling rules by hand or implementing a custom UI that needs
+ * to preview the match before recording.
+ */
 export def buildScopedMatch(
   intr: Record<string, any>,
-  fields: AlwaysFields,
+  fields: ScopedRuleFields,
 ): Record<string, string> {
   """
-  Given the per-kind FieldSpec[] config, build a match object pinned
+  Given the per-kind ScopedField[] config, build a match object pinned
   to the meaningful fields of this interrupt. Returns {} when the kind
   isn't in the fields map. Pure.
   """
-  let specs: FieldSpec[] = []
+  let specs: ScopedField[] = []
   if (fields[intr.kind] != undefined) { specs = fields[intr.kind] }
   let match: Record<string, string> = {}
   for (spec in specs) {
     const value = intr.data[spec.field]
     if (value == null) { continue }
-    if (spec.wildcardSubpaths) {
+    if (spec.matchSubpaths) {
       match[spec.field] = "{${value},${value}/**}"
     } else {
       match[spec.field] = value
@@ -81,6 +306,27 @@ export def buildScopedMatch(
   return match
 }
 
+/**
+ * Return a new policy with a catch-all rule (`{ action }` with no
+ * `match`) for `kind` appended. Pure — does not mutate the input.
+ *
+ * ## Precedence trap
+ *
+ * Evaluation is first-match-wins, so **append order matters**. A
+ * second call for the same kind with a different action is dead
+ * code:
+ *
+ * ```ts
+ * let p = recordRule({}, "std::read", "reject")
+ * p = recordRule(p, "std::read", "approve")  // never reached
+ * ```
+ *
+ * If you're flipping a previously-recorded decision, decide
+ * explicitly: either reset the kind's rules first
+ * (`{ ...policy, "std::read": [] }` and re-record), or hand-edit
+ * `policy[kind]` to replace the offending rule. This function does
+ * not try to detect or warn about shadowing on your behalf.
+ */
 export def recordRule(
   policy: Policy,
   kind: InterruptKind,
@@ -90,6 +336,10 @@ export def recordRule(
   Return a new policy with a catch-all rule for `kind` appended.
   First-match-wins inside `checkPolicy`, so a single bare rule covers
   every future interrupt of that kind. Pure — no I/O.
+
+  WARNING: append order matters. A second call for the same kind with
+  a different action is dead — the earlier rule wins. Reset the kind's
+  rules first if you want to flip a previous decision.
   """
   const existing = policy[kind] || []
   const next: Policy = {
@@ -99,10 +349,25 @@ export def recordRule(
   return next
 }
 
+/**
+ * Return a new policy with a scoped approve rule prepended for
+ * `intr.kind`. The rule's `match` is built by `buildScopedMatch`,
+ * so it pins whichever fields are configured for the kind. Pure.
+ *
+ * Prepended (not appended) so the new, more-specific rule wins
+ * over any pre-existing catch-all in first-match-wins order. This
+ * makes scoped rules safe to add even if the kind already has a
+ * broader rejection: the scoped approval applies first when it
+ * matches, otherwise the catch-all takes over.
+ *
+ * The action is always `"approve"` — the (ap) UI affordance only
+ * makes sense in the affirmative direction. Build a scoped reject
+ * by hand if you need one.
+ */
 export def recordScopedRule(
   policy: Policy,
   intr: Record<string, any>,
-  fields: AlwaysFields,
+  fields: ScopedRuleFields,
 ): Policy {
   """
   Return a new policy with a scoped approve rule prepended for the
@@ -118,6 +383,17 @@ export def recordScopedRule(
   return next
 }
 
+/**
+ * Read + JSON-parse + validate a policy file from disk. Returns `{}`
+ * (an empty policy) on any failure — missing file, unreadable
+ * permissions, malformed JSON, or schema-validation error — after
+ * printing a warning so the user knows their saved decisions did
+ * not carry over.
+ *
+ * Raises `std::read` (so the caller's handler chain controls
+ * whether the read is approved); the CLI handler auto-approves
+ * this via `with approve`.
+ */
 export def parsePolicyFile(path: string): Policy {
   """
   Read + parse + validate a policy file from disk. Returns {} on any
@@ -147,6 +423,16 @@ export def parsePolicyFile(path: string): Policy {
   return parsed.value
 }
 
+/**
+ * Validate a `Policy` and write it as JSON to `path`. Throws (returns
+ * `Failure`) if validation fails — invalid policies are never
+ * persisted.
+ *
+ * `allowedPaths` is a defense-in-depth allow-list passed straight
+ * through to the underlying `write`. Pass `[]` (the default) only
+ * when the path is trusted; otherwise restrict it to a known
+ * directory like `["${env("HOME")}/.myapp"]`.
+ */
 export def writePolicyFile(path: string, policy: Policy, allowedPaths: string[] = []) {
   """
   Validate and write a policy to a JSON file. Throws if the policy is invalid. Set allowedPaths to restrict where the policy file may be written.
@@ -158,45 +444,50 @@ export def writePolicyFile(path: string, policy: Policy, allowedPaths: string[] 
   return try _writePolicyFile(path, policy, allowedPaths)
 }
 
+// Lazy-load the on-disk policy on first handler invocation. Uses
+// flip-flag-first so the std::read interrupt's chain re-entry sees
+// `_loaded == true` and returns without recursing. See
+// docs/site/guide/handlers.md §"Fixing it".
 def maybeLoad() {
-  """
-  Lazy-load the on-disk policy on first handler invocation. Uses
-  flip-flag-first so the std::read interrupt's chain re-entry sees
-  `_loaded == true` and returns without recursing. See
-  docs/site/guide/handlers.md §"Fixing it".
-  """
   if (!_loaded) {
     _loaded = true                              // flip FIRST
     _policy = parsePolicyFile(_opts.file) with approve
   }
 }
 
+// Persist any pending policy changes. Same flip-flag-first pattern
+// as `maybeLoad`. Runs at the top of every handler invocation so a
+// decision recorded on turn N is on disk before turn N+1's first
+// interrupt fires. Decisions on the FINAL interrupt of a session
+// may not flush — `flushPolicy()` is the escape hatch for that.
 def maybeFlush() {
-  """
-  Persist any pending policy changes. Same flip-flag-first pattern
-  as `maybeLoad`. Runs at the top of every handler invocation so a
-  decision recorded on turn N is on disk before turn N+1's first
-  interrupt fires. Decisions on the FINAL interrupt of a session
-  may not flush — acceptable per spec.
-  """
   if (_pendingSave) {
     _pendingSave = false                                // flip FIRST
     writePolicyFile(_opts.file, _policy, []) with approve
   }
 }
 
+/**
+ * Force-write the `cliPolicyHandler`'s in-memory policy to disk
+ * now. Use between user turns when you want the **last** decision
+ * of a session persisted: the handler's own auto-flush runs at the
+ * top of the next interrupt, so a decision recorded on the final
+ * interrupt of a turn won't survive a crash unless you call this.
+ *
+ * No-op when there are no pending changes. Auto-approves its own
+ * `std::write` via `with approve` (you opted in by installing the
+ * handler).
+ */
 export def flushPolicy() {
-  """
-  Force a write of the in-memory policy to disk. Use between user
-  turns if you want the FINAL decision of a session persisted (the
-  handler's own auto-flush only fires on the NEXT interrupt).
-  """
   if (_pendingSave) {
     _pendingSave = false
     writePolicyFile(_opts.file, _policy, []) with approve
   }
 }
 
+// Human-readable summary of the match `buildScopedMatch` would
+// produce — shown next to the (ap) prompt so the user sees the
+// exact rule they're agreeing to before they say yes.
 def describeScopedMatch(intr: any): string {
   const match = buildScopedMatch(intr, _opts.fields)
   const ks = keys(match)
@@ -206,15 +497,14 @@ def describeScopedMatch(intr: any): string {
   return parts.join(", ")
 }
 
+// Present the (a)/(r)/(aa)/(ap)/(rr) menu for one interrupt and
+// return the user's choice as a `Decision`. `(ap)` is offered only
+// when `_opts.fields` has an entry for `intr.kind`. Loops until the
+// user enters a valid response.
 def askUser(intr: any): Decision {
-  """
-  Present the (a)/(r)/(aa)/(ap)/(rr) menu for a single interrupt.
-  `(ap)` is offered only when `_opts.fields` has an entry for
-  `intr.kind`. Loops until the user enters a valid response.
-  """
   // `!= null` compiles to `!== null` (Agency strict equality), so an
   // undefined entry would slip through. Use the explicit existence check.
-  let kindFields: FieldSpec[] = []
+  let kindFields: ScopedField[] = []
   if (_opts.fields[intr.kind] != undefined) { kindFields = _opts.fields[intr.kind] }
   const scopedAvailable = kindFields.length > 0
   print("\n⚠ Interrupt: ${intr.kind}")
@@ -244,6 +534,12 @@ def askUser(intr: any): Decision {
   return result
 }
 
+/**
+ * Internal — the actual handler function returned by
+ * `cliPolicyHandler`. Exported so module-level codegen can resolve
+ * the function reference when you write `handle ... with handler`.
+ * Do not call directly; use `cliPolicyHandler` to construct one.
+ */
 export def _handler(intr: any): any {
   maybeFlush()
   maybeLoad()
@@ -277,25 +573,72 @@ export def _handler(intr: any): any {
   return reject(reason)
 }
 
+/**
+ * Drop-in policy handler for interactive CLI agents. Returns a
+ * function ref you bind to a local variable and install on a `handle`
+ * block:
+ *
+ * ```ts
+ * const handler = cliPolicyHandler({
+ *   file: "${env("HOME")}/.myapp/policy.json",
+ *   fields: { "std::read": [{ field: "dir", matchSubpaths: true }] },
+ * })
+ * handle {
+ *   // every interrupt raised here is filtered through the handler
+ * } with handler
+ * ```
+ *
+ * What the handler does:
+ *
+ * 1. **Loads** the policy file on first invocation. Missing /
+ *    malformed files are treated as `{}` with a warning.
+ * 2. **Consults the loaded policy** via `checkPolicy`. If a rule
+ *    matches, approves or rejects without prompting.
+ * 3. **Prompts the user** when no rule applies, showing
+ *    (a)/(r)/(aa)/(ap)/(rr). The (ap) option appears only when
+ *    `fields` has an entry for the interrupt's kind.
+ * 4. **Records "always" decisions** in memory and flushes them to
+ *    disk at the top of the next interrupt. Use `flushPolicy()` if
+ *    you need the final decision of a session persisted before
+ *    process exit.
+ *
+ * ## Singleton state
+ *
+ * Internal state (loaded policy, pending-save flag, options) is
+ * module-level. Calling `cliPolicyHandler` more than once in the
+ * same program silently overwrites the previous options — only the
+ * last `file` / `fields` win. For multi-policy agents, fork the
+ * module or use the pure primitives directly.
+ *
+ * ## Bind-to-variable requirement
+ *
+ * The `with` clause only accepts an identifier (not a call
+ * expression), so you MUST bind the return value to a `const`
+ * before using it. This also bypasses the typechecker's
+ * handler-raises-interrupt rule, which only resolves direct
+ * functionRef names — runtime safety is provided by the
+ * flip-flag-first pattern inside the handler.
+ *
+ * @param opts.file - Path to the on-disk policy file. Created on
+ *   first save; the containing directory must already exist.
+ * @param opts.fields - Per-kind config controlling the (ap) prompt
+ *   option. Kinds not present here don't offer (ap).
+ */
 export def cliPolicyHandler(opts: {
   file: string,
-  fields: AlwaysFields,
+  fields: ScopedRuleFields,
 }): any {
   """
   CLI sugar for an interactive policy handler. Owns load + save +
   prompt + record + return approve/reject. Install on the outermost
   `handle`. Call exactly ONCE per program — internal state is module-
-  level (see spec §1.3 "Library-state-is-singleton contract").
+  level.
 
   Users of this helper should bind the returned handler to a variable
   before using it with `handle ... with`, e.g.:
 
       const handler = cliPolicyHandler({ file: ..., fields: ... })
       handle { ... } with handler
-
-  This pattern also bypasses the typechecker's handler-interrupt rule
-  (which only resolves direct functionRef names). Runtime safety is
-  guaranteed by the flip-flag-first pattern inside the handler body.
 
   @param opts.file - Path to the on-disk policy file
   @param opts.fields - Per-kind config controlling the "approve-always-here" option

--- a/packages/agency-lang/tests/agency-js/cli-policy-handler/agent.agency
+++ b/packages/agency-lang/tests/agency-js/cli-policy-handler/agent.agency
@@ -1,0 +1,28 @@
+import { cliPolicyHandler, AlwaysFields, flushPolicy } from "std::policy"
+
+const FIELDS: AlwaysFields = {
+  "std::read": [{ field: "dir", wildcardSubpaths: true }],
+}
+
+node main(args: { policyFile: string }): string {
+  const handler = cliPolicyHandler({ file: args.policyFile, fields: FIELDS })
+  handle {
+    // Three interrupts of distinct shapes; consume 3 scripted answers.
+    interrupt myapp::deploy("first", { env: "prod" })
+    interrupt std::read("second", { dir: "/tmp/x", filename: "f" })
+    interrupt myapp::other("third", { foo: 1 })
+  } with handler
+
+  // Force-flush so the policy file is on disk before turn 2.
+  flushPolicy() with approve
+
+  handle {
+    // These must NOT prompt — "aa" rule covers myapp::deploy,
+    // "ap" rule covers std::read subpaths. If a 4th prompt fires
+    // the test hangs (or throws — depends on override behavior).
+    interrupt myapp::deploy("auto1", { env: "prod" })
+    interrupt std::read("auto2", { dir: "/tmp/x/sub", filename: "g" })
+  } with handler
+
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency-js/cli-policy-handler/agent.agency
+++ b/packages/agency-lang/tests/agency-js/cli-policy-handler/agent.agency
@@ -1,7 +1,7 @@
-import { cliPolicyHandler, AlwaysFields, flushPolicy } from "std::policy"
+import { cliPolicyHandler, ScopedRuleFields, flushPolicy } from "std::policy"
 
-const FIELDS: AlwaysFields = {
-  "std::read": [{ field: "dir", wildcardSubpaths: true }],
+const FIELDS: ScopedRuleFields = {
+  "std::read": [{ field: "dir", matchSubpaths: true }],
 }
 
 node main(args: { policyFile: string }): string {

--- a/packages/agency-lang/tests/agency-js/cli-policy-handler/fixture.json
+++ b/packages/agency-lang/tests/agency-js/cli-policy-handler/fixture.json
@@ -1,0 +1,4 @@
+{
+  "result": "pass",
+  "remainingAnswers": 0
+}

--- a/packages/agency-lang/tests/agency-js/cli-policy-handler/test.js
+++ b/packages/agency-lang/tests/agency-js/cli-policy-handler/test.js
@@ -1,0 +1,27 @@
+import { main } from "./agent.js";
+import { writeFileSync, mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const dir = mkdtempSync(join(tmpdir(), "cli-policy-"));
+const policyFile = join(dir, "policy.json");
+
+// Scripted answers consumed in order. If the handler issues more
+// prompts than we have answers, the override throws — surfacing the
+// over-prompting as a clear test failure instead of a hang.
+const answers = ["aa", "ap", "a"];
+globalThis.__agencyInputOverride = async () => {
+  const a = answers.shift();
+  if (a === undefined) throw new Error("Unexpected extra input() call");
+  return a;
+};
+
+try {
+  const result = await main({ policyFile });
+  writeFileSync("__result.json", JSON.stringify({
+    result: result.data,
+    remainingAnswers: answers.length,  // 0 = all consumed correctly
+  }, null, 2));
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/packages/agency-lang/tests/agency-js/policy-parse-file/agent.agency
+++ b/packages/agency-lang/tests/agency-js/policy-parse-file/agent.agency
@@ -1,0 +1,13 @@
+import { parsePolicyFile } from "std::policy"
+
+node main(args: { policyFile: string, missingFile: string }) {
+  // Existing valid file → loads.
+  const p1 = parsePolicyFile(args.policyFile) with approve
+  if (keys(p1).length == 0) { return "FAIL: existing file did not load" }
+
+  // Missing file → returns {} (warn-and-return-empty).
+  const p2 = parsePolicyFile(args.missingFile) with approve
+  if (keys(p2).length != 0) { return "FAIL: missing file should be empty" }
+
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency-js/policy-parse-file/fixture.json
+++ b/packages/agency-lang/tests/agency-js/policy-parse-file/fixture.json
@@ -1,0 +1,3 @@
+{
+  "result": "pass"
+}

--- a/packages/agency-lang/tests/agency-js/policy-parse-file/test.js
+++ b/packages/agency-lang/tests/agency-js/policy-parse-file/test.js
@@ -1,0 +1,16 @@
+import { main } from "./agent.js";
+import { writeFileSync, mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const dir = mkdtempSync(join(tmpdir(), "policy-parse-"));
+const policyFile = join(dir, "policy.json");
+const missingFile = join(dir, "absent.json");
+writeFileSync(policyFile, JSON.stringify({ "std::read": [{ action: "approve" }] }));
+
+try {
+  const result = await main({ policyFile, missingFile });
+  writeFileSync("__result.json", JSON.stringify({ result: result.data }, null, 2));
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/packages/agency-lang/tests/agency/policy-build-scoped-match/main.agency
+++ b/packages/agency-lang/tests/agency/policy-build-scoped-match/main.agency
@@ -1,11 +1,11 @@
-import { buildScopedMatch, FieldSpec, AlwaysFields } from "std::policy"
+import { buildScopedMatch, ScopedField, ScopedRuleFields } from "std::policy"
 
 node main() {
-  const fields: AlwaysFields = {
-    "std::read": [{ field: "dir", wildcardSubpaths: true }],
+  const fields: ScopedRuleFields = {
+    "std::read": [{ field: "dir", matchSubpaths: true }],
     "std::exec": [
-      { field: "command", wildcardSubpaths: false },
-      { field: "subcommand", wildcardSubpaths: false },
+      { field: "command", matchSubpaths: false },
+      { field: "subcommand", matchSubpaths: false },
     ],
   }
   const readIntr = {
@@ -13,7 +13,7 @@ node main() {
     data: { dir: "/Users/x/project", filename: "foo.ts" }
   }
   const m1 = buildScopedMatch(readIntr, fields)
-  // wildcardSubpaths brace-expands the value
+  // matchSubpaths brace-expands the value
   if (m1.dir != "{/Users/x/project,/Users/x/project/**}") {
     return "FAIL: brace-expansion wrong, got ${m1.dir}"
   }

--- a/packages/agency-lang/tests/agency/policy-build-scoped-match/main.agency
+++ b/packages/agency-lang/tests/agency/policy-build-scoped-match/main.agency
@@ -1,0 +1,35 @@
+import { buildScopedMatch, FieldSpec, AlwaysFields } from "std::policy"
+
+node main() {
+  const fields: AlwaysFields = {
+    "std::read": [{ field: "dir", wildcardSubpaths: true }],
+    "std::exec": [
+      { field: "command", wildcardSubpaths: false },
+      { field: "subcommand", wildcardSubpaths: false },
+    ],
+  }
+  const readIntr = {
+    kind: "std::read",
+    data: { dir: "/Users/x/project", filename: "foo.ts" }
+  }
+  const m1 = buildScopedMatch(readIntr, fields)
+  // wildcardSubpaths brace-expands the value
+  if (m1.dir != "{/Users/x/project,/Users/x/project/**}") {
+    return "FAIL: brace-expansion wrong, got ${m1.dir}"
+  }
+
+  const execIntr = {
+    kind: "std::exec",
+    data: { command: "git", subcommand: "log", args: ["log"] }
+  }
+  const m2 = buildScopedMatch(execIntr, fields)
+  if (m2.command != "git") { return "FAIL: command not pinned" }
+  if (m2.subcommand != "log") { return "FAIL: subcommand not pinned" }
+
+  // Kind not in the fields map → empty match
+  const otherIntr = { kind: "myapp::deploy", data: { env: "prod" } }
+  const m3 = buildScopedMatch(otherIntr, fields)
+  if (keys(m3).length != 0) { return "FAIL: should be empty for unknown kind" }
+
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/policy-build-scoped-match/main.test.json
+++ b/packages/agency-lang/tests/agency/policy-build-scoped-match/main.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/policy-record-rule/main.agency
+++ b/packages/agency-lang/tests/agency/policy-record-rule/main.agency
@@ -1,0 +1,20 @@
+import { recordRule } from "std::policy"
+
+node main() {
+  const p1 = recordRule({}, "std::read", "approve")
+  if (p1["std::read"].length != 1) { return "FAIL: expected 1 rule" }
+  if (p1["std::read"][0].action != "approve") { return "FAIL: wrong action" }
+  if (p1["std::read"][0].match != undefined) { return "FAIL: should be catch-all" }
+
+  // Adds, doesn't replace, existing rules for the same kind.
+  const p2 = recordRule(p1, "std::read", "reject")
+  if (p2["std::read"].length != 2) { return "FAIL: should have 2 rules" }
+  if (p2["std::read"][1].action != "reject") { return "FAIL: appended wrong" }
+
+  // Other kinds untouched.
+  const p3 = recordRule(p2, "std::write", "approve")
+  if (p3["std::read"].length != 2) { return "FAIL: clobbered other kind" }
+  if (p3["std::write"].length != 1) { return "FAIL: new kind missing" }
+
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/policy-record-rule/main.test.json
+++ b/packages/agency-lang/tests/agency/policy-record-rule/main.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/policy-record-scoped-rule/main.agency
+++ b/packages/agency-lang/tests/agency/policy-record-scoped-rule/main.agency
@@ -1,8 +1,8 @@
-import { recordScopedRule, checkPolicy, AlwaysFields } from "std::policy"
+import { recordScopedRule, checkPolicy, ScopedRuleFields } from "std::policy"
 
 node main() {
-  const fields: AlwaysFields = {
-    "std::read": [{ field: "dir", wildcardSubpaths: true }],
+  const fields: ScopedRuleFields = {
+    "std::read": [{ field: "dir", matchSubpaths: true }],
   }
   const intr = {
     kind: "std::read",

--- a/packages/agency-lang/tests/agency/policy-record-scoped-rule/main.agency
+++ b/packages/agency-lang/tests/agency/policy-record-scoped-rule/main.agency
@@ -1,0 +1,34 @@
+import { recordScopedRule, checkPolicy, AlwaysFields } from "std::policy"
+
+node main() {
+  const fields: AlwaysFields = {
+    "std::read": [{ field: "dir", wildcardSubpaths: true }],
+  }
+  const intr = {
+    kind: "std::read",
+    data: { dir: "/Users/x/project", filename: "foo.ts" }
+  }
+  const policy = recordScopedRule({}, intr, fields)
+
+  // Should auto-approve a matching read.
+  const d1 = checkPolicy(policy, intr)
+  if (d1.type != "approve") { return "FAIL: matching read should auto-approve" }
+
+  // Should NOT auto-approve a non-matching read.
+  const otherIntr = {
+    kind: "std::read",
+    data: { dir: "/Users/x/secrets", filename: "passwd" }
+  }
+  const d2 = checkPolicy(policy, otherIntr)
+  if (d2.type == "approve") { return "FAIL: non-matching read should not auto-approve" }
+
+  // Subpath of the original dir should still match (brace-expansion).
+  const subIntr = {
+    kind: "std::read",
+    data: { dir: "/Users/x/project/sub", filename: "a.ts" }
+  }
+  const d3 = checkPolicy(policy, subIntr)
+  if (d3.type != "approve") { return "FAIL: subpath should match" }
+
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/policy-record-scoped-rule/main.test.json
+++ b/packages/agency-lang/tests/agency/policy-record-scoped-rule/main.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/router-basic/main.agency
+++ b/packages/agency-lang/tests/agency/router-basic/main.agency
@@ -1,0 +1,15 @@
+import { route } from "std::agent"
+
+def hello(): string { return "hi" }
+
+node main() {
+  const reply = route({
+    start: "only",
+    agents: {
+      only: { systemPrompt: "say hello", tools: [hello] }
+    },
+    maxHops: 3,
+  }, "hi there")
+  if (reply == "") { return "FAIL: empty reply" }
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/router-basic/main.test.json
+++ b/packages/agency-lang/tests/agency/router-basic/main.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Single-agent run with no handoff returns the LLM's reply.",
+      "llmMocks": [
+        { "return": "hello back" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/router-fallback/main.agency
+++ b/packages/agency-lang/tests/agency/router-fallback/main.agency
@@ -1,0 +1,16 @@
+import { route } from "std::agent"
+
+def codeOnly(): string { return "edited" }
+def researchOnly(): string { return "found" }
+
+node main(): string {
+  const reply = route({
+    start: "code",
+    agents: {
+      code:     { systemPrompt: "code agent", tools: [codeOnly] },
+      research: { systemPrompt: "research agent", tools: [researchOnly] },
+    },
+    maxHops: 2,
+  }, "ping pong")
+  return reply
+}

--- a/packages/agency-lang/tests/agency/router-fallback/main.test.json
+++ b/packages/agency-lang/tests/agency/router-fallback/main.test.json
@@ -1,0 +1,18 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"fallback answer\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Hop limit reached: fallback mode runs once more with handoff tool stripped.",
+      "llmMocks": [
+        { "toolCall": { "name": "handoff", "args": { "category": "research", "reason": "ping" } } },
+        { "return": "discarded code reply" },
+        { "toolCall": { "name": "handoff", "args": { "category": "code", "reason": "pong" } } },
+        { "return": "discarded research reply" },
+        { "return": "fallback answer" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/router-handoff/main.agency
+++ b/packages/agency-lang/tests/agency/router-handoff/main.agency
@@ -1,0 +1,16 @@
+import { route } from "std::agent"
+
+def codeOnly(): string { return "edited" }
+def researchOnly(): string { return "found" }
+
+node main(): string {
+  const reply = route({
+    start: "code",
+    agents: {
+      code:     { systemPrompt: "code agent", tools: [codeOnly] },
+      research: { systemPrompt: "research agent", tools: [researchOnly] },
+    },
+    maxHops: 3,
+  }, "look up X")
+  return reply
+}

--- a/packages/agency-lang/tests/agency/router-handoff/main.test.json
+++ b/packages/agency-lang/tests/agency/router-handoff/main.test.json
@@ -1,0 +1,16 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"final research answer\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "Two-agent run: code agent hands off to research, research replies.",
+      "llmMocks": [
+        { "toolCall": { "name": "handoff", "args": { "category": "research", "reason": "needs lookup" } } },
+        { "return": "ok handing off" },
+        { "return": "final research answer" }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -26,6 +26,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  createLogger as __createLogger,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -239,6 +240,25 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// Surface the underlying exception via logger + statelog before
+// converting to a Failure. Without this, a caller that doesn't
+// inspect the result (the common case for void side-effect calls)
+// silently loses the error — a debugging nightmare. See the
+// recordAlwaysScoped bug debugged in
+// https://ampcode.com/threads/T-019e7a3a-edfa-74d6-917a-255c31bf8491.
+{
+  const __errMsg = __error instanceof Error ? __error.message : String(__error);
+  const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+  const __log = __createLogger(__ctx.logLevel);
+  __log.error("Function " + "add" + " threw an exception (converted to Failure): " + __errMsg);
+  if (__errStack) __log.error(__errStack);
+  __ctx.statelogClient?.error?.({
+    errorType: "runtimeError",
+    message: __errMsg,
+    functionName: "add",
+    retryable: __self.__retryable,
+  });
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -363,8 +383,18 @@ await callHook({
     if (__error instanceof GuardExceededError) {
       throw __error
     }
-    console.error(`\nAgent crashed: ${__error.message}`)
-    console.error(__error.stack)
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node main crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "main",
+              });
+            }
     return {
       messages: __threads(),
       data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -26,6 +26,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  createLogger as __createLogger,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -233,8 +234,18 @@ await callHook({
     if (__error instanceof GuardExceededError) {
       throw __error
     }
-    console.error(`\nAgent crashed: ${__error.message}`)
-    console.error(__error.stack)
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node main crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "main",
+              });
+            }
     return {
       messages: __threads(),
       data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -26,6 +26,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  createLogger as __createLogger,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -266,8 +267,18 @@ await callHook({
     if (__error instanceof GuardExceededError) {
       throw __error
     }
-    console.error(`\nAgent crashed: ${__error.message}`)
-    console.error(__error.stack)
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node main crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "main",
+              });
+            }
     return {
       messages: __threads(),
       data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -26,6 +26,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  createLogger as __createLogger,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -222,8 +223,18 @@ await callHook({
     if (__error instanceof GuardExceededError) {
       throw __error
     }
-    console.error(`\nAgent crashed: ${__error.message}`)
-    console.error(__error.stack)
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node main crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "main",
+              });
+            }
     return {
       messages: __threads(),
       data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -26,6 +26,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  createLogger as __createLogger,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -230,6 +231,25 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// Surface the underlying exception via logger + statelog before
+// converting to a Failure. Without this, a caller that doesn't
+// inspect the result (the common case for void side-effect calls)
+// silently loses the error — a debugging nightmare. See the
+// recordAlwaysScoped bug debugged in
+// https://ampcode.com/threads/T-019e7a3a-edfa-74d6-917a-255c31bf8491.
+{
+  const __errMsg = __error instanceof Error ? __error.message : String(__error);
+  const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+  const __log = __createLogger(__ctx.logLevel);
+  __log.error("Function " + "double" + " threw an exception (converted to Failure): " + __errMsg);
+  if (__errStack) __log.error(__errStack);
+  __ctx.statelogClient?.error?.({
+    errorType: "runtimeError",
+    message: __errMsg,
+    functionName: "double",
+    retryable: __self.__retryable,
+  });
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -359,6 +379,25 @@ return;
 if (__error instanceof GuardExceededError) {
   throw __error;
 }
+// Surface the underlying exception via logger + statelog before
+// converting to a Failure. Without this, a caller that doesn't
+// inspect the result (the common case for void side-effect calls)
+// silently loses the error — a debugging nightmare. See the
+// recordAlwaysScoped bug debugged in
+// https://ampcode.com/threads/T-019e7a3a-edfa-74d6-917a-255c31bf8491.
+{
+  const __errMsg = __error instanceof Error ? __error.message : String(__error);
+  const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+  const __log = __createLogger(__ctx.logLevel);
+  __log.error("Function " + "addAndDouble" + " threw an exception (converted to Failure): " + __errMsg);
+  if (__errStack) __log.error(__errStack);
+  __ctx.statelogClient?.error?.({
+    errorType: "runtimeError",
+    message: __errMsg,
+    functionName: "addAndDouble",
+    retryable: __self.__retryable,
+  });
+}
 return failure(
   __error instanceof Error ? __error.message : String(__error),
   {
@@ -474,8 +513,18 @@ await callHook({
     if (__error instanceof GuardExceededError) {
       throw __error
     }
-    console.error(`\nAgent crashed: ${__error.message}`)
-    console.error(__error.stack)
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node main crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "main",
+              });
+            }
     return {
       messages: __threads(),
       data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -26,6 +26,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
+  createLogger as __createLogger,
 } from "agency-lang/runtime";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -223,8 +224,18 @@ await callHook({
     if (__error instanceof GuardExceededError) {
       throw __error
     }
-    console.error(`\nAgent crashed: ${__error.message}`)
-    console.error(__error.stack)
+    {
+              const __errMsg = __error instanceof Error ? __error.message : String(__error);
+              const __errStack = __error instanceof Error && __error.stack ? __error.stack : "";
+              const __log = __createLogger(__ctx.logLevel);
+              __log.error(`Node main crashed: ${__errMsg}`);
+              if (__errStack) __log.error(__errStack);
+              __ctx.statelogClient?.error?.({
+                errorType: "runtimeError",
+                message: __errMsg,
+                functionName: "main",
+              });
+            }
     return {
       messages: __threads(),
       data: failure(__error instanceof Error ? __error.message : String(__error), { functionName: "main" })


### PR DESCRIPTION
## Summary

Lifts the agency-agent's interactive policy handler and multi-agent
routing/handoff machinery into the standard library, then refactors
the agency-agent to use them. The agent collapses from ~750 lines of
agent-local plumbing into a ~150-line wrapper that wires two
specialists into one `route()` call.

Specs / plan:
- [Spec](docs/superpowers/specs/2026-05-30-stdlib-policy-and-router-design.md)
- [Plan](docs/superpowers/plans/2026-05-30-stdlib-policy-and-router.md)

## What's new

### `std::policy`

- Types: `Decision`, `FieldSpec`, `AlwaysFields`
- Pure primitives: `recordRule`, `buildScopedMatch`,
  `recordScopedRule`, `parsePolicyFile`
- CLI sugar: `cliPolicyHandler({file, fields})` — installable on a
  `handle` block, owns load + save + prompt + record. Uses the
  flip-flag-first pattern so the policy file's own `std::read`
  doesn't recurse.
- `flushPolicy()` — force-flush between turns (the auto-flush only
  fires on the next interrupt).

### `std::agent`

- Types: `AgentSpec`, `RouterConfig`
- `route(config, userMsg)` — multi-specialist hop loop. Each
  specialist gets a PFA-bound `handoff` tool injected; when the
  hop limit is reached, the last call strips `handoff` so the LLM
  is forced to answer.
- `handoff(category, reason, validCategories)` and
  `consumeHandoff()` — the underlying signal primitives. Module-
  level state lives in the GlobalStore so concurrent runs in
  separate RuntimeContexts don't collide.

### Codegen fix

The generator previously emitted bare `__call(handlerName, ...)`
for `handle ... with <handler>`, ignoring scope. Locally-bound
handlers like `const h = cliPolicyHandler(...); handle { } with h`
crashed at runtime. Fixed in `lib/types/handleBlock.ts`,
`lib/preprocessors/typescriptPreprocessor.ts`,
`lib/backends/typescriptBuilder.ts` — the preprocessor now
resolves the handler ref's scope and the builder emits
`scopedVar(name, scope, moduleId)` when scope is present.

### Agency-agent refactor (acceptance test)

`lib/agents/agency-agent/*` collapses onto the new stdlib. Deleted:
`defaultHandler`, `loadPolicy`, `savePolicy`, `ensurePolicyLoaded`,
`recordAlways`, `recordAlwaysScoped`, `buildScopedMatch`,
`describeScopedMatch`, `askUser`, `runForCategory`, `MAX_HOPS`,
`runCode`, `runResearch`, `_handoffTarget`, `handoff`,
`consumeHandoff`, `Decision`/`FieldSpec`/`AgentContext` types.

The new `agent.agency` is just the banner, REPL loop, the per-kind
`ALWAYS_FIELDS` map, and a single `route(...)` call inside `handle
{ ... } with handler`.

## Tests

All 4698 existing unit tests still pass.

New tests:
- `tests/agency/policy-record-rule/`
- `tests/agency/policy-record-scoped-rule/`
- `tests/agency/policy-build-scoped-match/`
- `tests/agency-js/policy-parse-file/`
- `tests/agency-js/cli-policy-handler/` — full turn-1 records,
  turn-2 auto-approves flow
- `tests/agency/router-basic/`
- `tests/agency/router-handoff/`
- `tests/agency/router-fallback/`

Manual smoke test: the agency-agent boots, prints its banner,
accepts input, and exits cleanly. The interactive paths (handoff
to research, "aa"/"ap" prompts, policy persistence to
`~/.agency-agent/policy.json`) are not exercised by CI and need a
manual session to confirm end-to-end.

## Diff stat

```
stdlib/policy.agency           +200 lines
stdlib/agent.agency            +130 lines
lib/agents/agency-agent/*      -630 lines net
```

Roughly matches the plan's predicted shape, with the agent
collapse coming in a bit deeper than the predicted -300.

## Known caveat

`codeTools` and `researchTools` are now `static const` arrays whose
`workspace.read`/etc. references are captured once at module load.
The old `runCode` rebuilt the array on every call, so an LLM-driven
`setCwd` re-anchored future tools. With the static array, `setCwd`
updates the `workspace` `let` but the cached method references stay
bound to the original dir. If this surfaces in practice, the fix is
to switch `codeTools` to a `def` and call it from the router-config
site, or to mutate the existing workspace object in `setCwd` instead
of rebinding the variable.
