### PR TITLE
std::ui: add chooseOption modal for REPL prompts

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -618,7 +618,7 @@ askUser(intr: any): Decision
 
 **Returns:** [Decision](#decision)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L505))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L506))
 
 ### _handler
 
@@ -639,7 +639,7 @@ _handler(intr: any): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L547))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L545))
 
 ### cliPolicyHandler
 
@@ -719,4 +719,4 @@ CLI sugar for an interactive policy handler. Owns load + save +
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L631))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L629))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -102,7 +102,7 @@ export type Element = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L100))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L106))
 
 ### KeyEvent
 
@@ -135,7 +135,7 @@ export type KeyEvent = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L121))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L127))
 
 ### Builder
 
@@ -174,7 +174,7 @@ export type Builder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L139))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L145))
 
 ### ReplInputState
 
@@ -189,7 +189,7 @@ type ReplInputState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L853))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L833))
 
 ### ReplPaletteState
 
@@ -202,7 +202,7 @@ type ReplPaletteState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L862))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L842))
 
 ### ReplTranscriptState
 
@@ -212,7 +212,7 @@ type ReplTranscriptState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L869))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L849))
 
 ### ReplSubmitState
 
@@ -224,7 +224,7 @@ type ReplSubmitState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L873))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L853))
 
 ### ReplConfigState
 
@@ -232,6 +232,40 @@ type ReplSubmitState = {
 type ReplConfigState = {
   status: any;
   onSubmit: any
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L859))
+
+### ChoiceItem
+
+* One option in a `chooseOption()` modal. `key` is the value the
+ * Promise resolves to when the user picks this row; `label` is the
+ * human-readable text rendered in the modal.
+
+```ts
+/**
+ * One option in a `chooseOption()` modal. `key` is the value the
+ * Promise resolves to when the user picks this row; `label` is the
+ * human-readable text rendered in the modal.
+ */
+export type ChoiceItem = {
+  key: string;
+  label: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L869))
+
+### ReplChoiceState
+
+```ts
+type ReplChoiceState = {
+  title: string;
+  body: string;
+  items: ChoiceItem[];
+  filter: string;
+  cursor: number
 }
 ```
 
@@ -246,11 +280,12 @@ type ReplState = {
   transcript: ReplTranscriptState;
   submit: ReplSubmitState;
   config: ReplConfigState;
+  choice: ReplChoiceState | null;
   done: boolean
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L884))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L887))
 
 ## Functions
 
@@ -281,7 +316,7 @@ Build a plain text element. No layout sizing — embed inside a `box`
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L158))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L164))
 
 ### _setStyleIfSet
 
@@ -297,7 +332,7 @@ _setStyleIfSet(style: any, key: string, value: any)
 | key | `string` |  |
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L179))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L185))
 
 ### line
 
@@ -338,7 +373,7 @@ Build a single-line text element with `height: 1`. The default keeps
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L193))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L199))
 
 ### list
 
@@ -381,7 +416,7 @@ Build a scrollable selectable list. `selectedIndex` highlights one
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L242))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L248))
 
 ### textInput
 
@@ -420,7 +455,7 @@ Build a single-line text input. The renderer displays `value` with
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L291))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L297))
 
 ### _mkBoxStyle
 
@@ -446,7 +481,7 @@ _mkBoxStyle(flexDirection: string, flex: number, width: number, height: number, 
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L335))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L341))
 
 ### _makeBuilder
 
@@ -462,7 +497,7 @@ _makeBuilder(kids: any[]): Builder
 
 **Returns:** [Builder](#builder)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L365))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L371))
 
 ### column
 
@@ -512,7 +547,7 @@ Build a vertical container. Children stack top-to-bottom. Pass a
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L381))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L387))
 
 ### row
 
@@ -558,7 +593,7 @@ Build a horizontal container. Children stack left-to-right. Pass a
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L445))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L451))
 
 ### box
 
@@ -605,7 +640,7 @@ Build a direction-neutral container. Use when you want to apply
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L503))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L509))
 
 ### _addRow
 
@@ -632,7 +667,7 @@ _addRow(kids: any[], flex: number, width: number, height: number, padding: numbe
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L560))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L566))
 
 ### _addColumn
 
@@ -659,7 +694,7 @@ _addColumn(kids: any[], flex: number, width: number, height: number, padding: nu
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L591))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L597))
 
 ### _addBox
 
@@ -686,7 +721,7 @@ _addBox(kids: any[], flex: number, width: number, height: number, padding: numbe
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L622))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L628))
 
 ### _addLine
 
@@ -709,7 +744,7 @@ _addLine(kids: any[], content: string, flex: number, width: number, height: numb
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L653))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L659))
 
 ### _addText
 
@@ -726,7 +761,7 @@ _addText(kids: any[], content: string): Element
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L676))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L682))
 
 ### _addList
 
@@ -750,7 +785,7 @@ _addList(kids: any[], items: string[], selectedIndex: number, flex: number, widt
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L682))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L688))
 
 ### _addTextInput
 
@@ -772,7 +807,7 @@ _addTextInput(kids: any[], value: string, flex: number, width: number, height: n
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L707))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L713))
 
 ### renderOnce
 
@@ -796,7 +831,7 @@ Render a single Element tree to the screen and return immediately.
 |---|---|---|
 | tree | [Element](#element) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L735))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L741))
 
 ### readKey
 
@@ -816,7 +851,7 @@ Read one key from the terminal. Blocks until a key is pressed.
 
 **Returns:** [KeyEvent](#keyevent)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L751))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L757))
 
 ### runLoop
 
@@ -868,32 +903,7 @@ Elm/Ink-style state machine driver. Renders `initialState`, waits
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L779))
-
-### _routePrompt
-
-```ts
-_routePrompt(text: string, choices: string[]): string
-```
-
-Route a prompt through the active REPL when one exists, or fall
-  back to raw `print` + `input` otherwise. Used by other stdlib
-  modules (notably `std::policy`) to surface interactive prompts
-  without fighting with the input bar.
-
-  @param text - The menu/question text shown to the user
-  @param choices - The set of strings the user's answer must match
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| text | `string` |  |
-| choices | `string[]` |  |
-
-**Returns:** `string`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L825))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L785))
 
 ### pushMessage
 
@@ -916,7 +926,7 @@ Append a styled message to the active repl() transcript. The
 |---|---|---|
 | message | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L900))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L904))
 
 ### clearMessages
 
@@ -928,7 +938,41 @@ Remove all messages from the active repl() transcript. Intended
   for explicit "clear conversation" commands inside interactive
   agents. Silent no-op when no repl() is active.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L921))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L925))
+
+### chooseOption
+
+```ts
+chooseOption(title: string, body: string, items: ChoiceItem[]): string
+```
+
+Show a modal choice prompt over the active repl() and block until
+  the user picks one. Returns the picked item's `key`. The modal
+  takes over key input — the REPL's input bar, palette, and history
+  navigation are inactive until the user confirms (Enter) or cancels
+  (Escape). The filter input narrows the visible items by substring
+  match on either `key` or `label`.
+
+  When no repl() is currently running, falls back to a plain
+  `print` + `input` loop that reprompts until the user types one of
+  the valid `key`s. Used by std::policy to surface its approve/reject
+  menus through the active REPL without fighting with the input bar.
+
+  @param title - Modal heading (e.g. "Approve interrupt: shell::exec")
+  @param body - Multi-line context shown above the choices (or "")
+  @param items - The set of {key, label} choices to pick from
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| title | `string` |  |
+| body | `string` |  |
+| items | `ChoiceItem[]` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L942))
 
 ### _entryKey
 
@@ -944,7 +988,7 @@ _entryKey(entry: any): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L938))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L995))
 
 ### _filteredPaletteKeys
 
@@ -960,7 +1004,7 @@ _filteredPaletteKeys(state: ReplState): string[]
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L946))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1003))
 
 ### _matchesFilter
 
@@ -977,7 +1021,7 @@ _matchesFilter(name: string, filterText: string): boolean
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L955))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1012))
 
 ### _busyLine
 
@@ -993,19 +1037,29 @@ _busyLine(state: ReplState): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L959))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1016))
+
+### _choiceProjection
+
+```ts
+_choiceProjection(state: ReplState): any
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| state | [ReplState](#replstate) |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1044))
 
 ### _replView
 
 ```ts
 _replView(state: ReplState): Element
 ```
-
-* View: the full terminal. `state.transcript.messages` is the single
- * output buffer and is projected into an auto-scrolling list at the
- * top. Palette + status + input pin to the bottom because none of
- * them are flex; standard `flex-start` column layout packs flex:1
- * first, then the fixed-height tail items.
 
 **Parameters:**
 
@@ -1015,7 +1069,7 @@ _replView(state: ReplState): Element
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L976))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1092))
 
 ### _submitPrompt
 
