### PR TITLE
Closure-wide init bootstrap so imported statics initialize before any node runs

### DIFF
--- a/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/sectionAssembler.ts
@@ -612,6 +612,20 @@ function buildInitializeGlobalsFn(opts: AssembleSectionsOpts): TsNode {
       opts.globalLocalOrder ?? [],
       (opts.globalAwaitModules ?? []).map((m) => m.sourceModuleId),
     ),
+    // Idempotence guard: Phase B runs once per execCtx. The closure-
+    // wide bootstrap loop in `runNode` iterates every registered
+    // module, and other modules' `__initializeGlobals` prelude also
+    // `await __awaitGlobalsInit(...)` for any module they depend on
+    // — without this guard those overlapping calls would each re-run
+    // the body, double-executing top-level globals and bare
+    // statements. Same per-execCtx flag that the per-function lazy
+    // guard already checks; safe and cheap.
+    ts.if(
+      ts.methodCall(ts.prop(ctxParam, "globals"), "isInitialized", [
+        ts.str(opts.moduleId),
+      ]),
+      ts.return(),
+    ),
     // Mark this module as initialized BEFORE running init statements.
     // This prevents infinite recursion when a global init expression
     // calls a function defined in the same module (which would trigger

--- a/packages/agency-lang/lib/runtime/crossModuleInitRegistry.ts
+++ b/packages/agency-lang/lib/runtime/crossModuleInitRegistry.ts
@@ -77,3 +77,43 @@ export async function __awaitGlobalsInit(
   if (!fn) return;
   await fn(ctx);
 }
+
+/**
+ * Closure-wide bootstrap: ensure every JS-loaded Agency module has had
+ * Phase A (statics) and Phase B (globals) initialized on this ctx
+ * before user code runs.
+ *
+ * Called once from {@link runNode} on every fresh agent run, right
+ * after the entry module's own `initializeGlobals` runs. Iteration
+ * order doesn't matter for correctness — each module's
+ * `__initializeGlobals` has its own `await __awaitGlobalsInit(...)`
+ * prelude for its dep modules, and Phase A is deduped per process
+ * via the `__staticInitPromise` guard in each module, Phase B per
+ * execCtx via the `globals.isInitialized(...)` early-return baked
+ * into `__initializeGlobals`. So even if we visit a module before
+ * one of its deps, the dep gets pulled in first by the nested await
+ * chain and the duplicate visit becomes a no-op.
+ *
+ * Why this exists: the per-variable dep graph in `compileClosure`
+ * only sees references in *initializer expressions*. A `static const`
+ * read from inside a function/node body doesn't show up there, so
+ * if the entry module never directly references one of its
+ * dependencies' statics in an initializer, that dependency's init
+ * would never get triggered — and the read inside the function body
+ * would hit `__UNINIT_STATIC` and throw at runtime. This loop closes
+ * that hole by treating "imported into the closure" as enough reason
+ * to initialize.
+ */
+export async function __initAllRegistered(ctx: unknown): Promise<void> {
+  // Statics first across the whole closure, then globals. Each
+  // module's `__initializeGlobals` would do its own static init
+  // anyway, but doing it as a separate pass here keeps "Phase A
+  // completes before any Phase B starts" visible at the runtime
+  // boundary instead of relying on per-module ordering.
+  for (const moduleId of Object.keys(staticInits)) {
+    await staticInits[moduleId](ctx);
+  }
+  for (const moduleId of Object.keys(globalsInits)) {
+    await globalsInits[moduleId](ctx);
+  }
+}

--- a/packages/agency-lang/lib/runtime/node.ts
+++ b/packages/agency-lang/lib/runtime/node.ts
@@ -12,6 +12,7 @@ import {
 } from "./errors.js";
 import { State, StateStack } from "./state/stateStack.js";
 import { ThreadStore } from "./state/threadStore.js";
+import { __initAllRegistered } from "./crossModuleInitRegistry.js";
 import { resolveTraceFilePath } from "./trace/traceWriter.js";
 import { GraphState, RunNodeResult } from "./types.js";
 import { createReturnObject } from "./utils.js";
