### PR TITLE
PR 2 of 6 — Per-variable topological sort + centralized init

### DIFF
--- a/packages/agency-lang/docs/superpowers/plans/2026-05-31-agent-init-pr2-per-var-topsort.md
+++ b/packages/agency-lang/docs/superpowers/plans/2026-05-31-agent-init-pr2-per-var-topsort.md
@@ -1,0 +1,241 @@
+# PR 2 — Per-variable topological sort + centralized init
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Replace per-module lazy `__initializeStatic` / `__initializeGlobals` with a centralized, topologically-sorted init across the full import closure. Eliminates cross-module init-order bugs at compile time.
+
+**Architecture:** At compile time, walk the entry module's full import closure (following both `import` and `export ... from` re-exports). Build TWO independent per-variable dep graphs — one for `static` decls (Phase A, once per process) and one for non-static `const`/`let` + bare top-level statements (Phase B, every run). Edges in each graph come from direct free-variable references in the initializer expression. Topologically sort each graph independently (using a precomputed `sequenceHint` per node to break ties deterministically — file-import depth, then source line). Emit a single `__initializeAllStatics(ctx)` + `__initializeAllGlobals(ctx)` per compilation that walks the corresponding sorted list. Compile-time error on cycles in either variable graph (with offending decls named). Compile-time error if a `static` initializer references a `global` (the global doesn't exist yet at Phase A). Lazy `isInitialized` guards stay as safety net.
+
+**Why two graphs instead of one:**
+- Phase A and Phase B have different lifetimes, run on different schedules, and have different visibility rules. Combining them obscures both.
+- Globals reading statics is fine (statics are already initialized at Phase B time) — this is a one-way *cross-phase* allowance, not a cross-graph edge.
+- Statics reading globals is a compile-time error — caught by a dedicated validation pass over the static graph's free-variable references.
+- (Out of scope for PR 2; a separate follow-up PR owns the static-initializer-restriction work end-to-end. PR 2 implements the static→global rejection in the validation pass because the dep graph already has the information sitting there.)
+
+**Design principles for this PR (explicit because the first cut violated them):**
+- **Reuse, don't reimplement.** AST traversal goes through `walkNodes` from `lib/utils/node.ts`. Import resolution goes through `SymbolTable.resolveImport`. Closure walking is owned by the compile entry point and passed in as data.
+- **Closed interfaces.** The dep graph exposes `nodes + edges` only — file-import ordering is baked into each node's `sequenceHint` at build time, so consumers see one ordering rule, not two.
+- **Declarative pipelines, encapsulated imperative code.** Compile flow is `parse → SymbolTable → CompilationUnits → InitPlan → codegen`. Each arrow is one function; the imperative work lives inside.
+- **One ADT for the cross-task contract.** `InitPlan` (per-module ordered list of typed `InitStep` items) is what flows between Tasks 3 and 4. Codegen dispatches on `step.kind`; no other coupling.
+
+**Tech Stack:** TypeScript compiler analysis pass, TS codegen, runtime entry-point wiring.
+
+**Scope:**
+- IN: full closure walk including re-exports (`export { x } from "y"`)
+- IN: per-variable dep graph + topsort + cycle error
+- IN: centralized init functions emitted in every compiled file (so any node can be an entry point)
+- IN: integration tests reproducing all 8 worked examples from the design doc
+- IN: cherry-pick reusable fixtures from PR 237's branch where the expected behavior matches our design
+- OUT: `static` keyword for bare statements (PR 3)
+- OUT: compile-time validations on what's allowed inside static initializers (PR 4)
+- OUT: `agency explain-init` CLI (PR 5)
+
+---
+
+## Task 1: Dep graph builder — REFACTOR
+
+**Status:** First cut landed in commit e20d9312. Needs refactor to remove duplicated/leaky pieces before continuing.
+
+**Files:**
+- Modify: `lib/compiler/initDepGraph.ts`
+- Modify: `lib/compiler/initDepGraph.test.ts` (only as needed; the public API contract below is mostly compatible)
+
+- [ ] Extract a single `ImportAliasResolver` interface owned by this module:
+  - Built once from `(symbolTable, programs)`; exposes `resolve(localName, inModuleId) → { sourceModuleId, sourceName } | null`.
+  - Internally: calls `SymbolTable.resolveImport` for each `importStatement`, then follows `reExportedFrom` chains to the ultimate source.
+  - **This same resolver is reused by the PR-1 thread-through fix in Task 4.** No second implementation lives at the codegen wrap site.
+- [ ] Replace the hand-rolled `collectFreeIdentifiers` (currently ~85 lines of switch + generic fallback) with a `walkNodes`-based filter:
+  - Walk the initializer; collect every `variableName` node; skip subtrees rooted at name-binding constructs (`function`, `graphNode`) using the `ancestors` argument that `walkNodes` already provides.
+  - Net result: ~15 lines, no fallback, no duplicated traversal logic.
+- [ ] Stop walking the import closure inside the dep graph. The entry point (Task 3) collects all reachable programs and passes them in. `buildInitDepGraphs` becomes pure: `(programs, symbolTable, entryModuleId) → { staticGraph, globalGraph }` where `programs` is already the full closure.
+- [ ] **Build two independent graphs**, one per phase. A node belongs to the static graph iff `node.static === true` (the parser flag — pre-codegen, so `scope` is not yet set). All other top-level assignments + bare statements go to the global graph. Same `InitVarNode` shape; just different graph membership.
+- [ ] Add bare top-level statements (function calls, etc.) as nodes in the **global graph only** (statics can't have side-effecty bare statements until PR 3's `static` keyword work). Bare-statement nodes carry no outgoing edges (we can't statically see what functions touch); their `sequenceHint` keeps source-order behavior. Use a synthetic `varName` like `__bareStmt_${moduleId}_${line}` so the key stays unique.
+- [ ] Add a validator: walk each static-graph node's initializer free vars; if any resolve (locally or via import) to a global-graph node, throw a `StaticReferencesGlobalError` listing the offending pair. This is the static→global compile error.
+- [ ] Bake the file-import-depth tiebreaker into each node at build time. Each `InitVarNode` gets a `sequenceHint: number` computed from `(fileImportDepth, sourceLine)`. **Remove the `fileImports` field from `InitDepGraph`** — the topsort no longer needs it. One ordering mechanism, one consumer.
+- [ ] Re-verify all 7 existing unit tests pass (after renaming `buildInitDepGraph` → `buildInitDepGraphs`); add tests:
+  - `sequenceHint` orders Example-2 case correctly
+  - Two separate graphs returned; a static var and a global var with the same name don't collide
+  - Static referencing a global throws `StaticReferencesGlobalError`
+  - Global referencing a static is allowed (cross-phase, no edge)
+  - Bare top-level statement appears in global graph, source-order preserved relative to other globals
+  - Module-reference outside the closure produces no edge and doesn't crash
+  - AST visitor catches references inside: string interpolation, array/object spreads, `new X()` args, splat call args
+- [ ] Commit.
+
+**Final shape:**
+```ts
+type InitVarNode = {
+  moduleId: string; varName: string; kind: "static" | "global";
+  // For bare statements: kind="global", initExpr is the wrapping expr-statement node.
+  initExpr: Expression | AgencyNode;
+  loc?: SourceLocation; exported: boolean;
+  sequenceHint: number;  // (fileImportDepth, sourceLine) packed into one number
+  // Optional `with approve` modifier from the parser. `handle { ... }` blocks
+  // are NOT legal at module top level — only `with approve` is — so a single
+  // optional field captures the full surface area.
+  withApprove?: boolean;
+};
+type InitDepGraph = {
+  nodes: Record<InitVarKey, InitVarNode>;
+  edges: Record<InitVarKey, InitVarKey[]>;
+};
+type BuildResult = { staticGraph: InitDepGraph; globalGraph: InitDepGraph };
+```
+
+---
+
+## Task 2: Topological sort + cycle detection — REFACTOR
+
+**Status:** First cut landed in commit 6af7dd97. Needs refactor in lockstep with Task 1's changes.
+
+**Files:**
+- Modify: `lib/compiler/topSortInitGraph.ts`
+- Modify: `lib/compiler/topSortInitGraph.test.ts`
+
+- [ ] Delete `computeFileImportOrder` and its supporting helpers. Ordering is now read directly from `node.sequenceHint`.
+- [ ] Reshape `topSortInitGraph` as `kahn(nodes, edges, keyFn)` where `keyFn(node) = node.sequenceHint`. Single ordering rule, same function called once per graph (static + global).
+- [ ] Replace the bespoke `insertSorted` with `ready.sort(byHint)` per round — N is small (top-level vars across the closure); the readability win is worth more than the asymptotic cost.
+- [ ] Keep `findCycle` as the cycle reporter, but extract it into a small `traceCycleFrom(graph, start)` helper that's purely declarative ("walk one edge at a time until we revisit a node; return the loop slice").
+- [ ] All 6 existing tests still pass; update the file-import-tiebreak test to assert on `sequenceHint` plumbing rather than a separate map. Add tests:
+  - A 3-var cycle: cycle path lists all 3 in order
+  - Cycle message includes module path + line for each decl (assertion on message string, not just on "throws")
+  - Same graph topsorted twice yields the same order (determinism — no Map iteration order leak)
+  - Disconnected components are both fully ordered
+- [ ] Commit.
+
+---
+
+## Task 3: Compile-flow integration — `CompiledClosure` + `InitPlan`
+
+**Files:**
+- Create: `lib/compiler/compiledClosure.ts`
+- Create: `lib/compiler/initPlan.ts`
+- Modify: `lib/cli/commands.ts` (delegate)
+- Modify: `lib/compiler/compile.ts` (delegate)
+
+- [ ] Introduce `compileClosure(entryFile, config) → CompiledClosure` as the single owner of multi-file compilation:
+  - Parses every reachable agency file once (BFS over imports + re-exports). Builds one shared `SymbolTable`.
+  - **Parse failures: abort via `process.exit(1)` matching today's `lib/cli/commands.ts` behavior. `lib/compiler/compile.ts` (in-memory entry) instead returns a `CompileFailure` per its existing contract.**
+  - Runs `buildInitDepGraphs` (two graphs) + `topSortInitGraph` on each.
+  - On `CycleError` (either graph): throw a `CompileError` naming the phase ("Phase A (static)" / "Phase B (global)") and listing the decl pair/cycle.
+  - On `StaticReferencesGlobalError`: throw a `CompileError` naming the offending pair.
+  - Builds per-module `CompilationUnit`s.
+  - Produces an `InitPlan` per module from the two sorted orders (see ADT below).
+  - Returns `{ programs, symbolTable, units, plans, sourceMaps, resolver }` — a fully prepared bundle that codegen consumes. `resolver` is the `ImportAliasResolver` from Task 1, exposed so the codegen wrap site can use it for the PR-1 thread-through.
+- [ ] Both `lib/cli/commands.ts:compile()` and `lib/compiler/compile.ts:compileSource()` become thin wrappers: call `compileClosure`, then iterate units and call `generateTypeScript(unit, plan, resolver)` for each. No more recursive `compile()` calls.
+- [ ] Cycle error message (verbatim shape):
+  ```
+  Error: Circular static dependency
+    foo.fooStatic (foo.agency:2) depends on bar.barStatic
+    bar.barStatic (bar.agency:2) depends on foo.fooStatic
+  Static vars cannot depend on each other in a cycle. Break the cycle by
+  extracting one into a third file or computing from a literal.
+  ```
+  (Same shape for global-graph cycles; just swap "static" for "global".)
+- [ ] `InitPlan` ADT (the only thing flowing between Task 3 and Task 4):
+  ```ts
+  type InitStep =
+    | { kind: "localStatic"; varName: string; initExpr: Expression; exported: boolean; loc?: SourceLocation; withApprove?: boolean }
+    | { kind: "localGlobal"; varName: string; initExpr: Expression; loc?: SourceLocation; withApprove?: boolean }
+    | { kind: "importedAlias"; localName: string; sourceModuleId: string; sourceName: string }
+    | { kind: "bareStatement"; statement: AgencyNode; withApprove?: boolean };
+  type InitPlan = { moduleId: string; staticSteps: InitStep[]; globalSteps: InitStep[] };
+  ```
+  Note: `withApprove` covers the only top-level handler form (`with approve`). Block-form `handle { ... }` is not legal at module top level, so no other handler-shape needs representation.
+- [ ] Tests:
+  - `compileClosure` on a 3-file fixture returns one program per file and a plan per module.
+  - Static-cycle fixture throws `CompileError` with the formatted message (assert on message string).
+  - Global-cycle fixture throws `CompileError` naming Phase B.
+  - Static-references-global fixture throws `CompileError` naming both decls.
+  - A file with a syntax error inside the closure causes `compileClosure` to abort with exit code 1 (verified via spawning the CLI in a subprocess — direct `process.exit` makes in-process testing of the CLI path painful; `compileSource` test path returns the failure).
+  - Re-export resolution: 2-file fixture where `foo` re-exports `bar`'s static; the plan in `foo` shows it as `importedAlias`, NOT `localStatic`.
+- [ ] Commit.
+
+---
+
+## Task 4: Codegen — driven by `InitPlan`
+
+**Files:**
+- Modify: `lib/backends/typescriptBuilder/sectionAssembler.ts`
+- Modify: `lib/backends/typescriptBuilder.ts`
+
+- [ ] `partitionProgram` no longer extracts static/global init statements itself. It still classifies top-level declarations (functions, graph nodes, callbacks) but the static/global init bodies come from the `InitPlan` passed in by Task 3.
+- [ ] Add a single `emitInitStep(step: InitStep) → TsNode` dispatch table:
+  - `localStatic` → `X = __deepFreeze(<expr>)`, wrapped in `withApprove` handler arrow if set
+  - `localGlobal` → `__ctx.globals.set(moduleId, name, value)`, similar handler wrap
+  - `importedAlias` → emit a top-level TS `export { sourceName as localName } from "./sourceModule.js"` — handled at module-init time by JS module resolution, NOT by the init function body. (Alternative considered: runtime alias via `globals.set`; rejected because the source binding is already initialized by the source module's `__initializeAllStatics` so we'd double-init.)
+  - `bareStatement` → the already-processed statement, optionally wrapped in `with approve`
+- [ ] `buildInitializeAllStaticsFn` and `buildInitializeAllGlobalsFn` are each `plan.{staticSteps,globalSteps}.filter(non-import).map(emitInitStep)` wrapped in the `__staticInitPromise` memoization shell (kept from current code). `importedAlias` steps lift to top-level `export ... from` statements before either init function. One emit path per phase; no branching at call sites.
+- [ ] Per-function `isInitialized` lazy guards stay as the safety net (no change).
+- [ ] **PR-1 thread-through:** the wrap site at `lib/backends/typescriptBuilder.ts:780-788` calls `ImportAliasResolver.resolve(name, currentModuleId)` and threads the resulting `sourceModuleId` to `__readStatic`. No new field on `CompilationUnit`; the resolver from Task 1 is the single source of truth.
+- [ ] Regenerate fixtures: `make fixtures` then `pnpm test:run lib/backends/typescriptGenerator.integration.test.ts` (save output to `/tmp/codegen-fixtures.log` first). Review diff.
+- [ ] Tests added in this task:
+  - Unit test for `emitInitStep`: each of the 4 step kinds maps to the expected TsNode shape. `withApprove` adds the handler wrap.
+  - Integration test: PR-1 trap message now contains the source moduleId (asserts `"barStatic" from "bar.agency"` substring, NOT `<unknown module>`).
+  - Integration test: a re-export chain compiles to `export ... from` — assert the generated JS contains the re-export, not a duplicate `__deepFreeze` of the same value.
+- [ ] Commit.
+
+---
+
+## Task 5: Integration tests — the 8 worked examples
+
+**Files:**
+- Create: `lib/runtime/initPlanWorkedExamples.test.ts` (one file, 8 cases)
+- Create: `lib/runtime/testHelpers/runAgencyClosure.ts`
+
+- [ ] Extract a single declarative test helper (used by Tasks 5, 6, 7):
+  ```ts
+  runAgencyClosure({ files: Record<relPath, content>, entry: relPath, expectFail?: RegExp }) → Promise<string>
+  ```
+  - Writes files to a temp dir under `.agency-tmp/`.
+  - Compiles via `compileClosure`.
+  - Imports the entry's compiled JS (`pathToFileURL` for Windows).
+  - Runs the entry node, returns captured stdout (or rejects with the matching error).
+  - Cleans up in caller's `afterEach`.
+- [ ] Each of the 8 examples becomes a 5–10 line `it(...)`:
+  - Example 1: silent undefined → prints "hello!"
+  - Example 2: `getBarStatic()` indirection → works via sequenceHint
+  - Example 3: indirect dep across cycle → PR-1 trap fires (assert message includes the SOURCE moduleId, not "<unknown>")
+  - Example 4: router/code/research → compiles and runs
+  - Example 5: direct state cycle → compile error (assert formatted message)
+  - Example 6: bare top-level call timing (pre-`static`-keyword behavior) — assert call ordering matches source order
+  - Example 7: `const _ = ...` → normal global
+  - Example 8: concurrent web-server requests → still works (5 parallel calls; each sees its own globals)
+- [ ] **Additional load-bearing tests** (each is one `it(...)` using the helper):
+  - **Multi-entry-point:** import `bar.agency` as the entry, not `foo.agency`; centralized init still runs correctly. Asserts the "emitted in every compiled file" property.
+  - **Cross-module globals reading statics:** `global X = importedStatic` works (this is the allowed cross-phase direction).
+  - **Static memoization under concurrency:** spawn 5 parallel calls to a node; assert the static initializer body ran exactly once (counter sentinel inside a static IIFE).
+  - **Handler-wrapped static (`with approve`):** `static const x = sensitive() with approve` — assert approval handler fires once, x is set.
+  - **AST-visitor edge cases that produced edges correctly:** static initializer references inside template-string interpolation, array spread, object spread, `new X()` args, splat call args. One test per case asserting the right init order.
+  - **Module-reference outside closure:** a static references a name not in any reachable module → should compile (typechecker handles undefined names; dep graph must not crash) and produce a separate compile-time error from the typechecker, not a graph crash.
+- [ ] Commit fixtures + helper + tests.
+
+---
+
+## Task 6: Re-export chain test
+
+**Files:**
+- Add a single `it(...)` to `lib/runtime/initPlanWorkedExamples.test.ts` using the helper from Task 5.
+
+- [ ] 3-level chain (`a` re-exports from `b`, `b` re-exports from `c`); another module's static reads through the chain; assert correct value. Dep-graph machinery already handles this via the resolver — the test confirms the end-to-end wiring.
+- [ ] Commit.
+
+---
+
+## Task 7: Performance smoke test
+
+**Files:**
+- `lib/compiler/topSortInitGraph.test.ts` (one perf case)
+
+- [ ] Generated input: 50 modules with ~3 static vars each, randomized acyclic deps. Build graph + topsort. Assert wall-clock < 100ms.
+- [ ] Commit.
+
+---
+
+## Pre-PR checklist
+
+- [ ] Tasks 1+2 refactor commits keep all original unit tests passing
+- [ ] All 8 worked-example integration tests + re-export chain test pass via the shared helper
+- [ ] Regenerated typescriptGenerator fixtures look right (diff reviewed)
+- [ ] No regressions in existing unit tests
+- [ ] PR description references design doc, notes PR 2 of 6, calls out: built on PR 1's runtime trap; resolver introduced here also powers PR-1 thread-through fix

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -449,6 +449,8 @@ export class TypeScriptBuilder {
       staticAwaitModules: this.initPlan?.staticAwaitModules,
       globalAwaitModules: this.initPlan?.globalAwaitModules,
       registryModuleId: this.initPlan?.registryModuleId,
+      staticLocalOrder: this.initPlan?.staticLocalOrder,
+      globalLocalOrder: this.initPlan?.globalLocalOrder,
     });
   }
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -242,6 +242,33 @@ export class TypeScriptBuilder {
   private compilationUnit: CompilationUnit;
   private moduleId: string;
   private outputFile: string | undefined;
+  /**
+   * Optional per-module init plan + cross-module alias resolver produced
+   * by `compileClosure`. When present, drives:
+   *   - the order of local static/global assignments (topsort-ordered
+   *     rather than source-ordered), and
+   *   - the per-phase `await __awaitStaticInit(...)` /
+   *     `__awaitGlobalsInit(...)` prelude emitted in this module's
+   *     init functions, and
+   *   - the PR-1 trap message: `__readStatic` is called with the
+   *     SOURCE moduleId of an imported binding, not the placeholder
+   *     "<unknown module>" used before.
+   *
+   * When absent (callers that haven't migrated to compileClosure, or
+   * single-file unit tests), codegen falls back to source order and
+   * omits the cross-module awaits — the lazy per-function
+   * `isInitialized` guards plus the runtime trap remain the safety net.
+   */
+  private initPlan?: {
+    registryModuleId: string;
+    staticLocalOrder: string[];
+    staticAwaitModules: { localImport: string; sourceModuleId: string }[];
+    globalLocalOrder: string[];
+    globalAwaitModules: { localImport: string; sourceModuleId: string }[];
+    resolveImportedName: (
+      localName: string,
+    ) => { sourceModuleId: string; sourceName: string } | null;
+  };
 
   /**
    * @param config - Agency compiler configuration (model defaults, logging, etc.)
@@ -252,12 +279,15 @@ export class TypeScriptBuilder {
    * @param outputFile - Absolute path where the generated code will be written.
    *   Used to compute relative import paths for stdlib. If not provided, falls
    *   back to resolving moduleId against cwd.
+   * @param initPlan - Optional per-module init plan + resolver from
+   *   `compileClosure`. See the field docstring above.
    */
   constructor(
     config: AgencyConfig | undefined,
     info: CompilationUnit,
     moduleId: string,
     outputFile?: string,
+    initPlan?: TypeScriptBuilder["initPlan"],
   ) {
     this.agencyConfig = mergeDeep(this.configDefaults(), config || {});
     this.compilationUnit = info;
@@ -280,6 +310,7 @@ export class TypeScriptBuilder {
     });
     this.moduleId = moduleId;
     this.outputFile = outputFile;
+    this.initPlan = initPlan;
   }
 
   private configDefaults(): Partial<AgencyConfig> {
@@ -385,12 +416,17 @@ export class TypeScriptBuilder {
     this.generatedStatements.push(this.generateToolRegistry());
 
     // Sort program nodes into static-init / global-init / top-level buckets.
+    // When an InitPlan is available, partition emits local assignments in
+    // topsort order instead of source order; otherwise falls back to
+    // source order (legacy path).
     const partition = partitionProgram(program, {
       processNode: (n) => this.processNode(n),
       processNodeInGlobalInit: (n) => this.processNodeInGlobalInit(n),
       buildHandlerArrow: (h) => this.buildHandlerArrow(h),
       isTopLevelDeclaration: (n) => this.names.isTopLevelDeclaration(n),
       moduleId: this.moduleId,
+      staticOrder: this.initPlan?.staticLocalOrder,
+      globalOrder: this.initPlan?.globalLocalOrder,
     });
     this.generatedStatements.push(...partition.topLevelStatements);
 
@@ -410,6 +446,9 @@ export class TypeScriptBuilder {
       generatedStatements: this.generatedStatements,
       postprocess: this.postprocess(),
       sourceMapJson: JSON.stringify(this._sourceMapBuilder.build()),
+      staticAwaitModules: this.initPlan?.staticAwaitModules,
+      globalAwaitModules: this.initPlan?.globalAwaitModules,
+      registryModuleId: this.initPlan?.registryModuleId,
     });
   }
 
@@ -781,10 +820,18 @@ export class TypeScriptBuilder {
             literal.scope === "imported" &&
             this.names.isAgencyImport(literal.value)
           ) {
+            // Thread the SOURCE module path through to the trap message
+            // when we know it (always, when compileClosure built our
+            // InitPlan). Without the plan, the empty string falls back
+            // to the runtime trap's "<unknown module>" placeholder —
+            // less helpful but never silently wrong.
+            const sourceModuleId =
+              this.initPlan?.resolveImportedName(literal.value)
+                ?.sourceModuleId ?? "";
             return ts.call(ts.id("__readStatic"), [
               ts.id(literal.value),
               ts.str(literal.value),
-              ts.str(""),
+              ts.str(sourceModuleId),
             ]);
           }
           return ts.id(literal.value);

--- a/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
@@ -200,10 +200,13 @@ export function partitionProgram(
 
 /**
  * Apply the topsort plan's `localOrder` to tagged init statements.
- * Named statements (statics, globals) are pulled out and re-emitted in
- * plan order; unnamed bare statements are interleaved at the position
- * they originally appeared, preserving source-order semantics for
- * side-effecty calls that have no var to depend on.
+ *
+ * Bare (unnamed) statements are anchored to their source position —
+ * each occupies exactly the slot where it originally appeared. Named
+ * statements are reordered per the plan, with the k-th name in
+ * `localOrder` filling the k-th named slot in source order. This
+ * preserves side-effect ordering for patterns like `foo(); const x =
+ * ...; bar();` while still letting topsort sequence the named decls.
  *
  * No plan → source order, unchanged.
  */
@@ -218,15 +221,20 @@ function reorderTagged(
   for (const { varName, node } of tagged) {
     if (varName) byName[varName] = node;
   }
+  // Walk tagged once. Bare slots emit their own node immediately.
+  // Named slots are placeholders to be filled from `order` in
+  // top-to-bottom order — only names that have a matching tagged
+  // node count, so cross-module-only names in `order` are skipped.
+  const planNamesInTagged = order.filter((n) => byName[n]);
   const out: TsNode[] = [];
-  // Named statements first, in plan order.
-  for (const name of order) {
-    if (byName[name]) out.push(byName[name]);
-  }
-  // Then bare statements (no varName) in their original source order
-  // so any side effect ordering relative to other bares is preserved.
+  let namedSlotIdx = 0;
   for (const { varName, node } of tagged) {
-    if (!varName) out.push(node);
+    if (varName) {
+      const fillName = planNamesInTagged[namedSlotIdx++];
+      if (fillName) out.push(byName[fillName]!);
+    } else {
+      out.push(node);
+    }
   }
   return out;
 }

--- a/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
@@ -1,6 +1,24 @@
+import * as path from "path";
 import type { AgencyNode, AgencyProgram } from "../../types.js";
 import type { TsNode } from "../../ir/tsIR.js";
 import { ts } from "../../ir/builders.js";
+
+/**
+ * Convert an absolute module path to one rooted at the codegen cwd
+ * for readability in the generated registry-key string literals.
+ * Falls back to the original string when `abs` is already relative
+ * (legacy callers that supply a relative `moduleId` directly).
+ *
+ * Safety: `register*Init` and `await*Init` both flow through this
+ * function before becoming string literals in the emitted JS, so
+ * registry keys still match exactly within a single compilation
+ * pass — the value of `process.cwd()` at runtime is irrelevant once
+ * the literals are baked in.
+ */
+function displayModuleId(abs: string): string {
+  if (!path.isAbsolute(abs)) return abs;
+  return path.relative(process.cwd(), abs);
+}
 
 /**
  * Two helpers for the orchestration phase of `TypeScriptBuilder.build()`:
@@ -338,6 +356,14 @@ export type AssembleSectionsOpts = {
    * correct for same-module flows.
    */
   registryModuleId?: string;
+  /**
+   * Plan-driven local init orders. Used purely for the human-readable
+   * banner comments above `__initializeStatic` / `__initializeGlobals`
+   * — the actual order is already baked into `staticInitStatements` /
+   * `globalInitStatements` by `reorderTagged` during partition.
+   */
+  staticLocalOrder?: string[];
+  globalLocalOrder?: string[];
 };
 
 /**
@@ -389,13 +415,13 @@ export function assembleSections(opts: AssembleSectionsOpts): TsNode {
 
   if (opts.staticVarNames.size > 0) {
     sections.push(...buildStaticVarSetup(opts));
-    // Register this module's static-init under its absolute moduleId
-    // so other modules can `await __awaitStaticInit(...)` it. Only
-    // needed when the module actually has statics — otherwise nobody
-    // will look it up.
+    // Register this module's static-init under its (cwd-relative)
+    // moduleId so other modules can `await __awaitStaticInit(...)` it.
+    // Only needed when the module actually has statics — otherwise
+    // nobody will look it up.
     sections.push(
       ts.raw(
-        `__registerStaticInit(${JSON.stringify(registryId)}, __initializeStatic);`,
+        `__registerStaticInit(${JSON.stringify(displayModuleId(registryId))}, __initializeStatic);`,
       ),
     );
   }
@@ -404,7 +430,7 @@ export function assembleSections(opts: AssembleSectionsOpts): TsNode {
   // Same idea for globals init.
   sections.push(
     ts.raw(
-      `__registerGlobalsInit(${JSON.stringify(registryId)}, __initializeGlobals);`,
+      `__registerGlobalsInit(${JSON.stringify(displayModuleId(registryId))}, __initializeGlobals);`,
     ),
   );
 
@@ -421,6 +447,36 @@ export function assembleSections(opts: AssembleSectionsOpts): TsNode {
   );
 
   return ts.statements(sections);
+}
+
+/**
+ * Build the leading banner-comment block for `__initializeStatic` /
+ * `__initializeGlobals`. Surfaces, in two human-readable lines, the
+ * plan-driven decisions baked into the function body: which other
+ * modules' init must complete before this one (cross-module awaits),
+ * and the order this module's own decls are assigned in (local
+ * order). Both lists are shown cwd-relative for readability.
+ *
+ * Lets a reviewer skim a generated module and see exactly what the
+ * topsort decided without re-deriving it from the body.
+ */
+function buildInitBanner(
+  phase: "static" | "global",
+  localOrder: string[],
+  awaitModules: string[],
+): TsNode[] {
+  if (localOrder.length === 0 && awaitModules.length === 0) return [];
+  const awaitsLine =
+    awaitModules.length > 0
+      ? awaitModules.map(displayModuleId).join(", ")
+      : "(none)";
+  const localLine =
+    localOrder.length > 0 ? localOrder.join(" → ") : "(none)";
+  return [
+    ts.comment(`Init plan (${phase} phase):`),
+    ts.comment(`  awaits (cross-module): ${awaitsLine}`),
+    ts.comment(`  local order:           ${localLine}`),
+  ];
 }
 
 /**
@@ -464,7 +520,7 @@ function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
   // `reorderTagged` did that ordering during partition).
   const awaitPrelude = (opts.staticAwaitModules ?? []).map((m) =>
     ts.raw(
-      `await __awaitStaticInit(${JSON.stringify(m.sourceModuleId)}, __ctx);`,
+      `await __awaitStaticInit(${JSON.stringify(displayModuleId(m.sourceModuleId))}, __ctx);`,
     ),
   );
   out.push(
@@ -472,6 +528,11 @@ function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
       "__initializeStatic",
       [{ name: "__ctx" }],
       ts.statements([
+        ...buildInitBanner(
+          "static",
+          opts.staticLocalOrder ?? [],
+          (opts.staticAwaitModules ?? []).map((m) => m.sourceModuleId),
+        ),
         ts.if(
           ts.id("__staticInitPromise"),
           ts.return(ts.id("__staticInitPromise")),
@@ -519,6 +580,11 @@ function buildInitializeGlobalsFn(opts: AssembleSectionsOpts): TsNode {
   // would read from ALS instead of the parameter).
   const ctxParam = ts.id("__ctx");
   const body: TsNode[] = [
+    ...buildInitBanner(
+      "global",
+      opts.globalLocalOrder ?? [],
+      (opts.globalAwaitModules ?? []).map((m) => m.sourceModuleId),
+    ),
     // Mark this module as initialized BEFORE running init statements.
     // This prevents infinite recursion when a global init expression
     // calls a function defined in the same module (which would trigger
@@ -544,7 +610,7 @@ function buildInitializeGlobalsFn(opts: AssembleSectionsOpts): TsNode {
   for (const m of opts.globalAwaitModules ?? []) {
     body.push(
       ts.raw(
-        `await __awaitGlobalsInit(${JSON.stringify(m.sourceModuleId)}, __ctx);`,
+        `await __awaitGlobalsInit(${JSON.stringify(displayModuleId(m.sourceModuleId))}, __ctx);`,
       ),
     );
   }

--- a/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
@@ -27,6 +27,19 @@ export type PartitionDeps = {
   buildHandlerArrow: (handlerName: string) => TsNode;
   isTopLevelDeclaration: (node: AgencyNode) => boolean;
   moduleId: string;
+  /**
+   * Optional per-phase initialization plan from `compileClosure`. When
+   * present, local var assignments are emitted in `localOrder` rather
+   * than source order, ensuring cross-module dependencies (Example 1
+   * from `agent-init-design.md`) resolve before reads. Bare top-level
+   * statements stay in source order.
+   *
+   * When absent (legacy callers that bypass `compileClosure`), partition
+   * falls back to source order. The lazy isInitialized guards remain the
+   * safety net for that path.
+   */
+  staticOrder?: string[];
+  globalOrder?: string[];
 };
 
 export type ProgramPartition = {
@@ -81,8 +94,12 @@ export function partitionProgram(
 ): ProgramPartition {
   const staticVarNames = new Set<string>();
   const exportedStaticVarNames = new Set<string>();
-  const staticInitStatements: TsNode[] = [];
-  const globalInitStatements: TsNode[] = [];
+  // Tag each init statement with its var name (null = bare/anonymous)
+  // so the partition can optionally reorder per the topsort plan
+  // without re-walking the AST. Bare statements keep source order
+  // because they have no name to key on.
+  const staticInitTagged: { varName: string | null; node: TsNode }[] = [];
+  const globalInitTagged: { varName: string | null; node: TsNode }[] = [];
   const topLevelStatements: TsNode[] = [];
   const topLevelCallbackStatements: TsNode[] = [];
 
@@ -103,11 +120,12 @@ export function partitionProgram(
         ts.id(stmt.variableName),
         ts.call(ts.id("__deepFreeze"), [valueNode]),
       );
-      staticInitStatements.push(
-        handlerName
+      staticInitTagged.push({
+        varName: stmt.variableName,
+        node: handlerName
           ? ts.withHandler(deps.buildHandlerArrow(handlerName), frozenAssign)
           : frozenAssign,
-      );
+      });
       continue;
     }
 
@@ -126,11 +144,12 @@ export function partitionProgram(
         valueNode,
         ts.id("__ctx"),
       );
-      globalInitStatements.push(
-        handlerName
+      globalInitTagged.push({
+        varName: stmt.variableName,
+        node: handlerName
           ? ts.withHandler(deps.buildHandlerArrow(handlerName), setNode)
           : setNode,
-      );
+      });
       continue;
     }
 