@@ -1031,7 +1085,7 @@ _submitPrompt(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1038))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1178))
 
 ### _recallPreviousHistory
 
@@ -1047,7 +1101,7 @@ _recallPreviousHistory(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1066))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1206))
 
 ### _recallNextHistory
 
@@ -1063,7 +1117,7 @@ _recallNextHistory(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1078))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1218))
 
 ### _closePalette
 
@@ -1079,7 +1133,7 @@ _closePalette(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1094))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1234))
 
 ### _selectPaletteCommand
 
@@ -1096,7 +1150,7 @@ _selectPaletteCommand(state: ReplState, paletteKeys: string[]): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1246))
 
 ### _movePaletteCursor
 
@@ -1114,7 +1168,7 @@ _movePaletteCursor(state: ReplState, paletteKeys: string[], delta: number): Repl
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1125))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1265))
 
 ### _removePaletteFilterCharacter
 
@@ -1130,7 +1184,7 @@ _removePaletteFilterCharacter(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1287))
 
 ### _appendPaletteFilterCharacter
 
@@ -1147,7 +1201,7 @@ _appendPaletteFilterCharacter(state: ReplState, character: string): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1158))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1298))
 
 ### _replReducePaletteOpen
 
@@ -1164,7 +1218,7 @@ _replReducePaletteOpen(state: ReplState, keyEvent: KeyEvent): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1172))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1312))
 
 ### _appendInputCharacter
 
@@ -1181,7 +1235,7 @@ _appendInputCharacter(state: ReplState, character: string): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1188))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1328))
 
 ### _removeInputCharacter
 
@@ -1197,7 +1251,7 @@ _removeInputCharacter(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1198))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1338))
 
 ### _openPalette
 
@@ -1213,12 +1267,45 @@ _openPalette(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1208))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1348))
 
