### PR TITLE
Fix cross-module static/global init order (#232)

### DIFF
--- a/packages/agency-lang/docs/dev/cross-module-init.md
+++ b/packages/agency-lang/docs/dev/cross-module-init.md
@@ -1,0 +1,417 @@
+# Cross-module Static / Global Init Order
+
+This document explains how Agency guarantees that imported `static const` (and top-level `let` / `const`) values are populated before any importer reads them. It is the internals doc for the subsystem that landed as PR #237 and fixed issue #232.
+
+If you are looking for the *user-facing* contract, see [`docs/site/guide/execution-model.md`](../site/guide/execution-model.md#cross-module-init-order). If you are looking for the older global-variable init story (top-level expressions running outside any node context, esbuild async issues, etc.), see [`docs/dev/init.md`](./init.md). That doc covers a different problem; this one is strictly about cross-module ordering.
+
+---
+
+## The bug
+
+Before the fix, this code crashed with `TypeError: Cannot read property of undefined`:
+
+```agency
+// shared.agency
+export static const BASE_DIR = "${env(\"HOME\")}/.myapp"
+```
+
+```agency
+// main.agency
+import { BASE_DIR } from "./shared.agency"
+
+export static const CONFIG_PATH = "${BASE_DIR}/config.json"
+
+node main() { return read(CONFIG_PATH) }
+```
+
+The codegen emitted each module's top-level code into an `__initializeGlobals(__ctx)` function and triggered that function lazily on the first node-entry of each module. The lazy-init check was *per-module*. Concretely:
+
+```diagram
+╭────────────────────────────────────────────────────────────╮
+│ Node loads main.js                                         │
+│   → ES module body runs                                    │
+│   → static let CONFIG_PATH;     ← decl only, not init      │
+│                                                            │
+│ User calls mod.main()                                      │
+│   → entry to node `main` triggers lazy-init                │
+│   → if (!__ctx.globals.isInitialized("main")) {            │
+│       await __initializeGlobals(__ctx)                     │
+│       │  CONFIG_PATH = `${BASE_DIR}/config.json`           │
+│       │      ↑ reads BASE_DIR from shared.js               │
+│       │      ↑ but shared.js's __initializeGlobals         │
+│       │        has NEVER run, because no function in       │
+│       │        shared.js has been called!                  │
+│       │  → BASE_DIR is undefined → crash                   │
+│     }                                                      │
+╰────────────────────────────────────────────────────────────╯
+```
+
+The pre-fix design relied on each module being self-sufficient: a module would init its own globals on first use. That falls apart when a module's init expression *reads from another module*. The importer's init fires first (because the importer is what the user called into), but the imported module's init has never been triggered.
+
+The fix had to guarantee: *every* reachable module's statics must be populated *before* any of them are read, regardless of which module hosts the entry point.
+
+---
+
+## Architecture: two-phase init with a process-global orchestrator
+
+The fix introduces three pieces that work together:
+
+1. **Per-static memoized async getters** (`__init_X`) — every top-level `static const X = expr` is compiled into a lazy async getter; the assignment to the underlying `let X` happens inside that getter. Reads of an imported `X` cascade through the getter graph.
+2. **A two-phase per-module init split** — each module gets `__initializeStatic(__ctx)` (populates statics) and `__runImperatives(__ctx)` (runs top-level imperatives). They MUST run in two distinct phases globally: every module's Phase 1 before any module's Phase 2.
+3. **A process-global registry + orchestrator** — every compiled module self-registers at ES-import time. The entry module's `__initializeGlobals` iterates the registry, running Phase 1 across all modules, then Phase 2 across all modules.
+
+```diagram
+                       ╭──────────────────────────╮
+                       │ ES module load (Node)    │
+                       │  depth-first post-order  │
+                       ╰──────────┬───────────────╯
+                                  │
+                                  ▼
+            ┌──────────────────────────────────────────────┐
+            │ Each module's top-level code runs:           │
+            │   - decls (`let X`)                          │
+            │   - getter pairs (`__init_X = __initVar...`) │
+            │   - __registerModule({                       │
+            │       __moduleId,                            │
+            │       __initializeStatic,                    │
+            │       __runImperatives,                      │
+            │     })                                       │
+            └──────────────────────┬───────────────────────┘
+                                   │
+                                   ▼
+            User awaits a node (e.g. `await mod.main()`)
+                                   │
+                                   ▼
+            ┌──────────────────────────────────────────────┐
+            │ Lazy first-call check at function entry:     │
+            │   if (!__ctx.globals.isInitialized(...))     │
+            │     await __initializeGlobals(__ctx)         │
+            └──────────────────────┬───────────────────────┘
+                                   │
+                                   ▼
+            ┌──────────────────────────────────────────────┐
+            │ __initializeGlobals(__ctx):                  │
+            │   const registered = __getRegisteredModules()│
+            │   ╭── Phase 1 ────────────────────────────╮  │
+            │   │ for (const mod of registered)         │  │
+            │   │   await mod.__initializeStatic(__ctx) │  │
+            │   ╰───────────────────────────────────────╯  │
+            │   ╭── Phase 2 ────────────────────────────╮  │
+            │   │ for (const mod of registered)         │  │
+            │   │   await mod.__runImperatives(__ctx)   │  │
+            │   ╰───────────────────────────────────────╯  │
+            └──────────────────────────────────────────────┘
+                                   │
+                                   ▼
+                            Node body runs.
+```
+
+The two phases exist because top-level imperatives in module C may read a `static const X` from module B that no init expression depends on. If we ran Phase 1 and Phase 2 interleaved per module, the imperative would observe `undefined` when it ran before B's Phase 1.
+
+---
+
+## The per-static getter cascade
+
+The user writes:
+
+```agency
+// shared.agency
+export static const A = computeA()
+
+// main.agency
+import { A } from "./shared.agency"
+export static const B = transform(A)
+```
+
+The codegen emits, in each module:
+
+```ts
+// shared.js
+export let A;
+async function __init_A_compute(__ctx) {
+  A = __deepFreeze(await computeA(__ctx));
+  return A;
+}
+const __init_A = __initVar("shared:A", __init_A_compute);
+export { __init_A };
+```
+
+```ts
+// main.js
+import { __init_A } from "./shared.js";
+
+export let B;
+async function __init_B_compute(__ctx) {
+  // The cross-module read of `A` was rewritten by InitGetterRewriter
+  // into a `__init_A(__ctx)` cascade.
+  B = __deepFreeze(await transform(__ctx, await __init_A(__ctx)));
+  return B;
+}
+const __init_B = __initVar("main:B", __init_B_compute);
+export { __init_B };
+```
+
+`__initVar` is a memoized async-getter factory ([`lib/runtime/initVar.ts`](../../lib/runtime/initVar.ts)). The first call kicks off the compute and caches the resulting promise; every subsequent call (and every concurrent call) gets the same cached promise. So no matter how many places `await __init_A(__ctx)` shows up — in `__init_B`'s compute, in another module's compute, in a function body — `__init_A_compute` runs exactly once. Permanent failures (rejected promises) are also cached: a rejection is never retried.
+
+This cascade is the mechanism that handles *cross-module reads inside init expressions*. The orchestrator's Phase 1 just makes sure every getter is *touched at least once* per execCtx so populated values are visible to Phase 2 imperatives and to function bodies that read them later.
+
+---
+
+## Important files
+
+### Runtime (`lib/runtime/`)
+
+| File | Role |
+| --- | --- |
+| [`initVar.ts`](../../lib/runtime/initVar.ts) | The memoized async-getter primitive. `__initVar(name, computeFn)` returns a getter; the first call invokes `computeFn`, every subsequent call returns the same cached promise. Includes cycle detection (throws if a getter awaits itself transitively) and the `__requireInitVar` helper that throws a clean error when consumers import a pre-#232 compiled module. |
+| [`initOrchestrator.ts`](../../lib/runtime/initOrchestrator.ts) | The process-global module registry. `__registerModule(mod)` appends or replaces in place (last-write-wins on `__moduleId`, preserves DFS position). `__getRegisteredModules()` returns a snapshot in registration order. `__resetModuleRegistry()` is a test-only hook. |
+| [`initOrchestrator.test.ts`](../../lib/runtime/initOrchestrator.test.ts) | Unit tests for the registry (append-on-first, replace-on-duplicate). |
+| [`initVar.test.ts`](../../lib/runtime/initVar.test.ts) | Unit tests for the memoized getter (concurrent calls, diamond deps, cycle detection, permanent-failure semantics, cross-module cycle behavior). |
+| [`index.ts`](../../lib/runtime/index.ts) | Re-exports `__initVar`, `__requireInitVar`, `__registerModule`, `__getRegisteredModules`, `__resetModuleRegistry`, `ModuleInitHandle` so generated modules and the stdlib can `import` them via the `agency-lang/runtime` barrel. |
+
+### Codegen (`lib/backends/typescriptBuilder/`)
+
+| File | Role |
+| --- | --- |
+| [`sectionAssembler.ts`](../../lib/backends/typescriptBuilder/sectionAssembler.ts) | Emits the per-module init shape: `let X` decls, `__init_X_compute` + `__init_X` pairs, the `__MY_INIT_GETTERS` array, `__initializeStatic`, `__runImperatives`, `__initializeGlobals`, and the self-registration call. The three relevant functions are `buildStaticVarSetup`, `buildRunImperativesFn`, and `buildInitializeGlobalsFn`. |
+| [`initGetterRewriter.ts`](../../lib/backends/typescriptBuilder/initGetterRewriter.ts) | Helper that rewrites references to imported statics inside init-context compute bodies — e.g. `transform(A)` becomes `transform(await __init_A(__ctx))`. Single owner of the `__init_X` / `__init_X_compute` naming convention (exposed via `InitGetterRewriter.getterName(name)` and `InitGetterRewriter.computeName(name)`). |
+| [`lib/backends/typescriptBuilder.ts`](../../lib/backends/typescriptBuilder.ts) | The driver. Sets up the partition between static-init exprs and top-level imperatives via `partitionProgram` (with the `onStaticVarNamesCollected` callback that pre-populates the rewriter's known-static-names set), and emits the lazy first-call orchestrator trigger inside every `setupFunction` / `setupNode` epilogue (the `if (!__ctx.globals.isInitialized(...)) await __initializeGlobals(...)` block around line 1602). Also contains the docstring-interpolation eager-init shim around line 3439 (see "Known limitations"). |
+
+### Codegen templates (`lib/templates/`)
+
+| File | Role |
+| --- | --- |
+| [`backends/typescriptGenerator/imports.mustache`](../../lib/templates/backends/typescriptGenerator/imports.mustache) | The header every generated `.js` file gets. Imports `__initVar`, `__requireInitVar`, `__registerModule`, `__getRegisteredModules` from `agency-lang/runtime`. Change this and run `pnpm run templates` to regenerate `imports.ts`. |
+| [`backends/typescriptGenerator/imports.ts`](../../lib/templates/backends/typescriptGenerator/imports.ts) | Generated from the mustache file. Do not edit by hand. |
+
+### Tests
+
+| File | Role |
+| --- | --- |
+| [`lib/backends/static-init-runtime.test.ts`](../../lib/backends/static-init-runtime.test.ts) | Runtime-side coverage: concurrent runs share memoization, resume / repeat invocations don't re-run init, trace captures populated cross-module state, backward-compat guard fires when a `pkg::` dep is pre-#232. Calls `__resetModuleRegistry()` before each dynamic import so registry state doesn't leak between tests. |
+| `tests/agency/static-init-concurrent-runs/` | Fixture: two parallel `main()` calls share a single static-init pass. |
+| `tests/agency/static-init-cross-module/` | Fixture: importer reads exporter's `static const`. The canonical #232 repro. |
+| `tests/agency/static-init-function-mediated/` | Fixture: `static const X = computeX()` where `computeX` is a top-level `def` that reads another module's static. Exercises the function-mediated init path that gated `markInitialized` placement. |
+| `tests/agency/static-init-cross-module-diamond/` | Fixture: diamond import graph (A imported by B and C, both imported by main); confirms A's compute runs once. |
+| `tests/agency/static-init-cross-module-cycle/` | Fixture: documents that cross-module `.agency` import cycles do compile but crash at module load with a TDZ error in `__registerTool` (a pre-existing limitation unrelated to #232). |
+| `tests/agency/static-init-mixed-module/` | Fixture: mixed module with both statics and imperatives; observes the phase ordering via `onFunctionStart` callbacks. |
+| `tests/agency/static-init-cycle/` | Fixture: init-expression cycle; expects `__initVar`'s cycle-detection error. |
+| `tests/agency/global-let-cross-module/` | Fixture: cross-module *importer-side* global; the source module exports `static const`, the importer creates a top-level `const` that captures it. |
+| Many `tests/typescriptGenerator/*.mjs`, `tests/typescriptBuilder/*.mjs` | Snapshot fixtures regenerated by `make fixtures` whenever codegen changes. Most of PR #237's line count is these regenerations. |
+
+### Documentation
+
+| File | Role |
+| --- | --- |
+| [`docs/site/guide/execution-model.md`](../site/guide/execution-model.md#cross-module-init-order) | User-facing contract: what guarantees Agency provides about init ordering. |
+| [`docs/dev/init.md`](./init.md) | The *older* init story — top-level expressions running outside any node context, esbuild async issues, debugger / interrupt / checkpoint integration. Predates and is orthogonal to this doc. |
+| PR [#237](https://github.com/egonSchiele/agency-lang/pull/237) + issue [#232](https://github.com/egonSchiele/agency-lang/issues/232) | The implementation PR and the bug report that drove it. Skim for the original design discussion, alternatives considered in review, and the rollout sequence. |
+
+---
+
+## Anatomy of a generated module
+
+When you compile any `.agency` file under this subsystem, every generated module has the following shape (annotated):
+
+```ts
+// === imports (from imports.mustache) ===
+import { __initVar, __registerModule, __getRegisteredModules /* ... */ } from "agency-lang/runtime";
+import { __init_A } from "./shared.js";  // cross-module getter imports
+
+// === per-static let decls ===
+export let B;
+
+// === per-static getter pairs ===
+async function __init_B_compute(__ctx) {
+  B = __deepFreeze(await transform(__ctx, await __init_A(__ctx)));
+  return B;
+}
+const __init_B = __initVar("main:B", __init_B_compute);
+export { __init_B };
+
+// === orchestrator-facing array ===
+const __MY_INIT_GETTERS = [__init_B];
+
+// === Phase 1 ===
+async function __initializeStatic(__ctx) {
+  __ctx.globals.markInitialized("main");  // ← see "markInitialized placement"
+  for (const init of __MY_INIT_GETTERS) await init(__ctx);
+  await __ctx.writeStaticStateToTrace(__globalCtx.getStaticVars());
+}
+
+// === static-state snapshot for trace writer ===
+function __getStaticVars() { return { B }; }
+__globalCtx.getStaticVars = __getStaticVars;
+
+// === Phase 2 ===
+async function __runImperatives(__ctx) {
+  // (top-level let X = ..., bare top-level calls, etc.)
+}
+
+// === backward-compat shim ===
+async function __initializeGlobals(__ctx) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) await mod.__initializeStatic(__ctx);
+  for (const mod of __registered) await mod.__runImperatives(__ctx);
+}
+
+// === self-register ===
+__registerModule({
+  __moduleId: "main",
+  __initializeStatic,
+  __runImperatives,
+});
+
+// === user-written top-level code (handlers, tool registrations, etc.) ===
+// ...
+```
+
+Function bodies emitted elsewhere in the module (nodes, defs) all start with:
+
+```ts
+if (!__ctx.globals.isInitialized("main")) {
+  await __initializeGlobals(__ctx);
+}
+```
+
+That lazy first-call check is what kicks the orchestrator. Whichever module hosts the entry point, the orchestrator walks the *full* registry — so every module's statics get populated, not just this one's.
+
+---
+
+## Invariants
+
+These are the load-bearing rules. Break any of them and #232 (or a related bug) comes back.
+
+### 1. Phase 1 fully finishes before Phase 2 starts on ANY module
+
+The phase split is the whole point. Top-level imperatives can read statics from other modules. If we run Phase 1+Phase 2 per module (instead of all-Phase-1 then all-Phase-2), a Phase-2 statement in module C might observe an unpopulated static in module B because B's Phase 1 hasn't run yet.
+
+Concretely: never let an imperative in `__runImperatives` start running before every registered module's `__initializeStatic` has resolved.
+
+### 2. `markInitialized` lives at the TOP of `__initializeStatic`, not inside `__runImperatives`
+
+The marking placement matters for re-entrancy. Consider:
+
+```agency
+static const X = computeX()  // computeX is a top-level `def`
+def computeX(): number { return read("/etc/version") }
+```
+
+`__init_X_compute` calls `computeX(__ctx)`. `computeX` is a function, so on entry it hits the lazy first-call check — `if (!__ctx.globals.isInitialized("...")) await __initializeGlobals(...)`. Without marking the module up front, this would re-enter `__initializeGlobals`, which would re-enter `__initializeStatic`, which would re-await `__init_X` — and `__init_X`'s cached promise is in-flight, so we'd deadlock.
+
+Marking at the top of `__initializeStatic` (BEFORE the for-loop iterates the getters) short-circuits that re-entry. The orchestrator still drives every module's `__runImperatives` from the outer `__initializeGlobals` call, so global-init side effects still happen — the lazy-init check just stops re-firing the orchestrator from inside `computeX`.
+
+### 3. The orchestrator iterates SEQUENTIALLY with `for await`, not `Promise.all`
+
+Two reasons:
+- **Trace and checkpoint replay determinism.** `Promise.all` interleaves dep chains in whatever microtask order they happen to resolve, which makes trace events arrive in different orders run-to-run.
+- **The phase invariant.** With `Promise.all`, one module's `__runImperatives` could conceivably start before another module's `__initializeStatic` finished (if one phase's `Promise.all` resolves before another's). Sequential `for await` makes the phase split impossible to violate accidentally.
+
+### 4. `__init_X_compute` must be a NAMED function declaration
+
+The `__initVar` cycle-detection error message tells the user "every frame named `__init_*` is a participating variable." That promise only holds if the compute closures actually have names V8 prints in stack traces. An anonymous arrow inside the `__initVar` call expression would show up as just `<anonymous>` and the error would be useless.
+
+`InitGetterRewriter.computeName(name)` is the single owner of the naming convention; codegen always uses it.
+
+### 5. Registration order is fixed by ES module load order
+
+Don't add registration calls from anywhere other than each module's own top-level code. The order matters: post-order DFS over the static import graph (deps register before importers, entry module registers last). The orchestrator relies on that ordering for trace determinism and for the Phase 2 invariant.
+
+### 6. The cross-module init contract is NOT serialized into checkpoints
+
+`__ctx.globals.isInitialized(moduleId)` and the `__init_X` memoization caches are *runtime* state, not checkpoint state. On resume after rewind/restore, `__initializeGlobals` is re-invoked on the restored execCtx, and the `__init_X` caches are repopulated. The `__initVar` memoization makes this free (cached promises resolve immediately).
+
+If you find yourself trying to serialize init state, stop and re-read this section.
+
+---
+
+## Common pitfalls
+
+### Editing `imports.mustache` without regenerating
+
+The mustache file is the source; `imports.ts` is generated. Edit only the `.mustache` file and run `pnpm run templates` to regenerate. Forgetting this means generated modules import a stale shape and you get cryptic "no matching export" errors at runtime — exactly what bit the `pack` test when the rename in PR #237 first landed.
+
+### Editing codegen without running `make fixtures`
+
+The hundreds of `tests/typescriptGenerator/*.mjs` and `tests/typescriptBuilder/*.mjs` files are full-module snapshots. Any codegen change rewrites them. After editing `sectionAssembler.ts` or `typescriptBuilder.ts`, always:
+
+```bash
+make fixtures      # regenerates everything under tests/typescriptGenerator/ + tests/typescriptBuilder/
+make stdlib        # rebuilds stdlib .js if the imports template changed
+```
+
+### Test isolation: forgetting `__resetModuleRegistry()`
+
+The orchestrator registry is a process-global. Any test that dynamically imports a freshly-compiled fixture must call `__resetModuleRegistry()` first, or it will iterate handles from prior fixtures and re-run their `__initializeStatic` / `__runImperatives`. See [`lib/backends/static-init-runtime.test.ts`](../../lib/backends/static-init-runtime.test.ts) for the pattern.
+
+### Believing the docstring before reading the code
+
+Several docstrings in PR #237's first commits drifted from the implementation during refactoring (e.g. claiming `__runImperatives` has an `isInitialized` guard when it doesn't). The post-merge review caught those. When in doubt, read the actual emitted statements, not the comment block above the function.
+
+---
+
+## Known limitations
+
+### Circular `.agency` imports crash at module load
+
+If `a.agency` imports `b.agency` and `b.agency` imports `a.agency`, the generated `a.js` ↔ `b.js` ES modules form a static cycle. ES module resolution handles cycles fine for plain bindings, but `__registerTool` (emitted at the top of every Agency module's bound functions) reads from the importing module's let-bindings before they're populated and crashes with a TDZ error.
+
+This is a *pre-existing* limitation unrelated to #232. The init subsystem doesn't make it worse, but doesn't fix it either. See the cycle test fixture at `tests/agency/static-init-cross-module-cycle/` and the cycle-related test in [`initVar.test.ts`](../../lib/runtime/initVar.test.ts) for the documented behavior.
+
+### Cycles within `__initVar` getters throw a clear error
+
+In contrast to module-level cycles, init *expression* cycles — `static const A = f(B)` where `B = g(A)` — are detected by `__initVar` and throw with a list of participating `__init_*` frames. That's the intended behavior; the error tells the user which definitions form the cycle.
+
+### Per-process registry, not per-entry
+
+The registry is a single process-global list. If a long-lived process loads multiple unrelated compiled Agency programs (or a test runner imports many fixtures back-to-back without resetting), every registered module is visited by every subsequent `__initializeGlobals` call. Per-entry scoping would require recording dependency edges at registration time and walking only the reachable subgraph from the entry module — tracked as a follow-up but not implemented.
+
+For production (single-entry processes) this is a non-issue. For tests, see "Test isolation" above.
+
+### Docstring interpolation triggers eager init at module load (#239)
+
+When a module has a function with `${global}` interpolation inside its docstring, codegen emits a fire-and-forget `__runImperatives(__globalCtx);` at module-load time so the description string can read populated globals synchronously. This has two ugly side effects:
+
+1. **Every top-level imperative fires at import time**, not just the `globals.set` calls the docstring needs. A user's top-level `sendStartupMetric(...)` will fire whenever any module imports the file.
+2. **Those imperatives fire AGAIN when `main()` runs**, because the eager call wrote to `__globalCtx` but the lazy first-call check at function entry reads `__ctx.globals.isInitialized` on the per-execution `__ctx`. They're separate stores.
+
+The proper fix is to make tool descriptions *lazy* (a thunk or a getter property), so nothing has to run at import time. Tracked as issue #239.
+
+### Cross-module re-imports under cache-busting
+
+PR #237's commit `Cross-module init: last-write-wins on __registerModule (#238)` handles HMR / cache-busted dynamic re-imports by replacing the stale module's handles in place when a new instance registers under the same `__moduleId`. The DFS position is preserved. Normal ESM operation is unaffected (a module body only runs once per realm, so `__registerModule` is called exactly once per `__moduleId`).
+
+---
+
+## When you change this subsystem
+
+A rough checklist:
+
+1. Read this doc.
+2. Skim PR #237 + the comments thread for design context.
+3. Make your change in `lib/runtime/` or `lib/backends/typescriptBuilder/`.
+4. If you touched `imports.mustache`, run `pnpm run templates`.
+5. Run `pnpm run build`.
+6. Run `make fixtures` to regenerate snapshot fixtures.
+7. If you changed runtime exports or codegen, run `make stdlib` so the bundled `.js` reflects the change.
+8. Run the targeted tests:
+   ```bash
+   pnpm vitest run lib/runtime/initVar.test.ts lib/runtime/initOrchestrator.test.ts lib/backends/static-init-runtime.test.ts
+   ```
+9. Run the full lib unit suite:
+   ```bash
+   pnpm vitest run lib/
+   ```
+10. If you changed anything user-observable, update `docs/site/guide/execution-model.md`.
+11. If you broke any invariant above (intentionally or otherwise), update *this* doc.
+
+---
+
+## Related docs
+
+- [`docs/dev/init.md`](./init.md) — the older global-variable init story (esbuild async, checkpoint integration, debugger / interrupt support).
+- [`docs/dev/globalstore.md`](./globalstore.md) — the per-execCtx globals store that backs `__ctx.globals.get` / `set` / `isInitialized` / `markInitialized`.
+- [`docs/dev/checkpointing.md`](./checkpointing.md) — checkpoint state model; explains why init state is NOT serialized.
+- [`docs/dev/interrupts.md`](./interrupts.md) — interrupt-response path; calls `__initializeGlobals` on resume.
+- [`docs/dev/typescript-ir.md`](./typescript-ir.md) — the `TsNode` tree the codegen emits into.
+- [`docs/dev/pkg-imports.md`](./pkg-imports.md) — `pkg::` imports; relevant to the backward-compat-guard path.

--- a/packages/agency-lang/docs/site/guide/execution-model.md
+++ b/packages/agency-lang/docs/site/guide/execution-model.md
@@ -59,3 +59,27 @@ Static variables:
 - Are **shared across all runs** — every call to the agent sees the same value
 
 If you need mutable state that is shared across runs, implement it in TypeScript and import the functions into your Agency code.
+
+### Cross-module init order
+
+You can read an imported `static const` (or top-level `let` / `const`) from another module's `static const` initializer — the value is guaranteed populated before your initializer evaluates, regardless of which module the entry point lives in:
+
+```ts
+// shared.agency
+export static const BASE_DIR = "${env("HOME")}/.myapp"
+```
+
+```ts
+// agent.agency
+import { BASE_DIR } from "./shared.agency"
+
+// BASE_DIR is populated before this evaluates — no need to defer the
+// read into a `def`.
+static const POLICY_PATH = "${BASE_DIR}/policy.json"
+```
+
+Each top-level static compiles to a memoized async getter; cross-module reads in initializer expressions become awaited calls to the source module's getter, so dependencies resolve on demand. Function-call-mediated reads work too: if a `def` reads a top-level static or global, the value is guaranteed populated before any `def` is invoked.
+
+If two modules' top-level values depend on each other in a true cycle (`a` depends on `b`, `b` depends on `a`), the runtime detects the cycle the first time it's traversed and throws an `Init cycle on <module>:<var>` error. The JS stack trace's `__init_<var>_compute` frames spell out the dependency chain. To break the cycle, move one of the values into a `def` (which runs after init completes), or restructure so one side stops being a top-level read.
+
+Imperative top-level statements in different modules still run in module-import order. If you need a specific imperative-side-effect ordering, restructure to a `static const` plus a `def` call.

--- a/packages/agency-lang/docs/superpowers/ideas/2026-05-31-statics-as-js-module-bindings.md
+++ b/packages/agency-lang/docs/superpowers/ideas/2026-05-31-statics-as-js-module-bindings.md
@@ -1,0 +1,337 @@
+# Lift `static` Out of `__ctx.globals` Into JS Module Bindings
+
+> Status: **idea** / RFC. Not implemented. Captured here so the architectural intent doesn't live only in chat history.
+
+## TL;DR
+
+Today, Agency's `static const X = expr` compiles to a runtime entry in `__ctx.globals` — even though `static` semantically means "this value is fixed across all runs of the agent." The mismatch (cross-run value, per-execution store) is the structural reason PR #237 had to introduce a process-global module registry, a two-phase orchestrator, and per-variable memoized async getters. None of that machinery is needed if `static` values live where they semantically belong: **as plain ES module exports**. Node already handles cross-module init ordering, async compute (via top-level await), and re-exports for free. The proposal: lift statics into JS module-let bindings, leverage Node's existing semantics, and delete most of PR #237's runtime + codegen.
+
+Concurrently, introduce a `static foo()` statement form so users can express "this bare call runs once at module load" cleanly, instead of contorting through `static const _ = foo()`.
+
+## Why this idea exists
+
+PR #237 fixed [issue #232](https://github.com/egonSchiele/agency-lang/issues/232) (cross-module `static const` reads returning `undefined`) with a tactical mechanism: every `static const X` became a memoized async getter (`__init_X`) keyed in a process-global registry; an orchestrator (`__initializeGlobals`) walked the registry in two phases — first populating all statics, then running all top-level imperatives.
+
+That works. But the architectural retrospective revealed the complexity is irreducible *only because Agency tries to make `static` live inside `__ctx.globals`*. If you accept that statics are JS module-level (they are! that's what `static` means), Node's ES module resolution already provides:
+
+- Depth-first post-order import resolution → deps initialized before importers.
+- Top-level await → async statics work.
+- Re-exports (`export { X } from "./D"`) → name routing through intermediate modules.
+- Module-singleton-per-realm → no double init.
+
+Everything PR #237's orchestrator + registry + `__initVar` does is a hand-rolled version of these, but inside `__ctx.globals` instead of in the JS module system.
+
+## The proposal
+
+### 1. `static const X` compiles to a plain ES module export
+
+```agency
+// shared.agency
+export static const BASE_DIR = "${env(\"HOME\")}/.myapp"
+```
+
+```ts
+// shared.js — proposed
+import { env } from "agency-lang/stdlib/system.js";
+export const BASE_DIR = `${env(__globalCtx, "HOME")}/.myapp`;
+```
+
+Importers consume it as a plain JS import:
+
+```agency
+// main.agency
+import { BASE_DIR } from "./shared.agency"
+export static const CONFIG_PATH = "${BASE_DIR}/config.json"
+```
+
+```ts
+// main.js — proposed
+import { BASE_DIR } from "./shared.js";
+export const CONFIG_PATH = `${BASE_DIR}/config.json`;
+```
+
+Node guarantees `shared.js`'s body runs before `main.js`'s body (DFS post-order over static imports). `BASE_DIR` is populated before `CONFIG_PATH` reads it. **No `__init_X` getter, no orchestrator, no registry, no two-phase split.**
+
+Asynchronous statics use top-level await:
+
+```agency
+static const TOKEN = httpGet("/auth")
+```
+
+```ts
+export const TOKEN = await httpGet(__globalCtx, "/auth");
+```
+
+Cycles in the static-import graph crash at module load with a TDZ error — same as the current `.agency` cycle behavior, and the same as any plain ES module cycle in JS. Neither design fixes cycles.
+
+### 2. `static foo()` statement form for one-time imperatives
+
+Symmetric with `static const`. Defaults are now crisp:
+
+| Source | Semantics |
+| --- | --- |
+| `static const X = expr` | Value fixed at module load, shared across all runs. |
+| `static foo()` | Call fires once at module load, before any run starts. |
+| `let X = expr` | Per-run global; re-initialized on every agent run. |
+| `foo()` | Per-run side effect; fires whenever the orchestrator runs imperatives. |
+
+This eliminates the existing `static const _x = sideEffect()` workaround idiom (which today is the only way to express "side effect once at load") and removes the bare-call ambiguity entirely — the user just writes what they mean.
+
+Codegen:
+
+```agency
+static sendBootMetric("greeter loaded")
+```
+
+```ts
+await sendBootMetric(__globalCtx, "greeter loaded");   // top-level, at module load
+```
+
+### 3. Non-static top-level code stays per-execution
+
+Nothing about `let X = expr` or bare `foo()` changes. They still compile into a per-module `__runImperatives(__ctx)` function fired by the lazy first-call check at function entry. This is the pre-#232 behavior, restored — and it's correct now, because the cross-module ordering problem only exists for *statics*, which are no longer in `__ctx.globals`.
+
+```agency
+let counter = 0
+sendStartupMetric("greeter started")
+```
+
+```ts
+async function __runImperatives(__ctx) {
+  __ctx.globals.set("counter", 0);
+  await sendStartupMetric(__ctx, "greeter started");
+}
+```
+
+The `__initializeGlobals(__ctx)` shim becomes per-module, no orchestrator — just calls this module's `__runImperatives`. No registry, no cross-module imperative firing (which was also a behavior change in #237 vs pre-#232, see the simpler-alternative analysis).
+
+### 4. Static initializers calling Agency functions
+
+This is the load-bearing question. The answer is: **yes, they can, provided the called functions don't depend on per-execution state**.
+
+Agency `def` already compiles to a JS function whose first arg is `__ctx`. At module load, we pass `__globalCtx` — the module-level context that already exists.
+
+Works:
+
+```agency
+import { BASE_DIR } from "./shared.agency"
+static const PATH = composePath()
+def composePath(): string { return "${BASE_DIR}/config" }
+```
+
+```ts
+import { BASE_DIR } from "./shared.js";
+function composePath(__ctx) { return `${BASE_DIR}/config`; }
+export const PATH = composePath(__globalCtx);
+```
+
+Cross-module function-mediated chains:
+
+```agency
+import { otherFn } from "./other.agency"
+static const X = wrapped()
+def wrapped(): string { return otherFn() }
+```
+
+```ts
+import { otherFn } from "./other.js";
+function wrapped(__ctx) { return otherFn(__ctx); }
+export const X = wrapped(__globalCtx);
+```
+
+If `otherFn` reads a static from yet another module, Node has already initialized that module too (DFS guarantee).
+
+Fails honestly:
+
+```agency
+static const X = currentNodeId()    // reads __ctx.stateStack — undefined at load
+```
+
+Throws at module load with something like `Cannot read 'stateStack' of undefined`. The error is loud and discoverable; the constraint matches the user's intuition that `static` means "doesn't depend on per-execution state."
+
+### 5. The `with approve` handler case
+
+User explicitly asked for this to work at static init:
+
+```agency
+static const _ = enableMemory({dir: "..."}) with approve
+```
+
+Today this idiom is used in `lib/agents/agency-agent/shared.agency` to wire memory at module load. `enableMemory` may interrupt for approval; the `with approve` handler auto-approves so module load doesn't suspend on an interactive prompt.
+
+Requires a `__withHandler` runtime helper that installs a module-level handler frame:
+
+```ts
+export const _ = await __withHandler(__globalCtx, "approve", (__ctx) =>
+  enableMemory(__ctx, {dir: "..."})
+);
+```
+
+`__withHandler` pushes a handler onto a module-level handler stack, runs the callback (passing the same `__globalCtx`), pops the handler, returns the result. Any interrupt thrown by `enableMemory` is caught by the handler and resolved. This is the trickiest piece of the proposal but is bounded — single new runtime helper, ~30 lines.
+
+Other handlers (e.g. user-facing approvals, exception handlers that need a node context) can stay illegal at static init by simply not having a module-level equivalent installed. The honest crash is the same as case 4.
+
+### 6. Trace integration
+
+Today the trace writer snapshots `__ctx.globals` to capture static state. Under this proposal, static state lives in JS module bindings, not in `__ctx.globals`.
+
+Each module exports a small `__getStaticState()` helper:
+
+```ts
+// Generated alongside the static exports.
+export function __getStaticState() { return { BASE_DIR, PATH }; }
+```
+
+Trace startup walks every loaded module (via a small registry that just enumerates known module URLs — much simpler than the full orchestrator registry) and calls `__getStaticState()` to snapshot the populated values. One trace event per module, written when the first run starts.
+
+This is a smaller "registry" than #237's — it only enumerates modules for trace purposes, has no init-orchestration role, and isn't on any hot path.
+
+### 7. Per-execution `__ctx.globals` API stays the same
+
+The runtime `__ctx.globals.get`/`set`/`isInitialized`/`markInitialized` API is unchanged. It just stops being used for statics. Non-static top-level `let X` and bare per-run calls still live there. All existing usages (interrupts, rewind, checkpoints) continue to work.
+
+## What this deletes
+
+If we land the proposal, the following code becomes vestigial:
+
+- `lib/runtime/initVar.ts` (~80 lines) — the memoized async getter primitive. Node's import resolution provides the same guarantee.
+- `lib/runtime/initOrchestrator.ts` (~85 lines) — the process-global registry + getter snapshot.
+- `lib/runtime/initOrchestrator.test.ts` (~50 lines).
+- `lib/backends/typescriptBuilder/initGetterRewriter.ts` — the per-variable `__init_X` naming convention and read rewrite.
+- The per-static `__init_X = __initVar(...)` getter emit, the `__MY_INIT_GETTERS` array, and the `__initializeStatic` function in `sectionAssembler.ts`.
+- The two-phase `__initializeGlobals` body (registry walk, Phase 1 / Phase 2 loops).
+- The `__registerModule(...)` self-registration call at the bottom of every generated module.
+- The `__requireInitVar` backward-compat guard.
+- Issue #238 (cache-busted re-imports) — dissolves; no registry.
+- Issue #239 (docstring-interpolation eager init runs ALL imperatives) — dissolves; statics are already populated by the time the description literal evaluates, no eager call needed.
+- The "per-process registry leak" follow-up in `docs/dev/cross-module-init.md` — dissolves; no registry.
+- The test-only `__resetModuleRegistry()` hook and the obligation for every fixture test to call it.
+
+Net delta: **~250 LOC of runtime deleted, ~100 LOC of codegen deleted, three documented follow-ups dissolved, one whole subsystem removed.**
+
+## Things that stay
+
+- `let X` / non-static globals: per-execution, `__ctx.globals`-backed. Unchanged.
+- `__runImperatives(__ctx)` per module: per-execution imperatives. Unchanged.
+- The lazy first-call check at function entry: per-module, no orchestrator.
+- Handlers, callbacks, interrupts, rewind, checkpoints, traces: API-compatible.
+- The cross-module name resolution (handled by `import { X } from "./B"` instead of `__ctx.globals.get("X")`).
+
+## What this changes for users
+
+- **`static const X = ...` is now a real JS export.** Other JS code can `import { X } from "./foo.js"` and use it directly, without going through Agency's runtime. Plain interop.
+- **`static foo()` is new syntax.** Users opt into one-time semantics explicitly; no more `static const _ = foo()` idiom.
+- **Top-level await is now visible at the module-load level.** A `static const X = httpGet(...)` blocks `import "./foo.js"` until httpGet resolves. This is consistent with how any other ES module with top-level await works. Cold-start cost for agents with async statics is paid up front, once.
+- **Static initializers calling per-execution functions crash at module load** with a clear error. Today they silently misbehave. Loud failures > silent ones.
+- **Bare top-level calls in modules whose functions are never called from main()** still don't fire under this design — but under `static foo()` they do (because static fires at module load, not at lazy first-call). The non-static `foo()` keeps pre-#232 lazy-fire behavior. The semantic split is now clear and opt-in.
+- **Backward compatibility**: every compiled `.js` would need rebuilding. Acceptable per egonSchiele.
+
+## Open design questions
+
+### Q1. How do we mark functions as static-safe?
+
+Three options:
+- **Honest runtime crash.** Calling a non-static-safe function from static init throws when it tries to read missing per-execution state. User learns by experience. Pro: zero spec; matches user mental model. Con: only catches bugs that exercise the bad path.
+- **Annotation on `def`.** `@static-safe def composePath(): string { ... }` opts in. Static-init contexts only allow calling annotated functions. Pro: catchable at typecheck time. Con: viral annotation requirement; existing code needs migration.
+- **Inferred from body.** Typechecker walks the def's body, sees if it touches per-execution state. Pro: zero user-facing change. Con: complex; would need to track which stdlib functions are per-execution-dependent.
+
+I'd lean toward (1) for the first version; revisit (2) or (3) if it bites.
+
+### Q2. What is the `__globalCtx` available at static init?
+
+`__globalCtx` already exists as a module-level `new RuntimeContext({...})` in every generated module. We'd reuse it. It needs to provide:
+- `cwd` (for path resolution in stdlib).
+- `env` access (for `env(...)`).
+- A handler stack (for `with approve` and similar).
+- `globals.get`/`set` for any top-level `let` that fires per-run (these still go through `__ctx`, not `__globalCtx`).
+
+What it does NOT provide: per-execution `stateStack`, per-execution `threads`, the interrupt-driven `respondToInterrupts` machinery. Functions that touch these crash honestly per Q1.
+
+### Q3. Trace timing
+
+Today the trace captures static state when `__initializeStatic` finishes (one event per module per run). Under the proposal, statics populate at module load — long before any run. We have options:
+
+- **Emit static-state events at module load**, before any per-run trace stream exists. Buffer them and prepend to the first per-run trace.
+- **Emit static-state events at the start of each per-run trace**, by walking modules and calling `__getStaticState()` per run. Slightly redundant (the values are the same across runs) but matches per-run trace shape.
+
+The second is probably cleaner for trace consumers.
+
+### Q4. What about `pkg::` imports / npm packages?
+
+Today, a `pkg::` import of an Agency package's compiled `.js` works because the consumer's codegen knows to import `__init_X` from it. Under the proposal, the package just exports plain consts; consumers import them as plain JS imports. Strictly simpler. Backward-compat with pre-proposal packages is gone (per egonSchiele), so we just rebuild.
+
+### Q5. Codegen name classifier
+
+The current name classifier distinguishes statics from non-statics inside def bodies so reads of statics become `__ctx.globals.get("X")` and reads of imported names become whatever. Under the proposal, reads of statics become plain JS identifiers (`BASE_DIR`). The classifier needs an updated rule but the change is local to one module.
+
+### Q6. What about `static let`?
+
+Today: parser rejects. Under the proposal: still reject. `static` means "set once at load, immutable across runs." `let` means "mutable." The combination is contradictory. Keep the existing rejection.
+
+### Q7. Module-load-time interrupts other than `with approve`
+
+If a user writes:
+
+```agency
+static const X = promptUser("API key?")
+```
+
+…with no `with approve` handler, what happens? The function throws an interrupt, no handler catches it, and the throw propagates out of module load. Module fails to load. Clear failure; user adds a handler or rethinks the design. Same answer as Q1.
+
+## Comparison to current architecture
+
+```diagram
+╭─────────────────────────────╮         ╭─────────────────────────────╮
+│       Current (PR #237)     │         │         Proposed            │
+├─────────────────────────────┤         ├─────────────────────────────┤
+│ static lives in __ctx.globals│         │ static lives in JS exports │
+│ __init_X memoized getters   │         │ plain ES module init        │
+│ process-global registry      │   →    │ (none)                      │
+│ __initializeGlobals          │         │ Node's module loader        │
+│ two-phase orchestrator       │         │ (none)                      │
+│ Phase 1: static, Phase 2:    │         │ statics at module load;     │
+│   imperatives across modules │         │   __runImperatives per-mod  │
+│ + backward-compat guard      │         │ + plain JS imports          │
+│ + reset-registry test hook   │         │ + (none)                    │
+│ ~750 LOC subsystem           │         │ ~50 LOC remaining           │
+╰─────────────────────────────╯         ╰─────────────────────────────╯
+```
+
+## Rollout if we do this
+
+1. **Land #237 first** (already done — it fixes the bug correctly). Get bake-in.
+2. **File the proposal as an issue** (this doc, or a summary) referencing the cross-module-init internals doc.
+3. **Implement in stages:**
+   - a. Parser: add `static foo()` statement form. Standalone change, no codegen impact yet.
+   - b. Runtime: add `__withHandler` for module-level handler frames.
+   - c. Codegen: switch `static const` emit to plain ES module export with top-level await. Reads inside def bodies become plain JS identifiers.
+   - d. Trace integration: per-module `__getStaticState()`; trace startup walks modules.
+   - e. Delete the orchestrator subsystem: `initVar.ts`, `initOrchestrator.ts`, `initGetterRewriter.ts`, the registry codegen, `__requireInitVar`, the related tests.
+   - f. Update `docs/dev/cross-module-init.md` → either deleted entirely or rewritten to "we use Node's module system."
+4. **Backward compat**: per egonSchiele, just rebuild all compiled `.js` — small enough user base.
+
+Each stage is independently shippable; the architecture only fully simplifies when all stages land.
+
+## Why this is genuinely better
+
+- **Smaller surface area.** ~700 fewer LOC, three fewer subsystems, three dissolved follow-up issues.
+- **Familiarity.** Compiles to plain ES modules. JS developers reading generated code see plain `export const X = ...`, not `__init_X = __initVar("modId:X", __init_X_compute)`.
+- **Free interop.** Any JS/TS code can `import { X } from "./agency-output.js"` and use Agency statics directly. Today they'd have to call through the Agency runtime.
+- **Loud failures.** Calling per-execution functions at static init fails loudly. Today it might silently observe stale or wrong values.
+- **No tactical complexity.** The current design has correctness-load-bearing rules that read like "markInitialized must be at the TOP of `__initializeStatic`, NOT inside `__runImperatives`." Under the proposal, those rules dissolve because the underlying machinery dissolves.
+
+## Why this might not be worth doing
+
+- **PR #237 already shipped.** The bug is fixed. The current architecture, while complex, works. Refactoring for elegance has opportunity cost.
+- **Migration cost.** Every compiled `.js` rebuilds. Snapshot fixtures regenerate. Anything depending on `__init_X` exports (the `pkg::` backward-compat guard) breaks. All manageable, but real.
+- **Discoverability of static-safe functions.** Q1 above is unresolved; the honest-crash answer might be unsatisfying once users hit it in practice.
+- **Top-level await as a hard dependency.** Locks Agency to Node 14+ (already true via `@types/node` floor, but worth re-noting).
+
+## Related
+
+- PR [#237](https://github.com/egonSchiele/agency-lang/pull/237) — the cross-module init fix this proposal would partially replace.
+- Issue [#232](https://github.com/egonSchiele/agency-lang/issues/232) — the original bug.
+- Issue [#238](https://github.com/egonSchiele/agency-lang/issues/238) — cache-busted re-imports; dissolves under this proposal.
+- Issue [#239](https://github.com/egonSchiele/agency-lang/issues/239) — docstring-interpolation eager init; dissolves under this proposal.
+- [`docs/dev/cross-module-init.md`](../../dev/cross-module-init.md) — internals doc for the current architecture; would shrink dramatically or be rewritten.
+- [`pr-237-simpler-alternative.md`](../../../pr-237-simpler-alternative.md) — a smaller intermediate refactor (drop registry/orchestrator, keep `__init_X` getters in `__ctx.globals`). Compared to this proposal, the simpler alternative is one step short of the cleanup.

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -7,6 +7,7 @@ import { cwd, env } from "std::system"
 
 import { codeSysPrompt, codeTools } from "./code.agency"
 import { researchSysPrompt, researchTools } from "./research.agency"
+import { AGENCY_AGENT_DIR } from "./shared.agency"
 
 
 /*
@@ -62,19 +63,11 @@ callback("onToolCallEnd") as data {
   }
 }
 
-// On-disk policy at `$HOME/.agency-agent/policy.json`. We duplicate the
-// home-dir computation here instead of importing `AGENCY_AGENT_DIR` from
-// `shared.agency` because Agency doesn't guarantee imported static-const
-// init runs before the importer reads it (upstream #232).
-const POLICY_FILE = "policy.json"
-def policyDir(): string {
-  const home = env("HOME")
-  if (home == null) {
-    return "./.agency-agent"
-  }
-  return "${home}/.agency-agent"
-}
-def policyPath(): string { return "${policyDir()}/${POLICY_FILE}" }
+// On-disk policy at `$HOME/.agency-agent/policy.json`. We compose the
+// path from `shared.agency`'s `AGENCY_AGENT_DIR` static const; the
+// cross-module init-order fix (#232) guarantees the value is populated
+// before this static const evaluates.
+export static const POLICY_PATH = "${AGENCY_AGENT_DIR}/policy.json"
 
 // Per-kind config driving the "approve-always-here" option. For each
 // kind we list the data fields the scoped rule should pin, plus a
@@ -141,7 +134,7 @@ node main() {
   // Bind the handler to a local var so `with handler` parses (the
   // `with` clause only accepts an identifier, not a call expression).
   const handler = cliPolicyHandler({
-    file: policyPath(),
+    file: POLICY_PATH,
     fields: ALWAYS_FIELDS,
   })
 

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -7,7 +7,6 @@ import { cwd, env } from "std::system"
 
 import { codeSysPrompt, codeTools } from "./code.agency"
 import { researchSysPrompt, researchTools } from "./research.agency"
-import { AGENCY_AGENT_DIR } from "./shared.agency"
 
 
 /*
@@ -63,11 +62,19 @@ callback("onToolCallEnd") as data {
   }
 }
 
-// On-disk policy at `$HOME/.agency-agent/policy.json`. We compose the
-// path from `shared.agency`'s `AGENCY_AGENT_DIR` static const; the
-// cross-module init-order fix (#232) guarantees the value is populated
-// before this static const evaluates.
-export static const POLICY_PATH = "${AGENCY_AGENT_DIR}/policy.json"
+// On-disk policy at `$HOME/.agency-agent/policy.json`. We duplicate the
+// home-dir computation here instead of importing `AGENCY_AGENT_DIR` from
+// `shared.agency` because Agency doesn't guarantee imported static-const
+// init runs before the importer reads it (upstream #232).
+const POLICY_FILE = "policy.json"
+def policyDir(): string {
+  const home = env("HOME")
+  if (home == null) {
+    return "./.agency-agent"
+  }
+  return "${home}/.agency-agent"
+}
+def policyPath(): string { return "${policyDir()}/${POLICY_FILE}" }
 
 // Per-kind config driving the "approve-always-here" option. For each
 // kind we list the data fields the scoped rule should pin, plus a
@@ -134,7 +141,7 @@ node main() {
   // Bind the handler to a local var so `with handler` parses (the
   // `with` clause only accepts an identifier, not a call expression).
   const handler = cliPolicyHandler({
-    file: POLICY_PATH,
+    file: policyPath(),
     fields: ALWAYS_FIELDS,
   })
 

--- a/packages/agency-lang/lib/backends/docstringInterpolationRuntime.test.ts
+++ b/packages/agency-lang/lib/backends/docstringInterpolationRuntime.test.ts
@@ -48,12 +48,17 @@ describe("doc string interpolation — runtime resolution", () => {
     );
 
     // Eager init is still emitted so the global is populated before
-    // the description template literal evaluates. The previously
+    // the description template literal evaluates. Post-#232, we call
+    // `__runImperatives` directly (not the two-phase
+    // `__initializeGlobals` shim) so the synchronous `globals.set`
+    // imperatives run sync before the description literal evaluates;
+    // the shim's first statement awaits `__initializeStatic`, which
+    // would suspend before any `globals.set` ran. The previously
     // emitted `const __ctx = __globalCtx;` top-level rebind was
     // removed — it would now shadow the `__ctx` runtime import (which
     // is a function in the post-ALS migration) and break every
     // accessor call.
-    expect(compiled).toContain("__initializeGlobals(__globalCtx);");
+    expect(compiled).toContain("__runImperatives(__globalCtx);");
   });
 
   it("evaluates the tool description to the interpolated global value at runtime", async () => {

--- a/packages/agency-lang/lib/backends/static-init-cycle.test.ts
+++ b/packages/agency-lang/lib/backends/static-init-cycle.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import path from "path";
+import fs from "fs";
+import { pathToFileURL } from "url";
+import { compile } from "@/cli/commands.js";
+
+// Verifies the runtime cycle-detection path from #232's design:
+// a `static const` whose value depends on another `static const`
+// that depends back on it triggers `__initVar`'s `running` flag at
+// re-entry and throws a "Init cycle on …" error naming the var.
+describe("static init cycle — runtime detection", () => {
+  const repoRoot = path.resolve(__dirname, "../..");
+  const agencyFile = path.join(
+    repoRoot,
+    "tests/agency/static-init-cycle/cycle-same-module.agency",
+  );
+  const jsFile = agencyFile.replace(/\.agency$/, ".js");
+
+  beforeAll(() => {
+    compile({}, agencyFile);
+  });
+
+  afterAll(() => {
+    fs.rmSync(jsFile, { force: true });
+  });
+
+  it("throws an 'Init cycle on …' error naming one of the participating vars", async () => {
+    const mod = await import(pathToFileURL(jsFile).href);
+    let caught: Error | null = null;
+    try {
+      await mod.main();
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    // The cycle is `a → b → a`, so whichever getter the orchestrator
+    // fires first names that var in the thrown error. Either `:a` or
+    // `:b` is acceptable.
+    expect(caught!.message).toMatch(
+      /Init cycle on tests\/agency\/static-init-cycle\/cycle-same-module\.agency:(a|b)\b/,
+    );
+    // Confirm the JS stack trace contains both cyclic compute frames.
+    // The codegen emits `async function __init_<X>_compute(__ctx) {…}`
+    // (a named function declaration, not an anonymous arrow) so V8's
+    // stack-frame inference picks up both names — backing the
+    // `__initVar` error message's promise that "every frame named
+    // `__init_*` is a participating variable."
+    expect(caught!.stack).toMatch(/__init_a_compute\b/);
+    expect(caught!.stack).toMatch(/__init_b_compute\b/);
+  });
+});

--- a/packages/agency-lang/lib/backends/static-init-runtime.test.ts
+++ b/packages/agency-lang/lib/backends/static-init-runtime.test.ts
@@ -3,6 +3,7 @@ import path from "path";
 import fs from "fs";
 import { pathToFileURL } from "url";
 import { compile } from "@/cli/commands.js";
+import { __resetModuleRegistry } from "@/runtime/initOrchestrator.js";
 
 // Project-local scratch dir — must live inside the workspace so the
 // generated `.js` files can resolve `agency-lang/stdlib/index.js`
@@ -43,6 +44,14 @@ async function loadFreshModule(tmpDir: string): Promise<{
   const stale = path.join(tmpDir, "main.js");
   if (fs.existsSync(stale)) fs.rmSync(stale);
   compile({}, path.join(tmpDir, "main.agency"));
+  // Reset the process-global init orchestrator registry IMMEDIATELY
+  // before importing this fixture. The registry accumulates module
+  // handles across every dynamic import in this vitest worker;
+  // without clearing it, `__getRegisteredModules()` inside the
+  // fresh module's `__initializeGlobals` would also iterate handles
+  // from prior fixtures and re-run their `__initializeStatic` /
+  // `__runImperatives`, polluting counters and traces.
+  __resetModuleRegistry();
   const mod: any = await import(pathToFileURL(path.join(tmpDir, "main.js")).href);
   const counterMod: any = await import(
     pathToFileURL(path.join(tmpDir, "counter.js")).href
@@ -152,6 +161,9 @@ describe("cross-module init — backward-compat guard for pre-fix .js modules", 
 
     let caught: Error | null = null;
     try {
+      // See note in `loadFreshModule` re: clearing the process-global
+      // init registry before importing a fresh fixture.
+      __resetModuleRegistry();
       await import(pathToFileURL(path.join(tmpDir, "main.js")).href);
     } catch (e) {
       caught = e as Error;
@@ -189,6 +201,9 @@ describe("cross-module init — trace captures populated static state", () => {
       if (fs.existsSync(p)) fs.rmSync(p);
     }
     compile({}, path.join(tmpDir, "main.agency"));
+    // See note in `loadFreshModule` re: clearing the process-global
+    // init registry before importing a fresh fixture.
+    __resetModuleRegistry();
     const mod: any = await import(
       pathToFileURL(path.join(tmpDir, "main.js")).href
     );

--- a/packages/agency-lang/lib/backends/static-init-runtime.test.ts
+++ b/packages/agency-lang/lib/backends/static-init-runtime.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import path from "path";
+import fs from "fs";
+import { pathToFileURL } from "url";
+import { compile } from "@/cli/commands.js";
+
+// Project-local scratch dir — must live inside the workspace so the
+// generated `.js` files can resolve `agency-lang/stdlib/index.js`
+// via the repo's node_modules. (`/tmp` has no node_modules.)
+const SCRATCH_ROOT = path.resolve(__dirname, "../..", ".js-tmp/static-init-runtime");
+
+beforeAll(() => {
+  fs.mkdirSync(SCRATCH_ROOT, { recursive: true });
+});
+
+// Runtime-side coverage for the cross-module init subsystem (#232).
+// Each describe block compiles a fresh module under a unique temp
+// directory so module-level memoization in `__initVar` starts from a
+// clean slate — these tests rely on observable counters that would
+// be polluted by previously-loaded module instances.
+
+const repoRoot = path.resolve(__dirname, "../..");
+const sourceDir = path.join(
+  repoRoot,
+  "tests/agency/static-init-concurrent-runs",
+);
+
+/** Copy `static-init-concurrent-runs/{main.agency, counter.js}` into a
+ *  fresh tmp dir, compile, and dynamically import. Each test gets its
+ *  OWN module instance — that's the whole point: closure-scoped
+ *  memoization in `__initVar` survives across calls to a single
+ *  imported module, but a new `import()` produces a new closure. */
+async function loadFreshModule(tmpDir: string): Promise<{
+  /** Calls the compiled module's `main()` and unwraps `.data` (the
+   *  user-visible return value; `runNode` wraps it alongside thread
+   *  / token metadata). */
+  main: () => Promise<unknown>;
+  counterRead: () => number;
+}> {
+  fs.cpSync(sourceDir, tmpDir, { recursive: true });
+  // Wipe any stale generated .js from the source dir copy so compile
+  // really runs.
+  const stale = path.join(tmpDir, "main.js");
+  if (fs.existsSync(stale)) fs.rmSync(stale);
+  compile({}, path.join(tmpDir, "main.agency"));
+  const mod: any = await import(pathToFileURL(path.join(tmpDir, "main.js")).href);
+  const counterMod: any = await import(
+    pathToFileURL(path.join(tmpDir, "counter.js")).href
+  );
+  const main = async () => (await mod.main()).data;
+  return { main, counterRead: counterMod.read };
+}
+
+describe("cross-module init — concurrent runs share memoization", () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(SCRATCH_ROOT, "init-concurrent-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("two concurrent main() calls invoke the static-init compute exactly once", async () => {
+    const { main, counterRead } = await loadFreshModule(tmpDir);
+    const [a, b] = await Promise.all([main(), main()]);
+    expect(a).toBe("init-call-1");
+    expect(b).toBe("init-call-1");
+    expect(counterRead()).toBe(1);
+  });
+
+  it("repeated sequential main() calls also share the memoized init", async () => {
+    const { main, counterRead } = await loadFreshModule(tmpDir);
+    expect(await main()).toBe("init-call-1");
+    expect(await main()).toBe("init-call-1");
+    expect(await main()).toBe("init-call-1");
+    expect(counterRead()).toBe(1);
+  });
+});
+
+describe("cross-module init — memoization persists across resume / repeat invocations", () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(SCRATCH_ROOT, "init-resume-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // We don't drive `respondToInterrupts` here — the agency-agent's
+  // resume path calls `__initializeGlobals(__ctx)` on every resume,
+  // which in turn calls each module's `__initializeStatic(__ctx)`
+  // again. The memoization invariant is that EVERY such re-call
+  // resolves to the same cached promise without re-running the
+  // compute body — same observable behavior as repeat main() calls,
+  // exercised against the SAME runtime helper code path.
+  it("calling main() many times in a row does not re-run static init", async () => {
+    const { main, counterRead } = await loadFreshModule(tmpDir);
+    // 10 sequential calls — simulating the resume codepath calling
+    // __initializeGlobals (and therefore __initializeStatic) once
+    // per resume cycle.
+    for (let i = 0; i < 10; i++) {
+      const v = await main();
+      expect(v).toBe("init-call-1");
+    }
+    // If memoization were lost between calls (the regression we
+    // worry about), the counter would equal 10 here.
+    expect(counterRead()).toBe(1);
+  });
+});
+
+describe("cross-module init — backward-compat guard for pre-fix .js modules", () => {
+  let tmpDir: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(SCRATCH_ROOT, "init-backcompat-"));
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  // Simulates a `pkg::` or relative import whose source module was
+  // compiled BEFORE this PR landed and therefore never exported
+  // `__init_X`. Importer codegen emits an import-time check; an
+  // undefined `__init_X` binding should crash with a pointed error
+  // naming the offending module rather than a generic TypeError at
+  // first use.
+  it("throws a clear 'compiled with an older agency-lang' error at module load when the dep is missing __init_X", async () => {
+    const src = path.join(
+      repoRoot,
+      "tests/agency/static-init-cross-module",
+    );
+    fs.cpSync(src, tmpDir, { recursive: true });
+    // Make sure compile actually runs (no stale .js).
+    for (const f of ["main.js", "shared.js"]) {
+      const p = path.join(tmpDir, f);
+      if (fs.existsSync(p)) fs.rmSync(p);
+    }
+    compile({}, path.join(tmpDir, "main.agency"));
+
+    // Strip every `__init_*` symbol from `shared.js` to simulate the
+    // older codegen shape: rewrite the `export { ... }` list to drop
+    // `__init_*` names, and delete the `const __init_X = __initVar(...)`
+    // declarations. (Leaving them undefined inside the exporter would
+    // be even more realistic, but stripping the export is enough to
+    // make ESM hand back `undefined` to the importer.)
+    const sharedPath = path.join(tmpDir, "shared.js");
+    let sharedSrc = fs.readFileSync(sharedPath, "utf-8");
+    sharedSrc = sharedSrc.replace(
+      /^\s*__init_[A-Za-z0-9_]+,?\s*$/gm,
+      "",
+    );
+    fs.writeFileSync(sharedPath, sharedSrc);
+
+    let caught: Error | null = null;
+    try {
+      await import(pathToFileURL(path.join(tmpDir, "main.js")).href);
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).toMatch(/older agency-lang version/);
+    expect(caught!.message).toMatch(/cross-module init export for "AGENCY_DIR"/);
+    expect(caught!.message).toMatch(/Rebuild .* with the current toolchain/);
+  });
+});
+
+describe("cross-module init — trace captures populated static state", () => {
+  let tmpDir: string;
+  let tracePath: string;
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(SCRATCH_ROOT, "init-trace-"));
+    tracePath = path.join(tmpDir, "out.agencytrace");
+  });
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("static state captured via writeStaticStateToTrace reflects the populated cross-module value", async () => {
+    // Copy the function-mediated fixture (has an importer reading a
+    // cross-module function-initialized static — closest match to
+    // the plan's "trace shows VERSION = '1.0.0' not undefined"
+    // requirement).
+    const src = path.join(
+      repoRoot,
+      "tests/agency/static-init-function-mediated",
+    );
+    fs.cpSync(src, tmpDir, { recursive: true });
+    for (const f of ["main.js", "lib.js"]) {
+      const p = path.join(tmpDir, f);
+      if (fs.existsSync(p)) fs.rmSync(p);
+    }
+    compile({}, path.join(tmpDir, "main.agency"));
+    const mod: any = await import(
+      pathToFileURL(path.join(tmpDir, "main.js")).href
+    );
+    mod.__setTraceFile(tracePath);
+    await mod.main();
+
+    // Read the trace file. The format is one JSON object per line;
+    // we only care about lines with a `staticState` field. Each
+    // module writes one such line at the end of its
+    // `__initializeStatic`.
+    const lines = fs
+      .readFileSync(tracePath, "utf-8")
+      .split("\n")
+      .filter((l) => l.trim().length > 0);
+    const staticStateLines = lines
+      .map((l) => JSON.parse(l))
+      .filter((j) => j.type === "static-state");
+    // Both `lib.agency` and `main.agency` should have written a
+    // static-state line. Confirm BASE shows as populated, not undef.
+    const allValues = staticStateLines.flatMap((j) => Object.entries(j.values));
+    const baseEntry = allValues.find(([k]) => k === "BASE");
+    expect(baseEntry).toBeDefined();
+    expect(baseEntry?.[1]).toBe("/lib/base");
+    // FULL is in main.agency's static state and must also be
+    // populated — would be "undefined/full" before the fix.
+    const fullEntry = allValues.find(([k]) => k === "FULL");
+    expect(fullEntry).toBeDefined();
+    expect(fullEntry?.[1]).toBe("/lib/base/full");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -109,6 +109,7 @@ import { StepPathTracker } from "./typescriptBuilder/stepPathTracker.js";
 import { NameClassifier } from "./typescriptBuilder/nameClassifier.js";
 import { PipeChainEmitter } from "./typescriptBuilder/pipeChainEmitter.js";
 import { AssignmentEmitter } from "./typescriptBuilder/assignmentEmitter.js";
+import { InitGetterRewriter } from "./typescriptBuilder/initGetterRewriter.js";
 import {
   assembleSections,
   partitionProgram,
@@ -168,27 +169,6 @@ function markTopLevelScopedVars<T extends TsNode>(node: T): T {
  * without a `kind` discriminator but still hold nested TsNode
  * children (e.g. `parts[i].expr` for templateLit).
  */
-/**
- * Local mirror of sectionAssembler's `unwrapStaticAssignment` for the
- * pre-scan in `build()`. Returns the var name if `node` is a top-level
- * `static const X = …` (optionally wrapped in `with handler`),
- * otherwise null. Kept here to avoid exporting the partition's
- * internal helper.
- */
-function unwrapStaticAssignmentNameForBuilder(node: AgencyNode): string | null {
-  if (node.type === "assignment" && node.scope === "static") {
-    return node.variableName;
-  }
-  if (
-    node.type === "withModifier" &&
-    node.statement.type === "assignment" &&
-    node.statement.scope === "static"
-  ) {
-    return node.statement.variableName;
-  }
-  return null;
-}
-
 function walkMarkTopLevel(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(walkMarkTopLevel);
@@ -246,43 +226,29 @@ export class TypeScriptBuilder {
   private insideGlobalInit: boolean = false;
   /**
    * Set while processing the RHS of a top-level `static const X = …`.
-   * Reads of imported top-level statics (or same-module statics) are
-   * rewritten to `await __init_<dep>(__ctx)` so the source module's
-   * getter cascade fires before the value is observed — the runtime
-   * mechanism that fixes #232. See `generateLiteral`'s `variableName`
-   * case for the rewrite site.
+   * Gates the `InitGetterRewriter` (otherwise reads from inside `def`
+   * bodies — where statics are guaranteed populated by the orchestrator
+   * — would also get the `await __init_X(__ctx)` wrap).
    */
   private insideStaticInit: boolean = false;
   /**
-   * The var currently being initialized in a static-init context.
-   * Used to avoid emitting `await __init_X(__ctx)` for a literal
-   * self-reference inside `static const X = …`. (Such self-refs
-   * either reduce to `undefined` at runtime today or are picked up
-   * as cycles by `__initVar`; either way, suppressing the rewrite
-   * for the trivially-same name keeps codegen well-defined.)
+   * The var currently being initialized in a static-init context, or
+   * null. Passed to `InitGetterRewriter.rewrite` so a literal
+   * self-reference (`static const X = X + 1`) is left alone (cycle
+   * detection in `__initVar` will catch the recursive case anyway).
    */
   private currentStaticInitVar: string | null = null;
   /**
-   * Names of `__init_X` getters that we need to `import { ... }` from
-   * other Agency modules because at least one cross-module read in a
-   * static-init context was rewritten to use them. Keyed by the local
-   * (alias-aware) name `X`; value is the source modulePath string as
-   * it appeared in the original `import` statement (so we can re-use
-   * `toCompiledImportPath` later).
+   * Single owner of the cross-module / same-module init-getter
+   * rewrite logic. Encapsulates: the rewrite-eligibility predicates,
+   * the `__init_X` naming convention, and the recorded cross-module
+   * deps that the import-emission loop in `build()` consumes.
    *
-   * Populated lazily by `generateLiteral` and consumed by
-   * `processImportStatement`, which appends `__init_X` to the
-   * generated `import { X, … }` list when it emits the statement.
+   * The builder feeds it inputs (`setOwnStaticVarNames`, passes
+   * `importedConstants` per rewrite call) but never inspects its
+   * internals — see `lib/backends/typescriptBuilder/initGetterRewriter.ts`.
    */
-  private crossModuleInitGetters: Map<string, string> = new Map();
-  /**
-   * Names of same-module statics — populated by `partitionProgram`
-   * after the pre-pass. Used by `generateLiteral` to decide whether
-   * a scope:"static" reference inside a static-init context should
-   * be rewritten to `await __init_X(__ctx)`. (Cross-module references
-   * use `compilationUnit.importedConstants` instead.)
-   */
-  private ownStaticVarNames: Set<string> = new Set();
+  private initGetters: InitGetterRewriter = new InitGetterRewriter();
 
   /*
   We break up every function and node body into steps,
@@ -444,18 +410,12 @@ export class TypeScriptBuilder {
     // Generate tool registry (empty — AgencyFunction.create() populates it)
     this.generatedStatements.push(this.generateToolRegistry());
 
-    // Pre-scan top-level static var names so `processStaticInitValue`
-    // can rewrite same-module forward references (e.g. `static const
-    // A = B + 1` where B is declared further down). The set is built
-    // again by `partitionProgram`, but partition processes value
-    // expressions inline — we need the set populated BEFORE that
-    // walk starts, or forward refs won't rewrite.
-    for (const node of program.nodes) {
-      const unwrapped = unwrapStaticAssignmentNameForBuilder(node);
-      if (unwrapped) this.ownStaticVarNames.add(unwrapped);
-    }
-
-    // Sort program nodes into static-init / global-init / top-level buckets.
+    // Sort program nodes into static-init / global-init / top-level
+    // buckets. partition collects same-module static-var names in its
+    // first pass and surfaces them via `ownStaticVarNames` BEFORE
+    // calling `processStaticInitValue` on any RHS — so forward
+    // references between statics (`static const A = B + 1` where B is
+    // declared below) rewrite correctly into init-getter calls.
     const partition = partitionProgram(program, {
       processNode: (n) => this.processNode(n),
       processNodeInGlobalInit: (n) => this.processNodeInGlobalInit(n),
@@ -464,41 +424,33 @@ export class TypeScriptBuilder {
       buildHandlerArrow: (h) => this.buildHandlerArrow(h),
       isTopLevelDeclaration: (n) => this.names.isTopLevelDeclaration(n),
       moduleId: this.moduleId,
+      onStaticVarNamesCollected: (names) =>
+        this.initGetters.setOwnStaticVarNames(names),
     });
     this.generatedStatements.push(...partition.topLevelStatements);
 
-    // Emit additional `import { __init_X } from "<dep>"` statements
-    // for every cross-module top-level static read that
-    // `generateLiteral` rewrote into a `__init_X` call. Done AFTER
-    // partition so we've fully populated `crossModuleInitGetters`
-    // before emitting. Separate `import` statements (rather than
+    // Emit one `import { __init_X } from "<dep>"` plus a
+    // `__requireInitVar(...)` module-load guard for every cross-module
+    // getter `generateLiteral` recorded on the rewriter during the
+    // partition pass. Separate `import` statements (rather than
     // appending to the existing `import { X } from "./mod.js"`) keep
-    // the emit path simple: no need to walk and mutate previously
-    // constructed TsNode import statements.
-    for (const [name, modulePath] of this.crossModuleInitGetters) {
+    // the emit path simple — no walk-and-mutate of constructed import
+    // TsNodes.
+    for (const [name, modulePath] of this.initGetters.crossModuleGetters()) {
       const compiledPath = toCompiledImportPath(
         modulePath,
         this.outputFile ?? path.resolve(this.moduleId),
       );
+      const getterName = InitGetterRewriter.getterName(name);
       this.importStatements.push(
-        ts.raw(`import { __init_${name} } from ${JSON.stringify(compiledPath)};`),
+        ts.raw(`import { ${getterName} } from ${JSON.stringify(compiledPath)};`),
       );
-      // Backward-compat guard: ES modules return `undefined` for any
-      // imported name the source module doesn't export. Without this
-      // check, the first cross-module init read at runtime would
-      // crash with a generic `TypeError: __init_X is not a function`.
-      // Module-load check fires fast at import time instead, with a
-      // pointer to the likely cause (a `pkg::` or relative import
-      // compiled by an older agency-lang that pre-dates the
-      // cross-module init export shape).
       this.importStatements.push(
-        ts.raw(
-          `if (typeof __init_${name} !== "function") throw new Error(` +
-            `${JSON.stringify(compiledPath)} + ` +
-            `${JSON.stringify(
-              ` was compiled with an older agency-lang version and is missing the cross-module init export for "${name}". Rebuild the imported module with the current toolchain (\`make\`).`,
-            )});`,
-        ),
+        ts.call(ts.id("__requireInitVar"), [
+          ts.id(getterName),
+          ts.str(name),
+          ts.str(compiledPath),
+        ]),
       );
     }
 
@@ -893,43 +845,20 @@ export class TypeScriptBuilder {
           literal.scope === "imported" || !literal.scope;
         const isBuiltinVar = BUILTIN_VARIABLES.includes(literal.value);
         const isLoopVar = this.loopVars.includes(literal.value);
-        // Rewrite reads of top-level static deps (this module's or an
-        // imported module's) into `await __init_<dep>(__ctx)` when we
-        // are emitting the RHS of a `static const`. This is the
-        // single mechanism that fixes #232 — see `__initVar` /
-        // `processStaticInitValue` docstrings for the bigger picture.
-        // The current-var guard suppresses self-reference rewrites
-        // (`static const X = X + 1`); those would cycle anyway, but
-        // emitting `__init_X` for the very binding being created
-        // would also forward-reference an undeclared symbol.
-        if (
-          this.insideStaticInit &&
-          !isBuiltinVar &&
-          !isLoopVar &&
-          literal.value !== this.currentStaticInitVar
-        ) {
-          if (literal.scope === "imported" || !literal.scope) {
-            const importedConst =
-              this.compilationUnit.importedConstants[literal.value];
-            if (importedConst) {
-              // Remember to add `__init_X` to the `import { ... }`
-              // statement when we emit imports.
-              this.crossModuleInitGetters.set(
-                literal.value,
-                importedConst.modulePath,
-              );
-              return ts.await(
-                ts.call(ts.id(`__init_${literal.value}`), [ts.id("__ctx")]),
-              );
-            }
-          } else if (
-            literal.scope === "static" &&
-            this.ownStaticVarNames.has(literal.value)
-          ) {
-            return ts.await(
-              ts.call(ts.id(`__init_${literal.value}`), [ts.id("__ctx")]),
-            );
-          }
+        // Inside a `static const X = …` RHS, top-level static reads
+        // need to await the source module's `__init_*` getter so the
+        // cross-module init cascade fires before the value is
+        // observed. The rewriter owns the rules + naming; the builder
+        // just asks "should this read rewrite?" and emits whatever
+        // the rewriter returns. Builtins and loop vars never rewrite
+        // — they can't be top-level statics.
+        if (this.insideStaticInit && !isBuiltinVar && !isLoopVar) {
+          const rewritten = this.initGetters.rewrite(
+            literal,
+            this.compilationUnit.importedConstants,
+            this.currentStaticInitVar,
+          );
+          if (rewritten) return rewritten;
         }
         if (importedOrUnknownScope || isBuiltinVar || isLoopVar) {
           return ts.id(literal.value);

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -483,6 +483,23 @@ export class TypeScriptBuilder {
       this.importStatements.push(
         ts.raw(`import { __init_${name} } from ${JSON.stringify(compiledPath)};`),
       );
+      // Backward-compat guard: ES modules return `undefined` for any
+      // imported name the source module doesn't export. Without this
+      // check, the first cross-module init read at runtime would
+      // crash with a generic `TypeError: __init_X is not a function`.
+      // Module-load check fires fast at import time instead, with a
+      // pointer to the likely cause (a `pkg::` or relative import
+      // compiled by an older agency-lang that pre-dates the
+      // cross-module init export shape).
+      this.importStatements.push(
+        ts.raw(
+          `if (typeof __init_${name} !== "function") throw new Error(` +
+            `${JSON.stringify(compiledPath)} + ` +
+            `${JSON.stringify(
+              ` was compiled with an older agency-lang version and is missing the cross-module init export for "${name}". Rebuild the imported module with the current toolchain (\`make\`).`,
+            )});`,
+        ),
+      );
     }
 
     return assembleSections({

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -168,6 +168,27 @@ function markTopLevelScopedVars<T extends TsNode>(node: T): T {
  * without a `kind` discriminator but still hold nested TsNode
  * children (e.g. `parts[i].expr` for templateLit).
  */
+/**
+ * Local mirror of sectionAssembler's `unwrapStaticAssignment` for the
+ * pre-scan in `build()`. Returns the var name if `node` is a top-level
+ * `static const X = …` (optionally wrapped in `with handler`),
+ * otherwise null. Kept here to avoid exporting the partition's
+ * internal helper.
+ */
+function unwrapStaticAssignmentNameForBuilder(node: AgencyNode): string | null {
+  if (node.type === "assignment" && node.scope === "static") {
+    return node.variableName;
+  }
+  if (
+    node.type === "withModifier" &&
+    node.statement.type === "assignment" &&
+    node.statement.scope === "static"
+  ) {
+    return node.statement.variableName;
+  }
+  return null;
+}
+
 function walkMarkTopLevel(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(walkMarkTopLevel);
@@ -223,6 +244,45 @@ export class TypeScriptBuilder {
   private loopVars: string[] = [];
   private insideHandlerBody: boolean = false;
   private insideGlobalInit: boolean = false;
+  /**
+   * Set while processing the RHS of a top-level `static const X = …`.
+   * Reads of imported top-level statics (or same-module statics) are
+   * rewritten to `await __init_<dep>(__ctx)` so the source module's
+   * getter cascade fires before the value is observed — the runtime
+   * mechanism that fixes #232. See `generateLiteral`'s `variableName`
+   * case for the rewrite site.
+   */
+  private insideStaticInit: boolean = false;
+  /**
+   * The var currently being initialized in a static-init context.
+   * Used to avoid emitting `await __init_X(__ctx)` for a literal
+   * self-reference inside `static const X = …`. (Such self-refs
+   * either reduce to `undefined` at runtime today or are picked up
+   * as cycles by `__initVar`; either way, suppressing the rewrite
+   * for the trivially-same name keeps codegen well-defined.)
+   */
+  private currentStaticInitVar: string | null = null;
+  /**
+   * Names of `__init_X` getters that we need to `import { ... }` from
+   * other Agency modules because at least one cross-module read in a
+   * static-init context was rewritten to use them. Keyed by the local
+   * (alias-aware) name `X`; value is the source modulePath string as
+   * it appeared in the original `import` statement (so we can re-use
+   * `toCompiledImportPath` later).
+   *
+   * Populated lazily by `generateLiteral` and consumed by
+   * `processImportStatement`, which appends `__init_X` to the
+   * generated `import { X, … }` list when it emits the statement.
+   */
+  private crossModuleInitGetters: Map<string, string> = new Map();
+  /**
+   * Names of same-module statics — populated by `partitionProgram`
+   * after the pre-pass. Used by `generateLiteral` to decide whether
+   * a scope:"static" reference inside a static-init context should
+   * be rewritten to `await __init_X(__ctx)`. (Cross-module references
+   * use `compilationUnit.importedConstants` instead.)
+   */
+  private ownStaticVarNames: Set<string> = new Set();
 
   /*
   We break up every function and node body into steps,
@@ -384,15 +444,46 @@ export class TypeScriptBuilder {
     // Generate tool registry (empty — AgencyFunction.create() populates it)
     this.generatedStatements.push(this.generateToolRegistry());
 
+    // Pre-scan top-level static var names so `processStaticInitValue`
+    // can rewrite same-module forward references (e.g. `static const
+    // A = B + 1` where B is declared further down). The set is built
+    // again by `partitionProgram`, but partition processes value
+    // expressions inline — we need the set populated BEFORE that
+    // walk starts, or forward refs won't rewrite.
+    for (const node of program.nodes) {
+      const unwrapped = unwrapStaticAssignmentNameForBuilder(node);
+      if (unwrapped) this.ownStaticVarNames.add(unwrapped);
+    }
+
     // Sort program nodes into static-init / global-init / top-level buckets.
     const partition = partitionProgram(program, {
       processNode: (n) => this.processNode(n),
       processNodeInGlobalInit: (n) => this.processNodeInGlobalInit(n),
+      processStaticInitValue: (varName, n) =>
+        this.processStaticInitValue(varName, n),
       buildHandlerArrow: (h) => this.buildHandlerArrow(h),
       isTopLevelDeclaration: (n) => this.names.isTopLevelDeclaration(n),
       moduleId: this.moduleId,
     });
     this.generatedStatements.push(...partition.topLevelStatements);
+
+    // Emit additional `import { __init_X } from "<dep>"` statements
+    // for every cross-module top-level static read that
+    // `generateLiteral` rewrote into a `__init_X` call. Done AFTER
+    // partition so we've fully populated `crossModuleInitGetters`
+    // before emitting. Separate `import` statements (rather than
+    // appending to the existing `import { X } from "./mod.js"`) keep
+    // the emit path simple: no need to walk and mutate previously
+    // constructed TsNode import statements.
+    for (const [name, modulePath] of this.crossModuleInitGetters) {
+      const compiledPath = toCompiledImportPath(
+        modulePath,
+        this.outputFile ?? path.resolve(this.moduleId),
+      );
+      this.importStatements.push(
+        ts.raw(`import { __init_${name} } from ${JSON.stringify(compiledPath)};`),
+      );
+    }
 
     return assembleSections({
       moduleId: this.moduleId,
@@ -404,13 +495,38 @@ export class TypeScriptBuilder {
       typeAliases: this.generatedTypeAliases,
       staticVarNames: partition.staticVarNames,
       exportedStaticVarNames: partition.exportedStaticVarNames,
-      staticInitStatements: partition.staticInitStatements,
+      staticInitVars: partition.staticInitVars,
       globalInitStatements: partition.globalInitStatements,
       topLevelCallbackStatements: partition.topLevelCallbackStatements,
       generatedStatements: this.generatedStatements,
       postprocess: this.postprocess(),
       sourceMapJson: JSON.stringify(this._sourceMapBuilder.build()),
     });
+  }
+
+  /**
+   * Process the RHS of a top-level `static const <varName> = …`,
+   * setting the flags that cause `generateLiteral` to rewrite reads
+   * of imported top-level statics (and same-module statics) into
+   * `await __init_<dep>(__ctx)` calls. Goes through
+   * `processNodeInGlobalInit` so the inner `insideGlobalInit` flag
+   * is also set (matters for some emission paths — e.g. callback
+   * arg encoding).
+   */
+  private processStaticInitValue(
+    varName: string,
+    node: AgencyNode,
+  ): TsNode {
+    const prevInside = this.insideStaticInit;
+    const prevVar = this.currentStaticInitVar;
+    this.insideStaticInit = true;
+    this.currentStaticInitVar = varName;
+    try {
+      return this.processNodeInGlobalInit(node);
+    } finally {
+      this.insideStaticInit = prevInside;
+      this.currentStaticInitVar = prevVar;
+    }
   }
 
   // ------- Node dispatch -------
@@ -760,6 +876,44 @@ export class TypeScriptBuilder {
           literal.scope === "imported" || !literal.scope;
         const isBuiltinVar = BUILTIN_VARIABLES.includes(literal.value);
         const isLoopVar = this.loopVars.includes(literal.value);
+        // Rewrite reads of top-level static deps (this module's or an
+        // imported module's) into `await __init_<dep>(__ctx)` when we
+        // are emitting the RHS of a `static const`. This is the
+        // single mechanism that fixes #232 — see `__initVar` /
+        // `processStaticInitValue` docstrings for the bigger picture.
+        // The current-var guard suppresses self-reference rewrites
+        // (`static const X = X + 1`); those would cycle anyway, but
+        // emitting `__init_X` for the very binding being created
+        // would also forward-reference an undeclared symbol.
+        if (
+          this.insideStaticInit &&
+          !isBuiltinVar &&
+          !isLoopVar &&
+          literal.value !== this.currentStaticInitVar
+        ) {
+          if (literal.scope === "imported" || !literal.scope) {
+            const importedConst =
+              this.compilationUnit.importedConstants[literal.value];
+            if (importedConst) {
+              // Remember to add `__init_X` to the `import { ... }`
+              // statement when we emit imports.
+              this.crossModuleInitGetters.set(
+                literal.value,
+                importedConst.modulePath,
+              );
+              return ts.await(
+                ts.call(ts.id(`__init_${literal.value}`), [ts.id("__ctx")]),
+              );
+            }
+          } else if (
+            literal.scope === "static" &&
+            this.ownStaticVarNames.has(literal.value)
+          ) {
+            return ts.await(
+              ts.call(ts.id(`__init_${literal.value}`), [ts.id("__ctx")]),
+            );
+          }
+        }
         if (importedOrUnknownScope || isBuiltinVar || isLoopVar) {
           return ts.id(literal.value);
         }
@@ -3307,8 +3461,24 @@ export class TypeScriptBuilder {
     // every `TsScopedVar` in the description subtree (via
     // `markTopLevelScopedVars`); the pretty-printer then emits
     // `__globalCtx.globals.get(...)` for those reads. Triggering
-    // `__initializeGlobals(__globalCtx)` eagerly populates the values
+    // `__runImperatives(__globalCtx)` eagerly populates the values
     // before the descriptions evaluate.
+    //
+    // We call `__runImperatives` directly (not the two-phase
+    // `__initializeGlobals` shim) because the docstring-interpolation
+    // contract is: only SYNCHRONOUS global-set imperatives in THIS
+    // module are observed by the description literals. The shim's
+    // first statement is `await mod.__initializeStatic(...)`, which
+    // suspends before any `globals.set` runs — making it useless for
+    // the synchronous read sequence the docstring template needs.
+    // `__runImperatives` runs the `__ctx.globals.set(...)` calls
+    // synchronously up to the first await, which is enough for the
+    // common case (literal-valued module globals).
+    //
+    // This is a fire-and-forget call (no await); we rely on JS
+    // hoisting so the call sees the `__runImperatives` declaration
+    // emitted further down the file. Function declarations are fully
+    // hoisted (both name and value).
     //
     // Previously this block also emitted `const __ctx = __globalCtx;`
     // as a module-top-level rebind so descriptions could read
@@ -3317,13 +3487,12 @@ export class TypeScriptBuilder {
     // post-ALS migration) and break every accessor call. The
     // topLevel-flagged scopedVars handle the description case directly.
     //
-    // Caveat: `__initializeGlobals` is async; for modules with
-    // `static` declarations or async global initializers, top-level
-    // interpolation may still see uninitialized values. Synchronous
-    // literal globals are populated before the function returns.
+    // Caveat: any `static` declarations or async global initializers
+    // still won't be populated before the description literals
+    // evaluate — same caveat as the pre-#232 design.
     if (this.hasDocStringInterpolation()) {
       runtimeCtxStatements.push(
-        ts.raw(`__initializeGlobals(__globalCtx);`),
+        ts.raw(`__runImperatives(__globalCtx);`),
       );
     }
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder/initGetterRewriter.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/initGetterRewriter.ts
@@ -1,0 +1,132 @@
+import type { Literal } from "../../types.js";
+import type { TsNode } from "../../ir/tsIR.js";
+import { ts } from "../../ir/builders.js";
+
+/**
+ * Owns the codegen rules for the cross-module init-getter rewrite
+ * that fixes #232.
+ *
+ * Inside the RHS of a top-level `static const X = …` ("static-init
+ * context"), every read of a top-level static — same-module or
+ * imported — must be rewritten from a bare identifier into a call to
+ * the source module's memoized getter:
+ *
+ *     X            →   await __init_X(__ctx)
+ *
+ * This class is the single source of truth for:
+ *
+ *   1. The `__init_<name>` naming convention.
+ *   2. The two rewrite-eligibility predicates (same-module static vs
+ *      cross-module imported static).
+ *   3. The set of cross-module getters that need an additional
+ *      `import { __init_X } from "<dep>"` emitted at the top of the
+ *      generated module.
+ *
+ * Lifecycle:
+ *
+ *   const rewriter = new InitGetterRewriter();
+ *   rewriter.setOwnStaticVarNames(names);     // before any rewrite
+ *   const node = rewriter.rewrite(literal, importedConstants, currentVar);
+ *   if (node) return node;                    // rewrite hit
+ *   ...
+ *   for (const [name, modulePath] of rewriter.crossModuleGetters()) {
+ *     // emit `import { __init_${name} } from "${compiled(modulePath)}"`
+ *     // and one `__requireInitVar(...)` validation call
+ *   }
+ *
+ * The class deliberately holds NO references to the builder, the
+ * compilation unit, or the program AST. Inputs come in as method
+ * args. That makes the rewrite logic easy to unit-test in isolation
+ * and removes a layer of order-dependent mutable state from the
+ * builder.
+ */
+export type ImportedConstantInfo = {
+  /** Original import-path string (`"./shared.agency"`) as it appeared
+   *  in the source. Resolved to a `.js` compiled path at emission
+   *  time, NOT here. */
+  modulePath: string;
+};
+
+export class InitGetterRewriter {
+  /** Same-module top-level `static const` names. Populated once via
+   *  `setOwnStaticVarNames` before any rewrite call. */
+  private ownStaticVarNames: ReadonlySet<string> = new Set();
+
+  /** Cross-module getters that have been used at least once. Keyed by
+   *  local (alias-aware) name; value is the original modulePath
+   *  string. Codegen iterates this after all rewrites to emit one
+   *  `import { __init_X } from "<dep>"` per entry. */
+  private readonly crossModuleGetters_: Map<string, string> = new Map();
+
+  setOwnStaticVarNames(names: ReadonlySet<string>): void {
+    this.ownStaticVarNames = names;
+  }
+
+  /**
+   * Decide whether `literal` (a `variableName` Literal) inside a
+   * static-init context should be rewritten to an `__init_*` call,
+   * and return the rewritten IR node if so. Returns `null` when no
+   * rewrite applies (caller emits the default identifier / scopedVar
+   * binding).
+   *
+   * `currentVar` is the name of the static currently being
+   * initialized. A read of that same name resolves to `null` here so
+   * the trivially-disallowed self-reference (`static const X = X + 1`)
+   * doesn't generate a forward-reference to its own undeclared
+   * getter; downstream `__initVar` would catch the cycle anyway, but
+   * suppressing the rewrite keeps codegen well-defined.
+   */
+  rewrite(
+    literal: Literal & { type: "variableName" },
+    importedConstants: Record<string, ImportedConstantInfo>,
+    currentVar: string | null,
+  ): TsNode | null {
+    if (literal.value === currentVar) return null;
+
+    // Imported-static branch — looked up via the compilation unit's
+    // `importedConstants` map (populated when an `import { X } from
+    // "./mod.agency"` brought a `static const X` into scope).
+    if (literal.scope === "imported" || !literal.scope) {
+      const info = importedConstants[literal.value];
+      if (!info) return null;
+      this.crossModuleGetters_.set(literal.value, info.modulePath);
+      return this.buildGetterCall(literal.value);
+    }
+
+    // Same-module-static branch.
+    if (literal.scope === "static" && this.ownStaticVarNames.has(literal.value)) {
+      return this.buildGetterCall(literal.value);
+    }
+
+    return null;
+  }
+
+  /** Iterable of cross-module getter (localName, modulePath) pairs
+   *  recorded during rewrites. Codegen consumes this AFTER all RHS
+   *  processing is done. */
+  crossModuleGetters(): ReadonlyMap<string, string> {
+    return this.crossModuleGetters_;
+  }
+
+  // ── naming convention (single source of truth) ──
+
+  /** `__init_X` — the exported getter name for a top-level static. */
+  static getterName(varName: string): string {
+    return `__init_${varName}`;
+  }
+
+  /** `__init_X_compute` — the named async function whose body runs
+   *  the static's compute. Named (not anonymous) so V8 stack traces
+   *  surface participating vars in init-cycle errors. */
+  static computeName(varName: string): string {
+    return `__init_${varName}_compute`;
+  }
+
+  // ── private ──
+
+  private buildGetterCall(varName: string): TsNode {
+    return ts.await(
+      ts.call(ts.id(InitGetterRewriter.getterName(varName)), [ts.id("__ctx")]),
+    );
+  }
+}

--- a/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
@@ -391,7 +391,7 @@ export function assembleSections(opts: AssembleSectionsOpts): TsNode {
   // module-load time (a side effect of being ES-imported). ES module
   // loading is post-order DFS over static imports, so deps register
   // before their importers — exactly the order we want
-  // `__getReachableModules` to yield for the entry-time orchestration.
+  // `__getRegisteredModules` to yield for the entry-time orchestration.
   // The exported __moduleId / __initializeStatic / __runImperatives
   // are the only Agency-side contract the orchestrator depends on.
   sections.push(
@@ -583,8 +583,6 @@ function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
 /**
  * Emit:
  *   async function __runImperatives(__ctx) {
- *     if (__ctx.globals.isInitialized(moduleId)) return;
- *     __ctx.globals.markInitialized(moduleId);
  *     …globalInitStatements   // top-level let X = expr → globals.set,
  *                             //   bare top-level calls, etc.
  *   }
@@ -596,17 +594,15 @@ function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
  * static read. (See the inline phase-invariant comment in
  * `buildInitializeGlobalsFn` below.)
  *
- * Idempotent via `globals.isInitialized` — safe to call multiple times
- * on the same execution context. The first call wins; subsequent calls
- * return early without re-running side effects.
+ * NO idempotency guard inside this function — `markInitialized` lives
+ * at the top of `__initializeStatic` instead (so the lazy first-call
+ * check at function entry short-circuits without ever calling
+ * `__runImperatives` twice for the same execCtx). The orchestrator
+ * (`__initializeGlobals`) is the single-flight caller, and it fires
+ * at most once per execCtx — re-entering `__runImperatives` outside
+ * that orchestrator would re-run side effects.
  */
 function buildRunImperativesFn(opts: AssembleSectionsOpts): TsNode {
-  // No isInitialized check / mark here: `__initializeStatic` marks
-  // this module as initialized at its top (see `buildStaticVarSetup`),
-  // which is what gates the lazy first-call init at function entry.
-  // The orchestrator that drives __runImperatives is single-flight
-  // per execCtx (only `__initializeGlobals` calls it, and that fires
-  // at most once per execCtx — see the doc on `buildInitializeGlobalsFn`).
   void opts.moduleId; // satisfies eslint; opts.moduleId not needed here
   return ts.functionDecl(
     "__runImperatives",
@@ -629,9 +625,9 @@ function buildRunImperativesFn(opts: AssembleSectionsOpts): TsNode {
  *     // re-introduce the cross-module-undefined bug this subsystem
  *     // exists to prevent (#232).
  *     // ============================
- *     const reachable = __getReachableModules();
- *     for (const mod of reachable) await mod.__initializeStatic(__ctx);
- *     for (const mod of reachable) await mod.__runImperatives(__ctx);
+ *     const registered = __getRegisteredModules();
+ *     for (const mod of registered) await mod.__initializeStatic(__ctx);
+ *     for (const mod of registered) await mod.__runImperatives(__ctx);
  *   }
  *
  * Kept as a single function so the existing callers continue to work
@@ -647,8 +643,13 @@ function buildRunImperativesFn(opts: AssembleSectionsOpts): TsNode {
  *     also still works — the shim runs both phases.
  *
  * `__initializeGlobals` does NOT mark this module as initialized
- * directly; that happens inside each module's `__runImperatives` so
- * fresh callers driving in via another entry point get the same
+ * directly. Per-module marking happens at the TOP of each module's
+ * `__initializeStatic` (see `buildStaticVarSetup`) — placed there so
+ * that function-mediated init reads (a `static const X = computeX()`
+ * where `computeX` is a top-level `def`) cannot re-enter
+ * `__initializeGlobals` via the lazy first-call check and deadlock
+ * on the in-flight `__init_X` promise. Marking up front also gives
+ * fresh callers driving in via any entry point the same per-module
  * idempotency.
  */
 function buildInitializeGlobalsFn(opts: AssembleSectionsOpts): TsNode {
@@ -658,24 +659,24 @@ function buildInitializeGlobalsFn(opts: AssembleSectionsOpts): TsNode {
   // would read from ALS instead of the parameter).
   const ctxParam = ts.id("__ctx");
   const body: TsNode[] = [
-    ts.constDecl("__reachable", ts.call(ts.id("__getReachableModules"), [])),
-    // Phase 1: every reachable module's static phase. Each module's
+    ts.constDecl("__registered", ts.call(ts.id("__getRegisteredModules"), [])),
+    // Phase 1: every registered module's static phase. Each module's
     // __initializeStatic iterates __MY_INIT_GETTERS sequentially; the
     // per-var getters cascade through their deps via inline awaits.
     // Memoization in __initVar makes redundant calls free.
     ts.forOf(
       "mod",
-      ts.id("__reachable"),
+      ts.id("__registered"),
       ts.awaitMethodCall(ts.id("mod"), "__initializeStatic", [ctxParam]),
     ),
-    // Phase 2: every reachable module's top-level imperative
+    // Phase 2: every registered module's top-level imperative
     // statements, in import order. IMPORTANT: sequential for-await —
     // DO NOT switch to Promise.all (breaks trace/checkpoint replay
     // determinism, AND breaks the phase invariant if any Promise.all
     // entry resolves before another).
     ts.forOf(
       "mod",
-      ts.id("__reachable"),
+      ts.id("__registered"),
       ts.awaitMethodCall(ts.id("mod"), "__runImperatives", [ctxParam]),
     ),
   ];

--- a/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
@@ -24,9 +24,43 @@ import { ts } from "../../ir/builders.js";
 export type PartitionDeps = {
   processNode: (node: AgencyNode) => TsNode;
   processNodeInGlobalInit: (node: AgencyNode) => TsNode;
+  /**
+   * Process the RHS of a `static const X = …` declaration in a
+   * static-init context. The callback is responsible for:
+   *  - Marking codegen state so reads of imported / same-module top
+   *    level statics inside the value expression are rewritten to
+   *    `await __init_<dep>(__ctx)` (the getter cascade that fixes the
+   *    cross-module init ordering bug #232).
+   *  - Restoring codegen state on return (try/finally).
+   * The `varName` arg is the var currently being initialized — used by
+   * the rewriter to avoid emitting a self-call for the trivially-cyclic
+   * (and therefore disallowed) case of `static const X = X + 1`.
+   */
+  processStaticInitValue: (varName: string, node: AgencyNode) => TsNode;
   buildHandlerArrow: (handlerName: string) => TsNode;
   isTopLevelDeclaration: (node: AgencyNode) => boolean;
   moduleId: string;
+};
+
+/**
+ * Compiled per-variable init spec. One produced per top-level
+ * `static const`. The codegen turns this into:
+ *
+ *   let X;            // or `export let X;` if `exported`
+ *   const __init_X = __initVar("<moduleId>:X", async (__ctx) => {
+ *     ...computeBody  // typically: X = __deepFreeze(<rewritten rhs>); return X;
+ *   });
+ *
+ * The compute body owns both the assignment to the module-level `let`
+ * AND the `return` of the value (so callers of `__init_X` get the
+ * populated value back). Putting the assignment + return inside the
+ * same closure means concurrent callers all observe the same final
+ * value because `__initVar` memoizes on its compute's promise.
+ */
+export type InitVarSpec = {
+  varName: string;
+  exported: boolean;
+  computeBody: TsNode[];
 };
 
 export type ProgramPartition = {
@@ -34,8 +68,13 @@ export type ProgramPartition = {
   staticVarNames: Set<string>;
   /** Subset of `staticVarNames` that are `export`-ed. */
   exportedStaticVarNames: Set<string>;
-  /** Statements that initialize static variables, run once. */
-  staticInitStatements: TsNode[];
+  /**
+   * Per-variable init specs in source declaration order. Source order
+   * does NOT determine init order at runtime — the getter cascade does
+   * — but it's the order they'll appear in `__MY_INIT_GETTERS`, which
+   * pins iteration order for trace/checkpoint replay determinism.
+   */
+  staticInitVars: InitVarSpec[];
   /** Statements that initialize global variables / run top-level code per execution. */
   globalInitStatements: TsNode[];
   /** Top-level declarations (functions, graph nodes, type aliases, classes). */
@@ -81,7 +120,7 @@ export function partitionProgram(
 ): ProgramPartition {
   const staticVarNames = new Set<string>();
   const exportedStaticVarNames = new Set<string>();
-  const staticInitStatements: TsNode[] = [];
+  const staticInitVars: InitVarSpec[] = [];
   const globalInitStatements: TsNode[] = [];
   const topLevelStatements: TsNode[] = [];
   const topLevelCallbackStatements: TsNode[] = [];
@@ -98,16 +137,23 @@ export function partitionProgram(
       staticVarNames.add(stmt.variableName);
       if (stmt.exported) exportedStaticVarNames.add(stmt.variableName);
 
-      const valueNode = deps.processNodeInGlobalInit(stmt.value);
+      // Process the rhs inside a static-init context so reads of
+      // imported / same-module top-level statics get rewritten to
+      // `await __init_<dep>(__ctx)` (the getter cascade — see
+      // `processStaticInitValue` docstring above).
+      const valueNode = deps.processStaticInitValue(stmt.variableName, stmt.value);
       const frozenAssign = ts.assign(
         ts.id(stmt.variableName),
         ts.call(ts.id("__deepFreeze"), [valueNode]),
       );
-      staticInitStatements.push(
-        handlerName
-          ? ts.withHandler(deps.buildHandlerArrow(handlerName), frozenAssign)
-          : frozenAssign,
-      );
+      const assignStmt = handlerName
+        ? ts.withHandler(deps.buildHandlerArrow(handlerName), frozenAssign)
+        : frozenAssign;
+      staticInitVars.push({
+        varName: stmt.variableName,
+        exported: !!stmt.exported,
+        computeBody: [assignStmt, ts.return(ts.id(stmt.variableName))],
+      });
       continue;
     }
 
@@ -168,7 +214,7 @@ export function partitionProgram(
   return {
     staticVarNames,
     exportedStaticVarNames,
-    staticInitStatements,
+    staticInitVars,
     globalInitStatements,
     topLevelStatements,
     topLevelCallbackStatements,
@@ -245,7 +291,12 @@ export type AssembleSectionsOpts = {
   typeAliases: TsNode[];
   staticVarNames: Set<string>;
   exportedStaticVarNames: Set<string>;
-  staticInitStatements: TsNode[];
+  /**
+   * Per-variable static init specs. Each spec becomes one `let X;` +
+   * `const __init_X = __initVar(...)` pair plus an entry in
+   * `__MY_INIT_GETTERS`. See {@link InitVarSpec} for the contract.
+   */
+  staticInitVars: InitVarSpec[];
   globalInitStatements: TsNode[];
   topLevelCallbackStatements: TsNode[];
   generatedStatements: TsNode[];
@@ -264,8 +315,13 @@ export type AssembleSectionsOpts = {
  *   generated builtins (template)
  *   tool registrations
  *   type aliases
- *   static-var declarations + __initializeStatic + __getStaticVars (if any)
- *   __initializeGlobals
+ *   static-var let decls + per-var __init_X getters + __MY_INIT_GETTERS
+ *     + __initializeStatic + __getStaticVars (always emitted; the
+ *     no-statics case degrades to empty array + no-op for-loop)
+ *   __runImperatives
+ *   __initializeGlobals (backward-compat shim)
+ *   __registerTopLevelCallbacks
+ *   module self-registration with the init orchestrator
  *   generated statements
  *   postprocess
  *   __sourceMap export
@@ -295,13 +351,31 @@ export function assembleSections(opts: AssembleSectionsOpts): TsNode {
     sections.push(alias);
   }
 
-  if (opts.staticVarNames.size > 0) {
-    sections.push(...buildStaticVarSetup(opts));
-  }
+  // Always emit (the no-statics case folds to `__MY_INIT_GETTERS = []`
+  // + an empty for-loop). Skipping the `if (size > 0)` guard avoids a
+  // useless special case and lets the entry orchestrator iterate
+  // unconditionally.
+  sections.push(...buildStaticVarSetup(opts));
+
+  sections.push(buildRunImperativesFn(opts));
 
   sections.push(buildInitializeGlobalsFn(opts));
 
   sections.push(buildRegisterTopLevelCallbacksFn(opts));
+
+  // Self-register with the cross-module orchestrator. This runs at
+  // module-load time (a side effect of being ES-imported). ES module
+  // loading is post-order DFS over static imports, so deps register
+  // before their importers — exactly the order we want
+  // `__getReachableModules` to yield for the entry-time orchestration.
+  // The exported __moduleId / __initializeStatic / __runImperatives
+  // are the only Agency-side contract the orchestrator depends on.
+  sections.push(
+    ts.raw(
+      `__registerModule({ __moduleId: ${JSON.stringify(opts.moduleId)}, ` +
+      `__initializeStatic, __runImperatives });`,
+    ),
+  );
 
   sections.push(ts.statements(opts.generatedStatements));
 
@@ -317,52 +391,163 @@ export function assembleSections(opts: AssembleSectionsOpts): TsNode {
 }
 
 /**
- * Emit:
- *   let __staticInitPromise = null
- *   [export] let x        ←─── one per static var
+ * Emit (per the cross-module init-order design — see
+ * `docs/superpowers/plans/2026-05-30-cross-module-init-order.md`):
+ *
+ *   [export] let x;          ←─── one per static var
+ *   const __init_x = __initVar("modId:x", async (__ctx) => {
+ *     x = __deepFreeze(<rewritten rhs>);
+ *     return x;
+ *   });
+ *   ...
+ *   export { __init_x, ... };  ←─── exported so cross-module init
+ *                                   reads can `import { __init_x }`
+ *                                   without leaking the value let
+ *                                   binding name itself.
+ *
+ *   // IMPORTANT: sequential `for await` — DO NOT switch to
+ *   // Promise.all (breaks trace/checkpoint replay determinism).
+ *   const __MY_INIT_GETTERS = [__init_x, ...];
  *   async function __initializeStatic(__ctx) {
- *     if (__staticInitPromise) return __staticInitPromise
- *     __staticInitPromise = (async () => { …staticInitStatements })()
- *     return __staticInitPromise
+ *     for (const init of __MY_INIT_GETTERS) await init(__ctx);
+ *     await __ctx.writeStaticStateToTrace(__getStaticVars());
  *   }
  *   function __getStaticVars() { return { x, … } }
  *   __globalCtx.getStaticVars = __getStaticVars;
+ *
+ * Always emitted; modules with zero statics still produce an empty
+ * `__MY_INIT_GETTERS` and a no-op `__initializeStatic` so the
+ * orchestrator can iterate without a presence check (drops the prior
+ * `if (staticVarNames.size > 0)` guard).
  */
 function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
   const out: TsNode[] = [];
-  const staticLetDecls = [...opts.staticVarNames].map((name) =>
-    opts.exportedStaticVarNames.has(name)
-      ? ts.export(ts.letDecl(name))
-      : ts.letDecl(name),
+  const ctxParam = ts.id("__ctx");
+
+  // `let X` (or `export let X`) for every static. Source order; matches
+  // the order they appear in `staticInitVars`.
+  const staticLetDecls = opts.staticInitVars.map((iv) =>
+    iv.exported ? ts.export(ts.letDecl(iv.varName)) : ts.letDecl(iv.varName),
+  );
+  if (staticLetDecls.length > 0) {
+    out.push(ts.statements(staticLetDecls));
+  }
+
+  // Per-var getter pair:
+  //   async function __init_X_compute(__ctx) { ...computeBody }
+  //   const __init_X = __initVar("modId:X", __init_X_compute);
+  //
+  // We use a NAMED function declaration for the compute (not an
+  // anonymous arrow) so V8's stack traces show `__init_X_compute`
+  // frames at every level of a cyclic / cascading init chain. The
+  // `__initVar` error message says "every frame named `__init_*` is
+  // a participating variable" — that promise only holds if the
+  // closures are actually named, which an anonymous arrow inside the
+  // `__initVar` call expression is not.
+  //
+  // The compute body owns both assignment to the module-level `let X`
+  // and returning the value, so callers awaiting __init_X get the
+  // final populated value.
+  const initVarDecls: TsNode[] = [];
+  for (const iv of opts.staticInitVars) {
+    initVarDecls.push(
+      ts.functionDecl(
+        `__init_${iv.varName}_compute`,
+        [{ name: "__ctx" }],
+        ts.statements(iv.computeBody),
+        { async: true },
+      ),
+    );
+    initVarDecls.push(
+      ts.constDecl(
+        `__init_${iv.varName}`,
+        ts.call(ts.id("__initVar"), [
+          ts.str(`${opts.moduleId}:${iv.varName}`),
+          ts.id(`__init_${iv.varName}_compute`),
+        ]),
+      ),
+    );
+  }
+  if (initVarDecls.length > 0) {
+    out.push(ts.statements(initVarDecls));
+  }
+
+  // Export the `__init_X` getters so importers can call them in their
+  // own init contexts. Done as a single `export { ... }` statement to
+  // keep the diff in generated output small and to avoid colliding
+  // with same-name `__init_X` symbols on the importing side (they
+  // import via named-aliased binding).
+  if (opts.staticInitVars.length > 0) {
+    const exportList = opts.staticInitVars
+      .map((iv) => `__init_${iv.varName}`)
+      .join(", ");
+    out.push(ts.raw(`export { ${exportList} };`));
+  }
+
+  // `__MY_INIT_GETTERS = [__init_A, __init_B, ...]`. Source-order
+  // pinning — does NOT affect correctness (the cascade handles deps)
+  // but does affect WHICH chain gets kicked off first by the
+  // orchestrator. Deterministic order keeps trace/checkpoint replays
+  // stable.
+  out.push(
+    ts.constDecl(
+      "__MY_INIT_GETTERS",
+      ts.arr(opts.staticInitVars.map((iv) => ts.id(`__init_${iv.varName}`))),
+    ),
   );
 
-  out.push(ts.statements([
-    ts.letDecl("__staticInitPromise", ts.raw("null")),
-    ...staticLetDecls,
-  ]));
-
-  // Promise-based guard: concurrent callers await the same init promise.
+  // `__initializeStatic`: sequential for-await over __MY_INIT_GETTERS.
+  // IMPORTANT: keep this sequential — `Promise.all` would break trace
+  // and checkpoint replay determinism (the order in which dep chains
+  // get fired off varies otherwise).
+  //
+  // markInitialized is called BEFORE iterating the getters so that
+  // function-mediated init reads work: a `static const X = computeX()`
+  // where `computeX` is a top-level `def` would otherwise re-enter
+  // `__initializeGlobals` via the lazy first-call init check at
+  // `typescriptBuilder.ts:~1660` and deadlock on the in-flight
+  // __init_X promise. Marking up front matches the pre-#232 design's
+  // semantics: "this module's init has started; don't re-enter it
+  // from below". The orchestrator guarantees Phase 2 (`__runImperatives`)
+  // runs for every reachable module so global-init side effects still
+  // happen even though the lazy-init check now short-circuits.
+  const initStaticBody: TsNode[] = [
+    ts.methodCall(
+      ts.prop(ctxParam, "globals"),
+      "markInitialized",
+      [ts.str(opts.moduleId)],
+    ),
+    ts.forOf(
+      "init",
+      ts.id("__MY_INIT_GETTERS"),
+      ts.await(ts.call(ts.id("init"), [ctxParam])),
+    ),
+  ];
+  // Trace capture (once per module per fresh init cycle, as before).
+  // `__initVar` memoization makes subsequent calls cheap, but we still
+  // want one trace event per module to record the populated static
+  // state.
+  if (opts.staticInitVars.length > 0) {
+    initStaticBody.push(
+      ts.awaitMethodCall(ctxParam, "writeStaticStateToTrace", [
+        ts.methodCall(ts.runtime.globalCtx, "getStaticVars"),
+      ]),
+    );
+  }
   out.push(
     ts.functionDecl(
       "__initializeStatic",
       [{ name: "__ctx" }],
-      ts.statements([
-        ts.if(
-          ts.id("__staticInitPromise"),
-          ts.return(ts.id("__staticInitPromise")),
-        ),
-        ts.assign(
-          ts.id("__staticInitPromise"),
-          ts.iife({ async: true, body: opts.staticInitStatements }),
-        ),
-        ts.return(ts.id("__staticInitPromise")),
-      ]),
+      ts.statements(initStaticBody),
       { async: true },
     ),
   );
 
+  // `__getStaticVars` + `__globalCtx.getStaticVars` registration:
+  // unchanged from the previous design. Used by the trace writer to
+  // snapshot top-level statics on each init cycle.
   const staticVarObj = ts.obj(
-    [...opts.staticVarNames].map((n) => ts.set(n, ts.id(n))),
+    opts.staticInitVars.map((iv) => ts.set(iv.varName, ts.id(iv.varName))),
   );
   out.push(ts.statements([
     ts.functionDecl("__getStaticVars", [], ts.return(staticVarObj)),
@@ -377,12 +562,74 @@ function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
 
 /**
  * Emit:
- *   async function __initializeGlobals(__ctx) {
- *     __ctx.globals.markInitialized(moduleId)
- *     [await __initializeStatic(__ctx)]  ← only if there are static vars
- *     [await __ctx.writeStaticStateToTrace(__globalCtx.getStaticVars())]
- *     …globalInitStatements
+ *   async function __runImperatives(__ctx) {
+ *     if (__ctx.globals.isInitialized(moduleId)) return;
+ *     __ctx.globals.markInitialized(moduleId);
+ *     …globalInitStatements   // top-level let X = expr → globals.set,
+ *                             //   bare top-level calls, etc.
  *   }
+ *
+ * This is the second phase of init. Static-var population is in
+ * `__initializeStatic`; imperative side effects live here so the
+ * orchestrator can fan static init across every reachable module
+ * BEFORE any imperative observes a potentially-undefined cross-module
+ * static read. (See the inline phase-invariant comment in
+ * `buildInitializeGlobalsFn` below.)
+ *
+ * Idempotent via `globals.isInitialized` — safe to call multiple times
+ * on the same execution context. The first call wins; subsequent calls
+ * return early without re-running side effects.
+ */
+function buildRunImperativesFn(opts: AssembleSectionsOpts): TsNode {
+  // No isInitialized check / mark here: `__initializeStatic` marks
+  // this module as initialized at its top (see `buildStaticVarSetup`),
+  // which is what gates the lazy first-call init at function entry.
+  // The orchestrator that drives __runImperatives is single-flight
+  // per execCtx (only `__initializeGlobals` calls it, and that fires
+  // at most once per execCtx — see the doc on `buildInitializeGlobalsFn`).
+  void opts.moduleId; // satisfies eslint; opts.moduleId not needed here
+  return ts.functionDecl(
+    "__runImperatives",
+    [{ name: "__ctx" }],
+    ts.statements(opts.globalInitStatements),
+    { async: true },
+  );
+}
+
+/**
+ * Emit:
+ *   async function __initializeGlobals(__ctx) {
+ *     // === Init phase invariant ===
+ *     // Phase 1 (all modules' __initializeStatic) MUST fully complete
+ *     // before Phase 2 (all modules' __runImperatives) begins on ANY
+ *     // module. Top-level imperatives may read static/global values
+ *     // declared in OTHER modules; those must be populated before any
+ *     // imperative anywhere observes them. Interleaving phases per
+ *     // module (or inlining a Phase-2 step into Phase 1) WILL
+ *     // re-introduce the cross-module-undefined bug this subsystem
+ *     // exists to prevent (#232).
+ *     // ============================
+ *     const reachable = __getReachableModules();
+ *     for (const mod of reachable) await mod.__initializeStatic(__ctx);
+ *     for (const mod of reachable) await mod.__runImperatives(__ctx);
+ *   }
+ *
+ * Kept as a single function so the existing callers continue to work
+ * unchanged:
+ *   - The lazy first-call init at `typescriptBuilder.ts:~1502`
+ *     (`if (!__ctx.globals.isInitialized(...)) await __initializeGlobals(...)`)
+ *     fires when any node in this module starts.
+ *   - `runtime/interrupts.ts` and `runtime/rewind.ts` call
+ *     `__initializeGlobals` on resume; `__initVar` memoization +
+ *     `globals.isInitialized` idempotency make this free on second+
+ *     invocations.
+ *   - The eager docstring-interpolation path at `typescriptBuilder.ts:~3326`
+ *     also still works — the shim runs both phases.
+ *
+ * `__initializeGlobals` does NOT mark this module as initialized
+ * directly; that happens inside each module's `__runImperatives` so
+ * fresh callers driving in via another entry point get the same
+ * idempotency.
  */
 function buildInitializeGlobalsFn(opts: AssembleSectionsOpts): TsNode {
   // Inside this function body `__ctx` is the parameter (no ALS frame
@@ -391,28 +638,32 @@ function buildInitializeGlobalsFn(opts: AssembleSectionsOpts): TsNode {
   // would read from ALS instead of the parameter).
   const ctxParam = ts.id("__ctx");
   const body: TsNode[] = [
-    // Mark this module as initialized BEFORE running init statements.
-    // This prevents infinite recursion when a global init expression
-    // calls a function defined in the same module (which would trigger
-    // __initializeGlobals again via the isInitialized check).
-    ts.methodCall(
-      ts.prop(ctxParam, "globals"),
-      "markInitialized",
-      [ts.str(opts.moduleId)],
+    ts.constDecl("__reachable", ts.call(ts.id("__getReachableModules"), [])),
+    // Phase 1: every reachable module's static phase. Each module's
+    // __initializeStatic iterates __MY_INIT_GETTERS sequentially; the
+    // per-var getters cascade through their deps via inline awaits.
+    // Memoization in __initVar makes redundant calls free.
+    ts.forOf(
+      "mod",
+      ts.id("__reachable"),
+      ts.awaitMethodCall(ts.id("mod"), "__initializeStatic", [ctxParam]),
+    ),
+    // Phase 2: every reachable module's top-level imperative
+    // statements, in import order. IMPORTANT: sequential for-await —
+    // DO NOT switch to Promise.all (breaks trace/checkpoint replay
+    // determinism, AND breaks the phase invariant if any Promise.all
+    // entry resolves before another).
+    ts.forOf(
+      "mod",
+      ts.id("__reachable"),
+      ts.awaitMethodCall(ts.id("mod"), "__runImperatives", [ctxParam]),
     ),
   ];
-
-  if (opts.staticVarNames.size > 0) {
-    body.push(
-      ts.awaitCall(ts.id("__initializeStatic"), [ctxParam]),
-      ts.awaitMethodCall(ctxParam, "writeStaticStateToTrace", [
-        ts.methodCall(ts.runtime.globalCtx, "getStaticVars"),
-      ]),
-    );
-  }
-
-  body.push(...opts.globalInitStatements);
-
+  // Reference opts.moduleId / opts.staticInitVars to keep eslint happy
+  // about the unused parameter (the moduleId is consumed indirectly
+  // via __runImperatives' own markInitialized call).
+  void opts.moduleId;
+  void opts.staticInitVars;
   return ts.functionDecl(
     "__initializeGlobals",
     [{ name: "__ctx" }],

--- a/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
@@ -1,6 +1,7 @@
 import type { AgencyNode, AgencyProgram } from "../../types.js";
 import type { TsNode } from "../../ir/tsIR.js";
 import { ts } from "../../ir/builders.js";
+import { InitGetterRewriter } from "./initGetterRewriter.js";
 
 /**
  * Two helpers for the orchestration phase of `TypeScriptBuilder.build()`:
@@ -40,6 +41,15 @@ export type PartitionDeps = {
   buildHandlerArrow: (handlerName: string) => TsNode;
   isTopLevelDeclaration: (node: AgencyNode) => boolean;
   moduleId: string;
+  /**
+   * Invoked once with the set of every same-module top-level static
+   * var name BEFORE any RHS is processed via `processStaticInitValue`.
+   * Lets the caller register names with its init-getter rewriter so
+   * forward references (`static const A = B + 1` where B is declared
+   * later) rewrite correctly. Optional: callers that don't need the
+   * rewrite (e.g. one-shot inspection of partition output) can omit it.
+   */
+  onStaticVarNamesCollected?: (names: ReadonlySet<string>) => void;
 };
 
 /**
@@ -125,6 +135,18 @@ export function partitionProgram(
   const topLevelStatements: TsNode[] = [];
   const topLevelCallbackStatements: TsNode[] = [];
 
+  // First pass: collect every same-module top-level static var name
+  // and surface them via the optional callback BEFORE any RHS is
+  // processed. Required so `processStaticInitValue` rewrites forward
+  // references between statics correctly (`static const A = B + 1`
+  // where B is declared further down). Cheap — only inspects each
+  // node's shape, never recurses into expressions.
+  for (const node of program.nodes) {
+    const staticAssign = unwrapStaticAssignment(node);
+    if (staticAssign) staticVarNames.add(staticAssign.stmt.variableName);
+  }
+  deps.onStaticVarNamesCollected?.(staticVarNames);
+
   for (const node of program.nodes) {
     if (isTopLevelCallbackCall(node)) {
       topLevelCallbackStatements.push(deps.processNodeInGlobalInit(node));
@@ -134,7 +156,9 @@ export function partitionProgram(
     const staticAssign = unwrapStaticAssignment(node);
     if (staticAssign) {
       const { stmt, handlerName } = staticAssign;
-      staticVarNames.add(stmt.variableName);
+      // `staticVarNames` was already populated in the first pass —
+      // skipping the redundant `.add()` here keeps the data flow
+      // obvious (one writer per set).
       if (stmt.exported) exportedStaticVarNames.add(stmt.variableName);
 
       // Process the rhs inside a static-init context so reads of
@@ -425,13 +449,12 @@ function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
   const ctxParam = ts.id("__ctx");
 
   // `let X` (or `export let X`) for every static. Source order; matches
-  // the order they appear in `staticInitVars`.
+  // the order they appear in `staticInitVars`. Always emitted (an
+  // empty `ts.statements([])` is a no-op — no special case needed).
   const staticLetDecls = opts.staticInitVars.map((iv) =>
     iv.exported ? ts.export(ts.letDecl(iv.varName)) : ts.letDecl(iv.varName),
   );
-  if (staticLetDecls.length > 0) {
-    out.push(ts.statements(staticLetDecls));
-  }
+  out.push(ts.statements(staticLetDecls));
 
   // Per-var getter pair:
   //   async function __init_X_compute(__ctx) { ...computeBody }
@@ -447,42 +470,35 @@ function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
   //
   // The compute body owns both assignment to the module-level `let X`
   // and returning the value, so callers awaiting __init_X get the
-  // final populated value.
+  // final populated value. Naming goes through `InitGetterRewriter`
+  // so the convention has one owner.
   const initVarDecls: TsNode[] = [];
   for (const iv of opts.staticInitVars) {
     initVarDecls.push(
       ts.functionDecl(
-        `__init_${iv.varName}_compute`,
+        InitGetterRewriter.computeName(iv.varName),
         [{ name: "__ctx" }],
         ts.statements(iv.computeBody),
         { async: true },
       ),
-    );
-    initVarDecls.push(
       ts.constDecl(
-        `__init_${iv.varName}`,
+        InitGetterRewriter.getterName(iv.varName),
         ts.call(ts.id("__initVar"), [
           ts.str(`${opts.moduleId}:${iv.varName}`),
-          ts.id(`__init_${iv.varName}_compute`),
+          ts.id(InitGetterRewriter.computeName(iv.varName)),
         ]),
       ),
     );
   }
-  if (initVarDecls.length > 0) {
-    out.push(ts.statements(initVarDecls));
-  }
+  out.push(ts.statements(initVarDecls));
 
   // Export the `__init_X` getters so importers can call them in their
-  // own init contexts. Done as a single `export { ... }` statement to
-  // keep the diff in generated output small and to avoid colliding
-  // with same-name `__init_X` symbols on the importing side (they
-  // import via named-aliased binding).
-  if (opts.staticInitVars.length > 0) {
-    const exportList = opts.staticInitVars
-      .map((iv) => `__init_${iv.varName}`)
-      .join(", ");
-    out.push(ts.raw(`export { ${exportList} };`));
-  }
+  // own init contexts. Empty `export { };` is valid ES — no guard
+  // needed.
+  const exportList = opts.staticInitVars
+    .map((iv) => InitGetterRewriter.getterName(iv.varName))
+    .join(", ");
+  out.push(ts.raw(`export { ${exportList} };`));
 
   // `__MY_INIT_GETTERS = [__init_A, __init_B, ...]`. Source-order
   // pinning — does NOT affect correctness (the cascade handles deps)
@@ -492,7 +508,11 @@ function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
   out.push(
     ts.constDecl(
       "__MY_INIT_GETTERS",
-      ts.arr(opts.staticInitVars.map((iv) => ts.id(`__init_${iv.varName}`))),
+      ts.arr(
+        opts.staticInitVars.map((iv) =>
+          ts.id(InitGetterRewriter.getterName(iv.varName)),
+        ),
+      ),
     ),
   );
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder/topLevelWith.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/topLevelWith.test.ts
@@ -32,16 +32,17 @@ describe("issue #229: top-level bare `with` modifier", () => {
     expect(() => compileSource(src)).not.toThrow();
   });
 
-  it("emits a pushHandler/popHandler wrapper inside __initializeGlobals", () => {
+  it("emits a pushHandler/popHandler wrapper inside __runImperatives", () => {
     const src = `def foo(): number { return 42 }\n` +
       `foo() with approve\n` +
       `node main() { print("ok") }\n`;
     const out = compileSource(src);
     // The wrapper uses the same `withHandler` lowering as static/global
     // init handlers. Verify both halves of the wrapper appear inside
-    // `__initializeGlobals` and that the wrapped call to `foo` sits
-    // between them.
-    const initStart = out.indexOf("async function __initializeGlobals");
+    // `__runImperatives` (the post-#232 second phase of init that
+    // contains module-level imperative side effects) and that the
+    // wrapped call to `foo` sits between them.
+    const initStart = out.indexOf("async function __runImperatives");
     expect(initStart).toBeGreaterThan(-1);
     const initBody = out.slice(initStart);
     const push = initBody.indexOf("pushHandler");

--- a/packages/agency-lang/lib/compilationUnit.ts
+++ b/packages/agency-lang/lib/compilationUnit.ts
@@ -105,6 +105,20 @@ export type CompilationUnit = {
   safeFunctions: Record<string, boolean>;
   importedFunctions: Record<string, ImportedFunctionSignature>;
   /**
+   * Local names brought in via `import { X } from "./mod.agency"` that
+   * the source module exports as `static const X = …`. Keyed by the
+   * local (alias-aware) name, value carries the original module path
+   * string from the importStatement (so the codegen can translate to
+   * a compiled .js import via `toCompiledImportPath`).
+   *
+   * The typescript builder consults this map when generating
+   * static/global init expressions: a reference to a key in this map
+   * inside a static-init context is rewritten to
+   * `await __init_<X>(__ctx)` so the source module's getter cascade
+   * runs before the read.
+   */
+  importedConstants: Record<string, { modulePath: string }>;
+  /**
    * Local names brought in by non-Agency `import { … } from "some.js"`
    * statements. We don't have signatures for these (they're JS), so they
    * live in their own bag and the typechecker treats them as untyped
@@ -152,6 +166,7 @@ export function buildCompilationUnit(
     importedNodes: [],
     importStatements: [],
     importedFunctions: {},
+    importedConstants: {},
     jsImportedNames: {},
     safeFunctions: {},
     sourceText,
@@ -257,6 +272,12 @@ export function buildCompilationUnit(
         }
         if (r.symbol.kind === "function" && r.symbol.safe) {
           unit.safeFunctions[r.localName] = true;
+        }
+        if (r.symbol.kind === "constant") {
+          // Remember the import path string from the stmt so the
+          // codegen can build an `import { __init_X } from "..."` on
+          // demand. Same alias-aware localName the user wrote.
+          unit.importedConstants[r.localName] = { modulePath: stmt.modulePath };
         }
         if (r.symbol.kind === "type") {
           unit.typeAliases.add(

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -26,6 +26,13 @@ export {
   __ctx,
   type AgencyStore,
 } from "./asyncContext.js";
+export { __initVar } from "./initVar.js";
+export {
+  __registerModule,
+  __getReachableModules,
+  __resetModuleRegistry,
+  type ModuleInitHandle,
+} from "./initOrchestrator.js";
 export { StateStack, State } from "./state/stateStack.js";
 export { GlobalStore } from "./state/globalStore.js";
 export { MessageThread } from "./state/messageThread.js";

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -29,7 +29,7 @@ export {
 export { __initVar, __requireInitVar } from "./initVar.js";
 export {
   __registerModule,
-  __getReachableModules,
+  __getRegisteredModules,
   __resetModuleRegistry,
   type ModuleInitHandle,
 } from "./initOrchestrator.js";

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -26,7 +26,7 @@ export {
   __ctx,
   type AgencyStore,
 } from "./asyncContext.js";
-export { __initVar } from "./initVar.js";
+export { __initVar, __requireInitVar } from "./initVar.js";
 export {
   __registerModule,
   __getReachableModules,

--- a/packages/agency-lang/lib/runtime/initOrchestrator.test.ts
+++ b/packages/agency-lang/lib/runtime/initOrchestrator.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  __getRegisteredModules,
+  __registerModule,
+  __resetModuleRegistry,
+  type ModuleInitHandle,
+} from "./initOrchestrator.js";
+
+function makeHandle(moduleId: string): ModuleInitHandle {
+  return {
+    __moduleId: moduleId,
+    __initializeStatic: async () => {},
+    __runImperatives: async () => {},
+  };
+}
+
+describe("__registerModule", () => {
+  beforeEach(() => {
+    __resetModuleRegistry();
+  });
+
+  it("appends new module ids in registration (DFS) order", () => {
+    __registerModule(makeHandle("a"));
+    __registerModule(makeHandle("b"));
+    __registerModule(makeHandle("c"));
+
+    expect(__getRegisteredModules().map((m) => m.__moduleId)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  it("last-write-wins: re-registering the same moduleId replaces the handles in place", () => {
+    const first = makeHandle("hot");
+    const second = makeHandle("hot");
+    __registerModule(makeHandle("before"));
+    __registerModule(first);
+    __registerModule(makeHandle("after"));
+
+    __registerModule(second); // simulates HMR / cache-bust re-import
+
+    const registered = __getRegisteredModules();
+    expect(registered.map((m) => m.__moduleId)).toEqual([
+      "before",
+      "hot",
+      "after",
+    ]);
+    // The slot still holds "hot", but the handles are the fresh ones.
+    expect(registered[1]).toBe(second);
+    expect(registered[1]).not.toBe(first);
+  });
+});

--- a/packages/agency-lang/lib/runtime/initOrchestrator.ts
+++ b/packages/agency-lang/lib/runtime/initOrchestrator.ts
@@ -12,12 +12,12 @@
  * backward-compat shim that the codegen still emits) can run the
  * two-phase init:
  *
- *   Phase 1: every reachable module's `__initializeStatic` — populates
- *            all top-level static vars (and as a side effect, any
- *            top-level `let`/`const` reads that flowed through the
- *            getter cascade).
- *   Phase 2: every reachable module's `__runImperatives` — top-level
- *            imperative side effects in import order.
+ *   Phase 1: every registered module's `__initializeStatic` —
+ *            populates all top-level static vars (and as a side
+ *            effect, any top-level `let`/`const` reads that flowed
+ *            through the getter cascade).
+ *   Phase 2: every registered module's `__runImperatives` —
+ *            top-level imperative side effects in import order.
  *
  * The phase split is the invariant: every static everywhere must be
  * populated before ANY imperative runs anywhere. Imperatives in
@@ -29,6 +29,15 @@
  * which is itself fixed by the static import graph. Sequential
  * `for await` (NOT `Promise.all`) over the registry preserves a
  * deterministic checkpoint/trace replay order.
+ *
+ * Scoping: the registry is a single process-global list, NOT scoped to
+ * a particular entry module. If a long-lived process loads multiple
+ * unrelated compiled Agency programs (or a test runner imports many
+ * fixtures back-to-back without resetting), every registered module
+ * will be visited by every subsequent `__initializeGlobals` call.
+ * Per-entry scoping would require recording dependency edges at
+ * registration time and walking only the reachable subgraph from the
+ * entry module — tracked as a follow-up.
  */
 
 export type ModuleInitHandle = {
@@ -40,9 +49,21 @@ export type ModuleInitHandle = {
 const modules: ModuleInitHandle[] = [];
 
 /**
- * Register a compiled module's init handles. Idempotent: a module that
- * gets imported by multiple parents only registers once. The first
- * registration wins (it preserves the natural import-order DFS).
+ * Register a compiled module's init handles. Idempotent on
+ * `__moduleId`: a module that gets imported by multiple parents only
+ * registers once. The FIRST registration wins (it preserves the
+ * natural import-order DFS).
+ *
+ * Caveat: if the same compiled `.js` file is dynamically imported more
+ * than once with cache-busting (query-string differs, hot reload, some
+ * test setups), each ES module instance is independent but they share
+ * the same `__moduleId`. The first instance's `__initializeStatic` and
+ * `__runImperatives` capture the let-bindings from the FIRST module
+ * instance, so subsequent instances' top-level statics will never
+ * populate even though the orchestrator iterates over the stale
+ * handles. Production code does not exercise this path; tests that
+ * recompile and reimport must call `__resetModuleRegistry()` between
+ * fixtures to keep instances isolated.
  */
 export function __registerModule(mod: ModuleInitHandle): void {
   for (const m of modules) {
@@ -51,8 +72,12 @@ export function __registerModule(mod: ModuleInitHandle): void {
   modules.push(mod);
 }
 
-/** Snapshot of the registered modules in registration (= dependency) order. */
-export function __getReachableModules(): ModuleInitHandle[] {
+/**
+ * Snapshot of every registered module in registration order. NOT
+ * scoped to "reachable from a particular entry" — see the file
+ * docstring for the scoping caveat.
+ */
+export function __getRegisteredModules(): ModuleInitHandle[] {
   return modules.slice();
 }
 

--- a/packages/agency-lang/lib/runtime/initOrchestrator.ts
+++ b/packages/agency-lang/lib/runtime/initOrchestrator.ts
@@ -49,25 +49,33 @@ export type ModuleInitHandle = {
 const modules: ModuleInitHandle[] = [];
 
 /**
- * Register a compiled module's init handles. Idempotent on
- * `__moduleId`: a module that gets imported by multiple parents only
- * registers once. The FIRST registration wins (it preserves the
- * natural import-order DFS).
+ * Register a compiled module's init handles. Last-write-wins on
+ * `__moduleId` while preserving the original DFS position:
  *
- * Caveat: if the same compiled `.js` file is dynamically imported more
- * than once with cache-busting (query-string differs, hot reload, some
- * test setups), each ES module instance is independent but they share
- * the same `__moduleId`. The first instance's `__initializeStatic` and
- * `__runImperatives` capture the let-bindings from the FIRST module
- * instance, so subsequent instances' top-level statics will never
- * populate even though the orchestrator iterates over the stale
- * handles. Production code does not exercise this path; tests that
- * recompile and reimport must call `__resetModuleRegistry()` between
- * fixtures to keep instances isolated.
+ *   - First-ever registration for a `__moduleId` appends to the
+ *     registry, pinning the import-order DFS slot.
+ *   - Subsequent registrations REPLACE the handles in-place at that
+ *     same slot.
+ *
+ * Two scenarios this matters for (both rare in production):
+ *   - Hot module replacement: the stale module's `__initializeStatic`
+ *     and `__runImperatives` close over let-bindings from the old
+ *     realm; replacing in place lets the orchestrator initialize the
+ *     fresh instance.
+ *   - Cache-busted dynamic re-imports (e.g. `import(url + "?v=" + n)`):
+ *     user intent is "use the latest version"; in-place replacement
+ *     honors that.
+ *
+ * Normal ESM behavior is unaffected — a module body only runs once
+ * per realm, so `__registerModule` is called exactly once per
+ * `__moduleId` and the first branch falls through unchanged.
  */
 export function __registerModule(mod: ModuleInitHandle): void {
-  for (const m of modules) {
-    if (m.__moduleId === mod.__moduleId) return;
+  for (let i = 0; i < modules.length; i++) {
+    if (modules[i].__moduleId === mod.__moduleId) {
+      modules[i] = mod;
+      return;
+    }
   }
   modules.push(mod);
 }

--- a/packages/agency-lang/lib/runtime/initOrchestrator.ts
+++ b/packages/agency-lang/lib/runtime/initOrchestrator.ts
@@ -1,0 +1,66 @@
+/**
+ * Cross-module init orchestrator.
+ *
+ * Each compiled Agency module calls `__registerModule(...)` at top
+ * level (as a side effect of being loaded). The registry preserves
+ * registration order, which — because ES module loading is depth-first
+ * post-order over static imports — is exactly the dependency order we
+ * want: deps before importers, entry module last.
+ *
+ * The orchestrator does NOT do init itself. It exposes the ordered
+ * list so the entry module's `__initializeGlobals` (the
+ * backward-compat shim that the codegen still emits) can run the
+ * two-phase init:
+ *
+ *   Phase 1: every reachable module's `__initializeStatic` — populates
+ *            all top-level static vars (and as a side effect, any
+ *            top-level `let`/`const` reads that flowed through the
+ *            getter cascade).
+ *   Phase 2: every reachable module's `__runImperatives` — top-level
+ *            imperative side effects in import order.
+ *
+ * The phase split is the invariant: every static everywhere must be
+ * populated before ANY imperative runs anywhere. Imperatives in
+ * module C may read a `static const X` from module B that no init
+ * expression depends on; without Phase 1 finishing first, that read
+ * would observe `undefined`.
+ *
+ * Determinism: registration order is fixed by ES module load order,
+ * which is itself fixed by the static import graph. Sequential
+ * `for await` (NOT `Promise.all`) over the registry preserves a
+ * deterministic checkpoint/trace replay order.
+ */
+
+export type ModuleInitHandle = {
+  __moduleId: string;
+  __initializeStatic: (ctx: any) => Promise<void>;
+  __runImperatives: (ctx: any) => Promise<void>;
+};
+
+const modules: ModuleInitHandle[] = [];
+
+/**
+ * Register a compiled module's init handles. Idempotent: a module that
+ * gets imported by multiple parents only registers once. The first
+ * registration wins (it preserves the natural import-order DFS).
+ */
+export function __registerModule(mod: ModuleInitHandle): void {
+  for (const m of modules) {
+    if (m.__moduleId === mod.__moduleId) return;
+  }
+  modules.push(mod);
+}
+
+/** Snapshot of the registered modules in registration (= dependency) order. */
+export function __getReachableModules(): ModuleInitHandle[] {
+  return modules.slice();
+}
+
+/**
+ * Test-only reset hook. Clears the registry so tests that load
+ * recompiled modules don't accumulate stale handles across runs.
+ * Production code MUST NOT call this.
+ */
+export function __resetModuleRegistry(): void {
+  modules.length = 0;
+}

--- a/packages/agency-lang/lib/runtime/initVar.test.ts
+++ b/packages/agency-lang/lib/runtime/initVar.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { __initVar } from "./initVar.js";
+
+describe("__initVar", () => {
+  it("runs compute exactly once across many sequential and concurrent calls", async () => {
+    let count = 0;
+    const get = __initVar<number, undefined>("X", async () => {
+      count++;
+      return 42;
+    });
+
+    const concurrent = await Promise.all(
+      Array.from({ length: 10 }, () => get(undefined)),
+    );
+    for (let i = 0; i < 10; i++) {
+      await get(undefined);
+    }
+    expect(count).toBe(1);
+    expect(concurrent.every((v) => v === 42)).toBe(true);
+  });
+
+  it("returns the same promise reference for concurrent calls", () => {
+    const get = __initVar<number, undefined>("X", async () => 1);
+    const a = get(undefined);
+    const b = get(undefined);
+    expect(a).toBe(b);
+  });
+
+  it("diamond dependency runs the shared root exactly once", async () => {
+    let dCount = 0;
+    const getD = __initVar<number, undefined>("D", async () => {
+      dCount++;
+      return 1;
+    });
+    const getB = __initVar<number, undefined>("B", async (ctx) => {
+      return (await getD(ctx)) + 10;
+    });
+    const getC = __initVar<number, undefined>("C", async (ctx) => {
+      return (await getD(ctx)) + 100;
+    });
+    const getA = __initVar<number, undefined>("A", async (ctx) => {
+      const b = await getB(ctx);
+      const c = await getC(ctx);
+      return b + c;
+    });
+
+    const a = await getA(undefined);
+    expect(a).toBe(11 + 101);
+    expect(dCount).toBe(1);
+  });
+
+  it("linear cascade resolves in dep order", async () => {
+    const getC = __initVar<number, undefined>("C", async () => 1);
+    const getB = __initVar<number, undefined>("B", async (ctx) =>
+      (await getC(ctx)) + 1,
+    );
+    const getA = __initVar<number, undefined>("A", async (ctx) =>
+      (await getB(ctx)) + 1,
+    );
+    expect(await getA(undefined)).toBe(3);
+  });
+
+  it("detects a cycle between two vars and the error names the var", async () => {
+    // Forward decls so the closures can refer to each other.
+    let getA: (ctx: undefined) => Promise<number> = null as any;
+    let getB: (ctx: undefined) => Promise<number> = null as any;
+    getA = __initVar<number, undefined>("A", async (ctx) => {
+      return (await getB(ctx)) + 1;
+    });
+    getB = __initVar<number, undefined>("B", async (ctx) => {
+      return (await getA(ctx)) + 1;
+    });
+
+    let caught: Error | null = null;
+    try {
+      await getA(undefined);
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    // The re-entry happens on A (A→B→A), so the throw names A.
+    expect(caught!.message).toMatch(/Init cycle on A\b/);
+  });
+
+  it("detects a self-cycle", async () => {
+    let getA: (ctx: undefined) => Promise<number> = null as any;
+    getA = __initVar<number, undefined>("A", async (ctx) => {
+      return (await getA(ctx)) + 1;
+    });
+
+    let caught: Error | null = null;
+    try {
+      await getA(undefined);
+    } catch (e) {
+      caught = e as Error;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught!.message).toMatch(/Init cycle on A\b/);
+  });
+
+  it("propagates async rejection and caches the rejected promise (permanent failure)", async () => {
+    let count = 0;
+    const get = __initVar<number, undefined>("X", async () => {
+      count++;
+      throw new Error("boom");
+    });
+
+    await expect(get(undefined)).rejects.toThrow("boom");
+    // Subsequent calls return the same cached rejection — compute does
+    // NOT re-run.
+    await expect(get(undefined)).rejects.toThrow("boom");
+    await expect(get(undefined)).rejects.toThrow("boom");
+    expect(count).toBe(1);
+  });
+
+  it("handles synchronous throw inside compute before first await (resets running, caches rejection)", async () => {
+    let count = 0;
+    const get = __initVar<number, undefined>("X", async () => {
+      count++;
+      throw new Error("sync-boom");
+    });
+
+    await expect(get(undefined)).rejects.toThrow("sync-boom");
+    await expect(get(undefined)).rejects.toThrow("sync-boom");
+    expect(count).toBe(1);
+  });
+
+  it("passes context through to compute", async () => {
+    type Ctx = { tag: string };
+    let seen: Ctx | null = null;
+    const get = __initVar<string, Ctx>("X", async (ctx) => {
+      seen = ctx;
+      return ctx.tag;
+    });
+    const v = await get({ tag: "hello" });
+    expect(v).toBe("hello");
+    expect(seen).toEqual({ tag: "hello" });
+  });
+});

--- a/packages/agency-lang/lib/runtime/initVar.test.ts
+++ b/packages/agency-lang/lib/runtime/initVar.test.ts
@@ -60,6 +60,14 @@ describe("__initVar", () => {
     expect(await getA(undefined)).toBe(3);
   });
 
+  // This test covers both same-module AND cross-module cycle
+  // detection — the runtime mechanism is identical regardless of
+  // whether the two getters were declared in one file or imported
+  // across files. (A cross-module integration fixture can't be
+  // written in Agency: circular .agency imports compile but crash at
+  // module load with a TDZ error from `__registerTool(...)`,
+  // unrelated to our fix. Same-module cycles via static-init-cycle/
+  // exercise the codegen + runtime path end-to-end.)
   it("detects a cycle between two vars and the error names the var", async () => {
     // Forward decls so the closures can refer to each other.
     let getA: (ctx: undefined) => Promise<number> = null as any;

--- a/packages/agency-lang/lib/runtime/initVar.ts
+++ b/packages/agency-lang/lib/runtime/initVar.ts
@@ -31,6 +31,32 @@
  * logic lives. Codegen produces pure data (a compute closure +
  * the var name for error reporting); the runtime owns the "how."
  */
+/**
+ * Validate that a cross-module `__init_X` import resolved to a real
+ * getter function. Emitted by codegen once per cross-module init
+ * import; runs at module load time so the failure mode is "module
+ * fails to load with a clear pointer at the broken dep" rather than
+ * "node runs partway, then crashes with `TypeError: __init_X is not
+ * a function` at first use."
+ *
+ * Triggered when the source module was compiled by an older
+ * agency-lang that pre-dates the cross-module init export shape, or
+ * when a `pkg::` import points to an Agency package whose published
+ * `.js` files are stale.
+ */
+export function __requireInitVar(
+  fn: unknown,
+  varName: string,
+  modulePath: string,
+): void {
+  if (typeof fn === "function") return;
+  throw new Error(
+    `${modulePath} was compiled with an older agency-lang version and ` +
+      `is missing the cross-module init export for "${varName}". ` +
+      "Rebuild the imported module with the current toolchain (`make`).",
+  );
+}
+
 export function __initVar<T, Ctx>(
   varName: string,
   compute: (ctx: Ctx) => Promise<T>,

--- a/packages/agency-lang/lib/runtime/initVar.ts
+++ b/packages/agency-lang/lib/runtime/initVar.ts
@@ -1,0 +1,71 @@
+/**
+ * Build a memoized async getter for one top-level static or global
+ * variable. The returned function:
+ *
+ *   1. On synchronous re-entry while compute's sync prefix is still
+ *      running → throw with the var name. This is the cycle-detection
+ *      path. JS async functions run synchronously up to the first
+ *      `await`; the codegen places cross-module init reads
+ *      (`await __init_X(__ctx)`) at the head of compute bodies, so a
+ *      cyclic dependency chain re-enters the original `__init_X`
+ *      synchronously and hits the `running` flag BEFORE any await
+ *      suspends.
+ *   2. On subsequent calls after compute's sync prefix has returned a
+ *      promise → return the memoized promise. Compute runs exactly
+ *      once. (`running` is reset as soon as `compute(ctx)` returns its
+ *      promise — purely-outside concurrent callers do NOT trip the
+ *      cycle detector because they only re-enter after compute has
+ *      yielded on its first await.)
+ *   3. The compute body itself awaits its OWN deps via other
+ *      `__init_*` calls — the cascade encodes the dep DAG without a
+ *      centralized topological sort.
+ *
+ * Failure semantics: PERMANENT FAILURE. If `compute` rejects, the
+ * rejected promise is cached and returned on every subsequent call.
+ * Re-attempting an init that already failed is a footgun — once a
+ * top-level value's compute body throws, every consumer of that value
+ * sees the same diagnosable error rather than racing into different
+ * partial-init states.
+ *
+ * This is the only place in the codebase where init orchestration
+ * logic lives. Codegen produces pure data (a compute closure +
+ * the var name for error reporting); the runtime owns the "how."
+ */
+export function __initVar<T, Ctx>(
+  varName: string,
+  compute: (ctx: Ctx) => Promise<T>,
+): (ctx: Ctx) => Promise<T> {
+  let running = false;
+  let p: Promise<T> | null = null;
+  return (ctx) => {
+    // Order matters: check `running` BEFORE the memoized promise.
+    // During cyclic re-entry both `running` is true and `p` is null
+    // (we set running before assigning p), so this branch fires first.
+    if (running) {
+      throw new Error(
+        `Init cycle on ${varName}. The dependency chain that led here ` +
+        `appears in the JS stack trace above (every frame named ` +
+        `\`__init_*\` is a participating variable). To fix, restructure ` +
+        `so the dependency is not circular — typically by moving one of ` +
+        `the values into a \`def\` that runs after initialization.`,
+      );
+    }
+    if (p) return p;
+    running = true;
+    // compute is async — calling it executes its sync prefix and
+    // returns a Promise. The sync prefix is the cycle-detection
+    // window: any `__init_*` re-entry that happens here lands while
+    // `running` is still true. As soon as compute's prefix yields on
+    // its first await, the call below returns and we drop `running`
+    // back to false so external concurrent callers don't trip the
+    // detector.
+    let computePromise: Promise<T>;
+    try {
+      computePromise = compute(ctx);
+    } finally {
+      running = false;
+    }
+    p = computePromise;
+    return p;
+  };
+}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -29,7 +29,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -28,6 +28,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -27,6 +27,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,

--- a/packages/agency-lang/tests/agency/global-let-cross-module/bar.agency
+++ b/packages/agency-lang/tests/agency/global-let-cross-module/bar.agency
@@ -1,0 +1,6 @@
+// Source-module side of the global-let cross-module test. Exports a
+// `static const` (the only top-level value Agency permits exporting).
+// The importing module's top-level `const Y = X` is a *global* on
+// the importer side — codegen routes Y through __ctx.globals.set/get,
+// distinct from X's module-level `let` binding.
+export static const X = "/global/x"

--- a/packages/agency-lang/tests/agency/global-let-cross-module/main.agency
+++ b/packages/agency-lang/tests/agency/global-let-cross-module/main.agency
@@ -1,0 +1,13 @@
+import { X } from "./bar.agency"
+
+// Top-level `const Y` in the importer (NOT `static const`) reads a
+// cross-module value. Y becomes a *global* on the importer side —
+// codegen lowers reads to `__ctx.globals.get(...)` and the init
+// writes via `__ctx.globals.set(...)`. The cross-module init fix
+// has to make sure the cascade hits this global-flavored init path
+// the same way it hits a same-module-static path.
+const Y = "${X}/y"
+
+node main() {
+  return Y
+}

--- a/packages/agency-lang/tests/agency/global-let-cross-module/main.test.json
+++ b/packages/agency-lang/tests/agency/global-let-cross-module/main.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Importer's top-level `const Y` (a *global*) reads an imported `static const X`. Y's compute goes through __ctx.globals.set; the read in `node main` goes through __ctx.globals.get. Exercises the cross-module init cascade through the global-flavored codegen path.",
+      "expectedOutput": "\"/global/x/y\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/static-init-concurrent-runs/counter.js
+++ b/packages/agency-lang/tests/agency/static-init-concurrent-runs/counter.js
@@ -1,0 +1,16 @@
+// JS-side counter for the concurrent-runs test. The Agency module's
+// static const is computed from this counter. Concurrent `main()`
+// calls (and repeated sequential calls in the same process) must
+// see the counter at exactly 1, since `__initVar`'s memoization
+// caches the in-flight promise across all callers.
+let __count = 0;
+export function bump() {
+  __count++;
+  return __count;
+}
+export function read() {
+  return __count;
+}
+export function reset() {
+  __count = 0;
+}

--- a/packages/agency-lang/tests/agency/static-init-concurrent-runs/main.agency
+++ b/packages/agency-lang/tests/agency/static-init-concurrent-runs/main.agency
@@ -1,0 +1,11 @@
+import { bump } from "./counter.js"
+
+// Single `static const` whose value records the JS-side counter at
+// init time. Used by `static-init-concurrent-runs.test.ts` to verify
+// that concurrent `main()` invocations (and sequential repeats) all
+// share the same memoized init — the counter must read 1, not 2+.
+static const RECORDED = "init-call-${bump()}"
+
+node main() {
+  return RECORDED
+}

--- a/packages/agency-lang/tests/agency/static-init-cross-module-diamond/counter.js
+++ b/packages/agency-lang/tests/agency/static-init-cross-module-diamond/counter.js
@@ -1,0 +1,8 @@
+let __count = 0;
+export function bump() {
+  __count++;
+  return __count;
+}
+export function read() {
+  return __count;
+}

--- a/packages/agency-lang/tests/agency/static-init-cross-module-diamond/left.agency
+++ b/packages/agency-lang/tests/agency/static-init-cross-module-diamond/left.agency
@@ -1,0 +1,2 @@
+import { ROOT } from "./root.agency"
+export static const LEFT = "${ROOT}/left"

--- a/packages/agency-lang/tests/agency/static-init-cross-module-diamond/main.agency
+++ b/packages/agency-lang/tests/agency/static-init-cross-module-diamond/main.agency
@@ -1,0 +1,13 @@
+import { LEFT } from "./left.agency"
+import { RIGHT } from "./right.agency"
+
+// Read both branches of the diamond in a static-init context to
+// exercise the cross-module getter cascade twice on the same `ROOT`.
+// __initVar memoization guarantees `ROOT`'s compute body runs exactly
+// once even though both __init_LEFT and __init_RIGHT each await
+// __init_ROOT.
+static const COMBINED = "${LEFT}|${RIGHT}"
+
+node main() {
+  return COMBINED
+}

--- a/packages/agency-lang/tests/agency/static-init-cross-module-diamond/main.test.json
+++ b/packages/agency-lang/tests/agency/static-init-cross-module-diamond/main.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Diamond import graph: main → {left, right} → root. Both branches' getter cascade hits __init_ROOT; __initVar memoization keeps the compute body single-execution.",
+      "expectedOutput": "\"/var/root/left|/var/root/right\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/static-init-cross-module-diamond/main.test.json
+++ b/packages/agency-lang/tests/agency/static-init-cross-module-diamond/main.test.json
@@ -3,8 +3,8 @@
     {
       "nodeName": "main",
       "input": "",
-      "description": "Diamond import graph: main → {left, right} → root. Both branches' getter cascade hits __init_ROOT; __initVar memoization keeps the compute body single-execution.",
-      "expectedOutput": "\"/var/root/left|/var/root/right\"",
+      "description": "Diamond import graph: main → {left, right} → root. Both branches' getter cascade hits __init_ROOT; __initVar memoization keeps the compute body single-execution (verified by the shared JS-side `bump()` counter: if memoization broke, ROOT would be \"root-call-2\" somewhere in the output).",
+      "expectedOutput": "\"root-call-1/left|root-call-1/right\"",
       "evaluationCriteria": [
         {
           "type": "exact"

--- a/packages/agency-lang/tests/agency/static-init-cross-module-diamond/right.agency
+++ b/packages/agency-lang/tests/agency/static-init-cross-module-diamond/right.agency
@@ -1,0 +1,2 @@
+import { ROOT } from "./root.agency"
+export static const RIGHT = "${ROOT}/right"

--- a/packages/agency-lang/tests/agency/static-init-cross-module-diamond/root.agency
+++ b/packages/agency-lang/tests/agency/static-init-cross-module-diamond/root.agency
@@ -1,11 +1,9 @@
+import { bump } from "./counter.js"
+
 // Root of a diamond import graph used by left.agency, right.agency,
 // and main.agency. Verifies that a shared dep's static const is
 // init'd exactly once when reached by both branches of the diamond.
-//
-// (The plan's original "mutual" test case had `foo` and `bar`
-// importing each other, but Agency doesn't currently support
-// circular .agency imports — the compile pipeline fails resolving
-// the second-compiled file's reference to the first one. The
-// diamond shape exercises the same getter-cascade memoization
-// without needing cyclic imports.)
-export static const ROOT = "/var/root"
+// The shared `bump()` call returns a monotonically increasing integer
+// from a JS-side module counter; if `__init_ROOT_compute` ran twice,
+// the value would be 2 (and the test's exact-match would fail).
+export static const ROOT = "root-call-${bump()}"

--- a/packages/agency-lang/tests/agency/static-init-cross-module-diamond/root.agency
+++ b/packages/agency-lang/tests/agency/static-init-cross-module-diamond/root.agency
@@ -1,0 +1,11 @@
+// Root of a diamond import graph used by left.agency, right.agency,
+// and main.agency. Verifies that a shared dep's static const is
+// init'd exactly once when reached by both branches of the diamond.
+//
+// (The plan's original "mutual" test case had `foo` and `bar`
+// importing each other, but Agency doesn't currently support
+// circular .agency imports — the compile pipeline fails resolving
+// the second-compiled file's reference to the first one. The
+// diamond shape exercises the same getter-cascade memoization
+// without needing cyclic imports.)
+export static const ROOT = "/var/root"

--- a/packages/agency-lang/tests/agency/static-init-cross-module/main.agency
+++ b/packages/agency-lang/tests/agency/static-init-cross-module/main.agency
@@ -1,0 +1,12 @@
+// Regression test for issue #232: a `static const` in this module
+// reads an imported `static const` from another module. The expected
+// value is "/tmp/agency-fixture/policy.json"; before the fix this
+// resolved to "undefined/policy.json" because the importer's static
+// init ran before the dep's.
+import { AGENCY_DIR } from "./shared.agency"
+
+export static const POLICY_DIR = "${AGENCY_DIR}/policy.json"
+
+node main() {
+  return POLICY_DIR
+}

--- a/packages/agency-lang/tests/agency/static-init-cross-module/main.test.json
+++ b/packages/agency-lang/tests/agency/static-init-cross-module/main.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Regression for #232: importer's static const that reads an imported static const must see the populated value (not 'undefined/...').",
+      "expectedOutput": "\"/tmp/agency-fixture/policy.json\"",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/static-init-cross-module/shared.agency
+++ b/packages/agency-lang/tests/agency/static-init-cross-module/shared.agency
@@ -1,0 +1,11 @@
+// Reproduces the exporting side of issue #232: a top-level
+// `static const` whose value is computed by a helper function.
+// Importers of this constant must observe the populated value, not
+// undefined, regardless of whether they read it from another
+// `static const` init expression or from a `def` body.
+
+def computeDir(): string {
+  return "/tmp/agency-fixture"
+}
+
+export static const AGENCY_DIR = computeDir()

--- a/packages/agency-lang/tests/agency/static-init-cycle/cycle-same-module.agency
+++ b/packages/agency-lang/tests/agency/static-init-cycle/cycle-same-module.agency
@@ -1,0 +1,15 @@
+// Same-module init cycle. `a` reads `b`, `b` reads `a`. The cascade
+// re-enters `__init_a` synchronously while the original call is still
+// in its sync prefix → `__initVar`'s `running` flag is true → throw.
+//
+// We can't easily build a cross-module cycle test in Agency because
+// the compile pipeline doesn't support circular .agency imports
+// (the second-compiled file's reference to the first one fails to
+// resolve). The same-module cycle exercises the same `__initVar`
+// re-entry detection logic.
+static const a = b + 1
+static const b = a + 1
+
+node main() {
+  return a
+}

--- a/packages/agency-lang/tests/agency/static-init-function-mediated/lib.agency
+++ b/packages/agency-lang/tests/agency/static-init-function-mediated/lib.agency
@@ -1,0 +1,16 @@
+// `def`-mediated static init: a `static const` whose value comes from
+// a top-level function call. This is the agency-agent #232 shape —
+// `static const AGENCY_AGENT_DIR = computeAgentDir()` — and was
+// broken in two ways before the fix:
+//   1) Importer's static const reading this value saw undefined.
+//   2) The function body's lazy first-call init check could re-enter
+//      `__initializeGlobals` while the static was still computing
+//      (because nothing had been markInitialized yet), deadlocking
+//      on the in-flight `__init_AGENCY_DIR` promise.
+def computeBase(): string {
+  return "/lib/base"
+}
+
+export static const BASE = computeBase()
+
+export def echoBase(): string { return BASE }

--- a/packages/agency-lang/tests/agency/static-init-function-mediated/main.agency
+++ b/packages/agency-lang/tests/agency/static-init-function-mediated/main.agency
@@ -1,0 +1,13 @@
+import { BASE, echoBase } from "./lib.agency"
+
+// Static-const read of the imported function-mediated static. With
+// the cross-module init fix, BASE is populated via the cascade
+// (__init_BASE → compute → __call(computeBase) → "/lib/base") before
+// this static const evaluates.
+static const FULL = "${BASE}/full"
+
+// And confirm a def in the importing module that reads BASE through
+// the imported `echoBase()` function gets the same populated value.
+node main() {
+  return { full: FULL, echoed: echoBase() }
+}

--- a/packages/agency-lang/tests/agency/static-init-function-mediated/main.test.json
+++ b/packages/agency-lang/tests/agency/static-init-function-mediated/main.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Function-mediated cross-module static: importing module's static const reads an exported `static const X = someFn()` from another module AND the source module's def-body read of X returns the populated value.",
+      "expectedOutput": "{\"full\":\"/lib/base/full\",\"echoed\":\"/lib/base\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/static-init-mixed-module/lib.agency
+++ b/packages/agency-lang/tests/agency/static-init-mixed-module/lib.agency
@@ -1,0 +1,2 @@
+// Source module — exports a `static const` used by the mixed module.
+export static const BASE = "/base"

--- a/packages/agency-lang/tests/agency/static-init-mixed-module/main.agency
+++ b/packages/agency-lang/tests/agency/static-init-mixed-module/main.agency
@@ -1,0 +1,39 @@
+import { BASE } from "./lib.agency"
+
+// Mixed module exercising the partition between Phase 1 (static init)
+// and Phase 2 (top-level imperatives / callback registration).
+//
+//   STATIC_VAL   — static const, reads cross-module BASE          (Phase 1)
+//   GLOBAL_VAL   — top-level const → global, reads STATIC_VAL     (Phase 1)
+//   seenValue    — global mutated by a callback registration      (Phase 1 decl, Phase 2 set when cb fires)
+//
+// The orchestration invariant: every reachable module's Phase 1
+// fully completes before any module's Phase 2 begins. The callback
+// registration itself runs in Phase 2; the callback *body* fires
+// later (when `helper()` is invoked from `main`) — by then all
+// statics and globals are guaranteed populated.
+
+static const STATIC_VAL = "${BASE}/static"
+const GLOBAL_VAL = "${STATIC_VAL}/global"
+
+let seenValue = ""
+
+def helper(): string { return "h" }
+
+callback("onFunctionStart") as data {
+  // First fire wins; subsequent fires get suppressed by the guard.
+  // We only care that *some* invocation observes GLOBAL_VAL as
+  // populated, not that EVERY invocation does.
+  if (seenValue == "") {
+    seenValue = GLOBAL_VAL
+  }
+}
+
+node main() {
+  helper()
+  return {
+    static_val: STATIC_VAL,
+    global_val: GLOBAL_VAL,
+    seen: seenValue,
+  }
+}

--- a/packages/agency-lang/tests/agency/static-init-mixed-module/main.test.json
+++ b/packages/agency-lang/tests/agency/static-init-mixed-module/main.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Mixed module: static const + top-level const (global) + top-level callback registration. Verifies the Phase 1 / Phase 2 split: all statics + globals populated before any callback registration runs, and callback bodies (fired in node execution) observe populated globals.",
+      "expectedOutput": "{\"static_val\":\"/base/static\",\"global_val\":\"/base/static/global\",\"seen\":\"/base/static/global\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -25,6 +25,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -154,6 +155,9 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/function-call-test.agency")

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -24,6 +24,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -152,12 +154,33 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/function-call-test.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "tests/debugger/function-call-test.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 
 async function __add_impl(a: any, b: number) {

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -26,7 +26,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -173,11 +173,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -25,6 +25,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -154,6 +155,9 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/if-else-test.agency")

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -26,7 +26,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -173,11 +173,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -24,6 +24,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -152,12 +154,33 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/if-else-test.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "tests/debugger/if-else-test.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 
 graph.node("main", async (__state: GraphState) => {

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -25,6 +25,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -154,6 +155,9 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/interrupt-test.agency")

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -24,6 +24,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -152,12 +154,33 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/interrupt-test.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "tests/debugger/interrupt-test.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 
 graph.node("main", async (__state: GraphState) => {

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -26,7 +26,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -173,11 +173,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -24,6 +24,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -152,12 +154,33 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/loop-test.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "tests/debugger/loop-test.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 
 graph.node("main", async (__state: GraphState) => {

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -26,7 +26,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -173,11 +173,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -25,6 +25,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -154,6 +155,9 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/loop-test.agency")

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -25,6 +25,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -154,6 +155,9 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/nested-calls-test.agency")

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -24,6 +24,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -152,12 +154,33 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/nested-calls-test.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "tests/debugger/nested-calls-test.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 
 async function __double_impl(n: number) {

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -26,7 +26,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -173,11 +173,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -26,7 +26,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -173,11 +173,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -24,6 +24,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -152,12 +154,33 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/step-test.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "tests/debugger/step-test.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 
 graph.node("main", async (__state: GraphState) => {

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -25,6 +25,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -154,6 +155,9 @@ __registerTool(values);
 __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/step-test.agency")

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("assignment.agency")

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("assignment.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "assignment.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -24,6 +24,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -136,6 +137,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("safe-function.agency")

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -23,6 +23,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -134,12 +136,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("safe-function.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "safe-function.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 
 async function __safeLookup_impl(id: string) {

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -25,7 +25,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -155,11 +155,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("simple.agency")

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("simple.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "simple.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("array.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("array.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "array.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,8 +135,18 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("arrayAndObject.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
   __ctx.globals.set("arrayAndObject.agency", "nums", [1, 2, 3, 4, 5])
   await __call(print, {
     type: "positional",
@@ -208,9 +220,19 @@ async function __initializeGlobals(__ctx) {
     args: [getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "personName")]
   })
 }
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
+}
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "arrayAndObject.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Test arrays and objects
 //  Simple array

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("arrayAndObject.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -225,11 +225,11 @@ async function __runImperatives(__ctx) {
   })
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("assignment.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("assignment.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "assignment.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("asyncAssigned.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "asyncAssigned.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __compute_impl(val: number) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("asyncAssigned.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("asyncLlm.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("asyncLlm.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "asyncLlm.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("asyncUnassigned.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "asyncUnassigned.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __append_impl(sleepTime: number, value: any) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("asyncUnassigned.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("bangParams.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("bangParams.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "bangParams.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __process_impl(data: number) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("bangReturnType.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("bangReturnType.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "bangReturnType.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __process_impl(x: number) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("bangValidation.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("bangValidation.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "bangValidation.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 const Category = z.union([z.literal("bug"), z.literal("feature"), z.literal("docs")]);
 type Category = z.infer<typeof Category>;

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("blockBasic.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("blockBasic.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "blockBasic.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __twice_impl(block: () => string) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("blockParams.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "blockParams.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __mapItems_impl(items: any[], block: (any) => any) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("blockParams.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("checkpoint-restore.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("checkpoint-restore.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "checkpoint-restore.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -155,11 +155,11 @@ async function __runImperatives(__ctx) {
   __ctx.globals.set("comments.agency", "y", `hello`)
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,14 +135,34 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("comments.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
   __ctx.globals.set("comments.agency", "x", 42)
   __ctx.globals.set("comments.agency", "y", `hello`)
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "comments.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  This is a single line comment at the top of the file
 //  Variable assignment with comment above

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("comments.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -161,11 +161,11 @@ async function __runImperatives(__ctx) {
   })
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("defaultValues.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,8 +135,18 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("defaultValues.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
   await __call(greet, {
     type: "positional",
     args: [`world`]
@@ -144,9 +156,19 @@ async function __initializeGlobals(__ctx) {
     args: [`world`, `Hi`]
   })
 }
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
+}
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "defaultValues.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -155,11 +155,11 @@ async function __runImperatives(__ctx) {
   __ctx.globals.set("docstrings.agency", "toolVersion", `2.0`)
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -136,6 +137,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("docstrings.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -60,7 +62,7 @@ const __globalCtx = new RuntimeContext({
   }
 });
 const graph = __globalCtx.graph;
-__initializeGlobals(__globalCtx);
+__runImperatives(__globalCtx);
 
 // Handler result builtins and interrupt response constructors (unified types)
 export function approve(value?: any) { return { type: "approve" as const, value }; }
@@ -134,13 +136,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("docstrings.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
   __ctx.globals.set("docstrings.agency", "toolVersion", `2.0`)
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "docstrings.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Test docstrings in functions
 async function __add_impl(a: any, b: any) {

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0001.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0001.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "euler-0001.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 1: Multiples of 3 or 5
 //  Find the sum of all the multiples of 3 or 5 below 1000.

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0002.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "euler-0002.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 2: Even Fibonacci Numbers
 //  Find the sum of the even-valued Fibonacci terms not exceeding four million.

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0002.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0003.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "euler-0003.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 3: Largest Prime Factor
 //  Find the largest prime factor of 600851475143.

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0003.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0004.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "euler-0004.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 4: Largest Palindrome Product
 //  Find the largest palindrome made from the product of two 3-digit numbers.

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0004.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0005.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0005.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "euler-0005.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 5: Smallest Multiple
 //  Find the smallest positive number evenly divisible by all numbers from 1 to 20.

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0006.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "euler-0006.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 6: Sum Square Difference
 //  Find the difference between the sum of the squares and the square of the sum

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0006.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0007.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "euler-0007.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 7: 10001st Prime
 //  Find the 10001st prime number.

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0007.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0008.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0008.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "euler-0008.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 8: Largest Product in a Series
 //  Find the thirteen adjacent digits in the 1000-digit number that have

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0009.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0009.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "euler-0009.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 9: Special Pythagorean Triplet
 //  Find the product abc where a + b + c = 1000 and a^2 + b^2 = c^2.

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0010.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "euler-0010.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Project Euler Problem 10: Summation of Primes
 //  Find the sum of all the primes below two million.

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("euler-0010.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("forLoop.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("forLoop.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "forLoop.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("function-with-types.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("function-with-types.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "function-with-types.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __add_impl(x: number, y: number) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("function.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "function.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __test_impl() {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("function.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("functionRef.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("functionRef.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "functionRef.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __greet_impl(name: string) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("genericAliasValidation.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "genericAliasValidation.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 
 async function __process_impl(c: Container<number>) {

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("genericAliasValidation.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("goto.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("goto.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "goto.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("foo", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("gotoWithArgs.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("gotoWithArgs.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "gotoWithArgs.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("greet", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("graph-node-with-types.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("graph-node-with-types.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "graph-node-with-types.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Test graph nodes with typed parameters
 graph.node("greet", async (__state: GraphState) => {

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("ifElse.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "ifElse.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("ifElse.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -37,6 +37,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -150,12 +152,33 @@ function registerTools(tools: any[]) {
 
 __registerTool(foo);
 __registerTool(foo);
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("imports.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "imports.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 
 

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -39,7 +39,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -171,11 +171,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -38,6 +38,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -152,6 +153,9 @@ function registerTools(tools: any[]) {
 
 __registerTool(foo);
 __registerTool(foo);
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("imports.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("inlineBlockBasic.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "inlineBlockBasic.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __twice_impl(block: () => string) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("inlineBlockBasic.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("inlineBlockParams.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("inlineBlockParams.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "inlineBlockParams.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __mapItems_impl(items: any[], block: (any) => any) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("input.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "input.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("input.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("interpolation.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("interpolation.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "interpolation.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("interrupt-2-deep-in-function.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("interrupt-2-deep-in-function.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "interrupt-2-deep-in-function.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __greet_impl(name: string, age: number) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("interrupt-assignment.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("interrupt-assignment.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "interrupt-assignment.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("interrupt-in-node.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("interrupt-in-node.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "interrupt-in-node.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __greet_impl(name: string, age: number) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -156,11 +156,11 @@ async function __runImperatives(__ctx) {
   })
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,15 +135,35 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("llmConfigParam.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
   __ctx.globals.set("llmConfigParam.agency", "config", {
     "model": `gemini-2.5-flash-lite`
   })
 }
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
+}
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "llmConfigParam.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("llmConfigParam.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("matchBlock.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "matchBlock.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("matchBlock.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("multiLineComment.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,13 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("multiLineComment.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
   __ctx.globals.set("multiLineComment.agency", "x", 42)
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "multiLineComment.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 
 

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
   __ctx.globals.set("multiLineComment.agency", "x", 42)
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("multipleNodes.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("multipleNodes.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "multipleNodes.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("greet", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,8 +135,18 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("namedArgs.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
   await __call(greet, {
     type: "named",
     positionalArgs: [],
@@ -151,9 +163,19 @@ async function __initializeGlobals(__ctx) {
     }
   })
 }
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
+}
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "namedArgs.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -168,11 +168,11 @@ async function __runImperatives(__ctx) {
   })
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("namedArgs.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("namedArgsReorder.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "namedArgsReorder.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET, punctuation: string | typeof __UNSET = __UNSET) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("namedArgsReorder.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("noResponseFormat.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "noResponseFormat.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("noResponseFormat.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("objectDescription.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("objectDescription.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "objectDescription.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,8 +135,18 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("optionalParams.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
   await __call(greet, {
     type: "positional",
     args: [`world`]
@@ -144,9 +156,19 @@ async function __initializeGlobals(__ctx) {
     args: [`world`, `Hi`]
   })
 }
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
+}
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "optionalParams.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __greet_impl(name: string, greeting: string | typeof __UNSET = __UNSET) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -161,11 +161,11 @@ async function __runImperatives(__ctx) {
   })
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("optionalParams.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("pipe-operator.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "pipe-operator.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __double_impl(x: number) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("pipe-operator.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("recordIndex.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "recordIndex.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Test Record<K, V> codegen, property/index access, and for-in iteration
 graph.node("main", async (__state: GraphState) => {

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("recordIndex.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("result-basic.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "result-basic.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __checkAge_impl(age: number) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("result-basic.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("result-guards.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("result-guards.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "result-guards.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __checkValue_impl(r: Result) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("returnValue.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("returnValue.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "returnValue.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("rewindCheckpoint.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("rewindCheckpoint.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "rewindCheckpoint.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -23,6 +23,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -134,12 +136,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("safe.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "safe.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 
 export default graph

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -25,7 +25,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -155,11 +155,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -24,6 +24,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -136,6 +137,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("safe.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("schemaAccess.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("schemaAccess.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "schemaAccess.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 const Category = z.union([z.literal("bug"), z.literal("feature"), z.literal("docs")]);
 type Category = z.infer<typeof Category>;

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("schemaParamInjection.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "schemaParamInjection.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 //  Verifies the schema-parameter-injection feature.
 // 

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("schemaParamInjection.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -24,6 +24,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -136,6 +137,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("setLLMClient.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -25,7 +25,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -159,11 +159,11 @@ async function __runImperatives(__ctx) {
   await setLLMClient(getRuntimeContext().ctx.globals.get("setLLMClient.agency", "client"))
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -23,6 +23,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -134,17 +136,37 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("setLLMClient.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
   __ctx.globals.set("setLLMClient.agency", "client", await __call(SimpleOpenAIClient, {
     type: "positional",
     args: []
   }))
   await setLLMClient(getRuntimeContext().ctx.globals.get("setLLMClient.agency", "client"))
 }
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
+}
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "setLLMClient.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 
 graph.node("main", async (__state: GraphState) => {

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("simple.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("simple.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "simple.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("skill.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("skill.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "skill.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("analyzeData", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("slice.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("slice.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "slice.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("sliceAssign.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "sliceAssign.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("sliceAssign.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("sourceMap.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("sourceMap.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "sourceMap.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __greet_impl(name: string) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("splat.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -171,11 +171,11 @@ async function __runImperatives(__ctx) {
   })
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,8 +135,18 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("splat.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
   __ctx.globals.set("splat.agency", "arr1", [1, 2])
   __ctx.globals.set("splat.agency", "arr2", [3, 4])
   __ctx.globals.set("splat.agency", "combined", [...getRuntimeContext().ctx.globals.get("splat.agency", "arr1"), ...getRuntimeContext().ctx.globals.get("splat.agency", "arr2")])
@@ -154,9 +166,19 @@ async function __initializeGlobals(__ctx) {
     "c": 3
   })
 }
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
+}
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "splat.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 export default graph
 export const __sourceMap = {};

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -161,11 +161,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,16 +135,20 @@ function registerTools(tools: any[]) {
   }
 }
 
-let __staticInitPromise = null;
 let foo;
+async function __init_foo_compute(__ctx) {
+  foo = __deepFreeze(1);
+  return foo;
+}
+const __init_foo = __initVar("static.agency:foo", __init_foo_compute);
+export { __init_foo };
+const __MY_INIT_GETTERS = [__init_foo];
 async function __initializeStatic(__ctx) {
-  if (__staticInitPromise) {
-    return __staticInitPromise;
+  __ctx.globals.markInitialized("static.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
   }
-  __staticInitPromise = (async () => {
-    foo = __deepFreeze(1);
-  })();
-  return __staticInitPromise;
+  await __ctx.writeStaticStateToTrace(__globalCtx.getStaticVars())
 }
 function __getStaticVars() {
   return {
@@ -150,14 +156,22 @@ function __getStaticVars() {
   };
 }
 __globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
 async function __initializeGlobals(__ctx) {
-  __ctx.globals.markInitialized("static.agency")
-  await __initializeStatic(__ctx)
-  await __ctx.writeStaticStateToTrace(__globalCtx.getStaticVars())
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "static.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("streaming.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "streaming.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("foo", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("streaming.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("string-interpolation.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "string-interpolation.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("string-interpolation.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("stringConcat.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "stringConcat.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("foo", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("stringConcat.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("threadsAndSubthreads.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("threadsAndSubthreads.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "threadsAndSubthreads.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __foo_impl() {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("typeHints.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("typeHints.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "typeHints.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("exportedTypeAlias.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("exportedTypeAlias.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "exportedTypeAlias.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 export const Color = z.union([z.literal("red"), z.literal("green"), z.literal("blue")]);
 export type Color = z.infer<typeof Color>;

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("literal.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "literal.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("literal.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("nestedTypeAlias.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "nestedTypeAlias.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 const Name = z.string();
 type Name = z.infer<typeof Name>;

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("nestedTypeAlias.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("typeAlias.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "typeAlias.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 const Coords = z.object({ "x": z.number(), "y": z.number() });
 type Coords = z.infer<typeof Coords>;

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("typeAlias.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("unitLiterals.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "unitLiterals.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("unitLiterals.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("valueAccessInterpolation.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "valueAccessInterpolation.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("valueAccessInterpolation.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("varTypes.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "varTypes.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("varTypes.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("variadic.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -157,11 +157,11 @@ async function __runImperatives(__ctx) {
   })
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,16 +135,36 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("variadic.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
   await __call(log, {
     type: "positional",
     args: [`INFO`, `hello`, `world`]
   })
 }
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
+}
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "variadic.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __log_impl(prefix: string, messages: string[]) {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("withModifier.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("withModifier.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "withModifier.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 async function __foo_impl() {
   const __setupData = setupFunction();

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -23,6 +23,7 @@ import {
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
+  __requireInitVar,
   __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
@@ -135,6 +136,9 @@ function registerTools(tools: any[]) {
   }
 }
 
+
+
+export {  };
 const __MY_INIT_GETTERS = [];
 async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("withParam.agency")

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -24,7 +24,7 @@ import {
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
   __initVar,
   __requireInitVar,
-  __registerModule, __getReachableModules,
+  __registerModule, __getRegisteredModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -154,11 +154,11 @@ async function __runImperatives(__ctx) {
 
 }
 async function __initializeGlobals(__ctx) {
-  const __reachable = __getReachableModules();
-  for (const mod of __reachable) {
+  const __registered = __getRegisteredModules();
+  for (const mod of __registered) {
     await mod.__initializeStatic(__ctx)
   }
-  for (const mod of __reachable) {
+  for (const mod of __registered) {
     await mod.__runImperatives(__ctx)
   }
 }

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -22,6 +22,8 @@ import {
   Schema, __validateType, __validateChain, __validateChainRecursive,
   AgencyFunction as __AgencyFunction, UNSET as __UNSET,
   __call, __callMethod, __threads, __stateStack, getRuntimeContext, agencyStore,
+  __initVar,
+  __registerModule, __getReachableModules,
   functionRefReviver as __functionRefReviver,
   DeterministicClient as __DeterministicClient,
   createLogger as __createLogger,
@@ -133,12 +135,33 @@ function registerTools(tools: any[]) {
   }
 }
 
-async function __initializeGlobals(__ctx) {
+const __MY_INIT_GETTERS = [];
+async function __initializeStatic(__ctx) {
   __ctx.globals.markInitialized("withParam.agency")
+  for (const init of __MY_INIT_GETTERS) {
+    await init(__ctx)
+  }
+}
+function __getStaticVars() {
+  return {};
+}
+__globalCtx.getStaticVars = __getStaticVars;
+async function __runImperatives(__ctx) {
+
+}
+async function __initializeGlobals(__ctx) {
+  const __reachable = __getReachableModules();
+  for (const mod of __reachable) {
+    await mod.__initializeStatic(__ctx)
+  }
+  for (const mod of __reachable) {
+    await mod.__runImperatives(__ctx)
+  }
 }
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }
+__registerModule({ __moduleId: "withParam.agency", __initializeStatic, __runImperatives });
 __functionRefReviver.registry = __toolRegistry;
 graph.node("main", async (__state: GraphState) => {
   const __setupData = setupNode({


### PR DESCRIPTION
Fixes #232.

## Problem

When module A imports a `static const` (or top-level `let`/`const`) from module B, A's initializer previously read the live ES binding before B's `__initializeStatic` ran, silently producing `undefined` and downstream corruption like `"undefined/policy.json"`.

The agency-agent had been working around this by inlining a duplicate `policyDir` def instead of importing `AGENCY_AGENT_DIR` from `shared.agency`.

## Solution

Each top-level `static const` (and top-level global) compiles to a memoized async **getter** that initializes the variable on first invocation. Compute bodies read other top-level static/global values via getter calls, so the topological ordering of initialization falls out of the runtime call chain — no compile-time DAG, no topo sort.

Cycle detection happens at runtime via a synchronous `_running` flag that fires on re-entry before the recursive await suspends. The thrown error names the variable and the JS stack trace shows the dependency chain.

Two-phase entry orchestration preserves the "all values populated before any imperative runs anywhere" invariant:
1. **Phase 1:** every reachable module's `__initializeStatic` fires.
2. **Phase 2:** every reachable module's `__runImperatives` fires in import order.

`__initializeGlobals` is preserved as a backward-compat shim for lazy first-call init, resume/rewind, and doc-string interpolation eager eval.

## Generated code shape

```js
// shared.js
let AGENCY_AGENT_DIR;
async function __init_AGENCY_AGENT_DIR_compute(__ctx) {
  AGENCY_AGENT_DIR = __deepFreeze(await computeAgentDir());
  return AGENCY_AGENT_DIR;
}
const __init_AGENCY_AGENT_DIR = __initVar(
  "shared.agency:AGENCY_AGENT_DIR",
  __init_AGENCY_AGENT_DIR_compute,
);
const __MY_INIT_GETTERS = [__init_AGENCY_AGENT_DIR];
export { AGENCY_AGENT_DIR, __init_AGENCY_AGENT_DIR, __MY_INIT_GETTERS, __initializeStatic };

// agent.js
import { __init_AGENCY_AGENT_DIR } from "./shared.js";
let POLICY_PATH;
async function __init_POLICY_PATH_compute(__ctx) {
  POLICY_PATH = __deepFreeze(`${await __init_AGENCY_AGENT_DIR(__ctx)}/policy.json`);
  return POLICY_PATH;
}
const __init_POLICY_PATH = __initVar("agent.agency:POLICY_PATH", __init_POLICY_PATH_compute);
```

The reference to `__init_AGENCY_AGENT_DIR` inside `__init_POLICY_PATH`'s compute body IS the dep declaration AND the runtime mechanism that enforces ordering.

## Files

**Runtime:**
- `lib/runtime/initVar.ts` (new) — memoized async getter helper with cycle detection (permanent-failure semantics).
- `lib/runtime/initOrchestrator.ts` (new) — module registry + two-phase orchestrator.
- `lib/runtime/index.ts` — re-exports.
- `lib/templates/backends/typescriptGenerator/imports.mustache` — imports new runtime helpers into every generated module.

**Codegen:**
- `lib/backends/typescriptBuilder.ts` — rewrites init-context reads to `await __init_X(__ctx)`; tracks which imports need getter wrapping.
- `lib/backends/typescriptBuilder/sectionAssembler.ts` — partitions init vars into spec objects; emits per-var named compute fns + getters; splits init into static + imperative phases.
- `lib/compilationUnit.ts` — tracks `importedConstants`.

**Tests:**
- `lib/runtime/initVar.test.ts` — 9 unit tests (memoization, diamond, linear cascade, self-cycle, mutual cycle, permanent failure, sync exception).
- `lib/backends/static-init-cycle.test.ts` — end-to-end cycle error assertion.
- `tests/agency/static-init-cross-module/` — regression for #232.
- `tests/agency/static-init-cross-module-diamond/` — shared dep through diamond, initialized exactly once.
- `tests/agency/static-init-function-mediated/` — `static const X = someFn()` where the importing module reads X transitively.
- `tests/agency/static-init-cycle/cycle-same-module.agency` — runtime cycle fixture.

**Workaround removed:**
- `lib/agents/agency-agent/agent.agency` — restored canonical import of `AGENCY_AGENT_DIR`; added `export static const POLICY_PATH`.

**Docs:**
- `docs/site/guide/execution-model.md` — new section covering cross-module init order, two-phase guarantee, and cycle error UX.

**Fixture updates:**
- Snapshot tests under `tests/typescriptGenerator/` and `tests/typescriptBuilder/` updated to reflect the new per-module `__init_*` / `__MY_INIT_GETTERS` / `__initializeStatic` / `__runImperatives` emit shape.

## Verification

- `make` clean build ✓
- `pnpm run lint:structure` ✓
- New unit tests: 10/10 ✓
- New integration tests: 3/3 ✓
- Cycle test: throws `Init cycle on cycle-same-module.agency:a` with `__init_a` and `__init_b` frames in stack ✓
- All `lib/backends/` + `lib/compilationUnit.test.ts` tests: 252/252 ✓
- Agency-agent compiles and `agent.js` correctly emits `await __init_AGENCY_AGENT_DIR(__ctx)` in the `POLICY_PATH` compute body ✓

The full agency execution test suite will run in CI.