@@ -180,6 +181,19 @@ export async function runNode({
   if (initializeGlobals) {
     await runInBootstrapFrame(execCtx, () => initializeGlobals(execCtx), { moduleDir });
   }
+  // Closure-wide bootstrap: initialize every other JS-loaded Agency
+  // module that the entry's own init didn't transitively reach.
+  // Reads of imported `static const` values from inside function /
+  // node bodies don't show up in the compile-time per-variable dep
+  // graph (it only sees initializer expressions), so without this
+  // loop a `node main() { route({ systemPrompt: foreignStatic }) }`
+  // pattern would hit the `__UNINIT_STATIC` trap because the foreign
+  // module's init was never triggered. Each module's
+  // `__initializeGlobals` is idempotent per execCtx (early-return on
+  // `globals.isInitialized(...)`) and Phase A is process-idempotent
+  // via `__staticInitPromise`, so calling already-initialized
+  // modules here is a cheap no-op.
+  await runInBootstrapFrame(execCtx, () => __initAllRegistered(execCtx), { moduleDir });
   // Top-level callbacks are re-registered every fresh run AFTER global
   // init so any module-level vars they reference (via `__ctx.globals`)
   // are already set up. The registration sequence mirrors what

--- a/packages/agency-lang/lib/runtime/staticInit.crossModule.test.ts
+++ b/packages/agency-lang/lib/runtime/staticInit.crossModule.test.ts
@@ -66,3 +66,61 @@ describe("cross-module static dep resolves correctly via PR-2 topsort", () => {
     expect(result.data).toBe("hello!");
   });
 });
+
+/**
+ * Regression: an imported `static const` that's only ever read from
+ * inside a function/node body (never from another static initializer)
+ * must still be initialized before `node main()` runs.
+ *
+ * The compile-time per-variable dep graph walks initializer
+ * expressions; reads inside function bodies don't contribute deps. Yet
+ * `runNode` must guarantee Phase A is complete for the entire JS-loaded
+ * closure before user code starts — otherwise the PR-1
+ * `__UNINIT_STATIC` trap fires the first time the node runs (mirroring
+ * the agency-agent bug where `agent.agency` imported `codeSysPrompt`
+ * from `code.agency` and only read it inside `_runTurn`).
+ *
+ * The closure-wide bootstrap in `runNode` (calls `__initAllRegistered`)
+ * is what makes this work.
+ */
+describe("imported static used only from a function body initializes via closure bootstrap", () => {
+  const fixturesRoot = path.resolve(
+    __dirname,
+    "../../.agency-tmp/static-cross-module-fn-body",
+  );
+  const mainAgency = path.join(fixturesRoot, "main.agency");
+  const dataAgency = path.join(fixturesRoot, "data.agency");
+  const mainJs = mainAgency.replace(/\.agency$/, ".js");
+
+  beforeAll(() => {
+    fs.mkdirSync(fixturesRoot, { recursive: true });
+    fs.writeFileSync(
+      dataAgency,
+      'export static const greeting = "hello"\n',
+    );
+    fs.writeFileSync(
+      mainAgency,
+      'import { greeting } from "./data.agency";\n' +
+        '\n' +
+        'def render(): string {\n' +
+        '  return greeting + "!"\n' +
+        '}\n' +
+        '\n' +
+        'node main() {\n' +
+        '  return render()\n' +
+        '}\n',
+    );
+    resetCompilationCache();
+    compile({}, mainAgency);
+  });
+
+  afterAll(() => {
+    fs.rmSync(fixturesRoot, { recursive: true, force: true });
+  });
+
+  it("does not throw the read-before-init trap and returns 'hello!'", async () => {
+    const mod = await import(pathToFileURL(mainJs).href);
+    const result = await mod.main();
+    expect(result.data).toBe("hello!");
+  });
+});