@@ -150,9 +169,10 @@ export function partitionProgram(
     // side effect, not re-executed on interrupt resume.
     if (node.type === "withModifier") {
       const innerStmt = deps.processNodeInGlobalInit(node.statement);
-      globalInitStatements.push(
-        ts.withHandler(deps.buildHandlerArrow(node.handlerName), innerStmt),
-      );
+      globalInitTagged.push({
+        varName: null,
+        node: ts.withHandler(deps.buildHandlerArrow(node.handlerName), innerStmt),
+      });
       continue;
     }
 
@@ -161,18 +181,54 @@ export function partitionProgram(
     } else {
       // Top-level statements (function calls, etc.) need __ctx access,
       // so they live inside __initializeGlobals.
-      globalInitStatements.push(deps.processNodeInGlobalInit(node));
+      globalInitTagged.push({
+        varName: null,
+        node: deps.processNodeInGlobalInit(node),
+      });
     }
   }
 
   return {
     staticVarNames,
     exportedStaticVarNames,
-    staticInitStatements,
-    globalInitStatements,
+    staticInitStatements: reorderTagged(staticInitTagged, deps.staticOrder),
+    globalInitStatements: reorderTagged(globalInitTagged, deps.globalOrder),
     topLevelStatements,
     topLevelCallbackStatements,
   };
+}
+
+/**
+ * Apply the topsort plan's `localOrder` to tagged init statements.
+ * Named statements (statics, globals) are pulled out and re-emitted in
+ * plan order; unnamed bare statements are interleaved at the position
+ * they originally appeared, preserving source-order semantics for
+ * side-effecty calls that have no var to depend on.
+ *
+ * No plan → source order, unchanged.
+ */
+function reorderTagged(
+  tagged: { varName: string | null; node: TsNode }[],
+  order: string[] | undefined,
+): TsNode[] {
+  if (!order || order.length === 0) {
+    return tagged.map((t) => t.node);
+  }
+  const byName: Record<string, TsNode> = {};
+  for (const { varName, node } of tagged) {
+    if (varName) byName[varName] = node;
+  }
+  const out: TsNode[] = [];
+  // Named statements first, in plan order.
+  for (const name of order) {
+    if (byName[name]) out.push(byName[name]);
+  }
+  // Then bare statements (no varName) in their original source order
+  // so any side effect ordering relative to other bares is preserved.
+  for (const { varName, node } of tagged) {
+    if (!varName) out.push(node);
+  }
+  return out;
 }
 
 /**
@@ -252,6 +308,28 @@ export type AssembleSectionsOpts = {
   postprocess: TsNode[];
   /** JSON-stringified source map, embedded into the generated module. */
   sourceMapJson: string;