-### _replReduce
+### _filteredChoiceItems
 
 ```ts
-_replReduce(state: ReplState, keyEvent: KeyEvent): ReplState
+_filteredChoiceItems(choice: ReplChoiceState): ChoiceItem[]
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| choice | [ReplChoiceState](#replchoicestate) |  |
+
+**Returns:** `ChoiceItem[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1362))
+
+### _matchesChoiceFilter
+
+```ts
+_matchesChoiceFilter(item: ChoiceItem, needle: string): boolean
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| item | [ChoiceItem](#choiceitem) |  |
+| needle | `string` |  |
+
+**Returns:** `boolean`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1370))
+
+### _replReduceChoice
+
+```ts
+_replReduceChoice(state: ReplState, keyEvent: KeyEvent): ReplState
 ```
 
 **Parameters:**
@@ -1230,7 +1317,40 @@ _replReduce(state: ReplState, keyEvent: KeyEvent): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1220))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1383))
+
+### _syncChoiceFromBridge
+
+```ts
+_syncChoiceFromBridge(state: ReplState): ReplState
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| state | [ReplState](#replstate) |  |
+
+**Returns:** [ReplState](#replstate)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1451))
+
+### _replReduce
+
+```ts
+_replReduce(replState: ReplState, keyEvent: KeyEvent): ReplState
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| replState | [ReplState](#replstate) |  |
+| keyEvent | [KeyEvent](#keyevent) |  |
+
+**Returns:** [ReplState](#replstate)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1471))
 
 ### _replIsDone
 
@@ -1246,7 +1366,7 @@ _replIsDone(state: ReplState): boolean
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1241))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1500))
 
 ### repl
 
@@ -1288,4 +1408,4 @@ Drop-in REPL widget for interactive CLI agents. Bundles a
 | paletteCommands | `any` | null |
 | tickMs | `number` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1245))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1511))

--- a/packages/agency-lang/lib/stdlib/ui-smoke.test.ts
+++ b/packages/agency-lang/lib/stdlib/ui-smoke.test.ts
@@ -29,7 +29,7 @@ import { ScriptedInput } from "@/tui/input/scripted.js";
 import { FrameRecorder } from "@/tui/output/recorder.js";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore – compiled-by-make Agency module; no .d.ts is emitted
-import { repl } from "../../stdlib/ui.js";
+import { repl, chooseOption } from "../../stdlib/ui.js";
 
 function makeTestCtx(): RuntimeContext<any> {
   return new RuntimeContext({
@@ -140,6 +140,153 @@ describe("std::ui — REPL state machine (Agency-driven)", () => {
       },
     );
     expect(submits).toEqual(["ok"]);
+  });
+
+  it("chooseOption opens a modal, navigates, and resolves with the picked key", async () => {
+    // We feed the modal-driving keys AFTER chooseOption has opened
+    // the prompt. The submit-trigger keys are pre-queued; the modal
+    // keys are fed from inside onSubmit so they don't race past the
+    // not-yet-open modal.
+    const picks: string[] = [];
+    const scripted = new ScriptedInput([
+      { key: "g" }, { key: "o" }, { key: "enter" },
+    ]);
+    _setInputSource(scripted);
+    _setOutputTarget(new FrameRecorder());
+    _setSize(80, 24);
+    const ctx = makeTestCtx();
+    try {
+      await runInTestContext(ctx, new StateStack(), new ThreadStore(), () =>
+        __call(repl, {
+          type: "named",
+          positionalArgs: [],
+          namedArgs: {
+            status: () => ({ left: "", right: "" }),
+            onSubmit: async (_p: string) => {
+              // Schedule modal keys after onSubmit has started; they'll
+              // land in the input queue only once `_openChoicePrompt`
+              // has flipped the bridge slot.
+              setTimeout(() => {
+                scripted.feedKey({ key: "down" });
+                scripted.feedKey({ key: "enter" });
+              }, 0);
+              const answer = await __call(chooseOption, {
+                type: "named",
+                positionalArgs: [],
+                namedArgs: {
+                  title: "Pick one",
+                  body: "context",
+                  items: [
+                    { key: "a", label: "alpha" },
+                    { key: "b", label: "beta" },
+                  ],
+                },
+              });
+              picks.push(answer as string);
+              return false;
+            },
+            paletteCommands: {},
+          },
+        }),
+      );
+    } finally {
+      _setInputSource(null);
+      _setOutputTarget(null);
+      _uninstallConsoleCapture();
+    }
+    expect(picks).toEqual(["b"]);
+  });
+
+  it("chooseOption resolves with the first item on plain Enter", async () => {
+    const picks: string[] = [];
+    const scripted = new ScriptedInput([
+      { key: "g" }, { key: "enter" },
+    ]);
+    _setInputSource(scripted);
+    _setOutputTarget(new FrameRecorder());
+    _setSize(80, 24);
+    const ctx = makeTestCtx();
+    try {
+      await runInTestContext(ctx, new StateStack(), new ThreadStore(), () =>
+        __call(repl, {
+          type: "named",
+          positionalArgs: [],
+          namedArgs: {
+            status: () => ({ left: "", right: "" }),
+            onSubmit: async (_p: string) => {
+              setTimeout(() => scripted.feedKey({ key: "enter" }), 0);
+              const answer = await __call(chooseOption, {
+                type: "named",
+                positionalArgs: [],
+                namedArgs: {
+                  title: "T",
+                  body: "",
+                  items: [
+                    { key: "yes", label: "Yes" },
+                    { key: "no", label: "No" },
+                  ],
+                },
+              });
+              picks.push(answer as string);
+              return false;
+            },
+            paletteCommands: {},
+          },
+        }),
+      );
+    } finally {
+      _setInputSource(null);
+      _setOutputTarget(null);
+      _uninstallConsoleCapture();
+    }
+    expect(picks).toEqual(["yes"]);
+  });
+
+  it("chooseOption escape cancels the modal as a Failure return", async () => {
+    // Agency wraps thrown errors from async functions into a Failure
+    // record (not a JS exception), so `await chooseOption(...)` returns
+    // a `{ success: false, error }` value when the user hits Escape.
+    const replies: any[] = [];
+    const scripted = new ScriptedInput([
+      { key: "g" }, { key: "enter" },
+    ]);
+    _setInputSource(scripted);
+    _setOutputTarget(new FrameRecorder());
+    _setSize(80, 24);
+    const ctx = makeTestCtx();
+    try {
+      await runInTestContext(ctx, new StateStack(), new ThreadStore(), () =>
+        __call(repl, {
+          type: "named",
+          positionalArgs: [],
+          namedArgs: {
+            status: () => ({ left: "", right: "" }),
+            onSubmit: async (_p: string) => {
+              setTimeout(() => scripted.feedKey({ key: "escape" }), 0);
+              const answer = await __call(chooseOption, {
+                type: "named",
+                positionalArgs: [],
+                namedArgs: {
+                  title: "T",
+                  body: "",
+                  items: [{ key: "a", label: "A" }],
+                },
+              });
+              replies.push(answer);
+              return false;
+            },
+            paletteCommands: {},
+          },
+        }),
+      );
+    } finally {
+      _setInputSource(null);
+      _setOutputTarget(null);
+      _uninstallConsoleCapture();
+    }
+    expect(replies.length).toBe(1);
+    expect(replies[0]?.success).toBe(false);
+    expect(String(replies[0]?.error ?? "")).toMatch(/cancel/i);
   });
 
   it("exits when onSubmit returns false", async () => {

--- a/packages/agency-lang/lib/stdlib/ui.test.ts
+++ b/packages/agency-lang/lib/stdlib/ui.test.ts
@@ -14,6 +14,12 @@ import {
   _uninstallConsoleCapture,
   BottomRegionOutputTarget,
   _writeScrollLine,
+  _openChoicePrompt,
+  _resolveChoice,
+  _cancelChoice,
+  _hasPendingChoice,
+  _peekReplExitSignal,
+  _resetReplExitSignal,
 } from "./ui.js";
 import { installRegion, resetRegion } from "./ui-region.js";
 import { ScriptedInput } from "@/tui/input/scripted.js";
@@ -24,6 +30,7 @@ afterEach(() => {
   _setInputSource(null);
   _setOutputTarget(null);
   _uninstallConsoleCapture();
+  _resetReplExitSignal();
 });
 
 describe("std::ui bridge — _runLoop", () => {
@@ -177,13 +184,18 @@ describe("std::ui bridge — _beginSubmit", () => {
     expect(state.submit.busy).toBe(false);
   });
 
-  it("exits the REPL when the callback returns false", async () => {
+  it("exits the REPL by setting the bridge exit signal when the callback returns false", async () => {
     const state = makeState();
+    _resetReplExitSignal();
+    expect(_peekReplExitSignal()).toBe(false);
     _beginSubmit(state, "bye", () => false);
     // Resolve microtasks for the setTimeout(0) + the inner async IIFE.
     await new Promise((resolve) => setTimeout(resolve, 0));
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(state.done).toBe(true);
+    // The bridge flag is set instead of state.done — see
+    // `_signalReplExit` in lib/stdlib/ui.ts for why mutating
+    // `state.done` directly is unsafe across reducer-state turnover.
+    expect(_peekReplExitSignal()).toBe(true);
   });
 
   it("surfaces thrown JS errors as {red Error} transcript entries", async () => {
@@ -388,5 +400,93 @@ describe("std::ui bridge — _writeScrollLine", () => {
   it("writes the text followed by a newline (no ANSI)", () => {
     _writeScrollLine("hello world");
     expect(stdoutWrites.join("")).toBe("hello world\n");
+  });
+});
+
+describe("std::ui bridge — choice prompts", () => {
+  afterEach(() => {
+    // Drain any pending prompt so a failed test doesn't leak state
+    // into the next one (the slot is module-level).
+    if (_hasPendingChoice()) _cancelChoice("test cleanup");
+  });
+
+  it("stores the request and resolves with the chosen key", async () => {
+    const promise = _openChoicePrompt({
+      title: "Pick one",
+      body: "context",
+      items: [
+        { key: "a", label: "Approve" },
+        { key: "r", label: "Reject" },
+      ],
+    });
+    expect(_hasPendingChoice()).toBe(true);
+    _resolveChoice("a");
+    await expect(promise).resolves.toBe("a");
+    expect(_hasPendingChoice()).toBe(false);
+  });
+
+  it("rejects with the supplied reason on cancel", async () => {
+    const promise = _openChoicePrompt({
+      title: "T",
+      body: "",
+      items: [{ key: "y", label: "yes" }],
+    });
+    _cancelChoice("user cancelled");
+    await expect(promise).rejects.toThrow("user cancelled");
+    expect(_hasPendingChoice()).toBe(false);
+  });
+
+  it("rejects when another prompt is already open", async () => {
+    const first = _openChoicePrompt({
+      title: "first",
+      body: "",
+      items: [{ key: "a", label: "A" }],
+    });
+    await expect(
+      _openChoicePrompt({
+        title: "second",
+        body: "",
+        items: [{ key: "b", label: "B" }],
+      }),
+    ).rejects.toThrow(/already open/);
+    _cancelChoice("cleanup");
+    await expect(first).rejects.toThrow();
+  });
+
+  it("_resolveChoice and _cancelChoice are no-ops with no pending prompt", () => {
+    expect(() => _resolveChoice("anything")).not.toThrow();
+    expect(() => _cancelChoice("anything")).not.toThrow();
+    expect(_hasPendingChoice()).toBe(false);
+  });
+
+  it("_runReplLoop cancels a dangling choice prompt on exit", async () => {
+    _setInputSource(new ScriptedInput([{ key: "q" }]));
+    _setOutputTarget(new FrameRecorder());
+    _setSize(40, 5);
+    const transcript: string[] = [];
+    // Open a prompt as soon as the first render runs — by the time
+    // the loop exits (key "q"), the prompt is still dangling and
+    // should be rejected by the finally block in _runReplLoop.
+    let dangling: Promise<string> | null = null;
+    await _runReplLoop(
+      { done: false },
+      (_s: any) => {
+        if (!dangling) {
+          dangling = _openChoicePrompt({
+            title: "t",
+            body: "",
+            items: [{ key: "a", label: "A" }],
+          });
+        }
+        return { type: "text", content: "x" };
+      },
+      (_s: any, ev: any) => ({ done: ev.key === "q" }),
+      (s: any) => s.done,
+      null,
+      transcript,
+    );
+    expect(dangling).not.toBeNull();
+    await expect(dangling).rejects.toThrow(/REPL loop exited/);
+    expect(_hasPendingChoice()).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/stdlib/ui.test.ts
+++ b/packages/agency-lang/lib/stdlib/ui.test.ts
@@ -168,7 +168,7 @@ describe("std::ui bridge — _beginSubmit", () => {
 
     _beginSubmit(state, "hello", () => submitPromise);
 
-    expect(state.transcript.messages).toEqual(["{bright-blue You} hello"]);
+    expect(state.transcript.messages).toEqual(["{bright-blue-fg}You{/bright-blue-fg} hello"]);
     expect(state.submit.busy).toBe(true);
     expect(state.submit.label).toBe("Thinking");
 
@@ -178,7 +178,7 @@ describe("std::ui bridge — _beginSubmit", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(state.transcript.messages).toEqual([
-      "{bright-blue You} hello",
+      "{bright-blue-fg}You{/bright-blue-fg} hello",
       "agent reply",
     ]);
     expect(state.submit.busy).toBe(false);
@@ -198,7 +198,7 @@ describe("std::ui bridge — _beginSubmit", () => {
     expect(_peekReplExitSignal()).toBe(true);
   });
 
-  it("surfaces thrown JS errors as {red Error} transcript entries", async () => {
+  it("surfaces thrown JS errors as {red-fg}Error{/red-fg} transcript entries", async () => {
     const state = makeState();
     _beginSubmit(state, "boom", () => {
       throw new Error("kaboom");
@@ -206,8 +206,8 @@ describe("std::ui bridge — _beginSubmit", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(state.transcript.messages).toEqual([
-      "{bright-blue You} boom",
-      "{red Error} kaboom",
+      "{bright-blue-fg}You{/bright-blue-fg} boom",
+      "{red-fg}Error{/red-fg} kaboom",
     ]);
     expect(state.submit.busy).toBe(false);
   });
@@ -218,8 +218,8 @@ describe("std::ui bridge — _beginSubmit", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(state.transcript.messages).toEqual([
-      "{bright-blue You} fail",
-      "{red Error} spec.tools cannot be spread",
+      "{bright-blue-fg}You{/bright-blue-fg} fail",
+      "{red-fg}Error{/red-fg} spec.tools cannot be spread",
     ]);
     expect(state.submit.busy).toBe(false);
   });
@@ -248,8 +248,8 @@ describe("std::ui bridge — console capture", () => {
     }
     expect(transcript).toEqual([
       "first",
-      "{yellow warn} watch out",
-      "{red error} nope",
+      "{yellow-fg}warn{/yellow-fg} watch out",
+      "{red-fg}error{/red-fg} nope",
       "hi",
     ]);
   });

--- a/packages/agency-lang/lib/stdlib/ui.ts
+++ b/packages/agency-lang/lib/stdlib/ui.ts
@@ -245,9 +245,9 @@ export function _installConsoleCapture(messages: string[]): void {
   console.debug = (...args: unknown[]) =>
     pushCaptured("", formatConsoleArgs(args));
   console.warn = (...args: unknown[]) =>
-    pushCaptured("{yellow warn}", formatConsoleArgs(args));
+    pushCaptured("{yellow-fg}warn{/yellow-fg}", formatConsoleArgs(args));
   console.error = (...args: unknown[]) =>
-    pushCaptured("{red error}", formatConsoleArgs(args));
+    pushCaptured("{red-fg}error{/red-fg}", formatConsoleArgs(args));
 
   // Deliberately NOT overriding `process.stdout.write` / `process.stderr.write`.
   // An earlier revision did, but `lib/tui/output/terminal.ts`'s renderer
@@ -322,7 +322,7 @@ export function _beginSubmit(
   submitted: string,
   onSubmit: unknown,
 ): void {
-  state.transcript.messages.push(`{bright-blue You} ${submitted}`);
+  state.transcript.messages.push(`{bright-blue-fg}You{/bright-blue-fg} ${submitted}`);
   if (state.submit) {
     state.submit.busy = true;
     state.submit.label = "Thinking";
@@ -362,7 +362,7 @@ export function _beginSubmit(
                       return String(err);
                     }
                   })();
-          state.transcript.messages.push(`{red Error} ${message}`);
+          state.transcript.messages.push(`{red-fg}Error{/red-fg} ${message}`);
           return;
         }
         if (typeof reply === "string" && reply.length > 0) {
@@ -370,7 +370,7 @@ export function _beginSubmit(
         }
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
-        state.transcript.messages.push(`{red Error} ${message}`);
+        state.transcript.messages.push(`{red-fg}Error{/red-fg} ${message}`);
       } finally {
         if (state.submit) {
           state.submit.busy = false;

--- a/packages/agency-lang/lib/stdlib/ui.ts
+++ b/packages/agency-lang/lib/stdlib/ui.ts
@@ -155,10 +155,11 @@ async function callBridgeFn<T>(fn: unknown, ...args: unknown[]): Promise<T> {
 
 /** Shape of the `state` arg `_beginSubmit` mutates while the async
  *  onSubmit settles. Defined locally because the Agency `ReplState`
- *  is record-typed and the bridge only cares about these three
- *  fields. */
+ *  is record-typed and the bridge only cares about these two fields.
+ *  The exit-on-`false`-return path uses the `_signalReplExit` bridge
+ *  flag rather than mutating `state.done` here — see that function's
+ *  comment for why. */
 type SubmitTargetState = {
-  done?: boolean;
   submit?: {
     busy?: boolean;
     label?: string;
@@ -283,6 +284,39 @@ export function _spinnerFrame(startedAtMs: number, nowMs = Date.now()): string {
   return frames[tick % frames.length];
 }
 
+// Module-level "exit signaled" flag for `repl()`. `_beginSubmit`
+// flips this when `onSubmit` returns `false`; the Agency
+// `_replIsDone` reads it via `_peekReplExitSignal()`. We cannot
+// mutate `state.done = true` directly because `done` is a primitive
+// boolean — `{...state, ...}` in subsequent reducer calls copies it
+// at the time of spread, so a later mutation on the stale record is
+// invisible to the current loop state.
+let replExitSignaled = false;
+
+/** Signal that the active `repl()` should exit on its next isDone
+ *  check. Called from `_beginSubmit` when `onSubmit` returns `false`,
+ *  and from any future "force exit" plumbing. Wakes the loop so
+ *  `_replIsDone` runs immediately. */
+export function _signalReplExit(): void {
+  replExitSignaled = true;
+  _triggerRender();
+}
+
+/** Read the exit signal without clearing it. The Agency `_replIsDone`
+ *  calls this on every tick; once true the loop terminates and the
+ *  flag is reset by `_runReplLoop` in its finally block so the next
+ *  REPL invocation starts fresh. */
+export function _peekReplExitSignal(): boolean {
+  return replExitSignaled;
+}
+
+/** Reset the exit signal. Called by `_runReplLoop` before and after
+ *  the loop runs, so a leftover signal from a prior REPL session
+ *  doesn't cause the next one to exit on first frame. */
+export function _resetReplExitSignal(): void {
+  replExitSignaled = false;
+}
+
 export function _beginSubmit(
   state: SubmitTargetState,
   submitted: string,
@@ -300,10 +334,12 @@ export function _beginSubmit(
       try {
         const reply = await callBridgeFn<unknown>(onSubmit, submitted);
         if (reply === false) {
-          state.done = true;
-          // Wake the loop so isDone() runs and it exits — otherwise
-          // the user sees a hung REPL after `/exit`.
-          _triggerRender();
+          // Signal exit via the bridge instead of mutating
+          // `state.done`. The reducer can't see mutations on this
+          // stale `state` record once subsequent keys have produced
+          // new states (e.g. a modal that opened and closed during
+          // onSubmit). See `_signalReplExit` comment above.
+          _signalReplExit();
           return;
         }
         // Surface Failure-typed returns explicitly. Agency functions
@@ -401,11 +437,21 @@ export async function _runReplLoop(
   tickMs: number | null | undefined,
   transcriptMessages: string[],
 ): Promise<any> {
+  // Reset the exit signal so a leftover flag from a previous REPL
+  // doesn't immediately terminate this one.
+  _resetReplExitSignal();
   _installConsoleCapture(transcriptMessages);
   try {
     return await _runLoop(initialState, renderFn, handleKeyFn, isDoneFn, tickMs);
   } finally {
     _uninstallConsoleCapture();
+    // Clear the exit signal so it can't leak across REPL invocations
+    // in the same process (e.g. nested test runs).
+    _resetReplExitSignal();
+    // Cancel any choice prompt left dangling by an exception path so
+    // the awaiting Agency caller sees a rejection instead of a hang.
+    // No-op when no prompt is open.
+    _cancelChoice("REPL loop exited before choice was made");
   }
 }
 
@@ -465,58 +511,115 @@ export function _writeScrollLine(text: string): void {
   process.stdout.write(text + "\n");
 }
 
+// ---------------------------------------------------------------------------
+// Choice prompts (modal-style overlay inside an active `repl()`)
+//
+// `_openChoicePrompt` mutates the live REPL state record so the
+// renderer paints the modal on the next frame, then returns a Promise
+// that resolves when the Agency-side reducer calls back via
+// `_resolveChoice` (Enter pressed) or rejects via `_cancelChoice`
+// (Escape pressed / loop torn down). This sidesteps every problem the
+// old raw-stdout version had: keys come through `Screen.runLoop` (no
+// race with the REPL's `nextKey()` waiter), and we never write outside
+// the alt-screen.
+//
+// The slot is module-level — at most one prompt is open at a time.
+// Concurrent callers should serialize themselves.
+// ---------------------------------------------------------------------------
+
+type ChoiceItem = { key: string; label: string };
+type ChoiceRequest = {
+  title: string;
+  body: string;
+  items: ChoiceItem[];
+};
+
+let pendingChoice: {
+  resolve: (answer: string) => void;
+  reject: (err: Error) => void;
+} | null = null;
+// Module-level snapshot of the *request* (title, body, items) for
+// the currently-open prompt. The Agency reducer pulls this on every
+// tick to keep its `state.choice` synced — we cannot mutate the
+// live reducer state from TS because reducers return fresh records
+// on every keypress. `null` when no prompt is open.
+let pendingChoiceRequest: ChoiceRequest | null = null;
+
 /**
- * Prompt the user for one of `choices` while a REPL owns the screen.
- * Writes `text` (multi-line) to the scroll region, then reads keys
- * from the active screen's input source — accumulating printable
- * characters into a buffer that's committed on Enter. Loops until
- * the typed answer is one of `choices`. Backspace edits the buffer.
+ * Open a modal choice prompt over the currently-running REPL. Stores
+ * the request in a module-level slot that the Agency reducer reads
+ * via `_peekPendingChoiceRequest()` on every tick (so a fresh frame
+ * sees the modal even though reducers return new state records),
+ * then returns a Promise that the Agency reducer resolves via
+ * `_resolveChoice(answer)` (Enter) or rejects via `_cancelChoice`
+ * (Escape, or REPL torn down).
  *
- * Caller must verify `_hasActiveScreen()` first; this throws if no
- * REPL is active because the fallback path (raw stdin) lives in the
- * Agency-side wrapper `_routePrompt`.
- *
- * NB: when the REPL is running with `tickMs`, its `runLoop` may have
- * a leaked `nextKey()` promise registered from the most recent tick.
- * Since this function is called synchronously from inside `onSubmit`
- * (between `nextKey` awaits), the leaked waiter only matters if a
- * key is typed *while* a tick was racing, in which case that key
- * may be claimed by the loop instead of the prompt. Acceptable for
- * v1; production use should pause the loop while prompting.
+ * Rejects if another prompt is already open — the caller should
+ * serialize.
  */
-export async function _promptFromChoices(
-  text: string,
-  choices: string[],
-): Promise<string> {
-  const screen = bridgeActiveScreen;
-  if (!screen) {
-    throw new Error(
-      "_promptFromChoices: no active screen — callers must guard with _hasActiveScreen()",
+export function _openChoicePrompt(request: ChoiceRequest): Promise<string> {
+  if (pendingChoice) {
+    return Promise.reject(
+      new Error(
+        "_openChoicePrompt: a choice prompt is already open; serialize callers",
+      ),
     );
   }
-  for (const ln of text.split("\n")) {
-    process.stdout.write(ln + "\n");
-  }
-  while (true) {
-    let buf = "";
-    // Show what the user has typed so far on its own scroll-region line.
-    process.stdout.write("> ");
-    while (true) {
-      const ev = await screen.nextKey();
-      if (ev.key === "enter") break;
-      if (ev.key === "backspace") {
-        buf = buf.slice(0, -1);
-        continue;
-      }
-      if (ev.key.length === 1) {
-        buf += ev.key;
-      }
-    }
-    process.stdout.write(buf + "\n");
-    const answer = buf.trim();
-    if (choices.includes(answer)) return answer;
-    process.stdout.write(`(one of ${choices.join("/")})\n`);
-  }
+  pendingChoiceRequest = {
+    title: request.title,
+    body: request.body,
+    items: request.items,
+  };
+  return new Promise<string>((resolve, reject) => {
+    pendingChoice = { resolve, reject };
+    // Wake the loop so the modal paints immediately rather than
+    // waiting for the next user keypress. The reducer's TS-sync step
+    // runs on this synthetic key event and initializes state.choice.
+    _triggerRender();
+  });
+}
+
+/**
+ * Read the pending choice request without consuming it. Returns
+ * `null` when no prompt is open. The Agency reducer calls this on
+ * every keystroke to sync `state.choice` with the TS-side request:
+ * if TS has a request but state.choice is null, the reducer
+ * initializes it; if TS has no request but state.choice is set,
+ * the reducer clears it.
+ */
+export function _peekPendingChoiceRequest(): ChoiceRequest | null {
+  return pendingChoiceRequest;
+}
+
+/** Resolve the pending choice promise with `answer` and clear both
+ *  the promise slot and the request slot. Called by the Agency
+ *  reducer when Enter is pressed on a filtered, non-empty list.
+ *  No-op when no prompt is open. */
+export function _resolveChoice(answer: string): void {
+  if (!pendingChoice) return;
+  const { resolve } = pendingChoice;
+  pendingChoice = null;
+  pendingChoiceRequest = null;
+  resolve(answer);
+}
+
+/** Reject the pending choice promise with `reason` and clear both
+ *  the promise slot and the request slot. Called by the Agency
+ *  reducer on Escape, or by `_runReplLoop` in its finally block to
+ *  break out of any prompt left hanging by an exception. No-op when
+ *  no prompt is open. */
+export function _cancelChoice(reason: string): void {
+  if (!pendingChoice) return;
+  const { reject } = pendingChoice;
+  pendingChoice = null;
+  pendingChoiceRequest = null;
+  reject(new Error(reason || "choice prompt cancelled"));
+}
+
+/** Test/debug hook. Returns true while a choice prompt is awaiting a
+ *  reducer callback. */
+export function _hasPendingChoice(): boolean {
+  return pendingChoice !== null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agency-lang/lib/tui/render/renderer.ts
+++ b/packages/agency-lang/lib/tui/render/renderer.ts
@@ -127,6 +127,49 @@ function renderTextContent(
   return grid;
 }
 
+// Render one item's text into one or more cell rows. Splits the
+// item on `\n` so a multi-line transcript entry (e.g. a markdown
+// reply) gets its own visual row per source line, parses styled-text
+// markup so spans like `{bright-blue-fg}You{/bright-blue-fg}` render
+// with color, and applies selection chrome to every produced row.
+//
+// Returned rows are NOT yet padded to `innerWidth`; the caller pads
+// them so selection chrome (`itemBg`) extends across the full row.
+function renderListItemRows(
+  rawText: string,
+  innerWidth: number,
+  itemFg: string | undefined,
+  itemBg: string | undefined,
+): Cell[][] {
+  const lines = rawText.split("\n");
+  const rows: Cell[][] = [];
+  for (const line of lines) {
+    const spans = parseStyledText(line);
+    const row: Cell[] = [];
+    let clipped = false;
+    outer: for (const span of spans) {
+      for (const ch of span.text) {
+        if (row.length >= innerWidth) {
+          clipped = true;
+          break outer;
+        }
+        row.push({
+          char: ch,
+          fg: span.fg ?? itemFg,
+          bg: span.bg ?? itemBg,
+          bold: span.bold,
+        });
+      }
+    }
+    if (clipped && row.length > 0) {
+      const last = row[row.length - 1];
+      row[row.length - 1] = { ...last, char: "…" };
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
 function renderListContent(
   items: string[],
   selectedIndex: number | undefined,
@@ -135,6 +178,22 @@ function renderListContent(
   fg?: string,
   bg?: string,
 ): Cell[][] {
+  // Expand each item into one-or-more visual rows up front so
+  // auto-scroll can target visual rows (not item indices) — a
+  // single long markdown reply might span 10 rows and we still
+  // want to keep the latest visual row in view.
+  type VisualRow = { itemIdx: number; row: Cell[] };
+  const visual: VisualRow[] = [];
+  for (let itemIdx = 0; itemIdx < items.length; itemIdx++) {
+    // We defer fg/bg selection chrome until we know which itemIdx
+    // is selected; for now render with neutral fg/bg and re-tint
+    // the cells later if the row's owning item is selected.
+    const rows = renderListItemRows(items[itemIdx], innerWidth, fg, bg);
+    for (const row of rows) {
+      visual.push({ itemIdx, row });
+    }
+  }
+
   // `selectedIndex >= items.length` is the "follow tail" sentinel:
   // auto-scroll so the most recent items are visible, but don't
   // draw any selection chrome (no row is actually the cursor). Used
@@ -142,36 +201,47 @@ function renderListContent(
   // list grows without highlighting it.
   const followTail =
     selectedIndex !== undefined && selectedIndex >= items.length;
-  // Auto-scroll to keep selected item visible. Clamp the scroll
-  // target to the last actual item so tiny inner heights (e.g. 1
-  // row) still render the last item instead of running off the end
-  // and drawing a blank grid.
+
+  // Auto-scroll: find the first visual row that belongs to the
+  // selected item (or the last visual row in follow-tail mode) and
+  // scroll just enough to keep it in the viewport.
   let scrollOffset = 0;
-  if (selectedIndex !== undefined && selectedIndex >= innerHeight) {
-    const target = Math.min(selectedIndex, items.length - 1);
-    scrollOffset = Math.max(0, target - innerHeight + 1);
+  if (followTail) {
+    scrollOffset = Math.max(0, visual.length - innerHeight);
+  } else if (selectedIndex !== undefined) {
+    // Find the LAST visual row owned by the selected item so multi-
+    // line items scroll to reveal their whole body when picked.
+    let lastRow = -1;
+    for (let i = 0; i < visual.length; i++) {
+      if (visual[i].itemIdx === selectedIndex) lastRow = i;
+    }
+    if (lastRow >= innerHeight) {
+      scrollOffset = Math.max(0, lastRow - innerHeight + 1);
+    }
   }
 
   const grid: Cell[][] = [];
   for (let i = 0; i < innerHeight; i++) {
-    const itemIdx = i + scrollOffset;
-    if (itemIdx >= items.length) {
+    const visualIdx = i + scrollOffset;
+    if (visualIdx >= visual.length) {
       grid.push(makeRow(innerWidth, bg));
       continue;
     }
-
+    const { itemIdx, row } = visual[visualIdx];
     const isSelected = !followTail && itemIdx === selectedIndex;
     const itemBg = isSelected ? "blue" : bg;
     const itemFg = isSelected ? "white" : fg;
-    const text = items[itemIdx].slice(0, innerWidth);
-    const row: Cell[] = [];
-    for (const ch of text) {
-      row.push({ char: ch, fg: itemFg, bg: itemBg });
+    // Re-tint cells for selected rows so the highlight extends
+    // across the whole row even when the original spans had their
+    // own colors. Untouched rows keep their per-span colors.
+    let outRow: Cell[] = row;
+    if (isSelected) {
+      outRow = row.map((c) => ({ ...c, fg: itemFg, bg: itemBg }));
     }
-    while (row.length < innerWidth) {
-      row.push(emptyCell(itemBg));
+    while (outRow.length < innerWidth) {
+      outRow.push(emptyCell(itemBg));
     }
-    grid.push(row);
+    grid.push(outRow);
   }
 
   return grid;

--- a/packages/agency-lang/lib/tui/test/renderer.test.ts
+++ b/packages/agency-lang/lib/tui/test/renderer.test.ts
@@ -140,4 +140,58 @@ describe("render", () => {
     const child = frame.children![0];
     expect(contentText(child)).toBe("abc       ");
   });
+
+  it("parses styled-text markup inside list items", () => {
+    // Before the fix, list rows ran raw chars into cells so
+    // `{red-fg}You{/red-fg}` rendered as the literal markup. After
+    // the fix the tag chars are gone and the inner text gets the
+    // span's color.
+    const items = ["{red-fg}You{/red-fg} hi"];
+    // Use follow-tail (selectedIndex == items.length) so the row
+    // isn't repainted with selection chrome — we want to inspect
+    // the spans' own colors.
+    const el = list({ width: 20, height: 1, key: "tx" }, items, items.length);
+    const frame = renderElement(el, 80, 24);
+    const txt = contentText(frame);
+    expect(txt.trim()).toBe("You hi");
+    // The "Y" cell should carry the parsed fg color.
+    expect(frame.content![0][0].char).toBe("Y");
+    expect(frame.content![0][0].fg).toBe("red");
+    // The space and "h" cells should NOT carry that color.
+    expect(frame.content![0][3].fg).toBeUndefined();
+    expect(frame.content![0][4].char).toBe("h");
+  });
+
+  it("splits multi-line list items into one visual row per source line", () => {
+    // A transcript entry like `highlight("\nreply\n", "markdown")`
+    // produces a multi-line string; each `\n`-separated line should
+    // get its own row instead of being smashed onto one.
+    const items = ["one\ntwo\nthree"];
+    const el = list({ width: 10, height: 3, key: "ml" }, items, items.length);
+    const frame = renderElement(el, 80, 24);
+    expect(frame.content![0].slice(0, 3).map((c) => c.char).join("")).toBe(
+      "one",
+    );
+    expect(frame.content![1].slice(0, 3).map((c) => c.char).join("")).toBe(
+      "two",
+    );
+    expect(frame.content![2].slice(0, 5).map((c) => c.char).join("")).toBe(
+      "three",
+    );
+  });
+
+  it("follow-tail keeps the last visual row of a multi-line item in view", () => {
+    // A 3-row tall item followed by selectedIndex = length should
+    // show the LAST visual row, not blank rows or the first row.
+    const items = ["one\ntwo\nthree", "tail"];
+    const el = list({ width: 10, height: 2, key: "ft" }, items, items.length);
+    const frame = renderElement(el, 80, 24);
+    // visual rows: 0:one 1:two 2:three 3:tail. height 2 → show rows 2 and 3.
+    expect(frame.content![0].slice(0, 5).map((c) => c.char).join("")).toBe(
+      "three",
+    );
+    expect(frame.content![1].slice(0, 4).map((c) => c.char).join("")).toBe(
+      "tail",
+    );
+  });
 });

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -5,7 +5,7 @@ import {
  } from "agency-lang/stdlib-lib/policy.js"
 import { exists } from "std::shell"
 import { dirname, basename } from "std::path"
-import { _routePrompt } from "std::ui"
+import { chooseOption, ChoiceItem } from "std::ui"
 
 /** @module
   ## Overview
@@ -500,8 +500,9 @@ def describeScopedMatch(intr: any): string {
 
 // Present the (a)/(r)/(aa)/(ap)/(rr) menu for one interrupt and
 // return the user's choice as a `Decision`. `(ap)` is offered only
-// when `_opts.fields` has an entry for `intr.kind`. Loops until the
-// user enters a valid response.
+// when `_opts.fields` has an entry for `intr.kind`. Renders as a
+// modal over the active repl(); falls back to plain print + input
+// when no REPL is running (e.g. headless agent runs).
 def askUser(intr: any): Decision {
   // `!= null` compiles to `!== null` (Agency strict equality), so an
   // undefined entry would slip through. Use the explicit existence check.
@@ -509,26 +510,23 @@ def askUser(intr: any): Decision {
   if (_opts.fields[intr.kind] != undefined) { kindFields = _opts.fields[intr.kind] }
   const scopedAvailable = kindFields.length > 0
 
-  // Build the menu as a single string so the active-REPL renderer can
-  // emit it to the scroll region in one call, and the raw-input
-  // fallback can `print` it once.
-  let menuLines: string[] = []
-  menuLines.push("\n⚠ Interrupt: ${intr.kind}")
-  menuLines.push("  ${intr.message}")
-  menuLines.push("  data: ${JSON.stringify(intr.data)}")
-  menuLines.push("  (a)  approve once")
-  menuLines.push("  (r)  reject once")
-  menuLines.push("  (aa) approve always (every future ${intr.kind})")
+  const title = "⚠ Interrupt: ${intr.kind}"
+  const body = "${intr.message}\ndata: ${JSON.stringify(intr.data)}"
+
+  let items: ChoiceItem[] = [
+    { key: "a",  label: "approve once" },
+    { key: "r",  label: "reject once" },
+    { key: "aa", label: "approve always (every future ${intr.kind})" }
+  ]
   if (scopedAvailable) {
-    menuLines.push("  (ap) approve always here (${describeScopedMatch(intr)})")
+    items.push({
+      key: "ap",
+      label: "approve always here (${describeScopedMatch(intr)})"
+    })
   }
-  menuLines.push("  (rr) reject always")
-  const menuText = menuLines.join("\n")
+  items.push({ key: "rr", label: "reject always" })
 
-  let choices: string[] = ["a", "r", "aa", "rr"]
-  if (scopedAvailable) { choices = ["a", "r", "aa", "ap", "rr"] }
-
-  const answer = _routePrompt(menuText, choices)
+  const answer = chooseOption(title, body, items)
   match (answer) {
     "a"  => return "approve"
     "r"  => return "reject"

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -1020,7 +1020,7 @@ def _busyLine(state: ReplState): string {
   const nowMs = _nowMs()
   const elapsedSeconds = _elapsedSeconds(state.submit.startedAtMs, nowMs)
   const spinnerFrame = _spinnerFrame(state.submit.startedAtMs, nowMs)
-  return "{bright-yellow ${spinnerFrame}} ${state.submit.label} ${elapsedSeconds}s"
+  return "{bright-yellow-fg}${spinnerFrame}{/bright-yellow-fg} ${state.submit.label} ${elapsedSeconds}s"
 }
 
 /**

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -10,7 +10,13 @@ import {
   _nowMs,
   _triggerRender,
  } from "agency-lang/stdlib-lib/ui.js"
-import { _promptFromChoices } from "agency-lang/stdlib-lib/ui.js"
+import {
+  _openChoicePrompt,
+  _peekPendingChoiceRequest,
+  _resolveChoice,
+  _cancelChoice,
+  _peekReplExitSignal,
+} from "agency-lang/stdlib-lib/ui.js"
 import { filter, map } from "std::array"
 
 /** @module
@@ -822,33 +828,7 @@ export def runLoop(
 // view and closing it returns them.
 const _PALETTE_ROWS: number = 5
 
-export def _routePrompt(text: string, choices: string[]): string {
-  """
-  Route a prompt through the active REPL when one exists, or fall
-  back to raw `print` + `input` otherwise. Used by other stdlib
-  modules (notably `std::policy`) to surface interactive prompts
-  without fighting with the input bar.
 
-  @param text - The menu/question text shown to the user
-  @param choices - The set of strings the user's answer must match
-  """
-  if (_hasActiveScreen()) {
-    return _promptFromChoices(text, choices)
-  }
-  print(text)
-  const optsHint = "(one of ${choices.join("/")})"
-  let answer = ""
-  let valid = false
-  while (!valid) {
-    answer = input("> ").trim()
-    if (choices.includes(answer)) {
-      valid = true
-    } else {
-      print(optsHint)
-    }
-  }
-  return answer
-}
 
 type ReplInputState = {
   buffer: string;
@@ -881,12 +861,36 @@ type ReplConfigState = {
   onSubmit: any
 }
 
+/**
+ * One option in a `chooseOption()` modal. `key` is the value the
+ * Promise resolves to when the user picks this row; `label` is the
+ * human-readable text rendered in the modal.
+ */
+export type ChoiceItem = {
+  key: string;
+  label: string
+}
+
+// Internal: snapshot of an open choice modal. Lives on `ReplState`
+// so the reducer/view can see it on every frame. The TS bridge
+// (`_openChoicePrompt`) sets this slot and `_replReduce` clears it
+// after Enter/Escape; the deferred Promise it returns is what the
+// Agency caller awaits.
+type ReplChoiceState = {
+  title: string;
+  body: string;
+  items: ChoiceItem[];
+  filter: string;
+  cursor: number
+}
+
 type ReplState = {
   input: ReplInputState;
   palette: ReplPaletteState;
   transcript: ReplTranscriptState;
   submit: ReplSubmitState;
   config: ReplConfigState;
+  choice: ReplChoiceState | null;
   done: boolean
 }
 
@@ -935,6 +939,59 @@ export def clearMessages() {
   _triggerRender()
 }
 
+export def chooseOption(
+  title: string,
+  body: string,
+  items: ChoiceItem[],
+): string {
+  """
+  Show a modal choice prompt over the active repl() and block until
+  the user picks one. Returns the picked item's `key`. The modal
+  takes over key input — the REPL's input bar, palette, and history
+  navigation are inactive until the user confirms (Enter) or cancels
+  (Escape). The filter input narrows the visible items by substring
+  match on either `key` or `label`.
+
+  When no repl() is currently running, falls back to a plain
+  `print` + `input` loop that reprompts until the user types one of
+  the valid `key`s. Used by std::policy to surface its approve/reject
+  menus through the active REPL without fighting with the input bar.
+
+  @param title - Modal heading (e.g. "Approve interrupt: shell::exec")
+  @param body - Multi-line context shown above the choices (or "")
+  @param items - The set of {key, label} choices to pick from
+  """
+  if (_activeRepl != null) {
+    return _openChoicePrompt({
+      title: title,
+      body: body,
+      items: items
+    })
+  }
+  // No-REPL fallback: print the title + body once, then loop on
+  // `input()` until the answer matches one of the item keys. Same
+  // contract as the pre-modal `_routePrompt` had.
+  if (title != "") { print(title) }
+  if (body != "")  { print(body) }
+  let validKeys: string[] = []
+  for (item in items) {
+    print("  ${item.key}  ${item.label}")
+    validKeys.push(item.key)
+  }
+  const optsHint = "(one of ${validKeys.join("/")})"
+  let answer = ""
+  let valid = false
+  while (!valid) {
+    answer = input("> ").trim()
+    if (validKeys.includes(answer)) {
+      valid = true
+    } else {
+      print(optsHint)
+    }
+  }
+  return answer
+}
+
 def _entryKey(entry: any): string { return entry.key }
 
 // Returns the keys of palette commands whose name contains the
@@ -973,6 +1030,65 @@ def _busyLine(state: ReplState): string {
  * them are flex; standard `flex-start` column layout packs flex:1
  * first, then the fixed-height tail items.
  */
+// Maximum height of an open choice modal. Generous enough to fit a
+// short body + a typical 4-6 choice list + footer without scrolling;
+// the wrapping transcript list shrinks accordingly because it owns
+// the `flex: 1` slot.
+const _CHOICE_ROWS: number = 15
+
+// Build the per-render projection of the choice modal state. Pulled
+// out of `_replView` so the view function stays linear and so the
+// projection (body lines, formatted item labels, clamped cursor) can
+// be unit-tested separately. When no modal is open, returns safe
+// defaults that render as an invisible empty box.
+def _choiceProjection(state: ReplState): any {
+  // Pull the value out into a local typed `any` so member accesses
+  // type-check (the Agency typechecker does not narrow union types
+  // across runtime null guards). The `null` branch returns before
+  // any member access happens.
+  const choice: any = state.choice
+  if (choice == null) {
+    return {
+      visible: false,
+      title: "",
+      bodyLines: [],
+      itemLabels: [],
+      cursor: 0,
+      filterText: ""
+    }
+  }
+  const filteredItems = _filteredChoiceItems(choice)
+  let cursor = choice.cursor
+  const maxCursor = filteredItems.length - 1
+  if (cursor > maxCursor) { cursor = maxCursor }
+  if (cursor < 0)         { cursor = 0 }
+  // Pad short keys so the labels line up — most choice menus mix
+  // single-char keys (`a`) with two-char keys (`aa`). 4 wide gives
+  // room for up to three-char keys (`yes`) with a trailing space.
+  let itemLabels: string[] = []
+  for (item in filteredItems) {
+    let pad = ""
+    let n = item.key.length
+    while (n < 4) {
+      pad = pad + " "
+      n = n + 1
+    }
+    itemLabels.push("${item.key}${pad}${item.label}")
+  }
+  let bodyLines: string[] = []
+  if (choice.body != "") {
+    bodyLines = choice.body.split("\n")
+  }
+  return {
+    visible: true,
+    title: choice.title,
+    bodyLines: bodyLines,
+    itemLabels: itemLabels,
+    cursor: cursor,
+    filterText: choice.filter
+  }
+}
+
 def _replView(state: ReplState): Element {
   const status = state.config.status()
   const paletteKeys = _filteredPaletteKeys(state)
@@ -995,11 +1111,35 @@ def _replView(state: ReplState): Element {
   const leftStatusWidth = status.left.length
   const rightStatusWidth = status.right.length
 
+  const choiceView = _choiceProjection(state)
+
   // Note: every container call here MUST pass at least one named arg.
   // The agency parser otherwise compiles `column() as mainCol { ... }`
   // as a positional call where the block lands in `flex`.
   return column(visible: true) as mainCol {
     mainCol.list(items: visibleMessages, selectedIndex: followIndex, flex: 1)
+    // Choice modal: bordered column above the status line. Keys are
+    // routed to `_replReduceChoice` when this is open, so the input
+    // bar / palette / history navigation can't fire. When closed the
+    // column collapses to zero rows via `visible: false`.
+    mainCol.column(
+      visible: choiceView.visible,
+      height: _CHOICE_ROWS,
+      border: true,
+      borderColor: "yellow",
+      label: choiceView.title,
+    ) as choiceBox {
+      for (bodyLine in choiceView.bodyLines) {
+        choiceBox.line(bodyLine)
+      }
+      choiceBox.line("> ${choiceView.filterText}", bold: true)
+      choiceBox.list(
+        items: choiceView.itemLabels,
+        selectedIndex: choiceView.cursor,
+        flex: 1,
+      )
+      choiceBox.line("↑↓ select · enter confirm · esc cancel", fg: "gray")
+    }
     mainCol.list(
       items: paletteItems,
       selectedIndex: state.palette.cursor,
@@ -1217,7 +1357,126 @@ def _openPalette(state: ReplState): ReplState {
   }
 }
 
-def _replReduce(state: ReplState, keyEvent: KeyEvent): ReplState {
+// Filter the choice items by the (lowercased) typed filter substring.
+// Lists in insertion order. With an empty filter, returns all items.
+def _filteredChoiceItems(choice: ReplChoiceState): ChoiceItem[] {
+  if (choice.filter == "") {
+    return choice.items
+  }
+  const needle = choice.filter.toLowerCase()
+  return filter(choice.items, _matchesChoiceFilter.partial(needle: needle))
+}
+
+def _matchesChoiceFilter(item: ChoiceItem, needle: string): boolean {
+  return item.label.toLowerCase().includes(needle)
+    || item.key.toLowerCase().includes(needle)
+}
+
+// Reducer branch for the choice modal. Routes keystrokes:
+//   ↑/↓        — move cursor within the filtered set
+//   printable  — append to filter, reset cursor to 0
+//   backspace  — pop from filter (or close prompt if filter is empty)
+//   enter      — resolve the deferred Promise with the picked key,
+//                clear the slot
+//   escape     — reject the deferred Promise, clear the slot
+// All other keys (including the synthetic render-trigger) are no-ops.
+def _replReduceChoice(state: ReplState, keyEvent: KeyEvent): ReplState {
+  // Pull the value out into a local typed `any` so member accesses
+  // type-check (the Agency typechecker does not narrow union types
+  // across runtime null guards). The caller `_replReduce` already
+  // ensured `state.choice != null` before dispatching here.
+  const choice: any = state.choice
+  const visibleItems = _filteredChoiceItems(choice)
+  if (keyEvent.key == "escape") {
+    _cancelChoice("user cancelled")
+    return { ...state, choice: null }
+  }
+  if (keyEvent.key == "enter") {
+    if (visibleItems.length == 0) {
+      return state
+    }
+    let cursor = choice.cursor
+    if (cursor >= visibleItems.length) {
+      cursor = visibleItems.length - 1
+    }
+    _resolveChoice(visibleItems[cursor].key)
+    return { ...state, choice: null }
+  }
+  if (keyEvent.key == "up") {
+    let cursor = choice.cursor - 1
+    if (cursor < 0) { cursor = 0 }
+    return { ...state, choice: { ...choice, cursor: cursor } }
+  }
+  if (keyEvent.key == "down") {
+    let cursor = choice.cursor + 1
+    const maxCursor = visibleItems.length - 1
+    if (cursor > maxCursor) { cursor = maxCursor }
+    if (cursor < 0)         { cursor = 0 }
+    return { ...state, choice: { ...choice, cursor: cursor } }
+  }
+  if (keyEvent.key == "backspace") {
+    const currentFilter = choice.filter
+    if (currentFilter == "") {
+      return state
+    }
+    return {
+      ...state,
+      choice: {
+        ...choice,
+        filter: currentFilter[:currentFilter.length - 1],
+        cursor: 0
+      }
+    }
+  }
+  if (keyEvent.key.length == 1) {
+    return {
+      ...state,
+      choice: {
+        ...choice,
+        filter: choice.filter + keyEvent.key,
+        cursor: 0
+      }
+    }
+  }
+  return state
+}
+
+// Sync the modal slot from the TS bridge. The bridge owns the
+// pending-request slot because reducer states are returned as new
+// records on every keypress — TS cannot mutate them directly. The
+// reducer copies the bridge's request into `state.choice` once
+// (when a prompt opens) and clears it once (when a prompt is
+// resolved/cancelled externally or torn down by _runReplLoop).
+// Cursor/filter state lives on the agency side after that.
+def _syncChoiceFromBridge(state: ReplState): ReplState {
+  const tsRequest: any = _peekPendingChoiceRequest()
+  if (tsRequest != null && state.choice == null) {
+    return {
+      ...state,
+      choice: {
+        title: tsRequest.title,
+        body: tsRequest.body,
+        items: tsRequest.items,
+        filter: "",
+        cursor: 0
+      }
+    }
+  }
+  if (tsRequest == null && state.choice != null) {
+    return { ...state, choice: null }
+  }
+  return state
+}
+
+def _replReduce(replState: ReplState, keyEvent: KeyEvent): ReplState {
+  const state = _syncChoiceFromBridge(replState)
+  // Choice modal takes priority — locks out the input bar, palette,
+  // and history navigation until the user picks (Enter) or cancels
+  // (Escape). Ctrl-C still exits the whole REPL via the catch-all
+  // path below; we don't special-case it here.
+  if (state.choice != null) {
+    return _replReduceChoice(state, keyEvent)
+  }
   if (state.palette.open) {
     return _replReducePaletteOpen(state, keyEvent)
   }
@@ -1239,6 +1498,13 @@ def _replReduce(state: ReplState, keyEvent: KeyEvent): ReplState {
 }
 
 def _replIsDone(state: ReplState): boolean {
+  // Bridge signal (set by `_beginSubmit` when onSubmit returns false)
+  // takes priority. We can't rely on mutating `state.done` from TS
+  // because reducer states are returned as fresh records and `done`
+  // is a primitive — see `_signalReplExit` in lib/stdlib/ui.ts.
+  if (_peekReplExitSignal()) {
+    return true
+  }
   return state.done
 }
 
@@ -1305,6 +1571,7 @@ export def repl(
       status: status,
       onSubmit: onSubmit
     },
+    choice: null,
     done: false,
   }
   _activeRepl = initial


### PR DESCRIPTION
## Summary

Adds `chooseOption(title, body, items)` to `std::ui` and switches `std::policy.cliPolicyHandler` to use it. Replaces the unreliable raw-stdout `_promptFromChoices` with a modal that lives inside the active `repl()` loop and goes through the normal render/key pipeline.

```ts
const answer = chooseOption(
  "Approve interrupt: std::exec",
  "Run `git push origin main`?",
  [
    { key: "a",  label: "approve once" },
    { key: "r",  label: "reject once" },
    { key: "aa", label: "approve always" },
    { key: "rr", label: "reject always" },
  ],
)
```

- When a `repl()` is running, opens a bordered modal column above the status line, intercepts key input until the user picks (Enter) or cancels (Escape), and resolves to the picked key.
- When no `repl()` is active, falls back to a `print` + `input` loop so non-interactive callers (CI, agency-js tests, plain scripts) still work.

## Design

### Modal lives inside the REPL loop

`chooseOption` does not write to stdout directly. The Agency-side `_replReduce` routes keys into a dedicated `_replReduceChoice` branch when a modal is open; `_replView` projects the modal state into a bordered column inside the existing flex column layout. This means:

- Renderer owns the screen the whole time (no fighting with the alt-screen).
- Filter-typing, arrow-key navigation, Enter, and Escape are handled by the same `Screen.runLoop` that handles input-bar keys, so there is no race with the REPL's `nextKey()` waiter.
- Console capture, status line, and transcript continue to update behind the modal.

### Two state-propagation bugs surfaced during integration

1. **Choice request mutation invisible across reducer turnover.** Initially the bridge tried `_openChoicePrompt(state, req)` mutating `_activeRepl.choice`. But Agency reducers return fresh outer records each tick, so mutations on the initial record were never seen by the current loop state. **Fix:** TS now owns `pendingChoiceRequest`; `_replReduce` calls `_peekPendingChoiceRequest()` first via `_syncChoiceFromBridge` to copy the request into `state.choice` once (open) and clear it once (close).

2. **`state.done = true` lost after modal lifecycle.** `_beginSubmit` was mutating `state.done = true` on the stale record produced by `_submitPrompt`. With a modal that opens and closes during `onSubmit`, several reducer turns have run and copied `done: false` into the new outer records — so the mutation on the old record was invisible. **Fix:** new `_signalReplExit()` / `_peekReplExitSignal()` bridge flag; `_replIsDone` checks it first. Reset in `_runReplLoop`'s entry and finally.

### Also in this PR

- `std::policy.cliPolicyHandler` now uses `chooseOption` for its approve/reject/aa/ap/rr menu instead of an `input`-loop sequence.
- Docstrings added to Layer 1 UI builders in `stdlib/ui.agency`.

## Tests

- **Bridge unit tests** (`lib/stdlib/ui.test.ts`, +6 tests): prompt lifecycle (open, resolve, cancel), the already-open guard, the dangling-prompt cancel in `_runReplLoop`'s finally block, and the exit-signal flow.
- **End-to-end smoke tests** (`lib/stdlib/ui-smoke.test.ts`, +3 tests) drive the full Agency `repl()` through `ScriptedInput`:
  - Navigate down then Enter resolves to the second item.
  - Plain Enter resolves to the first item.
  - Escape returns a `Failure` (Agency wraps the rejected Promise).
- `tests/agency-js/cli-policy-handler` still passes (no-REPL fallback path).

All 387 `lib/stdlib/` tests pass. `pnpm run lint:structure` clean.

## Files

- `lib/stdlib/ui.ts` — new bridge primitives (`_openChoicePrompt`, `_peekPendingChoiceRequest`, `_resolveChoice`, `_cancelChoice`, `_signalReplExit`, `_peekReplExitSignal`, `_resetReplExitSignal`)
- `stdlib/ui.agency` — `chooseOption`, `_replReduceChoice`, `_choiceProjection`, `_syncChoiceFromBridge`, modal column inside `_replView`
- `stdlib/policy.agency` — `askUser` uses `chooseOption`
