### PR TITLE
Agent init PR 1 of 6: runtime read-before-init trap

### DIFF
--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Language
+- Static variables now throw a clear runtime error when read before their initializer has run (previously returned `undefined` silently). The error names the variable and module and suggests common fixes (circular imports, indirect reads through function calls). The wrap is transparent for initialized values — binary operations, template interpolations, indexing, etc. continue to work unchanged. PR 1 of a 6-PR series; subsequent PRs add topological initialization order across modules and the `agency explain-init` CLI.
+
 ## May 28 2026 — v0.3
 
 ### Language

--- a/packages/agency-lang/CHANGELOG.md
+++ b/packages/agency-lang/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Language
-- Static variables now throw a clear runtime error when read before their initializer has run (previously returned `undefined` silently). The error names the variable and module and suggests common fixes (circular imports, indirect reads through function calls). The wrap is transparent for initialized values — binary operations, template interpolations, indexing, etc. continue to work unchanged. PR 1 of a 6-PR series; subsequent PRs add topological initialization order across modules and the `agency explain-init` CLI.
+- Static variables now throw a clear runtime error when read before their initializer has run (previously returned `undefined` silently). The error names the variable and suggests common fixes (circular imports, indirect reads through function calls). Coverage includes both same-module and cross-module reads — an `import { x } from "./y.agency"` where `x` is a `static const` is wrapped in the trap at every user-code read site. The wrap is transparent for initialized values — binary operations, template interpolations, indexing, etc. continue to work unchanged. PR 1 of a 6-PR series; subsequent PRs add topological initialization order across modules (eliminating most cases where the trap would fire) and the `agency explain-init` CLI.
 
 ## May 28 2026 — v0.3
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -773,10 +773,12 @@ export class TypeScriptBuilder {
           // never statics. Compiler-emitted boilerplate (e.g.
           // `__registerTool(name)`) builds its source with `ts.raw`, not
           // through this case, so it is unaffected.
+          //
+          // `scope === "imported"` is mutually exclusive with builtin
+          // and loop-var names at the source level, so we only need to
+          // check the import side.
           if (
             literal.scope === "imported" &&
-            !isBuiltinVar &&
-            !isLoopVar &&
             this.names.isAgencyImport(literal.value)
           ) {
             return ts.call(ts.id("__readStatic"), [

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -761,6 +761,30 @@ export class TypeScriptBuilder {
         const isBuiltinVar = BUILTIN_VARIABLES.includes(literal.value);
         const isLoopVar = this.loopVars.includes(literal.value);
         if (importedOrUnknownScope || isBuiltinVar || isLoopVar) {
+          // Agency imports may resolve to a `static const` in the source
+          // module, whose value is `__UNINIT_STATIC` until its initializer
+          // has run. Wrap reads in `__readStatic` so an early access
+          // throws a clear error instead of silently propagating the
+          // sentinel (which would surface as a confusing JS engine error
+          // like "Cannot convert a Symbol value to a string"). For
+          // non-static agency imports (functions, nodes) the wrap is a
+          // no-op because the binding never equals the sentinel. JS
+          // imports, builtins, and loop vars are not wrapped — they're
+          // never statics. Compiler-emitted boilerplate (e.g.
+          // `__registerTool(name)`) builds its source with `ts.raw`, not
+          // through this case, so it is unaffected.
+          if (
+            literal.scope === "imported" &&
+            !isBuiltinVar &&
+            !isLoopVar &&
+            this.names.isAgencyImport(literal.value)
+          ) {
+            return ts.call(ts.id("__readStatic"), [
+              ts.id(literal.value),
+              ts.str(literal.value),
+              ts.str(""),
+            ]);
+          }
           return ts.id(literal.value);
         }
         return ts.scopedVar(literal.value, literal.scope!, this.moduleId);

--- a/packages/agency-lang/lib/backends/typescriptBuilder/nameClassifier.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/nameClassifier.ts
@@ -76,6 +76,19 @@ export class NameClassifier {
   }
 
   /**
+   * True if `name` was brought in by an `import { … } from "<some>.agency"`
+   * statement (as opposed to a `.js`/`.ts` import). Used by the codegen to
+   * decide whether a read of `name` in user code should be wrapped with
+   * `__readStatic` — agency imports could be `static const` values which
+   * hold the `__UNINIT_STATIC` sentinel before their initializer runs.
+   * Non-static agency imports (functions, nodes) will never equal the
+   * sentinel, so the wrap is a no-op for them.
+   */
+  isAgencyImport(name: string): boolean {
+    return this.agencyImportNames.has(name);
+  }
+
+  /**
    * True if `functionName` is one of the plain-JS helpers that bypass the
    * `__call` dispatcher (`approve`, `reject`, `success`, `failure`, …).
    */

--- a/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
@@ -330,10 +330,18 @@ export function assembleSections(opts: AssembleSectionsOpts): TsNode {
  */
 function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
   const out: TsNode[] = [];
+  // Initialize each static `let` to the sentinel `__UNINIT_STATIC`
+  // so that any read of the variable before its initializer has run
+  // is caught by the `__readStatic` wrapper (emitted around static
+  // reads by the pretty-printer). Without this initializer the
+  // binding would be `undefined`, which collides with legitimate user
+  // values and produced silent bugs like `fooStatic = barStatic + "!"`
+  // evaluating to `"undefined!"` when bar's init had not yet run.
+  const sentinel = ts.id("__UNINIT_STATIC");
   const staticLetDecls = [...opts.staticVarNames].map((name) =>
     opts.exportedStaticVarNames.has(name)
-      ? ts.export(ts.letDecl(name))
-      : ts.letDecl(name),
+      ? ts.export(ts.letDecl(name, sentinel))
+      : ts.letDecl(name, sentinel),
   );
 
   out.push(ts.statements([

--- a/packages/agency-lang/lib/ir/prettyPrint.ts
+++ b/packages/agency-lang/lib/ir/prettyPrint.ts
@@ -282,6 +282,22 @@ export function printTs(node: TsNode, indent = 0): string {
         const ctxRef = node.topLevel ? "__globalCtx" : "getRuntimeContext().ctx";
         return `${ctxRef}.globals.get(${JSON.stringify(node.moduleId)}, ${JSON.stringify(node.name)})`;
       }
+      if (node.scope === "static") {
+        // Wrap static reads in `__readStatic` so that reading a static
+        // before its initializer has run throws a clear, actionable
+        // error (the `let` binding holds the sentinel
+        // `__UNINIT_STATIC` until then). The wrapper is transparent
+        // for initialized values — `__readStatic(x, ...)` returns `x`
+        // unchanged — so binary operations, template interpolations,
+        // indexing, etc. continue to work without any other change.
+        //
+        // `moduleId` may be undefined for static-scoped scopedVars
+        // produced in contexts where it wasn't propagated; fall back
+        // to the empty string in that case so the error message still
+        // points at the variable name.
+        const moduleIdLit = JSON.stringify(node.moduleId ?? "");
+        return `__readStatic(${node.name}, ${JSON.stringify(node.name)}, ${moduleIdLit})`;
+      }
       const prefix = scopeToPrefix(node.scope);
       if (prefix === "") return node.name;
       return `${prefix}.${node.name}`;

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -45,6 +45,8 @@ export {
   updateTokenStats,
 } from "./utils.js";
 
+export { __UNINIT_STATIC, __readStatic } from "./staticInit.js";
+
 export { functionRefReviver } from "./revivers/index.js";
 export { AgencyFunction, UNSET } from "./agencyFunction.js";
 export type { FuncParam, CallType, ToolDefinition, AgencyFunctionOpts } from "./agencyFunction.js";

--- a/packages/agency-lang/lib/runtime/staticInit.crossModule.test.ts
+++ b/packages/agency-lang/lib/runtime/staticInit.crossModule.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+/**
+ * Cross-module read-before-init: compile a small two-file program where
+ * foo.agency's static initializer reads `barStatic` imported from
+ * bar.agency. Today (before PR 2's topological-sort fix) bar.agency's
+ * `__initializeStatic` has not yet run when foo's body executes, so
+ * `barStatic` holds the sentinel. The wrap installed by the codegen for
+ * agency-imported reads in user expressions catches this and throws a
+ * clear error naming the variable.
+ *
+ * This test is the canonical PR 1 trap verifier — same-module reads
+ * cannot trigger the trap because source order naturally orders
+ * statics within a module.
+ */
+describe("cross-module read-before-init throws friendly trap", () => {
+  const tmpRoot = path.join(__dirname, "../../.agency-tmp/cross-module-trap");
+
+  beforeAll(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+    fs.mkdirSync(tmpRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpRoot, "bar.agency"),
+      'export static const barStatic = "hello"\n',
+    );
+    fs.writeFileSync(
+      path.join(tmpRoot, "main.agency"),
+      'import { barStatic } from "./bar.agency";\n' +
+      'static const fooStatic = barStatic + "!"\n' +
+      '\n' +
+      'node main() {\n' +
+      '  return fooStatic;\n' +
+      '}\n',
+    );
+
+    const cli = path.join(__dirname, "../../dist/scripts/agency.js");
+    const result = spawnSync(
+      process.execPath,
+      [cli, "compile", path.join(tmpRoot, "main.agency")],
+      { encoding: "utf-8" },
+    );
+    if (result.status !== 0) {
+      throw new Error(
+        `compile failed: ${result.stdout}\n${result.stderr}`,
+      );
+    }
+  });
+
+  it("throws an error naming the variable", async () => {
+    const mod = await import(path.join(tmpRoot, "main.js"));
+    let caught: any = null;
+    try {
+      await mod.main();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught.message).toMatch(
+      /Tried to read static `barStatic`.*before its initializer ran/i,
+    );
+  });
+});

--- a/packages/agency-lang/lib/runtime/staticInit.crossModule.test.ts
+++ b/packages/agency-lang/lib/runtime/staticInit.crossModule.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeAll } from "vitest";
-import { spawnSync } from "node:child_process";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { pathToFileURL } from "url";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { compile, resetCompilationCache } from "../cli/commands.js";
 
 /**
  * Cross-module read-before-init: compile a small two-file program where
@@ -15,42 +16,53 @@ import * as path from "node:path";
  * This test is the canonical PR 1 trap verifier — same-module reads
  * cannot trigger the trap because source order naturally orders
  * statics within a module.
+ *
+ * Implementation notes:
+ *   • We compile in-process (via `compile()` from `lib/cli/commands.ts`)
+ *     rather than shelling out to a `dist/` binary, so the test always
+ *     exercises the current source tree.
+ *   • The compiled `.js` is written next to its `.agency` source so the
+ *     generated `agency-lang/runtime` imports can resolve through the
+ *     workspace's `node_modules`. The fixtures live under
+ *     `.agency-tmp/static-cross-module-trap/` (gitignored as a
+ *     dot-prefixed directory) and are cleaned up in `afterAll`.
+ *   • We `import()` via `pathToFileURL(...).href` for Windows
+ *     portability — bare filesystem paths fail on win32.
  */
 describe("cross-module read-before-init throws friendly trap", () => {
-  const tmpRoot = path.join(__dirname, "../../.agency-tmp/cross-module-trap");
+  const fixturesRoot = path.resolve(
+    __dirname,
+    "../../.agency-tmp/static-cross-module-trap",
+  );
+  const mainAgency = path.join(fixturesRoot, "main.agency");
+  const barAgency = path.join(fixturesRoot, "bar.agency");
+  const mainJs = mainAgency.replace(/\.agency$/, ".js");
 
   beforeAll(() => {
-    fs.rmSync(tmpRoot, { recursive: true, force: true });
-    fs.mkdirSync(tmpRoot, { recursive: true });
+    fs.mkdirSync(fixturesRoot, { recursive: true });
     fs.writeFileSync(
-      path.join(tmpRoot, "bar.agency"),
+      barAgency,
       'export static const barStatic = "hello"\n',
     );
     fs.writeFileSync(
-      path.join(tmpRoot, "main.agency"),
+      mainAgency,
       'import { barStatic } from "./bar.agency";\n' +
-      'static const fooStatic = barStatic + "!"\n' +
-      '\n' +
-      'node main() {\n' +
-      '  return fooStatic;\n' +
-      '}\n',
+        'static const fooStatic = barStatic + "!"\n' +
+        '\n' +
+        'node main() {\n' +
+        '  return fooStatic;\n' +
+        '}\n',
     );
+    resetCompilationCache();
+    compile({}, mainAgency);
+  });
 
-    const cli = path.join(__dirname, "../../dist/scripts/agency.js");
-    const result = spawnSync(
-      process.execPath,
-      [cli, "compile", path.join(tmpRoot, "main.agency")],
-      { encoding: "utf-8" },
-    );
-    if (result.status !== 0) {
-      throw new Error(
-        `compile failed: ${result.stdout}\n${result.stderr}`,
-      );
-    }
+  afterAll(() => {
+    fs.rmSync(fixturesRoot, { recursive: true, force: true });
   });
 
   it("throws an error naming the variable", async () => {
-    const mod = await import(path.join(tmpRoot, "main.js"));
+    const mod = await import(pathToFileURL(mainJs).href);
     let caught: any = null;
     try {
       await mod.main();

--- a/packages/agency-lang/lib/runtime/staticInit.test.ts
+++ b/packages/agency-lang/lib/runtime/staticInit.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { __UNINIT_STATIC, __readStatic } from "./staticInit.js";
+
+describe("__readStatic", () => {
+  it("returns plain values unchanged", () => {
+    expect(__readStatic(5, "x", "foo.agency")).toBe(5);
+    expect(__readStatic("hello", "x", "foo.agency")).toBe("hello");
+    expect(__readStatic(null, "x", "foo.agency")).toBe(null);
+    expect(__readStatic(undefined, "x", "foo.agency")).toBe(undefined);
+    expect(__readStatic({ a: 1 }, "x", "foo.agency")).toEqual({ a: 1 });
+    expect(__readStatic([1, 2, 3], "x", "foo.agency")).toEqual([1, 2, 3]);
+    expect(__readStatic(0, "x", "foo.agency")).toBe(0);
+    expect(__readStatic(false, "x", "foo.agency")).toBe(false);
+    expect(__readStatic(NaN, "x", "foo.agency")).toBeNaN();
+  });
+
+  it("throws on sentinel", () => {
+    expect(() =>
+      __readStatic(__UNINIT_STATIC as any, "barStatic", "bar.agency"),
+    ).toThrow(/Tried to read static `barStatic` from bar\.agency/);
+  });
+
+  it("error message includes diagnostic context", () => {
+    try {
+      __readStatic(__UNINIT_STATIC as any, "x", "y.agency");
+      throw new Error("expected throw");
+    } catch (e: any) {
+      expect(e.message).toMatch(/before its initializer ran/i);
+      expect(e.message).toMatch(/circular import|indirect/i);
+    }
+  });
+
+  it("works transparently in binary operations and templates", () => {
+    const x = __readStatic("hello", "x", "f.agency");
+    expect(x + "!").toBe("hello!");
+    expect(`${x} world`).toBe("hello world");
+
+    const n = __readStatic(5, "n", "f.agency");
+    expect(n + 1).toBe(6);
+    expect(n * 2).toBe(10);
+
+    const arr = __readStatic([1, 2, 3], "arr", "f.agency");
+    expect(arr.length).toBe(3);
+    expect([...arr, 4]).toEqual([1, 2, 3, 4]);
+
+    const obj = __readStatic({ port: 8080 }, "obj", "f.agency");
+    expect(obj.port * 2).toBe(16160);
+  });
+
+  it("does not confuse sentinel with other symbols or falsy values", () => {
+    // sentinel is a unique Symbol — must not collide
+    expect(__readStatic(Symbol("uninit"), "x", "f.agency")).not.toBe(
+      __UNINIT_STATIC,
+    );
+    // Other falsy / quirky values pass through normally
+    expect(() => __readStatic(0 as any, "x", "f.agency")).not.toThrow();
+    expect(() => __readStatic("" as any, "x", "f.agency")).not.toThrow();
+    expect(() => __readStatic(null as any, "x", "f.agency")).not.toThrow();
+  });
+});

--- a/packages/agency-lang/lib/runtime/staticInit.ts
+++ b/packages/agency-lang/lib/runtime/staticInit.ts
@@ -56,8 +56,14 @@ export function __readStatic<T>(
   moduleId: string,
 ): T {
   if ((value as unknown) === UNINIT_STATIC_SYMBOL) {
+    // PR 2's per-variable dep graph will thread the source module id
+    // through to every wrap site. Until then, some cross-module wraps
+    // emit an empty string here; substitute a placeholder so the
+    // message stays readable ("from <unknown module>" rather than
+    // "from  before…").
+    const where = moduleId ? moduleId : "<unknown module>";
     throw new Error(
-      `Tried to read static \`${name}\` from ${moduleId} before its ` +
+      `Tried to read static \`${name}\` from ${where} before its ` +
         `initializer ran.\n\n` +
         `This usually means one of:\n` +
         `  • A circular import where module init order is not well-defined.\n` +

--- a/packages/agency-lang/lib/runtime/staticInit.ts
+++ b/packages/agency-lang/lib/runtime/staticInit.ts
@@ -1,0 +1,73 @@
+/**
+ * Static-variable initialization safety net.
+ *
+ * Agency's `static const` declarations are compiled to module-level
+ * `let` bindings whose assignment happens inside a per-module init
+ * function (`__initializeStatic`). Until that function runs, the
+ * binding holds an unset value. Historically it was plain `undefined`,
+ * which meant a cross-module read before init silently produced
+ * `undefined` and propagated through expressions like
+ * `fooStatic = barStatic + "!"` as `"undefined!"`.
+ *
+ * To turn that silent failure into a loud one:
+ *
+ *   1. Codegen initializes every `static const` binding to
+ *      `__UNINIT_STATIC` (a unique sentinel value).
+ *   2. Codegen wraps every *read* of a static name with
+ *      `__readStatic(value, name, moduleId)`.
+ *   3. `__readStatic` returns the value unchanged if it's not the
+ *      sentinel, or throws a clear error if it is.
+ *
+ * The wrapper is transparent — `__readStatic(x, ...)` evaluates to the
+ * same value `x` would have, so binary operations, template
+ * interpolations, indexing, and spreads all continue to work without
+ * any change to user code or generated expression shapes.
+ */
+
+const UNINIT_STATIC_SYMBOL = Symbol("agency.static.uninit");
+
+/**
+ * Sentinel assigned to `static const` bindings before their initializer
+ * runs. Tagged with a unique symbol so it cannot collide with any user
+ * value, including `undefined`, `null`, `NaN`, `0`, `""`, other
+ * symbols, frozen objects, etc.
+ *
+ * The codegen references this by name in the emitted source; do not
+ * rename without updating the codegen.
+ */
+export const __UNINIT_STATIC = UNINIT_STATIC_SYMBOL;
+
+/**
+ * Read a static variable's current value. Returns `value` unchanged
+ * unless it is the uninitialized sentinel — in which case throws a
+ * clear error naming the variable and module, with guidance on the
+ * common causes.
+ *
+ * The codegen emits a call to this around every read of a top-level
+ * `static const` name. Users never write `__readStatic` directly.
+ *
+ *   __readStatic(barStatic, "barStatic", "bar.agency") + "!"
+ *   `${__readStatic(prompt, "prompt", "x.agency")} world`
+ *   __readStatic(items, "items", "x.agency").length
+ */
+export function __readStatic<T>(
+  value: T,
+  name: string,
+  moduleId: string,
+): T {
+  if ((value as unknown) === UNINIT_STATIC_SYMBOL) {
+    throw new Error(
+      `Tried to read static \`${name}\` from ${moduleId} before its ` +
+        `initializer ran.\n\n` +
+        `This usually means one of:\n` +
+        `  • A circular import where module init order is not well-defined.\n` +
+        `  • An indirect read through a function call: a static initializer ` +
+        `calls a function that transitively reads this static before this ` +
+        `static's own initializer has executed.\n\n` +
+        `To fix: break the circular import, or restructure so the static ` +
+        `is read only after initialization completes (e.g. inside a node ` +
+        `or def, not at the top level of another static initializer).`,
+    );
+  }
+  return value;
+}

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -22,6 +22,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/agency/static-binary-ops.agency
+++ b/packages/agency-lang/tests/agency/static-binary-ops.agency
@@ -1,0 +1,22 @@
+static const n = 5
+static const greeting = "hello"
+static const items = [1, 2, 3]
+static const cfg = { port: 8080 }
+
+node main() {
+  const a = n + 1
+  const b = `${greeting} world`
+  const c = items.length
+  const d = cfg.port * 2
+  const e = n * n
+  const f = greeting + "!"
+
+  return {
+    a: a,
+    b: b,
+    c: c,
+    d: d,
+    e: e,
+    f: f
+  }
+}

--- a/packages/agency-lang/tests/agency/static-binary-ops.test.json
+++ b/packages/agency-lang/tests/agency/static-binary-ops.test.json
@@ -1,0 +1,15 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Static vars work transparently in binary ops, templates, indexing, property access after the __readStatic wrap is applied to every read",
+      "expectedOutput": "{\"a\":6,\"b\":\"hello world\",\"c\":3,\"d\":16160,\"e\":25,\"f\":\"hello!\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -19,6 +19,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -19,6 +19,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -19,6 +19,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -19,6 +19,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -19,6 +19,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -19,6 +19,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -18,6 +18,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -32,6 +32,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -18,6 +18,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -18,6 +18,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -134,7 +135,7 @@ function registerTools(tools: any[]) {
 }
 
 let __staticInitPromise = null;
-let foo;
+let foo = __UNINIT_STATIC;
 async function __initializeStatic(__ctx) {
   if (__staticInitPromise) {
     return __staticInitPromise;
@@ -188,7 +189,7 @@ await callHook({
       await runner.step(1, async (runner) => {
 runner.halt({
           messages: __threads(),
-          data: foo
+          data: __readStatic(foo, "foo", "static.agency")
         })
 return;
       });

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -17,6 +17,7 @@ import {
   GuardExceededError,
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
+  __UNINIT_STATIC, __readStatic,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,


### PR DESCRIPTION
PR 1 of 6 in the agent-initialization redesign series. Replaces silent `undefined` reads of uninitialized static variables with loud, actionable runtime errors. Establishes the safety net that subsequent PRs rely on.

Design doc: `agent-init-design.md`
Plan: `docs/superpowers/plans/2026-05-31-agent-init-pr1-read-before-init-trap.md`

## What changes

Today, when one module reads a `static const` from another module before that module's `__initializeStatic` has run, the read silently returns `undefined`, which propagates through expressions like `fooStatic = barStatic + "!"` as `"undefined!"`. This PR turns that silent failure into a loud one.

**Runtime** (`lib/runtime/staticInit.ts`):
- New `__UNINIT_STATIC` sentinel — a unique Symbol that cannot collide with any user value.
- New `__readStatic(value, name, moduleId)` wrapper — returns the value unchanged, except when the value is the sentinel, in which case it throws a clear error naming the variable and suggesting common fixes (circular imports, indirect-through-function-call reads).

**Codegen**:
- Every `static const X = ...` now compiles to `let X = __UNINIT_STATIC;` instead of `let X;`. The assignment inside `__initializeStatic` replaces the sentinel with the real value.
- The IR pretty-printer wraps every read of a static-scoped `scopedVar` with `__readStatic(X, "X", "module.agency")`.
- `variableName` references with scope "imported" that resolve to agency imports are also wrapped — closes the cross-module gap where the sentinel would otherwise propagate into expressions and surface as a confusing JS engine error ("Cannot convert a Symbol value to a string").

The wrap is transparent for initialized values — `__readStatic(x, ...)` returns `x` unchanged — so binary operations, template interpolations, indexing, spreads, and property access all continue to work without any other change. For non-static agency imports (functions, nodes), the wrap is a no-op because the binding never equals the sentinel.

Compiler-emitted boilerplate (e.g. `__registerTool(barStatic)`) builds its source with `ts.raw` and does not flow through the wrapped paths, so module-load-time tool registration is unaffected.

## Caveat

For cross-module reads, the error message currently shows an empty `moduleId` because the codegen site for imported names does not easily know the source module's id. PR 2's cross-module dep graph will fill it in. The variable name is correct, which makes the error actionable.

## Tests

- `lib/runtime/staticInit.test.ts` — 5 unit tests covering plain values, sentinel throws, error-message content, transparency in binary ops / templates / indexing, and Symbol uniqueness.
- `lib/runtime/staticInit.crossModule.test.ts` — end-to-end vitest that compiles a two-file program exhibiting the silent-undefined bug, runs it, and asserts the friendly error fires.
- `tests/agency/static-binary-ops.agency` — Agency integration test exercising statics through `+`, template literals, indexing, property access, and arithmetic; all return correct values, confirming wrap transparency.
- Regenerated `tests/typescriptGenerator/` (83 fixtures), `tests/typescriptBuilder/` (3 fixtures), and `tests/debugger/` (6 fixtures) — almost all changes are just the added import line.

Full `lib/` suite: 4713 pass / 1 fail. The 1 failure is pre-existing on main (stdlib/ui named-arg issue, unrelated to this PR).

## Coming up

This unblocks the rest of the series:
- PR 2 — Per-variable topological sort across the import closure (eliminates most ordering bugs that the trap would otherwise catch; populates the real source moduleId for cross-module wraps).
- PR 3 — `static` prefix on bare top-level statements.
- PR 4 — Compile-time validations for static initializers.
- PR 5 — `agency explain-init` CLI + trace events.
- PR 6 — Docs rewrite.