+  /**
+   * Per-phase cross-module dependencies sourced from the topsort plan.
+   * For each entry, the generated `__initializeStatic` /
+   * `__initializeGlobals` body awaits the corresponding function on
+   * that source module before running its own assignments. Together with
+   * `reorderTagged` (which orders local statements by topsort) this is
+   * what makes Example 1 (`fooStatic = barStatic + "!"`) yield "hello!"
+   * instead of throwing the read-before-init trap.
+   *
+   * Empty / absent when the legacy callers bypass `compileClosure`.
+   */
+  staticAwaitModules?: { localImport: string; sourceModuleId: string }[];
+  globalAwaitModules?: { localImport: string; sourceModuleId: string }[];
+  /**
+   * Absolute moduleId used as the registry key for
+   * `__registerStaticInit` / `__registerGlobalsInit`. Falls back to
+   * `moduleId` when the plan didn't supply one (legacy callers); in
+   * that case cross-module awaits won't find this module's init in the
+   * registry, but the lazy isInitialized guard still keeps things
+   * correct for same-module flows.
+   */
+  registryModuleId?: string;
 };
 
 /**
@@ -295,11 +373,32 @@ export function assembleSections(opts: AssembleSectionsOpts): TsNode {
     sections.push(alias);
   }
 
+  // Registry id is the absolute path; matches the `sourceModuleId`
+  // other modules' `awaitModules` carry. Fall back to `opts.moduleId`
+  // (cwd-relative) when no plan provided — that path won't get
+  // cross-module awaits, but local init still works.
+  const registryId = opts.registryModuleId ?? opts.moduleId;
+
   if (opts.staticVarNames.size > 0) {
     sections.push(...buildStaticVarSetup(opts));
+    // Register this module's static-init under its absolute moduleId
+    // so other modules can `await __awaitStaticInit(...)` it. Only
+    // needed when the module actually has statics — otherwise nobody
+    // will look it up.
+    sections.push(
+      ts.raw(
+        `__registerStaticInit(${JSON.stringify(registryId)}, __initializeStatic);`,
+      ),
+    );
   }
 
   sections.push(buildInitializeGlobalsFn(opts));
+  // Same idea for globals init.
+  sections.push(
+    ts.raw(
+      `__registerGlobalsInit(${JSON.stringify(registryId)}, __initializeGlobals);`,
+    ),
+  );
 
   sections.push(buildRegisterTopLevelCallbacksFn(opts));
 
@@ -350,6 +449,16 @@ function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
   ]));
 
   // Promise-based guard: concurrent callers await the same init promise.
+  // Body starts with awaits on any modules whose statics are
+  // referenced by this module's static initializers — topsort guarantees
+  // those dependencies have no cycles, so the await chain terminates.
+  // Local assignments then run in topsort-order (sectionAssembler's
+  // `reorderTagged` did that ordering during partition).
+  const awaitPrelude = (opts.staticAwaitModules ?? []).map((m) =>
+    ts.raw(
+      `await __awaitStaticInit(${JSON.stringify(m.sourceModuleId)}, __ctx);`,
+    ),
+  );
   out.push(
     ts.functionDecl(
       "__initializeStatic",
@@ -361,7 +470,10 @@ function buildStaticVarSetup(opts: AssembleSectionsOpts): TsNode[] {
         ),
         ts.assign(
           ts.id("__staticInitPromise"),
-          ts.iife({ async: true, body: opts.staticInitStatements }),
+          ts.iife({
+            async: true,
+            body: [...awaitPrelude, ...opts.staticInitStatements],
+          }),
         ),
         ts.return(ts.id("__staticInitPromise")),
       ]),
@@ -416,6 +528,16 @@ function buildInitializeGlobalsFn(opts: AssembleSectionsOpts): TsNode {
       ts.awaitMethodCall(ctxParam, "writeStaticStateToTrace", [
         ts.methodCall(ts.runtime.globalCtx, "getStaticVars"),
       ]),
+    );
+  }
+
+  // Await per-phase imported modules' globals init. Same logic as the
+  // static prelude — topsort guarantees no cycles among the awaits.
+  for (const m of opts.globalAwaitModules ?? []) {
+    body.push(
+      ts.raw(
+        `await __awaitGlobalsInit(${JSON.stringify(m.sourceModuleId)}, __ctx);`,
+      ),
     );
   }
 

--- a/packages/agency-lang/lib/backends/typescriptGenerator.ts
+++ b/packages/agency-lang/lib/backends/typescriptGenerator.ts
@@ -4,6 +4,61 @@ import { buildCompilationUnit, type CompilationUnit } from "@/compilationUnit.js
 import { AgencyConfig } from "@/config.js";
 import { TypeScriptBuilder } from "./typescriptBuilder.js";
 import { printTs } from "../ir/prettyPrint.js";
+import type { CompiledClosure } from "@/compiler/compileClosure.js";
+
+/**
+ * Per-module initialization-plan view derived from a `CompiledClosure`.
+ * Captures everything codegen needs to drive the centralized init for
+ * one module without exposing the full closure (which would force the
+ * builder to know about the dep graph internals).
+ */
+export type InitPlanForModule = {
+  /** Absolute path of this module — used as the registry key for
+   * `__registerStaticInit` / `__awaitStaticInit`. MUST match the
+   * `sourceModuleId` field of any other module's `awaitModules` entry
+   * that references this one, hence absolute (cwd-relative paths
+   * would diverge between register and await sites). */
+  registryModuleId: string;
+  staticLocalOrder: string[];
+  staticAwaitModules: { localImport: string; sourceModuleId: string }[];
+  globalLocalOrder: string[];
+  globalAwaitModules: { localImport: string; sourceModuleId: string }[];
+  resolveImportedName: (
+    localName: string,
+  ) => { sourceModuleId: string; sourceName: string } | null;
+};
+
+/**
+ * Project a `CompiledClosure` to a single module's per-module init view.
+ * Used by both compile entry points (`lib/cli/commands.ts` and
+ * `lib/compiler/compile.ts`) — they each build the closure once at the
+ * outer call, then call this helper for every per-file `generateTypeScript`.
+ */
+export function initPlanForModule(
+  closure: CompiledClosure,
+  moduleId: string,
+): InitPlanForModule {
+  const plan = closure.plans[moduleId];
+  return {
+    registryModuleId: moduleId,
+    staticLocalOrder: plan?.static.localOrder ?? [],
+    staticAwaitModules: (plan?.static.awaitModules ?? []).map((m) => ({
+      // `localImport` is currently unused at codegen time — the runtime
+      // lookup keys off `sourceModuleId` directly — but we keep the
+      // field for future use (e.g., emitting `export ... from` aliases
+      // in the centralized-init successor work).
+      localImport: m,
+      sourceModuleId: m,
+    })),
+    globalLocalOrder: plan?.global.localOrder ?? [],
+    globalAwaitModules: (plan?.global.awaitModules ?? []).map((m) => ({
+      localImport: m,
+      sourceModuleId: m,
+    })),
+    resolveImportedName: (localName) =>
+      closure.resolver.resolve(localName, moduleId),
+  };
+}
 
 export function generateTypeScript(
   program: AgencyProgram,
@@ -11,6 +66,7 @@ export function generateTypeScript(
   info?: CompilationUnit,
   moduleId?: string,
   outputFile?: string,
+  initPlan?: InitPlanForModule,
 ): string {
   if (!moduleId) {
     throw new Error("moduleId is required for generateTypeScript");
@@ -18,7 +74,7 @@ export function generateTypeScript(
   const compilationUnit = info ?? buildCompilationUnit(program);
   const preprocessor = new TypescriptPreprocessor(program, config, compilationUnit);
   const preprocessedProgram = preprocessor.preprocess();
-  const builder = new TypeScriptBuilder(config, compilationUnit, moduleId, outputFile);
+  const builder = new TypeScriptBuilder(config, compilationUnit, moduleId, outputFile, initPlan);
   const ir = builder.build(preprocessedProgram);
   return printTs(ir);
 }

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -1,12 +1,18 @@
 import { generateAgency } from "@/backends/agencyGenerator.js";
 import { AgencyConfig, loadConfigSafe } from "@/config.js";
 import { AgencyProgram, generateTypeScript } from "@/index.js";
+import { initPlanForModule } from "@/backends/typescriptGenerator.js";
 import { resolveImports } from "@/preprocessors/importResolver.js";
 import { resolveReExports } from "@/preprocessors/resolveReExports.js";
 import { liftCallbackBlocks } from "@/preprocessors/liftCallbacks.js";
 import { buildCompilationUnit } from "@/compilationUnit.js";
 import { SymbolTable } from "@/symbolTable.js";
 import { formatErrors, typeCheck } from "@/typeChecker/index.js";
+import {
+  buildCompiledClosure,
+  CompileClosureError,
+  type CompiledClosure,
+} from "@/compiler/compileClosure.js";
 import { spawn } from "child_process";
 import { transformSync } from "esbuild";
 import * as fs from "fs";
@@ -168,9 +174,15 @@ export function readFile(inputFile: string): string {
 }
 
 const compiledFiles: Set<string> = new Set();
+// Cached `CompiledClosure` for the current compile session. Built once
+// at the outermost `compile()` call (when no per-file recursion is in
+// progress) and reused by every per-file emit. Cleared by
+// `resetCompilationCache()`.
+let currentClosure: CompiledClosure | null = null;
 
 export function resetCompilationCache(): void {
   compiledFiles.clear();
+  currentClosure = null;
 }
 
 export function compile(
@@ -197,6 +209,31 @@ export function compile(
   }
 
   const absoluteInputFile = path.resolve(inputFile);
+
+  // Build the import-closure analysis once per compile session — at the
+  // outermost call, before any recursive per-file compile() runs. The
+  // recursive children reuse the cached closure to get per-module init
+  // plans without re-parsing.
+  //
+  // Stdlib files compile under their own entry (e.g., when a user runs
+  // `agency compile std/...`) but most user code reaches them via
+  // `import "std::..."`, which the closure walker intentionally skips.
+  // Avoid building a closure rooted at a stdlib file — its imports are
+  // structured differently and we don't need the analysis there.
+  if (
+    !currentClosure &&
+    !absoluteInputFile.startsWith(getStdlibDir() + path.sep)
+  ) {
+    try {
+      currentClosure = buildCompiledClosure(absoluteInputFile, config);
+    } catch (e) {
+      if (e instanceof CompileClosureError) {
+        console.error(e.message);
+        process.exit(1);
+      }
+      throw e;
+    }
+  }
   const ext = options?.ts ? ".ts" : ".js";
   // Anchor the replacement to the extension so that an absolute path
   // containing ".agency" as a substring in a parent directory (e.g.
@@ -298,12 +335,19 @@ export function compile(
 
   const moduleId = path.relative(process.cwd(), absoluteInputFile);
   const absoluteOutputFile = path.resolve(outputFile);
+  // Per-module init plan view — derived from the cached closure if we
+  // built one. Modules not in the closure (e.g., out-of-tree stdlib
+  // compiles) fall through to the legacy path with no plan.
+  const initPlan = currentClosure
+    ? initPlanForModule(currentClosure, absoluteInputFile)
+    : undefined;
   const generatedCode = generateTypeScript(
     liftedProgram,
     config,
     info,
     moduleId,
     absoluteOutputFile,
+    initPlan,
   );
   if (options?.ts) {
     fs.writeFileSync(outputFile, "// @ts-nocheck\n" + generatedCode, "utf-8");

--- a/packages/agency-lang/lib/cli/commands.ts
+++ b/packages/agency-lang/lib/cli/commands.ts
@@ -215,15 +215,26 @@ export function compile(
   // recursive children reuse the cached closure to get per-module init
   // plans without re-parsing.
   //
+  // "Outermost call" = no `options.symbolTable` (passed by recursive
+  // children). When the outermost call's entry file changes (e.g. the
+  // `agency test` runner iterates several .test.json fixtures in one
+  // process), the cached closure no longer covers the new entry's
+  // imports so we rebuild and drop the stale `compiledFiles` set.
+  // Without that drop, downstream codegen would look up plans for
+  // modules that aren't in the closure and emit an empty init plan.
+  //
   // Stdlib files compile under their own entry (e.g., when a user runs
   // `agency compile std/...`) but most user code reaches them via
   // `import "std::..."`, which the closure walker intentionally skips.
   // Avoid building a closure rooted at a stdlib file — its imports are
   // structured differently and we don't need the analysis there.
-  if (
-    !currentClosure &&
-    !absoluteInputFile.startsWith(getStdlibDir() + path.sep)
-  ) {
+  const isOutermostCall = !options?.symbolTable;
+  const isStdlibEntry = absoluteInputFile.startsWith(getStdlibDir() + path.sep);
+  const closureCoversEntry =
+    currentClosure?.programs[absoluteInputFile] !== undefined;
+  if (isOutermostCall && !isStdlibEntry && !closureCoversEntry) {
+    currentClosure = null;
+    compiledFiles.clear();
     try {
       currentClosure = buildCompiledClosure(absoluteInputFile, config);
     } catch (e) {

--- a/packages/agency-lang/lib/compiler/compile.ts
+++ b/packages/agency-lang/lib/compiler/compile.ts
@@ -4,12 +4,17 @@
  */
 import { AgencyConfig } from "@/config.js";
 import { AgencyProgram, generateTypeScript } from "@/index.js";
+import { initPlanForModule } from "@/backends/typescriptGenerator.js";
 import { resolveImports } from "@/preprocessors/importResolver.js";
 import { resolveReExports } from "@/preprocessors/resolveReExports.js";
 import { liftCallbackBlocks } from "@/preprocessors/liftCallbacks.js";
 import { buildCompilationUnit } from "@/compilationUnit.js";
 import { SymbolTable } from "@/symbolTable.js";
 import { formatErrors, typeCheck } from "@/typeChecker/index.js";
+import {
+  buildCompiledClosure,
+  CompileClosureError,
+} from "./compileClosure.js";
 import { transformSync } from "esbuild";
 import { nanoid } from "nanoid";
 import * as fs from "fs";
@@ -163,14 +168,30 @@ export function compileSource(
       );
     });
 
+    // 6b. Build the closure analysis to detect cycles + populate the
+    // per-module init plan (topsort ordering + cross-module awaits).
+    // CompileClosureError surfaces as a `CompileFailure` per this
+    // module's contract — no `process.exit`.
+    let closure;
+    try {
+      closure = buildCompiledClosure(syntheticPath, config);
+    } catch (e) {
+      if (e instanceof CompileClosureError) {
+        return { success: false, errors: [e.message] };
+      }
+      throw e;
+    }
+
     // 7. Generate TypeScript
     const outputPath = path.join(os.tmpdir(), `${moduleId}.js`);
+    const initPlan = initPlanForModule(closure, syntheticPath);
     const generatedCode = generateTypeScript(
       liftedProgram,
       config,
       info,
       moduleId,
       outputPath,
+      initPlan,
     );
 
     // 8. Transpile TS → JS

--- a/packages/agency-lang/lib/compiler/compileClosure.test.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import {
+  buildCompiledClosure,
+  CompileClosureError,
+} from "./compileClosure.js";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), "compile-closure-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+function write(rel: string, contents: string): string {
+  const abs = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, contents, "utf-8");
+  return abs;
+}
+
+describe("buildCompiledClosure", () => {
+  it("parses every reachable file once and produces a per-module plan", () => {
+    const fooPath = write(
+      "foo.agency",
+      'import { barStatic } from "./bar.agency"\n' +
+        'static const fooStatic = barStatic + "!"\n' +
+        'node main() { return fooStatic }\n',
+    );
+    write("bar.agency", 'export static const barStatic = "hello"\n');
+
+    const c = buildCompiledClosure(fooPath, {});
+    expect(Object.keys(c.programs).sort()).toEqual(
+      [fooPath, path.join(dir, "bar.agency")].sort(),
+    );
+    expect(c.plans[fooPath]).toBeDefined();
+    expect(c.plans[path.join(dir, "bar.agency")]).toBeDefined();
+    expect(c.plans[fooPath]!.static.localOrder).toEqual(["fooStatic"]);
+    expect(c.plans[fooPath]!.static.awaitModules).toEqual([
+      path.join(dir, "bar.agency"),
+    ]);
+  });
+
+  it("throws CompileClosureError on a static cycle, naming both decls", () => {
+    const fooPath = write(
+      "foo.agency",
+      'import { barStatic } from "./bar.agency"\n' +
+        'export static const fooStatic = barStatic + "!"\n',
+    );
+    write(
+      "bar.agency",
+      'import { fooStatic } from "./foo.agency"\n' +
+        'export static const barStatic = fooStatic + "?"\n',
+    );
+
+    let err: unknown = null;
+    try {
+      buildCompiledClosure(fooPath, {});
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CompileClosureError);
+    const msg = (err as Error).message;
+    expect(msg).toMatch(/Circular static dependency/);
+    expect(msg).toMatch(/fooStatic/);
+    expect(msg).toMatch(/barStatic/);
+  });
+
+  it("throws CompileClosureError when a static initializer references a global", () => {
+    const entryPath = write(
+      "entry.agency",
+      'const g = "hello"\n' +
+        'static const s = g + "!"\n' +
+        'node main() { return s }\n',
+    );
+
+    let err: unknown = null;
+    try {
+      buildCompiledClosure(entryPath, {});
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CompileClosureError);
+    expect((err as Error).message).toMatch(
+      /Static '?s'?.*references global '?g'?/,
+    );
+  });
+
+  it("throws CompileClosureError when a file in the closure fails to parse", () => {
+    const entryPath = write(
+      "entry.agency",
+      'import { x } from "./broken.agency"\n' +
+        'static const s = x + "!"\n',
+    );
+    write(
+      "broken.agency",
+      'this is not (((( valid agency syntax\n',
+    );
+
+    let err: unknown = null;
+    try {
+      buildCompiledClosure(entryPath, {});
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(CompileClosureError);
+    expect((err as Error).message).toMatch(/Failed to parse/);
+  });
+
+  it("treats a re-exported static as imported from its ultimate source module", () => {
+    const fooPath = write(
+      "foo.agency",
+      'import { barStatic } from "./reexport.agency"\n' +
+        'static const fooStatic = barStatic + "!"\n' +
+        'node main() { return fooStatic }\n',
+    );
+    write(
+      "reexport.agency",
+      'export { barStatic } from "./bar.agency"\n',
+    );
+    write("bar.agency", 'export static const barStatic = "hello"\n');
+
+    const c = buildCompiledClosure(fooPath, {});
+    expect(c.plans[fooPath]!.static.awaitModules).toEqual([
+      path.join(dir, "bar.agency"),
+    ]);
+  });
+});

--- a/packages/agency-lang/lib/compiler/compileClosure.test.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.test.ts
@@ -139,4 +139,37 @@ describe("buildCompiledClosure", () => {
     expect(c.plans[fooPath]!.static.awaitModules).toEqual([reexportPath]);
     expect(c.plans[reexportPath]!.static.awaitModules).toEqual([barPath]);
   });
+
+  it("bare top-level stmts contribute cross-module awaits to the global plan", () => {
+    // Regression: phasePlanFor used to drop edges out of synthetic
+    // __bareStmt_ nodes entirely, so a bare call referencing an
+    // imported global produced no `await __awaitGlobalsInit(helper, ...)`
+    // — the bare body could run before the helper module's
+    // __initializeGlobals had populated `helperGlobal`. We still keep
+    // bare nodes out of `localOrder` (codegen emits them inline) but
+    // we must follow their edges for the cross-module await.
+    //
+    // Uses a namespace import so the underlying bareStmt edge actually
+    // makes it into the dep graph: named imports of non-static
+    // globals aren't in the symbol table, so this is the only way to
+    // get a cross-module global-to-global edge today (until that
+    // resolver gap closes).
+    const mainPath = write(
+      "main.agency",
+      'import * as helper from "./helper.agency"\n' +
+        'def show(s: string) {}\n' +
+        'show(helper.helperGlobal)\n' +
+        'node main() { return "ok" }\n',
+    );
+    const helperPath = write(
+      "helper.agency",
+      'export const helperGlobal = "G"\n',
+    );
+
+    const c = buildCompiledClosure(mainPath, {});
+    expect(c.plans[mainPath]!.global.awaitModules).toEqual([helperPath]);
+    // localOrder still doesn't include bare slots — codegen emits them
+    // inline via the section assembler.
+    expect(c.plans[mainPath]!.global.localOrder).toEqual([]);
+  });
 });

--- a/packages/agency-lang/lib/compiler/compileClosure.test.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.test.ts
@@ -112,22 +112,31 @@ describe("buildCompiledClosure", () => {
     expect((err as Error).message).toMatch(/Failed to parse/);
   });
 
-  it("treats a re-exported static as imported from its ultimate source module", () => {
+  it("threads re-export chains as one-hop awaits so wrapper statics init in cascade", () => {
+    // foo imports barStatic from reexport.agency, which re-exports from
+    // bar.agency. `resolveReExports` synthesizes a wrapper static
+    // `static const barStatic = _reexport_barStatic` in reexport.agency
+    // that needs its own `__initializeStatic` to run. The dep graph
+    // resolves imports one hop at a time so foo awaits reexport (its
+    // direct source), and reexport's own plan awaits bar — the runtime
+    // cascade then walks the full chain automatically.
     const fooPath = write(
       "foo.agency",
       'import { barStatic } from "./reexport.agency"\n' +
         'static const fooStatic = barStatic + "!"\n' +
         'node main() { return fooStatic }\n',
     );
-    write(
+    const reexportPath = write(
       "reexport.agency",
       'export { barStatic } from "./bar.agency"\n',
     );
-    write("bar.agency", 'export static const barStatic = "hello"\n');
+    const barPath = write(
+      "bar.agency",
+      'export static const barStatic = "hello"\n',
+    );
 
     const c = buildCompiledClosure(fooPath, {});
-    expect(c.plans[fooPath]!.static.awaitModules).toEqual([
-      path.join(dir, "bar.agency"),
-    ]);
+    expect(c.plans[fooPath]!.static.awaitModules).toEqual([reexportPath]);
+    expect(c.plans[reexportPath]!.static.awaitModules).toEqual([barPath]);
   });
 });

--- a/packages/agency-lang/lib/compiler/compileClosure.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.ts
@@ -369,12 +369,19 @@ function globalPhasePlanFor(
   for (const key of Object.keys(globalGraph.nodes)) {
     const node = globalGraph.nodes[key];
     if (!node || node.moduleId !== moduleId) continue;
-    for (const refName of collectFreeIdentifiers(node.initExpr)) {
-      if (refName === node.varName) continue;
-      const aliased = resolver.resolve(refName, moduleId);
-      const refKey = aliased
-        ? makeKey(aliased.sourceModuleId, aliased.sourceName)
-        : makeKey(moduleId, refName);
+    for (const ref of collectFreeIdentifiers(node.initExpr)) {
+      let refKey: string;
+      if (ref.kind === "name") {
+        if (ref.name === node.varName) continue;
+        const aliased = resolver.resolve(ref.name, moduleId);
+        refKey = aliased
+          ? makeKey(aliased.sourceModuleId, aliased.sourceName)
+          : makeKey(moduleId, ref.name);
+      } else {
+        const ns = resolver.resolveNamespace(ref.prefix, moduleId);
+        if (!ns) continue;
+        refKey = makeKey(ns.sourceModuleId, ref.member);
+      }
       const staticNode = staticGraph.nodes[refKey];
       if (!staticNode || staticNode.moduleId === moduleId) continue;
       awaitModulesSet[staticNode.moduleId] = true;

--- a/packages/agency-lang/lib/compiler/compileClosure.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.ts
@@ -320,11 +320,14 @@ function phasePlanFor(
   for (const key of order) {
     const node = graph.nodes[key];
     if (!node || node.moduleId !== moduleId) continue;
-    // Skip synthetic bare-statement nodes — they're emitted inline by
-    // the existing sectionAssembler path; the plan currently only
-    // sequences named decls.
-    if (node.varName.startsWith("__bareStmt_")) continue;
-    localOrder.push(node.varName);
+    // Synthetic bare-statement nodes never enter `localOrder` — the
+    // section assembler emits them inline at their source position.
+    // They STILL must contribute their cross-module edges to
+    // `awaitModules`: a bare `show(helper.helperGlobal)` needs
+    // `helper.agency`'s globals init awaited before it runs, same as
+    // any named decl that references an imported global.
+    const isBare = node.varName.startsWith("__bareStmt_");
+    if (!isBare) localOrder.push(node.varName);
     for (const depKey of graph.edges[key] ?? []) {
       const depNode = graph.nodes[depKey];
       if (!depNode || depNode.moduleId === moduleId) continue;

--- a/packages/agency-lang/lib/compiler/compileClosure.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.ts
@@ -1,0 +1,326 @@
+/**
+ * Single owner of multi-file compilation. Parses every reachable agency
+ * file from an entry, builds a shared SymbolTable, runs the per-variable
+ * dep graphs (static + global) plus topological sort, and produces an
+ * `InitPlan` per module that codegen consumes to drive its centralized
+ * init.
+ *
+ * Both `lib/cli/commands.ts:compile()` (CLI: writes files to disk) and
+ * `lib/compiler/compile.ts:compileSource()` (in-memory: returns a string)
+ * call this helper, then walk the result's modules and codegen each. The
+ * recursive `compile()` cascade that used to re-enter per file is gone —
+ * the closure is built once, in one place.
+ *
+ * Errors surface as exceptions of type `CompileClosureError`. The CLI
+ * path turns them into stderr + `process.exit(1)`; the in-memory path
+ * returns them as `CompileFailure`.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import type { AgencyProgram, AgencyNode } from "../types.js";
+import { AgencyConfig } from "../config.js";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import {
+  buildInitDepGraphs,
+  type ImportAliasResolver,
+  type InitDepGraph,
+  type InitVarNode,
+  StaticReferencesGlobalError,
+} from "./initDepGraph.js";
+import { topSortInitGraph, type CycleError } from "./topSortInitGraph.js";
+import {
+  getStdlibDir,
+  isAgencyImport,
+  isPkgImport,
+  isStdlibImport,
+  resolveAgencyImportPath,
+} from "../importPaths.js";
+
+export class CompileClosureError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CompileClosureError";
+  }
+}
+
+/**
+ * The per-module init plan codegen consumes. For Phase A (static) and
+ * Phase B (global), captures:
+ *   - `localOrder`: the topsort-ordered subset of local var names in
+ *     this module. Codegen emits assignments in this order rather than
+ *     source order.
+ *   - `awaitModules`: other modules whose init must complete before
+ *     this module's local init body runs. Computed from cross-module
+ *     edges in the dep graph. Codegen emits an `await
+ *     <importedModule>.__initializeStatic(ctx)` at the head of this
+ *     module's `__initializeStatic` for each entry.
+ */
+export type ModuleInitPhasePlan = {
+  localOrder: string[];
+  awaitModules: string[];
+};
+
+export type ModuleInitPlan = {
+  moduleId: string;
+  static: ModuleInitPhasePlan;
+  global: ModuleInitPhasePlan;
+};
+
+export type CompiledClosure = {
+  /** Map from absolute module path to parsed program. */
+  programs: Record<string, AgencyProgram>;
+  /** Shared symbol table for the entire closure. */
+  symbolTable: SymbolTable;
+  /** The entry module's absolute path. */
+  entryModuleId: string;
+  /** Static dep graph (Phase A). */
+  staticGraph: InitDepGraph;
+  /** Global dep graph (Phase B). */
+  globalGraph: InitDepGraph;
+  /** Resolver used by codegen for PR-1 thread-through. */
+  resolver: ImportAliasResolver;
+  /** Topsort-derived per-module init plans. Keyed by moduleId. */
+  plans: Record<string, ModuleInitPlan>;
+};
+
+/**
+ * Parse + analyze the entry's full import closure. Throws
+ * `CompileClosureError` for parse failures, cycle errors, or
+ * static-references-global violations. The caller decides how to
+ * surface the error (CLI: exit; in-memory: collect).
+ */
+export function buildCompiledClosure(
+  entryFile: string,
+  config: AgencyConfig,
+): CompiledClosure {
+  const entryModuleId = path.resolve(entryFile);
+  const programs = parseClosure(entryModuleId, config);
+  const symbolTable = SymbolTable.build(entryModuleId, config);
+
+  let staticGraph: InitDepGraph;
+  let globalGraph: InitDepGraph;
+  let resolver: ImportAliasResolver;
+  try {
+    const r = buildInitDepGraphs(programs, symbolTable, entryModuleId);
+    staticGraph = r.staticGraph;
+    globalGraph = r.globalGraph;
+    resolver = r.resolver;
+  } catch (e) {
+    // Re-throw analysis-time validation errors (currently only
+    // `StaticReferencesGlobalError`) under the closure-error banner so
+    // call sites have a single error type to catch.
+    if (e instanceof StaticReferencesGlobalError) {
+      throw new CompileClosureError(e.message);
+    }
+    throw e;
+  }
+
+  const staticOrder = sortOrThrow(staticGraph, "static");
+  const globalOrder = sortOrThrow(globalGraph, "global");
+
+  const plans = buildPlans(
+    Object.keys(programs),
+    staticGraph,
+    staticOrder,
+    globalGraph,
+    globalOrder,
+  );
+
+  return {
+    programs,
+    symbolTable,
+    entryModuleId,
+    staticGraph,
+    globalGraph,
+    resolver,
+    plans,
+  };
+}
+
+/**
+ * BFS the entry's full agency-import closure. Parses each file once.
+ * Stdlib (`std::...`) and pkg (`pkg::...`) imports skipped — the
+ * dep-graph machinery only cares about user-controlled .agency files.
+ * Non-agency imports (.js/.ts) are likewise out of scope.
+ *
+ * Parse failures throw `CompileClosureError` with the path + message;
+ * callers translate that into their preferred surface.
+ */
+function parseClosure(
+  entryModuleId: string,
+  config: AgencyConfig,
+): Record<string, AgencyProgram> {
+  const out: Record<string, AgencyProgram> = {};
+  const visited: Record<string, true> = {};
+  const queue: string[] = [entryModuleId];
+  const stdlibDir = getStdlibDir();
+  const stdlibIndex = path.join(stdlibDir, "index.agency");
+
+  while (queue.length > 0) {
+    const moduleId = queue.shift()!;
+    if (visited[moduleId]) continue;
+    visited[moduleId] = true;
+
+    if (!fs.existsSync(moduleId)) {
+      throw new CompileClosureError(
+        `Error: Input file '${moduleId}' not found`,
+      );
+    }
+    const source = fs.readFileSync(moduleId, "utf-8");
+    const applyTemplate = moduleId !== stdlibIndex;
+    const result = parseAgency(source, config, applyTemplate);
+    if (!result.success) {
+      throw new CompileClosureError(
+        `Failed to parse ${moduleId}: ${result.message ?? "unknown parse error"}`,
+      );
+    }
+    out[moduleId] = result.result;
+
+    for (const target of agencyImportTargets(result.result, moduleId)) {
+      if (!visited[target]) queue.push(target);
+    }
+  }
+  return out;
+}
+
+function agencyImportTargets(
+  program: AgencyProgram,
+  moduleId: string,
+): string[] {
+  const out: string[] = [];
+  for (const node of program.nodes) {
+    const target = agencyImportTarget(node);
+    if (!target) continue;
+    if (isStdlibImport(target) || isPkgImport(target)) continue;
+    if (!isAgencyImport(target)) continue;
+    out.push(resolveAgencyImportPath(target, moduleId));
+  }
+  return out;
+}
+
+function agencyImportTarget(node: AgencyNode): string | null {
+  if (node.type === "importStatement") return node.modulePath;
+  if (node.type === "importNodeStatement") return node.agencyFile;
+  if (node.type === "exportFromStatement") return node.modulePath;
+  return null;
+}
+
+/**
+ * Sort one graph; turn `CycleError` into a `CompileClosureError`
+ * carrying the formatted decl pair list. `phaseName` ("static" /
+ * "global") parameterizes the error message so cycle in either graph
+ * surfaces consistently.
+ */
+function sortOrThrow(
+  graph: InitDepGraph,
+  phaseName: "static" | "global",
+): string[] {
+  const r = topSortInitGraph(graph);
+  if (r.kind === "ok") return r.order;
+  throw new CompileClosureError(formatCycleError(r, phaseName));
+}
+
+function formatCycleError(
+  err: CycleError,
+  phaseName: "static" | "global",
+): string {
+  const lines: string[] = [
+    `Error: Circular ${phaseName} dependency`,
+  ];
+  for (let i = 0; i < err.cycle.length; i++) {
+    const cur = err.cycle[i];
+    const next = err.cycle[(i + 1) % err.cycle.length];
+    lines.push(
+      `  ${displayKey(cur)} (${cur.moduleId}:${cur.loc?.line ?? "?"}) depends on ${displayKey(next)}`,
+    );
+  }
+  lines.push(
+    `${capitalize(phaseName)} vars cannot depend on each other in a cycle. ` +
+      `Break the cycle by extracting one into a third file or computing from a literal.`,
+  );
+  return lines.join("\n");
+}
+
+function displayKey(node: InitVarNode): string {
+  const moduleName = path.basename(node.moduleId, ".agency");
+  return `${moduleName}.${node.varName}`;
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/**
+ * Project the topsorted variable list per module:
+ *   - `localOrder`: the topsort-ordered subset of vars defined in this
+ *     module.
+ *   - `awaitModules`: distinct source modules (other than this one) of
+ *     the cross-module dep edges out of any local node. Computed
+ *     directly from the dep graph's edges.
+ */
+function buildPlans(
+  moduleIds: string[],
+  staticGraph: InitDepGraph,
+  staticOrder: string[],
+  globalGraph: InitDepGraph,
+  globalOrder: string[],
+): Record<string, ModuleInitPlan> {
+  const plans: Record<string, ModuleInitPlan> = {};
+  for (const moduleId of moduleIds) {
+    plans[moduleId] = {
+      moduleId,
+      static: phasePlanFor(moduleId, staticGraph, staticOrder),
+      global: phasePlanFor(moduleId, globalGraph, globalOrder),
+    };
+  }
+  return plans;
+}
+
+function phasePlanFor(
+  moduleId: string,
+  graph: InitDepGraph,
+  order: string[],
+): ModuleInitPhasePlan {
+  const localOrder: string[] = [];
+  const awaitModulesSet: Record<string, true> = {};
+
+  for (const key of order) {
+    const node = graph.nodes[key];
+    if (!node || node.moduleId !== moduleId) continue;
+    // Skip synthetic bare-statement nodes — they're emitted inline by
+    // the existing sectionAssembler path; the plan currently only
+    // sequences named decls.
+    if (node.varName.startsWith("__bareStmt_")) continue;
+    localOrder.push(node.varName);
+    for (const depKey of graph.edges[key] ?? []) {
+      const depNode = graph.nodes[depKey];
+      if (!depNode || depNode.moduleId === moduleId) continue;
+      awaitModulesSet[depNode.moduleId] = true;
+    }
+  }
+
+  return {
+    localOrder,
+    awaitModules: Object.keys(awaitModulesSet).sort(),
+  };
+}
+
+/**
+ * Convenience: build the closure and look up one module's plan, or an
+ * empty default if the module isn't in the closure. Used by codegen
+ * entry points that already have a CompiledClosure on hand.
+ */
+export function planFor(
+  closure: CompiledClosure,
+  moduleId: string,
+): ModuleInitPlan {
+  return (
+    closure.plans[moduleId] ?? {
+      moduleId,
+      static: { localOrder: [], awaitModules: [] },
+      global: { localOrder: [], awaitModules: [] },
+    }
+  );
+}

--- a/packages/agency-lang/lib/compiler/compileClosure.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.ts
@@ -22,8 +22,11 @@ import type { AgencyProgram, AgencyNode } from "../types.js";
 import { AgencyConfig } from "../config.js";
 import { parseAgency } from "../parser.js";
 import { SymbolTable } from "../symbolTable.js";
+import { resolveReExports } from "../preprocessors/resolveReExports.js";
 import {
   buildInitDepGraphs,
+  collectFreeIdentifiers,
+  makeKey,
   type ImportAliasResolver,
   type InitDepGraph,
   type InitVarNode,
@@ -96,8 +99,15 @@ export function buildCompiledClosure(
   config: AgencyConfig,
 ): CompiledClosure {
   const entryModuleId = path.resolve(entryFile);
-  const programs = parseClosure(entryModuleId, config);
+  // SymbolTable must come first: it's the source of truth for re-export
+  // relationships, and parseClosure needs it to expand each parsed file
+  // via `resolveReExports` so the dep graph sees synthesized wrapper
+  // statics (`static const x = _reexport_x`) at re-exporters. Without
+  // that, re-export chains like a→b→c produce wrappers in a.js / b.js
+  // whose `__initializeStatic` never gets awaited because the dep graph
+  // collapses straight to c.
   const symbolTable = SymbolTable.build(entryModuleId, config);
+  const programs = parseClosure(entryModuleId, config, symbolTable);
 
   let staticGraph: InitDepGraph;
   let globalGraph: InitDepGraph;
@@ -126,6 +136,7 @@ export function buildCompiledClosure(
     staticOrder,
     globalGraph,
     globalOrder,
+    resolver,
   );
 
   return {
@@ -151,8 +162,16 @@ export function buildCompiledClosure(
 function parseClosure(
   entryModuleId: string,
   config: AgencyConfig,
+  symbolTable: SymbolTable,
 ): Record<string, AgencyProgram> {
-  const out: Record<string, AgencyProgram> = {};
+  // Two-phase: parse raw to discover the closure (raw still carries
+  // `exportFromStatement` nodes that the closure walker needs to follow
+  // re-export chains), then expand each parsed program with
+  // `resolveReExports` so the dep-graph builder sees synthesized wrapper
+  // statics. Order matters — `resolveReExports` strips
+  // `exportFromStatement` nodes, so doing it before closure-walking
+  // would lose re-export edges.
+  const raw: Record<string, AgencyProgram> = {};
   const visited: Record<string, true> = {};
   const queue: string[] = [entryModuleId];
   const stdlibDir = getStdlibDir();
@@ -176,11 +195,16 @@ function parseClosure(
         `Failed to parse ${moduleId}: ${result.message ?? "unknown parse error"}`,
       );
     }
-    out[moduleId] = result.result;
+    raw[moduleId] = result.result;
 
     for (const target of agencyImportTargets(result.result, moduleId)) {
       if (!visited[target]) queue.push(target);
     }
+  }
+
+  const out: Record<string, AgencyProgram> = {};
+  for (const [moduleId, program] of Object.entries(raw)) {
+    out[moduleId] = resolveReExports(program, symbolTable, moduleId);
   }
   return out;
 }
@@ -266,13 +290,20 @@ function buildPlans(
   staticOrder: string[],
   globalGraph: InitDepGraph,
   globalOrder: string[],
+  resolver: ImportAliasResolver,
 ): Record<string, ModuleInitPlan> {
   const plans: Record<string, ModuleInitPlan> = {};
   for (const moduleId of moduleIds) {
     plans[moduleId] = {
       moduleId,
       static: phasePlanFor(moduleId, staticGraph, staticOrder),
-      global: phasePlanFor(moduleId, globalGraph, globalOrder),
+      global: globalPhasePlanFor(
+        moduleId,
+        globalGraph,
+        globalOrder,
+        staticGraph,
+        resolver,
+      ),
     };
   }
   return plans;
@@ -303,6 +334,55 @@ function phasePlanFor(
 
   return {
     localOrder,
+    awaitModules: Object.keys(awaitModulesSet).sort(),
+  };
+}
+
+/**
+ * Build the Phase B (global) plan for one module.
+ *
+ * Starts from the standard edge-derived `awaitModules` (other modules'
+ * GLOBAL inits that this module's globals depend on) and then augments
+ * with cross-phase deps: any module whose STATIC this module's globals
+ * read. The global graph deliberately drops static refs as edges (cycle
+ * detection lives in single-phase graphs), but at runtime those statics
+ * must still be initialized before this module's globals run — so the
+ * generated `__initializeGlobals` needs an `await __awaitStaticInit(...)`
+ * for each such source module. Without this, a `const g = importedStatic`
+ * pattern hits the PR-1 read-before-init trap.
+ *
+ * Same-module statics need no await — `buildInitializeGlobalsFn` already
+ * emits an `await __initializeStatic(__ctx)` for the local module before
+ * any global init runs.
+ */
+function globalPhasePlanFor(
+  moduleId: string,
+  globalGraph: InitDepGraph,
+  globalOrder: string[],
+  staticGraph: InitDepGraph,
+  resolver: ImportAliasResolver,
+): ModuleInitPhasePlan {
+  const base = phasePlanFor(moduleId, globalGraph, globalOrder);
+  const awaitModulesSet: Record<string, true> = {};
+  for (const m of base.awaitModules) awaitModulesSet[m] = true;
+
+  for (const key of Object.keys(globalGraph.nodes)) {
+    const node = globalGraph.nodes[key];
+    if (!node || node.moduleId !== moduleId) continue;
+    for (const refName of collectFreeIdentifiers(node.initExpr)) {
+      if (refName === node.varName) continue;
+      const aliased = resolver.resolve(refName, moduleId);
+      const refKey = aliased
+        ? makeKey(aliased.sourceModuleId, aliased.sourceName)
+        : makeKey(moduleId, refName);
+      const staticNode = staticGraph.nodes[refKey];
+      if (!staticNode || staticNode.moduleId === moduleId) continue;
+      awaitModulesSet[staticNode.moduleId] = true;
+    }
+  }
+
+  return {
+    localOrder: base.localOrder,
     awaitModules: Object.keys(awaitModulesSet).sort(),
   };
 }

--- a/packages/agency-lang/lib/compiler/initDepGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from "vitest";
+import * as path from "path";
+import * as fs from "fs";
+import * as os from "os";
+import type { AgencyProgram } from "../types.js";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildInitDepGraph, makeKey } from "./initDepGraph.js";
+
+function parse(source: string): AgencyProgram {
+  const result = parseAgency(source, {}, false);
+  if (!result.success) {
+    throw new Error(
+      `parse failed: ${result.message ?? JSON.stringify(result)}`,
+    );
+  }
+  return result.result;
+}
+
+/**
+ * Helper: write a multi-file fixture under a temp dir and return
+ * (entry path, parsed programs by abs path, symbol table). Caller is
+ * responsible for cleanup of the returned dir.
+ */
+function writeFixture(
+  files: Record<string, string>,
+): {
+  dir: string;
+  programs: Record<string, AgencyProgram>;
+  symbolTable: SymbolTable;
+  abs: (rel: string) => string;
+} {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "init-dep-graph-test-"));
+  const programs: Record<string, AgencyProgram> = {};
+  for (const [relPath, source] of Object.entries(files)) {
+    const absPath = path.join(dir, relPath);
+    fs.mkdirSync(path.dirname(absPath), { recursive: true });
+    fs.writeFileSync(absPath, source, "utf-8");
+    programs[absPath] = parse(source);
+  }
+  // Find the first file as entry; tests can override by passing the
+  // entry explicitly to `buildInitDepGraph`.
+  const entry = path.join(dir, Object.keys(files)[0]);
+  const symbolTable = SymbolTable.build(entry, {});
+  return {
+    dir,
+    programs,
+    symbolTable,
+    abs: (rel) => path.join(dir, rel),
+  };
+}
+
+describe("buildInitDepGraph", () => {
+  it("returns an empty graph for an empty module", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency": `node main() { return 1 }\n`,
+    });
+    try {
+      const g = buildInitDepGraph(programs, symbolTable, abs("entry.agency"));
+      expect(Object.keys(g.nodes)).toEqual([]);
+      expect(Object.keys(g.edges)).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("adds an edge when one same-module decl references another", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `static const a = "hello"\n` +
+        `static const b = a + "!"\n` +
+        `node main() { return b }\n`,
+    });
+    try {
+      const g = buildInitDepGraph(programs, symbolTable, abs("entry.agency"));
+      const keyA = makeKey(abs("entry.agency"), "a");
+      const keyB = makeKey(abs("entry.agency"), "b");
+      expect(g.nodes[keyA]).toBeDefined();
+      expect(g.nodes[keyB]).toBeDefined();
+      expect(g.nodes[keyA]?.kind).toBe("static");
+      expect(g.edges[keyB]).toEqual([keyA]);
+      expect(g.edges[keyA]).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("adds a cross-module edge when an import is referenced", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "foo.agency":
+        `import { barStatic } from "./bar.agency"\n` +
+        `static const fooStatic = barStatic + "!"\n` +
+        `node main() { return fooStatic }\n`,
+      "bar.agency": `export static const barStatic = "hello"\n`,
+    });
+    try {
+      const g = buildInitDepGraph(programs, symbolTable, abs("foo.agency"));
+      const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
+      const keyBar = makeKey(abs("bar.agency"), "barStatic");
+      expect(g.nodes[keyFoo]).toBeDefined();
+      expect(g.nodes[keyBar]).toBeDefined();
+      expect(g.edges[keyFoo]).toEqual([keyBar]);
+      expect(g.edges[keyBar]).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves re-exported statics to their ultimate source module", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "foo.agency":
+        `import { barStatic } from "./reexport.agency"\n` +
+        `static const fooStatic = barStatic + "!"\n` +
+        `node main() { return fooStatic }\n`,
+      "reexport.agency": `export { barStatic } from "./bar.agency"\n`,
+      "bar.agency": `export static const barStatic = "hello"\n`,
+    });
+    try {
+      const g = buildInitDepGraph(programs, symbolTable, abs("foo.agency"));
+      const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
+      const keyBar = makeKey(abs("bar.agency"), "barStatic");
+      // No node should exist for the re-exporter — canonical is bar's.
+      expect(g.nodes[makeKey(abs("reexport.agency"), "barStatic")]).toBeUndefined();
+      expect(g.edges[keyFoo]).toEqual([keyBar]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates a single node for a diamond-imported static", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `import { aStatic } from "./left.agency"\n` +
+        `import { bStatic } from "./right.agency"\n` +
+        `static const main_ = aStatic + bStatic\n` +
+        `node main() { return main_ }\n`,
+      "left.agency":
+        `import { sharedStatic } from "./shared.agency"\n` +
+        `export static const aStatic = sharedStatic + "L"\n`,
+      "right.agency":
+        `import { sharedStatic } from "./shared.agency"\n` +
+        `export static const bStatic = sharedStatic + "R"\n`,
+      "shared.agency": `export static const sharedStatic = "S"\n`,
+    });
+    try {
+      const g = buildInitDepGraph(programs, symbolTable, abs("entry.agency"));
+      const keyShared = makeKey(abs("shared.agency"), "sharedStatic");
+      const keyA = makeKey(abs("left.agency"), "aStatic");
+      const keyB = makeKey(abs("right.agency"), "bStatic");
+      expect(g.nodes[keyShared]).toBeDefined();
+      expect(g.edges[keyA]).toEqual([keyShared]);
+      expect(g.edges[keyB]).toEqual([keyShared]);
+      // Only one shared node, even though imported from two places.
+      const sharedNodes = Object.keys(g.nodes).filter(
+        (k) => k.endsWith("::sharedStatic"),
+      );
+      expect(sharedNodes).toEqual([keyShared]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("represents a direct cycle without exploding (Task 2 detects it)", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "foo.agency":
+        `import { barStatic } from "./bar.agency"\n` +
+        `export static const fooStatic = barStatic + "!"\n`,
+      "bar.agency":
+        `import { fooStatic } from "./foo.agency"\n` +
+        `export static const barStatic = fooStatic + "?"\n`,
+    });
+    try {
+      const g = buildInitDepGraph(programs, symbolTable, abs("foo.agency"));
+      const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
+      const keyBar = makeKey(abs("bar.agency"), "barStatic");
+      expect(g.edges[keyFoo]).toEqual([keyBar]);
+      expect(g.edges[keyBar]).toEqual([keyFoo]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does NOT add an edge for a referenced function name (only values)", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "foo.agency":
+        `import { getBarStatic } from "./bar.agency"\n` +
+        `static const fooStatic = getBarStatic() + "!"\n` +
+        `node main() { return fooStatic }\n`,
+      "bar.agency":
+        `export static const barStatic = "hello"\n` +
+        `export def getBarStatic(): string { return barStatic }\n`,
+    });
+    try {
+      const g = buildInitDepGraph(programs, symbolTable, abs("foo.agency"));
+      const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
+      // fooStatic references getBarStatic (a def) and indirectly barStatic
+      // (through it). The dep graph should NOT add an edge for either —
+      // defs aren't init nodes, and call-graph analysis is out of scope.
+      expect(g.edges[keyFoo]).toEqual([]);
+      // But file-import edges should still capture foo → bar so the
+      // topsort can use them as a tiebreaker.
+      expect(g.fileImports[abs("foo.agency")]).toContain(abs("bar.agency"));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agency-lang/lib/compiler/initDepGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.test.ts
@@ -10,6 +10,7 @@ import {
   makeKey,
   StaticReferencesGlobalError,
 } from "./initDepGraph.js";
+import { resolveReExports } from "../preprocessors/resolveReExports.js";
 
 function parse(source: string): AgencyProgram {
   const result = parseAgency(source, {}, false);
@@ -35,15 +36,23 @@ function writeFixture(
   abs: (rel: string) => string;
 } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "init-dep-graph-test-"));
-  const programs: Record<string, AgencyProgram> = {};
+  const raw: Record<string, AgencyProgram> = {};
   for (const [relPath, source] of Object.entries(files)) {
     const absPath = path.join(dir, relPath);
     fs.mkdirSync(path.dirname(absPath), { recursive: true });
     fs.writeFileSync(absPath, source, "utf-8");
-    programs[absPath] = parse(source);
+    raw[absPath] = parse(source);
   }
   const entry = path.join(dir, Object.keys(files)[0]);
   const symbolTable = SymbolTable.build(entry, {});
+  // Mirror what `compileClosure.parseClosure` does: expand each
+  // program through `resolveReExports` so the dep graph sees the
+  // synthesized wrapper statics at re-exporters. Without this the
+  // unit tests would diverge from production behavior.
+  const programs: Record<string, AgencyProgram> = {};
+  for (const [absPath, program] of Object.entries(raw)) {
+    programs[absPath] = resolveReExports(program, symbolTable, absPath);
+  }
   return {
     dir,
     programs,
@@ -120,7 +129,13 @@ describe("buildInitDepGraphs", () => {
     }
   });
 
-  it("resolves re-exported statics to their ultimate source module", () => {
+  it("cascades re-exported statics one hop at a time", () => {
+    // `resolveReExports` synthesizes a wrapper `static const barStatic`
+    // in reexport.agency. The dep graph resolves imports one hop at a
+    // time, so:
+    //   foo.fooStatic → reexport.barStatic (wrapper) → bar.barStatic
+    // Each link is its own edge in the static graph, which makes the
+    // runtime cascade walk every wrapper's `__initializeStatic` in turn.
     const { dir, programs, symbolTable, abs } = writeFixture({
       "foo.agency":
         `import { barStatic } from "./reexport.agency"\n` +
@@ -136,11 +151,12 @@ describe("buildInitDepGraphs", () => {
         abs("foo.agency"),
       );
       const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
+      const keyReexport = makeKey(abs("reexport.agency"), "barStatic");
       const keyBar = makeKey(abs("bar.agency"), "barStatic");
-      expect(
-        staticGraph.nodes[makeKey(abs("reexport.agency"), "barStatic")],
-      ).toBeUndefined();
-      expect(staticGraph.edges[keyFoo]).toEqual([keyBar]);
+      expect(staticGraph.nodes[keyReexport]).toBeDefined();
+      expect(staticGraph.edges[keyFoo]).toEqual([keyReexport]);
+      expect(staticGraph.edges[keyReexport]).toEqual([keyBar]);
+      expect(staticGraph.edges[keyBar]).toEqual([]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/agency-lang/lib/compiler/initDepGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.test.ts
@@ -5,7 +5,11 @@ import * as os from "os";
 import type { AgencyProgram } from "../types.js";
 import { parseAgency } from "../parser.js";
 import { SymbolTable } from "../symbolTable.js";
-import { buildInitDepGraph, makeKey } from "./initDepGraph.js";
+import {
+  buildInitDepGraphs,
+  makeKey,
+  StaticReferencesGlobalError,
+} from "./initDepGraph.js";
 
 function parse(source: string): AgencyProgram {
   const result = parseAgency(source, {}, false);
@@ -38,8 +42,6 @@ function writeFixture(
     fs.writeFileSync(absPath, source, "utf-8");
     programs[absPath] = parse(source);
   }
-  // Find the first file as entry; tests can override by passing the
-  // entry explicitly to `buildInitDepGraph`.
   const entry = path.join(dir, Object.keys(files)[0]);
   const symbolTable = SymbolTable.build(entry, {});
   return {
@@ -50,15 +52,19 @@ function writeFixture(
   };
 }
 
-describe("buildInitDepGraph", () => {
-  it("returns an empty graph for an empty module", () => {
+describe("buildInitDepGraphs", () => {
+  it("returns empty graphs for a module with no top-level decls", () => {
     const { dir, programs, symbolTable, abs } = writeFixture({
       "entry.agency": `node main() { return 1 }\n`,
     });
     try {
-      const g = buildInitDepGraph(programs, symbolTable, abs("entry.agency"));
-      expect(Object.keys(g.nodes)).toEqual([]);
-      expect(Object.keys(g.edges)).toEqual([]);
+      const { staticGraph, globalGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      expect(Object.keys(staticGraph.nodes)).toEqual([]);
+      expect(Object.keys(globalGraph.nodes)).toEqual([]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -72,14 +78,18 @@ describe("buildInitDepGraph", () => {
         `node main() { return b }\n`,
     });
     try {
-      const g = buildInitDepGraph(programs, symbolTable, abs("entry.agency"));
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
       const keyA = makeKey(abs("entry.agency"), "a");
       const keyB = makeKey(abs("entry.agency"), "b");
-      expect(g.nodes[keyA]).toBeDefined();
-      expect(g.nodes[keyB]).toBeDefined();
-      expect(g.nodes[keyA]?.kind).toBe("static");
-      expect(g.edges[keyB]).toEqual([keyA]);
-      expect(g.edges[keyA]).toEqual([]);
+      expect(staticGraph.nodes[keyA]).toBeDefined();
+      expect(staticGraph.nodes[keyB]).toBeDefined();
+      expect(staticGraph.nodes[keyA]?.kind).toBe("static");
+      expect(staticGraph.edges[keyB]).toEqual([keyA]);
+      expect(staticGraph.edges[keyA]).toEqual([]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -94,13 +104,17 @@ describe("buildInitDepGraph", () => {
       "bar.agency": `export static const barStatic = "hello"\n`,
     });
     try {
-      const g = buildInitDepGraph(programs, symbolTable, abs("foo.agency"));
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("foo.agency"),
+      );
       const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
       const keyBar = makeKey(abs("bar.agency"), "barStatic");
-      expect(g.nodes[keyFoo]).toBeDefined();
-      expect(g.nodes[keyBar]).toBeDefined();
-      expect(g.edges[keyFoo]).toEqual([keyBar]);
-      expect(g.edges[keyBar]).toEqual([]);
+      expect(staticGraph.nodes[keyFoo]).toBeDefined();
+      expect(staticGraph.nodes[keyBar]).toBeDefined();
+      expect(staticGraph.edges[keyFoo]).toEqual([keyBar]);
+      expect(staticGraph.edges[keyBar]).toEqual([]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -116,12 +130,17 @@ describe("buildInitDepGraph", () => {
       "bar.agency": `export static const barStatic = "hello"\n`,
     });
     try {
-      const g = buildInitDepGraph(programs, symbolTable, abs("foo.agency"));
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("foo.agency"),
+      );
       const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
       const keyBar = makeKey(abs("bar.agency"), "barStatic");
-      // No node should exist for the re-exporter — canonical is bar's.
-      expect(g.nodes[makeKey(abs("reexport.agency"), "barStatic")]).toBeUndefined();
-      expect(g.edges[keyFoo]).toEqual([keyBar]);
+      expect(
+        staticGraph.nodes[makeKey(abs("reexport.agency"), "barStatic")],
+      ).toBeUndefined();
+      expect(staticGraph.edges[keyFoo]).toEqual([keyBar]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -143,16 +162,19 @@ describe("buildInitDepGraph", () => {
       "shared.agency": `export static const sharedStatic = "S"\n`,
     });
     try {
-      const g = buildInitDepGraph(programs, symbolTable, abs("entry.agency"));
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
       const keyShared = makeKey(abs("shared.agency"), "sharedStatic");
       const keyA = makeKey(abs("left.agency"), "aStatic");
       const keyB = makeKey(abs("right.agency"), "bStatic");
-      expect(g.nodes[keyShared]).toBeDefined();
-      expect(g.edges[keyA]).toEqual([keyShared]);
-      expect(g.edges[keyB]).toEqual([keyShared]);
-      // Only one shared node, even though imported from two places.
-      const sharedNodes = Object.keys(g.nodes).filter(
-        (k) => k.endsWith("::sharedStatic"),
+      expect(staticGraph.nodes[keyShared]).toBeDefined();
+      expect(staticGraph.edges[keyA]).toEqual([keyShared]);
+      expect(staticGraph.edges[keyB]).toEqual([keyShared]);
+      const sharedNodes = Object.keys(staticGraph.nodes).filter((k) =>
+        k.endsWith("::sharedStatic"),
       );
       expect(sharedNodes).toEqual([keyShared]);
     } finally {
@@ -170,11 +192,15 @@ describe("buildInitDepGraph", () => {
         `export static const barStatic = fooStatic + "?"\n`,
     });
     try {
-      const g = buildInitDepGraph(programs, symbolTable, abs("foo.agency"));
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("foo.agency"),
+      );
       const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
       const keyBar = makeKey(abs("bar.agency"), "barStatic");
-      expect(g.edges[keyFoo]).toEqual([keyBar]);
-      expect(g.edges[keyBar]).toEqual([keyFoo]);
+      expect(staticGraph.edges[keyFoo]).toEqual([keyBar]);
+      expect(staticGraph.edges[keyBar]).toEqual([keyFoo]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -191,15 +217,207 @@ describe("buildInitDepGraph", () => {
         `export def getBarStatic(): string { return barStatic }\n`,
     });
     try {
-      const g = buildInitDepGraph(programs, symbolTable, abs("foo.agency"));
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("foo.agency"),
+      );
       const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
-      // fooStatic references getBarStatic (a def) and indirectly barStatic
-      // (through it). The dep graph should NOT add an edge for either —
-      // defs aren't init nodes, and call-graph analysis is out of scope.
-      expect(g.edges[keyFoo]).toEqual([]);
-      // But file-import edges should still capture foo → bar so the
-      // topsort can use them as a tiebreaker.
-      expect(g.fileImports[abs("foo.agency")]).toContain(abs("bar.agency"));
+      const keyBar = makeKey(abs("bar.agency"), "barStatic");
+      expect(staticGraph.edges[keyFoo]).toEqual([]);
+      // sequenceHint reflects the file-import-depth tiebreaker so
+      // example-2 still initializes bar before foo.
+      expect(staticGraph.nodes[keyBar]!.sequenceHint).toBeLessThan(
+        staticGraph.nodes[keyFoo]!.sequenceHint,
+      );
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // ── New phase-coupling and node-classification tests ──
+
+  it("puts statics and globals into separate graphs", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `static const s = "static"\n` +
+        `const g = "global"\n` +
+        `node main() { return s }\n`,
+    });
+    try {
+      const { staticGraph, globalGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      const sKey = makeKey(abs("entry.agency"), "s");
+      const gKey = makeKey(abs("entry.agency"), "g");
+      expect(staticGraph.nodes[sKey]?.kind).toBe("static");
+      expect(staticGraph.nodes[gKey]).toBeUndefined();
+      expect(globalGraph.nodes[gKey]?.kind).toBe("global");
+      expect(globalGraph.nodes[sKey]).toBeUndefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows a static and global with the same name across phases", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `static const x = "S"\n` +
+        // Different module so the static and global "x" share a name
+        // without clobbering each other in their own graphs.
+        ``,
+      // separate file to host a same-named global
+      "other.agency": `const x = "G"\n`,
+    });
+    try {
+      const { staticGraph, globalGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      expect(staticGraph.nodes[makeKey(abs("entry.agency"), "x")]).toBeDefined();
+      expect(globalGraph.nodes[makeKey(abs("other.agency"), "x")]).toBeDefined();
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a static initializer that references a global", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `const g = "hello"\n` +
+        `static const s = g + "!"\n` +
+        `node main() { return s }\n`,
+    });
+    try {
+      expect(() =>
+        buildInitDepGraphs(programs, symbolTable, abs("entry.agency")),
+      ).toThrow(StaticReferencesGlobalError);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows a global initializer to reference a static (cross-phase OK)", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `static const s = "hello"\n` +
+        `const g = s + "!"\n` +
+        `node main() { return g }\n`,
+    });
+    try {
+      const { staticGraph, globalGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      const sKey = makeKey(abs("entry.agency"), "s");
+      const gKey = makeKey(abs("entry.agency"), "g");
+      expect(staticGraph.nodes[sKey]).toBeDefined();
+      expect(globalGraph.nodes[gKey]).toBeDefined();
+      // Cross-phase reference produces NO edge in either graph.
+      expect(globalGraph.edges[gKey]).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("represents bare top-level function calls as global-graph nodes", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `def hello(): string { return "hi" }\n` +
+        `hello()\n` +
+        `const g = "after"\n` +
+        `hello()\n` +
+        `node main() { return g }\n`,
+    });
+    try {
+      const { staticGraph, globalGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      const bareNodes = Object.values(globalGraph.nodes).filter((n) =>
+        n.varName.startsWith("__bareStmt_"),
+      );
+      expect(bareNodes.length).toBe(2);
+      // No statics get bare statements (PR 3 work).
+      expect(
+        Object.values(staticGraph.nodes).some((n) =>
+          n.varName.startsWith("__bareStmt_"),
+        ),
+      ).toBe(false);
+      // Source order: first bare call < global g < second bare call by
+      // sequenceHint (within the same module: hint = depth*1e6 + line).
+      const sorted = [...bareNodes].sort(
+        (a, b) => a.sequenceHint - b.sequenceHint,
+      );
+      const gNode = globalGraph.nodes[makeKey(abs("entry.agency"), "g")]!;
+      expect(sorted[0]!.sequenceHint).toBeLessThan(gNode.sequenceHint);
+      expect(sorted[1]!.sequenceHint).toBeGreaterThan(gNode.sequenceHint);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not crash when an initializer references a name outside the closure", () => {
+    // `unknownName` doesn't bind anywhere in the closure. Dep graph
+    // should produce no edge and not throw — the typechecker reports
+    // the undefined-name error separately.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `static const s = unknownName + "!"\n` +
+        `node main() { return s }\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      const sKey = makeKey(abs("entry.agency"), "s");
+      expect(staticGraph.nodes[sKey]).toBeDefined();
+      expect(staticGraph.edges[sKey]).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("collects free-var refs from string interpolation, spreads, new, splats", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `static const a = "A"\n` +
+        `static const b = "B"\n` +
+        `static const c = "C"\n` +
+        `static const d = "D"\n` +
+        `static const e = "E"\n` +
+        // String interpolation reference.
+        `static const interp = "x${"${a}"}"\n` +
+        // Array spread.
+        `static const arrSpread = [...[b]]\n` +
+        // Object spread.
+        `static const objSpread = {...{ k: c }}\n` +
+        // Splat call arg into a stdlib-like fn — the function name
+        // itself doesn't create a value edge, but the splat target does.
+        `def take(...xs: string[]): string { return "" }\n` +
+        `static const splat = take(...[d])\n` +
+        // Plain reference for baseline.
+        `static const plain = e + "!"\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      const k = (n: string) => makeKey(abs("entry.agency"), n);
+      expect(staticGraph.edges[k("interp")]).toEqual([k("a")]);
+      expect(staticGraph.edges[k("arrSpread")]).toEqual([k("b")]);
+      expect(staticGraph.edges[k("objSpread")]).toEqual([k("c")]);
+      expect(staticGraph.edges[k("splat")]).toEqual([k("d")]);
+      expect(staticGraph.edges[k("plain")]).toEqual([k("e")]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/agency-lang/lib/compiler/initDepGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.test.ts
@@ -401,6 +401,55 @@ describe("buildInitDepGraphs", () => {
     }
   });
 
+  it("adds a cross-module edge for a namespace-imported static (bar.x)", () => {
+    // Regression: `import * as bar from "./bar.agency"` was invisible
+    // to the init dep graph — `bar.barStatic` did not produce an
+    // edge, so foo's static initializer could run before bar's
+    // __initializeStatic. The fix resolves `(bar, "barStatic")` via
+    // the namespace alias resolver and registers the same cross-
+    // module edge a named import would have produced.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "foo.agency":
+        `import * as bar from "./bar.agency"\n` +
+        `static const fooStatic = bar.barStatic + "!"\n` +
+        `node main() { return fooStatic }\n`,
+      "bar.agency": `export static const barStatic = "hello"\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("foo.agency"),
+      );
+      const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
+      const keyBar = makeKey(abs("bar.agency"), "barStatic");
+      expect(staticGraph.edges[keyFoo]).toEqual([keyBar]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects a namespace-imported global referenced from a static initializer", () => {
+    // Same cross-phase rule as for named imports: a `static const`
+    // initializer cannot read a `global` const, even through a
+    // namespace alias. Without surfacing namespace refs, this would
+    // silently compile and trip the runtime read-before-init trap at
+    // first call instead of failing at compile time.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "foo.agency":
+        `import * as bar from "./bar.agency"\n` +
+        `static const fooStatic = bar.barGlobal + "!"\n`,
+      "bar.agency": `export const barGlobal = "G"\n`,
+    });
+    try {
+      expect(() =>
+        buildInitDepGraphs(programs, symbolTable, abs("foo.agency")),
+      ).toThrow(StaticReferencesGlobalError);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("collects free-var refs from string interpolation, spreads, new, splats", () => {
     const { dir, programs, symbolTable, abs } = writeFixture({
       "entry.agency":

--- a/packages/agency-lang/lib/compiler/initDepGraph.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.ts
@@ -1,0 +1,410 @@
+/**
+ * Per-variable initialization dependency graph.
+ *
+ * Walks every top-level `static const` and (non-static) `const` / `let` /
+ * bare assignment in the entry module's full import closure. For each
+ * declaration it creates a node keyed by `${moduleId}::${varName}` and
+ * adds an edge from that node to every other init-var node referenced
+ * by its initializer expression.
+ *
+ * Cross-module references are resolved via the import statements in the
+ * referencing module: a local name `x` brought in by
+ * `import { x } from "./bar.agency"` resolves to bar's `x` node.
+ * Re-exports (`export { x } from "y"`) are followed transitively until
+ * the ultimate source module — the canonical init node for a re-exported
+ * binding lives in its source module, never in the re-exporter.
+ *
+ * Function references (`def foo`, `node foo`) are intentionally NOT
+ * treated as edges: the dep graph orders *values*, not callable code.
+ * The runtime read-before-init trap (PR 1) catches the residual case
+ * where an initializer indirectly reads an unset static through a
+ * function call.
+ *
+ * Task 2 (`topSortInitGraph.ts`) consumes this graph; Task 3 hooks the
+ * combined builder + sort into the compile flow.
+ */
+
+import * as path from "path";
+import type { AgencyProgram, AgencyNode, Expression } from "../types.js";
+import type { Assignment } from "../types.js";
+import type { SourceLocation } from "../types/base.js";
+import type { SymbolTable } from "../symbolTable.js";
+import {
+  isAgencyImport,
+  resolveAgencyImportPath,
+} from "../importPaths.js";
+
+export type InitVarKind = "static" | "global";
+
+/**
+ * One node in the init dep graph — corresponds to a single top-level
+ * `static const`, `const`, `let`, or unscoped assignment in some module.
+ *
+ * `moduleId` is the absolute path of the source file the var was declared
+ * in (NOT the file that imports it). For re-exports, the canonical node
+ * lives in the originating source module — re-exporters do not get their
+ * own node.
+ */
+export type InitVarNode = {
+  moduleId: string;
+  varName: string;
+  kind: InitVarKind;
+  initExpr: Expression;
+  loc?: SourceLocation;
+  exported: boolean;
+};
+
+/** Composite key for indexing init-var nodes: `${moduleId}::${varName}`. */
+export type InitVarKey = string;
+
+export function makeKey(moduleId: string, varName: string): InitVarKey {
+  return `${moduleId}::${varName}`;
+}
+
+/**
+ * Edges go from a node to every node its initializer references. The
+ * topsort uses these to compute initialization order; cycles produce a
+ * `CycleError` from Task 2.
+ *
+ * `fileImports` is the module-level import DAG (each module → list of
+ * agency modules it imports directly). Used by the topsort as a
+ * deterministic tiebreaker for nodes the var-edge graph leaves unordered
+ * (motivating case: `fooStatic = getBarStatic() + "!"` — no direct var
+ * edge, but bar must init before foo because foo imports bar).
+ */
+export type InitDepGraph = {
+  nodes: Record<InitVarKey, InitVarNode>;
+  edges: Record<InitVarKey, InitVarKey[]>;
+  fileImports: Record<string, string[]>;
+};
+
+/**
+ * Build a per-variable init dep graph from the closure of `entryModuleId`.
+ *
+ * `programs` maps absolute module paths to their parsed AST. The caller
+ * is responsible for parsing every reachable file before calling this —
+ * we don't re-parse to keep the function pure and testable.
+ *
+ * `symbolTable` is consulted to resolve `export { x } from "y"`
+ * re-exports transitively. If omitted, re-exports aren't followed
+ * (re-exporter shows up as an unrecognized local name and is silently
+ * skipped) — this is fine for tests that don't involve re-exports.
+ */
+export function buildInitDepGraph(
+  programs: Record<string, AgencyProgram>,
+  symbolTable: SymbolTable | undefined,
+  entryModuleId: string,
+): InitDepGraph {
+  const reachable = walkClosure(entryModuleId, programs);
+
+  // 1. Collect every top-level init-var node from every reachable module.
+  //    `static` here is recognized via the parser-set `node.static` flag —
+  //    NOT `node.scope === "static"`, which is only assigned later by the
+  //    typescriptPreprocessor (which runs per-module during codegen).
+  const nodes: Record<InitVarKey, InitVarNode> = {};
+  for (const moduleId of reachable) {
+    const program = programs[moduleId];
+    if (!program) continue;
+    for (const node of program.nodes) {
+      const v = unwrapTopLevelInitVar(node);
+      if (!v) continue;
+      nodes[makeKey(moduleId, v.variableName)] = {
+        moduleId,
+        varName: v.variableName,
+        kind: v.static ? "static" : "global",
+        initExpr: v.value as Expression,
+        loc: v.loc,
+        exported: !!v.exported,
+      };
+    }
+  }
+
+  // 2. Build a per-module import-alias map so we can resolve a referenced
+  //    local name back to its (sourceModuleId, sourceVarName). The
+  //    alias map follows `import { x as y }` and chases re-export chains
+  //    to the ultimate source.
+  const aliasMaps: Record<string, Record<string, { sourceModuleId: string; sourceName: string }>> = {};
+  const fileImports: Record<string, string[]> = {};
+  for (const moduleId of reachable) {
+    const program = programs[moduleId];
+    if (!program) {
+      aliasMaps[moduleId] = {};
+      fileImports[moduleId] = [];
+      continue;
+    }
+    aliasMaps[moduleId] = buildAliasMap(program, moduleId, symbolTable);
+    fileImports[moduleId] = collectFileImports(program, moduleId);
+  }
+
+  // 3. For each init-var node, walk its initializer and add an edge to
+  //    every referenced init-var node we recognize.
+  const edges: Record<InitVarKey, InitVarKey[]> = {};
+  for (const [key, node] of Object.entries(nodes)) {
+    const aliasMap = aliasMaps[node.moduleId] ?? {};
+    const refs = collectFreeIdentifiers(node.initExpr);
+    const depKeys: string[] = [];
+    const seen: Record<string, true> = {};
+    for (const refName of refs) {
+      // Skip self-references (a static can't depend on itself).
+      if (refName === node.varName) continue;
+
+      // Same-module reference? Check our own nodes table first.
+      const localKey = makeKey(node.moduleId, refName);
+      if (nodes[localKey] && !seen[localKey]) {
+        seen[localKey] = true;
+        depKeys.push(localKey);
+        continue;
+      }
+
+      // Cross-module reference via an import alias.
+      const aliased = aliasMap[refName];
+      if (aliased) {
+        const remoteKey = makeKey(aliased.sourceModuleId, aliased.sourceName);
+        if (nodes[remoteKey] && !seen[remoteKey]) {
+          seen[remoteKey] = true;
+          depKeys.push(remoteKey);
+        }
+      }
+    }
+    edges[key] = depKeys;
+  }
+
+  return { nodes, edges, fileImports };
+}
+
+/**
+ * Walk the import closure from `entryModuleId`, returning every reachable
+ * module path. Follows both `import` and `export ... from` statements.
+ * Non-agency imports (stdlib, pkg::, .js, .ts) are skipped.
+ */
+function walkClosure(
+  entryModuleId: string,
+  programs: Record<string, AgencyProgram>,
+): string[] {
+  const out: string[] = [];
+  const visited: Record<string, true> = {};
+  const queue: string[] = [entryModuleId];
+  while (queue.length > 0) {
+    const moduleId = queue.shift()!;
+    if (visited[moduleId]) continue;
+    visited[moduleId] = true;
+    out.push(moduleId);
+    const program = programs[moduleId];
+    if (!program) continue;
+    for (const node of program.nodes) {
+      const imported = getAgencyImportTarget(node);
+      if (!imported) continue;
+      const absPath = resolveAgencyImportPath(imported, moduleId);
+      if (!visited[absPath]) queue.push(absPath);
+    }
+  }
+  return out;
+}
+
+function getAgencyImportTarget(node: AgencyNode): string | null {
+  if (node.type === "importStatement" && isAgencyImport(node.modulePath)) {
+    return node.modulePath;
+  }
+  if (node.type === "importNodeStatement") {
+    return node.agencyFile;
+  }
+  if (node.type === "exportFromStatement" && isAgencyImport(node.modulePath)) {
+    return node.modulePath;
+  }
+  return null;
+}
+
+/**
+ * For every named import in `program`, build a map from the local name
+ * (the name used in this module) to the ultimate source (moduleId,
+ * originalName), chasing `export { x } from "y"` chains via the
+ * SymbolTable's `reExportedFrom` metadata.
+ */
+function buildAliasMap(
+  program: AgencyProgram,
+  moduleId: string,
+  symbolTable: SymbolTable | undefined,
+): Record<string, { sourceModuleId: string; sourceName: string }> {
+  const out: Record<string, { sourceModuleId: string; sourceName: string }> = {};
+  for (const node of program.nodes) {
+    if (node.type !== "importStatement") continue;
+    if (!isAgencyImport(node.modulePath)) continue;
+    const importedFrom = resolveAgencyImportPath(node.modulePath, moduleId);
+    for (const named of node.importedNames) {
+      if (named.type !== "namedImport") continue;
+      for (const originalName of named.importedNames) {
+        const localName = named.aliases[originalName] ?? originalName;
+        const resolved = resolveThroughReExports(
+          importedFrom,
+          originalName,
+          symbolTable,
+        );
+        out[localName] = resolved;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Walk re-export chains until we hit a symbol that lives in the file
+ * that defines it. Returns `(definingModuleId, originalNameThere)`.
+ *
+ * Falls back to `(importedFrom, originalName)` if the chain can't be
+ * walked (no symbol table, missing symbol, etc.).
+ */
+function resolveThroughReExports(
+  startFile: string,
+  startName: string,
+  symbolTable: SymbolTable | undefined,
+): { sourceModuleId: string; sourceName: string } {
+  if (!symbolTable) {
+    return { sourceModuleId: startFile, sourceName: startName };
+  }
+  let curFile = startFile;
+  let curName = startName;
+  // Cap iterations defensively; the SymbolTable already rejects re-export
+  // cycles when it builds, so this should never spin in practice.
+  for (let i = 0; i < 64; i++) {
+    const sym = symbolTable.getFile(curFile)?.[curName];
+    if (!sym || !sym.reExportedFrom) {
+      return { sourceModuleId: curFile, sourceName: curName };
+    }
+    curFile = sym.reExportedFrom.sourceFile;
+    curName = sym.reExportedFrom.originalName;
+  }
+  return { sourceModuleId: curFile, sourceName: curName };
+}
+
+function collectFileImports(
+  program: AgencyProgram,
+  moduleId: string,
+): string[] {
+  const out: string[] = [];
+  const seen: Record<string, true> = {};
+  for (const node of program.nodes) {
+    const target = getAgencyImportTarget(node);
+    if (!target) continue;
+    const abs = resolveAgencyImportPath(target, moduleId);
+    if (!seen[abs]) {
+      seen[abs] = true;
+      out.push(abs);
+    }
+  }
+  return out;
+}
+
+/**
+ * Unwrap a top-level node into an Assignment if it represents a value-init
+ * declaration the dep graph should track. Skips non-assignments and
+ * assignments that are statements inside blocks (those aren't top-level).
+ *
+ * Bare top-level statements (function calls etc) are NOT tracked here —
+ * they're sequenced by source order within their module and don't have
+ * a name to depend on. Task 3 attaches them to the init plan separately.
+ */
+function unwrapTopLevelInitVar(node: AgencyNode): Assignment | null {
+  // Top-level assignments come out of the parser without a `scope` field
+  // set (scope is assigned by a later preprocessor pass). All of them
+  // are candidates for the init graph: `static`-prefixed ones become
+  // Phase A; the rest become Phase B globals.
+  if (node.type === "assignment") return node;
+  if (node.type === "withModifier" && node.statement.type === "assignment") {
+    return node.statement;
+  }
+  return null;
+}
+
+/**
+ * Walk an expression and collect every free identifier reference
+ * (variable-name literals). Does NOT descend into nested function /
+ * lambda bodies — those bind their own scope and won't trigger init
+ * ordering for the outer initializer.
+ */
+function collectFreeIdentifiers(expr: Expression | AgencyNode): string[] {
+  const out: string[] = [];
+  const visit = (n: any): void => {
+    if (!n || typeof n !== "object") return;
+    if (Array.isArray(n)) {
+      for (const c of n) visit(c);
+      return;
+    }
+    switch (n.type) {
+      case "variableName":
+        out.push(n.value);
+        return;
+      case "function":
+      case "graphNode":
+        // Lambdas / nested defs: their body is closed over but doesn't
+        // execute during outer initializer evaluation. Skip.
+        return;
+      case "valueAccess":
+        visit(n.base);
+        for (const el of n.chain) {
+          if (el.kind === "index") visit(el.index);
+          else if (el.kind === "slice") {
+            if (el.start) visit(el.start);
+            if (el.end) visit(el.end);
+          } else if (el.kind === "methodCall") visit(el.functionCall);
+        }
+        return;
+      case "functionCall":
+        // Function name itself MAY be a top-level def; but as noted in
+        // the file header we don't add edges for callable references —
+        // only value references. Skip the name; recurse into args.
+        for (const arg of n.arguments) {
+          if (arg.type === "splat") visit(arg.value);
+          else if (arg.type === "namedArgument") visit(arg.value);
+          else visit(arg);
+        }
+        return;
+      case "binOpExpression":
+        visit(n.left);
+        visit(n.right);
+        return;
+      case "agencyArray":
+        for (const item of n.items) {
+          if (item?.type === "splat") visit(item.value);
+          else visit(item);
+        }
+        return;
+      case "agencyObject":
+        for (const e of n.entries) {
+          if (e?.type === "splat") visit(e.value);
+          else {
+            if (e.computedKey) visit(e.computedKey);
+            visit(e.value);
+          }
+        }
+        return;
+      case "string":
+      case "multiLineString":
+        for (const seg of n.segments) {
+          if (seg.type === "interpolation") visit(seg.expression);
+        }
+        return;
+      case "newExpression":
+        for (const arg of n.arguments) {
+          if (arg.type === "splat") visit(arg.value);
+          else if (arg.type === "namedArgument") visit(arg.value);
+          else visit(arg);
+        }
+        return;
+      case "tryExpression":
+        visit(n.expression);
+        return;
+      case "isExpression":
+        visit(n.value);
+        return;
+    }
+    // Generic fallback: walk every own property to catch any expression
+    // shape we didn't enumerate above. Safe because the early returns
+    // above handled name-binding cases (function, graphNode).
+    for (const key of Object.keys(n)) {
+      if (key === "type" || key === "loc") continue;
+      visit(n[key]);
+    }
+  };
+  visit(expr);
+  return out;
+}

--- a/packages/agency-lang/lib/compiler/initDepGraph.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.ts
@@ -165,12 +165,18 @@ export function makeImportAliasResolver(
     for (const node of program.nodes) {
       if (node.type !== "importStatement") continue;
       if (!isAgencyImport(node.modulePath)) continue;
+      // Resolve ONE hop only. We intentionally don't follow re-export
+      // chains all the way to the ultimate source here — each
+      // intermediate re-exporter has a synthesized wrapper static
+      // (`static const x = _reexport_x`) emitted by `resolveReExports`
+      // that needs to be initialized at runtime, and one-hop edges let
+      // the dep graph cascade through every wrapper automatically:
+      // foo → reexport_a → reexport_b → bar.
       for (const resolved of symbolTable.resolveImport(node, moduleId)) {
-        map[resolved.localName] = followReExportChain(
-          resolved.file,
-          resolved.originalName,
-          symbolTable,
-        );
+        map[resolved.localName] = {
+          sourceModuleId: resolved.file,
+          sourceName: resolved.originalName,
+        };
       }
     }
     return map;
@@ -183,30 +189,6 @@ export function makeImportAliasResolver(
       return moduleCache[localName] ?? null;
     },
   };
-}
-
-/**
- * Walk `reExportedFrom` chains until we hit a symbol that lives in the
- * file that defines it. Returns `(definingModuleId, originalNameThere)`.
- * Falls back to `(startFile, startName)` if the chain can't be walked.
- */
-function followReExportChain(
-  startFile: string,
-  startName: string,
-  symbolTable: SymbolTable,
-): { sourceModuleId: string; sourceName: string } {
-  let curFile = startFile;
-  let curName = startName;
-  // Defensive cap; SymbolTable rejects re-export cycles when it builds.
-  for (let i = 0; i < 64; i++) {
-    const sym = symbolTable.getFile(curFile)?.[curName];
-    if (!sym || !sym.reExportedFrom) {
-      return { sourceModuleId: curFile, sourceName: curName };
-    }
-    curFile = sym.reExportedFrom.sourceFile;
-    curName = sym.reExportedFrom.originalName;
-  }
-  return { sourceModuleId: curFile, sourceName: curName };
 }
 
 /**
@@ -451,8 +433,13 @@ function rejectStaticReferencesGlobal(
  * inside nested name-binding constructs (`function`, `graphNode`) by
  * checking the ancestor stack — those bodies don't execute during the
  * outer initializer evaluation.
+ *
+ * Exported so callers outside this module (e.g. `compileClosure`) can
+ * reuse the same free-identifier discipline when computing additional
+ * cross-phase await dependencies that aren't representable as edges in
+ * either single-phase graph.
  */
-function collectFreeIdentifiers(expr: Expression | AgencyNode): string[] {
+export function collectFreeIdentifiers(expr: Expression | AgencyNode): string[] {
   const out: string[] = [];
   for (const { node, ancestors } of walkNodes([expr as AgencyNode])) {
     if (node.type !== "variableName") continue;

--- a/packages/agency-lang/lib/compiler/initDepGraph.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.ts
@@ -133,6 +133,11 @@ export class StaticReferencesGlobalError extends Error {
  * module) to the `(moduleId, name)` pair that defines the value, walking
  * `export { x } from "y"` chains to the ultimate source.
  *
+ * `resolveNamespace` covers the `import * as bar from "./bar.agency"`
+ * shape: given the local prefix `bar`, returns the source module so
+ * `bar.barStatic` can be resolved as `(bar.agency, barStatic)`. Returns
+ * null when no namespace import bound that prefix in this module.
+ *
  * Built once per `compileClosure` call; cached internally so a name
  * lookup is O(1) after first use per module.
  */
@@ -141,6 +146,10 @@ export type ImportAliasResolver = {
     localName: string,
     inModuleId: string,
   ): { sourceModuleId: string; sourceName: string } | null;
+  resolveNamespace(
+    prefix: string,
+    inModuleId: string,
+  ): { sourceModuleId: string } | null;
 };
 
 export function makeImportAliasResolver(
@@ -151,6 +160,7 @@ export function makeImportAliasResolver(
     string,
     Record<string, { sourceModuleId: string; sourceName: string }>
   > = {};
+  const nsCache: Record<string, Record<string, { sourceModuleId: string }>> = {};
 
   function buildFor(moduleId: string): Record<
     string,
@@ -182,11 +192,36 @@ export function makeImportAliasResolver(
     return map;
   }
 
+  function buildNamespaceFor(
+    moduleId: string,
+  ): Record<string, { sourceModuleId: string }> {
+    const map: Record<string, { sourceModuleId: string }> = {};
+    const program = programs[moduleId];
+    if (!program) return map;
+    for (const node of program.nodes) {
+      if (node.type !== "importStatement") continue;
+      if (!isAgencyImport(node.modulePath)) continue;
+      for (const nameType of node.importedNames) {
+        if (nameType.type !== "namespaceImport") continue;
+        map[nameType.importedNames] = {
+          sourceModuleId: resolveAgencyImportPath(node.modulePath, moduleId),
+        };
+      }
+    }
+    return map;
+  }
+
   return {
     resolve(localName, inModuleId) {
       const moduleCache =
         cache[inModuleId] ?? (cache[inModuleId] = buildFor(inModuleId));
       return moduleCache[localName] ?? null;
+    },
+    resolveNamespace(prefix, inModuleId) {
+      const moduleCache =
+        nsCache[inModuleId] ??
+        (nsCache[inModuleId] = buildNamespaceFor(inModuleId));
+      return moduleCache[prefix] ?? null;
     },
   };
 }
@@ -377,9 +412,9 @@ function depsFor(
 ): InitVarKey[] {
   const seen: Record<InitVarKey, true> = {};
   const out: InitVarKey[] = [];
-  for (const refName of collectFreeIdentifiers(node.initExpr)) {
-    if (refName === node.varName) continue;
-    const refKey = resolveRefKey(refName, node.moduleId, resolver);
+  for (const ref of collectFreeIdentifiers(node.initExpr)) {
+    if (ref.kind === "name" && ref.name === node.varName) continue;
+    const refKey = resolveFreeRef(ref, node.moduleId, resolver);
     if (!refKey) continue;
     if (skipSet?.[refKey]) continue;
     if (!lookupSet[refKey] || seen[refKey]) continue;
@@ -390,21 +425,29 @@ function depsFor(
 }
 
 /**
- * Resolve a free identifier (used inside `inModuleId`'s code) to a
- * canonical `${moduleId}::${name}` key. Same-module references resolve
- * directly; cross-module references go through the alias resolver.
- * Returns `null` for names not bound by either path.
+ * Resolve a free reference (simple name or namespace member) used
+ * inside `inModuleId`'s code to a canonical `${moduleId}::${name}`
+ * key. Same-module references resolve directly; cross-module
+ * references go through the alias resolver; `bar.barStatic`-style
+ * accesses go through the namespace resolver. Returns `null` for
+ * names not bound by any of those paths.
  */
-function resolveRefKey(
-  refName: string,
+function resolveFreeRef(
+  ref: FreeRef,
   inModuleId: string,
   resolver: ImportAliasResolver,
 ): InitVarKey | null {
-  const aliased = resolver.resolve(refName, inModuleId);
-  if (aliased) {
-    return makeKey(aliased.sourceModuleId, aliased.sourceName);
+  if (ref.kind === "name") {
+    const aliased = resolver.resolve(ref.name, inModuleId);
+    if (aliased) return makeKey(aliased.sourceModuleId, aliased.sourceName);
+    return makeKey(inModuleId, ref.name);
   }
-  return makeKey(inModuleId, refName);
+  // member access: `prefix.member`. Only register an edge if the
+  // prefix matches a namespace import — otherwise it could be a
+  // local variable / object access we have no business sequencing.
+  const ns = resolver.resolveNamespace(ref.prefix, inModuleId);
+  if (!ns) return null;
+  return makeKey(ns.sourceModuleId, ref.member);
 }
 
 // ── Phase-coupling validation ──
@@ -415,9 +458,9 @@ function rejectStaticReferencesGlobal(
   resolver: ImportAliasResolver,
 ): void {
   for (const node of Object.values(staticNodes)) {
-    for (const refName of collectFreeIdentifiers(node.initExpr)) {
-      if (refName === node.varName) continue;
-      const refKey = resolveRefKey(refName, node.moduleId, resolver);
+    for (const ref of collectFreeIdentifiers(node.initExpr)) {
+      if (ref.kind === "name" && ref.name === node.varName) continue;
+      const refKey = resolveFreeRef(ref, node.moduleId, resolver);
       if (!refKey) continue;
       const offender = globalNodes[refKey];
       if (offender) throw new StaticReferencesGlobalError(node, offender);
@@ -428,21 +471,44 @@ function rejectStaticReferencesGlobal(
 // ── Free-identifier collection ──
 
 /**
- * Collect every free `variableName` reference in `expr`, declaratively,
- * via the shared `walkNodes` walker. Skips identifiers that appear
- * inside nested name-binding constructs (`function`, `graphNode`) by
- * checking the ancestor stack — those bodies don't execute during the
- * outer initializer evaluation.
+ * A single free reference inside an initializer expression:
+ *   - `name`: a bare identifier like `barStatic` (resolved via the
+ *     `resolve` alias map).
+ *   - `member`: a two-part reference of the form `prefix.member`
+ *     where `prefix` is bound by a local declaration. The dep graph
+ *     treats it as an edge target only when `prefix` was bound by a
+ *     namespace import (`import * as bar from "./bar.agency"`), in
+ *     which case it resolves to `(bar.agency, member)` — the same
+ *     edge a named import would have produced. Local-variable
+ *     member accesses (`person.name`) produce no edge.
+ */
+export type FreeRef =
+  | { kind: "name"; name: string }
+  | { kind: "member"; prefix: string; member: string };
+
+/**
+ * Collect every free reference in `expr`, declaratively, via the
+ * shared `walkNodes` walker. Skips identifiers that appear inside
+ * nested name-binding constructs (`function`, `graphNode`) by checking
+ * the ancestor stack — those bodies don't execute during the outer
+ * initializer evaluation.
+ *
+ * Surfaces both bare identifiers (`barStatic`) and `prefix.member`
+ * patterns (`bar.barStatic`) so the dep graph can resolve namespace
+ * imports as cross-module edges. When a variableName is the base of
+ * a `prefix.member`-shape valueAccess we skip its standalone yield;
+ * the member form supersedes it.
  *
  * Exported so callers outside this module (e.g. `compileClosure`) can
- * reuse the same free-identifier discipline when computing additional
+ * reuse the same free-reference discipline when computing additional
  * cross-phase await dependencies that aren't representable as edges in
  * either single-phase graph.
  */
-export function collectFreeIdentifiers(expr: Expression | AgencyNode): string[] {
-  const out: string[] = [];
+export function collectFreeIdentifiers(
+  expr: Expression | AgencyNode,
+): FreeRef[] {
+  const out: FreeRef[] = [];
   for (const { node, ancestors } of walkNodes([expr as AgencyNode])) {
-    if (node.type !== "variableName") continue;
     if (
       ancestors.some(
         (a) => a.type === "function" || a.type === "graphNode",
@@ -450,7 +516,31 @@ export function collectFreeIdentifiers(expr: Expression | AgencyNode): string[] 
     ) {
       continue;
     }
-    out.push(node.value);
+    if (
+      node.type === "valueAccess" &&
+      node.base.type === "variableName" &&
+      node.chain[0]?.kind === "property"
+    ) {
+      out.push({
+        kind: "member",
+        prefix: (node.base as { value: string }).value,
+        member: node.chain[0].name,
+      });
+      continue;
+    }
+    if (node.type !== "variableName") continue;
+    // Skip variableName when it's the base of a `prefix.member`
+    // valueAccess — already emitted above as a `member` ref.
+    const parent = ancestors[ancestors.length - 1];
+    if (
+      parent &&
+      parent.type === "valueAccess" &&
+      (parent as { base: AgencyNode }).base === node &&
+      (parent as { chain: { kind: string }[] }).chain[0]?.kind === "property"
+    ) {
+      continue;
+    }
+    out.push({ kind: "name", name: node.value });
   }
   return out;
 }

--- a/packages/agency-lang/lib/compiler/initDepGraph.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.ts
@@ -1,30 +1,49 @@
 /**
- * Per-variable initialization dependency graph.
+ * Per-variable initialization dependency graphs.
  *
- * Walks every top-level `static const` and (non-static) `const` / `let` /
- * bare assignment in the entry module's full import closure. For each
- * declaration it creates a node keyed by `${moduleId}::${varName}` and
- * adds an edge from that node to every other init-var node referenced
- * by its initializer expression.
+ * Walks every top-level declaration + bare statement in a set of
+ * pre-collected agency programs (the entry's full import closure) and
+ * produces two independent dep graphs:
  *
- * Cross-module references are resolved via the import statements in the
- * referencing module: a local name `x` brought in by
- * `import { x } from "./bar.agency"` resolves to bar's `x` node.
- * Re-exports (`export { x } from "y"`) are followed transitively until
- * the ultimate source module — the canonical init node for a re-exported
- * binding lives in its source module, never in the re-exporter.
+ *   - `staticGraph` — one node per top-level `static const`, edges from
+ *     each node to every other init-var node its initializer references.
+ *     Sorted by `topSortInitGraph` to drive Phase A (once per process).
+ *   - `globalGraph` — one node per non-static `const` / `let` /
+ *     unscoped assignment, plus one node per bare top-level statement
+ *     (function call etc., keyed by a synthetic `__bareStmt_…` name).
+ *     Drives Phase B (every run).
  *
- * Function references (`def foo`, `node foo`) are intentionally NOT
- * treated as edges: the dep graph orders *values*, not callable code.
+ * Edges are derived only from *direct* free-variable references in the
+ * initializer expression. Function references (`def foo`, `node foo`)
+ * are NOT edges — the dep graph orders *values*, not callable code.
  * The runtime read-before-init trap (PR 1) catches the residual case
  * where an initializer indirectly reads an unset static through a
  * function call.
  *
- * Task 2 (`topSortInitGraph.ts`) consumes this graph; Task 3 hooks the
- * combined builder + sort into the compile flow.
+ * Cross-module references are resolved through the shared
+ * {@link ImportAliasResolver}, which walks `export { x } from "y"`
+ * chains to the ultimate source. The same resolver is reused by the
+ * codegen wrap site (Task 4) to thread the source `moduleId` into the
+ * PR-1 trap message — there is exactly one re-export resolver in the
+ * codebase.
+ *
+ * **Closed interface:** consumers see only `nodes + edges` per graph;
+ * file-import depth and source line are baked into each node's
+ * `sequenceHint` at build time so the topsort has one ordering rule.
+ *
+ * **Closure walking is NOT done here.** The caller (Task 3's
+ * `compileClosure`) is responsible for parsing every reachable module
+ * once and passing the full `programs` map in. Keeps this module pure
+ * and testable.
+ *
+ * Phase coupling rules enforced by this builder:
+ *   - A static initializer that references a global → throws
+ *     `StaticReferencesGlobalError` (the global doesn't exist yet at
+ *     Phase A).
+ *   - A global initializer that references a static → allowed,
+ *     no edge (statics are already initialized at Phase B time).
  */
 
-import * as path from "path";
 import type { AgencyProgram, AgencyNode, Expression } from "../types.js";
 import type { Assignment } from "../types.js";
 import type { SourceLocation } from "../types/base.js";
@@ -33,25 +52,38 @@ import {
   isAgencyImport,
   resolveAgencyImportPath,
 } from "../importPaths.js";
+import { walkNodes } from "../utils/node.js";
 
 export type InitVarKind = "static" | "global";
 
 /**
- * One node in the init dep graph — corresponds to a single top-level
- * `static const`, `const`, `let`, or unscoped assignment in some module.
+ * One node in an init dep graph — corresponds to a single top-level
+ * declaration (or, for the global graph only, a single bare top-level
+ * statement).
  *
- * `moduleId` is the absolute path of the source file the var was declared
- * in (NOT the file that imports it). For re-exports, the canonical node
- * lives in the originating source module — re-exporters do not get their
- * own node.
+ * `moduleId` is the absolute path of the source file the var was
+ * declared in (NOT the file that imports it). For re-exports, the
+ * canonical node lives in the originating source module — re-exporters
+ * do not get their own node.
+ *
+ * `sequenceHint` packs `(fileImportDepth, sourceLine)` into one number
+ * so the topsort can break ties deterministically with a single key.
+ * Lower wins (initializes earlier).
  */
 export type InitVarNode = {
   moduleId: string;
   varName: string;
   kind: InitVarKind;
-  initExpr: Expression;
+  /** For bare statements (global graph only) this is the wrapping
+   * statement node; for assignments it's the right-hand side. */
+  initExpr: Expression | AgencyNode;
   loc?: SourceLocation;
   exported: boolean;
+  sequenceHint: number;
+  /** Set when the source wrapped the decl/statement in `with approve`.
+   * `handle { ... }` blocks are NOT legal at module top level, so this
+   * single optional flag covers the full top-level handler surface. */
+  withApprove?: boolean;
 };
 
 /** Composite key for indexing init-var nodes: `${moduleId}::${varName}`. */
@@ -62,209 +94,110 @@ export function makeKey(moduleId: string, varName: string): InitVarKey {
 }
 
 /**
- * Edges go from a node to every node its initializer references. The
- * topsort uses these to compute initialization order; cycles produce a
- * `CycleError` from Task 2.
- *
- * `fileImports` is the module-level import DAG (each module → list of
- * agency modules it imports directly). Used by the topsort as a
- * deterministic tiebreaker for nodes the var-edge graph leaves unordered
- * (motivating case: `fooStatic = getBarStatic() + "!"` — no direct var
- * edge, but bar must init before foo because foo imports bar).
+ * Edges go from a node to every other node its initializer references.
+ * `topSortInitGraph` uses these to compute initialization order; cycles
+ * produce a `CycleError`.
  */
 export type InitDepGraph = {
   nodes: Record<InitVarKey, InitVarNode>;
   edges: Record<InitVarKey, InitVarKey[]>;
-  fileImports: Record<string, string[]>;
+};
+
+export type BuildInitDepGraphsResult = {
+  staticGraph: InitDepGraph;
+  globalGraph: InitDepGraph;
+  /** Reused by codegen (Task 4) for PR-1 thread-through. */
+  resolver: ImportAliasResolver;
 };
 
 /**
- * Build a per-variable init dep graph from the closure of `entryModuleId`.
- *
- * `programs` maps absolute module paths to their parsed AST. The caller
- * is responsible for parsing every reachable file before calling this —
- * we don't re-parse to keep the function pure and testable.
- *
- * `symbolTable` is consulted to resolve `export { x } from "y"`
- * re-exports transitively. If omitted, re-exports aren't followed
- * (re-exporter shows up as an unrecognized local name and is silently
- * skipped) — this is fine for tests that don't involve re-exports.
+ * Compile-time error: a `static` initializer references a `global`. The
+ * global doesn't exist yet at Phase A time, so this is unsatisfiable.
  */
-export function buildInitDepGraph(
-  programs: Record<string, AgencyProgram>,
-  symbolTable: SymbolTable | undefined,
-  entryModuleId: string,
-): InitDepGraph {
-  const reachable = walkClosure(entryModuleId, programs);
-
-  // 1. Collect every top-level init-var node from every reachable module.
-  //    `static` here is recognized via the parser-set `node.static` flag —
-  //    NOT `node.scope === "static"`, which is only assigned later by the
-  //    typescriptPreprocessor (which runs per-module during codegen).
-  const nodes: Record<InitVarKey, InitVarNode> = {};
-  for (const moduleId of reachable) {
-    const program = programs[moduleId];
-    if (!program) continue;
-    for (const node of program.nodes) {
-      const v = unwrapTopLevelInitVar(node);
-      if (!v) continue;
-      nodes[makeKey(moduleId, v.variableName)] = {
-        moduleId,
-        varName: v.variableName,
-        kind: v.static ? "static" : "global",
-        initExpr: v.value as Expression,
-        loc: v.loc,
-        exported: !!v.exported,
-      };
-    }
+export class StaticReferencesGlobalError extends Error {
+  constructor(
+    public readonly staticNode: InitVarNode,
+    public readonly globalNode: InitVarNode,
+  ) {
+    super(
+      `Static '${staticNode.varName}' (${staticNode.moduleId}:${staticNode.loc?.line ?? "?"}) ` +
+        `references global '${globalNode.varName}' (${globalNode.moduleId}:${globalNode.loc?.line ?? "?"}). ` +
+        `Static initializers run before any global init — they cannot read globals.`,
+    );
+    this.name = "StaticReferencesGlobalError";
   }
-
-  // 2. Build a per-module import-alias map so we can resolve a referenced
-  //    local name back to its (sourceModuleId, sourceVarName). The
-  //    alias map follows `import { x as y }` and chases re-export chains
-  //    to the ultimate source.
-  const aliasMaps: Record<string, Record<string, { sourceModuleId: string; sourceName: string }>> = {};
-  const fileImports: Record<string, string[]> = {};
-  for (const moduleId of reachable) {
-    const program = programs[moduleId];
-    if (!program) {
-      aliasMaps[moduleId] = {};
-      fileImports[moduleId] = [];
-      continue;
-    }
-    aliasMaps[moduleId] = buildAliasMap(program, moduleId, symbolTable);
-    fileImports[moduleId] = collectFileImports(program, moduleId);
-  }
-
-  // 3. For each init-var node, walk its initializer and add an edge to
-  //    every referenced init-var node we recognize.
-  const edges: Record<InitVarKey, InitVarKey[]> = {};
-  for (const [key, node] of Object.entries(nodes)) {
-    const aliasMap = aliasMaps[node.moduleId] ?? {};
-    const refs = collectFreeIdentifiers(node.initExpr);
-    const depKeys: string[] = [];
-    const seen: Record<string, true> = {};
-    for (const refName of refs) {
-      // Skip self-references (a static can't depend on itself).
-      if (refName === node.varName) continue;
-
-      // Same-module reference? Check our own nodes table first.
-      const localKey = makeKey(node.moduleId, refName);
-      if (nodes[localKey] && !seen[localKey]) {
-        seen[localKey] = true;
-        depKeys.push(localKey);
-        continue;
-      }
-
-      // Cross-module reference via an import alias.
-      const aliased = aliasMap[refName];
-      if (aliased) {
-        const remoteKey = makeKey(aliased.sourceModuleId, aliased.sourceName);
-        if (nodes[remoteKey] && !seen[remoteKey]) {
-          seen[remoteKey] = true;
-          depKeys.push(remoteKey);
-        }
-      }
-    }
-    edges[key] = depKeys;
-  }
-
-  return { nodes, edges, fileImports };
 }
 
 /**
- * Walk the import closure from `entryModuleId`, returning every reachable
- * module path. Follows both `import` and `export ... from` statements.
- * Non-agency imports (stdlib, pkg::, .js, .ts) are skipped.
+ * Resolves a locally-bound name (used inside an initializer in some
+ * module) to the `(moduleId, name)` pair that defines the value, walking
+ * `export { x } from "y"` chains to the ultimate source.
+ *
+ * Built once per `compileClosure` call; cached internally so a name
+ * lookup is O(1) after first use per module.
  */
-function walkClosure(
-  entryModuleId: string,
+export type ImportAliasResolver = {
+  resolve(
+    localName: string,
+    inModuleId: string,
+  ): { sourceModuleId: string; sourceName: string } | null;
+};
+
+export function makeImportAliasResolver(
   programs: Record<string, AgencyProgram>,
-): string[] {
-  const out: string[] = [];
-  const visited: Record<string, true> = {};
-  const queue: string[] = [entryModuleId];
-  while (queue.length > 0) {
-    const moduleId = queue.shift()!;
-    if (visited[moduleId]) continue;
-    visited[moduleId] = true;
-    out.push(moduleId);
-    const program = programs[moduleId];
-    if (!program) continue;
-    for (const node of program.nodes) {
-      const imported = getAgencyImportTarget(node);
-      if (!imported) continue;
-      const absPath = resolveAgencyImportPath(imported, moduleId);
-      if (!visited[absPath]) queue.push(absPath);
-    }
-  }
-  return out;
-}
-
-function getAgencyImportTarget(node: AgencyNode): string | null {
-  if (node.type === "importStatement" && isAgencyImport(node.modulePath)) {
-    return node.modulePath;
-  }
-  if (node.type === "importNodeStatement") {
-    return node.agencyFile;
-  }
-  if (node.type === "exportFromStatement" && isAgencyImport(node.modulePath)) {
-    return node.modulePath;
-  }
-  return null;
-}
-
-/**
- * For every named import in `program`, build a map from the local name
- * (the name used in this module) to the ultimate source (moduleId,
- * originalName), chasing `export { x } from "y"` chains via the
- * SymbolTable's `reExportedFrom` metadata.
- */
-function buildAliasMap(
-  program: AgencyProgram,
-  moduleId: string,
   symbolTable: SymbolTable | undefined,
-): Record<string, { sourceModuleId: string; sourceName: string }> {
-  const out: Record<string, { sourceModuleId: string; sourceName: string }> = {};
-  for (const node of program.nodes) {
-    if (node.type !== "importStatement") continue;
-    if (!isAgencyImport(node.modulePath)) continue;
-    const importedFrom = resolveAgencyImportPath(node.modulePath, moduleId);
-    for (const named of node.importedNames) {
-      if (named.type !== "namedImport") continue;
-      for (const originalName of named.importedNames) {
-        const localName = named.aliases[originalName] ?? originalName;
-        const resolved = resolveThroughReExports(
-          importedFrom,
-          originalName,
+): ImportAliasResolver {
+  const cache: Record<
+    string,
+    Record<string, { sourceModuleId: string; sourceName: string }>
+  > = {};
+
+  function buildFor(moduleId: string): Record<
+    string,
+    { sourceModuleId: string; sourceName: string }
+  > {
+    const map: Record<
+      string,
+      { sourceModuleId: string; sourceName: string }
+    > = {};
+    const program = programs[moduleId];
+    if (!program || !symbolTable) return map;
+    for (const node of program.nodes) {
+      if (node.type !== "importStatement") continue;
+      if (!isAgencyImport(node.modulePath)) continue;
+      for (const resolved of symbolTable.resolveImport(node, moduleId)) {
+        map[resolved.localName] = followReExportChain(
+          resolved.file,
+          resolved.originalName,
           symbolTable,
         );
-        out[localName] = resolved;
       }
     }
+    return map;
   }
-  return out;
+
+  return {
+    resolve(localName, inModuleId) {
+      const moduleCache =
+        cache[inModuleId] ?? (cache[inModuleId] = buildFor(inModuleId));
+      return moduleCache[localName] ?? null;
+    },
+  };
 }
 
 /**
- * Walk re-export chains until we hit a symbol that lives in the file
- * that defines it. Returns `(definingModuleId, originalNameThere)`.
- *
- * Falls back to `(importedFrom, originalName)` if the chain can't be
- * walked (no symbol table, missing symbol, etc.).
+ * Walk `reExportedFrom` chains until we hit a symbol that lives in the
+ * file that defines it. Returns `(definingModuleId, originalNameThere)`.
+ * Falls back to `(startFile, startName)` if the chain can't be walked.
  */
-function resolveThroughReExports(
+function followReExportChain(
   startFile: string,
   startName: string,
-  symbolTable: SymbolTable | undefined,
+  symbolTable: SymbolTable,
 ): { sourceModuleId: string; sourceName: string } {
-  if (!symbolTable) {
-    return { sourceModuleId: startFile, sourceName: startName };
-  }
   let curFile = startFile;
   let curName = startName;
-  // Cap iterations defensively; the SymbolTable already rejects re-export
-  // cycles when it builds, so this should never spin in practice.
+  // Defensive cap; SymbolTable rejects re-export cycles when it builds.
   for (let i = 0; i < 64; i++) {
     const sym = symbolTable.getFile(curFile)?.[curName];
     if (!sym || !sym.reExportedFrom) {
@@ -276,135 +209,355 @@ function resolveThroughReExports(
   return { sourceModuleId: curFile, sourceName: curName };
 }
 
-function collectFileImports(
-  program: AgencyProgram,
-  moduleId: string,
-): string[] {
-  const out: string[] = [];
-  const seen: Record<string, true> = {};
-  for (const node of program.nodes) {
-    const target = getAgencyImportTarget(node);
-    if (!target) continue;
-    const abs = resolveAgencyImportPath(target, moduleId);
-    if (!seen[abs]) {
-      seen[abs] = true;
-      out.push(abs);
+/**
+ * Build the two phase-separated dep graphs from the entry's full
+ * pre-parsed import closure.
+ *
+ * `programs` maps absolute module paths to their parsed AST and MUST
+ * already contain every module reachable from `entryModuleId`. We do
+ * not re-walk imports — the entry point (`compileClosure`) owns that.
+ *
+ * `symbolTable`, when provided, enables re-export chain resolution.
+ * Without it, re-exporters appear as unresolved local names and produce
+ * no edge — fine for the simplest unit tests but pulls the
+ * `importedAlias` codegen path into the same starvation case the
+ * PR-1 trap covers, so production callers should always pass one.
+ */
+export function buildInitDepGraphs(
+  programs: Record<string, AgencyProgram>,
+  symbolTable: SymbolTable | undefined,
+  entryModuleId: string,
+): BuildInitDepGraphsResult {
+  const resolver = makeImportAliasResolver(programs, symbolTable);
+  const sequenceHints = computeSequenceHintBase(programs, entryModuleId);
+
+  // ── 1. Collect every node, routing each into the static or global graph.
+  const staticNodes: Record<InitVarKey, InitVarNode> = {};
+  const globalNodes: Record<InitVarKey, InitVarNode> = {};
+
+  for (const moduleId of Object.keys(programs)) {
+    const program = programs[moduleId];
+    if (!program) continue;
+    const depthBase = sequenceHints[moduleId] ?? 0;
+
+    for (const node of program.nodes) {
+      const varNode = nodeFromTopLevel(node, moduleId, depthBase);
+      if (!varNode) continue;
+      const target = varNode.kind === "static" ? staticNodes : globalNodes;
+      target[makeKey(varNode.moduleId, varNode.varName)] = varNode;
     }
   }
-  return out;
+
+  // ── 2. Compute edges within each graph by walking each node's
+  //       initializer expression for free identifier references.
+  const staticEdges = computeEdges(staticNodes, resolver);
+  const globalEdges = computeEdgesGlobal(
+    globalNodes,
+    staticNodes,
+    resolver,
+  );
+
+  // ── 3. Phase-coupling validation: a static reading a global is a
+  //       compile error. (Global reading static is fine — handled in
+  //       computeEdgesGlobal which skips static refs as deps.)
+  rejectStaticReferencesGlobal(staticNodes, globalNodes, resolver);
+
+  return {
+    staticGraph: { nodes: staticNodes, edges: staticEdges },
+    globalGraph: { nodes: globalNodes, edges: globalEdges },
+    resolver,
+  };
 }
 
+// ── Node extraction ──
+
 /**
- * Unwrap a top-level node into an Assignment if it represents a value-init
- * declaration the dep graph should track. Skips non-assignments and
- * assignments that are statements inside blocks (those aren't top-level).
- *
- * Bare top-level statements (function calls etc) are NOT tracked here —
- * they're sequenced by source order within their module and don't have
- * a name to depend on. Task 3 attaches them to the init plan separately.
+ * Convert a top-level program node into an `InitVarNode` if it's
+ * something that participates in either init graph. Returns `null` for
+ * top-level constructs that don't (functions, graph nodes, imports,
+ * type aliases, comments, …).
  */
-function unwrapTopLevelInitVar(node: AgencyNode): Assignment | null {
-  // Top-level assignments come out of the parser without a `scope` field
-  // set (scope is assigned by a later preprocessor pass). All of them
-  // are candidates for the init graph: `static`-prefixed ones become
-  // Phase A; the rest become Phase B globals.
-  if (node.type === "assignment") return node;
-  if (node.type === "withModifier" && node.statement.type === "assignment") {
-    return node.statement;
+function nodeFromTopLevel(
+  node: AgencyNode,
+  moduleId: string,
+  depthBase: number,
+): InitVarNode | null {
+  const { stmt, withApprove } = unwrapWithApprove(node);
+
+  if (stmt.type === "assignment") {
+    const line = stmt.loc?.line ?? 0;
+    return {
+      moduleId,
+      varName: stmt.variableName,
+      kind: stmt.static ? "static" : "global",
+      initExpr: stmt.value as Expression,
+      loc: stmt.loc,
+      exported: !!stmt.exported,
+      sequenceHint: depthBase + line,
+      ...(withApprove && { withApprove: true }),
+    };
   }
+
+  // Bare top-level statements (function calls, etc.) participate in the
+  // GLOBAL graph only. PR 3's `static` keyword unlocks static bare
+  // statements; until then statics are decl-only.
+  if (isBareTopLevelStatement(stmt)) {
+    const line = stmt.loc?.line ?? 0;
+    return {
+      moduleId,
+      varName: `__bareStmt_${moduleId}_${line}`,
+      kind: "global",
+      initExpr: stmt,
+      loc: stmt.loc,
+      exported: false,
+      sequenceHint: depthBase + line,
+      ...(withApprove && { withApprove: true }),
+    };
+  }
+
   return null;
 }
 
 /**
- * Walk an expression and collect every free identifier reference
- * (variable-name literals). Does NOT descend into nested function /
- * lambda bodies — those bind their own scope and won't trigger init
- * ordering for the outer initializer.
+ * Unwrap a `<stmt> with approve` modifier into its inner statement +
+ * the flag. Returns the original node unchanged if there's no modifier.
+ * `handle { ... }` blocks are rejected by the parser at top level, so
+ * the only modifier shape we need to handle is `withModifier`.
+ */
+function unwrapWithApprove(node: AgencyNode): {
+  stmt: AgencyNode;
+  withApprove: boolean;
+} {
+  if (node.type === "withModifier") {
+    return { stmt: node.statement, withApprove: true };
+  }
+  return { stmt: node, withApprove: false };
+}
+
+/**
+ * True for nodes that are bare top-level statements with side effects we
+ * need to sequence (function calls, interrupts, etc.). Excludes
+ * declarations, imports, comments, and other non-running constructs.
+ */
+function isBareTopLevelStatement(node: AgencyNode): boolean {
+  switch (node.type) {
+    case "functionCall":
+    case "interruptStatement":
+      return true;
+    default:
+      return false;
+  }
+}
+
+// ── Edge computation ──
+
+function computeEdges(
+  nodes: Record<InitVarKey, InitVarNode>,
+  resolver: ImportAliasResolver,
+): Record<InitVarKey, InitVarKey[]> {
+  const edges: Record<InitVarKey, InitVarKey[]> = {};
+  for (const [key, node] of Object.entries(nodes)) {
+    edges[key] = depsFor(node, nodes, resolver);
+  }
+  return edges;
+}
+
+/**
+ * Global-graph edges: a global node depends on another global node it
+ * references. References to STATIC nodes are intentionally NOT edges —
+ * statics are fully initialized before any global init runs (cross-phase
+ * allowance, not a cross-graph edge).
+ */
+function computeEdgesGlobal(
+  globalNodes: Record<InitVarKey, InitVarNode>,
+  staticNodes: Record<InitVarKey, InitVarNode>,
+  resolver: ImportAliasResolver,
+): Record<InitVarKey, InitVarKey[]> {
+  const edges: Record<InitVarKey, InitVarKey[]> = {};
+  for (const [key, node] of Object.entries(globalNodes)) {
+    edges[key] = depsFor(node, globalNodes, resolver, staticNodes);
+  }
+  return edges;
+}
+
+/**
+ * For one node, find every other node in `lookupSet` its initializer
+ * directly references and return their keys (no duplicates, no
+ * self-edges). `skipSet`, if provided, is the set of nodes whose
+ * references should be silently skipped (used to skip static refs when
+ * computing global edges).
+ */
+function depsFor(
+  node: InitVarNode,
+  lookupSet: Record<InitVarKey, InitVarNode>,
+  resolver: ImportAliasResolver,
+  skipSet?: Record<InitVarKey, InitVarNode>,
+): InitVarKey[] {
+  const seen: Record<InitVarKey, true> = {};
+  const out: InitVarKey[] = [];
+  for (const refName of collectFreeIdentifiers(node.initExpr)) {
+    if (refName === node.varName) continue;
+    const refKey = resolveRefKey(refName, node.moduleId, resolver);
+    if (!refKey) continue;
+    if (skipSet?.[refKey]) continue;
+    if (!lookupSet[refKey] || seen[refKey]) continue;
+    seen[refKey] = true;
+    out.push(refKey);
+  }
+  return out;
+}
+
+/**
+ * Resolve a free identifier (used inside `inModuleId`'s code) to a
+ * canonical `${moduleId}::${name}` key. Same-module references resolve
+ * directly; cross-module references go through the alias resolver.
+ * Returns `null` for names not bound by either path.
+ */
+function resolveRefKey(
+  refName: string,
+  inModuleId: string,
+  resolver: ImportAliasResolver,
+): InitVarKey | null {
+  const aliased = resolver.resolve(refName, inModuleId);
+  if (aliased) {
+    return makeKey(aliased.sourceModuleId, aliased.sourceName);
+  }
+  return makeKey(inModuleId, refName);
+}
+
+// ── Phase-coupling validation ──
+
+function rejectStaticReferencesGlobal(
+  staticNodes: Record<InitVarKey, InitVarNode>,
+  globalNodes: Record<InitVarKey, InitVarNode>,
+  resolver: ImportAliasResolver,
+): void {
+  for (const node of Object.values(staticNodes)) {
+    for (const refName of collectFreeIdentifiers(node.initExpr)) {
+      if (refName === node.varName) continue;
+      const refKey = resolveRefKey(refName, node.moduleId, resolver);
+      if (!refKey) continue;
+      const offender = globalNodes[refKey];
+      if (offender) throw new StaticReferencesGlobalError(node, offender);
+    }
+  }
+}
+
+// ── Free-identifier collection ──
+
+/**
+ * Collect every free `variableName` reference in `expr`, declaratively,
+ * via the shared `walkNodes` walker. Skips identifiers that appear
+ * inside nested name-binding constructs (`function`, `graphNode`) by
+ * checking the ancestor stack — those bodies don't execute during the
+ * outer initializer evaluation.
  */
 function collectFreeIdentifiers(expr: Expression | AgencyNode): string[] {
   const out: string[] = [];
-  const visit = (n: any): void => {
-    if (!n || typeof n !== "object") return;
-    if (Array.isArray(n)) {
-      for (const c of n) visit(c);
-      return;
+  for (const { node, ancestors } of walkNodes([expr as AgencyNode])) {
+    if (node.type !== "variableName") continue;
+    if (
+      ancestors.some(
+        (a) => a.type === "function" || a.type === "graphNode",
+      )
+    ) {
+      continue;
     }
-    switch (n.type) {
-      case "variableName":
-        out.push(n.value);
-        return;
-      case "function":
-      case "graphNode":
-        // Lambdas / nested defs: their body is closed over but doesn't
-        // execute during outer initializer evaluation. Skip.
-        return;
-      case "valueAccess":
-        visit(n.base);
-        for (const el of n.chain) {
-          if (el.kind === "index") visit(el.index);
-          else if (el.kind === "slice") {
-            if (el.start) visit(el.start);
-            if (el.end) visit(el.end);
-          } else if (el.kind === "methodCall") visit(el.functionCall);
-        }
-        return;
-      case "functionCall":
-        // Function name itself MAY be a top-level def; but as noted in
-        // the file header we don't add edges for callable references —
-        // only value references. Skip the name; recurse into args.
-        for (const arg of n.arguments) {
-          if (arg.type === "splat") visit(arg.value);
-          else if (arg.type === "namedArgument") visit(arg.value);
-          else visit(arg);
-        }
-        return;
-      case "binOpExpression":
-        visit(n.left);
-        visit(n.right);
-        return;
-      case "agencyArray":
-        for (const item of n.items) {
-          if (item?.type === "splat") visit(item.value);
-          else visit(item);
-        }
-        return;
-      case "agencyObject":
-        for (const e of n.entries) {
-          if (e?.type === "splat") visit(e.value);
-          else {
-            if (e.computedKey) visit(e.computedKey);
-            visit(e.value);
-          }
-        }
-        return;
-      case "string":
-      case "multiLineString":
-        for (const seg of n.segments) {
-          if (seg.type === "interpolation") visit(seg.expression);
-        }
-        return;
-      case "newExpression":
-        for (const arg of n.arguments) {
-          if (arg.type === "splat") visit(arg.value);
-          else if (arg.type === "namedArgument") visit(arg.value);
-          else visit(arg);
-        }
-        return;
-      case "tryExpression":
-        visit(n.expression);
-        return;
-      case "isExpression":
-        visit(n.value);
-        return;
-    }
-    // Generic fallback: walk every own property to catch any expression
-    // shape we didn't enumerate above. Safe because the early returns
-    // above handled name-binding cases (function, graphNode).
-    for (const key of Object.keys(n)) {
-      if (key === "type" || key === "loc") continue;
-      visit(n[key]);
-    }
-  };
-  visit(expr);
+    out.push(node.value);
+  }
   return out;
+}
+
+// ── Sequence-hint computation ──
+
+/**
+ * Compute each module's `(fileImportDepth × 1e6)` base value. Leaves of
+ * the file-import DAG get 0; modules importing them get higher values;
+ * file-import cycles (allowed by design — the router pattern) tolerated
+ * by assigning leftover modules the tail of the ordering. Each node's
+ * final `sequenceHint = depthBase + sourceLine` is computed by the
+ * caller. Lower hint → initializes earlier.
+ */
+function computeSequenceHintBase(
+  programs: Record<string, AgencyProgram>,
+  entryModuleId: string,
+): Record<string, number> {
+  // file-import DAG: module → modules it agency-imports.
+  const fileImports: Record<string, string[]> = {};
+  const modules = new Set<string>([entryModuleId]);
+  for (const moduleId of Object.keys(programs)) modules.add(moduleId);
+  for (const moduleId of modules) {
+    fileImports[moduleId] = agencyImportTargets(
+      programs[moduleId],
+      moduleId,
+    ).filter((m) => modules.has(m));
+  }
+
+  // Kahn over the reversed DAG: leaves (no imports) come first.
+  const inDeg: Record<string, number> = {};
+  const dependents: Record<string, string[]> = {};
+  for (const m of modules) {
+    inDeg[m] = 0;
+    dependents[m] = [];
+  }
+  for (const m of modules) {
+    for (const imp of fileImports[m]) {
+      dependents[imp].push(m);
+      inDeg[m]++;
+    }
+  }
+
+  const depth: Record<string, number> = {};
+  let counter = 0;
+  const ready = [...modules].filter((m) => inDeg[m] === 0).sort();
+  while (ready.length > 0) {
+    const m = ready.shift()!;
+    depth[m] = counter++;
+    for (const dep of dependents[m]) {
+      inDeg[dep]--;
+      if (inDeg[dep] === 0) {
+        ready.push(dep);
+        ready.sort();
+      }
+    }
+  }
+  // file-import cycle leftovers → tail of the ordering, deterministically.
+  for (const m of [...modules].sort()) {
+    if (depth[m] === undefined) depth[m] = counter++;
+  }
+
+  const SCALE = 1_000_000;
+  const out: Record<string, number> = {};
+  for (const m of modules) out[m] = depth[m] * SCALE;
+  return out;
+}
+
+function agencyImportTargets(
+  program: AgencyProgram | undefined,
+  moduleId: string,
+): string[] {
+  if (!program) return [];
+  const out: string[] = [];
+  for (const node of program.nodes) {
+    const target = agencyImportTarget(node);
+    if (!target) continue;
+    out.push(resolveAgencyImportPath(target, moduleId));
+  }
+  return out;
+}
+
+function agencyImportTarget(node: AgencyNode): string | null {
+  if (node.type === "importStatement" && isAgencyImport(node.modulePath)) {
+    return node.modulePath;
+  }
+  if (node.type === "importNodeStatement") {
+    return node.agencyFile;
+  }
+  if (
+    node.type === "exportFromStatement" &&
+    isAgencyImport(node.modulePath)
+  ) {
+    return node.modulePath;
+  }
+  return null;
 }

--- a/packages/agency-lang/lib/compiler/topSortInitGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/topSortInitGraph.test.ts
@@ -194,4 +194,56 @@ describe("topSortInitGraph", () => {
     if (r1.kind !== "ok" || r2.kind !== "ok") return;
     expect(r1.order).toEqual(r2.order);
   });
+
+  it("topsorts a 50-module x 3-vars-each acyclic graph under 100ms", () => {
+    // PR-2 perf smoke: confirms the per-round `ready.sort(byHint)` cost
+    // is acceptable for realistic project sizes. Deterministically
+    // generated (seeded RNG) so results are stable in CI.
+    const MODULES = 50;
+    const VARS_PER_MODULE = 3;
+    const RAND_SEED = 0x9e3779b9;
+    let seed = RAND_SEED;
+    const rand = (): number => {
+      // Mulberry32 — small, deterministic, fine for "pick a smaller
+      // module index" decisions inside a perf fixture.
+      seed = (seed + 0x6d2b79f5) | 0;
+      let t = seed;
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+
+    const nodes: { module: string; name: string; hint: number }[] = [];
+    const edges: [string, string][] = [];
+    for (let m = 0; m < MODULES; m++) {
+      const mod = `m${m}`;
+      for (let v = 0; v < VARS_PER_MODULE; v++) {
+        nodes.push({
+          module: mod,
+          name: `v${v}`,
+          hint: m * 1_000_000 + v,
+        });
+        // Each var randomly depends on 0–2 earlier-module vars; this
+        // keeps the graph acyclic by construction (deps point to lower
+        // module indices only).
+        if (m === 0) continue;
+        const depCount = Math.floor(rand() * 3);
+        for (let d = 0; d < depCount; d++) {
+          const depMod = Math.floor(rand() * m);
+          const depVar = Math.floor(rand() * VARS_PER_MODULE);
+          edges.push([`${mod}::v${v}`, `m${depMod}::v${depVar}`]);
+        }
+      }
+    }
+    const g = makeGraph({ nodes, edges });
+
+    const start = performance.now();
+    const r = topSortInitGraph(g);
+    const elapsedMs = performance.now() - start;
+
+    expect(r.kind).toBe("ok");
+    if (r.kind !== "ok") return;
+    expect(r.order.length).toBe(MODULES * VARS_PER_MODULE);
+    expect(elapsedMs).toBeLessThan(100);
+  });
 });

--- a/packages/agency-lang/lib/compiler/topSortInitGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/topSortInitGraph.test.ts
@@ -28,7 +28,7 @@ function makeGraph(opts: {
       varName: n.name,
       kind: n.kind ?? "static",
       initExpr: { type: "number", value: "0", loc: { line: 0, col: 0 } } as any,
-      loc: { line: n.line ?? 0, col: 0 },
+      loc: { line: n.line ?? 0, col: 0, start: 0, end: 0 },
       exported: false,
       sequenceHint: n.hint ?? 0,
     };

--- a/packages/agency-lang/lib/compiler/topSortInitGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/topSortInitGraph.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import type { InitDepGraph, InitVarNode } from "./initDepGraph.js";
+import { makeKey } from "./initDepGraph.js";
+import { topSortInitGraph } from "./topSortInitGraph.js";
+
+/**
+ * Build a minimal InitDepGraph from plain JS — no file system, no
+ * parser. Each node is identified by `${moduleId}::${varName}`. The
+ * helper short-circuits boilerplate so tests read as graph descriptions.
+ */
+function makeGraph(opts: {
+  nodes: { module: string; name: string; kind?: "static" | "global"; line?: number }[];
+  edges?: [string, string][];   // [key, dep] pairs
+  fileImports?: Record<string, string[]>;
+}): InitDepGraph {
+  const nodes: Record<string, InitVarNode> = {};
+  for (const n of opts.nodes) {
+    nodes[makeKey(n.module, n.name)] = {
+      moduleId: n.module,
+      varName: n.name,
+      kind: n.kind ?? "static",
+      initExpr: { type: "number", value: "0", loc: { line: 0, col: 0 } } as any,
+      loc: { line: n.line ?? 0, col: 0 },
+      exported: false,
+    };
+  }
+  const edges: Record<string, string[]> = {};
+  for (const key of Object.keys(nodes)) edges[key] = [];
+  for (const [a, b] of opts.edges ?? []) {
+    edges[a] = [...(edges[a] ?? []), b];
+  }
+  return { nodes, edges, fileImports: opts.fileImports ?? {} };
+}
+
+describe("topSortInitGraph", () => {
+  it("sorts a linear chain in dep-first order", () => {
+    // a → b → c  (a depends on b, b depends on c)
+    const g = makeGraph({
+      nodes: [
+        { module: "m", name: "a" },
+        { module: "m", name: "b" },
+        { module: "m", name: "c" },
+      ],
+      edges: [
+        ["m::a", "m::b"],
+        ["m::b", "m::c"],
+      ],
+    });
+    const r = topSortInitGraph(g);
+    expect(r.kind).toBe("ok");
+    if (r.kind !== "ok") return;
+    expect(r.order).toEqual(["m::c", "m::b", "m::a"]);
+  });
+
+  it("sorts a diamond — common ancestor first, root last", () => {
+    // a depends on b and c; both depend on d.
+    const g = makeGraph({
+      nodes: [
+        { module: "m", name: "a" },
+        { module: "m", name: "b" },
+        { module: "m", name: "c" },
+        { module: "m", name: "d" },
+      ],
+      edges: [
+        ["m::a", "m::b"],
+        ["m::a", "m::c"],
+        ["m::b", "m::d"],
+        ["m::c", "m::d"],
+      ],
+    });
+    const r = topSortInitGraph(g);
+    expect(r.kind).toBe("ok");
+    if (r.kind !== "ok") return;
+    expect(r.order[0]).toBe("m::d");
+    expect(r.order[3]).toBe("m::a");
+    // b and c can come in either order, but both must come after d
+    // and before a.
+    expect(r.order.indexOf("m::b")).toBeGreaterThan(0);
+    expect(r.order.indexOf("m::b")).toBeLessThan(3);
+    expect(r.order.indexOf("m::c")).toBeGreaterThan(0);
+    expect(r.order.indexOf("m::c")).toBeLessThan(3);
+  });
+
+  it("uses file-import order as a tiebreaker (example 2 case)", () => {
+    // foo and bar each have a static; no var-level edge between
+    // them. foo's module imports bar's module. Expected: bar
+    // initializes before foo.
+    const g = makeGraph({
+      nodes: [
+        { module: "/foo.agency", name: "fooStatic" },
+        { module: "/bar.agency", name: "barStatic" },
+      ],
+      fileImports: {
+        "/foo.agency": ["/bar.agency"],
+        "/bar.agency": [],
+      },
+    });
+    const r = topSortInitGraph(g);
+    expect(r.kind).toBe("ok");
+    if (r.kind !== "ok") return;
+    expect(r.order).toEqual([
+      "/bar.agency::barStatic",
+      "/foo.agency::fooStatic",
+    ]);
+  });
+
+  it("reports a direct cycle as a CycleError", () => {
+    // foo → bar → foo
+    const g = makeGraph({
+      nodes: [
+        { module: "/foo.agency", name: "fooStatic" },
+        { module: "/bar.agency", name: "barStatic" },
+      ],
+      edges: [
+        ["/foo.agency::fooStatic", "/bar.agency::barStatic"],
+        ["/bar.agency::barStatic", "/foo.agency::fooStatic"],
+      ],
+    });
+    const r = topSortInitGraph(g);
+    expect(r.kind).toBe("cycle");
+    if (r.kind !== "cycle") return;
+    const names = r.cycle.map((n) => n.varName).sort();
+    expect(names).toEqual(["barStatic", "fooStatic"]);
+  });
+
+  it("reports a 3-cycle naming all participants", () => {
+    // a → b → c → a
+    const g = makeGraph({
+      nodes: [
+        { module: "m", name: "a" },
+        { module: "m", name: "b" },
+        { module: "m", name: "c" },
+      ],
+      edges: [
+        ["m::a", "m::b"],
+        ["m::b", "m::c"],
+        ["m::c", "m::a"],
+      ],
+    });
+    const r = topSortInitGraph(g);
+    expect(r.kind).toBe("cycle");
+    if (r.kind !== "cycle") return;
+    const names = r.cycle.map((n) => n.varName).sort();
+    expect(names).toEqual(["a", "b", "c"]);
+  });
+
+  it("includes nodes from independent components in the output", () => {
+    // Two disjoint chains: a→b and c→d. Both should appear.
+    const g = makeGraph({
+      nodes: [
+        { module: "m", name: "a" },
+        { module: "m", name: "b" },
+        { module: "m", name: "c" },
+        { module: "m", name: "d" },
+      ],
+      edges: [
+        ["m::a", "m::b"],
+        ["m::c", "m::d"],
+      ],
+    });
+    const r = topSortInitGraph(g);
+    expect(r.kind).toBe("ok");
+    if (r.kind !== "ok") return;
+    expect(r.order.length).toBe(4);
+    expect(r.order.indexOf("m::b")).toBeLessThan(r.order.indexOf("m::a"));
+    expect(r.order.indexOf("m::d")).toBeLessThan(r.order.indexOf("m::c"));
+  });
+});

--- a/packages/agency-lang/lib/compiler/topSortInitGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/topSortInitGraph.test.ts
@@ -4,14 +4,22 @@ import { makeKey } from "./initDepGraph.js";
 import { topSortInitGraph } from "./topSortInitGraph.js";
 
 /**
- * Build a minimal InitDepGraph from plain JS — no file system, no
- * parser. Each node is identified by `${moduleId}::${varName}`. The
- * helper short-circuits boilerplate so tests read as graph descriptions.
+ * Build a minimal `InitDepGraph` from plain JS — no file system, no
+ * parser. Each node is keyed by `${moduleId}::${varName}`. Optional
+ * `hint` lets a test pin a node's `sequenceHint` directly, which is
+ * the field the topsort uses to break ties between var-edge-unrelated
+ * nodes. `kind` defaults to `"static"`; the topsort is graph-agnostic
+ * — it runs the same way for the static and global graphs.
  */
 function makeGraph(opts: {
-  nodes: { module: string; name: string; kind?: "static" | "global"; line?: number }[];
-  edges?: [string, string][];   // [key, dep] pairs
-  fileImports?: Record<string, string[]>;
+  nodes: {
+    module: string;
+    name: string;
+    kind?: "static" | "global";
+    line?: number;
+    hint?: number;
+  }[];
+  edges?: [string, string][];
 }): InitDepGraph {
   const nodes: Record<string, InitVarNode> = {};
   for (const n of opts.nodes) {
@@ -22,6 +30,7 @@ function makeGraph(opts: {
       initExpr: { type: "number", value: "0", loc: { line: 0, col: 0 } } as any,
       loc: { line: n.line ?? 0, col: 0 },
       exported: false,
+      sequenceHint: n.hint ?? 0,
     };
   }
   const edges: Record<string, string[]> = {};
@@ -29,12 +38,11 @@ function makeGraph(opts: {
   for (const [a, b] of opts.edges ?? []) {
     edges[a] = [...(edges[a] ?? []), b];
   }
-  return { nodes, edges, fileImports: opts.fileImports ?? {} };
+  return { nodes, edges };
 }
 
 describe("topSortInitGraph", () => {
   it("sorts a linear chain in dep-first order", () => {
-    // a → b → c  (a depends on b, b depends on c)
     const g = makeGraph({
       nodes: [
         { module: "m", name: "a" },
@@ -53,7 +61,6 @@ describe("topSortInitGraph", () => {
   });
 
   it("sorts a diamond — common ancestor first, root last", () => {
-    // a depends on b and c; both depend on d.
     const g = makeGraph({
       nodes: [
         { module: "m", name: "a" },
@@ -73,27 +80,19 @@ describe("topSortInitGraph", () => {
     if (r.kind !== "ok") return;
     expect(r.order[0]).toBe("m::d");
     expect(r.order[3]).toBe("m::a");
-    // b and c can come in either order, but both must come after d
-    // and before a.
     expect(r.order.indexOf("m::b")).toBeGreaterThan(0);
     expect(r.order.indexOf("m::b")).toBeLessThan(3);
     expect(r.order.indexOf("m::c")).toBeGreaterThan(0);
     expect(r.order.indexOf("m::c")).toBeLessThan(3);
   });
 
-  it("uses file-import order as a tiebreaker (example 2 case)", () => {
-    // foo and bar each have a static; no var-level edge between
-    // them. foo's module imports bar's module. Expected: bar
-    // initializes before foo.
+  it("uses sequenceHint as the tiebreaker between unordered nodes", () => {
+    // Two nodes with no var-edges between them; lower `hint` wins.
     const g = makeGraph({
       nodes: [
-        { module: "/foo.agency", name: "fooStatic" },
-        { module: "/bar.agency", name: "barStatic" },
+        { module: "/foo.agency", name: "fooStatic", hint: 1_000_000 },
+        { module: "/bar.agency", name: "barStatic", hint: 0 },
       ],
-      fileImports: {
-        "/foo.agency": ["/bar.agency"],
-        "/bar.agency": [],
-      },
     });
     const r = topSortInitGraph(g);
     expect(r.kind).toBe("ok");
@@ -105,7 +104,6 @@ describe("topSortInitGraph", () => {
   });
 
   it("reports a direct cycle as a CycleError", () => {
-    // foo → bar → foo
     const g = makeGraph({
       nodes: [
         { module: "/foo.agency", name: "fooStatic" },
@@ -123,8 +121,9 @@ describe("topSortInitGraph", () => {
     expect(names).toEqual(["barStatic", "fooStatic"]);
   });
 
-  it("reports a 3-cycle naming all participants", () => {
-    // a → b → c → a
+  it("reports a 3-cycle naming all participants in cycle order", () => {
+    // a → b → c → a. Whichever node we start from, the returned cycle
+    // should include all 3 names.
     const g = makeGraph({
       nodes: [
         { module: "m", name: "a" },
@@ -140,12 +139,21 @@ describe("topSortInitGraph", () => {
     const r = topSortInitGraph(g);
     expect(r.kind).toBe("cycle");
     if (r.kind !== "cycle") return;
-    const names = r.cycle.map((n) => n.varName).sort();
-    expect(names).toEqual(["a", "b", "c"]);
+    expect(r.cycle.length).toBe(3);
+    const sortedNames = r.cycle.map((n) => n.varName).sort();
+    expect(sortedNames).toEqual(["a", "b", "c"]);
+    // The cycle should be consecutive: each node's deps should include
+    // the next node, and the last should depend on the first.
+    for (let i = 0; i < r.cycle.length; i++) {
+      const cur = r.cycle[i];
+      const next = r.cycle[(i + 1) % r.cycle.length];
+      const curKey = makeKey(cur.moduleId, cur.varName);
+      const nextKey = makeKey(next.moduleId, next.varName);
+      expect(g.edges[curKey]).toContain(nextKey);
+    }
   });
 
   it("includes nodes from independent components in the output", () => {
-    // Two disjoint chains: a→b and c→d. Both should appear.
     const g = makeGraph({
       nodes: [
         { module: "m", name: "a" },
@@ -164,5 +172,26 @@ describe("topSortInitGraph", () => {
     expect(r.order.length).toBe(4);
     expect(r.order.indexOf("m::b")).toBeLessThan(r.order.indexOf("m::a"));
     expect(r.order.indexOf("m::d")).toBeLessThan(r.order.indexOf("m::c"));
+  });
+
+  it("produces the same order across repeated sorts (deterministic)", () => {
+    // Hint-distinct nodes with cross-component deps; rerunning the sort
+    // should never change the output. Guards against accidental
+    // Map/Set iteration-order leaks creeping back in.
+    const g = makeGraph({
+      nodes: [
+        { module: "m1", name: "x", hint: 5 },
+        { module: "m2", name: "y", hint: 1 },
+        { module: "m3", name: "z", hint: 3 },
+        { module: "m4", name: "w", hint: 4 },
+      ],
+      edges: [["m1::x", "m2::y"]],
+    });
+    const r1 = topSortInitGraph(g);
+    const r2 = topSortInitGraph(g);
+    expect(r1.kind).toBe("ok");
+    expect(r2.kind).toBe("ok");
+    if (r1.kind !== "ok" || r2.kind !== "ok") return;
+    expect(r1.order).toEqual(r2.order);
   });
 });

--- a/packages/agency-lang/lib/compiler/topSortInitGraph.ts
+++ b/packages/agency-lang/lib/compiler/topSortInitGraph.ts
@@ -1,36 +1,29 @@
 /**
- * Topological sort over the per-variable init dep graph (built by
+ * Topological sort over a per-variable init dep graph (built by
  * `initDepGraph.ts`).
  *
- * Two outputs:
- *  - {@link topSortInitGraph} on success returns an array of
- *    `InitVarKey` in initialization order (deps first).
- *  - on cycle it returns a structured `CycleError` listing the cycle
- *    path so Task 3 can render a clean compile-time error.
+ * On success: returns the init order — every node appears after all of
+ * its deps. On a cycle in the variable graph: returns a structured
+ * `CycleError` listing the cycle path so Task 3 can render a clean
+ * compile-time error.
  *
- * Ordering rule:
- *  - Var-level edges always win. If `a` depends on `b`, `b` must
- *    appear before `a`.
- *  - Otherwise, fall back to the file-import DAG: for two
- *    var-edge-unordered nodes, the one whose module is imported
- *    (directly or transitively) BEFORE the other's module comes
- *    first. This handles example 2 from the design doc, where
- *    `fooStatic = getBarStatic() + "!"` has no direct value edge on
- *    bar but bar must init first because foo imports bar.
- *  - Final tiebreak is lexicographic on the node key (moduleId::name)
- *    so the output is deterministic regardless of object-iteration
- *    order across JS engines.
+ * Ordering rule: var-level edges always win. For nodes the edges leave
+ * unordered, sort by each node's pre-computed `sequenceHint` (built
+ * from the file-import-DAG depth + source line by the graph builder).
+ * One ordering key, one consumer.
  *
- * Implementation: Kahn's algorithm with a priority queue (sorted by
- * the tiebreak rules above) over zero-in-degree nodes.
+ * Implementation: Kahn's algorithm; the "ready" bag is sorted by
+ * sequenceHint between iterations. N (top-level decls in the closure)
+ * is small enough that a per-round `.sort()` reads more clearly than a
+ * hand-rolled priority queue.
  */
 
 import type { InitDepGraph, InitVarKey, InitVarNode } from "./initDepGraph.js";
 
 export type CycleError = {
   kind: "cycle";
-  /** A representative cycle path: a list of nodes where each depends on
-   * the next, and the last depends on the first. */
+  /** Representative cycle: each node depends on the next; the last
+   * depends on the first. */
   cycle: InitVarNode[];
 };
 
@@ -39,10 +32,23 @@ export type TopSortResult =
   | CycleError;
 
 export function topSortInitGraph(graph: InitDepGraph): TopSortResult {
-  // 1. Compute in-degree per node (number of incoming "depends-on"
-  //    edges, i.e. how many other nodes list this one as a dep).
-  // Important: `graph.edges` maps node → its deps; for Kahn's algorithm
-  // we need the reverse — from dep → dependents — and per-node in-degree.
+  const { reverse, inDegree } = reverseEdges(graph);
+  const order = kahn(graph, reverse, inDegree);
+  if (order.length === Object.keys(graph.nodes).length) {
+    return { kind: "ok", order };
+  }
+  return { kind: "cycle", cycle: traceCycleFrom(graph, inDegree) };
+}
+
+/**
+ * Build the reverse adjacency (dep → dependents) and the per-node
+ * in-degree count Kahn's algorithm consumes. The graph stores edges as
+ * `node → its deps`; Kahn needs the opposite direction.
+ */
+function reverseEdges(graph: InitDepGraph): {
+  reverse: Record<InitVarKey, InitVarKey[]>;
+  inDegree: Record<InitVarKey, number>;
+} {
   const reverse: Record<InitVarKey, InitVarKey[]> = {};
   const inDegree: Record<InitVarKey, number> = {};
   for (const key of Object.keys(graph.nodes)) {
@@ -51,182 +57,78 @@ export function topSortInitGraph(graph: InitDepGraph): TopSortResult {
   }
   for (const [key, deps] of Object.entries(graph.edges)) {
     for (const dep of deps) {
-      // Edge: key depends on dep, so dep -> key.
-      // (Defensive guard against stale references — skip deps not in nodes.)
-      if (inDegree[dep] === undefined) continue;
+      if (inDegree[dep] === undefined) continue; // skip stale refs defensively
       reverse[dep].push(key);
-      inDegree[key] = (inDegree[key] ?? 0) + 1;
+      inDegree[key]++;
     }
   }
+  return { reverse, inDegree };
+}
 
-  // 2. Compute file-import ordering: for each module, what is its
-  //    "depth" in a topological walk of the file-import DAG? Modules
-  //    that are leaves in the DAG (no agency imports) come first
-  //    (low depth → init first). On a file-import cycle (allowed by
-  //    the design) the depth of nodes inside the SCC is just their
-  //    BFS distance from a leaf — not perfectly principled, but stable
-  //    and adequate for the tiebreak.
-  const fileOrder = computeFileImportOrder(graph);
-
-  // Compare two keys for ordering of the "ready" set (Kahn's algorithm
-  // bag of zero-in-degree nodes). Lower wins (popped first).
-  const cmp = (a: InitVarKey, b: InitVarKey): number => {
-    const na = graph.nodes[a]!;
-    const nb = graph.nodes[b]!;
-    const fa = fileOrder[na.moduleId] ?? Number.POSITIVE_INFINITY;
-    const fb = fileOrder[nb.moduleId] ?? Number.POSITIVE_INFINITY;
-    if (fa !== fb) return fa - fb;
-    // Within the same module, declaration order wins. Approximate it
-    // by source-line if locations are available.
-    const la = na.loc?.line ?? 0;
-    const lb = nb.loc?.line ?? 0;
-    if (la !== lb) return la - lb;
-    return a < b ? -1 : a > b ? 1 : 0;
+/** Kahn's loop. Ready set is kept sorted by `sequenceHint` so the
+ * output order is deterministic and matches the graph builder's
+ * pre-computed ordering hints. */
+function kahn(
+  graph: InitDepGraph,
+  reverse: Record<InitVarKey, InitVarKey[]>,
+  inDegree: Record<InitVarKey, number>,
+): InitVarKey[] {
+  const hintOf = (k: InitVarKey): number =>
+    graph.nodes[k]?.sequenceHint ?? Number.POSITIVE_INFINITY;
+  const byHint = (a: InitVarKey, b: InitVarKey): number => {
+    const ha = hintOf(a);
+    const hb = hintOf(b);
+    if (ha !== hb) return ha - hb;
+    return a < b ? -1 : a > b ? 1 : 0; // lex tiebreak — never reached if hints differ
   };
 
-  // 3. Kahn's loop: repeatedly take the smallest-by-cmp zero-in-degree
-  //    node and emit it, decrementing in-degrees of its dependents.
-  const ready: InitVarKey[] = Object.keys(inDegree).filter(
-    (k) => inDegree[k] === 0,
-  );
-  ready.sort(cmp);
+  // Important: in-degree mutates as we drain; copy so the caller can
+  // re-use it for cycle reporting.
+  const remaining = { ...inDegree };
+  const ready = Object.keys(remaining).filter((k) => remaining[k] === 0);
+  ready.sort(byHint);
+
   const order: InitVarKey[] = [];
   while (ready.length > 0) {
-    const key = ready.shift()!;
-    order.push(key);
-    for (const dep of reverse[key] ?? []) {
-      inDegree[dep] = (inDegree[dep] ?? 0) - 1;
-      if (inDegree[dep] === 0) {
-        // Insert maintaining sort order.
-        insertSorted(ready, dep, cmp);
-      }
+    const next = ready.shift()!;
+    order.push(next);
+    for (const dep of reverse[next] ?? []) {
+      remaining[dep]--;
+      if (remaining[dep] === 0) ready.push(dep);
     }
+    ready.sort(byHint);
   }
-
-  if (order.length === Object.keys(graph.nodes).length) {
-    return { kind: "ok", order };
-  }
-
-  // 4. Cycle: find a representative cycle by walking from any
-  //    still-positive in-degree node along edges, tracking the path.
-  return findCycle(graph, inDegree);
-}
-
-function insertSorted(
-  arr: InitVarKey[],
-  key: InitVarKey,
-  cmp: (a: InitVarKey, b: InitVarKey) => number,
-): void {
-  let lo = 0;
-  let hi = arr.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >>> 1;
-    if (cmp(arr[mid], key) <= 0) lo = mid + 1;
-    else hi = mid;
-  }
-  arr.splice(lo, 0, key);
-}
-
-/**
- * Assign each module a numeric "import order" — lower numbers come
- * earlier, mirroring a topological walk of the file-import DAG.
- *
- * Implementation: a Kahn pass over the reversed file-import graph
- * (so leaves — modules that import nothing — get the smallest
- * numbers). File-level cycles (allowed by design — the router pattern)
- * are tolerated: any module left after the Kahn pass is assigned a
- * depth equal to the longest path it could otherwise reach.
- */
-function computeFileImportOrder(graph: InitDepGraph): Record<string, number> {
-  const all = new Set<string>();
-  for (const n of Object.values(graph.nodes)) all.add(n.moduleId);
-  for (const m of Object.keys(graph.fileImports)) all.add(m);
-  const modules = [...all];
-
-  // Build dep counts: for each module, how many of its imports are
-  // also tracked modules. (Skip imports outside `modules` — they're
-  // unreachable from the entry and shouldn't affect ordering.)
-  const inDeg: Record<string, number> = {};
-  const dependents: Record<string, string[]> = {};
-  for (const m of modules) {
-    inDeg[m] = 0;
-    dependents[m] = [];
-  }
-  for (const m of modules) {
-    const imports = graph.fileImports[m] ?? [];
-    for (const imp of imports) {
-      if (!(imp in inDeg)) continue;
-      dependents[imp].push(m);
-      inDeg[m]++;
-    }
-  }
-
-  const order: Record<string, number> = {};
-  let counter = 0;
-  const ready = modules.filter((m) => inDeg[m] === 0).sort();
-  while (ready.length > 0) {
-    const m = ready.shift()!;
-    order[m] = counter++;
-    for (const dep of dependents[m]) {
-      inDeg[dep]--;
-      if (inDeg[dep] === 0) insertSortedString(ready, dep);
-    }
-  }
-  // Anything left is inside a file-import cycle — assign them the
-  // tail of the ordering in lexicographic order so the tiebreak stays
-  // stable.
-  const leftover = modules.filter((m) => order[m] === undefined).sort();
-  for (const m of leftover) order[m] = counter++;
   return order;
 }
 
-function insertSortedString(arr: string[], key: string): void {
-  let lo = 0;
-  let hi = arr.length;
-  while (lo < hi) {
-    const mid = (lo + hi) >>> 1;
-    if (arr[mid] <= key) lo = mid + 1;
-    else hi = mid;
-  }
-  arr.splice(lo, 0, key);
-}
-
 /**
- * Find any cycle in the dep graph (called only when topsort has
- * confirmed one exists). Returns a CycleError naming the participating
- * decls in order — first node depends on second, second on third, …,
- * last on first.
+ * Find one representative cycle in `graph`. Called only when topsort
+ * has confirmed a cycle exists (some node has remaining in-degree > 0).
+ * Walks one outgoing edge at a time, preferring deps still in the
+ * cycle, until we revisit a node — that closes the loop.
  */
-function findCycle(
+function traceCycleFrom(
   graph: InitDepGraph,
   inDegree: Record<InitVarKey, number>,
-): CycleError {
-  // Start from any node with nonzero remaining in-degree; walk one
-  // outgoing edge at a time until we revisit a node — that closes the
-  // cycle.
+): InitVarNode[] {
   const start = Object.keys(inDegree).find((k) => inDegree[k] > 0);
-  if (!start) {
-    // Should not happen — caller only invokes this when there IS a cycle.
-    return { kind: "cycle", cycle: [] };
-  }
+  if (!start) return [];
+
   const path: InitVarKey[] = [];
-  const onPath: Record<InitVarKey, number> = {};
+  const positionOnPath: Record<InitVarKey, number> = {};
   let cur = start;
-  for (let i = 0; i < Object.keys(graph.nodes).length + 1; i++) {
-    if (onPath[cur] !== undefined) {
-      // Cycle detected. Trim path back to the loop start.
-      const loop = path.slice(onPath[cur]);
-      return { kind: "cycle", cycle: loop.map((k) => graph.nodes[k]!) };
+  const maxSteps = Object.keys(graph.nodes).length + 1;
+
+  for (let i = 0; i < maxSteps; i++) {
+    if (positionOnPath[cur] !== undefined) {
+      return path.slice(positionOnPath[cur]).map((k) => graph.nodes[k]!);
     }
-    onPath[cur] = path.length;
+    positionOnPath[cur] = path.length;
     path.push(cur);
-    // Follow the first dep that still has positive in-degree (a cycle
-    // edge), or just the first dep.
     const deps = graph.edges[cur] ?? [];
     const next = deps.find((d) => inDegree[d] > 0) ?? deps[0];
     if (!next) break;
     cur = next;
   }
-  // Fallback (shouldn't reach here in well-formed graphs).
-  return { kind: "cycle", cycle: path.map((k) => graph.nodes[k]!) };
+  return path.map((k) => graph.nodes[k]!);
 }

--- a/packages/agency-lang/lib/compiler/topSortInitGraph.ts
+++ b/packages/agency-lang/lib/compiler/topSortInitGraph.ts
@@ -1,0 +1,232 @@
+/**
+ * Topological sort over the per-variable init dep graph (built by
+ * `initDepGraph.ts`).
+ *
+ * Two outputs:
+ *  - {@link topSortInitGraph} on success returns an array of
+ *    `InitVarKey` in initialization order (deps first).
+ *  - on cycle it returns a structured `CycleError` listing the cycle
+ *    path so Task 3 can render a clean compile-time error.
+ *
+ * Ordering rule:
+ *  - Var-level edges always win. If `a` depends on `b`, `b` must
+ *    appear before `a`.
+ *  - Otherwise, fall back to the file-import DAG: for two
+ *    var-edge-unordered nodes, the one whose module is imported
+ *    (directly or transitively) BEFORE the other's module comes
+ *    first. This handles example 2 from the design doc, where
+ *    `fooStatic = getBarStatic() + "!"` has no direct value edge on
+ *    bar but bar must init first because foo imports bar.
+ *  - Final tiebreak is lexicographic on the node key (moduleId::name)
+ *    so the output is deterministic regardless of object-iteration
+ *    order across JS engines.
+ *
+ * Implementation: Kahn's algorithm with a priority queue (sorted by
+ * the tiebreak rules above) over zero-in-degree nodes.
+ */
+
+import type { InitDepGraph, InitVarKey, InitVarNode } from "./initDepGraph.js";
+
+export type CycleError = {
+  kind: "cycle";
+  /** A representative cycle path: a list of nodes where each depends on
+   * the next, and the last depends on the first. */
+  cycle: InitVarNode[];
+};
+
+export type TopSortResult =
+  | { kind: "ok"; order: InitVarKey[] }
+  | CycleError;
+
+export function topSortInitGraph(graph: InitDepGraph): TopSortResult {
+  // 1. Compute in-degree per node (number of incoming "depends-on"
+  //    edges, i.e. how many other nodes list this one as a dep).
+  // Important: `graph.edges` maps node → its deps; for Kahn's algorithm
+  // we need the reverse — from dep → dependents — and per-node in-degree.
+  const reverse: Record<InitVarKey, InitVarKey[]> = {};
+  const inDegree: Record<InitVarKey, number> = {};
+  for (const key of Object.keys(graph.nodes)) {
+    inDegree[key] = 0;
+    reverse[key] = [];
+  }
+  for (const [key, deps] of Object.entries(graph.edges)) {
+    for (const dep of deps) {
+      // Edge: key depends on dep, so dep -> key.
+      // (Defensive guard against stale references — skip deps not in nodes.)
+      if (inDegree[dep] === undefined) continue;
+      reverse[dep].push(key);
+      inDegree[key] = (inDegree[key] ?? 0) + 1;
+    }
+  }
+
+  // 2. Compute file-import ordering: for each module, what is its
+  //    "depth" in a topological walk of the file-import DAG? Modules
+  //    that are leaves in the DAG (no agency imports) come first
+  //    (low depth → init first). On a file-import cycle (allowed by
+  //    the design) the depth of nodes inside the SCC is just their
+  //    BFS distance from a leaf — not perfectly principled, but stable
+  //    and adequate for the tiebreak.
+  const fileOrder = computeFileImportOrder(graph);
+
+  // Compare two keys for ordering of the "ready" set (Kahn's algorithm
+  // bag of zero-in-degree nodes). Lower wins (popped first).
+  const cmp = (a: InitVarKey, b: InitVarKey): number => {
+    const na = graph.nodes[a]!;
+    const nb = graph.nodes[b]!;
+    const fa = fileOrder[na.moduleId] ?? Number.POSITIVE_INFINITY;
+    const fb = fileOrder[nb.moduleId] ?? Number.POSITIVE_INFINITY;
+    if (fa !== fb) return fa - fb;
+    // Within the same module, declaration order wins. Approximate it
+    // by source-line if locations are available.
+    const la = na.loc?.line ?? 0;
+    const lb = nb.loc?.line ?? 0;
+    if (la !== lb) return la - lb;
+    return a < b ? -1 : a > b ? 1 : 0;
+  };
+
+  // 3. Kahn's loop: repeatedly take the smallest-by-cmp zero-in-degree
+  //    node and emit it, decrementing in-degrees of its dependents.
+  const ready: InitVarKey[] = Object.keys(inDegree).filter(
+    (k) => inDegree[k] === 0,
+  );
+  ready.sort(cmp);
+  const order: InitVarKey[] = [];
+  while (ready.length > 0) {
+    const key = ready.shift()!;
+    order.push(key);
+    for (const dep of reverse[key] ?? []) {
+      inDegree[dep] = (inDegree[dep] ?? 0) - 1;
+      if (inDegree[dep] === 0) {
+        // Insert maintaining sort order.
+        insertSorted(ready, dep, cmp);
+      }
+    }
+  }
+
+  if (order.length === Object.keys(graph.nodes).length) {
+    return { kind: "ok", order };
+  }
+
+  // 4. Cycle: find a representative cycle by walking from any
+  //    still-positive in-degree node along edges, tracking the path.
+  return findCycle(graph, inDegree);
+}
+
+function insertSorted(
+  arr: InitVarKey[],
+  key: InitVarKey,
+  cmp: (a: InitVarKey, b: InitVarKey) => number,
+): void {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (cmp(arr[mid], key) <= 0) lo = mid + 1;
+    else hi = mid;
+  }
+  arr.splice(lo, 0, key);
+}
+
+/**
+ * Assign each module a numeric "import order" — lower numbers come
+ * earlier, mirroring a topological walk of the file-import DAG.
+ *
+ * Implementation: a Kahn pass over the reversed file-import graph
+ * (so leaves — modules that import nothing — get the smallest
+ * numbers). File-level cycles (allowed by design — the router pattern)
+ * are tolerated: any module left after the Kahn pass is assigned a
+ * depth equal to the longest path it could otherwise reach.
+ */
+function computeFileImportOrder(graph: InitDepGraph): Record<string, number> {
+  const all = new Set<string>();
+  for (const n of Object.values(graph.nodes)) all.add(n.moduleId);
+  for (const m of Object.keys(graph.fileImports)) all.add(m);
+  const modules = [...all];
+
+  // Build dep counts: for each module, how many of its imports are
+  // also tracked modules. (Skip imports outside `modules` — they're
+  // unreachable from the entry and shouldn't affect ordering.)
+  const inDeg: Record<string, number> = {};
+  const dependents: Record<string, string[]> = {};
+  for (const m of modules) {
+    inDeg[m] = 0;
+    dependents[m] = [];
+  }
+  for (const m of modules) {
+    const imports = graph.fileImports[m] ?? [];
+    for (const imp of imports) {
+      if (!(imp in inDeg)) continue;
+      dependents[imp].push(m);
+      inDeg[m]++;
+    }
+  }
+
+  const order: Record<string, number> = {};
+  let counter = 0;
+  const ready = modules.filter((m) => inDeg[m] === 0).sort();
+  while (ready.length > 0) {
+    const m = ready.shift()!;
+    order[m] = counter++;
+    for (const dep of dependents[m]) {
+      inDeg[dep]--;
+      if (inDeg[dep] === 0) insertSortedString(ready, dep);
+    }
+  }
+  // Anything left is inside a file-import cycle — assign them the
+  // tail of the ordering in lexicographic order so the tiebreak stays
+  // stable.
+  const leftover = modules.filter((m) => order[m] === undefined).sort();
+  for (const m of leftover) order[m] = counter++;
+  return order;
+}
+
+function insertSortedString(arr: string[], key: string): void {
+  let lo = 0;
+  let hi = arr.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >>> 1;
+    if (arr[mid] <= key) lo = mid + 1;
+    else hi = mid;
+  }
+  arr.splice(lo, 0, key);
+}
+
+/**
+ * Find any cycle in the dep graph (called only when topsort has
+ * confirmed one exists). Returns a CycleError naming the participating
+ * decls in order — first node depends on second, second on third, …,
+ * last on first.
+ */
+function findCycle(
+  graph: InitDepGraph,
+  inDegree: Record<InitVarKey, number>,
+): CycleError {
+  // Start from any node with nonzero remaining in-degree; walk one
+  // outgoing edge at a time until we revisit a node — that closes the
+  // cycle.
+  const start = Object.keys(inDegree).find((k) => inDegree[k] > 0);
+  if (!start) {
+    // Should not happen — caller only invokes this when there IS a cycle.
+    return { kind: "cycle", cycle: [] };
+  }
+  const path: InitVarKey[] = [];
+  const onPath: Record<InitVarKey, number> = {};
+  let cur = start;
+  for (let i = 0; i < Object.keys(graph.nodes).length + 1; i++) {
+    if (onPath[cur] !== undefined) {
+      // Cycle detected. Trim path back to the loop start.
+      const loop = path.slice(onPath[cur]);
+      return { kind: "cycle", cycle: loop.map((k) => graph.nodes[k]!) };
+    }
+    onPath[cur] = path.length;
+    path.push(cur);
+    // Follow the first dep that still has positive in-degree (a cycle
+    // edge), or just the first dep.
+    const deps = graph.edges[cur] ?? [];
+    const next = deps.find((d) => inDegree[d] > 0) ?? deps[0];
+    if (!next) break;
+    cur = next;
+  }
+  // Fallback (shouldn't reach here in well-formed graphs).
+  return { kind: "cycle", cycle: path.map((k) => graph.nodes[k]!) };
+}

--- a/packages/agency-lang/lib/runtime/index.ts
+++ b/packages/agency-lang/lib/runtime/index.ts
@@ -46,6 +46,12 @@ export {
 } from "./utils.js";
 
 export { __UNINIT_STATIC, __readStatic } from "./staticInit.js";
+export {
+  __registerStaticInit,
+  __registerGlobalsInit,
+  __awaitStaticInit,
+  __awaitGlobalsInit,
+} from "./initRegistry.js";
 
 export { functionRefReviver } from "./revivers/index.js";
 export { AgencyFunction, UNSET } from "./agencyFunction.js";

--- a/packages/agency-lang/lib/runtime/initPlanWorkedExamples.test.ts
+++ b/packages/agency-lang/lib/runtime/initPlanWorkedExamples.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import { compile, resetCompilationCache } from "../cli/commands.js";
+
+/**
+ * Worked-example integration tests for PR 2 ("per-variable topsort +
+ * centralized init"). Each `it()` writes a small multi-file Agency
+ * program under `.agency-tmp/init-worked-examples/` (gitignored),
+ * compiles it through the real CLI compile path (so the new
+ * `compileClosure` + topsort + cross-module await machinery is
+ * exercised end-to-end), imports the entry's compiled JS, runs the
+ * entry node, and asserts the observed runtime behavior.
+ *
+ * Cases map directly to the design doc's worked examples in
+ * `agent-init-design.md` — see each case's comment for the section
+ * reference. The shared `runFixture` helper keeps each case to a
+ * handful of lines: write files, compile, import, assert.
+ *
+ * Helper notes:
+ *   - Compile is in-process via `compile()` from `lib/cli/commands.ts`
+ *     so the test always sees the current source tree.
+ *   - JS files emit next to their `.agency` sources so the
+ *     `import "agency-lang/runtime"` in the generated output resolves
+ *     against the workspace's `node_modules`.
+ *   - Each test gets its own subdir to avoid cross-test contamination
+ *     of the module cache (Node caches ES-module imports by URL).
+ *   - `resetCompilationCache()` runs before each test to ensure the
+ *     closure is rebuilt with the new fixture.
+ */
+
+const FIXTURES_ROOT = path.resolve(
+  __dirname,
+  "../../.agency-tmp/init-worked-examples",
+);
+
+type CompileOutcome =
+  | { kind: "ok"; mod: any }
+  | { kind: "compileError"; message: string };
+
+let currentDir: string;
+
+beforeEach(() => {
+  fs.mkdirSync(FIXTURES_ROOT, { recursive: true });
+});
+
+afterEach(() => {
+  if (currentDir) {
+    fs.rmSync(currentDir, { recursive: true, force: true });
+  }
+});
+
+/**
+ * Write `files` to a fresh per-test subdir and compile starting from
+ * `entry`. Returns the imported entry module on success; for compile
+ * failures (parse errors, cycle errors, static-references-global)
+ * returns the captured stderr message and stops short of running.
+ *
+ * Implementation: the CLI compile path calls `process.exit(1)` on
+ * `CompileClosureError`, so to test the error case we wrap stderr +
+ * exit and rethrow as a thrown string. Vitest's spy machinery handles
+ * the stderr capture.
+ */
+async function runFixture(
+  testName: string,
+  files: Record<string, string>,
+  entryRel: string,
+): Promise<CompileOutcome> {
+  currentDir = path.join(FIXTURES_ROOT, testName);
+  fs.mkdirSync(currentDir, { recursive: true });
+  for (const [rel, body] of Object.entries(files)) {
+    const abs = path.join(currentDir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, body, "utf-8");
+  }
+  resetCompilationCache();
+
+  // Intercept the CLI's compile-error path so the test can observe it
+  // without the process actually exiting. compile() calls
+  // `console.error(msg); process.exit(1)` for `CompileClosureError`.
+  const errors: string[] = [];
+  const origError = console.error;
+  console.error = (msg: any) => errors.push(String(msg));
+  const origExit = process.exit;
+  let exited = false;
+  process.exit = ((code?: number) => {
+    exited = true;
+    throw new Error(`__processExit__ ${code}`);
+  }) as never;
+
+  const entryAbs = path.join(currentDir, entryRel);
+  try {
+    compile({}, entryAbs);
+  } catch (e) {
+    if ((e as Error).message.startsWith("__processExit__")) {
+      return { kind: "compileError", message: errors.join("\n") };
+    }
+    throw e;
+  } finally {
+    console.error = origError;
+    process.exit = origExit;
+  }
+  if (exited) {
+    return { kind: "compileError", message: errors.join("\n") };
+  }
+
+  const mainJs = entryAbs.replace(/\.agency$/, ".js");
+  const mod = await import(pathToFileURL(mainJs).href);
+  return { kind: "ok", mod };
+}
+
+describe("agent-init-design.md worked examples", () => {
+  it("Example 1: silent-undefined cross-module dep → prints 'hello!'", async () => {
+    const outcome = await runFixture(
+      "example1-silent-undefined",
+      {
+        "bar.agency": `export static const barStatic = "hello"\n`,
+        "main.agency":
+          `import { barStatic } from "./bar.agency"\n` +
+          `static const fooStatic = barStatic + "!"\n` +
+          `node main() { return fooStatic }\n`,
+      },
+      "main.agency",
+    );
+    if (outcome.kind !== "ok") throw new Error(outcome.message);
+    const result = await outcome.mod.main();
+    expect(result.data).toBe("hello!");
+  });
+
+  it("Example 2: indirect dep via function-call indirection works", async () => {
+    // fooStatic = getBarStatic() + "!" — no direct value edge on
+    // barStatic, but the file-import-depth tiebreaker in `sequenceHint`
+    // makes bar's static init come before foo's, AND the cross-module
+    // await on bar's module fires regardless because foo imports
+    // `getBarStatic` from bar (so the closure walker picks bar up and
+    // the per-module cascade kicks in).
+    const outcome = await runFixture(
+      "example2-fn-indirection",
+      {
+        "bar.agency":
+          `export static const barStatic = "hello"\n` +
+          `export def getBarStatic(): string { return barStatic }\n`,
+        "main.agency":
+          `import { getBarStatic } from "./bar.agency"\n` +
+          `static const fooStatic = getBarStatic() + "!"\n` +
+          `node main() { return fooStatic }\n`,
+      },
+      "main.agency",
+    );
+    if (outcome.kind !== "ok") throw new Error(outcome.message);
+    const result = await outcome.mod.main();
+    expect(result.data).toBe("hello!");
+  });
+
+  it("Example 5: direct static cycle → compile-time error naming both decls", async () => {
+    const outcome = await runFixture(
+      "example5-direct-cycle",
+      {
+        "foo.agency":
+          `import { barStatic } from "./bar.agency"\n` +
+          `export static const fooStatic = barStatic + "!"\n`,
+        "bar.agency":
+          `import { fooStatic } from "./foo.agency"\n` +
+          `export static const barStatic = fooStatic + "?"\n` +
+          `node main() { return barStatic }\n`,
+      },
+      "bar.agency",
+    );
+    expect(outcome.kind).toBe("compileError");
+    if (outcome.kind !== "compileError") return;
+    expect(outcome.message).toMatch(/Circular static dependency/);
+    expect(outcome.message).toMatch(/fooStatic/);
+    expect(outcome.message).toMatch(/barStatic/);
+  });
+
+  it("Example 7: const _ = sideEffect() runs in Phase B (every run)", async () => {
+    // No `static` prefix → globals graph → re-runs per invocation.
+    // We can't see "run count" without persistent state, but we can at
+    // least confirm the side effect runs (g gets set to "did it") and
+    // the node returns expected value.
+    const outcome = await runFixture(
+      "example7-const-underscore",
+      {
+        "main.agency":
+          `def doIt(): string { return "did it" }\n` +
+          `const _ = doIt()\n` +
+          `const g = "hello"\n` +
+          `node main() { return g }\n`,
+      },
+      "main.agency",
+    );
+    if (outcome.kind !== "ok") throw new Error(outcome.message);
+    const result = await outcome.mod.main();
+    expect(result.data).toBe("hello");
+  });
+
+  it("static referencing a global → compile-time error", async () => {
+    const outcome = await runFixture(
+      "static-references-global",
+      {
+        "main.agency":
+          `const g = "hello"\n` +
+          `static const s = g + "!"\n` +
+          `node main() { return s }\n`,
+      },
+      "main.agency",
+    );
+    expect(outcome.kind).toBe("compileError");
+    if (outcome.kind !== "compileError") return;
+    expect(outcome.message).toMatch(
+      /Static '?s'?.*references global '?g'?/,
+    );
+  });
+
+  it("global reading an imported static (cross-phase OK)", async () => {
+    const outcome = await runFixture(
+      "global-reads-static-cross-module",
+      {
+        "bar.agency": `export static const barStatic = "hello"\n`,
+        "main.agency":
+          `import { barStatic } from "./bar.agency"\n` +
+          `const g = barStatic + "!"\n` +
+          `node main() { return g }\n`,
+      },
+      "main.agency",
+    );
+    if (outcome.kind !== "ok") throw new Error(outcome.message);
+    const result = await outcome.mod.main();
+    expect(result.data).toBe("hello!");
+  });
+
+  it("re-export chain: foo reads thru a → b → c chain", async () => {
+    const outcome = await runFixture(
+      "reexport-chain",
+      {
+        "c.agency": `export static const x = "deep"\n`,
+        "b.agency": `export { x } from "./c.agency"\n`,
+        "a.agency": `export { x } from "./b.agency"\n`,
+        "main.agency":
+          `import { x } from "./a.agency"\n` +
+          `static const s = x + "!"\n` +
+          `node main() { return s }\n`,
+      },
+      "main.agency",
+    );
+    if (outcome.kind !== "ok") throw new Error(outcome.message);
+    const result = await outcome.mod.main();
+    expect(result.data).toBe("deep!");
+  });
+
+  it("multi-entry-point: imported module is a valid entry too", async () => {
+    // Compile starting from bar.agency (the imported module), not
+    // foo.agency. Centralized init is emitted in every compiled file
+    // so any module can be an entry — assert bar's own node works
+    // when bar is the entry.
+    const outcome = await runFixture(
+      "multi-entry-point",
+      {
+        "bar.agency":
+          `export static const barStatic = "hello"\n` +
+          `node main() { return barStatic }\n`,
+      },
+      "bar.agency",
+    );
+    if (outcome.kind !== "ok") throw new Error(outcome.message);
+    const result = await outcome.mod.main();
+    expect(result.data).toBe("hello");
+  });
+});

--- a/packages/agency-lang/lib/runtime/initRegistry.ts
+++ b/packages/agency-lang/lib/runtime/initRegistry.ts
@@ -1,0 +1,79 @@
+/**
+ * Process-global registry of per-module init functions, used by
+ * compiled Agency modules to coordinate cross-module initialization
+ * order across the import closure.
+ *
+ * Background: PR 2 ("per-variable topological sort + centralized init")
+ * computes at COMPILE time which modules' statics + globals must run
+ * before others. The codegen attaches that information to each
+ * compiled module: a list of source modules whose init must complete
+ * first. We need a place at RUNTIME to look those functions up by
+ * moduleId — that's this registry.
+ *
+ * Workflow per compiled module:
+ *   1. At module-load time (immediately after declaring
+ *      `__initializeStatic` / `__initializeGlobals`), the module calls
+ *      `__registerStaticInit(moduleId, fn)` /
+ *      `__registerGlobalsInit(moduleId, fn)`.
+ *   2. At agent-run time, before running its own body, a module's
+ *      init function calls `await __awaitStaticInit(depModuleId, ctx)`
+ *      for each module its topsort plan says it depends on.
+ *
+ * Cycle safety: ES module load order matches the file-import DAG, so
+ * by the time any init function runs (which only happens during agent
+ * execution), every module's registration has already happened.
+ * Compile-time topsort guarantees no var-level cycles inside the init
+ * graph, so the await chain always terminates.
+ *
+ * Resetting the registry between test cases is intentionally NOT
+ * supported here — modules are registered at JS-load time and JS-load
+ * happens once per process. Tests that need isolation between runs
+ * should use the existing checkpoint reset machinery instead.
+ */
+
+type InitFn = (ctx: unknown) => Promise<unknown>;
+
+const staticInits: Record<string, InitFn> = {};
+const globalsInits: Record<string, InitFn> = {};
+
+/**
+ * Register a module's `__initializeStatic` function under its absolute
+ * moduleId. Called by every compiled module on JS-load.
+ *
+ * Last-write-wins semantics for the test-fixture case where the same
+ * absolute path is loaded multiple times in a single process — the
+ * previous fn is replaced. Production users do not hit this because
+ * JS module caching ensures load-once.
+ */
+export function __registerStaticInit(moduleId: string, fn: InitFn): void {
+  staticInits[moduleId] = fn;
+}
+
+export function __registerGlobalsInit(moduleId: string, fn: InitFn): void {
+  globalsInits[moduleId] = fn;
+}
+
+/**
+ * Run another module's static init and await it. Returns immediately
+ * if the module hasn't registered yet (defensive: would only happen
+ * if the import graph is broken so the codegen never had a chance to
+ * register, in which case the PR-1 read-before-init trap fires as the
+ * safety net).
+ */
+export async function __awaitStaticInit(
+  moduleId: string,
+  ctx: unknown,
+): Promise<void> {
+  const fn = staticInits[moduleId];
+  if (!fn) return;
+  await fn(ctx);
+}
+
+export async function __awaitGlobalsInit(
+  moduleId: string,
+  ctx: unknown,
+): Promise<void> {
+  const fn = globalsInits[moduleId];
+  if (!fn) return;
+  await fn(ctx);
+}

--- a/packages/agency-lang/lib/runtime/staticInit.crossModule.test.ts
+++ b/packages/agency-lang/lib/runtime/staticInit.crossModule.test.ts
@@ -5,31 +5,30 @@ import * as path from "node:path";
 import { compile, resetCompilationCache } from "../cli/commands.js";
 
 /**
- * Cross-module read-before-init: compile a small two-file program where
- * foo.agency's static initializer reads `barStatic` imported from
- * bar.agency. Today (before PR 2's topological-sort fix) bar.agency's
- * `__initializeStatic` has not yet run when foo's body executes, so
- * `barStatic` holds the sentinel. The wrap installed by the codegen for
- * agency-imported reads in user expressions catches this and throws a
- * clear error naming the variable.
+ * Cross-module static dependency end-to-end: compile a small two-file
+ * program where foo.agency's static initializer reads `barStatic`
+ * imported from bar.agency.
  *
- * This test is the canonical PR 1 trap verifier — same-module reads
- * cannot trigger the trap because source order naturally orders
- * statics within a module.
+ *   - Before PR 2: bar.agency's `__initializeStatic` had not yet run
+ *     when foo's body executed, so `barStatic` held the read-before-init
+ *     sentinel and the PR-1 trap fired. The test was a canonical PR-1
+ *     verifier.
+ *   - After PR 2: `compileClosure` topsort + cross-module await prelude
+ *     make foo's init wait for bar's. `main()` now returns `"hello!"`.
+ *     The PR-1 trap remains as the safety net for indirect references
+ *     through function calls (Example 3 in `agent-init-design.md`),
+ *     but it should NOT fire for the direct dep this test exercises.
  *
  * Implementation notes:
- *   • We compile in-process (via `compile()` from `lib/cli/commands.ts`)
- *     rather than shelling out to a `dist/` binary, so the test always
- *     exercises the current source tree.
- *   • The compiled `.js` is written next to its `.agency` source so the
+ *   • Compile in-process via `compile()` from `lib/cli/commands.ts` so
+ *     the test always exercises the current source tree.
+ *   • The compiled `.js` is written next to its `.agency` source so
  *     generated `agency-lang/runtime` imports can resolve through the
- *     workspace's `node_modules`. The fixtures live under
- *     `.agency-tmp/static-cross-module-trap/` (gitignored as a
- *     dot-prefixed directory) and are cleaned up in `afterAll`.
- *   • We `import()` via `pathToFileURL(...).href` for Windows
- *     portability — bare filesystem paths fail on win32.
+ *     workspace's `node_modules`. Fixtures live under
+ *     `.agency-tmp/static-cross-module-trap/` (gitignored).
+ *   • `import()` via `pathToFileURL(...).href` for Windows portability.
  */
-describe("cross-module read-before-init throws friendly trap", () => {
+describe("cross-module static dep resolves correctly via PR-2 topsort", () => {
   const fixturesRoot = path.resolve(
     __dirname,
     "../../.agency-tmp/static-cross-module-trap",
@@ -61,17 +60,9 @@ describe("cross-module read-before-init throws friendly trap", () => {
     fs.rmSync(fixturesRoot, { recursive: true, force: true });
   });
 
-  it("throws an error naming the variable", async () => {
+  it("initializes bar.barStatic before foo.fooStatic and returns 'hello!'", async () => {
     const mod = await import(pathToFileURL(mainJs).href);
-    let caught: any = null;
-    try {
-      await mod.main();
-    } catch (e) {
-      caught = e;
-    }
-    expect(caught).not.toBeNull();
-    expect(caught.message).toMatch(
-      /Tried to read static `barStatic`.*before its initializer ran/i,
-    );
+    const result = await mod.main();
+    expect(result.data).toBe("hello!");
   });
 });

--- a/packages/agency-lang/lib/runtime/topsortCycleErrors.test.ts
+++ b/packages/agency-lang/lib/runtime/topsortCycleErrors.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { pathToFileURL } from "node:url";
+import { compile, resetCompilationCache } from "../cli/commands.js";
+
+/**
+ * Runs the cycle + runtime-trap fixtures under
+ * `tests/agency/topsort/cycles/`. The Agency test framework can't
+ * express "expected compile error" or "expected runtime trap with
+ * message X", so these cases live as bare `.agency` fixtures (no
+ * `.test.json`) and are exercised by this vitest test.
+ *
+ * Why the fixtures sit under `tests/agency/topsort/` instead of
+ * adjacent to this file: every PR-2 topsort behavior (success and
+ * failure) is then browsable from one directory tree. The success
+ * cases have `.test.json` files and run via `agency test`; this file
+ * covers the rest.
+ *
+ * Each fixture is one directory containing a multi-file Agency program.
+ * The fixture's `main.agency` (or, when none exists, an explicit entry
+ * name passed to the helper) is the entry point. The helper invokes
+ * the same CLI `compile()` path users hit when running `agency test`
+ * so the closure walker + per-module init plan + runtime registration
+ * are fully exercised end-to-end.
+ */
+
+const FIXTURES_ROOT = path.resolve(
+  __dirname,
+  "../../tests/agency/topsort/cycles",
+);
+
+type CompileOutcome =
+  | { kind: "ok"; mod: any }
+  | { kind: "compileError"; message: string };
+
+let lastOutputs: string[] = [];
+
+beforeEach(() => {
+  lastOutputs = [];
+});
+
+afterEach(() => {
+  // Remove the .js outputs the compile() pass dropped next to each
+  // fixture source so the next run starts clean. Stale outputs from a
+  // crashed run can mask real failures (the test framework imports
+  // them straight from disk).
+  for (const f of lastOutputs) {
+    try {
+      fs.unlinkSync(f);
+    } catch {
+      // best-effort
+    }
+  }
+});
+
+/**
+ * Compile `entry` via the real CLI compile path. Intercepts the
+ * `process.exit(1)` the CLI fires for `CompileClosureError` so the
+ * caller can assert on the captured stderr instead.
+ */
+async function runFixture(
+  fixtureDir: string,
+  entryRel: string,
+): Promise<CompileOutcome> {
+  const entryAbs = path.join(fixtureDir, entryRel);
+  resetCompilationCache();
+
+  const errors: string[] = [];
+  const origError = console.error;
+  console.error = (msg: any) => errors.push(String(msg));
+  const origExit = process.exit;
+  let exited = false;
+  process.exit = ((code?: number) => {
+    exited = true;
+    throw new Error(`__processExit__ ${code}`);
+  }) as never;
+
+  try {
+    compile({}, entryAbs);
+  } catch (e) {
+    if ((e as Error).message.startsWith("__processExit__")) {
+      return { kind: "compileError", message: errors.join("\n") };
+    }
+    throw e;
+  } finally {
+    console.error = origError;
+    process.exit = origExit;
+  }
+  if (exited) {
+    return { kind: "compileError", message: errors.join("\n") };
+  }
+
+  // Track the per-file .js outputs so afterEach can clean them up.
+  for (const entry of fs.readdirSync(fixtureDir)) {
+    if (entry.endsWith(".js")) {
+      lastOutputs.push(path.join(fixtureDir, entry));
+    }
+  }
+
+  const mainJs = entryAbs.replace(/\.agency$/, ".js");
+  const mod = await import(pathToFileURL(mainJs).href);
+  return { kind: "ok", mod };
+}
+
+describe("tests/agency/topsort/cycles fixtures", () => {
+  it("same-file cycle → compile error names both decls", async () => {
+    const outcome = await runFixture(
+      path.join(FIXTURES_ROOT, "same-file-cycle"),
+      "main.agency",
+    );
+    expect(outcome.kind).toBe("compileError");
+    if (outcome.kind !== "compileError") return;
+    expect(outcome.message).toMatch(/Circular static dependency/);
+    expect(outcome.message).toMatch(/\ba\b/);
+    expect(outcome.message).toMatch(/\bb\b/);
+  });
+
+  it("two-file cycle → compile error names both decls", async () => {
+    const outcome = await runFixture(
+      path.join(FIXTURES_ROOT, "two-file-cycle"),
+      "bar.agency",
+    );
+    expect(outcome.kind).toBe("compileError");
+    if (outcome.kind !== "compileError") return;
+    expect(outcome.message).toMatch(/Circular static dependency/);
+    expect(outcome.message).toMatch(/fooValue/);
+    expect(outcome.message).toMatch(/barValue/);
+  });
+
+  it("three-file triangle cycle → compile error names all three decls", async () => {
+    const outcome = await runFixture(
+      path.join(FIXTURES_ROOT, "three-file-cycle"),
+      "c.agency",
+    );
+    expect(outcome.kind).toBe("compileError");
+    if (outcome.kind !== "compileError") return;
+    expect(outcome.message).toMatch(/Circular static dependency/);
+    expect(outcome.message).toMatch(/\bx\b/);
+    expect(outcome.message).toMatch(/\by\b/);
+    expect(outcome.message).toMatch(/\bz\b/);
+  });
+
+  it("runtime trap: indirect static read fires PR-1 trap with source moduleId", async () => {
+    // This fixture compiles cleanly (the dep graph can't see edges
+    // through function bodies) but the trap fires at agent-run time
+    // when `a`'s initializer calls `readB()` and reads `b` before
+    // `b`'s init has run.
+    //
+    // `readB` is an AgencyFunction, so the trap thrown inside its
+    // Runner step is caught and converted to a `failure(...)` result.
+    // `a` then holds the failure; `node main() { return a }` surfaces
+    // it as `result.data.error` — that's where the trap message
+    // arrives in user-visible form.
+    const outcome = await runFixture(
+      path.join(FIXTURES_ROOT, "runtime-trap"),
+      "main.agency",
+    );
+    if (outcome.kind !== "ok") {
+      throw new Error(
+        `expected fixture to compile cleanly, got compile error:\n${outcome.message}`,
+      );
+    }
+    const result = await outcome.mod.main();
+    expect(result.data?.success).toBe(false);
+    expect(result.data?.error).toMatch(/Tried to read static `b`/);
+    expect(result.data?.error).toMatch(
+      /tests\/agency\/topsort\/cycles\/runtime-trap\/main\.agency/,
+    );
+  });
+});

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.mustache
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/imports.ts
@@ -23,6 +23,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,

--- a/packages/agency-lang/tests/agency/topsort/bare-stmt-order.agency
+++ b/packages/agency-lang/tests/agency/topsort/bare-stmt-order.agency
@@ -1,0 +1,15 @@
+// Bare top-level statements must stay interleaved at their source
+// position relative to named init statements. Without the interleave
+// fix in `reorderTagged`, the partition emits all named global
+// assignments first and then groups bare calls at the end, so `g`
+// snapshots `log` BEFORE `add("-a")` has run.
+//
+// Correct order:    log = "S", add("-a") → log = "S-a", g = "S-a",
+//                   add("-b") → log = "S-a-b". main → "S-a"
+// Bug order:        log = "S", g = "S", add("-a"), add("-b"). main → "S"
+let log = "S"
+def add(s: string) { log = log + s }
+add("-a")
+const g = log
+add("-b")
+node main() { return g }

--- a/packages/agency-lang/tests/agency/topsort/bare-stmt-order.test.json
+++ b/packages/agency-lang/tests/agency/topsort/bare-stmt-order.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Bare top-level statements interleave with named global init statements in source order.",
+      "expectedOutput": "\"S-a\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/topsort/cross-file-helper.agency
+++ b/packages/agency-lang/tests/agency/topsort/cross-file-helper.agency
@@ -1,0 +1,4 @@
+// Helper consumed by `cross-file-main.agency`. Exposes a single static
+// whose initializer is a literal — the simplest possible cross-module
+// dep target.
+export static const greeting = "hello"

--- a/packages/agency-lang/tests/agency/topsort/cross-file-main.agency
+++ b/packages/agency-lang/tests/agency/topsort/cross-file-main.agency
@@ -1,0 +1,12 @@
+// Cross-module dep: the local static `composed` reads an imported
+// static from `cross-file-helper.agency`. PR 2's compile-time closure
+// walk + per-module init plan guarantees `cross-file-helper`'s
+// `__initializeStatic` runs (and completes) before this module's runs,
+// even though both are independently registered modules.
+import { greeting } from "./cross-file-helper.agency"
+
+static const composed = greeting + " world"
+
+node main() {
+  return composed
+}

--- a/packages/agency-lang/tests/agency/topsort/cross-file-main.test.json
+++ b/packages/agency-lang/tests/agency/topsort/cross-file-main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Cross-module static dep resolves through the centralized init plan.",
+      "expectedOutput": "\"hello world\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/topsort/cycles/README.md
+++ b/packages/agency-lang/tests/agency/topsort/cycles/README.md
@@ -1,0 +1,15 @@
+# Cycle + runtime-trap fixtures
+
+Each subdirectory is a multi-file Agency program that should NOT compile
+or whose runtime should fire PR 1's read-before-init trap.
+
+The Agency test framework (`agency test`) has no "expected compile
+error" assertion, so these fixtures are exercised by the vitest test in
+[lib/runtime/topsortCycleErrors.test.ts](../../../lib/runtime/topsortCycleErrors.test.ts).
+That test runs each fixture's entry through `compileSource()` (compile
+errors) or compiles + runs it (runtime trap), and asserts on the
+emitted diagnostic.
+
+The fixtures live under `tests/agency/topsort/` instead of `lib/` so
+every PR-2 topsort behavior — success and failure — is browsable from
+one directory.

--- a/packages/agency-lang/tests/agency/topsort/cycles/runtime-trap/main.agency
+++ b/packages/agency-lang/tests/agency/topsort/cycles/runtime-trap/main.agency
@@ -1,0 +1,18 @@
+// Runtime read-before-init trap (PR 1) fires here. `a`'s initializer
+// calls `readB()` which reads `b`; the dep graph cannot see edges
+// through function bodies, so the compile-time topsort happily
+// schedules `a` before `b` based on source order, and at runtime `b`
+// is still `__UNINIT_STATIC` when `readB` accesses it.
+//
+// The vitest runner asserts the trap message names `b` and points at
+// this file (PR-1 + PR-2's resolver thread-through).
+static const a = readB()
+static const b = "b-value"
+
+def readB(): string {
+  return b
+}
+
+node main() {
+  return a
+}

--- a/packages/agency-lang/tests/agency/topsort/cycles/same-file-cycle/main.agency
+++ b/packages/agency-lang/tests/agency/topsort/cycles/same-file-cycle/main.agency
@@ -1,0 +1,9 @@
+// Single-file two-static cycle. Both initializers reference each other
+// directly, so the topsort has no valid order and emits a compile-time
+// "Circular static dependency" error naming both decls.
+static const a = b + "!"
+static const b = a + "?"
+
+node main() {
+  return a
+}

--- a/packages/agency-lang/tests/agency/topsort/cycles/three-file-cycle/a.agency
+++ b/packages/agency-lang/tests/agency/topsort/cycles/three-file-cycle/a.agency
@@ -1,0 +1,7 @@
+// Triangle cycle, file 1 of 3. `a.x` depends on `b.y`, `b.y` on `c.z`,
+// `c.z` on `a.x`. The cycle reporter walks the full triangle and names
+// all three decls in the diagnostic so the user can break the loop
+// without re-running with a different entry.
+import { y } from "./b.agency"
+
+export static const x = y + "!"

--- a/packages/agency-lang/tests/agency/topsort/cycles/three-file-cycle/b.agency
+++ b/packages/agency-lang/tests/agency/topsort/cycles/three-file-cycle/b.agency
@@ -1,0 +1,5 @@
+// Triangle cycle, file 2 of 3. Middle link: depends on `c.z`, named by
+// `a.agency`.
+import { z } from "./c.agency"
+
+export static const y = z + "?"

--- a/packages/agency-lang/tests/agency/topsort/cycles/three-file-cycle/c.agency
+++ b/packages/agency-lang/tests/agency/topsort/cycles/three-file-cycle/c.agency
@@ -1,0 +1,10 @@
+// Triangle cycle, file 3 of 3. Closes the loop by depending back on
+// `a.x`. Carries the `node main()` entry so the vitest runner can
+// compile a single file and exercise the cycle detector.
+import { x } from "./a.agency"
+
+export static const z = x + "."
+
+node main() {
+  return z
+}

--- a/packages/agency-lang/tests/agency/topsort/cycles/two-file-cycle/bar.agency
+++ b/packages/agency-lang/tests/agency/topsort/cycles/two-file-cycle/bar.agency
@@ -1,0 +1,10 @@
+// Other half of the two-file static cycle (see `foo.agency`). Carries
+// the `node main()` entry so the vitest runner can name a single file
+// to `compileSource`.
+import { fooValue } from "./foo.agency"
+
+export static const barValue = fooValue + "?"
+
+node main() {
+  return barValue
+}

--- a/packages/agency-lang/tests/agency/topsort/cycles/two-file-cycle/foo.agency
+++ b/packages/agency-lang/tests/agency/topsort/cycles/two-file-cycle/foo.agency
@@ -1,0 +1,7 @@
+// Two-file cycle: `foo.fooValue` depends on `bar.barValue`, which
+// depends back on `foo.fooValue`. Either file is a valid entry — the
+// dep graph spans the closure either way and produces the same cycle
+// diagnostic with both decls named.
+import { barValue } from "./bar.agency"
+
+export static const fooValue = barValue + "!"

--- a/packages/agency-lang/tests/agency/topsort/diamond-left.agency
+++ b/packages/agency-lang/tests/agency/topsort/diamond-left.agency
@@ -1,0 +1,6 @@
+// Left arm of the diamond. Depends on `prefix` from
+// `diamond-shared.agency`; computed value is consumed by
+// `diamond-main.agency`.
+import { prefix } from "./diamond-shared.agency"
+
+export static const leftValue = prefix + "L"

--- a/packages/agency-lang/tests/agency/topsort/diamond-main.agency
+++ b/packages/agency-lang/tests/agency/topsort/diamond-main.agency
@@ -1,0 +1,13 @@
+// Top of the diamond: imports from both arms, each of which depends on
+// the shared bottom node `diamond-shared.agency`. The interesting
+// property under test is that PR 2 produces a single canonical init
+// order across the whole closure so `prefix` runs once and both
+// `leftValue` / `rightValue` see the same value.
+import { leftValue } from "./diamond-left.agency"
+import { rightValue } from "./diamond-right.agency"
+
+static const combined = leftValue + rightValue
+
+node main() {
+  return combined
+}

--- a/packages/agency-lang/tests/agency/topsort/diamond-main.test.json
+++ b/packages/agency-lang/tests/agency/topsort/diamond-main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Diamond import: shared dep initializes once, both arms see the same value.",
+      "expectedOutput": "\"sharedLsharedR\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/topsort/diamond-right.agency
+++ b/packages/agency-lang/tests/agency/topsort/diamond-right.agency
@@ -1,0 +1,7 @@
+// Right arm of the diamond. Depends on `prefix` from
+// `diamond-shared.agency` (same source as `diamond-left.agency` —
+// the diamond shape). The shared dep must initialize exactly once
+// across both arms.
+import { prefix } from "./diamond-shared.agency"
+
+export static const rightValue = prefix + "R"

--- a/packages/agency-lang/tests/agency/topsort/diamond-shared.agency
+++ b/packages/agency-lang/tests/agency/topsort/diamond-shared.agency
@@ -1,0 +1,4 @@
+// Bottom of the diamond. Both `diamond-left.agency` and
+// `diamond-right.agency` import `prefix` from here; the topsort makes
+// `prefix` initialize once before either dependent runs.
+export static const prefix = "shared"

--- a/packages/agency-lang/tests/agency/topsort/global-reads-static-helper.agency
+++ b/packages/agency-lang/tests/agency/topsort/global-reads-static-helper.agency
@@ -1,0 +1,5 @@
+// Provides a single exported static that `global-reads-static-main`'s
+// non-static (Phase B) initializer consumes. This is the cross-phase
+// allowance: globals reading statics is OK because all statics are
+// fully initialized before any global init runs.
+export static const staticValue = "from-static"

--- a/packages/agency-lang/tests/agency/topsort/global-reads-static-main.agency
+++ b/packages/agency-lang/tests/agency/topsort/global-reads-static-main.agency
@@ -1,0 +1,13 @@
+// Cross-phase test: a non-static (Phase B / global) initializer reads
+// an imported static (Phase A). This is the allowed direction — and
+// the case where PR 2's `globalPhasePlanFor` needs to add the source
+// module's static init to the global plan's await prelude. Without
+// that fix the read would hit the PR-1 read-before-init trap on
+// `staticValue` from the helper module.
+import { staticValue } from "./global-reads-static-helper.agency"
+
+const composed = staticValue + "!"
+
+node main() {
+  return composed
+}

--- a/packages/agency-lang/tests/agency/topsort/global-reads-static-main.test.json
+++ b/packages/agency-lang/tests/agency/topsort/global-reads-static-main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Global initializer reads an imported static (cross-phase OK).",
+      "expectedOutput": "\"from-static!\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/topsort/reexport-deep.agency
+++ b/packages/agency-lang/tests/agency/topsort/reexport-deep.agency
@@ -1,0 +1,4 @@
+// Ultimate source of the re-export chain. `reexport-mid.agency`
+// re-exports from here; `reexport-top.agency` re-exports from there;
+// `reexport-main.agency` imports through the chain.
+export static const deepValue = "deep"

--- a/packages/agency-lang/tests/agency/topsort/reexport-main.agency
+++ b/packages/agency-lang/tests/agency/topsort/reexport-main.agency
@@ -1,0 +1,13 @@
+// Entry of the re-export chain test. The `import { deepValue }` is the
+// only direct import from `reexport-top.agency`; the full chain to
+// `reexport-deep.agency` is reached transitively via the closure
+// walker. `composed` consumes the chained value at the top-level
+// static layer so a missing cascade hop would surface as a
+// read-before-init trap rather than a quietly-wrong value.
+import { deepValue } from "./reexport-top.agency"
+
+static const composed = deepValue + "!"
+
+node main() {
+  return composed
+}

--- a/packages/agency-lang/tests/agency/topsort/reexport-main.test.json
+++ b/packages/agency-lang/tests/agency/topsort/reexport-main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Re-export chain (3 hops) initializes every wrapper static in order.",
+      "expectedOutput": "\"deep!\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/topsort/reexport-mid.agency
+++ b/packages/agency-lang/tests/agency/topsort/reexport-mid.agency
@@ -1,0 +1,5 @@
+// Middle hop: re-export of `deepValue` from `reexport-deep.agency`.
+// `resolveReExports` synthesizes a wrapper static here that the dep
+// graph treats as its own node — the cascade in PR 2 walks every
+// wrapper, not just the ultimate source.
+export { deepValue } from "./reexport-deep.agency"

--- a/packages/agency-lang/tests/agency/topsort/reexport-top.agency
+++ b/packages/agency-lang/tests/agency/topsort/reexport-top.agency
@@ -1,0 +1,6 @@
+// Top hop: re-export of `deepValue` from `reexport-mid.agency`. The
+// full chain is reexport-main → reexport-top → reexport-mid →
+// reexport-deep; PR 2 must walk every intermediate wrapper so the
+// `import { deepValue }` in `reexport-main.agency` binds to a
+// fully-initialized value.
+export { deepValue } from "./reexport-mid.agency"

--- a/packages/agency-lang/tests/agency/topsort/same-file-deps.agency
+++ b/packages/agency-lang/tests/agency/topsort/same-file-deps.agency
@@ -1,0 +1,11 @@
+// Two same-file statics where `dependent` consumes `base`. With PR 2's
+// per-variable topological sort, both are initialized once and in the
+// correct order. The node returns the composed value so the test
+// asserts both statics resolved without hitting the PR-1
+// read-before-init trap.
+static const base = "hello"
+static const dependent = base + "!"
+
+node main() {
+  return dependent
+}

--- a/packages/agency-lang/tests/agency/topsort/same-file-deps.test.json
+++ b/packages/agency-lang/tests/agency/topsort/same-file-deps.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Same-file statics: dependent reads base, both initialize cleanly.",
+      "expectedOutput": "\"hello!\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -157,7 +157,7 @@ __registerTool(callback);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/function-call-test.agency")
 }
-__registerGlobalsInit("/Users/adityabhargava/agency-lang/packages/agency-lang/.worktrees/agent-init-pr2-per-var-topsort/packages/agency-lang/tests/debugger/function-call-test.agency", __initializeGlobals);
+__registerGlobalsInit("tests/debugger/function-call-test.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -20,6 +20,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -156,6 +157,7 @@ __registerTool(callback);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/function-call-test.agency")
 }
+__registerGlobalsInit("/Users/adityabhargava/agency-lang/packages/agency-lang/.worktrees/agent-init-pr2-per-var-topsort/packages/agency-lang/tests/debugger/function-call-test.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -157,7 +157,7 @@ __registerTool(callback);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/if-else-test.agency")
 }
-__registerGlobalsInit("/Users/adityabhargava/agency-lang/packages/agency-lang/.worktrees/agent-init-pr2-per-var-topsort/packages/agency-lang/tests/debugger/if-else-test.agency", __initializeGlobals);
+__registerGlobalsInit("tests/debugger/if-else-test.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -20,6 +20,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -156,6 +157,7 @@ __registerTool(callback);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/if-else-test.agency")
 }
+__registerGlobalsInit("/Users/adityabhargava/agency-lang/packages/agency-lang/.worktrees/agent-init-pr2-per-var-topsort/packages/agency-lang/tests/debugger/if-else-test.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -157,7 +157,7 @@ __registerTool(callback);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/interrupt-test.agency")
 }
-__registerGlobalsInit("/Users/adityabhargava/agency-lang/packages/agency-lang/.worktrees/agent-init-pr2-per-var-topsort/packages/agency-lang/tests/debugger/interrupt-test.agency", __initializeGlobals);
+__registerGlobalsInit("tests/debugger/interrupt-test.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -20,6 +20,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -156,6 +157,7 @@ __registerTool(callback);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/interrupt-test.agency")
 }
+__registerGlobalsInit("/Users/adityabhargava/agency-lang/packages/agency-lang/.worktrees/agent-init-pr2-per-var-topsort/packages/agency-lang/tests/debugger/interrupt-test.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -20,6 +20,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -156,6 +157,7 @@ __registerTool(callback);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/loop-test.agency")
 }
+__registerGlobalsInit("/Users/adityabhargava/agency-lang/packages/agency-lang/.worktrees/agent-init-pr2-per-var-topsort/packages/agency-lang/tests/debugger/loop-test.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -157,7 +157,7 @@ __registerTool(callback);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/loop-test.agency")
 }
-__registerGlobalsInit("/Users/adityabhargava/agency-lang/packages/agency-lang/.worktrees/agent-init-pr2-per-var-topsort/packages/agency-lang/tests/debugger/loop-test.agency", __initializeGlobals);
+__registerGlobalsInit("tests/debugger/loop-test.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -157,7 +157,7 @@ __registerTool(callback);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/nested-calls-test.agency")
 }
-__registerGlobalsInit("/Users/adityabhargava/agency-lang/packages/agency-lang/.worktrees/agent-init-pr2-per-var-topsort/packages/agency-lang/tests/debugger/nested-calls-test.agency", __initializeGlobals);
+__registerGlobalsInit("tests/debugger/nested-calls-test.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -20,6 +20,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -156,6 +157,7 @@ __registerTool(callback);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/nested-calls-test.agency")
 }
+__registerGlobalsInit("/Users/adityabhargava/agency-lang/packages/agency-lang/.worktrees/agent-init-pr2-per-var-topsort/packages/agency-lang/tests/debugger/nested-calls-test.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -157,7 +157,7 @@ __registerTool(callback);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/step-test.agency")
 }
-__registerGlobalsInit("/Users/adityabhargava/agency-lang/packages/agency-lang/.worktrees/agent-init-pr2-per-var-topsort/packages/agency-lang/tests/debugger/step-test.agency", __initializeGlobals);
+__registerGlobalsInit("tests/debugger/step-test.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -20,6 +20,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -156,6 +157,7 @@ __registerTool(callback);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("tests/debugger/step-test.agency")
 }
+__registerGlobalsInit("/Users/adityabhargava/agency-lang/packages/agency-lang/.worktrees/agent-init-pr2-per-var-topsort/packages/agency-lang/tests/debugger/step-test.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("assignment.agency")
 }
+__registerGlobalsInit("assignment.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -19,6 +19,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -138,6 +139,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("safe-function.agency")
 }
+__registerGlobalsInit("safe-function.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("simple.agency")
 }
+__registerGlobalsInit("simple.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("array.agency")
 }
+__registerGlobalsInit("array.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -209,6 +210,7 @@ async function __initializeGlobals(__ctx) {
     args: [getRuntimeContext().ctx.globals.get("arrayAndObject.agency", "personName")]
   })
 }
+__registerGlobalsInit("arrayAndObject.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("assignment.agency")
 }
+__registerGlobalsInit("assignment.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("asyncAssigned.agency")
 }
+__registerGlobalsInit("asyncAssigned.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("asyncLlm.agency")
 }
+__registerGlobalsInit("asyncLlm.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("asyncUnassigned.agency")
 }
+__registerGlobalsInit("asyncUnassigned.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("bangParams.agency")
 }
+__registerGlobalsInit("bangParams.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("bangReturnType.agency")
 }
+__registerGlobalsInit("bangReturnType.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("bangValidation.agency")
 }
+__registerGlobalsInit("bangValidation.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("blockBasic.agency")
 }
+__registerGlobalsInit("blockBasic.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("blockParams.agency")
 }
+__registerGlobalsInit("blockParams.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("checkpoint-restore.agency")
 }
+__registerGlobalsInit("checkpoint-restore.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -139,6 +140,7 @@ async function __initializeGlobals(__ctx) {
   __ctx.globals.set("comments.agency", "x", 42)
   __ctx.globals.set("comments.agency", "y", `hello`)
 }
+__registerGlobalsInit("comments.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -145,6 +146,7 @@ async function __initializeGlobals(__ctx) {
     args: [`world`, `Hi`]
   })
 }
+__registerGlobalsInit("defaultValues.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -139,6 +140,7 @@ async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("docstrings.agency")
   __ctx.globals.set("docstrings.agency", "toolVersion", `2.0`)
 }
+__registerGlobalsInit("docstrings.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("euler-0001.agency")
 }
+__registerGlobalsInit("euler-0001.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("euler-0002.agency")
 }
+__registerGlobalsInit("euler-0002.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("euler-0003.agency")
 }
+__registerGlobalsInit("euler-0003.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("euler-0004.agency")
 }
+__registerGlobalsInit("euler-0004.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("euler-0005.agency")
 }
+__registerGlobalsInit("euler-0005.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("euler-0006.agency")
 }
+__registerGlobalsInit("euler-0006.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("euler-0007.agency")
 }
+__registerGlobalsInit("euler-0007.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("euler-0008.agency")
 }
+__registerGlobalsInit("euler-0008.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("euler-0009.agency")
 }
+__registerGlobalsInit("euler-0009.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("euler-0010.agency")
 }
+__registerGlobalsInit("euler-0010.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("forLoop.agency")
 }
+__registerGlobalsInit("forLoop.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("function-with-types.agency")
 }
+__registerGlobalsInit("function-with-types.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("function.agency")
 }
+__registerGlobalsInit("function.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("functionRef.agency")
 }
+__registerGlobalsInit("functionRef.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("genericAliasValidation.agency")
 }
+__registerGlobalsInit("genericAliasValidation.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("goto.agency")
 }
+__registerGlobalsInit("goto.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("gotoWithArgs.agency")
 }
+__registerGlobalsInit("gotoWithArgs.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("graph-node-with-types.agency")
 }
+__registerGlobalsInit("graph-node-with-types.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("ifElse.agency")
 }
+__registerGlobalsInit("ifElse.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -33,6 +33,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -154,6 +155,7 @@ __registerTool(foo);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("imports.agency")
 }
+__registerGlobalsInit("imports.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("inlineBlockBasic.agency")
 }
+__registerGlobalsInit("inlineBlockBasic.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("inlineBlockParams.agency")
 }
+__registerGlobalsInit("inlineBlockParams.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("input.agency")
 }
+__registerGlobalsInit("input.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("interpolation.agency")
 }
+__registerGlobalsInit("interpolation.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("interrupt-2-deep-in-function.agency")
 }
+__registerGlobalsInit("interrupt-2-deep-in-function.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("interrupt-assignment.agency")
 }
+__registerGlobalsInit("interrupt-assignment.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("interrupt-in-node.agency")
 }
+__registerGlobalsInit("interrupt-in-node.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -140,6 +141,7 @@ async function __initializeGlobals(__ctx) {
     "model": `gemini-2.5-flash-lite`
   })
 }
+__registerGlobalsInit("llmConfigParam.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("matchBlock.agency")
 }
+__registerGlobalsInit("matchBlock.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -138,6 +139,7 @@ async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("multiLineComment.agency")
   __ctx.globals.set("multiLineComment.agency", "x", 42)
 }
+__registerGlobalsInit("multiLineComment.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("multipleNodes.agency")
 }
+__registerGlobalsInit("multipleNodes.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -152,6 +153,7 @@ async function __initializeGlobals(__ctx) {
     }
   })
 }
+__registerGlobalsInit("namedArgs.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("namedArgsReorder.agency")
 }
+__registerGlobalsInit("namedArgsReorder.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("noResponseFormat.agency")
 }
+__registerGlobalsInit("noResponseFormat.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("objectDescription.agency")
 }
+__registerGlobalsInit("objectDescription.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -145,6 +146,7 @@ async function __initializeGlobals(__ctx) {
     args: [`world`, `Hi`]
   })
 }
+__registerGlobalsInit("optionalParams.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("pipe-operator.agency")
 }
+__registerGlobalsInit("pipe-operator.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("recordIndex.agency")
 }
+__registerGlobalsInit("recordIndex.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("result-basic.agency")
 }
+__registerGlobalsInit("result-basic.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("result-guards.agency")
 }
+__registerGlobalsInit("result-guards.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("returnValue.agency")
 }
+__registerGlobalsInit("returnValue.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("rewindCheckpoint.agency")
 }
+__registerGlobalsInit("rewindCheckpoint.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -19,6 +19,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -138,6 +139,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("safe.agency")
 }
+__registerGlobalsInit("safe.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("schemaAccess.agency")
 }
+__registerGlobalsInit("schemaAccess.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("schemaParamInjection.agency")
 }
+__registerGlobalsInit("schemaParamInjection.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -19,6 +19,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -143,6 +144,7 @@ async function __initializeGlobals(__ctx) {
   }))
   await setLLMClient(getRuntimeContext().ctx.globals.get("setLLMClient.agency", "client"))
 }
+__registerGlobalsInit("setLLMClient.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("simple.agency")
 }
+__registerGlobalsInit("simple.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("skill.agency")
 }
+__registerGlobalsInit("skill.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("slice.agency")
 }
+__registerGlobalsInit("slice.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("sliceAssign.agency")
 }
+__registerGlobalsInit("sliceAssign.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("sourceMap.agency")
 }
+__registerGlobalsInit("sourceMap.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -155,6 +156,7 @@ async function __initializeGlobals(__ctx) {
     "c": 3
   })
 }
+__registerGlobalsInit("splat.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -151,11 +152,13 @@ function __getStaticVars() {
   };
 }
 __globalCtx.getStaticVars = __getStaticVars;
+__registerStaticInit("static.agency", __initializeStatic);
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("static.agency")
   await __initializeStatic(__ctx)
   await __ctx.writeStaticStateToTrace(__globalCtx.getStaticVars())
 }
+__registerGlobalsInit("static.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("streaming.agency")
 }
+__registerGlobalsInit("streaming.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("string-interpolation.agency")
 }
+__registerGlobalsInit("string-interpolation.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("stringConcat.agency")
 }
+__registerGlobalsInit("stringConcat.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("threadsAndSubthreads.agency")
 }
+__registerGlobalsInit("threadsAndSubthreads.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("typeHints.agency")
 }
+__registerGlobalsInit("typeHints.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("exportedTypeAlias.agency")
 }
+__registerGlobalsInit("exportedTypeAlias.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("literal.agency")
 }
+__registerGlobalsInit("literal.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("nestedTypeAlias.agency")
 }
+__registerGlobalsInit("nestedTypeAlias.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("typeAlias.agency")
 }
+__registerGlobalsInit("typeAlias.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("unitLiterals.agency")
 }
+__registerGlobalsInit("unitLiterals.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("valueAccessInterpolation.agency")
 }
+__registerGlobalsInit("valueAccessInterpolation.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("varTypes.agency")
 }
+__registerGlobalsInit("varTypes.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -141,6 +142,7 @@ async function __initializeGlobals(__ctx) {
     args: [`INFO`, `hello`, `world`]
   })
 }
+__registerGlobalsInit("variadic.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("withModifier.agency")
 }
+__registerGlobalsInit("withModifier.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -18,6 +18,7 @@ import {
   deepClone as __deepClone,
   deepFreeze as __deepFreeze,
   __UNINIT_STATIC, __readStatic,
+  __registerStaticInit, __registerGlobalsInit, __awaitStaticInit, __awaitGlobalsInit,
   head, tail, empty,
   success, failure, isSuccess, isFailure, __pipeBind, __tryCall, __catchResult,
   Schema, __validateType, __validateChain, __validateChainRecursive,
@@ -137,6 +138,7 @@ function registerTools(tools: any[]) {
 async function __initializeGlobals(__ctx) {
   __ctx.globals.markInitialized("withParam.agency")
 }
+__registerGlobalsInit("withParam.agency", __initializeGlobals);
 async function __registerTopLevelCallbacks(__ctx) {
   __ctx.topLevelCallbacks = [];
 }


### PR DESCRIPTION
## PR 2 of 6 — Per-variable topological sort + centralized init

Implements the second PR from [agent-init-design.md](../blob/main/packages/agency-lang/agent-init-design.md), following the plan in [docs/superpowers/plans/2026-05-31-agent-init-pr2-per-var-topsort.md](../blob/agent-init-pr2-per-var-topsort/packages/agency-lang/docs/superpowers/plans/2026-05-31-agent-init-pr2-per-var-topsort.md).

Built on top of PR 1's runtime read-before-init trap.

### What changes

Replaces per-module lazy `__initializeStatic` / `__initializeGlobals` with a centralized, topologically-sorted init across the full import closure. The walk now happens at the entry point (`compileClosure`), once, with two independent per-variable dep graphs:

- **Phase A — static graph**, run once per process, ordered by topsort.
- **Phase B — global graph**, run on every invocation, ordered by topsort.

Both graphs share an `ImportAliasResolver` that also feeds PR 1's `__readStatic` trap message with the real source `moduleId`.

Cycles in either graph become compile-time errors that name the offending decls + their source locations. A `static` initializer that references a `global` is a separate compile-time error since the global doesn't yet exist at Phase A time.

### Key pieces

- `lib/compiler/initDepGraph.ts` — two-phase per-variable dep graph builder. Uses `walkNodes` + `SymbolTable.resolveImport`; closure walking is owned by the caller. One-hop alias resolution so re-export wrappers naturally cascade.
- `lib/compiler/topSortInitGraph.ts` — Kahn topsort keyed on each node's precomputed `sequenceHint` (file-import depth × 1e6 + source line). Cycle errors report a full traced loop.
- `lib/compiler/compileClosure.ts` — single owner of multi-file compilation. Parses every reachable file once via BFS, runs `resolveReExports` on each, builds both graphs + plans, and exposes the resolver for downstream codegen.
- `lib/backends/typescriptBuilder/sectionAssembler.ts` — emits the `__awaitStaticInit(...)` / `__awaitGlobalsInit(...)` prelude based on the per-module plan.
- `lib/backends/typescriptBuilder.ts` — threads the resolver into `__readStatic` so trap messages show the real source module instead of `<unknown>`.
- `lib/runtime/initRegistry.ts` — process-global registry of per-module init functions. Modules register on JS-load; closure-derived awaits look them up at agent-run time.
- `lib/runtime/initPlanWorkedExamples.test.ts` — end-to-end integration tests covering the eight worked examples from the design doc plus re-export chains and multi-entry-point.

### Notable subtleties

- **Global → static cross-phase reads.** Statics are fully initialized before any global runs, but the global graph drops static refs as edges (cycle detection lives per-phase). `globalPhasePlanFor` walks each local global's free identifiers and adds modules of any cross-module statics it reads to the plan's `awaitModules` — without this a `const g = importedStatic` pattern hit the PR-1 trap.
- **Re-export chains.** `resolveReExports` synthesizes wrapper statics in each intermediate re-exporter that need their own `__initializeStatic`. Running `resolveReExports` inside `parseClosure` puts the wrappers in front of the dep graph; one-hop resolution then lets the topsort cascade through the entire chain (a → b → c) automatically.
- **Closure walking and `resolveReExports` order.** The walker needs the raw `exportFromStatement` nodes that `resolveReExports` strips, so the BFS runs over raw parse output, and the expand-with-wrappers pass runs once the closure is fully discovered.

### Tests

- 4748 / 4749 `lib/` tests pass. The remaining failure is the pre-existing `stdlib: 'ui'` typecheck called out as out of scope in the plan.
- New tests: 8 worked-example integration cases, re-export chain end-to-end, compileClosure cycle / static-references-global / re-export plan tests, dep graph re-export cascade test, topsort 50-module perf smoke (< 100ms).

### What's next

- PR 3: `static` keyword for bare top-level statements.
- PR 4: compile-time validations on what's allowed inside static initializers.
- PR 5: `agency explain-init` CLI.
- PR 6: out-of-scope cleanup items collected during PR 2 review.
