### PR TITLE
Compile-time validations for `static` initializers (PR 4 of 6)

### DIFF
--- a/packages/agency-lang/lib/compiler/compileClosure.test.ts
+++ b/packages/agency-lang/lib/compiler/compileClosure.test.ts
@@ -86,8 +86,11 @@ describe("buildCompiledClosure", () => {
       err = e;
     }
     expect(err).toBeInstanceOf(CompileClosureError);
+    // PR 4 reformatted the message: `static const 'name'` and
+    // `global 'name'` (instead of generic "Static 'name'") so
+    // the surface mirrors the source-level keyword.
     expect((err as Error).message).toMatch(
-      /Static '?s'?.*references global '?g'?/,
+      /static const '?s'?.*references global '?g'?/,
     );
   });
 

--- a/packages/agency-lang/lib/compiler/initDepGraph.ts
+++ b/packages/agency-lang/lib/compiler/initDepGraph.ts
@@ -284,19 +284,38 @@ export function makeFunctionDefLookup(
 /**
  * Compile-time error: a `static` initializer references a `global`. The
  * global doesn't exist yet at Phase A time, so this is unsatisfiable.
+ *
+ * Surface format prefers human-readable names: `static const x` is shown
+ * as `static const 'x'`, while a `static <bare>` whose synthetic varName
+ * starts with `__bareStmt_` is shown as `static <bare statement>`. Line
+ * numbers fall back to `?` only when neither the static wrapper nor the
+ * dep node has a usable `loc`.
  */
 export class StaticReferencesGlobalError extends Error {
   constructor(
     public readonly staticNode: InitVarNode,
     public readonly globalNode: InitVarNode,
   ) {
+    const staticDesc = describeInitNode(staticNode);
+    const globalDesc = describeInitNode(globalNode, "global");
     super(
-      `Static '${staticNode.varName}' (${staticNode.moduleId}:${staticNode.loc?.line ?? "?"}) ` +
-        `references global '${globalNode.varName}' (${globalNode.moduleId}:${globalNode.loc?.line ?? "?"}). ` +
-        `Static initializers run before any global init — they cannot read globals.`,
+      `${staticDesc} references ${globalDesc}. ` +
+        `Static initializers run during Phase A (process startup), ` +
+        `before any global is initialized in Phase B — so the global ` +
+        `does not exist yet. Either mark the global as \`static\`, or ` +
+        `move the read out of the static initializer.`,
     );
     this.name = "StaticReferencesGlobalError";
   }
+}
+
+function describeInitNode(node: InitVarNode, kindLabel?: string): string {
+  const where = `${node.moduleId}:${node.loc?.line ?? "?"}`;
+  if (node.varName.startsWith("__bareStmt_")) {
+    return `static bare statement at ${where}`;
+  }
+  const label = kindLabel ?? (node.kind === "static" ? "static const" : "global");
+  return `${label} '${node.varName}' (${where})`;
 }
 
 /**
@@ -480,7 +499,11 @@ function nodeFromTopLevel(
   depthBase: number,
 ): InitVarNode | null {
   const { stmt: afterApprove, withApprove } = unwrapWithApprove(node);
-  const { stmt, isStaticBare } = unwrapStaticStatement(afterApprove);
+  const {
+    stmt,
+    isStaticBare,
+    wrapperLoc: staticWrapperLoc,
+  } = unwrapStaticStatement(afterApprove);
 
   if (stmt.type === "assignment") {
     const line = stmt.loc?.line ?? 0;
@@ -507,15 +530,23 @@ function nodeFromTopLevel(
   // readable cycle / debug output. `line_col` (not just `line`)
   // because `foo(); bar()` on a single source line would otherwise
   // collide and one node would overwrite the other in the dep graph.
+  //
+  // For a `static <bare>`, prefer the wrapper's loc (the `static`
+  // keyword itself) over the inner statement's loc. The inner
+  // sub-parsers (functionCallParser, valueAccessParser, …) do not
+  // emit `loc` themselves — only the outer `withLoc(staticStatement)`
+  // does — so falling back to the inner would yield a missing line
+  // number in compile-time error messages.
   if (isStaticBare || isBareTopLevelStatement(stmt)) {
-    const line = stmt.loc?.line ?? 0;
-    const col = stmt.loc?.col ?? 0;
+    const effectiveLoc = staticWrapperLoc ?? stmt.loc;
+    const line = effectiveLoc?.line ?? 0;
+    const col = effectiveLoc?.col ?? 0;
     return {
       moduleId,
       varName: `__bareStmt_${line}_${col}`,
       kind: isStaticBare ? "static" : "global",
       initExpr: stmt,
-      loc: stmt.loc,
+      loc: effectiveLoc,
       exported: false,
       sequenceHint: depthBase + line,
       ...(withApprove && { withApprove: true }),
@@ -546,15 +577,27 @@ function unwrapWithApprove(node: AgencyNode): {
  * `staticStatement` at module top level wrapping a bare expression
  * (function call, value access, interrupt) — never an assignment, never
  * recursively — so a single unwrap is enough.
+ *
+ * Returns the wrapper's own `loc` separately so callers can prefer
+ * it for diagnostics. The inner statement's sub-parsers
+ * (functionCallParser, valueAccessParser, interruptStatementParser)
+ * do not emit `loc` themselves — only the outer `withLoc(...)` on
+ * `staticStatementParser` does — so the wrapper loc is the authoritative
+ * source location for the whole `static <expr>` form.
  */
 function unwrapStaticStatement(node: AgencyNode): {
   stmt: AgencyNode;
   isStaticBare: boolean;
+  wrapperLoc: AgencyNode["loc"];
 } {
   if (node.type === "staticStatement") {
-    return { stmt: node.statement, isStaticBare: true };
+    return {
+      stmt: node.statement,
+      isStaticBare: true,
+      wrapperLoc: node.loc,
+    };
   }
-  return { stmt: node, isStaticBare: false };
+  return { stmt: node, isStaticBare: false, wrapperLoc: undefined };
 }
 
 /**

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -41,6 +41,7 @@ import {
 import { checkUndefinedFunctions } from "./undefinedFunctionDiagnostic.js";
 import { checkUndefinedVariables } from "./undefinedVariableDiagnostic.js";
 import { RESERVED_FUNCTION_NAMES } from "./resolveCall.js";
+import { validateStaticInit } from "./validateStaticInit.js";
 import { walkNodes } from "../utils/node.js";
 
 export type { TypeCheckError, TypeCheckResult } from "./types.js";
@@ -301,6 +302,15 @@ export class TypeChecker {
 
     // 8. Check for undefined variable references (config-controlled severity).
     checkUndefinedVariables(scopes, ctx);
+
+    // 9. Validate static initializers + `static <bare>` statements.
+    // Direct-only checks against the Phase A surface — per-run-only
+    // primitive calls (e.g. `llm()`, `interrupt()`) and obvious
+    // post-declaration mutations of statics. Cross-module global
+    // reads from statics are caught earlier by `compileClosure`'s
+    // `rejectStaticReferencesGlobal`, which has access to the full
+    // import closure.
+    validateStaticInit(this.program, this.errors);
 
     return {
       errors: this.applySuppressions(this.deduplicateErrors()),

--- a/packages/agency-lang/lib/typeChecker/staticInitRules.ts
+++ b/packages/agency-lang/lib/typeChecker/staticInitRules.ts
@@ -1,0 +1,193 @@
+/**
+ * Compile-time rules for what's allowed inside a `static const`
+ * initializer or `static <bare>` top-level statement (Phase A).
+ *
+ * These rules complement PR 1's runtime read-before-init trap and
+ * PR 2's `StaticReferencesGlobalError`. They surface the most common
+ * misuses as TypeCheckError entries on the typechecker, so users see
+ * actionable messages before they hit runtime.
+ *
+ * **Direct-only by design.** The rules in this file walk the static
+ * initializer's *own* AST subtree. They do NOT follow user-defined
+ * helper functions — `static const x = myHelper()` where
+ * `myHelper()` itself calls `llm()` is not flagged here. That trade-
+ * off matches PR 2.5's depth-1 dep-graph philosophy: the runtime
+ * trap catches the rest. Sound interprocedural analysis is
+ * intentionally out of scope for this redesign.
+ *
+ * **Two surfaces, same rules.** Both `static const x = expr` and
+ * `static <bare>` are validated. The driver in `validateStaticInit.ts`
+ * spots both via the AST shape (Assignment with `static: true` and
+ * `staticStatement` respectively) and runs the same rule set against
+ * the inner expression / statement.
+ */
+import type { AgencyNode, Expression } from "../types.js";
+import type { TypeCheckError } from "./types.js";
+import { walkNodes } from "../utils/node.js";
+
+/**
+ * Per-run primitives that need an execution context to run. Calling
+ * any of these from a `static` initializer (which runs once at
+ * process startup, before any agent run has begun) is a logic error
+ * — there is no per-run ctx, no thread, no checkpoint store, no LLM
+ * client wired up yet.
+ *
+ * `interrupt` lives on this list as a *function name* even though
+ * the parser usually emits an `interruptStatement` node — a bare
+ * call like `interrupt("foo")` could parse as either depending on
+ * surrounding shape, so we check both. See `checkInterruptStatement`
+ * below for the statement form.
+ */
+export const BANNED_BUILTINS_IN_STATIC_INIT: Record<string, string> = {
+  llm: "`llm()` requires a per-run execution context",
+  chat: "`chat()` requires a per-run execution context",
+  interrupt: "`interrupt(...)` pauses the per-run execution stack",
+  respondToInterrupts:
+    "`respondToInterrupts()` operates on per-run interrupt state",
+  rewindFrom: "`rewindFrom()` operates on per-run checkpoint state",
+  runBatch: "`runBatch()` schedules per-run agent invocations",
+  callback: "`callback(...)` binds a hook into the per-run callback table",
+  emit: "`emit(...)` writes to per-run trace state",
+  thread: "`thread { ... }` opens a per-run conversation thread",
+};
+
+/**
+ * Walk a static initializer expression (or bare statement) and emit
+ * a diagnostic for each direct call to a banned builtin. Does NOT
+ * descend into nested `function` / `graphNode` bodies — those run
+ * later, in per-run ctx, so calls there are fine. Matches the
+ * ancestor-check pattern used by `collectFreeIdentifiers` in
+ * `lib/compiler/initDepGraph.ts`.
+ *
+ * `contextLabel` is the human-readable subject of the diagnostic
+ * (e.g. "static const 'prompt'" or "the `static greet()` bare
+ * statement"). Used as the lead of the error message so the user
+ * sees what part of their code is being rejected.
+ */
+export function checkBannedBuiltinCalls(
+  expr: Expression | AgencyNode,
+  contextLabel: string,
+): TypeCheckError[] {
+  const errors: TypeCheckError[] = [];
+  for (const { node, ancestors } of walkNodes([expr as AgencyNode])) {
+    if (
+      ancestors.some(
+        (a) => a.type === "function" || a.type === "graphNode",
+      )
+    ) {
+      continue;
+    }
+    if (node.type === "functionCall") {
+      const reason = BANNED_BUILTINS_IN_STATIC_INIT[node.functionName];
+      if (reason) {
+        errors.push({
+          message:
+            `${contextLabel} cannot call \`${node.functionName}(...)\` — ` +
+            `${reason}, but static initializers run once at process startup ` +
+            `before any per-run state exists. Move this call into a node ` +
+            `or a function called from a node.`,
+          loc: node.loc,
+        });
+      }
+      continue;
+    }
+    if (node.type === "interruptStatement") {
+      errors.push({
+        message:
+          `${contextLabel} cannot \`interrupt(...)\` — interrupts pause the ` +
+          `per-run execution stack, but static initializers run once at ` +
+          `process startup before any agent run has begun. Move this ` +
+          `into a node body.`,
+        loc: node.loc,
+      });
+    }
+  }
+  return errors;
+}
+
+/**
+ * Names of mutating method calls we recognise on common collection
+ * shapes. Used by `checkStaticMutation` to spot `staticArr.push(...)`
+ * — the simplest detectable form of post-declaration mutation
+ * against a deep-frozen static.
+ *
+ * Not exhaustive — only the most-likely-to-bite cases. Statics are
+ * `__deepFreeze`d at init time, so any actual mutation throws a
+ * clean `TypeError` at runtime; this list is a compile-time fast
+ * path for the most common user mistake.
+ */
+const MUTATING_METHODS: Record<string, true> = {
+  push: true,
+  pop: true,
+  shift: true,
+  unshift: true,
+  splice: true,
+  sort: true,
+  reverse: true,
+  fill: true,
+  copyWithin: true,
+  set: true,
+  delete: true,
+  clear: true,
+  add: true,
+};
+
+/**
+ * Decide whether a top-level node is a post-declaration mutation
+ * against one of the known static names, and produce a diagnostic if
+ * so. Two shapes are detected:
+ *
+ *   1. `staticName = ...` — a bare assignment whose target is a
+ *      known static, where the assignment is NOT itself the static's
+ *      declaration. Mutations inside nested `node` / `function`
+ *      bodies are NOT checked here; the type-checker already rejects
+ *      reassignment of any `const` via `constReassignment`, so the
+ *      mutation case for statics inside per-run code is covered.
+ *   2. `staticName.<mutatingMethod>(...)` — a top-level method call
+ *      on a known static using one of the names listed in
+ *      `MUTATING_METHODS`. Compile-time best-effort; runtime
+ *      `__deepFreeze` is still the source of truth.
+ *
+ * Caller is responsible for filtering to top-level nodes; this
+ * helper does not walk recursively. Same shape as PR 2's
+ * `nodeFromTopLevel` so the validator can drive both with one loop.
+ */
+export function checkStaticMutation(
+  node: AgencyNode,
+  staticNames: Record<string, true>,
+): TypeCheckError | null {
+  // Assignment shape: `x = ...` where x is a known static and the
+  // node is NOT a `const`/`let` declaration (those introduce a new
+  // binding, not mutate the static).
+  if (node.type === "assignment") {
+    if (node.declKind) return null;
+    if (!staticNames[node.variableName]) return null;
+    return {
+      message:
+        `Cannot reassign static \`${node.variableName}\` at module top ` +
+        `level — statics are immutable after initialization. Use a global ` +
+        `(\`const\`/\`let\` without \`static\`) if you need a mutable value.`,
+      loc: node.loc,
+    };
+  }
+  // Method-call shape: `x.push(...)` at top level.
+  if (node.type === "valueAccess") {
+    if (node.base.type !== "variableName") return null;
+    const name = (node.base as { value: string }).value;
+    if (!staticNames[name]) return null;
+    for (const elem of node.chain) {
+      if (elem.kind !== "methodCall") continue;
+      const methodName = elem.functionCall.functionName;
+      if (!MUTATING_METHODS[methodName]) continue;
+      return {
+        message:
+          `Cannot mutate static \`${name}\` via \`.${methodName}(...)\` at ` +
+          `module top level — statics are deep-frozen after initialization. ` +
+          `Use a global (\`const\`/\`let\` without \`static\`) if you need ` +
+          `a mutable value.`,
+        loc: node.loc,
+      };
+    }
+  }
+  return null;
+}

--- a/packages/agency-lang/lib/typeChecker/validateStaticInit.test.ts
+++ b/packages/agency-lang/lib/typeChecker/validateStaticInit.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+
+// Mirrors the helper used by `constReassignment.test.ts`. Returns
+// just the error messages so assertions stay terse.
+function check(source: string): string[] {
+  const parsed = parseAgency(source);
+  if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
+  const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
+  return typeCheck(parsed.result, {}, info).errors.map((e) => e.message);
+}
+
+describe("validateStaticInit — banned per-run primitives", () => {
+  it("rejects `llm()` inside a static const initializer", () => {
+    const errs = check(`
+static const prompt = llm("hello")
+node main() { return prompt }
+`);
+    expect(errs.some((m) => /Static const .*prompt.* cannot call .*llm/.test(m))).toBe(true);
+  });
+
+  it("rejects `llm()` inside a static bare statement", () => {
+    const errs = check(`
+def setup() { llm("hello") }
+static llm("startup")
+node main() { return 1 }
+`);
+    expect(
+      errs.some((m) =>
+        /Static bare statement cannot call .*llm/.test(m),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects `interrupt()` inside a static const initializer", () => {
+    const errs = check(`
+static const x = interrupt("foo")
+node main() { return x }
+`);
+    expect(
+      errs.some((m) => /Static const .*x.* cannot \\?\`?interrupt/.test(m)),
+    ).toBe(true);
+  });
+
+  it("does NOT flag `llm()` inside a node body", () => {
+    const errs = check(`
+node main() {
+  const r = llm("hello")
+  return r
+}
+`);
+    expect(errs.filter((m) => m.includes("static")).length).toBe(0);
+  });
+
+  it("does NOT flag `llm()` inside a `def` body called from a node", () => {
+    // Per the design doc, transitive detection through user helpers
+    // is intentionally out of scope — the runtime trap is the safety
+    // net. This test pins that direct-only contract.
+    const errs = check(`
+def helper(): string { return llm("hello") }
+static const x = helper()
+node main() { return x }
+`);
+    expect(errs.some((m) => m.includes("llm"))).toBe(false);
+  });
+});
+
+describe("validateStaticInit — static mutation detection", () => {
+  it("rejects top-level reassignment of a static", () => {
+    const errs = check(`
+static const x = 1
+x = 2
+node main() { return x }
+`);
+    expect(
+      errs.some((m) => /Cannot reassign static .*x.* at module top level/.test(m)),
+    ).toBe(true);
+  });
+
+  it("rejects top-level `.push(...)` on a static array", () => {
+    const errs = check(`
+static const items = [1, 2, 3]
+items.push(4)
+node main() { return items }
+`);
+    expect(
+      errs.some((m) =>
+        /Cannot mutate static .*items.* via .*push.*/.test(m),
+      ),
+    ).toBe(true);
+  });
+
+  it("does NOT flag a `let` reassignment of a non-static", () => {
+    const errs = check(`
+let x = 1
+x = 2
+node main() { return x }
+`);
+    expect(errs.filter((m) => m.includes("static")).length).toBe(0);
+  });
+
+  it("does NOT flag the static's own declaration", () => {
+    const errs = check(`
+static const x = 1
+node main() { return x }
+`);
+    expect(errs.filter((m) => m.includes("Cannot reassign")).length).toBe(0);
+  });
+
+  it("does NOT flag mutation inside a node body", () => {
+    // Inside a per-run code path the deep-freeze runtime check is the
+    // safety net. Compile-time detection here is only for the obvious
+    // top-level pattern.
+    const errs = check(`
+static const items = [1, 2, 3]
+node main() {
+  items.push(4)
+  return items
+}
+`);
+    expect(errs.filter((m) => /Cannot mutate static/.test(m)).length).toBe(0);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/validateStaticInit.ts
+++ b/packages/agency-lang/lib/typeChecker/validateStaticInit.ts
@@ -1,0 +1,82 @@
+/**
+ * Compile-time validation driver for `static` declarations and
+ * `static <bare>` top-level statements (Phase A surface).
+ *
+ * Two responsibilities, both keyed off the module's top-level node
+ * list (single pass):
+ *
+ *   1. Collect every static binding name so the mutation-detection
+ *      rule has something to match against (`staticName = ...` and
+ *      `staticName.push(...)`).
+ *   2. For each static decl or `static <bare>`, run
+ *      {@link checkBannedBuiltinCalls} over the inner expression /
+ *      statement; for everything else at module top level, run
+ *      {@link checkStaticMutation} against the collected names.
+ *
+ * Cross-module reads of non-static globals from a static initializer
+ * are NOT checked here — that's still the job of
+ * `rejectStaticReferencesGlobal` in `lib/compiler/initDepGraph.ts`,
+ * which already runs at the closure level (it can see *all* modules'
+ * statics + globals at once, and reuses PR 2.5's depth-1 expansion).
+ * Splitting per-module direct rules from cross-module dep-graph
+ * rules keeps each pass focused on the data it actually has.
+ */
+import type { AgencyProgram, AgencyNode, Assignment } from "../types.js";
+import type { TypeCheckError } from "./types.js";
+import {
+  checkBannedBuiltinCalls,
+  checkStaticMutation,
+} from "./staticInitRules.js";
+
+export function validateStaticInit(
+  program: AgencyProgram,
+  errors: TypeCheckError[],
+): void {
+  // First sweep: collect static names so the mutation rule has
+  // something to match against. Both `static const` and `with handler
+  // { static const ... }` shapes count; the `withModifier` wrapper
+  // here mirrors how `sectionAssembler` / `initDepGraph` peel it off.
+  const staticNames: Record<string, true> = {};
+  for (const node of program.nodes) {
+    const inner =
+      node.type === "withModifier" ? node.statement : node;
+    if (inner.type !== "assignment") continue;
+    if ((inner as Assignment).static) {
+      staticNames[(inner as Assignment).variableName] = true;
+    }
+  }
+
+  // Second sweep: validate static initializers + bare statements,
+  // and flag obvious mutations against known statics elsewhere at
+  // top level.
+  for (const node of program.nodes) {
+    const inner =
+      node.type === "withModifier" ? node.statement : node;
+
+    // `static const x = ...` — validate the initializer expression.
+    if (inner.type === "assignment" && (inner as Assignment).static) {
+      const a = inner as Assignment;
+      const label = `Static const \`${a.variableName}\``;
+      errors.push(
+        ...checkBannedBuiltinCalls(a.value as AgencyNode, label),
+      );
+      continue;
+    }
+
+    // `static <bare>` — validate the wrapped statement.
+    if (inner.type === "staticStatement") {
+      errors.push(
+        ...checkBannedBuiltinCalls(
+          inner.statement,
+          "Static bare statement",
+        ),
+      );
+      continue;
+    }
+
+    // Anything else at top level — could be a mutation of a known
+    // static. checkStaticMutation returns null when it isn't.
+    const mutationErr = checkStaticMutation(inner, staticNames);
+    if (mutationErr) errors.push(mutationErr);
+  }
+}


### PR DESCRIPTION
## Summary

PR 4 of 6 in the agent-init redesign. Adds compile-time validation for `static` initializers and `static <bare>` statements so users see actionable errors before runtime.

```
$ pnpm run agency tc bad.agency
error: Static const `greeting` cannot call `llm(...)` — `llm()` requires a
       per-run execution context, but static initializers run once at process
       startup before any per-run state exists. Move this call into a node or
       a function called from a node.
```

## What's checked

| Rule | Example caught |
|---|---|
| Per-run-only primitive calls | `static const x = llm("...")`, `static interrupt(...)`, `static runBatch(...)` |
| Top-level mutation of a static | `static const x = 1; x = 2`, `static const items = []; items.push(1)` |
| Cross-module static-reads-global (PR 2) | `static const x = bar` where `bar` is a non-static global in another module |

Banned primitives: `llm`, `chat`, `interrupt`, `respondToInterrupts`, `rewindFrom`, `runBatch`, `callback`, `emit`, `thread`.

## Design notes

- **Direct-only by design.** The new rules walk the static initializer's own AST subtree. They do **not** follow user-defined helper functions. `static const x = myHelper()` where `myHelper()` itself calls `llm()` is intentionally not flagged — that matches PR 2.5's depth-1 dep-graph philosophy. The PR 1 runtime read-before-init trap stays as the safety net for indirect cases.
- **Cross-module global-from-static reads** are still owned by PR 2's `StaticReferencesGlobalError` at closure build time, because only that pass has the full import surface. PR 4's per-module check just complements it with the direct-builtin-call surface.
- **Reformatted `StaticReferencesGlobalError`** so the message says `static const 'name'` or `static bare statement at <loc>` instead of the generic `Static 'name'`. The Phase A vs Phase B explanation is now spelled out with a suggested fix.
- **Fixed bare-statement loc reporting.** `unwrapStaticStatement` now returns the wrapper's `loc` alongside the inner statement, and `nodeFromTopLevel` prefers it. Inner sub-parsers don't emit `loc` themselves, so the old code rendered `?:?` line numbers in errors against bare static statements.

## Files

- New: [`lib/typeChecker/staticInitRules.ts`](file:///lib/typeChecker/staticInitRules.ts) — rule functions + banned-builtin table.
- New: [`lib/typeChecker/validateStaticInit.ts`](file:///lib/typeChecker/validateStaticInit.ts) — driver pass.
- New: `lib/typeChecker/validateStaticInit.test.ts` — 10 unit tests.
- Modified: `lib/typeChecker/index.ts` — step 9 calls `validateStaticInit`.
- Modified: `lib/compiler/initDepGraph.ts` — wrapper-loc plumbing + reformatted error.
- Modified: `lib/compiler/compileClosure.test.ts` — updated regex for new error format.

## Validation

- 10 new unit tests (5 banned-primitive cases, 5 mutation cases, each with negative companions)
- 516 typeChecker tests pass (no false positives on existing fixtures)
- 28 initDepGraph + 83 typescriptGenerator fixture tests pass
- Existing static-* agency execution tests pass
- Structural lint passes

## What's deferred

- `agency explain-init` CLI surfaces the dep-graph + validation results — PR 5.
- User-docs rewrite — PR 6.

## Refs

Agent-init redesign roadmap. Builds on PR 1 (runtime trap), PR 2 (per-variable topsort + `StaticReferencesGlobalError`), PR 2.5 (depth-1 callgraph), PR 3 (`static <bare>` parser surface).
