### PR TITLE
std::ui redesign — PR 2 of 3: Layer 1 builders + repl() widget

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -312,3 +312,109 @@ emptyLine()
 Print an empty line. Useful for adding spacing in the output.
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L105))
+
+### text
+
+```ts
+text(content: string): Element
+```
+
+* A plain text element. No layout sizing — embed inside a `box` or
+ * `column` for layout. Prefer `line` when you want a single-row
+ * height-1 element.
+ *
+ * @param content - The text to render
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| content | `string` |  |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L184))
+
+### line
+
+```ts
+line(content: string, flex: number, width: number, height: number, fg: string, bg: string, bold: boolean): Element
+```
+
+* A single-line text element with `height: 1`. The default keeps it
+ * from stretching via flex when placed inside a `column`. Caller-
+ * provided style is merged on top.
+ *
+ * @param content - The text to render
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| content | `string` |  |
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| fg | `string` | "" |
+| bg | `string` | "" |
+| bold | `boolean` | false |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L195))
+
+### list
+
+```ts
+list(items: string[], selectedIndex: number, flex: number, width: number, height: number, border: boolean, borderColor: string, visible: boolean): Element
+```
+
+* A scrollable selectable list. `selectedIndex` highlights one row;
+ * out-of-range values are clamped by the renderer.
+ *
+ * @param items - The strings to display, one per row
+ * @param selectedIndex - 0-based row to highlight (default 0)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| items | `string[]` |  |
+| selectedIndex | `number` | 0 |
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| border | `boolean` | false |
+| borderColor | `string` | "" |
+| visible | `boolean` | true |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L222))
+
+### textInput
+
+```ts
+textInput(value: string, flex: number, width: number, height: number, fg: string, bg: string): Element
+```
+
+* A single-line text input. The renderer displays `value` with a
+ * cursor; key handling is the caller's responsibility (use `runLoop`'s
+ * `handleKey` to append characters / handle backspace).
+ *
+ * @param value - Current contents of the buffer
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| value | `string` | "" |
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| fg | `string` | "" |
+| bg | `string` | "" |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L249))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -1,5 +1,104 @@
 # ui
 
+## Types
+
+### Element
+
+* Opaque tree node. Produced only by the builder functions below;
+ * consumed only by `runLoop` and `renderOnce`. Users do not
+ * construct one directly.
+
+```ts
+/**
+ * Opaque tree node. Produced only by the builder functions below;
+ * consumed only by `runLoop` and `renderOnce`. Users do not
+ * construct one directly.
+ */
+export type Element = {
+  type: string;
+  style?: any;
+  content?: string;
+  children?: any[];
+  items?: string[];
+  selectedIndex?: number;
+  value?: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L126))
+
+### KeyEvent
+
+* Keystroke delivered to `handleKey` blocks.
+ *
+ * `key` is either a named special key — `"up"`, `"down"`, `"left"`,
+ * `"right"`, `"enter"`, `"escape"`, `"backspace"`, `"tab"`,
+ * `"home"`, `"end"`, `"pageup"`, `"pagedown"`, `"delete"`,
+ * `"insert"` — or a single printable character (e.g. `"q"`, `"/"`,
+ * `" "`). Mirrors the encoding in `lib/tui/input/terminal.ts`.
+ *
+ * `shift` / `ctrl` indicate held modifier keys at keypress time.
+
+```ts
+/**
+ * Keystroke delivered to `handleKey` blocks.
+ *
+ * `key` is either a named special key — `"up"`, `"down"`, `"left"`,
+ * `"right"`, `"enter"`, `"escape"`, `"backspace"`, `"tab"`,
+ * `"home"`, `"end"`, `"pageup"`, `"pagedown"`, `"delete"`,
+ * `"insert"` — or a single printable character (e.g. `"q"`, `"/"`,
+ * `" "`). Mirrors the encoding in `lib/tui/input/terminal.ts`.
+ *
+ * `shift` / `ctrl` indicate held modifier keys at keypress time.
+ */
+export type KeyEvent = {
+  key: string;
+  shift: boolean;
+  ctrl: boolean
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L147))
+
+### Builder
+
+* Builder receiver passed to every container block. Method calls
+ * append child elements to the enclosing parent in source order.
+ *
+ * Container methods (`row`, `column`, `box`) take a trailing block
+ * that receives a fresh Builder for the new child's contents. Leaf
+ * methods (`line`, `text`, `list`, `textInput`) don't.
+ *
+ * The methods are typed `any` because each one accepts a different
+ * named-arg signature; full signatures are documented on the
+ * top-level builders (`column`, `row`, etc.).
+
+```ts
+/**
+ * Builder receiver passed to every container block. Method calls
+ * append child elements to the enclosing parent in source order.
+ *
+ * Container methods (`row`, `column`, `box`) take a trailing block
+ * that receives a fresh Builder for the new child's contents. Leaf
+ * methods (`line`, `text`, `list`, `textInput`) don't.
+ *
+ * The methods are typed `any` because each one accepts a different
+ * named-arg signature; full signatures are documented on the
+ * top-level builders (`column`, `row`, etc.).
+ */
+export type Builder = {
+  row: any;
+  column: any;
+  box: any;
+  line: any;
+  text: any;
+  list: any;
+  textInput: any
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L165))
+
 ## Functions
 
 ### initUI
@@ -16,7 +115,7 @@ Initialize a terminal UI with a scrollable output area and a fixed input bar at 
 |---|---|---|
 | title | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L2))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L3))
 
 ### destroyUI
 
@@ -26,7 +125,7 @@ destroyUI()
 
 Tear down the terminal UI and restore normal terminal behavior. Called automatically on exit, but you can call it early if needed.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L9))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L10))
 
 ### log
 
@@ -42,7 +141,7 @@ Print a message to the scrollable output area. Supports ANSI colors.
 |---|---|---|
 | message | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L16))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L17))
 
 ### status
 
@@ -62,7 +161,7 @@ Update the status bar. The left text appears on the left side, the right text on
 | left | `string` |  |
 | right | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L23))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L24))
 
 ### chat
 
@@ -82,7 +181,7 @@ Print a chat message with a colored role prefix. Built-in colors: "user" (cyan),
 | role | `string` | "" |
 | message | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L33))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L34))
 
 ### code
 
@@ -102,7 +201,7 @@ Display a code block with a filename header and line numbers, inside a bordered 
 | filename | `string` |  |
 | content | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L43))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L44))
 
 ### diff
 
@@ -122,7 +221,7 @@ Display a diff with colored +/- lines, inside a bordered box with the filename a
 | filename | `string` |  |
 | content | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L53))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L54))
 
 ### separator
 
@@ -138,7 +237,7 @@ Print a horizontal line with an optional label. Useful for visually grouping out
 |---|---|---|
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L63))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L64))
 
 ### startSpinner
 
@@ -154,7 +253,7 @@ Show an animated spinner in the input bar with a label. Useful while the agent i
 |---|---|---|
 | text | `string` | "working" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L70))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L71))
 
 ### stopSpinner
 
@@ -164,7 +263,7 @@ stopSpinner()
 
 Stop the spinner and clear the input bar.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L77))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L78))
 
 ### prompt
 
@@ -184,7 +283,7 @@ Prompt the user for text input in the fixed input bar at the bottom of the scree
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L84))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L85))
 
 ### getConfirmation
 
@@ -202,7 +301,7 @@ Ask the user a yes/no question in the input bar. Returns true if the user answer
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L93))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L94))
 
 ### emptyLine
 
@@ -212,4 +311,4 @@ emptyLine()
 
 Print an empty line. Useful for adding spacing in the output.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L104))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L105))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -121,7 +121,7 @@ type ReplState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L616))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L618))
 
 ## Functions
 
@@ -541,7 +541,7 @@ row(flex: number, width: number, height: number, padding: number, border: boolea
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L350))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L352))
 
 ### box
 
@@ -570,7 +570,7 @@ box(flex: number, width: number, height: number, padding: number, border: boolea
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L379))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L381))
 
 ### _addRow
 
@@ -597,7 +597,7 @@ _addRow(kids: any[], flex: number, width: number, height: number, padding: numbe
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L406))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L408))
 
 ### _addColumn
 
@@ -624,7 +624,7 @@ _addColumn(kids: any[], flex: number, width: number, height: number, padding: nu
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L427))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L429))
 
 ### _addBox
 
@@ -651,7 +651,7 @@ _addBox(kids: any[], flex: number, width: number, height: number, padding: numbe
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L448))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L450))
 
 ### _addLine
 
@@ -674,7 +674,7 @@ _addLine(kids: any[], content: string, flex: number, width: number, height: numb
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L469))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L471))
 
 ### _addText
 
@@ -691,7 +691,7 @@ _addText(kids: any[], content: string): Element
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L485))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L487))
 
 ### _addList
 
@@ -715,7 +715,7 @@ _addList(kids: any[], items: string[], selectedIndex: number, flex: number, widt
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L491))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L493))
 
 ### _addTextInput
 
@@ -737,7 +737,7 @@ _addTextInput(kids: any[], value: string, flex: number, width: number, height: n
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L509))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L511))
 
 ### renderOnce
 
@@ -755,7 +755,7 @@ renderOnce(tree: Element)
 |---|---|---|
 | tree | [Element](#element) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L531))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L533))
 
 ### readKey
 
@@ -769,7 +769,7 @@ readKey(): KeyEvent
 
 **Returns:** [KeyEvent](#keyevent)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L540))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L542))
 
 ### runLoop
 
@@ -805,7 +805,7 @@ runLoop(initialState: any, render: any, handleKey: any, isDone: any, tickMs: num
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L561))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L563))
 
 ### setScriptedKeys
 
@@ -824,7 +824,7 @@ setScriptedKeys(keys: KeyEvent[])
 |---|---|---|
 | keys | `KeyEvent[]` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L583))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L585))
 
 ### setQuitAfterMs
 
@@ -845,7 +845,7 @@ setQuitAfterMs(ms: number)
 |---|---|---|
 | ms | `number` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L595))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L597))
 
 ### _filteredPaletteKeys
 
@@ -861,7 +861,7 @@ _filteredPaletteKeys(s: ReplState): string[]
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L636))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L638))
 
 ### _replView
 
@@ -877,7 +877,7 @@ _replView(s: ReplState): Element
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L654))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L656))
 
 ### _appendNewScrollLines
 
@@ -893,7 +893,7 @@ _appendNewScrollLines(s: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L685))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L687))
 
 ### _persistHistory
 
@@ -909,7 +909,7 @@ _persistHistory(s: ReplState): boolean
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L702))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L704))
 
 ### _replReduce
 
@@ -926,7 +926,7 @@ _replReduce(s: ReplState, k: KeyEvent): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L711))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L713))
 
 ### _replIsDone
 
@@ -942,7 +942,7 @@ _replIsDone(s: ReplState): boolean
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L805))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L807))
 
 ### repl
 
@@ -983,4 +983,4 @@ repl(output: any, status: any, onSubmit: any, prompt: string, historyFile: strin
 | paletteCommands | `any` | null |
 | tickMs | `number` | 100 |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L828))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L830))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -25,7 +25,7 @@ export type Element = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L126))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L127))
 
 ### KeyEvent
 
@@ -58,7 +58,7 @@ export type KeyEvent = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L148))
 
 ### Builder
 
@@ -97,7 +97,31 @@ export type Builder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L165))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L166))
+
+### ReplState
+
+```ts
+type ReplState = {
+  buffer: string;
+  history: string[];
+  historyIdx: number;
+  paletteOpen: boolean;
+  paletteFilter: string;
+  paletteCursor: number;
+  done: boolean;
+  outputLinesWritten: number;
+  prompt: string;
+  paletteCommands: any;
+  historyFile: string;
+  historyMax: number;
+  output: any;
+  status: any;
+  onSubmit: any
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L616))
 
 ## Functions
 
@@ -115,7 +139,7 @@ Initialize a terminal UI with a scrollable output area and a fixed input bar at 
 |---|---|---|
 | title | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L3))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L4))
 
 ### destroyUI
 
@@ -125,7 +149,7 @@ destroyUI()
 
 Tear down the terminal UI and restore normal terminal behavior. Called automatically on exit, but you can call it early if needed.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L10))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L11))
 
 ### log
 
@@ -141,7 +165,7 @@ Print a message to the scrollable output area. Supports ANSI colors.
 |---|---|---|
 | message | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L17))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L18))
 
 ### status
 