--- a/packages/agency-lang/tests/agency/topsort/fn-body-read-helper.agency
+++ b/packages/agency-lang/tests/agency/topsort/fn-body-read-helper.agency
@@ -1,0 +1,8 @@
+// Helper for `fn-body-read-main.agency` — exposes one static const.
+// Used to verify the closure-wide runtime bootstrap: nothing in the
+// main file references `greeting` from another *initializer*, only
+// from inside a `def` body, so the compile-time per-variable dep
+// graph never sees an edge. Before the closure-wide bootstrap landed,
+// this module's `__initializeStatic` was never triggered and the
+// read in main hit the PR-1 read-before-init trap.
+export static const greeting = "hello"

--- a/packages/agency-lang/tests/agency/topsort/fn-body-read-main.agency
+++ b/packages/agency-lang/tests/agency/topsort/fn-body-read-main.agency
@@ -1,0 +1,16 @@
+// Regression for the agency-agent shape: an imported `static const`
+// is read ONLY from inside a function body, never from another
+// static / global initializer. The compile-time per-variable init
+// dep graph in `compileClosure` only walks initializer expressions,
+// so without the closure-wide runtime bootstrap added in this PR
+// the helper module's `__initializeStatic` would never fire and the
+// read inside `render()` would hit the PR-1 read-before-init trap.
+import { greeting } from "./fn-body-read-helper.agency"
+
+def render(): string {
+  return greeting + "!"
+}
+
+node main() {
+  return render()
+}

--- a/packages/agency-lang/tests/agency/topsort/fn-body-read-main.test.json
+++ b/packages/agency-lang/tests/agency/topsort/fn-body-read-main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Imported static read only from a function body initializes via the closure-wide runtime bootstrap (regression: agency-agent shape).",
+      "expectedOutput": "\"hello!\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/topsort/node-body-read-helper.agency
+++ b/packages/agency-lang/tests/agency/topsort/node-body-read-helper.agency
@@ -1,0 +1,6 @@
+// Helper for `node-body-read-main.agency`. Same shape as
+// `fn-body-read-helper.agency` but consumed from a `node` body
+// instead of a `def` body in the importer — confirms the closure-
+// wide bootstrap fires before *any* user code runs, not just before
+// nested function calls.
+export static const value = 42

--- a/packages/agency-lang/tests/agency/topsort/node-body-read-main.agency
+++ b/packages/agency-lang/tests/agency/topsort/node-body-read-main.agency
@@ -1,0 +1,10 @@
+// Variant of `fn-body-read-main.agency` where the imported static is
+// read directly from `node main()` instead of from a `def` body
+// called by main. Asserts that the closure-wide bootstrap completes
+// before the node body itself runs — not just before nested function
+// calls inside the node body.
+import { value } from "./node-body-read-helper.agency"
+
+node main() {
+  return value + 1
+}

--- a/packages/agency-lang/tests/agency/topsort/node-body-read-main.test.json
+++ b/packages/agency-lang/tests/agency/topsort/node-body-read-main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Imported static read directly from a node body (no intermediate def) initializes via the closure-wide runtime bootstrap.",
+      "expectedOutput": "43",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/topsort/transitive-a-main.agency
+++ b/packages/agency-lang/tests/agency/topsort/transitive-a-main.agency
@@ -1,0 +1,21 @@
+// Entry module of the transitive A → B → C chain.
+//
+// Imports `getX` from `transitive-b.agency` but NEVER imports
+// `transitive-c.agency` directly. `getX`'s body reads C's static.
+//
+// Before the closure-wide runtime bootstrap landed, the
+// compile-time per-variable dep graph saw zero edges into either B
+// or C from this file's *initializers* (there are none), so neither
+// helper module's `__initializeStatic` ever ran and the read of
+// C's `x` inside `getX` hit the PR-1 read-before-init trap on the
+// first call to `getX()`.
+//
+// With the bootstrap, the runtime walks the full JS-loaded import
+// registry before invoking `main`, so every module's statics
+// initialize regardless of whether the entry's initializers
+// referenced them.
+import { getX } from "./transitive-b.agency"
+
+node main() {
+  return getX()
+}

