### PR TITLE
PR 2.5: depth-1 function-body analysis for init dep edges

### DIFF
--- a/packages/agency-lang/docs/dev/init-topsort.md
+++ b/packages/agency-lang/docs/dev/init-topsort.md
@@ -100,10 +100,55 @@ references**. The edge set is derived by walking the initializer
 expression for free identifiers and resolving each one through the
 shared `ImportAliasResolver`.
 
-**Functions are never edges.** Only values participate. A static
-initializer that calls a function defined elsewhere produces no edge
-to that function's locals; the runtime trap (PR 1) is the safety
-net for unset statics read indirectly.
+**Functions are never edges themselves.** Only values are nodes in
+the graph. A bare reference to a function name never produces an
+edge to a function node — function defs aren't tracked.
+
+### Depth-1 function-body expansion
+
+When a free identifier in an init expression is a **direct call** of
+a top-level Agency function — bare (`getBar()`) or namespace-prefixed
+(`bar.getBar()`) — the dep graph walks that function's body once and
+treats every top-level value the body reads as an additional
+dependency of the enclosing init node. Inner references are resolved
+in the function's home module, not the caller's, so an import the
+function depends on contributes the correct cross-module edge.
+
+The boundary is exactly one function-body hop:
+
+  - Depth-2+ chains are not followed. The runtime trap (PR 1) is the
+    safety net.
+  - Function values stored in variables aren't traced. `const f =
+    getBar; const foo = f()` produces no expansion, because the call
+    site doesn't directly name `getBar`.
+  - Method calls on user objects (`obj.method()`) and stdlib/built-in
+    functions are silently skipped — we have no Agency AST to walk.
+
+`collectFreeIdentifiers` already skips identifiers inside nested
+`function` / `graphNode` bodies via the ancestor stack, so when we
+walk a function body for depth-1 expansion the walker naturally stops
+at any further nested closures. That gives us the depth-1 boundary
+for free — no additional bookkeeping required.
+
+The new piece in the source is the `FunctionDefLookup`
+(`lib/compiler/initDepGraph.ts`), which resolves bare or
+namespace-prefixed call names to the `(moduleId, FunctionDefinition)`
+pair that backs them. `collectDirectCalls` walks an init expression
+for call sites and consults the lookup; the body walk reuses
+`collectFreeIdentifiers` via `collectFunctionBodyFreeRefs`.
+
+The depth-1 expansion runs in three places, all in lockstep:
+
+  - `depsFor` — adds edges to both static and global graphs.
+  - `rejectStaticReferencesGlobal` — surfaces the cross-phase
+    violation when a single hop reveals a static reading a global.
+  - `globalPhasePlanFor` — augments the cross-phase `awaitModules`
+    set so a global reading a cross-module static through one
+    function call still emits the right `await __awaitStaticInit`.
+
+Conditional reads inside the called function are treated as
+always-reads — a safe over-approximation that may add a small number
+of extra `await`s but cannot change correctness.
 
 ### Cross-phase rules
 
@@ -369,10 +414,11 @@ match production behavior.
 
 ## Read-before-init trap (PR 1) — the safety net
 
-The dep graph orders **values**, not **callable code**. A
-static initializer that calls a function which transitively reads
-another static produces no edge in the graph, because function
-bodies don't execute during outer-initializer evaluation.
+The dep graph orders **values**, not **callable code**. With
+depth-1 function-body expansion (PR 2.5), one-hop function calls
+do contribute edges, but anything beyond that boundary — depth-2+
+call chains, function values stored in variables, methods on user
+objects, stdlib functions — produces no edge in the graph.
 
 The runtime read-before-init trap (`__readStatic`, PR 1) catches
 this case. Every static read in generated code is wrapped in
@@ -381,7 +427,8 @@ the `__UNINIT_STATIC` sentinel, the trap throws with a helpful
 message pointing at the source module of the unset static. The
 test suite exercises this in
 `lib/runtime/topsortCycleErrors.test.ts` (the `runtime-trap`
-fixture).
+fixture, deliberately written with a two-hop chain so depth-1
+analysis can't see it).
 
 ## Multi-entry compile cache
 
@@ -427,7 +474,7 @@ strips comments).
 
 | File | Purpose |
 | --- | --- |
-| `lib/compiler/initDepGraph.ts` | Build per-variable graphs from parsed programs. `FreeRef` + `ImportAliasResolver`. |
+| `lib/compiler/initDepGraph.ts` | Build per-variable graphs from parsed programs. `FreeRef` + `ImportAliasResolver` + `FunctionDefLookup` (depth-1 expansion). |
 | `lib/compiler/topSortInitGraph.ts` | Kahn's + cycle tracing. One ordering key (`sequenceHint`). |
 | `lib/compiler/compileClosure.ts` | One-stop entry: parse closure → graphs → topsort → per-module `ModuleInitPlan`. |
 | `lib/backends/typescriptGenerator.ts` | Projects `CompiledClosure` to `InitPlanForModule` for one file. |

--- a/packages/agency-lang/docs/site/guide/imports-and-packages.md
+++ b/packages/agency-lang/docs/site/guide/imports-and-packages.md
@@ -120,3 +120,41 @@ export { safe search, fetch } from "std::wikipedia"
 Re-exports work for functions, nodes, types, and `static const` constants. Classes cannot be re-exported.
 
 When two re-exports would produce the same local name (for example, two `export *` statements that both export `foo`, or a `*` and a named export of the same symbol), you must disambiguate explicitly with `as` — there is no implicit precedence.
+
+## Initializer dependencies through function calls
+
+When you write a top-level `static const` or `const`/`let` whose initializer references another top-level value from a different module, the compiler builds a dependency graph and arranges for the imported module's initialization to complete before yours runs. For direct references this is obvious:
+
+```
+// bar.agency
+export static const barStatic = "hello"
+
+// foo.agency
+import { barStatic } from "./bar.agency"
+static const fooStatic = barStatic + "!"  // bar's init runs first
+```
+
+The compiler also looks **one function deep** when discovering these dependencies. If your initializer calls a single function, the compiler walks that function's body once and treats any top-level value it reads as a dependency of your initializer:
+
+```
+// bar.agency
+export static const barStatic = "hello"
+export def getBar(): string { return barStatic }
+
+// foo.agency
+import { getBar } from "./bar.agency"
+static const fooStatic = getBar() + "!"  // bar.barStatic counts as a dep
+```
+
+This catches the common case where you have a small wrapper function reading a value. The boundary stops at exactly one function-body hop. The following are **not** detected by static analysis:
+
+- **Depth-2+ chains.** `getBar` calls `_helper` which reads `barStatic` — the compiler sees `getBar`'s body but does not follow `_helper`.
+- **Function values stored in variables.** `const f = pickHelper(); const foo = f()` — the compiler cannot tell which function `f` ends up pointing at.
+- **Method calls on user objects.** `obj.method()` — the compiler does not introspect class methods.
+- **Built-in / stdlib functions.** Their bodies aren't Agency code, so the compiler treats them as opaque. Assume they don't read your top-level state.
+
+Conditional reads inside a called function are treated as always-reads. That's a safe over-approximation: in the worst case you get a small amount of extra `await` work during initialization that doesn't affect correctness.
+
+If your code goes past these limits, the runtime **read-before-init trap** is the safety net. It fires with a clear error message naming the top-level value that was read too early and the module it came from. The recommended fix is to restructure so the read happens inside a `node` or `def` that runs after initialization, not at the top level of another initializer.
+
+For background on how static and global init are scheduled, see [Agency's execution model](/guide/execution-model).

--- a/packages/agency-lang/lib/compiler/compileClosure.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.ts
@@ -25,8 +25,11 @@ import { SymbolTable } from "../symbolTable.js";
 import { resolveReExports } from "../preprocessors/resolveReExports.js";
 import {
   buildInitDepGraphs,
+  collectDirectCalls,
   collectFreeIdentifiers,
+  collectFunctionBodyFreeRefs,
   makeKey,
+  type FunctionDefLookup,
   type ImportAliasResolver,
   type InitDepGraph,
   type InitVarNode,
@@ -112,11 +115,13 @@ export function buildCompiledClosure(
   let staticGraph: InitDepGraph;
   let globalGraph: InitDepGraph;
   let resolver: ImportAliasResolver;
+  let functionDefs: FunctionDefLookup;
   try {
     const r = buildInitDepGraphs(programs, symbolTable, entryModuleId);
     staticGraph = r.staticGraph;
     globalGraph = r.globalGraph;
     resolver = r.resolver;
+    functionDefs = r.functionDefs;
   } catch (e) {
     // Re-throw analysis-time validation errors (currently only
     // `StaticReferencesGlobalError`) under the closure-error banner so
@@ -158,6 +163,7 @@ export function buildCompiledClosure(
     globalGraph,
     globalOrder,
     resolver,
+    functionDefs,
   );
 
   return {
@@ -408,6 +414,7 @@ function buildPlans(
   globalGraph: InitDepGraph,
   globalOrder: string[],
   resolver: ImportAliasResolver,
+  functionDefs: FunctionDefLookup,
 ): Record<string, ModuleInitPlan> {
   const plans: Record<string, ModuleInitPlan> = {};
   for (const moduleId of moduleIds) {
@@ -420,6 +427,7 @@ function buildPlans(
         globalOrder,
         staticGraph,
         resolver,
+        functionDefs,
       ),
     };
   }
@@ -481,30 +489,60 @@ function globalPhasePlanFor(
   globalOrder: string[],
   staticGraph: InitDepGraph,
   resolver: ImportAliasResolver,
+  functionDefs: FunctionDefLookup,
 ): ModuleInitPhasePlan {
   const base = phasePlanFor(moduleId, globalGraph, globalOrder);
   const awaitModulesSet: Record<string, true> = {};
   for (const m of base.awaitModules) awaitModulesSet[m] = true;
 
+  // Same per-ref scan as before, but with PR-2.5 depth-1 expansion:
+  // when a free ref names a top-level Agency function, walk that
+  // function's body once and resolve its inner refs in the function's
+  // home module. Any cross-module static the function reads through a
+  // single hop contributes an await here.
+  const recordStatic = (refKey: string): void => {
+    const staticNode = staticGraph.nodes[refKey];
+    if (!staticNode || staticNode.moduleId === moduleId) return;
+    awaitModulesSet[staticNode.moduleId] = true;
+  };
+  const resolveAndRecord = (
+    ref: { kind: "name"; name: string } | { kind: "member"; prefix: string; member: string },
+    inModuleId: string,
+  ): void => {
+    if (ref.kind === "name") {
+      const aliased = resolver.resolve(ref.name, inModuleId);
+      recordStatic(
+        aliased
+          ? makeKey(aliased.sourceModuleId, aliased.sourceName)
+          : makeKey(inModuleId, ref.name),
+      );
+      return;
+    }
+    const ns = resolver.resolveNamespace(ref.prefix, inModuleId);
+    if (!ns) return;
+    recordStatic(makeKey(ns.sourceModuleId, ref.member));
+  };
+
   for (const key of Object.keys(globalGraph.nodes)) {
     const node = globalGraph.nodes[key];
     if (!node || node.moduleId !== moduleId) continue;
     for (const ref of collectFreeIdentifiers(node.initExpr)) {
-      let refKey: string;
-      if (ref.kind === "name") {
-        if (ref.name === node.varName) continue;
-        const aliased = resolver.resolve(ref.name, moduleId);
-        refKey = aliased
-          ? makeKey(aliased.sourceModuleId, aliased.sourceName)
-          : makeKey(moduleId, ref.name);
-      } else {
-        const ns = resolver.resolveNamespace(ref.prefix, moduleId);
-        if (!ns) continue;
-        refKey = makeKey(ns.sourceModuleId, ref.member);
+      if (ref.kind === "name" && ref.name === node.varName) continue;
+      resolveAndRecord(ref, moduleId);
+    }
+    // Depth-1: each direct call (bare or namespace) in this global's
+    // initializer contributes the body's free refs, resolved in the
+    // callee's home module. Mirrors `depsFor`'s expansion so a global
+    // that reads a cross-module static through one function hop still
+    // awaits the source module's static init.
+    for (const fnMatch of collectDirectCalls(
+      node.initExpr,
+      moduleId,
+      functionDefs,
+    )) {
+      for (const innerRef of collectFunctionBodyFreeRefs(fnMatch.def)) {
+        resolveAndRecord(innerRef, fnMatch.moduleId);
       }
-      const staticNode = staticGraph.nodes[refKey];
-      if (!staticNode || staticNode.moduleId === moduleId) continue;
-      awaitModulesSet[staticNode.moduleId] = true;
     }
   }
 

--- a/packages/agency-lang/lib/compiler/initDepGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.test.ts
@@ -537,12 +537,17 @@ describe("buildInitDepGraphs", () => {
     // through `getBarGlobal`'s body). Post-PR-2.5
     // `rejectStaticReferencesGlobal` runs the same depth-1 walk and
     // catches it at compile time.
+    //
+    // `barGlobal` is intentionally unexported: only `static const`
+    // declarations can be exported in Agency. The function that reads
+    // it is exported instead, which is the realistic pattern users
+    // hit and the one this rule needs to catch.
     const { dir, programs, symbolTable, abs } = writeFixture({
       "foo.agency":
         `import { getBarGlobal } from "./bar.agency"\n` +
         `static const fooStatic = getBarGlobal() + "!"\n`,
       "bar.agency":
-        `export const barGlobal = "G"\n` +
+        `const barGlobal = "G"\n` +
         `export def getBarGlobal(): string { return barGlobal }\n`,
     });
     try {
@@ -688,6 +693,87 @@ describe("buildInitDepGraphs", () => {
       const k = (n: string) => makeKey(abs("entry.agency"), n);
       expect(staticGraph.edges[k("derived")]).toContain(k("base"));
       expect(staticGraph.edges[k("derived")]).toContain(k("items"));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("depth-1: re-exported function expansion still finds the source-module dep", () => {
+    // The function `getBar` is re-exported once. Pre-fix, the depth-1
+    // lookup stopped at the re-exporter's synthesized wrapper
+    // (`return _reexport_getBar(...)`), whose body the free-ref walker
+    // can't see through — so no edge was added and the runtime trap
+    // would be the only safety net even though it's a single direct
+    // call in user source. The fix follows the SymbolTable's
+    // `reExportedFrom` chain to the ultimate `def` and walks that
+    // real body, contributing the cross-module edge to the source
+    // module's static.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "foo.agency":
+        `import { getBar } from "./mid.agency"\n` +
+        `static const fooStatic = getBar() + "!"\n` +
+        `node main() { return fooStatic }\n`,
+      "mid.agency": `export { getBar } from "./bar.agency"\n`,
+      "bar.agency":
+        `export static const barStatic = "hello"\n` +
+        `export def getBar(): string { return barStatic }\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("foo.agency"),
+      );
+      const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
+      const keyBar = makeKey(abs("bar.agency"), "barStatic");
+      expect(staticGraph.edges[keyFoo]).toContain(keyBar);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("depth-1: parameter that shadows a top-level decl does NOT create a spurious edge", () => {
+    // `readArg`'s body reads its own parameter `barStatic`, NOT the
+    // top-level static of the same name. Without parameter-shadow
+    // filtering in `collectFunctionBodyFreeRefs`, the inner ref would
+    // resolve to the top-level binding and add a phantom edge from
+    // `derived` to `barStatic` — which happens to be benign here
+    // (barStatic IS a static), but the same bug surfaces as a false
+    // `StaticReferencesGlobalError` if the shadowed name is a global.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `static const barStatic = "real"\n` +
+        `def readArg(barStatic: string): string { return barStatic }\n` +
+        `static const derived = readArg("arg") + "!"\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      const k = (n: string) => makeKey(abs("entry.agency"), n);
+      expect(staticGraph.edges[k("derived")]).toEqual([]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("depth-1: parameter shadowing a global does NOT cause a false static-references-global error", () => {
+    // The dangerous case: a function parameter shadows a top-level
+    // GLOBAL. Without filtering, walking the function body would
+    // resolve `g` to the top-level global and `rejectStaticReferencesGlobal`
+    // would throw, even though the body only reads the parameter.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `const g = "global"\n` +
+        `def readG(g: string): string { return g }\n` +
+        `static const s = readG("arg") + "!"\n`,
+    });
+    try {
+      expect(() =>
+        buildInitDepGraphs(programs, symbolTable, abs("entry.agency")),
+      ).not.toThrow();
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/agency-lang/lib/compiler/initDepGraph.test.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.test.ts
@@ -222,7 +222,14 @@ describe("buildInitDepGraphs", () => {
     }
   });
 
-  it("does NOT add an edge for a referenced function name (only values)", () => {
+  it("the function name itself is not an edge target (only values are)", () => {
+    // The bare reference to the function name `getBarStatic` does not
+    // become an edge to a function node — function defs aren't tracked
+    // as init-var nodes. PR-2.5 depth-1 expansion DOES add an edge to
+    // any top-level value the function's body reads (covered by the
+    // "depth-1: cross-module static read through a named-import
+    // function" test below); here we just confirm that the function
+    // node itself never appears in the graph.
     const { dir, programs, symbolTable, abs } = writeFixture({
       "foo.agency":
         `import { getBarStatic } from "./bar.agency"\n` +
@@ -240,7 +247,10 @@ describe("buildInitDepGraphs", () => {
       );
       const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
       const keyBar = makeKey(abs("bar.agency"), "barStatic");
-      expect(staticGraph.edges[keyFoo]).toEqual([]);
+      const keyGetBar = makeKey(abs("bar.agency"), "getBarStatic");
+      expect(staticGraph.nodes[keyGetBar]).toBeUndefined();
+      // Depth-1 expansion still finds the static read through the call.
+      expect(staticGraph.edges[keyFoo]).toEqual([keyBar]);
       // sequenceHint reflects the file-import-depth tiebreaker so
       // example-2 still initializes bar before foo.
       expect(staticGraph.nodes[keyBar]!.sequenceHint).toBeLessThan(
@@ -445,6 +455,239 @@ describe("buildInitDepGraphs", () => {
       expect(() =>
         buildInitDepGraphs(programs, symbolTable, abs("foo.agency")),
       ).toThrow(StaticReferencesGlobalError);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // ── PR-2.5: depth-1 function-body expansion ──────────────────────
+
+  it("depth-1: same-file static const consuming a local helper's static read", () => {
+    // `getBase()` reads `base`. Without depth-1, `derived → getBase`
+    // is a function reference, not a value edge — so the topsort
+    // wouldn't know `derived` needs `base` initialized first. With
+    // depth-1, walking `getBase`'s body adds the `base` edge.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `static const base = "hello"\n` +
+        `def getBase(): string { return base }\n` +
+        `static const derived = getBase() + "!"\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      const k = (n: string) => makeKey(abs("entry.agency"), n);
+      expect(staticGraph.edges[k("derived")]).toContain(k("base"));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("depth-1: cross-module static read through a named-import function", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "foo.agency":
+        `import { getBarStatic } from "./bar.agency"\n` +
+        `static const fooStatic = getBarStatic() + "!"\n`,
+      "bar.agency":
+        `export static const barStatic = "hello"\n` +
+        `export def getBarStatic(): string { return barStatic }\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("foo.agency"),
+      );
+      const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
+      const keyBar = makeKey(abs("bar.agency"), "barStatic");
+      expect(staticGraph.edges[keyFoo]).toContain(keyBar);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("depth-1: cross-module read through a namespace-prefixed call", () => {
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "foo.agency":
+        `import * as bar from "./bar.agency"\n` +
+        `static const fooStatic = bar.getBarStatic() + "!"\n`,
+      "bar.agency":
+        `export static const barStatic = "hello"\n` +
+        `export def getBarStatic(): string { return barStatic }\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("foo.agency"),
+      );
+      const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
+      const keyBar = makeKey(abs("bar.agency"), "barStatic");
+      expect(staticGraph.edges[keyFoo]).toContain(keyBar);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("depth-1: static reading a global through a function is a compile error", () => {
+    // Pre-PR-2.5 this compiled cleanly (the dep graph couldn't see
+    // through `getBarGlobal`'s body). Post-PR-2.5
+    // `rejectStaticReferencesGlobal` runs the same depth-1 walk and
+    // catches it at compile time.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "foo.agency":
+        `import { getBarGlobal } from "./bar.agency"\n` +
+        `static const fooStatic = getBarGlobal() + "!"\n`,
+      "bar.agency":
+        `export const barGlobal = "G"\n` +
+        `export def getBarGlobal(): string { return barGlobal }\n`,
+    });
+    try {
+      expect(() =>
+        buildInitDepGraphs(programs, symbolTable, abs("foo.agency")),
+      ).toThrow(StaticReferencesGlobalError);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("depth-1: depth-2 chain NOT chased; runtime trap covers", () => {
+    // `outerFn` calls `innerFn` which reads `barStatic`. Depth-1 only
+    // sees the *direct* call from `foo`'s init → `outerFn`. From
+    // `outerFn`'s body we collect refs and resolve in `bar.agency`,
+    // but `outerFn` only references `innerFn` — not `barStatic`
+    // directly. So `fooStatic` does NOT gain a direct edge to
+    // `barStatic`. The runtime PR-1 trap remains the safety net.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "foo.agency":
+        `import { outerFn } from "./bar.agency"\n` +
+        `static const fooStatic = outerFn() + "!"\n`,
+      "bar.agency":
+        `export static const barStatic = "hello"\n` +
+        `def innerFn(): string { return barStatic }\n` +
+        `export def outerFn(): string { return innerFn() }\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("foo.agency"),
+      );
+      const keyFoo = makeKey(abs("foo.agency"), "fooStatic");
+      const keyBar = makeKey(abs("bar.agency"), "barStatic");
+      expect(staticGraph.edges[keyFoo]).not.toContain(keyBar);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("depth-1: function value stored in a variable does NOT expand", () => {
+    // `f` is a function VALUE, not a callable name in the init
+    // expression that resolves to a function def. The depth-1
+    // expansion only fires when the call's identifier itself names a
+    // top-level function — `f` doesn't.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `static const base = "hello"\n` +
+        `def getBase(): string { return base }\n` +
+        // `helper` captures the function value; `derived` calls
+        // through the value. No expansion → no edge to `base`.
+        `static const helper = getBase\n` +
+        `static const derived = helper() + "!"\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      const k = (n: string) => makeKey(abs("entry.agency"), n);
+      expect(staticGraph.edges[k("derived")]).not.toContain(k("base"));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("depth-1: stdlib / unknown names skip silently with no edges", () => {
+    // No `uppercase` def anywhere in the closure — `FunctionDefLookup`
+    // returns null and the depth-1 path is a no-op.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `static const foo = "hi"\n` +
+        `static const result = uppercase(foo)\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      const k = (n: string) => makeKey(abs("entry.agency"), n);
+      // The direct ref to `foo` is still recorded; depth-1 just adds
+      // no extra edges since `uppercase` doesn't resolve to a def.
+      expect(staticGraph.edges[k("result")]).toEqual([k("foo")]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("depth-1: self-recursive function does not loop and yields the right edge", () => {
+    // `countDown` calls itself. The depth-1 expansion walks the body
+    // ONCE — recursion is not chased. The inner ref `countDown` is a
+    // function name, not in `lookupSet`, so no edge is added for it.
+    // The ref `base` inside the body DOES resolve to a top-level
+    // static and contributes the edge.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `static const base = "hello"\n` +
+        `def countDown(n: number): string {\n` +
+        `  if (n <= 0) { return base }\n` +
+        `  return countDown(n - 1)\n` +
+        `}\n` +
+        `static const derived = countDown(3) + "!"\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      const k = (n: string) => makeKey(abs("entry.agency"), n);
+      expect(staticGraph.edges[k("derived")]).toContain(k("base"));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("depth-1: walks block bodies inside the called function", () => {
+    // `map(arr) as x { ... }` is an inline block (NOT a nested
+    // function), so refs inside the block body still count toward the
+    // depth-1 expansion when we walk `mapWithBase`'s body. The block
+    // parameter `x` shadows nothing — it doesn't resolve to a top-
+    // level decl, so it falls out harmlessly.
+    const { dir, programs, symbolTable, abs } = writeFixture({
+      "entry.agency":
+        `static const base = "hello"\n` +
+        `static const items = ["a", "b"]\n` +
+        `def mapWithBase(): string[] {\n` +
+        `  return map(items) as x {\n` +
+        `    return x + base\n` +
+        `  }\n` +
+        `}\n` +
+        `static const derived = mapWithBase()\n`,
+    });
+    try {
+      const { staticGraph } = buildInitDepGraphs(
+        programs,
+        symbolTable,
+        abs("entry.agency"),
+      );
+      const k = (n: string) => makeKey(abs("entry.agency"), n);
+      expect(staticGraph.edges[k("derived")]).toContain(k("base"));
+      expect(staticGraph.edges[k("derived")]).toContain(k("items"));
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/agency-lang/lib/compiler/initDepGraph.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.ts
@@ -47,6 +47,7 @@
 import type { AgencyProgram, AgencyNode, Expression } from "../types.js";
 import type { Assignment } from "../types.js";
 import type { SourceLocation } from "../types/base.js";
+import type { FunctionDefinition } from "../types/function.js";
 import type { SymbolTable } from "../symbolTable.js";
 import {
   isAgencyImport,
@@ -108,7 +109,141 @@ export type BuildInitDepGraphsResult = {
   globalGraph: InitDepGraph;
   /** Reused by codegen (Task 4) for PR-1 thread-through. */
   resolver: ImportAliasResolver;
+  /** Look-up `(name | namespace.member) → top-level FunctionDefinition`,
+   * scoped to the importing module. PR-2.5 uses it to drive depth-1
+   * expansion of init-expression deps through direct function calls. */
+  functionDefs: FunctionDefLookup;
 };
+
+/**
+ * Resolves a name used inside one module to the top-level Agency
+ * function definition that backs it. Returns the function's home
+ * `moduleId` alongside the AST so callers can resolve free identifiers
+ * *inside* the function body against the function's own import surface
+ * — not the caller's.
+ *
+ * `find` handles bare-name calls (`getBar()`). `findNamespaceMember`
+ * handles namespace-prefixed calls (`bar.getBar()`).
+ *
+ * Returns `null` for names that don't resolve to an Agency function we
+ * have AST for — stdlib calls, function values stored in variables,
+ * unknown names, etc. The depth-1 expansion treats those as "no
+ * expansion", and the runtime read-before-init trap (PR 1) remains the
+ * safety net for anything the static analysis can't see.
+ *
+ * Built once per `compileClosure` call; cached per importing module so
+ * a lookup is O(1) after first use per module.
+ */
+export type FunctionDefLookup = {
+  find(
+    name: string,
+    inModuleId: string,
+  ): { moduleId: string; def: FunctionDefinition } | null;
+  findNamespaceMember(
+    prefix: string,
+    member: string,
+    inModuleId: string,
+  ): { moduleId: string; def: FunctionDefinition } | null;
+};
+
+/**
+ * Build a `FunctionDefLookup` over the entry's full import closure.
+ *
+ * Two layers of cache:
+ *   - `localDefsByModule[moduleId]` — name → FunctionDefinition for all
+ *     top-level `def` statements declared in that module. Populated
+ *     lazily; same shape used as the destination of both bare-name and
+ *     namespace-member lookups.
+ *   - `cache[inModuleId]` — name → resolved `(moduleId, def)` for the
+ *     importing module's view (local defs + named-import aliases of
+ *     functions declared elsewhere). Populated lazily on first lookup.
+ */
+export function makeFunctionDefLookup(
+  programs: Record<string, AgencyProgram>,
+  resolver: ImportAliasResolver,
+): FunctionDefLookup {
+  const localDefsByModule: Record<
+    string,
+    Record<string, FunctionDefinition>
+  > = {};
+
+  function localDefsFor(
+    moduleId: string,
+  ): Record<string, FunctionDefinition> {
+    const cached = localDefsByModule[moduleId];
+    if (cached) return cached;
+    const map: Record<string, FunctionDefinition> = {};
+    const program = programs[moduleId];
+    if (program) {
+      for (const node of program.nodes) {
+        if (node.type !== "function") continue;
+        map[node.functionName] = node;
+      }
+    }
+    localDefsByModule[moduleId] = map;
+    return map;
+  }
+
+  const cache: Record<
+    string,
+    Record<string, { moduleId: string; def: FunctionDefinition }>
+  > = {};
+
+  function buildFor(
+    inModuleId: string,
+  ): Record<string, { moduleId: string; def: FunctionDefinition }> {
+    const map: Record<string, { moduleId: string; def: FunctionDefinition }> =
+      {};
+    // Local defs win — same-file `def foo` is reachable as bare `foo`.
+    for (const [name, def] of Object.entries(localDefsFor(inModuleId))) {
+      map[name] = { moduleId: inModuleId, def };
+    }
+    // Named imports of functions defined in other modules. The resolver
+    // already followed re-export chains; for each resolved name, see if
+    // the target module has a local function def of that name.
+    const program = programs[inModuleId];
+    if (program) {
+      for (const node of program.nodes) {
+        if (node.type !== "importStatement") continue;
+        if (!isAgencyImport(node.modulePath)) continue;
+        for (const nameType of node.importedNames) {
+          if (nameType.type !== "namedImport") continue;
+          for (const original of nameType.importedNames) {
+            // Walk through the local alias the importer uses, not the
+            // original name — that's how the importer references it.
+            const localAlias =
+              (nameType.aliases && nameType.aliases[original]) ?? original;
+            const aliased = resolver.resolve(localAlias, inModuleId);
+            if (!aliased) continue;
+            const targetDef =
+              localDefsFor(aliased.sourceModuleId)[aliased.sourceName];
+            if (!targetDef) continue;
+            map[localAlias] = {
+              moduleId: aliased.sourceModuleId,
+              def: targetDef,
+            };
+          }
+        }
+      }
+    }
+    return map;
+  }
+
+  return {
+    find(name, inModuleId) {
+      const moduleCache =
+        cache[inModuleId] ?? (cache[inModuleId] = buildFor(inModuleId));
+      return moduleCache[name] ?? null;
+    },
+    findNamespaceMember(prefix, member, inModuleId) {
+      const ns = resolver.resolveNamespace(prefix, inModuleId);
+      if (!ns) return null;
+      const def = localDefsFor(ns.sourceModuleId)[member];
+      if (!def) return null;
+      return { moduleId: ns.sourceModuleId, def };
+    },
+  };
+}
 
 /**
  * Compile-time error: a `static` initializer references a `global`. The
@@ -246,6 +381,7 @@ export function buildInitDepGraphs(
   entryModuleId: string,
 ): BuildInitDepGraphsResult {
   const resolver = makeImportAliasResolver(programs, symbolTable);
+  const functionDefs = makeFunctionDefLookup(programs, resolver);
   const sequenceHints = computeSequenceHintBase(programs, entryModuleId);
 
   // ── 1. Collect every node, routing each into the static or global graph.
@@ -266,23 +402,31 @@ export function buildInitDepGraphs(
   }
 
   // ── 2. Compute edges within each graph by walking each node's
-  //       initializer expression for free identifier references.
-  const staticEdges = computeEdges(staticNodes, resolver);
+  //       initializer expression for free identifier references —
+  //       plus PR-2.5 depth-1 expansion through direct function calls.
+  const staticEdges = computeEdges(staticNodes, resolver, functionDefs);
   const globalEdges = computeEdgesGlobal(
     globalNodes,
     staticNodes,
     resolver,
+    functionDefs,
   );
 
   // ── 3. Phase-coupling validation: a static reading a global is a
   //       compile error. (Global reading static is fine — handled in
   //       computeEdgesGlobal which skips static refs as deps.)
-  rejectStaticReferencesGlobal(staticNodes, globalNodes, resolver);
+  rejectStaticReferencesGlobal(
+    staticNodes,
+    globalNodes,
+    resolver,
+    functionDefs,
+  );
 
   return {
     staticGraph: { nodes: staticNodes, edges: staticEdges },
     globalGraph: { nodes: globalNodes, edges: globalEdges },
     resolver,
+    functionDefs,
   };
 }
 
@@ -371,10 +515,11 @@ function isBareTopLevelStatement(node: AgencyNode): boolean {
 function computeEdges(
   nodes: Record<InitVarKey, InitVarNode>,
   resolver: ImportAliasResolver,
+  functionDefs: FunctionDefLookup,
 ): Record<InitVarKey, InitVarKey[]> {
   const edges: Record<InitVarKey, InitVarKey[]> = {};
   for (const [key, node] of Object.entries(nodes)) {
-    edges[key] = depsFor(node, nodes, resolver);
+    edges[key] = depsFor(node, nodes, resolver, functionDefs);
   }
   return edges;
 }
@@ -389,37 +534,76 @@ function computeEdgesGlobal(
   globalNodes: Record<InitVarKey, InitVarNode>,
   staticNodes: Record<InitVarKey, InitVarNode>,
   resolver: ImportAliasResolver,
+  functionDefs: FunctionDefLookup,
 ): Record<InitVarKey, InitVarKey[]> {
   const edges: Record<InitVarKey, InitVarKey[]> = {};
   for (const [key, node] of Object.entries(globalNodes)) {
-    edges[key] = depsFor(node, globalNodes, resolver, staticNodes);
+    edges[key] = depsFor(
+      node,
+      globalNodes,
+      resolver,
+      functionDefs,
+      staticNodes,
+    );
   }
   return edges;
 }
 
 /**
  * For one node, find every other node in `lookupSet` its initializer
- * directly references and return their keys (no duplicates, no
- * self-edges). `skipSet`, if provided, is the set of nodes whose
- * references should be silently skipped (used to skip static refs when
- * computing global edges).
+ * references — either directly or via a depth-1 call into a top-level
+ * Agency function whose body reads the target.
+ *
+ * `skipSet`, if provided, is the set of nodes whose references should
+ * be silently skipped (used to skip static refs when computing global
+ * edges).
+ *
+ * **Depth-1 expansion:** when a free reference in the init expression
+ * resolves to a top-level function definition (via `functionDefs`), we
+ * walk that function's body for free identifiers and resolve each one
+ * in the *function's* home module. The runtime read-before-init trap
+ * (PR 1) still covers depth-2+, function values, and any other case
+ * the static analysis can't see.
+ *
+ * `collectFreeIdentifiers` already skips identifiers inside nested
+ * `function` / `graphNode` bodies — that gives us the depth-1
+ * boundary for free. Blocks (`map(arr) as x { ... }`) are NOT skipped:
+ * they're not nested functions, they're inline code that runs in the
+ * outer function's scope, so any free refs inside a block body inside
+ * the called function still contribute deps.
  */
 function depsFor(
   node: InitVarNode,
   lookupSet: Record<InitVarKey, InitVarNode>,
   resolver: ImportAliasResolver,
+  functionDefs: FunctionDefLookup,
   skipSet?: Record<InitVarKey, InitVarNode>,
 ): InitVarKey[] {
   const seen: Record<InitVarKey, true> = {};
   const out: InitVarKey[] = [];
-  for (const ref of collectFreeIdentifiers(node.initExpr)) {
-    if (ref.kind === "name" && ref.name === node.varName) continue;
-    const refKey = resolveFreeRef(ref, node.moduleId, resolver);
-    if (!refKey) continue;
-    if (skipSet?.[refKey]) continue;
-    if (!lookupSet[refKey] || seen[refKey]) continue;
+  const addRef = (refKey: InitVarKey | null): void => {
+    if (!refKey) return;
+    if (skipSet?.[refKey]) return;
+    if (!lookupSet[refKey] || seen[refKey]) return;
     seen[refKey] = true;
     out.push(refKey);
+  };
+  for (const ref of collectFreeIdentifiers(node.initExpr)) {
+    if (ref.kind === "name" && ref.name === node.varName) continue;
+    addRef(resolveFreeRef(ref, node.moduleId, resolver));
+  }
+  // Depth-1 expansion: for every direct call in the init expression
+  // that resolves to a top-level Agency function we have AST for,
+  // contribute the deps from one walk of the function's body. Inner
+  // refs resolve in the function's home module.
+  for (const fnMatch of collectDirectCalls(
+    node.initExpr,
+    node.moduleId,
+    functionDefs,
+  )) {
+    for (const innerRef of collectFunctionBodyFreeRefs(fnMatch.def)) {
+      addRef(resolveFreeRef(innerRef, fnMatch.moduleId, resolver));
+    }
   }
   return out;
 }
@@ -456,16 +640,117 @@ function rejectStaticReferencesGlobal(
   staticNodes: Record<InitVarKey, InitVarNode>,
   globalNodes: Record<InitVarKey, InitVarNode>,
   resolver: ImportAliasResolver,
+  functionDefs: FunctionDefLookup,
 ): void {
   for (const node of Object.values(staticNodes)) {
-    for (const ref of collectFreeIdentifiers(node.initExpr)) {
-      if (ref.kind === "name" && ref.name === node.varName) continue;
-      const refKey = resolveFreeRef(ref, node.moduleId, resolver);
-      if (!refKey) continue;
+    const check = (refKey: InitVarKey | null): void => {
+      if (!refKey) return;
       const offender = globalNodes[refKey];
       if (offender) throw new StaticReferencesGlobalError(node, offender);
+    };
+    for (const ref of collectFreeIdentifiers(node.initExpr)) {
+      if (ref.kind === "name" && ref.name === node.varName) continue;
+      check(resolveFreeRef(ref, node.moduleId, resolver));
+    }
+    // Depth-1: any direct call (bare or namespace) into a top-level
+    // Agency function whose body reads a global also makes the
+    // enclosing static reference that global. Same rejection rule
+    // applies.
+    for (const fnMatch of collectDirectCalls(
+      node.initExpr,
+      node.moduleId,
+      functionDefs,
+    )) {
+      for (const innerRef of collectFunctionBodyFreeRefs(fnMatch.def)) {
+        check(resolveFreeRef(innerRef, fnMatch.moduleId, resolver));
+      }
     }
   }
+}
+
+/**
+ * Walk an init expression for **direct call sites** — both bare-name
+ * calls (`getBar()`) and namespace-method calls (`bar.getBar()`) — and
+ * return the FunctionDefinitions they resolve to, paired with the
+ * function's home module. Used by the depth-1 expansion to discover
+ * which functions to look inside.
+ *
+ * Skips identifiers inside nested `function` / `graphNode` bodies via
+ * the same ancestor check `collectFreeIdentifiers` uses, so when we
+ * are already mid-walk of one function's body we don't accidentally
+ * descend into another function defined alongside it.
+ *
+ * `collectFreeIdentifiers` cannot do this job because `walkNodes`'s
+ * `functionCall` branch deliberately does not yield the function name
+ * as a `variableName` (the call's identifier isn't a value
+ * reference). Method-call chain elements (`obj.method()`) likewise
+ * don't surface as `member` free refs — they're `methodCall` chain
+ * entries, not `property` chain entries.
+ */
+export function collectDirectCalls(
+  expr: Expression | AgencyNode,
+  inModuleId: string,
+  functionDefs: FunctionDefLookup,
+): { moduleId: string; def: FunctionDefinition }[] {
+  const out: { moduleId: string; def: FunctionDefinition }[] = [];
+  for (const { node, ancestors } of walkNodes([expr as AgencyNode])) {
+    if (
+      ancestors.some(
+        (a) => a.type === "function" || a.type === "graphNode",
+      )
+    ) {
+      continue;
+    }
+    if (node.type === "functionCall") {
+      // Skip a functionCall that lives inside a valueAccess methodCall
+      // chain (`x.foo()`) — handled by the valueAccess branch below
+      // where we have the namespace prefix to drive the lookup.
+      const parent = ancestors[ancestors.length - 1];
+      const isMethodCall =
+        parent &&
+        parent.type === "valueAccess" &&
+        (parent as { chain: { kind: string; functionCall?: unknown }[] }).chain.some(
+          (c) => c.kind === "methodCall" && (c as { functionCall: unknown }).functionCall === node,
+        );
+      if (isMethodCall) continue;
+      const match = functionDefs.find(node.functionName, inModuleId);
+      if (match) out.push(match);
+      continue;
+    }
+    if (node.type === "valueAccess" && node.base.type === "variableName") {
+      const prefix = (node.base as { value: string }).value;
+      for (const elem of node.chain) {
+        if (elem.kind !== "methodCall") continue;
+        const match = functionDefs.findNamespaceMember(
+          prefix,
+          elem.functionCall.functionName,
+          inModuleId,
+        );
+        if (match) out.push(match);
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Collect every free identifier in a function body, treating each top-
+ * level statement of the body independently so the function's *own*
+ * `function` node isn't on the ancestor stack (which would cause
+ * `collectFreeIdentifiers` to skip everything by design). The result
+ * still skips any further nested `function` / `graphNode` bodies — the
+ * depth-1 boundary holds.
+ *
+ * Function parameter names appear in the result as `{kind: "name"}`
+ * refs that don't resolve to any top-level decl, so they fall out
+ * harmlessly when `resolveFreeRef`'s caller misses them in `lookupSet`.
+ */
+export function collectFunctionBodyFreeRefs(def: FunctionDefinition): FreeRef[] {
+  const out: FreeRef[] = [];
+  for (const stmt of def.body) {
+    out.push(...collectFreeIdentifiers(stmt));
+  }
+  return out;
 }
 
 // ── Free-identifier collection ──

--- a/packages/agency-lang/lib/compiler/initDepGraph.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.ts
@@ -161,6 +161,7 @@ export type FunctionDefLookup = {
 export function makeFunctionDefLookup(
   programs: Record<string, AgencyProgram>,
   resolver: ImportAliasResolver,
+  symbolTable: SymbolTable | undefined,
 ): FunctionDefLookup {
   const localDefsByModule: Record<
     string,
@@ -184,6 +185,46 @@ export function makeFunctionDefLookup(
     return map;
   }
 
+  /**
+   * Follow a re-export chain to the module that owns the real `def`.
+   *
+   * `ImportAliasResolver.resolve` only walks one hop because the
+   * synthesized wrapper *static* at each re-exporter needs its own
+   * `__initializeStatic` to run — collapsing the chain in the
+   * resolver would lose those wrappers. **Functions don't have that
+   * constraint:** `resolveReExports` emits a wrapper function whose
+   * body is just `return _reexport_<orig>(...args)`, which the
+   * depth-1 free-identifier walker cannot see through (function-call
+   * names are not surfaced as free refs). Following the chain here
+   * gives the depth-1 expansion the *real* body to walk, so a single
+   * direct call in user source contributes the right edges even when
+   * the call resolves through one or more re-export hops.
+   *
+   * Defensive cap (`MAX_HOPS`) protects against an unforeseen
+   * cyclic SymbolTable entry — `SymbolTable.build` rejects ambiguous
+   * re-exports but a future bug there shouldn't hang this loop.
+   */
+  function resolveToUltimateDef(
+    moduleId: string,
+    name: string,
+  ): { moduleId: string; def: FunctionDefinition } | null {
+    const MAX_HOPS = 32;
+    let curModule = moduleId;
+    let curName = name;
+    for (let i = 0; i < MAX_HOPS; i++) {
+      const sym = symbolTable?.getFile(curModule)?.[curName];
+      if (sym && sym.reExportedFrom) {
+        curModule = sym.reExportedFrom.sourceFile;
+        curName = sym.reExportedFrom.originalName;
+        continue;
+      }
+      const def = localDefsFor(curModule)[curName];
+      if (!def) return null;
+      return { moduleId: curModule, def };
+    }
+    return null;
+  }
+
   const cache: Record<
     string,
     Record<string, { moduleId: string; def: FunctionDefinition }>
@@ -198,9 +239,7 @@ export function makeFunctionDefLookup(
     for (const [name, def] of Object.entries(localDefsFor(inModuleId))) {
       map[name] = { moduleId: inModuleId, def };
     }
-    // Named imports of functions defined in other modules. The resolver
-    // already followed re-export chains; for each resolved name, see if
-    // the target module has a local function def of that name.
+    // Named imports of functions defined in other modules.
     const program = programs[inModuleId];
     if (program) {
       for (const node of program.nodes) {
@@ -215,13 +254,12 @@ export function makeFunctionDefLookup(
               (nameType.aliases && nameType.aliases[original]) ?? original;
             const aliased = resolver.resolve(localAlias, inModuleId);
             if (!aliased) continue;
-            const targetDef =
-              localDefsFor(aliased.sourceModuleId)[aliased.sourceName];
-            if (!targetDef) continue;
-            map[localAlias] = {
-              moduleId: aliased.sourceModuleId,
-              def: targetDef,
-            };
+            const ultimate = resolveToUltimateDef(
+              aliased.sourceModuleId,
+              aliased.sourceName,
+            );
+            if (!ultimate) continue;
+            map[localAlias] = ultimate;
           }
         }
       }
@@ -238,9 +276,7 @@ export function makeFunctionDefLookup(
     findNamespaceMember(prefix, member, inModuleId) {
       const ns = resolver.resolveNamespace(prefix, inModuleId);
       if (!ns) return null;
-      const def = localDefsFor(ns.sourceModuleId)[member];
-      if (!def) return null;
-      return { moduleId: ns.sourceModuleId, def };
+      return resolveToUltimateDef(ns.sourceModuleId, member);
     },
   };
 }
@@ -381,7 +417,7 @@ export function buildInitDepGraphs(
   entryModuleId: string,
 ): BuildInitDepGraphsResult {
   const resolver = makeImportAliasResolver(programs, symbolTable);
-  const functionDefs = makeFunctionDefLookup(programs, resolver);
+  const functionDefs = makeFunctionDefLookup(programs, resolver, symbolTable);
   const sequenceHints = computeSequenceHintBase(programs, entryModuleId);
 
   // ── 1. Collect every node, routing each into the static or global graph.
@@ -741,14 +777,24 @@ export function collectDirectCalls(
  * still skips any further nested `function` / `graphNode` bodies — the
  * depth-1 boundary holds.
  *
- * Function parameter names appear in the result as `{kind: "name"}`
- * refs that don't resolve to any top-level decl, so they fall out
- * harmlessly when `resolveFreeRef`'s caller misses them in `lookupSet`.
+ * **Parameter-shadow filtering.** Drops refs whose name (or `prefix`,
+ * for member refs) matches one of the function's parameter names.
+ * Otherwise a parameter that happens to share a name with a top-level
+ * decl (e.g. `def readG(g: string) { return g }` when a top-level
+ * `g` exists) would resolve through the import alias resolver to the
+ * top-level binding and produce a spurious init edge or false
+ * `StaticReferencesGlobalError`.
  */
 export function collectFunctionBodyFreeRefs(def: FunctionDefinition): FreeRef[] {
+  const paramNames: Record<string, true> = {};
+  for (const param of def.parameters) paramNames[param.name] = true;
   const out: FreeRef[] = [];
   for (const stmt of def.body) {
-    out.push(...collectFreeIdentifiers(stmt));
+    for (const ref of collectFreeIdentifiers(stmt)) {
+      if (ref.kind === "name" && paramNames[ref.name]) continue;
+      if (ref.kind === "member" && paramNames[ref.prefix]) continue;
+      out.push(ref);
+    }
   }
   return out;
 }

--- a/packages/agency-lang/lib/runtime/topsortCycleErrors.test.ts
+++ b/packages/agency-lang/lib/runtime/topsortCycleErrors.test.ts
@@ -218,16 +218,18 @@ describe("tests/agency/topsort/cycles fixtures", () => {
   });
 
   it("runtime trap: indirect static read fires PR-1 trap with source moduleId", async () => {
-    // This fixture compiles cleanly (the dep graph can't see edges
-    // through function bodies) but the trap fires at agent-run time
-    // when `a`'s initializer calls `readB()` and reads `b` before
+    // This fixture compiles cleanly (PR-2.5's depth-1 expansion stops
+    // at one function-body hop, and the chain here is
+    // `a → outerReadB → innerReadB → b` — two hops away). The trap
+    // fires at agent-run time when `a`'s initializer calls
+    // `outerReadB()` which calls `innerReadB()` which reads `b` before
     // `b`'s init has run.
     //
-    // `readB` is an AgencyFunction, so the trap thrown inside its
-    // Runner step is caught and converted to a `failure(...)` result.
-    // `a` then holds the failure; `node main() { return a }` surfaces
-    // it as `result.data.error` — that's where the trap message
-    // arrives in user-visible form.
+    // The leaf reader is an AgencyFunction, so the trap thrown inside
+    // its Runner step is caught and converted to a `failure(...)`
+    // result. `a` then holds the failure; `node main() { return a }`
+    // surfaces it as `result.data.error` — that's where the trap
+    // message arrives in user-visible form.
     const outcome = await runFixture(
       path.join(FIXTURES_ROOT, "runtime-trap"),
       "main.agency",
@@ -243,5 +245,56 @@ describe("tests/agency/topsort/cycles fixtures", () => {
     expect(result.data?.error).toMatch(
       /tests\/agency\/topsort\/cycles\/runtime-trap\/main\.agency/,
     );
+  });
+
+  it("PR-2.5: static reading a global through one function call → compile error", async () => {
+    // Depth-1 expansion makes the static→global rejection see through
+    // a single function hop. Without it, the violation only surfaced
+    // as undefined behavior at runtime; with it, the compiler catches
+    // it with the same `Static '…' references global '…'` message used
+    // for direct refs.
+    const dir = writeUseBeforeDefFixture("static-reads-global-via-fn", {
+      "main.agency":
+        'const g = "hello"\n' +
+        "def readG(): string { return g }\n" +
+        'static const s = readG() + "!"\n' +
+        "\n" +
+        "node main() {\n" +
+        "  return s\n" +
+        "}\n",
+    });
+    const outcome = await runFixture(dir, "main.agency");
+    expect(outcome.kind).toBe("compileError");
+    if (outcome.kind !== "compileError") return;
+    expect(outcome.message).toMatch(/Static '.*' .*references global/);
+    expect(outcome.message).toMatch(/\bs\b/);
+    expect(outcome.message).toMatch(/\bg\b/);
+  });
+
+  it("PR-2.5: static reading a cross-module static through one function call → no trap", async () => {
+    // The exact case the runtime trap fired for pre-PR-2.5. With
+    // depth-1 the dep graph adds an edge from `s` to helper's
+    // `barStatic`, topsort schedules helper's static init first, and
+    // the program returns the composed value cleanly.
+    const dir = writeUseBeforeDefFixture("static-reads-static-via-fn", {
+      "main.agency":
+        'import { readBar } from "./helper.agency"\n' +
+        'static const s = readBar() + "!"\n' +
+        "\n" +
+        "node main() {\n" +
+        "  return s\n" +
+        "}\n",
+      "helper.agency":
+        'export static const barStatic = "hello"\n' +
+        "export def readBar(): string { return barStatic }\n",
+    });
+    const outcome = await runFixture(dir, "main.agency");
+    if (outcome.kind !== "ok") {
+      throw new Error(
+        `expected fixture to compile cleanly, got compile error:\n${outcome.message}`,
+      );
+    }
+    const result = await outcome.mod.main();
+    expect(result.data).toBe("hello!");
   });
 });

--- a/packages/agency-lang/tests/agency/topsort/cycles/runtime-trap/main.agency
+++ b/packages/agency-lang/tests/agency/topsort/cycles/runtime-trap/main.agency
@@ -1,15 +1,21 @@
-// Runtime read-before-init trap (PR 1) fires here. `a`'s initializer
-// calls `readB()` which reads `b`; the dep graph cannot see edges
-// through function bodies, so the compile-time topsort happily
-// schedules `a` before `b` based on source order, and at runtime `b`
-// is still `__UNINIT_STATIC` when `readB` accesses it.
+// Runtime read-before-init trap (PR 1) fires here. PR-2.5 made the
+// compile-time analysis depth-1: a static initializer that calls a
+// function whose body reads another static *directly* is now caught at
+// compile time. To still exercise the runtime trap we use a depth-2
+// chain — `a` → `outerReadB` → `innerReadB` → `b`. The compiler walks
+// one function deep, so it sees `outerReadB`'s body (which only calls
+// `innerReadB`), and the read of `b` is hidden behind that second hop.
 //
 // The vitest runner asserts the trap message names `b` and points at
 // this file (PR-1 + PR-2's resolver thread-through).
-static const a = readB()
+static const a = outerReadB()
 static const b = "b-value"
 
-def readB(): string {
+def outerReadB(): string {
+  return innerReadB()
+}
+
+def innerReadB(): string {
   return b
 }
 

--- a/packages/agency-lang/tests/agency/topsort/depth1-callgraph/bare-stmt-via-function/helper.agency
+++ b/packages/agency-lang/tests/agency/topsort/depth1-callgraph/bare-stmt-via-function/helper.agency
@@ -1,0 +1,9 @@
+// Helper for the depth-1 bare-stmt-via-function fixture.
+// Note: globals (`const`/`let`) can't be exported in Agency — only
+// statics can. The depth-1 expansion still finds this read by walking
+// `getBarGlobal`'s body in helper.agency's own namespace.
+const barGlobal = "hello"
+
+export def getBarGlobal(): string {
+  return barGlobal
+}

--- a/packages/agency-lang/tests/agency/topsort/depth1-callgraph/bare-stmt-via-function/main.agency
+++ b/packages/agency-lang/tests/agency/topsort/depth1-callgraph/bare-stmt-via-function/main.agency
@@ -1,0 +1,19 @@
+// PR-2.5 depth-1 expansion for bare top-level statements: the bare
+// call `record(getBarGlobal())` reaches into `helper.getBarGlobal`,
+// whose body reads `helper.barGlobal`. Depth-1 expansion makes the
+// dep graph aware that `helper.agency`'s globals must finish init
+// before this bare statement runs, and emits the corresponding
+// `__awaitGlobalsInit("helper.agency")` at the head of main's
+// `__initializeGlobals`. Without it the lazy global guard would still
+// resolve the read at runtime, but only with extra Promise machinery
+// — the explicit await is the correctness contract.
+import { getBarGlobal } from "./helper.agency"
+
+let log = ""
+def record(s: string) { log = log + s }
+
+record(getBarGlobal())
+
+node main() {
+  return log
+}

--- a/packages/agency-lang/tests/agency/topsort/depth1-callgraph/bare-stmt-via-function/main.test.json
+++ b/packages/agency-lang/tests/agency/topsort/depth1-callgraph/bare-stmt-via-function/main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Depth-1: a bare top-level call reaches into a function that reads a global in another module. The dep graph awaits that module's global init before the bare statement runs.",
+      "expectedOutput": "\"hello\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/topsort/depth1-callgraph/static-via-function/helper.agency
+++ b/packages/agency-lang/tests/agency/topsort/depth1-callgraph/static-via-function/helper.agency
@@ -1,0 +1,7 @@
+// Helper for the depth-1 static-via-function fixture. Exports a
+// static value and a function that reads it.
+export static const barStatic = "hello"
+
+export def getBarStatic(): string {
+  return barStatic
+}

--- a/packages/agency-lang/tests/agency/topsort/depth1-callgraph/static-via-function/main.agency
+++ b/packages/agency-lang/tests/agency/topsort/depth1-callgraph/static-via-function/main.agency
@@ -1,0 +1,16 @@
+// PR-2.5 depth-1 expansion: `fooStatic`'s initializer calls
+// `getBarStatic` in `helper.agency`, whose body reads `barStatic`.
+// Without depth-1 expansion, the static dep graph would have no edge
+// from `fooStatic` to `barStatic`, helper.__initializeStatic would not
+// run before main's, and the PR-1 runtime trap would fire when
+// `getBarStatic` accessed `barStatic` during main's static init.
+//
+// With depth-1, the dep graph sees the cross-module read, schedules
+// helper.barStatic first, and the assertion below passes.
+import { getBarStatic } from "./helper.agency"
+
+static const fooStatic = getBarStatic() + "!"
+
+node main() {
+  return fooStatic
+}

--- a/packages/agency-lang/tests/agency/topsort/depth1-callgraph/static-via-function/main.test.json
+++ b/packages/agency-lang/tests/agency/topsort/depth1-callgraph/static-via-function/main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Depth-1: a static initializer reads a cross-module static through a function call; dep graph schedules the helper's static init first.",
+      "expectedOutput": "\"hello!\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements [PR 2.5 from the agent-init roadmap](docs/superpowers/plans/2026-06-01-agent-init-pr2.5-depth1-callgraph.md): extend the per-variable init dep graph so that when an initializer calls a top-level Agency function, the graph walks that function's body **one level deep** for free identifiers and adds the resolutions as additional edges.

This catches the 90% case where an initializer reads a value through a single function call:

```
import { getBar } from "./bar.agency"
static const foo = getBar()  // bar.barStatic now counts as a dep edge
```

The boundary stops at one function-body hop. Depth-2+ chains, function values stored in variables, methods on user objects, and stdlib calls all remain covered by the PR 1 runtime read-before-init trap.

## Why depth-1 and not transitive

The boundary stays predictable: users can answer "will the compiler catch my case?" by asking "is this a single direct function call?" Transitive analysis introduces a fuzzy boundary that grows over time; the runtime trap handles the long tail with a clear error message either way.

## What this fixes

1. `static const foo = getBarStatic()` where `getBarStatic` reads a static in another module. Previously fired the runtime trap on first call; now compiles into a plan that awaits the source module's static init before `foo`.
2. `static const foo = getBarGlobal()` where `getBarGlobal` reads a global. Previously compiled cleanly even though statics can't read globals — now `rejectStaticReferencesGlobal` catches it at compile time.

## Mechanism

- `FunctionDefLookup` (`lib/compiler/initDepGraph.ts`) resolves bare or namespace-prefixed call names to their `(moduleId, FunctionDefinition)` source.
- `collectDirectCalls` walks an init expression for call sites (`functionCall` nodes + `valueAccess.methodCall` chain entries). `collectFunctionBodyFreeRefs` walks each matched function's body via the existing `collectFreeIdentifiers`, which already skips nested `function` / `graphNode` bodies — that gives the depth-1 boundary for free.
- Expansion is applied identically in `depsFor`, `rejectStaticReferencesGlobal`, and `globalPhasePlanFor` so static edges, the static-references-global compile error, and cross-phase `awaitModules` all stay in lockstep.

## Tests

- 9 new unit cases in `lib/compiler/initDepGraph.test.ts` cover direct expansion, namespace expansion, cross-phase rejection, depth-2 cap, function-value not chased, stdlib silent skip, self-recursion, and block bodies inside the called function.
- 2 new vitest cases in `lib/runtime/topsortCycleErrors.test.ts` cover compile-error and no-trap cases via inline fixtures.
- 2 new agency end-to-end fixtures under `tests/agency/topsort/depth1-callgraph/` (static-via-function, bare-stmt-via-function).
- The existing `runtime-trap` fixture is reworked to use a 2-hop chain (`a -> outerReadB -> innerReadB -> b`) so the runtime trap still has something to catch.

## Verification

- `pnpm test:run lib/compiler/ lib/runtime/ lib/backends/` → 1106/1106 pass
- `pnpm run agency test tests/agency/topsort/` → 8/8 pass (includes the two new depth-1 fixtures)
- `pnpm run lint:structure` → clean
- `make fixtures` → no diffs beyond the intentional `runtime-trap` rework

## Docs

- `docs/site/guide/imports-and-packages.md` — new user-facing "Initializer dependencies through function calls" section with examples + boundary list + safety-net note.
- `docs/dev/init-topsort.md` — new "Depth-1 function-body expansion" subsection, updated safety-net wording for the new boundary, file-map note for `FunctionDefLookup`.

## Plan + design references

- Plan: `docs/superpowers/plans/2026-06-01-agent-init-pr2.5-depth1-callgraph.md`
- Roadmap: `agent-init-roadmap.md`
- Builds on PR 1 (read-before-init trap) and PR 2 (per-variable topsort).