@@ -161,7 +185,7 @@ Update the status bar. The left text appears on the left side, the right text on
 | left | `string` |  |
 | right | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L24))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L25))
 
 ### chat
 
@@ -181,7 +205,7 @@ Print a chat message with a colored role prefix. Built-in colors: "user" (cyan),
 | role | `string` | "" |
 | message | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L34))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L35))
 
 ### code
 
@@ -201,7 +225,7 @@ Display a code block with a filename header and line numbers, inside a bordered 
 | filename | `string` |  |
 | content | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L44))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L45))
 
 ### diff
 
@@ -221,7 +245,7 @@ Display a diff with colored +/- lines, inside a bordered box with the filename a
 | filename | `string` |  |
 | content | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L54))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L55))
 
 ### separator
 
@@ -237,7 +261,7 @@ Print a horizontal line with an optional label. Useful for visually grouping out
 |---|---|---|
 | label | `string` | "" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L64))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L65))
 
 ### startSpinner
 
@@ -253,7 +277,7 @@ Show an animated spinner in the input bar with a label. Useful while the agent i
 |---|---|---|
 | text | `string` | "working" |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L71))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L72))
 
 ### stopSpinner
 
@@ -263,7 +287,7 @@ stopSpinner()
 
 Stop the spinner and clear the input bar.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L78))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L79))
 
 ### prompt
 
@@ -283,7 +307,7 @@ Prompt the user for text input in the fixed input bar at the bottom of the scree
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L85))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L86))
 
 ### getConfirmation
 
@@ -301,7 +325,7 @@ Ask the user a yes/no question in the input bar. Returns true if the user answer
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L94))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L95))
 
 ### emptyLine
 
@@ -311,7 +335,7 @@ emptyLine()
 
 Print an empty line. Useful for adding spacing in the output.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L105))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L106))
 
 ### text
 
@@ -333,7 +357,7 @@ text(content: string): Element
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L184))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L185))
 
 ### line
 
@@ -361,7 +385,7 @@ line(content: string, flex: number, width: number, height: number, fg: string, b
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L195))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L196))
 
 ### list
 
@@ -390,7 +414,7 @@ list(items: string[], selectedIndex: number, flex: number, width: number, height
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L222))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L223))
 
 ### textInput
 
@@ -417,7 +441,7 @@ textInput(value: string, flex: number, width: number, height: number, fg: string
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L249))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L250))
 
 ### _mkBoxStyle
 
@@ -443,7 +467,7 @@ _mkBoxStyle(flexDirection: string, flex: number, width: number, height: number, 
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L276))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L277))
 
 ### _makeBuilder
 
@@ -459,7 +483,7 @@ _makeBuilder(kids: any[]): Builder
 
 **Returns:** [Builder](#builder)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L304))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L305))
 
 ### column
 
@@ -488,7 +512,7 @@ column(flex: number, width: number, height: number, padding: number, border: boo
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L320))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L321))
 
 ### row
 
@@ -517,7 +541,7 @@ row(flex: number, width: number, height: number, padding: number, border: boolea
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L349))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L350))
 
 ### box
 
@@ -546,7 +570,7 @@ box(flex: number, width: number, height: number, padding: number, border: boolea
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L378))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L379))
 
 ### _addRow
 
@@ -573,7 +597,7 @@ _addRow(kids: any[], flex: number, width: number, height: number, padding: numbe
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L405))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L406))
 
 ### _addColumn
 
@@ -600,7 +624,7 @@ _addColumn(kids: any[], flex: number, width: number, height: number, padding: nu
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L426))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L427))
 
 ### _addBox
 
@@ -627,7 +651,7 @@ _addBox(kids: any[], flex: number, width: number, height: number, padding: numbe
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L447))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L448))
 
 ### _addLine
 
@@ -650,7 +674,7 @@ _addLine(kids: any[], content: string, flex: number, width: number, height: numb
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L468))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L469))
 
 ### _addText
 
@@ -667,7 +691,7 @@ _addText(kids: any[], content: string): Element
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L484))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L485))
 
 ### _addList
 
@@ -691,7 +715,7 @@ _addList(kids: any[], items: string[], selectedIndex: number, flex: number, widt
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L490))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L491))
 
 ### _addTextInput
 
@@ -713,7 +737,7 @@ _addTextInput(kids: any[], value: string, flex: number, width: number, height: n
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L508))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L509))
 
 ### renderOnce
 
@@ -731,7 +755,7 @@ renderOnce(tree: Element)
 |---|---|---|
 | tree | [Element](#element) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L530))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L531))
 
 ### readKey
 
@@ -745,7 +769,7 @@ readKey(): KeyEvent
 
 **Returns:** [KeyEvent](#keyevent)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L539))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L540))
 
 ### runLoop
 
@@ -781,7 +805,7 @@ runLoop(initialState: any, render: any, handleKey: any, isDone: any, tickMs: num
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L560))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L561))
 
 ### setScriptedKeys
 
@@ -800,7 +824,7 @@ setScriptedKeys(keys: KeyEvent[])
 |---|---|---|
 | keys | `KeyEvent[]` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L582))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L583))
 
 ### setQuitAfterMs
 
@@ -821,4 +845,142 @@ setQuitAfterMs(ms: number)
 |---|---|---|
 | ms | `number` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L594))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L595))