--- a/packages/agency-lang/tests/agency/topsort/transitive-a-main.test.json
+++ b/packages/agency-lang/tests/agency/topsort/transitive-a-main.test.json
@@ -1,0 +1,11 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "description": "Transitive A→B→C: A reads C's static via a helper from B; A never imports C. Closure-wide bootstrap initializes the full transitive closure, not just direct imports.",
+      "expectedOutput": "\"deep\"",
+      "evaluationCriteria": [{ "type": "exact" }]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/topsort/transitive-b.agency
+++ b/packages/agency-lang/tests/agency/topsort/transitive-b.agency
@@ -1,0 +1,8 @@
+// Middle module in the A → B → C chain. Imports a static from C and
+// re-exposes it via a `def` whose body reads the static. The body
+// read is the only path from A to C; A never imports C directly.
+import { x } from "./transitive-c.agency"
+
+export def getX(): string {
+  return x
+}

--- a/packages/agency-lang/tests/agency/topsort/transitive-c.agency
+++ b/packages/agency-lang/tests/agency/topsort/transitive-c.agency
@@ -1,0 +1,8 @@
+// Deepest module in the A → B → C chain used by
+// `transitive-a-main.agency`. Owns the static that's read through a
+// two-hop indirection. Crucially `transitive-a-main.agency` never
+// imports this file directly — it only imports `getX` from
+// `transitive-b.agency`. Confirms the runtime bootstrap reaches the
+// full transitive import closure, not just the entry's direct
+// imports.
+export static const x = "deep"