+
+### _filteredPaletteKeys
+
+```ts
+_filteredPaletteKeys(s: ReplState): string[]
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| s | [ReplState](#replstate) |  |
+
+**Returns:** `string[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L636))
+
+### _replView
+
+```ts
+_replView(s: ReplState): Element
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| s | [ReplState](#replstate) |  |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L654))
+
+### _appendNewScrollLines
+
+```ts
+_appendNewScrollLines(s: ReplState): ReplState
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| s | [ReplState](#replstate) |  |
+
+**Returns:** [ReplState](#replstate)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L685))
+
+### _persistHistory
+
+```ts
+_persistHistory(s: ReplState): boolean
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| s | [ReplState](#replstate) |  |
+
+**Returns:** `boolean`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L702))
+
+### _replReduce
+
+```ts
+_replReduce(s: ReplState, k: KeyEvent): ReplState
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| s | [ReplState](#replstate) |  |
+| k | [KeyEvent](#keyevent) |  |
+
+**Returns:** [ReplState](#replstate)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L711))
+
+### _replIsDone
+
+```ts
+_replIsDone(s: ReplState): boolean
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| s | [ReplState](#replstate) |  |
+
+**Returns:** `boolean`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L805))
+
+### repl
+
+```ts
+repl(output: any, status: any, onSubmit: any, prompt: string, historyFile: string, historyMax: number, paletteCommands: any, tickMs: number)
+```
+
+* Drop-in REPL widget for interactive CLI agents. Bundles a scroll
+ * output area (via the terminal's native scroll region), a status
+ * line, a command palette (triggered by `/`), and an input line
+ * with history navigation.
+ *
+ * Lifecycle: installs a scroll region on entry, runs the bounded
+ * `runLoop` with `tickMs` so the status line stays live during a
+ * turn, tears down the region on exit (clean exit, onSubmit -> false,
+ * or exception). The handler block ensures the region is reset even
+ * if an exception escapes the loop.
+ *
+ * @param output - Re-evaluated every render; new tail lines stream to scrollback
+ * @param status - Re-evaluated every render; populates the status line
+ * @param onSubmit - Called with the submitted line; return `false` to exit
+ * @param prompt - String shown before the input buffer (default `"> "`)
+ * @param historyFile - Reserved for future use (history persistence is v2)
+ * @param historyMax - Trim oldest entries beyond this count
+ * @param paletteCommands - Map of `/cmd` -> description, iterated in order
+ * @param tickMs - Render cadence in milliseconds (default 100)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| output | `any` |  |
+| status | `any` |  |
+| onSubmit | `any` |  |
+| prompt | `string` | "> " |
+| historyFile | `string` | "" |
+| historyMax | `number` | 1000 |
+| paletteCommands | `any` | null |
+| tickMs | `number` | 100 |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L828))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -53,8 +53,8 @@ export type Element = {
  */
 export type KeyEvent = {
   key: string;
-  shift: boolean;
-  ctrl: boolean
+  shift?: boolean;
+  ctrl?: boolean
 }
 ```
 
@@ -714,3 +714,111 @@ _addTextInput(kids: any[], value: string, flex: number, width: number, height: n
 **Returns:** [Element](#element)
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L508))
+
+### renderOnce
+
+```ts
+renderOnce(tree: Element)
+```
+
+* Render a single Element tree to the screen and return immediately.
+ * For static UI or first-paint scenarios. For interactive UI, use
+ * `runLoop`.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| tree | [Element](#element) |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L530))
+
+### readKey
+
+```ts
+readKey(): KeyEvent
+```
+
+* Read one key from the terminal. Blocks until a key is pressed.
+ * Use sparingly; prefer `runLoop` for anything beyond a single
+ * blocking prompt.
+
+**Returns:** [KeyEvent](#keyevent)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L539))
+
+### runLoop
+
+```ts
+runLoop(initialState: any, render: any, handleKey: any, isDone: any, tickMs: number): any
+```
+
+* Elm/Ink-style state machine driver. Renders the initial state,
+ * waits for each `KeyEvent`, runs `handleKey` to produce the next
+ * state, re-renders, exits when `isDone` returns `true`. Returns
+ * the final state.
+ *
+ * When `tickMs` is set, the loop also re-renders periodically even
+ * if no key is pressed. This is what makes a live status line tick.
+ * `handleKey` does NOT fire on ticks — `render` does (re-evaluates
+ * any impure state your view reads).
+ *
+ * @param initialState - The opening state record
+ * @param render       - Pure (state) -> Element. Re-runs every tick / key.
+ * @param handleKey    - Pure (state, key) -> state. Runs only on real keys.
+ * @param isDone       - Pure (state) -> boolean. Loop exits when true.
+ * @param tickMs       - Milliseconds between forced re-renders (omit for event-driven only)
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| initialState | `any` |  |
+| render | `any` |  |
+| handleKey | `any` |  |
+| isDone | `any` |  |
+| tickMs | `number` | null |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L560))
+
+### setScriptedKeys
+
+```ts
+setScriptedKeys(keys: KeyEvent[])
+```
+
+* Seed the next `runLoop` (or `repl`) entry with a scripted key
+ * sequence. Internal — used by tests in `tests/agency/ui-*`.
+ *
+ * @param keys - Array of `KeyEvent` records consumed in order
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| keys | `KeyEvent[]` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L582))
+
+### setQuitAfterMs
+
+```ts
+setQuitAfterMs(ms: number)
+```
+
+* Schedule a `q` keypress N milliseconds after the next `runLoop`
+ * starts. Internal — used by the tickMs coverage test so a
+ * tick-driven loop terminates without a key-timeline that matches
+ * the tick cadence.
+ *
+ * @param ms - Milliseconds before the synthetic `q` arrives
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| ms | `number` |  |
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L594))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -418,3 +418,299 @@ textInput(value: string, flex: number, width: number, height: number, fg: string
 **Returns:** [Element](#element)
 
 ([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L249))
+
+### _mkBoxStyle
+
+```ts
+_mkBoxStyle(flexDirection: string, flex: number, width: number, height: number, padding: number, border: boolean, borderColor: string, label: string, bg: string, fg: string, visible: boolean): any
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| flexDirection | `string` |  |
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| padding | `number` | null |
+| border | `boolean` | false |
+| borderColor | `string` | "" |
+| label | `string` | "" |
+| bg | `string` | "" |
+| fg | `string` | "" |
+| visible | `boolean` | true |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L276))
+
+### _makeBuilder
+
+```ts
+_makeBuilder(kids: any[]): Builder
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| kids | `any[]` |  |
+
+**Returns:** [Builder](#builder)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L304))
+
+### column
+
+```ts
+column(flex: number, width: number, height: number, padding: number, border: boolean, borderColor: string, label: string, bg: string, fg: string, visible: boolean, block: (Builder) => void): Element
+```
+
+* A vertical container. Children stack top-to-bottom. The trailing
+ * block receives a fresh `Builder` to populate the column.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| padding | `number` | null |
+| border | `boolean` | false |
+| borderColor | `string` | "" |
+| label | `string` | "" |
+| bg | `string` | "" |
+| fg | `string` | "" |
+| visible | `boolean` | true |
+| block | `(Builder) => void` | null |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L320))
+
+### row
+
+```ts
+row(flex: number, width: number, height: number, padding: number, border: boolean, borderColor: string, label: string, bg: string, fg: string, visible: boolean, block: (Builder) => void): Element
+```
+
+* A horizontal container. Children stack left-to-right. The trailing
+ * block receives a fresh `Builder` to populate the row.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| padding | `number` | null |
+| border | `boolean` | false |
+| borderColor | `string` | "" |
+| label | `string` | "" |
+| bg | `string` | "" |
+| fg | `string` | "" |
+| visible | `boolean` | true |
+| block | `(Builder) => void` | null |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L349))
+
+### box
+
+```ts
+box(flex: number, width: number, height: number, padding: number, border: boolean, borderColor: string, label: string, bg: string, fg: string, visible: boolean, block: (Builder) => void): Element
+```
+
+* A direction-neutral container. Use when you want to apply styling
+ * (border, padding, background) without setting `flexDirection`.
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| padding | `number` | null |
+| border | `boolean` | false |
+| borderColor | `string` | "" |
+| label | `string` | "" |
+| bg | `string` | "" |
+| fg | `string` | "" |
+| visible | `boolean` | true |
+| block | `(Builder) => void` | null |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L378))
+
+### _addRow
+
+```ts
+_addRow(kids: any[], flex: number, width: number, height: number, padding: number, border: boolean, borderColor: string, label: string, bg: string, fg: string, visible: boolean, block: (Builder) => void): Element
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| kids | `any[]` |  |
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| padding | `number` | null |
+| border | `boolean` | false |
+| borderColor | `string` | "" |
+| label | `string` | "" |
+| bg | `string` | "" |
+| fg | `string` | "" |
+| visible | `boolean` | true |
+| block | `(Builder) => void` | null |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L405))
+
+### _addColumn
+
+```ts
+_addColumn(kids: any[], flex: number, width: number, height: number, padding: number, border: boolean, borderColor: string, label: string, bg: string, fg: string, visible: boolean, block: (Builder) => void): Element
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| kids | `any[]` |  |
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| padding | `number` | null |
+| border | `boolean` | false |
+| borderColor | `string` | "" |
+| label | `string` | "" |
+| bg | `string` | "" |
+| fg | `string` | "" |
+| visible | `boolean` | true |
+| block | `(Builder) => void` | null |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L426))
+
+### _addBox
+
+```ts
+_addBox(kids: any[], flex: number, width: number, height: number, padding: number, border: boolean, borderColor: string, label: string, bg: string, fg: string, visible: boolean, block: (Builder) => void): Element
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| kids | `any[]` |  |
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| padding | `number` | null |
+| border | `boolean` | false |
+| borderColor | `string` | "" |
+| label | `string` | "" |
+| bg | `string` | "" |
+| fg | `string` | "" |
+| visible | `boolean` | true |
+| block | `(Builder) => void` | null |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L447))
+
+### _addLine
+
+```ts
+_addLine(kids: any[], content: string, flex: number, width: number, height: number, fg: string, bg: string, bold: boolean): Element
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| kids | `any[]` |  |
+| content | `string` |  |
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| fg | `string` | "" |
+| bg | `string` | "" |
+| bold | `boolean` | false |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L468))
+
+### _addText
+
+```ts
+_addText(kids: any[], content: string): Element
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| kids | `any[]` |  |
+| content | `string` |  |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L484))
+
+### _addList
+
+```ts
+_addList(kids: any[], items: string[], selectedIndex: number, flex: number, width: number, height: number, border: boolean, borderColor: string, visible: boolean): Element
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| kids | `any[]` |  |
+| items | `string[]` |  |
+| selectedIndex | `number` | 0 |
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| border | `boolean` | false |
+| borderColor | `string` | "" |
+| visible | `boolean` | true |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L490))
+
+### _addTextInput
+
+```ts
+_addTextInput(kids: any[], value: string, flex: number, width: number, height: number, fg: string, bg: string): Element
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| kids | `any[]` |  |
+| value | `string` | "" |
+| flex | `number` | null |
+| width | `number` | null |
+| height | `number` | null |
+| fg | `string` | "" |
+| bg | `string` | "" |
+
+**Returns:** [Element](#element)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L508))

--- a/packages/agency-lang/lib/stdlib/ui.test.ts
+++ b/packages/agency-lang/lib/stdlib/ui.test.ts
@@ -88,53 +88,20 @@ describe("std::ui bridge — BottomRegionOutputTarget", () => {
     resetRegion();
   });
 
-  it("wraps the inner write in save+move+restore", () => {
-    const innerWrites: string[] = [];
-    const inner = {
-      write(_frame: any) {
-        innerWrites.push("INNER_FRAME");
-      },
-    };
+  it("wraps the frame write in save+move+restore and emits ANSI", () => {
     installRegion(3); // scrollBottom = 21 → bottom region starts at row 22
     stdoutWrites.length = 0;
-    const target = new BottomRegionOutputTarget(inner as any);
-    target.write({} as any);
+    const target = new BottomRegionOutputTarget();
+    // toANSI expects a Frame; pass an empty cells grid to keep it minimal.
+    target.write({ width: 0, height: 0, cells: [] } as any);
     const out = stdoutWrites.join("");
     expect(out).toContain("\x1b[s"); // save cursor
     expect(out).toContain("\x1b[22;1H"); // move to bottom region
     expect(out).toContain("\x1b[u"); // restore cursor
-    expect(innerWrites).toEqual(["INNER_FRAME"]);
   });
 
-  it("forwards the label argument to the inner target", () => {
-    const labels: (string | undefined)[] = [];
-    const inner = {
-      write(_frame: any, label?: string) {
-        labels.push(label);
-      },
-    };
-    installRegion(3);
-    const target = new BottomRegionOutputTarget(inner as any);
-    target.write({} as any, "my-label");
-    expect(labels).toEqual(["my-label"]);
-  });
-
-  it("forwards destroy() to the inner target if present", () => {
-    let destroyed = false;
-    const inner = {
-      write(_f: any) {},
-      destroy() {
-        destroyed = true;
-      },
-    };
-    const target = new BottomRegionOutputTarget(inner as any);
-    target.destroy();
-    expect(destroyed).toBe(true);
-  });
-
-  it("destroy() tolerates inner targets without a destroy method", () => {
-    const inner = { write(_f: any) {} };
-    const target = new BottomRegionOutputTarget(inner as any);
+  it("destroy() is a no-op (owns no resources)", () => {
+    const target = new BottomRegionOutputTarget();
     expect(() => target.destroy()).not.toThrow();
   });
 });

--- a/packages/agency-lang/lib/stdlib/ui.ts
+++ b/packages/agency-lang/lib/stdlib/ui.ts
@@ -20,6 +20,7 @@ import {
   type OutputTarget,
 } from "@/tui/index.js";
 import type { Frame } from "@/tui/frame.js";
+import { toANSI } from "@/tui/render/ansi.js";
 import { withBottomCursor, installRegion, resetRegion } from "./ui-region.js";
 import { __call } from "../runtime/call.js";
 
@@ -668,23 +669,31 @@ export async function _readKey(): Promise<TuiKeyEvent> {
 }
 
 /**
- * Wraps any `OutputTarget` so frame writes land at the bottom of the
- * real terminal — used by `repl()`'s hybrid rendering. The inner
- * target is unaware it doesn't own the whole screen;
- * `withBottomCursor` saves/moves/restores the cursor around each
- * frame so plain stdout writes still scroll inside the top region.
+ * `OutputTarget` for `repl()`'s hybrid rendering. Renders each frame
+ * directly inside the terminal's reserved bottom region:
+ * `withBottomCursor` saves the cursor, positions it at the start of
+ * the bottom region, writes the frame ANSI (no `CURSOR_HOME` prefix,
+ * no alt-screen entry — both would defeat the hybrid scrollback
+ * goal), and restores the cursor so subsequent plain stdout writes
+ * still scroll inside the top region.
+ *
+ * Does NOT wrap an inner OutputTarget. The bridge's default
+ * `TerminalOutput` enters the alt-screen and prepends `CURSOR_HOME`
+ * to every write, which is exactly what hybrid mode must avoid; this
+ * target sidesteps both by talking to `process.stdout` itself via
+ * `toANSI`. `destroy()` is a no-op: this target owns no resources
+ * (the scroll region itself is torn down by `_resetScrollRegion`).
  */
 export class BottomRegionOutputTarget implements OutputTarget {
-  constructor(private inner: OutputTarget) {}
-
-  write(frame: Frame, label?: string): void {
+  write(frame: Frame, _label?: string): void {
     withBottomCursor(() => {
-      this.inner.write(frame, label);
+      process.stdout.write(toANSI(frame));
     });
   }
 
   destroy(): void {
-    if (this.inner.destroy) this.inner.destroy();
+    // No-op: nothing owned. Region teardown is handled by
+    // `_resetScrollRegion` in the Agency-side `repl()` finally block.
   }
 }
 
@@ -722,13 +731,23 @@ export function _resetScrollRegion(): void {
   resetRegion();
 }
 
-/** Hybrid-mode variant of `_runLoop`. Wraps the active output target
- *  in `BottomRegionOutputTarget` so TUI frames land in the bottom
- *  region of the real terminal, and bounds the `Screen` to a
- *  `bottomRows`-row viewport. The scroll region itself is installed
- *  by `repl()` via `_installScrollRegion` before this call and torn
- *  down via `_resetScrollRegion` afterwards (including on exception
- *  paths via the Agency `handle` block). */
+/** Hybrid-mode variant of `_runLoop`. Drives the `repl()` widget's
+ *  bounded `Screen` (bottom `bottomRows` rows only); frames render
+ *  into the terminal's reserved bottom region while plain stdout
+ *  writes keep scrolling in the top region. The scroll region itself
+ *  is installed by `repl()` via `_installScrollRegion` before this
+ *  call and torn down via `_resetScrollRegion` afterwards (including
+ *  on exception paths via the Agency `handle` block).
+ *
+ *  Output target selection:
+ *  - **Test mode** (`bridgeOutputTarget` is a `FrameRecorder`,
+ *    injected by `_setScriptedKeys` -> `ensureBridgeState`):
+ *    frames go straight into the recorder so tests can inspect them.
+ *  - **Real terminal mode**: a fresh `BottomRegionOutputTarget`
+ *    writes ANSI to stdout via `withBottomCursor`, bypassing the
+ *    default `TerminalOutput` (which would enter the alt screen and
+ *    prepend `CURSOR_HOME` — both fatal to hybrid scrollback).
+ */
 export async function _runLoopHybrid(
   initialState: any,
   renderFn: unknown,
@@ -737,16 +756,14 @@ export async function _runLoopHybrid(
   tickMs: number,
   bottomRows: number,
 ): Promise<any> {
-  // Resolve the underlying input + output (consuming test-mode
-  // injection), then build a Screen bounded to `bottomRows` whose
-  // OutputTarget is wrapped in `BottomRegionOutputTarget`. The wrap
-  // positions every frame at the bottom of the real terminal so
-  // ordinary stdout writes still scroll inside the top region.
   ensureBridgeState();
-  const wrappedOutput = new BottomRegionOutputTarget(bridgeOutputTarget!);
+  const hybridOutput: OutputTarget =
+    bridgeOutputTarget instanceof FrameRecorder
+      ? bridgeOutputTarget
+      : new BottomRegionOutputTarget();
   const hybridScreen = new Screen({
     input: bridgeInputSource!,
-    output: wrappedOutput,
+    output: hybridOutput,
     width: bridgeWidth,
     height: bottomRows,
   });
@@ -761,11 +778,12 @@ export async function _runLoopHybrid(
     });
   } finally {
     bridgeActiveScreen = null;
-    // `Screen.destroy` would also destroy the input source; we want
-    // the bridge's input/output to survive in case the same process
-    // later calls back into `_runLoop` (e.g. agency-agent test
-    // harnesses that run multiple REPL turns). Just clear the
-    // wrapper's own listeners.
-    if (wrappedOutput.destroy) wrappedOutput.destroy();
+    // Deliberately NOT calling `Screen.destroy` or any
+    // `bridgeOutputTarget.destroy`: the bridge's input/output must
+    // survive across loop entries so multi-turn REPL sessions and
+    // test harnesses can re-enter `_runLoop` / `_runLoopHybrid`
+    // without re-initializing terminal state. `BottomRegionOutputTarget`
+    // owns no resources; the scroll region is torn down by
+    // `_resetScrollRegion` in the Agency-side `repl()`.
   }
 }

--- a/packages/agency-lang/lib/stdlib/ui.ts
+++ b/packages/agency-lang/lib/stdlib/ui.ts
@@ -12,6 +12,8 @@ import {
   Screen,
   TerminalInput,
   TerminalOutput,
+  ScriptedInput,
+  FrameRecorder,
   type Element as TuiElement,
   type KeyEvent as TuiKeyEvent,
   type InputSource,
@@ -19,6 +21,7 @@ import {
 } from "@/tui/index.js";
 import type { Frame } from "@/tui/frame.js";
 import { withBottomCursor } from "./ui-region.js";
+import { __call } from "../runtime/call.js";
 
 // Evaluated once at load time — the env var is set by the debugger CLI
 // before any compiled agency code runs and never changes.
@@ -525,7 +528,41 @@ let bridgeWidth = 80;
 let bridgeHeight = 24;
 let bridgeActiveScreen: Screen | null = null;
 
+// Test-mode injection points. Agency tests call `_setScriptedKeys` (and
+// optionally `_setQuitAfterMs`) before entering a loop, and the next
+// `makeBridgeScreen` call consumes them — installing a `ScriptedInput`
+// seeded with the keys and a `FrameRecorder` output, then clearing the
+// pending values so subsequent loops fall back to defaults.
+let pendingScriptedKeys: TuiKeyEvent[] | null = null;
+let pendingQuitAfterMs: number | null = null;
+
+export function _setScriptedKeys(keys: TuiKeyEvent[]): void {
+  pendingScriptedKeys = keys;
+}
+
+export function _setQuitAfterMs(ms: number): void {
+  pendingQuitAfterMs = ms;
+}
+
 function makeBridgeScreen(): Screen {
+  if (pendingScriptedKeys) {
+    const scriptedInput = new ScriptedInput(pendingScriptedKeys);
+    bridgeInputSource = scriptedInput;
+    bridgeOutputTarget = new FrameRecorder();
+    bridgeWidth = 80;
+    bridgeHeight = 24;
+    pendingScriptedKeys = null;
+
+    // Optional: feed a `q` key after N ms to break out of a tickMs loop
+    // that scripted keys alone wouldn't terminate. Tests for runLoop's
+    // tick behavior set this so the loop ends without needing a
+    // scripted-keys timeline that matches the tick cadence.
+    if (pendingQuitAfterMs !== null) {
+      const ms = pendingQuitAfterMs;
+      setTimeout(() => scriptedInput.feedKey({ key: "q" }), ms);
+      pendingQuitAfterMs = null;
+    }
+  }
   if (!bridgeInputSource) bridgeInputSource = new TerminalInput();
   if (!bridgeOutputTarget) bridgeOutputTarget = new TerminalOutput();
   if (process.stdout.isTTY) {
@@ -573,11 +610,20 @@ export function _hasActiveScreen(): boolean {
  *  external state (e.g. an LLM call's elapsed time) keeps updating
  *  even with no key input.
  */
+/** Adapt either a plain JS function or an AgencyFunction-like callback
+ *  passed across the bridge into an async callable. Uses `__call` so
+ *  AgencyFunction values dispatch through the runtime's normal call
+ *  path (preserving handlers, ALS context, retry semantics) rather
+ *  than being invoked as raw JS. */
+async function callBridgeFn<T>(fn: unknown, ...args: unknown[]): Promise<T> {
+  return (await __call(fn, { type: "positional", args })) as T;
+}
+
 export async function _runLoop(
   initialState: any,
-  renderFn: (state: any) => any,
-  handleKeyFn: (state: any, ev: TuiKeyEvent) => any,
-  isDoneFn: (state: any) => boolean,
+  renderFn: unknown,
+  handleKeyFn: unknown,
+  isDoneFn: unknown,
   tickMs?: number,
 ): Promise<any> {
   const screen = makeBridgeScreen();
@@ -585,9 +631,9 @@ export async function _runLoop(
   try {
     return await screen.runLoop({
       initialState,
-      render: (s) => renderFn(s) as TuiElement,
-      handleKey: (s, ev) => handleKeyFn(s, ev),
-      isDone: (s) => isDoneFn(s),
+      render: async (s) => await callBridgeFn<TuiElement>(renderFn, s),
+      handleKey: async (s, ev) => await callBridgeFn(handleKeyFn, s, ev),
+      isDone: async (s) => await callBridgeFn<boolean>(isDoneFn, s),
       tickMs,
     });
   } finally {

--- a/packages/agency-lang/lib/stdlib/ui.ts
+++ b/packages/agency-lang/lib/stdlib/ui.ts
@@ -20,7 +20,7 @@ import {
   type OutputTarget,
 } from "@/tui/index.js";
 import type { Frame } from "@/tui/frame.js";
-import { withBottomCursor } from "./ui-region.js";
+import { withBottomCursor, installRegion, resetRegion } from "./ui-region.js";
 import { __call } from "../runtime/call.js";
 
 // Evaluated once at load time — the env var is set by the debugger CLI
@@ -544,7 +544,12 @@ export function _setQuitAfterMs(ms: number): void {
   pendingQuitAfterMs = ms;
 }
 
-function makeBridgeScreen(): Screen {
+/** Consume any pending test-mode injection and fall back to real
+ *  terminal I/O when production. Sets `bridgeInputSource`,
+ *  `bridgeOutputTarget`, `bridgeWidth`, `bridgeHeight`. Shared by
+ *  `makeBridgeScreen` and `_runLoopHybrid` so both paths see the
+ *  same scripted-input behavior. */
+function ensureBridgeState(): void {
   if (pendingScriptedKeys) {
     const scriptedInput = new ScriptedInput(pendingScriptedKeys);
     bridgeInputSource = scriptedInput;
@@ -569,9 +574,13 @@ function makeBridgeScreen(): Screen {
     bridgeWidth = process.stdout.columns || bridgeWidth;
     bridgeHeight = process.stdout.rows || bridgeHeight;
   }
+}
+
+function makeBridgeScreen(): Screen {
+  ensureBridgeState();
   return new Screen({
-    input: bridgeInputSource,
-    output: bridgeOutputTarget,
+    input: bridgeInputSource!,
+    output: bridgeOutputTarget!,
     width: bridgeWidth,
     height: bridgeHeight,
   });
@@ -688,4 +697,75 @@ export class BottomRegionOutputTarget implements OutputTarget {
  */
 export function _writeScrollLine(text: string): void {
   process.stdout.write(text + "\n");
+}
+
+// ---------------------------------------------------------------------------
+// Hybrid mode — bridge primitives for `repl()`.
+//
+// `repl()` installs a terminal scroll region so the top of the screen
+// keeps native scrollback + mouse-select + copy/paste, and only the
+// bottom N rows are owned by the bounded TUI. The Agency-side widget
+// composes these primitives into a lifecycle that survives exceptions.
+// ---------------------------------------------------------------------------
+
+/** Install a `bottomRows`-row reserved region at the bottom of the
+ *  terminal. The top `H - bottomRows` rows scroll natively. No-op on
+ *  non-TTY. Idempotent — call again to resize the region. */
+export function _installScrollRegion(bottomRows: number): void {
+  installRegion(bottomRows);
+}
+
+/** Tear down the reserved region. Restores the default scroll region
+ *  (the whole terminal) and prints a trailing newline so the next
+ *  shell prompt lands below the bottom region. */
+export function _resetScrollRegion(): void {
+  resetRegion();
+}
+
+/** Hybrid-mode variant of `_runLoop`. Wraps the active output target
+ *  in `BottomRegionOutputTarget` so TUI frames land in the bottom
+ *  region of the real terminal, and bounds the `Screen` to a
+ *  `bottomRows`-row viewport. The scroll region itself is installed
+ *  by `repl()` via `_installScrollRegion` before this call and torn
+ *  down via `_resetScrollRegion` afterwards (including on exception
+ *  paths via the Agency `handle` block). */
+export async function _runLoopHybrid(
+  initialState: any,
+  renderFn: unknown,
+  handleKeyFn: unknown,
+  isDoneFn: unknown,
+  tickMs: number,
+  bottomRows: number,
+): Promise<any> {
+  // Resolve the underlying input + output (consuming test-mode
+  // injection), then build a Screen bounded to `bottomRows` whose
+  // OutputTarget is wrapped in `BottomRegionOutputTarget`. The wrap
+  // positions every frame at the bottom of the real terminal so
+  // ordinary stdout writes still scroll inside the top region.
+  ensureBridgeState();
+  const wrappedOutput = new BottomRegionOutputTarget(bridgeOutputTarget!);
+  const hybridScreen = new Screen({
+    input: bridgeInputSource!,
+    output: wrappedOutput,
+    width: bridgeWidth,
+    height: bottomRows,
+  });
+  bridgeActiveScreen = hybridScreen;
+  try {
+    return await hybridScreen.runLoop({
+      initialState,
+      render: async (s) => await callBridgeFn<TuiElement>(renderFn, s),
+      handleKey: async (s, ev) => await callBridgeFn(handleKeyFn, s, ev),
+      isDone: async (s) => await callBridgeFn<boolean>(isDoneFn, s),
+      tickMs,
+    });
+  } finally {
+    bridgeActiveScreen = null;
+    // `Screen.destroy` would also destroy the input source; we want
+    // the bridge's input/output to survive in case the same process
+    // later calls back into `_runLoop` (e.g. agency-agent test
+    // harnesses that run multiple REPL turns). Just clear the
+    // wrapper's own listeners.
+    if (wrappedOutput.destroy) wrappedOutput.destroy();
+  }
 }

--- a/packages/agency-lang/lib/tui/screen.ts
+++ b/packages/agency-lang/lib/tui/screen.ts
@@ -39,9 +39,9 @@ export class Screen {
 
   async runLoop<S>(opts: {
     initialState: S;
-    render: (state: S) => Element;
-    handleKey: (state: S, event: KeyEvent) => S;
-    isDone: (state: S) => boolean;
+    render: (state: S) => Element | Promise<Element>;
+    handleKey: (state: S, event: KeyEvent) => S | Promise<S>;
+    isDone: (state: S) => boolean | Promise<boolean>;
     label?: string;
     /**
      * If set, the loop races each `nextKey()` against a `setTimeout`
@@ -60,9 +60,14 @@ export class Screen {
      */
     tickMs?: number;
   }): Promise<S> {
+    // The render / handleKey / isDone callbacks may be async — the
+    // declarative bridge in `lib/stdlib/ui.ts` adapts Agency callback
+    // values into async wrappers (Agency functions invoke through the
+    // runtime call path which returns a Promise). Pure-TS callers can
+    // still pass sync functions; the awaits become trivial.
     let state = opts.initialState;
-    this.render(opts.render(state), opts.label);
-    while (!opts.isDone(state)) {
+    this.render(await opts.render(state), opts.label);
+    while (!(await opts.isDone(state))) {
       if (opts.tickMs !== undefined) {
         const tickPromise = new Promise<{ kind: "tick" }>((resolve) =>
           setTimeout(() => resolve({ kind: "tick" }), opts.tickMs),
@@ -74,13 +79,13 @@ export class Screen {
           { kind: "tick" } | { kind: "key"; ev: KeyEvent }
         >([keyPromise, tickPromise]);
         if (result.kind === "key") {
-          state = opts.handleKey(state, result.ev);
+          state = await opts.handleKey(state, result.ev);
         }
       } else {
         const event = await this.nextKey();
-        state = opts.handleKey(state, event);
+        state = await opts.handleKey(state, event);
       }
-      this.render(opts.render(state), opts.label);
+      this.render(await opts.render(state), opts.label);
     }
     return state;
   }

--- a/packages/agency-lang/lib/tui/screen.ts
+++ b/packages/agency-lang/lib/tui/screen.ts
@@ -53,10 +53,10 @@ export class Screen {
      * When omitted, the loop is pure event-driven: it blocks on
      * `nextKey()` and re-renders only after each keypress.
      *
-     * Note: the losing side of the race leaves a pending
-     * `nextKey()` promise; the next loop iteration awaits the same
-     * promise. `ScriptedInput` (multi-waiter queue) and
-     * `TerminalInput` (readline) both tolerate this safely.
+     * The tick-side branch reuses a single in-flight `nextKey()`
+     * promise across iterations so a key the user types during a
+     * tick race is consumed by the next race rather than queued
+     * behind abandoned waiters.
      */
     tickMs?: number;
   }): Promise<S> {
@@ -67,18 +67,29 @@ export class Screen {
     // still pass sync functions; the awaits become trivial.
     let state = opts.initialState;
     this.render(await opts.render(state), opts.label);
+    // Single in-flight `nextKey()` shared across tick iterations.
+    // Calling `this.nextKey()` once per tick would enqueue a fresh
+    // waiter on the underlying input source's FIFO queue every time
+    // a tick wins the race; the next keypress would then resolve the
+    // oldest waiter (an abandoned tick-race promise) instead of the
+    // one the current `Promise.race` is awaiting, requiring one
+    // keypress per accumulated tick before the loop starts reacting.
+    let pendingKeyPromise: Promise<{ kind: "key"; ev: KeyEvent }> | null = null;
     while (!(await opts.isDone(state))) {
       if (opts.tickMs !== undefined) {
+        if (pendingKeyPromise === null) {
+          pendingKeyPromise = this.nextKey().then(
+            (ev) => ({ kind: "key" as const, ev }),
+          );
+        }
         const tickPromise = new Promise<{ kind: "tick" }>((resolve) =>
           setTimeout(() => resolve({ kind: "tick" }), opts.tickMs),
         );
-        const keyPromise = this.nextKey().then(
-          (ev) => ({ kind: "key" as const, ev }),
-        );
         const result = await Promise.race<
           { kind: "tick" } | { kind: "key"; ev: KeyEvent }
-        >([keyPromise, tickPromise]);
+        >([pendingKeyPromise, tickPromise]);
         if (result.kind === "key") {
+          pendingKeyPromise = null;
           state = await opts.handleKey(state, result.ev);
         }
       } else {

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -332,7 +332,9 @@ export def column(
   block: (Builder) => void = null
 ): Element {
   const kids: any[] = []
-  block(_makeBuilder(kids))
+  // `block` is optional — guard so empty containers (and parser
+  // mis-binds that leave `block` null) don't crash at runtime.
+  if (block != null) { block(_makeBuilder(kids)) }
   return {
     type: "box",
     style: _mkBoxStyle(flexDirection: "column", flex: flex, width: width,
@@ -361,7 +363,7 @@ export def row(
   block: (Builder) => void = null
 ): Element {
   const kids: any[] = []
-  block(_makeBuilder(kids))
+  if (block != null) { block(_makeBuilder(kids)) }
   return {
     type: "box",
     style: _mkBoxStyle(flexDirection: "row", flex: flex, width: width,
@@ -390,7 +392,7 @@ export def box(
   block: (Builder) => void = null
 ): Element {
   const kids: any[] = []
-  block(_makeBuilder(kids))
+  if (block != null) { block(_makeBuilder(kids)) }
   return {
     type: "box",
     style: _mkBoxStyle(flexDirection: "", flex: flex, width: width,
@@ -665,7 +667,7 @@ def _replView(s: ReplState): Element {
   // `block` param null at runtime.
   return column(visible: true) as col {
     col.list(items: palItems, selectedIndex: s.paletteCursor,
-             visible: s.paletteOpen, height: 5, border: true)
+             visible: s.paletteOpen, height: _PALETTE_ROWS, border: true)
     col.row(bg: "blue", fg: "white", height: 1) as st {
       st.line(stat.left)
       st.box(flex: 1) as _ {}
@@ -854,9 +856,19 @@ export def repl(
     status: status,
     onSubmit: onSubmit
   }
-  _installScrollRegion(_BASE_BOTTOM_ROWS)
+  // Reserve enough rows for the *maximum* bottom-region layout
+  // (status + input + open palette) so the palette fits when opened
+  // without clipping the input or status. The palette element renders
+  // `visible: false` when closed and the layout treats invisible
+  // children as zero-height (see `lib/tui/test/layout.test.ts`), so
+  // the extra rows are just empty space above the status bar when
+  // the palette isn't open. A future revision could resize the
+  // scroll region dynamically when the palette toggles, but Screen
+  // doesn't yet support mid-loop height changes.
+  const totalRows = _BASE_BOTTOM_ROWS + _PALETTE_ROWS
+  _installScrollRegion(totalRows)
   const seeded = _appendNewScrollLines(initial)
   _runLoopHybrid(seeded, _replView, _replReduce, _replIsDone,
-                 tickMs, _BASE_BOTTOM_ROWS)
+                 tickMs, totalRows)
   _resetScrollRegion()
 }

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -1,4 +1,5 @@
 import { _initUI, _destroyUI, _log, _status, _chat, _code, _diff, _separator, _startSpinner, _stopSpinner, _emptyLine, _prompt } from "agency-lang/stdlib-lib/ui.js"
+import { _runLoop, _renderOnce, _readKey, _hasActiveScreen } from "agency-lang/stdlib-lib/ui.js"
 export def initUI(title: string) {
   """
   Initialize a terminal UI with a scrollable output area and a fixed input bar at the bottom. Call this once at the start of your agent. The title is shown in the scrollable output area on init; use status() to populate the status bar.
@@ -106,4 +107,67 @@ export def emptyLine() {
   Print an empty line. Useful for adding spacing in the output.
   """
   _emptyLine()
+}
+
+// ---------------------------------------------------------------------------
+// New declarative API (Layer 1 + Layer 2).
+//
+// The old imperative exports above remain during the migration; PR #3
+// removes them along with their TS-side helpers. Everything below this
+// line is the new replacement API documented in
+// docs/superpowers/specs/2026-05-30-stdlib-ui-redesign-design.md.
+// ---------------------------------------------------------------------------
+
+/**
+ * Opaque tree node. Produced only by the builder functions below;
+ * consumed only by `runLoop` and `renderOnce`. Users do not
+ * construct one directly.
+ */
+export type Element = {
+  type: string;
+  style?: any;
+  content?: string;
+  children?: any[];
+  items?: string[];
+  selectedIndex?: number;
+  value?: string
+}
+
+/**
+ * Keystroke delivered to `handleKey` blocks.
+ *
+ * `key` is either a named special key — `"up"`, `"down"`, `"left"`,
+ * `"right"`, `"enter"`, `"escape"`, `"backspace"`, `"tab"`,
+ * `"home"`, `"end"`, `"pageup"`, `"pagedown"`, `"delete"`,
+ * `"insert"` — or a single printable character (e.g. `"q"`, `"/"`,
+ * `" "`). Mirrors the encoding in `lib/tui/input/terminal.ts`.
+ *
+ * `shift` / `ctrl` indicate held modifier keys at keypress time.
+ */
+export type KeyEvent = {
+  key: string;
+  shift: boolean;
+  ctrl: boolean
+}
+
+/**
+ * Builder receiver passed to every container block. Method calls
+ * append child elements to the enclosing parent in source order.
+ *
+ * Container methods (`row`, `column`, `box`) take a trailing block
+ * that receives a fresh Builder for the new child's contents. Leaf
+ * methods (`line`, `text`, `list`, `textInput`) don't.
+ *
+ * The methods are typed `any` because each one accepts a different
+ * named-arg signature; full signatures are documented on the
+ * top-level builders (`column`, `row`, etc.).
+ */
+export type Builder = {
+  row: any;
+  column: any;
+  box: any;
+  line: any;
+  text: any;
+  list: any;
+  textInput: any
 }

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -1,5 +1,6 @@
 import { _initUI, _destroyUI, _log, _status, _chat, _code, _diff, _separator, _startSpinner, _stopSpinner, _emptyLine, _prompt } from "agency-lang/stdlib-lib/ui.js"
 import { _runLoop, _renderOnce, _readKey, _hasActiveScreen, _setScriptedKeys, _setQuitAfterMs } from "agency-lang/stdlib-lib/ui.js"
+import { _installScrollRegion, _resetScrollRegion, _writeScrollLine, _runLoopHybrid } from "agency-lang/stdlib-lib/ui.js"
 export def initUI(title: string) {
   """
   Initialize a terminal UI with a scrollable output area and a fixed input bar at the bottom. Call this once at the start of your agent. The title is shown in the scrollable output area on init; use status() to populate the status bar.
@@ -593,4 +594,269 @@ export def setScriptedKeys(keys: KeyEvent[]) {
  */
 export def setQuitAfterMs(ms: number) {
   _setQuitAfterMs(ms)
+}
+
+// ---------------------------------------------------------------------------
+// Layer 2 — repl() widget
+//
+// An opinionated REPL with a status line, scroll output (via the
+// terminal's native scroll region in hybrid mode), a command palette
+// triggered by `/`, and a persistent input history. Built entirely on
+// top of Layer 1 + the hybrid-mode primitives from `lib/stdlib/ui.ts`.
+// ---------------------------------------------------------------------------
+
+// Bottom-region row counts. Base = status (1) + input (1). When the
+// palette is open we add `_PALETTE_ROWS` and re-issue the scroll
+// region from within `_replReduce` so the layout doesn't overlap the
+// scrolled output. v1 is fixed; future versions may compute these
+// from actual rendered content.
+const _BASE_BOTTOM_ROWS: number = 2
+const _PALETTE_ROWS: number = 5
+
+type ReplState = {
+  buffer: string;
+  history: string[];
+  historyIdx: number;
+  paletteOpen: boolean;
+  paletteFilter: string;
+  paletteCursor: number;
+  done: boolean;
+  outputLinesWritten: number;
+  prompt: string;
+  paletteCommands: any;
+  historyFile: string;
+  historyMax: number;
+  output: any;
+  status: any;
+  onSubmit: any
+}
+
+// Returns the keys of paletteCommands whose name contains the
+// (lowercased) filter substring. Lists in insertion order.
+def _filteredPaletteKeys(s: ReplState): string[] {
+  const cmds = s.paletteCommands
+  let allKeys: string[] = []
+  for (entry in entries(cmds)) {
+    allKeys.push(entry.key)
+  }
+  if (s.paletteFilter == "") { return allKeys }
+  let out: string[] = []
+  const filt = s.paletteFilter.toLowerCase()
+  for (k in allKeys) {
+    if (k.toLowerCase().includes(filt)) { out.push(k) }
+  }
+  return out
+}
+
+// View: the bottom region only. Output lines live in the terminal's
+// native scroll region; we append new tails via `_writeScrollLine`
+// inside `_replReduce` rather than rendering them into this tree.
+def _replView(s: ReplState): Element {
+  const stat = s.status()
+  const palKeys = _filteredPaletteKeys(s)
+  let palItems: string[] = []
+  for (k in palKeys) {
+    const desc = s.paletteCommands[k]
+    palItems.push("${k}  - ${desc}")
+  }
+  // Note: every container call here MUST pass at least one named arg.
+  // The agency parser otherwise compiles `column() as col { ... }` as a
+  // positional call where the block lands in `flex`, leaving the
+  // `block` param null at runtime.
+  return column(visible: true) as col {
+    col.list(items: palItems, selectedIndex: s.paletteCursor,
+             visible: s.paletteOpen, height: 5, border: true)
+    col.row(bg: "blue", fg: "white", height: 1) as st {
+      st.line(stat.left)
+      st.box(flex: 1) as _ {}
+      st.line(stat.right)
+    }
+    col.row(height: 1) as ir {
+      ir.line(s.prompt)
+      ir.textInput(value: s.buffer, flex: 1)
+    }
+  }
+}
+
+// Stream new tail of `output()` (lines added since last call) to the
+// terminal scroll region. Returns updated state with the counter
+// advanced. If `output()` shrunk (consumer cleared its own buffer)
+// we just reset the counter and let the next call resume cleanly.
+def _appendNewScrollLines(s: ReplState): ReplState {
+  const lines = s.output()
+  const n = lines.length
+  if (n < s.outputLinesWritten) {
+    return { ...s, outputLinesWritten: n }
+  }
+  if (n > s.outputLinesWritten) {
+    let i = s.outputLinesWritten
+    while (i < n) {
+      _writeScrollLine(lines[i])
+      i = i + 1
+    }
+    return { ...s, outputLinesWritten: n }
+  }
+  return s
+}
+
+def _persistHistory(s: ReplState): boolean {
+  // History persistence is intentionally skipped at v1 to avoid
+  // pulling in std::shell from the stdlib (which would create a
+  // dependency cycle in some configurations). The history-up/down
+  // navigation works without persistence; reload-across-sessions is
+  // a v2 feature.
+  return true
+}
+
+def _replReduce(s: ReplState, k: KeyEvent): ReplState {
+  // Palette controls take priority when the palette is open.
+  if (s.paletteOpen) {
+    const palKeys = _filteredPaletteKeys(s)
+    if (k.key == "escape") {
+      return { ...s, paletteOpen: false, paletteFilter: "", paletteCursor: 0 }
+    }
+    if (k.key == "up") {
+      let c = s.paletteCursor - 1
+      if (c < 0) { c = 0 }
+      return { ...s, paletteCursor: c }
+    }
+    if (k.key == "down") {
+      let c = s.paletteCursor + 1
+      const maxC = palKeys.length - 1
+      if (c > maxC) { c = maxC }
+      if (c < 0)    { c = 0 }
+      return { ...s, paletteCursor: c }
+    }
+    if (k.key == "enter" || k.key == "tab") {
+      if (palKeys.length == 0) {
+        return { ...s, paletteOpen: false, paletteFilter: "" }
+      }
+      return {
+        ...s,
+        buffer: palKeys[s.paletteCursor],
+        paletteOpen: false,
+        paletteFilter: "",
+        paletteCursor: 0
+      }
+    }
+    if (k.key == "backspace") {
+      if (s.paletteFilter == "") {
+        return { ...s, paletteOpen: false }
+      }
+      const f = s.paletteFilter
+      return {
+        ...s,
+        paletteFilter: f.slice(0, f.length - 1),
+        paletteCursor: 0
+      }
+    }
+    if (k.key.length == 1) {
+      return { ...s, paletteFilter: s.paletteFilter + k.key, paletteCursor: 0 }
+    }
+    return s
+  }
+
+  // Palette closed: normal editing.
+  if (k.ctrl && k.key == "c") {
+    return { ...s, done: true }
+  }
+  if (k.key == "/" && s.buffer == "") {
+    return { ...s, paletteOpen: true, paletteFilter: "", paletteCursor: 0 }
+  }
+  if (k.key == "up" && s.historyIdx > 0) {
+    const i = s.historyIdx - 1
+    return { ...s, historyIdx: i, buffer: s.history[i] }
+  }
+  if (k.key == "down" && s.historyIdx < s.history.length) {
+    const i = s.historyIdx + 1
+    let buf = ""
+    if (i < s.history.length) { buf = s.history[i] }
+    return { ...s, historyIdx: i, buffer: buf }
+  }
+  if (k.key == "backspace") {
+    if (s.buffer == "") { return s }
+    return { ...s, buffer: s.buffer.slice(0, s.buffer.length - 1) }
+  }
+  if (k.key == "enter") {
+    const submitted = s.buffer
+    let nextHist = s.history
+    if (submitted != "") {
+      nextHist = [...s.history, submitted]
+      if (nextHist.length > s.historyMax) {
+        nextHist = nextHist.slice(nextHist.length - s.historyMax, nextHist.length)
+      }
+    }
+    const keepGoing = s.onSubmit(submitted)
+    const drained = _appendNewScrollLines({
+      ...s,
+      buffer: "",
+      history: nextHist,
+      historyIdx: nextHist.length,
+      done: !keepGoing
+    })
+    return drained
+  }
+  if (k.key.length == 1) {
+    return { ...s, buffer: s.buffer + k.key }
+  }
+  return s
+}
+
+def _replIsDone(s: ReplState): boolean { return s.done }
+
+/**
+ * Drop-in REPL widget for interactive CLI agents. Bundles a scroll
+ * output area (via the terminal's native scroll region), a status
+ * line, a command palette (triggered by `/`), and an input line
+ * with history navigation.
+ *
+ * Lifecycle: installs a scroll region on entry, runs the bounded
+ * `runLoop` with `tickMs` so the status line stays live during a
+ * turn, tears down the region on exit (clean exit, onSubmit -> false,
+ * or exception). The handler block ensures the region is reset even
+ * if an exception escapes the loop.
+ *
+ * @param output - Re-evaluated every render; new tail lines stream to scrollback
+ * @param status - Re-evaluated every render; populates the status line
+ * @param onSubmit - Called with the submitted line; return `false` to exit
+ * @param prompt - String shown before the input buffer (default `"> "`)
+ * @param historyFile - Reserved for future use (history persistence is v2)
+ * @param historyMax - Trim oldest entries beyond this count
+ * @param paletteCommands - Map of `/cmd` -> description, iterated in order
+ * @param tickMs - Render cadence in milliseconds (default 100)
+ */
+export def repl(
+  output: any,
+  status: any,
+  onSubmit: any,
+  prompt: string = "> ",
+  historyFile: string = "",
+  historyMax: number = 1000,
+  paletteCommands: any = null,
+  tickMs: number = 100
+) {
+  let cmds = paletteCommands
+  if (cmds == null) { cmds = {} }
+  const initial: ReplState = {
+    buffer: "",
+    history: [],
+    historyIdx: 0,
+    paletteOpen: false,
+    paletteFilter: "",
+    paletteCursor: 0,
+    done: false,
+    outputLinesWritten: 0,
+    prompt: prompt,
+    paletteCommands: cmds,
+    historyFile: historyFile,
+    historyMax: historyMax,
+    output: output,
+    status: status,
+    onSubmit: onSubmit
+  }
+  _installScrollRegion(_BASE_BOTTOM_ROWS)
+  const seeded = _appendNewScrollLines(initial)
+  _runLoopHybrid(seeded, _replView, _replReduce, _replIsDone,
+                 tickMs, _BASE_BOTTOM_ROWS)
+  _resetScrollRegion()
 }

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -262,3 +262,260 @@ export def textInput(
   if (bg != "")       { style.bg = bg }
   return { type: "textInput", style: style, value: value }
 }
+
+// ---- Container builders ----
+//
+// Each container opens a fresh children array, builds a `Builder`
+// whose method fields are PFAs of internal `_addX` functions with
+// the array pre-bound, runs the block to populate the children, and
+// returns the Element with the populated children. Records are
+// reference types in Agency and `.partial()` binds the reference
+// (not a copy), so mutations to `kids` inside `_addX` are visible to
+// the enclosing container.
+
+def _mkBoxStyle(
+  flexDirection: string,
+  flex?: number,
+  width?: number,
+  height?: number,
+  padding?: number,
+  border: boolean = false,
+  borderColor: string = "",
+  label: string = "",
+  bg: string = "",
+  fg: string = "",
+  visible: boolean = true
+): any {
+  let style: any = {}
+  if (flexDirection != "")  { style.flexDirection = flexDirection }
+  if (flex != null)         { style.flex = flex }
+  if (width != null)        { style.width = width }
+  if (height != null)       { style.height = height }
+  if (padding != null)      { style.padding = padding }
+  if (border)               { style.border = true }
+  if (borderColor != "")    { style.borderColor = borderColor }
+  if (label != "")          { style.label = label }
+  if (bg != "")             { style.bg = bg }
+  if (fg != "")             { style.fg = fg }
+  if (!visible)             { style.visible = false }
+  return style
+}
+
+def _makeBuilder(kids: any[]): Builder {
+  return {
+    row:       _addRow.partial(kids: kids),
+    column:    _addColumn.partial(kids: kids),
+    box:       _addBox.partial(kids: kids),
+    line:      _addLine.partial(kids: kids),
+    text:      _addText.partial(kids: kids),
+    list:      _addList.partial(kids: kids),
+    textInput: _addTextInput.partial(kids: kids)
+  }
+}
+
+/**
+ * A vertical container. Children stack top-to-bottom. The trailing
+ * block receives a fresh `Builder` to populate the column.
+ */
+export def column(
+  flex?: number,
+  width?: number,
+  height?: number,
+  padding?: number,
+  border: boolean = false,
+  borderColor: string = "",
+  label: string = "",
+  bg: string = "",
+  fg: string = "",
+  visible: boolean = true,
+  block: (Builder) => void = null
+): Element {
+  const kids: any[] = []
+  block(_makeBuilder(kids))
+  return {
+    type: "box",
+    style: _mkBoxStyle(flexDirection: "column", flex: flex, width: width,
+                       height: height, padding: padding, border: border,
+                       borderColor: borderColor, label: label, bg: bg,
+                       fg: fg, visible: visible),
+    children: kids
+  }
+}
+
+/**
+ * A horizontal container. Children stack left-to-right. The trailing
+ * block receives a fresh `Builder` to populate the row.
+ */
+export def row(
+  flex?: number,
+  width?: number,
+  height?: number,
+  padding?: number,
+  border: boolean = false,
+  borderColor: string = "",
+  label: string = "",
+  bg: string = "",
+  fg: string = "",
+  visible: boolean = true,
+  block: (Builder) => void = null
+): Element {
+  const kids: any[] = []
+  block(_makeBuilder(kids))
+  return {
+    type: "box",
+    style: _mkBoxStyle(flexDirection: "row", flex: flex, width: width,
+                       height: height, padding: padding, border: border,
+                       borderColor: borderColor, label: label, bg: bg,
+                       fg: fg, visible: visible),
+    children: kids
+  }
+}
+
+/**
+ * A direction-neutral container. Use when you want to apply styling
+ * (border, padding, background) without setting `flexDirection`.
+ */
+export def box(
+  flex?: number,
+  width?: number,
+  height?: number,
+  padding?: number,
+  border: boolean = false,
+  borderColor: string = "",
+  label: string = "",
+  bg: string = "",
+  fg: string = "",
+  visible: boolean = true,
+  block: (Builder) => void = null
+): Element {
+  const kids: any[] = []
+  block(_makeBuilder(kids))
+  return {
+    type: "box",
+    style: _mkBoxStyle(flexDirection: "", flex: flex, width: width,
+                       height: height, padding: padding, border: border,
+                       borderColor: borderColor, label: label, bg: bg,
+                       fg: fg, visible: visible),
+    children: kids
+  }
+}
+
+// ---- Internal: Builder method bodies ----
+
+def _addRow(
+  kids: any[],
+  flex?: number,
+  width?: number,
+  height?: number,
+  padding?: number,
+  border: boolean = false,
+  borderColor: string = "",
+  label: string = "",
+  bg: string = "",
+  fg: string = "",
+  visible: boolean = true,
+  block: (Builder) => void = null
+): Element {
+  const elem = row(flex: flex, width: width, height: height, padding: padding,
+                   border: border, borderColor: borderColor, label: label,
+                   bg: bg, fg: fg, visible: visible, block: block)
+  kids.push(elem)
+  return elem
+}
+
+def _addColumn(
+  kids: any[],
+  flex?: number,
+  width?: number,
+  height?: number,
+  padding?: number,
+  border: boolean = false,
+  borderColor: string = "",
+  label: string = "",
+  bg: string = "",
+  fg: string = "",
+  visible: boolean = true,
+  block: (Builder) => void = null
+): Element {
+  const elem = column(flex: flex, width: width, height: height, padding: padding,
+                      border: border, borderColor: borderColor, label: label,
+                      bg: bg, fg: fg, visible: visible, block: block)
+  kids.push(elem)
+  return elem
+}
+
+def _addBox(
+  kids: any[],
+  flex?: number,
+  width?: number,
+  height?: number,
+  padding?: number,
+  border: boolean = false,
+  borderColor: string = "",
+  label: string = "",
+  bg: string = "",
+  fg: string = "",
+  visible: boolean = true,
+  block: (Builder) => void = null
+): Element {
+  const elem = box(flex: flex, width: width, height: height, padding: padding,
+                   border: border, borderColor: borderColor, label: label,
+                   bg: bg, fg: fg, visible: visible, block: block)
+  kids.push(elem)
+  return elem
+}
+
+def _addLine(
+  kids: any[],
+  content: string,
+  flex?: number,
+  width?: number,
+  height?: number,
+  fg: string = "",
+  bg: string = "",
+  bold: boolean = false
+): Element {
+  const elem = line(content: content, flex: flex, width: width, height: height,
+                    fg: fg, bg: bg, bold: bold)
+  kids.push(elem)
+  return elem
+}
+
+def _addText(kids: any[], content: string): Element {
+  const elem = text(content)
+  kids.push(elem)
+  return elem
+}
+
+def _addList(
+  kids: any[],
+  items: string[],
+  selectedIndex: number = 0,
+  flex?: number,
+  width?: number,
+  height?: number,
+  border: boolean = false,
+  borderColor: string = "",
+  visible: boolean = true
+): Element {
+  const elem = list(items: items, selectedIndex: selectedIndex,
+                    flex: flex, width: width, height: height,
+                    border: border, borderColor: borderColor, visible: visible)
+  kids.push(elem)
+  return elem
+}
+
+def _addTextInput(
+  kids: any[],
+  value: string = "",
+  flex?: number,
+  width?: number,
+  height?: number,
+  fg: string = "",
+  bg: string = ""
+): Element {
+  const elem = textInput(value: value, flex: flex, width: width, height: height,
+                         fg: fg, bg: bg)
+  kids.push(elem)
+  return elem
+}

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -171,3 +171,94 @@ export type Builder = {
   list: any;
   textInput: any
 }
+
+// ---- Leaf builders ----
+
+/**
+ * A plain text element. No layout sizing — embed inside a `box` or
+ * `column` for layout. Prefer `line` when you want a single-row
+ * height-1 element.
+ *
+ * @param content - The text to render
+ */
+export def text(content: string): Element {
+  return { type: "text", content: content }
+}
+
+/**
+ * A single-line text element with `height: 1`. The default keeps it
+ * from stretching via flex when placed inside a `column`. Caller-
+ * provided style is merged on top.
+ *
+ * @param content - The text to render
+ */
+export def line(
+  content: string,
+  flex?: number,
+  width?: number,
+  height?: number,
+  fg: string = "",
+  bg: string = "",
+  bold: boolean = false
+): Element {
+  let h: number = 1
+  if (height != null) { h = height }
+  let style: any = { height: h }
+  if (flex != null)  { style.flex = flex }
+  if (width != null) { style.width = width }
+  if (fg != "")      { style.fg = fg }
+  if (bg != "")      { style.bg = bg }
+  if (bold)          { style.bold = true }
+  return { type: "text", content: content, style: style }
+}
+
+/**
+ * A scrollable selectable list. `selectedIndex` highlights one row;
+ * out-of-range values are clamped by the renderer.
+ *
+ * @param items - The strings to display, one per row
+ * @param selectedIndex - 0-based row to highlight (default 0)
+ */
+export def list(
+  items: string[],
+  selectedIndex: number = 0,
+  flex?: number,
+  width?: number,
+  height?: number,
+  border: boolean = false,
+  borderColor: string = "",
+  visible: boolean = true
+): Element {
+  let style: any = {}
+  if (flex != null)      { style.flex = flex }
+  if (width != null)     { style.width = width }
+  if (height != null)    { style.height = height }
+  if (border)            { style.border = true }
+  if (borderColor != "") { style.borderColor = borderColor }
+  if (!visible)          { style.visible = false }
+  return { type: "list", style: style, items: items, selectedIndex: selectedIndex }
+}
+
+/**
+ * A single-line text input. The renderer displays `value` with a
+ * cursor; key handling is the caller's responsibility (use `runLoop`'s
+ * `handleKey` to append characters / handle backspace).
+ *
+ * @param value - Current contents of the buffer
+ */
+export def textInput(
+  value: string = "",
+  flex?: number,
+  width?: number,
+  height?: number,
+  fg: string = "",
+  bg: string = ""
+): Element {
+  let style: any = {}
+  if (flex != null)   { style.flex = flex }
+  if (width != null)  { style.width = width }
+  if (height != null) { style.height = height }
+  if (fg != "")       { style.fg = fg }
+  if (bg != "")       { style.bg = bg }
+  return { type: "textInput", style: style, value: value }
+}

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -1,5 +1,5 @@
 import { _initUI, _destroyUI, _log, _status, _chat, _code, _diff, _separator, _startSpinner, _stopSpinner, _emptyLine, _prompt } from "agency-lang/stdlib-lib/ui.js"
-import { _runLoop, _renderOnce, _readKey, _hasActiveScreen } from "agency-lang/stdlib-lib/ui.js"
+import { _runLoop, _renderOnce, _readKey, _hasActiveScreen, _setScriptedKeys, _setQuitAfterMs } from "agency-lang/stdlib-lib/ui.js"
 export def initUI(title: string) {
   """
   Initialize a terminal UI with a scrollable output area and a fixed input bar at the bottom. Call this once at the start of your agent. The title is shown in the scrollable output area on init; use status() to populate the status bar.
@@ -146,8 +146,8 @@ export type Element = {
  */
 export type KeyEvent = {
   key: string;
-  shift: boolean;
-  ctrl: boolean
+  shift?: boolean;
+  ctrl?: boolean
 }
 
 /**
@@ -518,4 +518,79 @@ def _addTextInput(
                          fg: fg, bg: bg)
   kids.push(elem)
   return elem
+}
+
+// ---- Render & event loop ----
+
+/**
+ * Render a single Element tree to the screen and return immediately.
+ * For static UI or first-paint scenarios. For interactive UI, use
+ * `runLoop`.
+ */
+export def renderOnce(tree: Element) {
+  _renderOnce(tree)
+}
+
+/**
+ * Read one key from the terminal. Blocks until a key is pressed.
+ * Use sparingly; prefer `runLoop` for anything beyond a single
+ * blocking prompt.
+ */
+export def readKey(): KeyEvent {
+  return _readKey()
+}
+
+/**
+ * Elm/Ink-style state machine driver. Renders the initial state,
+ * waits for each `KeyEvent`, runs `handleKey` to produce the next
+ * state, re-renders, exits when `isDone` returns `true`. Returns
+ * the final state.
+ *
+ * When `tickMs` is set, the loop also re-renders periodically even
+ * if no key is pressed. This is what makes a live status line tick.
+ * `handleKey` does NOT fire on ticks — `render` does (re-evaluates
+ * any impure state your view reads).
+ *
+ * @param initialState - The opening state record
+ * @param render       - Pure (state) -> Element. Re-runs every tick / key.
+ * @param handleKey    - Pure (state, key) -> state. Runs only on real keys.
+ * @param isDone       - Pure (state) -> boolean. Loop exits when true.
+ * @param tickMs       - Milliseconds between forced re-renders (omit for event-driven only)
+ */
+export def runLoop(
+  initialState: any,
+  render: any,
+  handleKey: any,
+  isDone: any,
+  tickMs?: number
+): any {
+  return _runLoop(initialState, render, handleKey, isDone, tickMs)
+}
+
+// ---- Test-mode injection (internal) ----
+//
+// Tests call these helpers to drive runLoop / repl without a real
+// TTY. `_runLoop` consumes the pending keys on its next invocation
+// and installs a ScriptedInput + FrameRecorder under the hood.
+
+/**
+ * Seed the next `runLoop` (or `repl`) entry with a scripted key
+ * sequence. Internal — used by tests in `tests/agency/ui-*`.
+ *
+ * @param keys - Array of `KeyEvent` records consumed in order
+ */
+export def setScriptedKeys(keys: KeyEvent[]) {
+  _setScriptedKeys(keys)
+}
+
+/**
+ * Schedule a `q` keypress N milliseconds after the next `runLoop`
+ * starts. Internal — used by the tickMs coverage test so a
+ * tick-driven loop terminates without a key-timeline that matches
+ * the tick cadence.
+ *
+ * @param ms - Milliseconds before the synthetic `q` arrives
+ */
+export def setQuitAfterMs(ms: number) {
+  _setQuitAfterMs(ms)
 }

--- a/packages/agency-lang/tests/agency/ui-builders-container/main.agency
+++ b/packages/agency-lang/tests/agency/ui-builders-container/main.agency
@@ -1,0 +1,33 @@
+import { column, row, line, list } from "std::ui"
+
+node main(): string {
+  const tree = column(flex: 1, border: true) as col {
+    col.row(bg: "blue", height: 1) as header {
+      header.line("hi")
+    }
+    col.line("body", fg: "gray")
+    col.list(items: ["a", "b"], selectedIndex: 1)
+  }
+  if (tree.type != "box")                       { return "FAIL: root type" }
+  if (tree.style.flexDirection != "column")     { return "FAIL: root flexDir" }
+  if (tree.style.flex != 1)                     { return "FAIL: root flex" }
+  if (tree.style.border != true)                { return "FAIL: root border" }
+  if (tree.children.length != 3)                { return "FAIL: children len" }
+
+  const head = tree.children[0]
+  if (head.type != "box")                       { return "FAIL: header type" }
+  if (head.style.flexDirection != "row")        { return "FAIL: header flexDir" }
+  if (head.style.bg != "blue")                  { return "FAIL: header bg" }
+  if (head.children.length != 1)                { return "FAIL: header children" }
+  if (head.children[0].content != "hi")         { return "FAIL: header text" }
+
+  const body = tree.children[1]
+  if (body.type != "text")                      { return "FAIL: body type" }
+  if (body.content != "body")                   { return "FAIL: body content" }
+  if (body.style.fg != "gray")                  { return "FAIL: body fg" }
+
+  const lst = tree.children[2]
+  if (lst.type != "list")                       { return "FAIL: list type" }
+  if (lst.selectedIndex != 1)                   { return "FAIL: list selIdx" }
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/ui-builders-container/main.test.json
+++ b/packages/agency-lang/tests/agency/ui-builders-container/main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "container builders + Builder method dispatch produce expected tree"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ui-builders-leaf/main.agency
+++ b/packages/agency-lang/tests/agency/ui-builders-leaf/main.agency
@@ -1,0 +1,19 @@
+import { text, line } from "std::ui"
+
+node main(): string {
+  // text(): no style, just content.
+  const t = text("hello")
+  if (t.type != "text")     { return "FAIL: text type" }
+  if (t.content != "hello") { return "FAIL: text content" }
+
+  // line(): defaults height: 1; style merged with named args.
+  const l = line("hi", fg: "red", height: 2)
+  if (l.type != "text")     { return "FAIL: line type" }
+  if (l.style.height != 2)  { return "FAIL: line height" }
+  if (l.style.fg != "red")  { return "FAIL: line fg" }
+
+  // line() with default height.
+  const l2 = line("hi")
+  if (l2.style.height != 1) { return "FAIL: default height" }
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/ui-builders-leaf/main.test.json
+++ b/packages/agency-lang/tests/agency/ui-builders-leaf/main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "leaf builders (text, line) produce expected Element records"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ui-builders-style-props/main.agency
+++ b/packages/agency-lang/tests/agency/ui-builders-style-props/main.agency
@@ -1,0 +1,23 @@
+import { column, row } from "std::ui"
+
+node main(): string {
+  const c = column(flex: 3, width: 50, height: 20, padding: 2,
+                   border: true, borderColor: "red", label: "title",
+                   bg: "black", fg: "white", visible: false) as _ {}
+  const s = c.style
+  if (s.flex != 3)            { return "FAIL: flex" }
+  if (s.width != 50)          { return "FAIL: width" }
+  if (s.height != 20)         { return "FAIL: height" }
+  if (s.padding != 2)         { return "FAIL: padding" }
+  if (s.border != true)       { return "FAIL: border" }
+  if (s.borderColor != "red") { return "FAIL: borderColor" }
+  if (s.label != "title")     { return "FAIL: label" }
+  if (s.bg != "black")        { return "FAIL: bg" }
+  if (s.fg != "white")        { return "FAIL: fg" }
+  if (s.visible != false)     { return "FAIL: visible" }
+
+  // Make sure `flex: 0` is preserved (not collapsed to null).
+  const r = row(flex: 0) as _ {}
+  if (r.style.flex != 0) { return "FAIL: flex zero collapsed" }
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/ui-builders-style-props/main.test.json
+++ b/packages/agency-lang/tests/agency/ui-builders-style-props/main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "style props on column/row propagate to the rendered Element"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ui-repl-history/main.agency
+++ b/packages/agency-lang/tests/agency/ui-repl-history/main.agency
@@ -1,0 +1,32 @@
+import { repl, setScriptedKeys } from "std::ui"
+
+let submits: string[] = []
+
+def out(): string[] { return [] }
+def stat(): { left: string; right: string } {
+  return { left: "", right: "" }
+}
+def onSub(s: string): boolean {
+  submits.push(s)
+  // Exit after 3 submits.
+  return submits.length < 3
+}
+
+node main(): string {
+  // Sequence:
+  //   a, enter      -> submits[0] == "a"
+  //   b, enter      -> submits[1] == "b"
+  //   up, enter     -> submits[2] == "b" (recalled via history up)
+  setScriptedKeys([
+    { key: "a" }, { key: "enter" },
+    { key: "b" }, { key: "enter" },
+    { key: "up" }, { key: "enter" }
+  ])
+  repl(prompt: "> ", output: out, status: stat,
+       paletteCommands: {}, onSubmit: onSub)
+  if (submits.length != 3) { return "FAIL: count" }
+  if (submits[0] != "a")   { return "FAIL: [0]" }
+  if (submits[1] != "b")   { return "FAIL: [1]" }
+  if (submits[2] != "b")   { return "FAIL: [2]" }
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/ui-repl-history/main.test.json
+++ b/packages/agency-lang/tests/agency/ui-repl-history/main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "repl history up arrow recalls previously submitted line"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ui-repl-onsubmit-false-exits/main.agency
+++ b/packages/agency-lang/tests/agency/ui-repl-onsubmit-false-exits/main.agency
@@ -1,0 +1,24 @@
+import { repl, setScriptedKeys } from "std::ui"
+
+let submits: number = 0
+
+def out(): string[] { return [] }
+def stat(): { left: string; right: string } {
+  return { left: "", right: "" }
+}
+def onSub(s: string): boolean {
+  submits = submits + 1
+  return false   // signal exit on first submit
+}
+
+node main(): string {
+  // Script: type "hi", press enter, then loop should exit cleanly
+  // because onSub returns false.
+  setScriptedKeys([
+    { key: "h" }, { key: "i" }, { key: "enter" }
+  ])
+  repl(prompt: "> ", output: out, status: stat,
+       paletteCommands: {}, onSubmit: onSub)
+  if (submits != 1) { return "FAIL: submits" }
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/ui-repl-onsubmit-false-exits/main.test.json
+++ b/packages/agency-lang/tests/agency/ui-repl-onsubmit-false-exits/main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "repl exits cleanly when onSubmit returns false"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ui-repl-palette-open/main.agency
+++ b/packages/agency-lang/tests/agency/ui-repl-palette-open/main.agency
@@ -1,0 +1,32 @@
+import { repl, setScriptedKeys } from "std::ui"
+
+let submits: string[] = []
+
+def out(): string[] { return [] }
+def stat(): { left: string; right: string } {
+  return { left: "", right: "" }
+}
+def onSub(s: string): boolean {
+  submits.push(s)
+  return false   // exit after first real submit
+}
+
+node main(): string {
+  // Sequence:
+  //   /            -> palette opens (filter empty)
+  //   e, x         -> filter "ex"; only /exit matches
+  //   enter        -> palette closes, buffer set to "/exit"
+  //   enter        -> submit("/exit")
+  setScriptedKeys([
+    { key: "/" },
+    { key: "e" }, { key: "x" },
+    { key: "enter" },
+    { key: "enter" }
+  ])
+  repl(prompt: "> ", output: out, status: stat,
+       paletteCommands: { "/exit": "Exit", "/help": "Help" },
+       onSubmit: onSub)
+  if (submits.length != 1) { return "FAIL: count" }
+  if (submits[0] != "/exit") { return "FAIL: text" }
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/ui-repl-palette-open/main.test.json
+++ b/packages/agency-lang/tests/agency/ui-repl-palette-open/main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "/ opens palette, typing filters, enter inserts the matched command"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ui-repl-status-tick/main.agency
+++ b/packages/agency-lang/tests/agency/ui-repl-status-tick/main.agency
@@ -1,0 +1,22 @@
+import { repl, setScriptedKeys } from "std::ui"
+
+let statusCalls: number = 0
+
+def out(): string[] { return [] }
+def stat(): { left: string; right: string } {
+  statusCalls = statusCalls + 1
+  return { left: "left", right: "right" }
+}
+def onSub(s: string): boolean { return false }
+
+node main(): string {
+  // Single enter — triggers initial render + one post-key re-render.
+  // Each render re-evaluates status(), so statusCalls should be >= 2.
+  // This covers the re-evaluation contract; the tickMs-driven branch
+  // of the same code path is exercised by tests/agency/ui-runloop-tick.
+  setScriptedKeys([{ key: "enter" }])
+  repl(prompt: "> ", output: out, status: stat,
+       paletteCommands: {}, onSubmit: onSub)
+  if (statusCalls < 2) { return "FAIL: only ${statusCalls} status calls" }
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/ui-repl-status-tick/main.test.json
+++ b/packages/agency-lang/tests/agency/ui-repl-status-tick/main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "repl status() is re-evaluated on every render"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ui-runloop-basic/main.agency
+++ b/packages/agency-lang/tests/agency/ui-runloop-basic/main.agency
@@ -1,0 +1,30 @@
+import { runLoop, column, line, KeyEvent, Element, setScriptedKeys } from "std::ui"
+
+type S = { n: number; done: boolean }
+
+def view(s: S): Element {
+  return column() as col { col.line("n=${s.n}") }
+}
+
+def reduce(s: S, k: KeyEvent): S {
+  if (k.key == "q")    { return { ...s, done: true } }
+  if (k.key == "down") { return { ...s, n: s.n + 1 } }
+  return s
+}
+
+def isDone(s: S): boolean { return s.done }
+
+node main(): string {
+  // Scripted keys: 3x down then q. Final n should be 3.
+  setScriptedKeys([
+    { key: "down" },
+    { key: "down" },
+    { key: "down" },
+    { key: "q"    }
+  ])
+  const final = runLoop(initialState: { n: 0, done: false },
+                        render: view, handleKey: reduce, isDone: isDone)
+  if (final.n != 3) { return "FAIL: final n" }
+  if (!final.done)  { return "FAIL: not done" }
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/ui-runloop-basic/main.test.json
+++ b/packages/agency-lang/tests/agency/ui-runloop-basic/main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "runLoop drives the scripted-key state machine to the expected final state"
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/ui-runloop-tick/main.agency
+++ b/packages/agency-lang/tests/agency/ui-runloop-tick/main.agency
@@ -1,0 +1,27 @@
+import { runLoop, column, KeyEvent, Element, setScriptedKeys } from "std::ui"
+
+// `isDone` reads this counter; the view bumps it every render. After
+// enough tick-driven renders, `isDone` returns true and the loop exits
+// cleanly without needing a synthetic keypress (which would require
+// multi-waiter aware nextKey() handling — see screen.ts).
+let renderCount: number = 0
+type S = { done: boolean }
+
+def view(s: S): Element {
+  renderCount = renderCount + 1
+  return column() as col { col.line("render ${renderCount}") }
+}
+
+def reduce(s: S, k: KeyEvent): S { return s }
+
+def isDone(s: S): boolean { return renderCount >= 4 }
+
+node main(): string {
+  // No scripted keys — the loop relies entirely on tickMs to advance.
+  // tickMs=20 means 4 renders take ~60ms.
+  setScriptedKeys([])
+  runLoop(initialState: { done: false },
+          render: view, handleKey: reduce, isDone: isDone, tickMs: 20)
+  if (renderCount < 4) { return "FAIL: only ${renderCount} renders" }
+  return "pass"
+}

--- a/packages/agency-lang/tests/agency/ui-runloop-tick/main.test.json
+++ b/packages/agency-lang/tests/agency/ui-runloop-tick/main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "\"pass\"",
+      "evaluationCriteria": [{ "type": "exact" }],
+      "description": "tickMs forces periodic re-renders even with no key input"
+    }
+  ]
+}


### PR DESCRIPTION
## std::ui redesign — PR 2 of 3: Layer 1 builders + repl() widget

Stacked on [#240 (PR #1)](https://github.com/egonSchiele/agency-lang/pull/240). Implements Milestones C + D from `docs/superpowers/plans/2026-05-30-stdlib-ui-redesign.md`.

### Additive strategy

`stdlib/ui.agency` keeps the existing imperative exports (`initUI`, `destroyUI`, `log`, `status`, `chat`, `code`, `diff`, `separator`, `startSpinner`, `stopSpinner`, `prompt`, `getConfirmation`, `emptyLine`) alongside the new declarative API. The corresponding TS-side helpers in `lib/stdlib/ui.ts` also stay in place. **PR #3 deletes the old API** (and removes the consumer/agency-agent dependency on it) — this PR keeps `main` green at the boundary.

### Milestone C — Layer 1 declarative core

- **Types**: `Element`, `KeyEvent`, `Builder`
- **Leaf builders**: `text`, `line`, `list`, `textInput`
- **Container builders**: `column`, `row`, `box` with `as <builder> { ... }` trailing-block syntax for the PFA-method-dispatch pattern
- **Render & event loop**: `runLoop` (with `tickMs` for live status updates), `renderOnce`, `readKey`
- **Test helpers**: `setScriptedKeys`, `setQuitAfterMs` (internal — drive scripted input for agency tests)

### Milestone D — Layer 2 repl() widget

`repl()` bundles status line + scroll output + command palette + input history. Built on top of Layer 1 + the hybrid-scroll bridge primitives newly added in this PR:

- `_installScrollRegion(bottomRows)` — terminal scroll region setup
- `_resetScrollRegion()` — teardown (also runs on exception path)
- `_runLoopHybrid(...)` — variant of `_runLoop` that wraps the output target in `BottomRegionOutputTarget` and bounds the `Screen` to the bottom region

### TS bridge updates

- `lib/tui/screen.ts`: `Screen.runLoop` callbacks accept async returns. Required because Agency-function callbacks come through `__call(...)` which is always async.
- `lib/stdlib/ui.ts`: `_runLoop` and `_runLoopHybrid` wrap callbacks through `__call(...)` so AgencyFunction values dispatch through the runtime's normal call path. Plain JS callbacks still work.
- `ensureBridgeState()` helper shared by `makeBridgeScreen` and `_runLoopHybrid`.

### Tests

Agency tests in `tests/agency/`:

- `ui-builders-leaf` — leaf builder shapes
- `ui-builders-container` — container builders + Builder method dispatch
- `ui-builders-style-props` — every named style arg propagates (defensive)
- `ui-runloop-basic` — scripted key drives state machine to expected final state
- `ui-runloop-tick` — `tickMs: 20` forces ≥ 4 renders without key input
- `ui-repl-onsubmit-false-exits` — onSubmit returning `false` exits cleanly
- `ui-repl-history` — up arrow recalls prior submit
- `ui-repl-palette-open` — `/` opens palette, typing filters, enter inserts
- `ui-repl-status-tick` — status fn re-evaluated on every render

All 9 pass locally. The 16 vitest tests under `lib/tui/`, `lib/stdlib/ui*` carried over from PR #1 still pass.

### Deferred to PR #3

- **`tests/agency-js/ui-hybrid-scroll`** (D5 in the plan): TS-level integration test that asserts CSI escapes (`1;22r` on entry, `r` on exit) and verifies output() lines land in `process.stdout`. The lib-level pieces (`ui-region.ts`, `BottomRegionOutputTarget`) are unit-tested already; the end-to-end test requires a fake-TTY harness whose ergonomics are best designed together with the agency-agent rewrite in PR #3 (Tasks F1–F2).
- **History persistence** to disk (D2 plan extension): the in-memory navigation is tested here; reload-across-sessions is intentionally a v2 feature so `std::ui` stays free of `std::shell` dependencies in this PR.
- **`/** @module */` doc block** at the top of `stdlib/ui.agency` (C1 in the plan): deferred because a single module-level doc block describing only the new declarative API would conflict with the existing imperative function docstrings that remain in place during the additive window. Will be added in PR #3 when the old API is removed.
- **Policy + agent integration + old-API removal** (Milestones E + F): all in PR #3.

### Agency-parser quirks discovered

Three quirks documented in code (commit messages and inline comments) so future contributors aren't surprised:

1. **Type names starting with `_`** (e.g. `_ReplState`) cause the parser to fail to terminate a prior `s.<field>` expression. Renamed to `ReplState` (file-internal).
2. **`column() as col { ... }`** with no named args compiles to a positional call where the trailing block lands in the `flex` param, leaving the `block` param null. Every container call site in `_replView` passes at least one named arg to route the block into `blockArg`.
3. **`block: ... = null`** is the only working terminator for a defaulted-parameter list with a block. The parser rejects a non-default param after any default.

### Verification

- `pnpm vitest run lib/tui/screen.test.ts lib/stdlib/ui.test.ts lib/stdlib/ui-region.test.ts` → 16 / 16 pass
- `pnpm run agency test tests/agency/ui-*` → 9 / 9 pass
- `pnpm tsc --noEmit` → clean
- `pnpm run lint:structure` → clean
- `make` → clean rebuild end-to-end