--- a/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/assignment.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("assignment.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("assignment.agency")
 }
 __registerGlobalsInit("assignment.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -137,6 +137,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("safe-function.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("safe-function.agency")
 }
 __registerGlobalsInit("safe-function.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptBuilder/simple.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/simple.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("simple.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("simple.agency")
 }
 __registerGlobalsInit("simple.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/array.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/array.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("array.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("array.agency")
 }
 __registerGlobalsInit("array.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/arrayAndObject.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("arrayAndObject.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("arrayAndObject.agency")
   __ctx.globals.set("arrayAndObject.agency", "nums", [1, 2, 3, 4, 5])
   await __call(print, {

--- a/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/assignment.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("assignment.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("assignment.agency")
 }
 __registerGlobalsInit("assignment.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("asyncAssigned.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("asyncAssigned.agency")
 }
 __registerGlobalsInit("asyncAssigned.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncLlm.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("asyncLlm.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("asyncLlm.agency")
 }
 __registerGlobalsInit("asyncLlm.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("asyncUnassigned.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("asyncUnassigned.agency")
 }
 __registerGlobalsInit("asyncUnassigned.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("bangParams.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("bangParams.agency")
 }
 __registerGlobalsInit("bangParams.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("bangReturnType.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("bangReturnType.agency")
 }
 __registerGlobalsInit("bangReturnType.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangValidation.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("bangValidation.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("bangValidation.agency")
 }
 __registerGlobalsInit("bangValidation.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("blockBasic.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("blockBasic.agency")
 }
 __registerGlobalsInit("blockBasic.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("blockParams.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("blockParams.agency")
 }
 __registerGlobalsInit("blockParams.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/checkpoint-restore.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("checkpoint-restore.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("checkpoint-restore.agency")
 }
 __registerGlobalsInit("checkpoint-restore.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("comments.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("comments.agency")
   __ctx.globals.set("comments.agency", "x", 42)
   __ctx.globals.set("comments.agency", "y", `hello`)

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("defaultValues.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("defaultValues.agency")
   await __call(greet, {
     type: "positional",

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -137,6 +137,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("docstrings.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("docstrings.agency")
   __ctx.globals.set("docstrings.agency", "toolVersion", `2.0`)
 }

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0001.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("euler-0001.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("euler-0001.agency")
 }
 __registerGlobalsInit("euler-0001.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0002.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("euler-0002.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("euler-0002.agency")
 }
 __registerGlobalsInit("euler-0002.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0003.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("euler-0003.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("euler-0003.agency")
 }
 __registerGlobalsInit("euler-0003.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("euler-0004.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("euler-0004.agency")
 }
 __registerGlobalsInit("euler-0004.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("euler-0005.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("euler-0005.agency")
 }
 __registerGlobalsInit("euler-0005.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0006.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("euler-0006.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("euler-0006.agency")
 }
 __registerGlobalsInit("euler-0006.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("euler-0007.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("euler-0007.agency")
 }
 __registerGlobalsInit("euler-0007.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("euler-0008.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("euler-0008.agency")
 }
 __registerGlobalsInit("euler-0008.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0009.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("euler-0009.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("euler-0009.agency")
 }
 __registerGlobalsInit("euler-0009.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("euler-0010.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("euler-0010.agency")
 }
 __registerGlobalsInit("euler-0010.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/forLoop.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("forLoop.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("forLoop.agency")
 }
 __registerGlobalsInit("forLoop.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("function-with-types.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("function-with-types.agency")
 }
 __registerGlobalsInit("function-with-types.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("function.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("function.agency")
 }
 __registerGlobalsInit("function.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("functionRef.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("functionRef.agency")
 }
 __registerGlobalsInit("functionRef.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("genericAliasValidation.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("genericAliasValidation.agency")
 }
 __registerGlobalsInit("genericAliasValidation.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/goto.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/goto.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("goto.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("goto.agency")
 }
 __registerGlobalsInit("goto.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/gotoWithArgs.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("gotoWithArgs.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("gotoWithArgs.agency")
 }
 __registerGlobalsInit("gotoWithArgs.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/graph-node-with-types.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("graph-node-with-types.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("graph-node-with-types.agency")
 }
 __registerGlobalsInit("graph-node-with-types.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/ifElse.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("ifElse.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("ifElse.agency")
 }
 __registerGlobalsInit("ifElse.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/imports.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/imports.mjs
@@ -153,6 +153,9 @@ function registerTools(tools: any[]) {
 __registerTool(foo);
 __registerTool(foo);
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("imports.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("imports.agency")
 }
 __registerGlobalsInit("imports.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("inlineBlockBasic.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("inlineBlockBasic.agency")
 }
 __registerGlobalsInit("inlineBlockBasic.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("inlineBlockParams.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("inlineBlockParams.agency")
 }
 __registerGlobalsInit("inlineBlockParams.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/input.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/input.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("input.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("input.agency")
 }
 __registerGlobalsInit("input.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interpolation.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("interpolation.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("interpolation.agency")
 }
 __registerGlobalsInit("interpolation.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("interrupt-2-deep-in-function.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("interrupt-2-deep-in-function.agency")
 }
 __registerGlobalsInit("interrupt-2-deep-in-function.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-assignment.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("interrupt-assignment.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("interrupt-assignment.agency")
 }
 __registerGlobalsInit("interrupt-assignment.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("interrupt-in-node.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("interrupt-in-node.agency")
 }
 __registerGlobalsInit("interrupt-in-node.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/llmConfigParam.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("llmConfigParam.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("llmConfigParam.agency")
   __ctx.globals.set("llmConfigParam.agency", "config", {
     "model": `gemini-2.5-flash-lite`

--- a/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/matchBlock.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("matchBlock.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("matchBlock.agency")
 }
 __registerGlobalsInit("matchBlock.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("multiLineComment.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("multiLineComment.agency")
   __ctx.globals.set("multiLineComment.agency", "x", 42)
 }

--- a/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multipleNodes.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("multipleNodes.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("multipleNodes.agency")
 }
 __registerGlobalsInit("multipleNodes.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("namedArgs.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("namedArgs.agency")
   await __call(greet, {
     type: "named",

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("namedArgsReorder.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("namedArgsReorder.agency")
 }
 __registerGlobalsInit("namedArgsReorder.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/noResponseFormat.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("noResponseFormat.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("noResponseFormat.agency")
 }
 __registerGlobalsInit("noResponseFormat.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/objectDescription.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("objectDescription.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("objectDescription.agency")
 }
 __registerGlobalsInit("objectDescription.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("optionalParams.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("optionalParams.agency")
   await __call(greet, {
     type: "positional",

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("pipe-operator.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("pipe-operator.agency")
 }
 __registerGlobalsInit("pipe-operator.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/recordIndex.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("recordIndex.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("recordIndex.agency")
 }
 __registerGlobalsInit("recordIndex.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("result-basic.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("result-basic.agency")
 }
 __registerGlobalsInit("result-basic.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("result-guards.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("result-guards.agency")
 }
 __registerGlobalsInit("result-guards.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/returnValue.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("returnValue.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("returnValue.agency")
 }
 __registerGlobalsInit("returnValue.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/rewindCheckpoint.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("rewindCheckpoint.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("rewindCheckpoint.agency")
 }
 __registerGlobalsInit("rewindCheckpoint.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/safe.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/safe.mjs
@@ -137,6 +137,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("safe.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("safe.agency")
 }
 __registerGlobalsInit("safe.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaAccess.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("schemaAccess.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("schemaAccess.agency")
 }
 __registerGlobalsInit("schemaAccess.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("schemaParamInjection.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("schemaParamInjection.agency")
 }
 __registerGlobalsInit("schemaParamInjection.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/setLLMClient.mjs
@@ -137,6 +137,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("setLLMClient.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("setLLMClient.agency")
   __ctx.globals.set("setLLMClient.agency", "client", await __call(SimpleOpenAIClient, {
     type: "positional",

--- a/packages/agency-lang/tests/typescriptGenerator/simple.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/simple.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("simple.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("simple.agency")
 }
 __registerGlobalsInit("simple.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/skill.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/skill.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("skill.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("skill.agency")
 }
 __registerGlobalsInit("skill.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/slice.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/slice.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("slice.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("slice.agency")
 }
 __registerGlobalsInit("slice.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sliceAssign.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("sliceAssign.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("sliceAssign.agency")
 }
 __registerGlobalsInit("sliceAssign.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("sourceMap.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("sourceMap.agency")
 }
 __registerGlobalsInit("sourceMap.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/splat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/splat.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("splat.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("splat.agency")
   __ctx.globals.set("splat.agency", "arr1", [1, 2])
   __ctx.globals.set("splat.agency", "arr2", [3, 4])

--- a/packages/agency-lang/tests/typescriptGenerator/static.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/static.mjs
@@ -154,6 +154,9 @@ function __getStaticVars() {
 __globalCtx.getStaticVars = __getStaticVars;
 __registerStaticInit("static.agency", __initializeStatic);
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("static.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("static.agency")
   await __initializeStatic(__ctx)
   await __ctx.writeStaticStateToTrace(__globalCtx.getStaticVars())

--- a/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/streaming.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("streaming.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("streaming.agency")
 }
 __registerGlobalsInit("streaming.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/string-interpolation.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("string-interpolation.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("string-interpolation.agency")
 }
 __registerGlobalsInit("string-interpolation.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/stringConcat.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("stringConcat.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("stringConcat.agency")
 }
 __registerGlobalsInit("stringConcat.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("threadsAndSubthreads.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("threadsAndSubthreads.agency")
 }
 __registerGlobalsInit("threadsAndSubthreads.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/typeHints.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("typeHints.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("typeHints.agency")
 }
 __registerGlobalsInit("typeHints.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/exportedTypeAlias.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("exportedTypeAlias.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("exportedTypeAlias.agency")
 }
 __registerGlobalsInit("exportedTypeAlias.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/literal.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("literal.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("literal.agency")
 }
 __registerGlobalsInit("literal.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/nestedTypeAlias.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("nestedTypeAlias.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("nestedTypeAlias.agency")
 }
 __registerGlobalsInit("nestedTypeAlias.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/types/typeAlias.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("typeAlias.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("typeAlias.agency")
 }
 __registerGlobalsInit("typeAlias.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/unitLiterals.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("unitLiterals.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("unitLiterals.agency")
 }
 __registerGlobalsInit("unitLiterals.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/valueAccessInterpolation.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("valueAccessInterpolation.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("valueAccessInterpolation.agency")
 }
 __registerGlobalsInit("valueAccessInterpolation.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/varTypes.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("varTypes.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("varTypes.agency")
 }
 __registerGlobalsInit("varTypes.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("variadic.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("variadic.agency")
   await __call(log, {
     type: "positional",

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("withModifier.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("withModifier.agency")
 }
 __registerGlobalsInit("withModifier.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withParam.mjs
@@ -136,6 +136,9 @@ function registerTools(tools: any[]) {
 }
 
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("withParam.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("withParam.agency")
 }
 __registerGlobalsInit("withParam.agency", __initializeGlobals);


### PR DESCRIPTION
## Problem

The compile-time per-variable init dep graph in `compileClosure` only walks **initializer expressions**. A `static const` imported from another module and read only from inside a `def` / `node` body never contributed an edge, so the source module's `__initializeStatic` / `__initializeGlobals` was never triggered — and the read hit the `__UNINIT_STATIC` sentinel and threw the PR-1 read-before-init trap.

The agency-agent in this tree was the canonical repro:

```agency
// agent.agency
import { codeSysPrompt, codeTools } from "./code.agency"

def _runTurn(msg: string): boolean {
  const reply = route({
    agents: {
      code: { systemPrompt: codeSysPrompt, tools: codeTools, ... },
      ...
    },
    ...
  }, msg)
  ...
}

node main() {
  repl(onSubmit: _runTurn, ...)
}
```

`codeSysPrompt` is read from inside a function body, not from a static or global initializer. So the dep graph saw zero edges into `code.agency`. The agent started up fine, displayed the REPL, and the very first time the user pressed Enter `__readStatic(codeSysPrompt, ...)` threw:

```
Tried to read static `codeSysPrompt` from .../code.agency before its initializer ran.
```

## Fix

Enter the runtime with the **whole closure** initialized.

1. **`runNode` calls `__initAllRegistered(execCtx)`** right after the entry module's own `initializeGlobals`. It walks the process-global init registry and awaits every module's `__initializeStatic` then `__initializeGlobals`. Iteration order doesn't matter for correctness — each module's `__initializeGlobals` keeps its existing `awaitModules` prelude that pulls in its real deps in topsort order, and idempotence handles the duplicate calls.

2. **`__initializeGlobals` is now per-execCtx idempotent**: an early-return guard at the top checks `globals.isInitialized(moduleId)` before the existing `markInitialized(...)` call. Phase A was already process-idempotent via `__staticInitPromise`.

3. **The existing per-function lazy init guard stays as a safety net** for direct TS calls into a compiled module that bypass `runNode`. Same with `awaitModules` — both remain correct under the idempotence guarantee.

### New contract

- **JS load:** every module registers its init functions. No execution.
- **First `runNode` of the process:** Phase A runs once for the entire closure in topsort order (deduped per process), Phase B runs in topsort order (deduped per execCtx), then the user node executes.
- **Subsequent runs:** Phase A is a no-op, Phase B re-runs.

## Verification

- New regression test `imported static used only from a function body initializes via closure bootstrap` in `lib/runtime/staticInit.crossModule.test.ts` — reproduces the agency-agent shape (an imported static read only from a `def` body) and asserts the trap no longer fires.
- Confirmed the test **fails without the runtime change** (PR-1 trap throws) and **passes with it** by temporarily reverting the three source changes.
- Existing `lib/runtime/`, `lib/compiler/`, `lib/backends/` suites: 1108 of 1110 pass; the 2 remaining failures are pre-existing on `main` (unrelated regex mismatch in error-message assertions).
- 89 fixture snapshots regenerated via `make fixtures` to include the new `if (isInitialized(...)) return;` guard.

## Files changed

- `lib/runtime/node.ts` — call `__initAllRegistered(execCtx)` after entry init.
- `lib/runtime/crossModuleInitRegistry.ts` — new `__initAllRegistered` walker.
- `lib/backends/typescriptBuilder/sectionAssembler.ts` — idempotence guard in emitted `__initializeGlobals`.
- `lib/runtime/staticInit.crossModule.test.ts` — regression test.
- `tests/typescriptGenerator/*.mjs`, `tests/typescriptBuilder/*.mjs` — regenerated fixtures.
