### PR TITLE
agent-fixes: precompile, checkpoint-leak, paste, multi-line input, error rendering

### DIFF
--- a/packages/agency-lang/docs/site/stdlib/policy.md
+++ b/packages/agency-lang/docs/site/stdlib/policy.md
@@ -618,7 +618,7 @@ askUser(intr: any): Decision
 
 **Returns:** [Decision](#decision)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L505))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L506))
 
 ### _handler
 
@@ -639,7 +639,7 @@ _handler(intr: any): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L547))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L545))
 
 ### cliPolicyHandler
 
@@ -719,4 +719,4 @@ CLI sugar for an interactive policy handler. Owns load + save +
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L631))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/policy.agency#L629))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -1093,7 +1093,7 @@ _submitPrompt(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1192))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1203))
 
 ### _recallPreviousHistory
 
@@ -1109,7 +1109,7 @@ _recallPreviousHistory(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1220))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1231))
 
 ### _recallNextHistory
 
@@ -1125,7 +1125,7 @@ _recallNextHistory(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1232))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1243))
 
 ### _closePalette
 
@@ -1141,7 +1141,7 @@ _closePalette(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1248))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1259))
 
 ### _selectPaletteCommand
 
@@ -1158,7 +1158,7 @@ _selectPaletteCommand(state: ReplState, paletteKeys: string[]): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1260))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1271))
 
 ### _movePaletteCursor
 
@@ -1176,7 +1176,7 @@ _movePaletteCursor(state: ReplState, paletteKeys: string[], delta: number): Repl
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1279))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1290))
 
 ### _removePaletteFilterCharacter
 
@@ -1192,7 +1192,7 @@ _removePaletteFilterCharacter(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1301))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1312))
 
 ### _appendPaletteFilterCharacter
 
@@ -1209,7 +1209,7 @@ _appendPaletteFilterCharacter(state: ReplState, character: string): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1312))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1323))
 
 ### _replReducePaletteOpen
 
@@ -1226,7 +1226,7 @@ _replReducePaletteOpen(state: ReplState, keyEvent: KeyEvent): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1326))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1337))
 
 ### _appendInputCharacter
 
@@ -1243,7 +1243,7 @@ _appendInputCharacter(state: ReplState, character: string): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1342))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1353))
 
 ### _appendPaste
 
@@ -1260,7 +1260,7 @@ _appendPaste(state: ReplState, pasted: string): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1357))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1368))
 
 ### _clearInputBuffer
 
@@ -1276,7 +1276,7 @@ _clearInputBuffer(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1373))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1383))
 
 ### _removeInputCharacter
 
@@ -1292,7 +1292,7 @@ _removeInputCharacter(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1383))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1393))
 
 ### _openPalette
 
@@ -1308,7 +1308,7 @@ _openPalette(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1393))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1403))
 
 ### _filteredChoiceItems
 
@@ -1324,7 +1324,7 @@ _filteredChoiceItems(choice: ReplChoiceState): ChoiceItem[]
 
 **Returns:** `ChoiceItem[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1407))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1417))
 
 ### _matchesChoiceFilter
 
@@ -1341,7 +1341,7 @@ _matchesChoiceFilter(item: ChoiceItem, needle: string): boolean
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1415))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1425))
 
 ### _replReduceChoice
 
@@ -1358,7 +1358,7 @@ _replReduceChoice(state: ReplState, keyEvent: KeyEvent): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1428))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1438))
 
 ### _syncChoiceFromBridge
 
@@ -1374,7 +1374,7 @@ _syncChoiceFromBridge(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1496))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1506))
 
 ### _replReduce
 
@@ -1391,7 +1391,7 @@ _replReduce(replState: ReplState, keyEvent: KeyEvent): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1516))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1526))
 
 ### _replIsDone
 
@@ -1407,7 +1407,7 @@ _replIsDone(state: ReplState): boolean
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1550))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1564))
 
 ### repl
 
@@ -1449,4 +1449,4 @@ Drop-in REPL widget for interactive CLI agents. Bundles a
 | paletteCommands | `any` | null |
 | tickMs | `number` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1561))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1575))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -102,7 +102,7 @@ export type Element = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L100))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L106))
 
 ### KeyEvent
 
@@ -135,7 +135,7 @@ export type KeyEvent = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L121))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L127))
 
 ### Builder
 
@@ -174,7 +174,7 @@ export type Builder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L139))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L145))
 
 ### ReplInputState
 
@@ -189,7 +189,7 @@ type ReplInputState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L853))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L842))
 
 ### ReplPaletteState
 
@@ -202,7 +202,7 @@ type ReplPaletteState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L862))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L851))
 
 ### ReplTranscriptState
 
@@ -212,7 +212,7 @@ type ReplTranscriptState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L869))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L858))
 
 ### ReplSubmitState
 
@@ -224,7 +224,7 @@ type ReplSubmitState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L873))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L862))
 
 ### ReplConfigState
 
@@ -235,7 +235,41 @@ type ReplConfigState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L879))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L868))
+
+### ChoiceItem
+
+* One option in a `chooseOption()` modal. `key` is the value the
+ * Promise resolves to when the user picks this row; `label` is the
+ * human-readable text rendered in the modal.
+
+```ts
+/**
+ * One option in a `chooseOption()` modal. `key` is the value the
+ * Promise resolves to when the user picks this row; `label` is the
+ * human-readable text rendered in the modal.
+ */
+export type ChoiceItem = {
+  key: string;
+  label: string
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L878))
+
+### ReplChoiceState
+
+```ts
+type ReplChoiceState = {
+  title: string;
+  body: string;
+  items: ChoiceItem[];
+  filter: string;
+  cursor: number
+}
+```
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L888))
 
 ### ReplState
 
@@ -246,11 +280,12 @@ type ReplState = {
   transcript: ReplTranscriptState;
   submit: ReplSubmitState;
   config: ReplConfigState;
+  choice: ReplChoiceState | null;
   done: boolean
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L884))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L896))
 
 ## Functions
 
@@ -281,7 +316,7 @@ Build a plain text element. No layout sizing — embed inside a `box`
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L158))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L164))
 
 ### _setStyleIfSet
 
@@ -297,18 +332,22 @@ _setStyleIfSet(style: any, key: string, value: any)
 | key | `string` |  |
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L179))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L185))
 
 ### line
 
 ```ts
-line(content: string, flex: number, width: number, height: number, fg: string, bg: string, bold: boolean): Element
+line(content: string, flex: number, width: number, height: number, fg: string, bg: string, bold: boolean, fill: string): Element
 ```
 
 Build a single-line text element with `height: 1`. The default keeps
   it from stretching via flex when placed inside a `column`. Style
   fields (`fg`, `bg`, `bold`) and layout fields (`flex`, `width`,
   `height`) merge on top of the height-1 default.
+
+  Set `fill` to a single character (e.g. `"─"`) to repeat that
+  character across the unused width, turning an empty-content line
+  into a horizontal rule.
 
   @param content - The text to render
   @param flex - Flex grow factor; omit for natural width
@@ -317,6 +356,7 @@ Build a single-line text element with `height: 1`. The default keeps
   @param fg - Foreground color (named or hex like "#fff")
   @param bg - Background color (named or hex like "#000")
   @param bold - Render the text bold
+  @param fill - Character used to pad unused cells (default: space)
 
 * A single-line text element with `height: 1`. The default keeps it
  * from stretching via flex when placed inside a `column`. Caller-
@@ -335,10 +375,11 @@ Build a single-line text element with `height: 1`. The default keeps
 | fg | `string` | "" |
 | bg | `string` | "" |
 | bold | `boolean` | false |
+| fill | `string` | "" |
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L193))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L199))
 
 ### list
 
@@ -381,7 +422,7 @@ Build a scrollable selectable list. `selectedIndex` highlights one
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L242))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L255))
 
 ### textInput
 
@@ -420,7 +461,7 @@ Build a single-line text input. The renderer displays `value` with
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L291))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L304))
 
 ### _mkBoxStyle
 
@@ -446,7 +487,7 @@ _mkBoxStyle(flexDirection: string, flex: number, width: number, height: number, 
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L335))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L348))
 
 ### _makeBuilder
 
@@ -462,7 +503,7 @@ _makeBuilder(kids: any[]): Builder
 
 **Returns:** [Builder](#builder)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L365))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L378))
 
 ### column
 
@@ -512,7 +553,7 @@ Build a vertical container. Children stack top-to-bottom. Pass a
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L381))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L394))
 
 ### row
 
@@ -558,7 +599,7 @@ Build a horizontal container. Children stack left-to-right. Pass a
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L445))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L458))
 
 ### box
 
@@ -605,7 +646,7 @@ Build a direction-neutral container. Use when you want to apply
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L503))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L516))
 
 ### _addRow
 
@@ -632,7 +673,7 @@ _addRow(kids: any[], flex: number, width: number, height: number, padding: numbe
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L560))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L573))
 
 ### _addColumn
 
@@ -659,7 +700,7 @@ _addColumn(kids: any[], flex: number, width: number, height: number, padding: nu
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L591))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L604))
 
 ### _addBox
 
@@ -686,12 +727,12 @@ _addBox(kids: any[], flex: number, width: number, height: number, padding: numbe
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L622))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L635))
 
 ### _addLine
 
 ```ts
-_addLine(kids: any[], content: string, flex: number, width: number, height: number, fg: string, bg: string, bold: boolean): Element
+_addLine(kids: any[], content: string, flex: number, width: number, height: number, fg: string, bg: string, bold: boolean, fill: string): Element
 ```
 
 **Parameters:**
@@ -706,10 +747,11 @@ _addLine(kids: any[], content: string, flex: number, width: number, height: numb
 | fg | `string` | "" |
 | bg | `string` | "" |
 | bold | `boolean` | false |
+| fill | `string` | "" |
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L653))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L666))
 
 ### _addText
 
@@ -726,7 +768,7 @@ _addText(kids: any[], content: string): Element
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L676))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L691))
 
 ### _addList
 
@@ -750,7 +792,7 @@ _addList(kids: any[], items: string[], selectedIndex: number, flex: number, widt
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L682))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L697))
 
 ### _addTextInput
 
@@ -772,7 +814,7 @@ _addTextInput(kids: any[], value: string, flex: number, width: number, height: n
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L707))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L722))
 
 ### renderOnce
 
@@ -796,7 +838,7 @@ Render a single Element tree to the screen and return immediately.
 |---|---|---|
 | tree | [Element](#element) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L735))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L750))
 
 ### readKey
 
@@ -816,7 +858,7 @@ Read one key from the terminal. Blocks until a key is pressed.
 
 **Returns:** [KeyEvent](#keyevent)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L751))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L766))
 
 ### runLoop
 
@@ -868,32 +910,7 @@ Elm/Ink-style state machine driver. Renders `initialState`, waits
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L779))
-
-### _routePrompt
-
-```ts
-_routePrompt(text: string, choices: string[]): string
-```
-
-Route a prompt through the active REPL when one exists, or fall
-  back to raw `print` + `input` otherwise. Used by other stdlib
-  modules (notably `std::policy`) to surface interactive prompts
-  without fighting with the input bar.
-
-  @param text - The menu/question text shown to the user
-  @param choices - The set of strings the user's answer must match
-
-**Parameters:**
-
-| Name | Type | Default |
-|---|---|---|
-| text | `string` |  |
-| choices | `string[]` |  |
-
-**Returns:** `string`
-
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L825))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L794))
 
 ### pushMessage
 
@@ -916,7 +933,7 @@ Append a styled message to the active repl() transcript. The
 |---|---|---|
 | message | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L900))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L913))
 
 ### clearMessages
 
@@ -928,7 +945,41 @@ Remove all messages from the active repl() transcript. Intended
   for explicit "clear conversation" commands inside interactive
   agents. Silent no-op when no repl() is active.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L921))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L934))
+
+### chooseOption
+
+```ts
+chooseOption(title: string, body: string, items: ChoiceItem[]): string
+```
+
+Show a modal choice prompt over the active repl() and block until
+  the user picks one. Returns the picked item's `key`. The modal
+  takes over key input — the REPL's input bar, palette, and history
+  navigation are inactive until the user confirms (Enter) or cancels
+  (Escape). The filter input narrows the visible items by substring
+  match on either `key` or `label`.
+
+  When no repl() is currently running, falls back to a plain
+  `print` + `input` loop that reprompts until the user types one of
+  the valid `key`s. Used by std::policy to surface its approve/reject
+  menus through the active REPL without fighting with the input bar.
+
+  @param title - Modal heading (e.g. "Approve interrupt: shell::exec")
+  @param body - Multi-line context shown above the choices (or "")
+  @param items - The set of {key, label} choices to pick from
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| title | `string` |  |
+| body | `string` |  |
+| items | `ChoiceItem[]` |  |
+
+**Returns:** `string`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L951))
 
 ### _entryKey
 
@@ -944,7 +995,7 @@ _entryKey(entry: any): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L938))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1004))
 
 ### _filteredPaletteKeys
 
@@ -960,7 +1011,7 @@ _filteredPaletteKeys(state: ReplState): string[]
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L946))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1012))
 
 ### _matchesFilter
 
@@ -977,7 +1028,7 @@ _matchesFilter(name: string, filterText: string): boolean
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L955))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1021))
 
 ### _busyLine
 
@@ -993,19 +1044,29 @@ _busyLine(state: ReplState): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L959))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1025))
+
+### _choiceProjection
+
+```ts
+_choiceProjection(state: ReplState): any
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| state | [ReplState](#replstate) |  |
+
+**Returns:** `any`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1053))
 
 ### _replView
 
 ```ts
 _replView(state: ReplState): Element
 ```
-
-* View: the full terminal. `state.transcript.messages` is the single
- * output buffer and is projected into an auto-scrolling list at the
- * top. Palette + status + input pin to the bottom because none of
- * them are flex; standard `flex-start` column layout packs flex:1
- * first, then the fixed-height tail items.
 
 **Parameters:**
 
@@ -1015,7 +1076,7 @@ _replView(state: ReplState): Element
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L976))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1101))
 
 ### _submitPrompt
 
@@ -1031,7 +1092,7 @@ _submitPrompt(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1038))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1186))
 
 ### _recallPreviousHistory
 
@@ -1047,7 +1108,7 @@ _recallPreviousHistory(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1066))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1214))
 
 ### _recallNextHistory
 
@@ -1063,7 +1124,7 @@ _recallNextHistory(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1078))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1226))
 
 ### _closePalette
 
@@ -1079,7 +1140,7 @@ _closePalette(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1094))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1242))
 
 ### _selectPaletteCommand
 
@@ -1096,7 +1157,7 @@ _selectPaletteCommand(state: ReplState, paletteKeys: string[]): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1106))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1254))
 
 ### _movePaletteCursor
 
@@ -1114,7 +1175,7 @@ _movePaletteCursor(state: ReplState, paletteKeys: string[], delta: number): Repl
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1125))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1273))
 
 ### _removePaletteFilterCharacter
 
@@ -1130,7 +1191,7 @@ _removePaletteFilterCharacter(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1147))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1295))
 
 ### _appendPaletteFilterCharacter
 
@@ -1147,7 +1208,7 @@ _appendPaletteFilterCharacter(state: ReplState, character: string): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1158))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1306))
 
 ### _replReducePaletteOpen
 
@@ -1164,7 +1225,7 @@ _replReducePaletteOpen(state: ReplState, keyEvent: KeyEvent): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1172))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1320))
 
 ### _appendInputCharacter
 
@@ -1181,7 +1242,7 @@ _appendInputCharacter(state: ReplState, character: string): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1188))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1336))
 
 ### _removeInputCharacter
 
@@ -1197,7 +1258,7 @@ _removeInputCharacter(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1198))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1346))
 
 ### _openPalette
 
@@ -1213,12 +1274,45 @@ _openPalette(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1208))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1356))
 
-### _replReduce
+### _filteredChoiceItems
 
 ```ts
-_replReduce(state: ReplState, keyEvent: KeyEvent): ReplState
+_filteredChoiceItems(choice: ReplChoiceState): ChoiceItem[]
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| choice | [ReplChoiceState](#replchoicestate) |  |
+
+**Returns:** `ChoiceItem[]`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1370))
+
+### _matchesChoiceFilter
+
+```ts
+_matchesChoiceFilter(item: ChoiceItem, needle: string): boolean
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| item | [ChoiceItem](#choiceitem) |  |
+| needle | `string` |  |
+
+**Returns:** `boolean`
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1378))
+
+### _replReduceChoice
+
+```ts
+_replReduceChoice(state: ReplState, keyEvent: KeyEvent): ReplState
 ```
 
 **Parameters:**
@@ -1230,7 +1324,40 @@ _replReduce(state: ReplState, keyEvent: KeyEvent): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1220))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1391))
+
+### _syncChoiceFromBridge
+
+```ts
+_syncChoiceFromBridge(state: ReplState): ReplState
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| state | [ReplState](#replstate) |  |
+
+**Returns:** [ReplState](#replstate)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1459))
+
+### _replReduce
+
+```ts
+_replReduce(replState: ReplState, keyEvent: KeyEvent): ReplState
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| replState | [ReplState](#replstate) |  |
+| keyEvent | [KeyEvent](#keyevent) |  |
+
+**Returns:** [ReplState](#replstate)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1479))
 
 ### _replIsDone
 
@@ -1246,7 +1373,7 @@ _replIsDone(state: ReplState): boolean
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1241))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1508))
 
 ### repl
 
@@ -1288,4 +1415,4 @@ Drop-in REPL widget for interactive CLI agents. Bundles a
 | paletteCommands | `any` | null |
 | tickMs | `number` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1245))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1519))

--- a/packages/agency-lang/docs/site/stdlib/ui.md
+++ b/packages/agency-lang/docs/site/stdlib/ui.md
@@ -131,7 +131,8 @@ export type Element = {
 export type KeyEvent = {
   key: string;
   shift?: boolean;
-  ctrl?: boolean
+  ctrl?: boolean;
+  text?: string
 }
 ```
 
@@ -174,7 +175,7 @@ export type Builder = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L145))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L151))
 
 ### ReplInputState
 
@@ -189,7 +190,7 @@ type ReplInputState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L842))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L848))
 
 ### ReplPaletteState
 
@@ -202,7 +203,7 @@ type ReplPaletteState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L851))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L857))
 
 ### ReplTranscriptState
 
@@ -212,7 +213,7 @@ type ReplTranscriptState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L858))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L864))
 
 ### ReplSubmitState
 
@@ -224,7 +225,7 @@ type ReplSubmitState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L862))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L868))
 
 ### ReplConfigState
 
@@ -235,7 +236,7 @@ type ReplConfigState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L868))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L874))
 
 ### ChoiceItem
 
@@ -255,7 +256,7 @@ export type ChoiceItem = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L878))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L884))
 
 ### ReplChoiceState
 
@@ -269,7 +270,7 @@ type ReplChoiceState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L888))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L894))
 
 ### ReplState
 
@@ -285,7 +286,7 @@ type ReplState = {
 }
 ```
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L896))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L902))
 
 ## Functions
 
@@ -316,7 +317,7 @@ Build a plain text element. No layout sizing — embed inside a `box`
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L164))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L170))
 
 ### _setStyleIfSet
 
@@ -332,7 +333,7 @@ _setStyleIfSet(style: any, key: string, value: any)
 | key | `string` |  |
 | value | `any` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L185))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L191))
 
 ### line
 
@@ -379,7 +380,7 @@ Build a single-line text element with `height: 1`. The default keeps
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L199))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L205))
 
 ### list
 
@@ -422,7 +423,7 @@ Build a scrollable selectable list. `selectedIndex` highlights one
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L255))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L261))
 
 ### textInput
 
@@ -461,7 +462,7 @@ Build a single-line text input. The renderer displays `value` with
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L304))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L310))
 
 ### _mkBoxStyle
 
@@ -487,7 +488,7 @@ _mkBoxStyle(flexDirection: string, flex: number, width: number, height: number, 
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L348))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L354))
 
 ### _makeBuilder
 
@@ -503,7 +504,7 @@ _makeBuilder(kids: any[]): Builder
 
 **Returns:** [Builder](#builder)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L378))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L384))
 
 ### column
 
@@ -553,7 +554,7 @@ Build a vertical container. Children stack top-to-bottom. Pass a
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L394))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L400))
 
 ### row
 
@@ -599,7 +600,7 @@ Build a horizontal container. Children stack left-to-right. Pass a
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L458))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L464))
 
 ### box
 
@@ -646,7 +647,7 @@ Build a direction-neutral container. Use when you want to apply
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L516))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L522))
 
 ### _addRow
 
@@ -673,7 +674,7 @@ _addRow(kids: any[], flex: number, width: number, height: number, padding: numbe
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L573))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L579))
 
 ### _addColumn
 
@@ -700,7 +701,7 @@ _addColumn(kids: any[], flex: number, width: number, height: number, padding: nu
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L604))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L610))
 
 ### _addBox
 
@@ -727,7 +728,7 @@ _addBox(kids: any[], flex: number, width: number, height: number, padding: numbe
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L635))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L641))
 
 ### _addLine
 
@@ -751,7 +752,7 @@ _addLine(kids: any[], content: string, flex: number, width: number, height: numb
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L666))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L672))
 
 ### _addText
 
@@ -768,7 +769,7 @@ _addText(kids: any[], content: string): Element
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L691))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L697))
 
 ### _addList
 
@@ -792,7 +793,7 @@ _addList(kids: any[], items: string[], selectedIndex: number, flex: number, widt
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L697))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L703))
 
 ### _addTextInput
 
@@ -814,7 +815,7 @@ _addTextInput(kids: any[], value: string, flex: number, width: number, height: n
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L722))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L728))
 
 ### renderOnce
 
@@ -838,7 +839,7 @@ Render a single Element tree to the screen and return immediately.
 |---|---|---|
 | tree | [Element](#element) |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L750))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L756))
 
 ### readKey
 
@@ -858,7 +859,7 @@ Read one key from the terminal. Blocks until a key is pressed.
 
 **Returns:** [KeyEvent](#keyevent)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L766))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L772))
 
 ### runLoop
 
@@ -910,7 +911,7 @@ Elm/Ink-style state machine driver. Renders `initialState`, waits
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L794))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L800))
 
 ### pushMessage
 
@@ -933,7 +934,7 @@ Append a styled message to the active repl() transcript. The
 |---|---|---|
 | message | `string` |  |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L913))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L919))
 
 ### clearMessages
 
@@ -945,7 +946,7 @@ Remove all messages from the active repl() transcript. Intended
   for explicit "clear conversation" commands inside interactive
   agents. Silent no-op when no repl() is active.
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L934))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L940))
 
 ### chooseOption
 
@@ -979,7 +980,7 @@ Show a modal choice prompt over the active repl() and block until
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L951))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L957))
 
 ### _entryKey
 
@@ -995,7 +996,7 @@ _entryKey(entry: any): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1004))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1010))
 
 ### _filteredPaletteKeys
 
@@ -1011,7 +1012,7 @@ _filteredPaletteKeys(state: ReplState): string[]
 
 **Returns:** `string[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1012))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1018))
 
 ### _matchesFilter
 
@@ -1028,7 +1029,7 @@ _matchesFilter(name: string, filterText: string): boolean
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1021))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1027))
 
 ### _busyLine
 
@@ -1044,7 +1045,7 @@ _busyLine(state: ReplState): string
 
 **Returns:** `string`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1025))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1031))
 
 ### _choiceProjection
 
@@ -1060,7 +1061,7 @@ _choiceProjection(state: ReplState): any
 
 **Returns:** `any`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1053))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1059))
 
 ### _replView
 
@@ -1076,7 +1077,7 @@ _replView(state: ReplState): Element
 
 **Returns:** [Element](#element)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1101))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1107))
 
 ### _submitPrompt
 
@@ -1092,7 +1093,7 @@ _submitPrompt(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1186))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1192))
 
 ### _recallPreviousHistory
 
@@ -1108,7 +1109,7 @@ _recallPreviousHistory(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1214))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1220))
 
 ### _recallNextHistory
 
@@ -1124,7 +1125,7 @@ _recallNextHistory(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1226))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1232))
 
 ### _closePalette
 
@@ -1140,7 +1141,7 @@ _closePalette(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1242))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1248))
 
 ### _selectPaletteCommand
 
@@ -1157,7 +1158,7 @@ _selectPaletteCommand(state: ReplState, paletteKeys: string[]): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1254))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1260))
 
 ### _movePaletteCursor
 
@@ -1175,7 +1176,7 @@ _movePaletteCursor(state: ReplState, paletteKeys: string[], delta: number): Repl
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1273))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1279))
 
 ### _removePaletteFilterCharacter
 
@@ -1191,7 +1192,7 @@ _removePaletteFilterCharacter(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1295))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1301))
 
 ### _appendPaletteFilterCharacter
 
@@ -1208,7 +1209,7 @@ _appendPaletteFilterCharacter(state: ReplState, character: string): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1306))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1312))
 
 ### _replReducePaletteOpen
 
@@ -1225,7 +1226,7 @@ _replReducePaletteOpen(state: ReplState, keyEvent: KeyEvent): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1320))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1326))
 
 ### _appendInputCharacter
 
@@ -1242,7 +1243,40 @@ _appendInputCharacter(state: ReplState, character: string): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1336))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1342))
+
+### _appendPaste
+
+```ts
+_appendPaste(state: ReplState, pasted: string): ReplState
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| state | [ReplState](#replstate) |  |
+| pasted | `string` |  |
+
+**Returns:** [ReplState](#replstate)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1357))
+
+### _clearInputBuffer
+
+```ts
+_clearInputBuffer(state: ReplState): ReplState
+```
+
+**Parameters:**
+
+| Name | Type | Default |
+|---|---|---|
+| state | [ReplState](#replstate) |  |
+
+**Returns:** [ReplState](#replstate)
+
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1373))
 
 ### _removeInputCharacter
 
@@ -1258,7 +1292,7 @@ _removeInputCharacter(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1346))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1383))
 
 ### _openPalette
 
@@ -1274,7 +1308,7 @@ _openPalette(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1356))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1393))
 
 ### _filteredChoiceItems
 
@@ -1290,7 +1324,7 @@ _filteredChoiceItems(choice: ReplChoiceState): ChoiceItem[]
 
 **Returns:** `ChoiceItem[]`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1370))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1407))
 
 ### _matchesChoiceFilter
 
@@ -1307,7 +1341,7 @@ _matchesChoiceFilter(item: ChoiceItem, needle: string): boolean
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1378))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1415))
 
 ### _replReduceChoice
 
@@ -1324,7 +1358,7 @@ _replReduceChoice(state: ReplState, keyEvent: KeyEvent): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1391))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1428))
 
 ### _syncChoiceFromBridge
 
@@ -1340,7 +1374,7 @@ _syncChoiceFromBridge(state: ReplState): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1459))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1496))
 
 ### _replReduce
 
@@ -1357,7 +1391,7 @@ _replReduce(replState: ReplState, keyEvent: KeyEvent): ReplState
 
 **Returns:** [ReplState](#replstate)
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1479))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1516))
 
 ### _replIsDone
 
@@ -1373,7 +1407,7 @@ _replIsDone(state: ReplState): boolean
 
 **Returns:** `boolean`
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1508))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1550))
 
 ### repl
 
@@ -1415,4 +1449,4 @@ Drop-in REPL widget for interactive CLI agents. Bundles a
 | paletteCommands | `any` | null |
 | tickMs | `number` | null |
 
-([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1519))
+([source](https://github.com/egonSchiele/agency-lang/tree/main/stdlib/ui.agency#L1561))

--- a/packages/agency-lang/lib/agents/agency-agent/agent.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/agent.agency
@@ -216,10 +216,11 @@ def _runTurn(msg: string): boolean {
   return true
 }
 
-def _buildStatus(): { left: string; right: string } {
+def _buildStatus(): { left: string; right: string; context: string } {
   return {
-    left: " agency-agent",
-    right: "$${getCost()} "
+    left: "agency-agent",
+    right: "$${getCost()}",
+    context: "/help for commands · /exit to quit"
   }
 }
 

--- a/packages/agency-lang/lib/agents/agency-agent/code.agency
+++ b/packages/agency-lang/lib/agents/agency-agent/code.agency
@@ -15,7 +15,6 @@ import { remember, recall } from "std::memory"
 import { highlight } from "std::syntax"
 import { cwd } from "std::system"
 
-
 // File-system tools handed to the LLM as a single bundle anchored to
 // one directory. `openDir(dir)` returns a Workspace whose `read` /
 // `write` / `edit` / `ls` / `glob` / `grep` / `bash` all resolve
@@ -23,7 +22,7 @@ import { cwd } from "std::system"
 // subtree. `setCwd` rebuilds the bundle to re-anchor. Module-level
 // `let` so the rebuilt bundle is visible to the next turn (Agency
 // stores module-level lets in the GlobalStore).
-let workspace: Workspace = openDir(cwd())
+static const workspace: Workspace = openDir(cwd())
 
 export def setCwd(dir: string): string {
   """
@@ -38,7 +37,7 @@ export def setCwd(dir: string): string {
   if (dir == "cwd") {
     dir = cwd()
   }
-  workspace = openDir(dir)
+  //workspace = openDir(dir)
   return "Working directory set to: ${dir}"
 }
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1520,9 +1520,11 @@ export class TypeScriptBuilder {
   }
 `;
     });
+    // moduleId/scopeName used to be threaded into the result-entry
+    // `createPinned` call. That call is now skipped (see template); the
+    // template only consumes `paramsStr` for the arg-override block.
+    void functionName;
     const str = renderResultCheckpointSetup.default({
-      moduleId: JSON.stringify(this.moduleId),
-      scopeName: JSON.stringify(functionName),
       paramsStr,
     });
 

--- a/packages/agency-lang/lib/cli/runBundledAgent.ts
+++ b/packages/agency-lang/lib/cli/runBundledAgent.ts
@@ -1,6 +1,7 @@
 import { AgencyConfig } from "@/config.js";
 import { compile, compiledOutputNodeArgs } from "./commands.js";
 import { spawn } from "child_process";
+import * as fs from "fs";
 import * as path from "path";
 
 const currentDir = path.dirname(new URL(import.meta.url).pathname);
@@ -12,11 +13,17 @@ export function runBundledAgent(
 ): void {
   const agentDir = path.resolve(currentDir, `../agents/${agentName}`);
   const agencyFile = path.join(agentDir, "agent.agency");
+  const precompiledFile = path.join(agentDir, "agent.js");
 
-  // The compiled agent.js already includes a top-level invocation of `main()`,
-  // so we run it directly. (Older code expected a hand-written run.js wrapper
-  // that no longer exists.)
-  const runFile = compile(config, agencyFile);
+  // Prefer the precompiled agent.js produced by `make agents` so users
+  // don't pay the compile cost on every invocation. Falls back to a
+  // fresh compile if the bundle hasn't been built yet.
+  let runFile: string | null;
+  if (fs.existsSync(precompiledFile)) {
+    runFile = precompiledFile;
+  } else {
+    runFile = compile(config, agencyFile);
+  }
   if (runFile === null) {
     console.error(`Failed to compile agent ${agentName}.`);
     process.exit(1);

--- a/packages/agency-lang/lib/logger.test.ts
+++ b/packages/agency-lang/lib/logger.test.ts
@@ -1,53 +1,95 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createLogger } from "./logger.js";
 
+// The logger now routes through `console.*` so that an active
+// `std::ui.repl()` capture (which monkeypatches the console sinks)
+// can funnel output into the on-screen transcript instead of having
+// raw `stderr.write` corrupt the rendered frame. Tests spy on
+// `console.error` / `.warn` / etc. to verify dispatch.
+
+type ConsoleMethod = "error" | "warn" | "info" | "debug";
+
 describe("createLogger", () => {
-  let spy: ReturnType<typeof vi.spyOn>;
+  const spies: Record<ConsoleMethod, ReturnType<typeof vi.spyOn>> = {
+    error: undefined as any,
+    warn: undefined as any,
+    info: undefined as any,
+    debug: undefined as any,
+  };
 
   beforeEach(() => {
-    spy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    spies.error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    spies.warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    spies.info = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    spies.debug = vi.spyOn(console, "debug").mockImplementation(() => undefined);
   });
 
-  afterEach(() => spy.mockRestore());
+  afterEach(() => {
+    spies.error.mockRestore();
+    spies.warn.mockRestore();
+    spies.info.mockRestore();
+    spies.debug.mockRestore();
+  });
+
+  function totalCalls(): number {
+    return (
+      spies.error.mock.calls.length +
+      spies.warn.mock.calls.length +
+      spies.info.mock.calls.length +
+      spies.debug.mock.calls.length
+    );
+  }
 
   it("logs at info level by default", () => {
     const log = createLogger("info");
     log.info("hello");
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy.mock.calls[0][0] as string).toContain("hello");
+    expect(spies.info).toHaveBeenCalledTimes(1);
+    expect(spies.info.mock.calls[0][0] as string).toContain("hello");
+  });
+
+  it("routes each level to the matching console.* sink", () => {
+    const log = createLogger("debug");
+    log.error("e");
+    log.warn("w");
+    log.info("i");
+    log.debug("d");
+    expect(spies.error).toHaveBeenCalledTimes(1);
+    expect(spies.warn).toHaveBeenCalledTimes(1);
+    expect(spies.info).toHaveBeenCalledTimes(1);
+    expect(spies.debug).toHaveBeenCalledTimes(1);
   });
 
   it("suppresses debug when level is info", () => {
     const log = createLogger("info");
     log.debug("hidden");
-    expect(spy).not.toHaveBeenCalled();
+    expect(totalCalls()).toBe(0);
   });
 
   it("shows debug when level is debug", () => {
     const log = createLogger("debug");
     log.debug("visible");
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spies.debug).toHaveBeenCalledTimes(1);
   });
 
   it("suppresses info when level is warn", () => {
     const log = createLogger("warn");
     log.warn("caution");
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spies.warn).toHaveBeenCalledTimes(1);
     log.info("suppressed");
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(totalCalls()).toBe(1);
   });
 
   it("suppresses warn when level is error", () => {
     const log = createLogger("error");
     log.error("bad");
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spies.error).toHaveBeenCalledTimes(1);
     log.warn("suppressed");
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(totalCalls()).toBe(1);
   });
 
   it("includes level label in output", () => {
     const log = createLogger("debug");
     log.warn("test");
-    expect(spy.mock.calls[0][0] as string).toContain("WARN");
+    expect(spies.warn.mock.calls[0][0] as string).toContain("WARN");
   });
 });

--- a/packages/agency-lang/lib/logger.ts
+++ b/packages/agency-lang/lib/logger.ts
@@ -17,10 +17,28 @@ export type Logger = {
 export function createLogger(level: LogLevel = "info"): Logger {
   const threshold = LEVEL_ORDER[level];
 
+  // Route through `console.*` rather than `process.stderr.write`.
+  // Reason: when an `std::ui.repl()` is active it owns the alt-screen
+  // and installs a console capture (`_installConsoleCapture` in
+  // lib/stdlib/ui.ts) that funnels console output into the transcript
+  // list. Raw `stderr.write` would bypass that, hit the terminal
+  // directly, and tear the rendered frame — exactly the breakage seen
+  // when a Wikipedia search failure raised a stack trace mid-REPL.
+  // Outside a REPL, `console.error` still writes to stderr by
+  // default, so headless behavior is unchanged.
   function log(msgLevel: LogLevel, message: string): void {
     if (LEVEL_ORDER[msgLevel] < threshold) return;
     const timestamp = new Date().toISOString().replace("T", " ").replace("Z", "");
-    process.stderr.write(`[${timestamp}] ${msgLevel.toUpperCase()} ${message}\n`);
+    const formatted = `[${timestamp}] ${msgLevel.toUpperCase()} ${message}`;
+    if (msgLevel === "error") {
+      console.error(formatted);
+    } else if (msgLevel === "warn") {
+      console.warn(formatted);
+    } else if (msgLevel === "debug") {
+      console.debug(formatted);
+    } else {
+      console.info(formatted);
+    }
   }
 
   return {

--- a/packages/agency-lang/lib/runtime/initPlanWorkedExamples.test.ts
+++ b/packages/agency-lang/lib/runtime/initPlanWorkedExamples.test.ts
@@ -209,7 +209,7 @@ describe("agent-init-design.md worked examples", () => {
     expect(outcome.kind).toBe("compileError");
     if (outcome.kind !== "compileError") return;
     expect(outcome.message).toMatch(
-      /Static '?s'?.*references global '?g'?/,
+      /static const '?s'?.*references global '?g'?/,
     );
   });
 

--- a/packages/agency-lang/lib/runtime/resumableScope.test.ts
+++ b/packages/agency-lang/lib/runtime/resumableScope.test.ts
@@ -229,12 +229,32 @@ describe("withResumableScope — callsite + options", () => {
     expect(moduleId).toBe("my.module");
   });
 
-  it("pinResultCheckpoint: true (default) creates a result-entry checkpoint findable via getResultCheckpoint()", async () => {
+  it("pinResultCheckpoint: false (default) skips createPinned", async () => {
+    // Default flipped from true to false: pinned checkpoints
+    // accumulated unbounded inside `repl()` loops and the per-entry
+    // JSON clone of stateStack + globals was a measurable
+    // per-keystroke cost. `result.retry()` becomes a no-op for
+    // scopes that don't explicitly opt in (the runtime sees an
+    // undefined entry checkpoint and silently skips the rewind).
     const ctx = makeMockCtx();
     const spy = vi.spyOn(ctx.checkpoints, "createPinned");
     await agency.withTestContext(
       { ctx, stack: ctx.stateStack, threads: new ThreadStore() },
-      () => agency.withResumableScope({ name: "pin" }, async () => "x"),
+      () => agency.withResumableScope({ name: "noPin" }, async () => "x"),
+    );
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("pinResultCheckpoint: true opt-in creates a result-entry checkpoint findable via getResultCheckpoint()", async () => {
+    const ctx = makeMockCtx();
+    const spy = vi.spyOn(ctx.checkpoints, "createPinned");
+    await agency.withTestContext(
+      { ctx, stack: ctx.stateStack, threads: new ThreadStore() },
+      () =>
+        agency.withResumableScope(
+          { name: "pin", pinResultCheckpoint: true },
+          async () => "x",
+        ),
     );
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy.mock.calls[0][2]).toMatchObject({
@@ -255,20 +275,6 @@ describe("withResumableScope — callsite + options", () => {
         cp.pinned && cp.label === RESULT_ENTRY_LABEL,
     );
     expect(resultEntry).toBeDefined();
-  });
-
-  it("pinResultCheckpoint: false skips createPinned", async () => {
-    const ctx = makeMockCtx();
-    const spy = vi.spyOn(ctx.checkpoints, "createPinned");
-    await agency.withTestContext(
-      { ctx, stack: ctx.stateStack, threads: new ThreadStore() },
-      () =>
-        agency.withResumableScope(
-          { name: "p", pinResultCheckpoint: false },
-          async () => "x",
-        ),
-    );
-    expect(spy).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/agency-lang/lib/runtime/resumableScope.ts
+++ b/packages/agency-lang/lib/runtime/resumableScope.ts
@@ -63,12 +63,16 @@ export type ResumableScopeOpts = {
    *  stack at runtime. Override when you want a TS helper to appear
    *  under a distinct module label in the debugger. */
   moduleId?: string;
-  /** Default: true. Pins a `result-entry` checkpoint at scope entry
-   *  so the calling Agency function's `result.retry()` rewinds to
-   *  this scope's start, exactly as it would for a generated
-   *  function body. Set false for TS helpers whose results should
-   *  not participate in retry. Not related to the debugger — for
-   *  that, see `agency.callsite()` and the per-step ALS frame. */
+  /** Default: false. When true, pins a `result-entry` checkpoint at
+   *  scope entry so the calling Agency function's `result.retry()`
+   *  rewinds to this scope's start, exactly as it would for a
+   *  generated function body. Disabled by default because pinned
+   *  checkpoints accumulate without bound (evictIfNeeded only evicts
+   *  unpinned) and the per-entry JSON deep-clone of stateStack +
+   *  globals is a real per-keystroke cost. Pair this with the
+   *  resultCheckpointSetup template which has the same behavior for
+   *  compiled Agency function bodies. Not related to the debugger —
+   *  for that, see `agency.callsite()` and the per-step ALS frame. */
   pinResultCheckpoint?: boolean;
 };
 
@@ -108,7 +112,7 @@ export async function withResumableScope<T>(
   body: (s: ResumableScope) => Promise<T>,
 ): Promise<T> {
   const moduleId = opts.moduleId ?? "<ts-helper>";
-  const pin = opts.pinResultCheckpoint ?? true;
+  const pin = opts.pinResultCheckpoint ?? false;
 
   const runtime = getRuntimeContext();
   const ctx = runtime.ctx;

--- a/packages/agency-lang/lib/runtime/topsortCycleErrors.test.ts
+++ b/packages/agency-lang/lib/runtime/topsortCycleErrors.test.ts
@@ -266,7 +266,7 @@ describe("tests/agency/topsort/cycles fixtures", () => {
     const outcome = await runFixture(dir, "main.agency");
     expect(outcome.kind).toBe("compileError");
     if (outcome.kind !== "compileError") return;
-    expect(outcome.message).toMatch(/Static '.*' .*references global/);
+    expect(outcome.message).toMatch(/static const '.*' .*references global/);
     expect(outcome.message).toMatch(/\bs\b/);
     expect(outcome.message).toMatch(/\bg\b/);
   });

--- a/packages/agency-lang/lib/stdlib/ui-smoke.test.ts
+++ b/packages/agency-lang/lib/stdlib/ui-smoke.test.ts
@@ -121,6 +121,72 @@ describe("std::ui — REPL state machine (Agency-driven)", () => {
     expect(submits).toEqual(["/exit"]);
   });
 
+  it("Ctrl+U clears the input buffer without affecting history", async () => {
+    // Type "junk", Ctrl+U to wipe it, then type "ok" + Enter. The
+    // only submit observed should be "ok"; "junk" never reaches
+    // onSubmit and never lands in history.
+    const submits: string[] = [];
+    await invokeRepl(
+      [
+        { key: "j" }, { key: "u" }, { key: "n" }, { key: "k" },
+        { key: "u", ctrl: true },
+        { key: "o" }, { key: "k" }, { key: "enter" },
+      ],
+      {
+        onSubmit: (p: string) => {
+          submits.push(p);
+          return false;
+        },
+      },
+    );
+    expect(submits).toEqual(["ok"]);
+  });
+
+  it("a bracketed paste lands in the buffer wholesale and submits intact", async () => {
+    // The terminal-input layer turns a real bracketed paste into a
+    // single `{ key: "paste", text }` event. The reducer must append
+    // the whole payload at once — including newlines — rather than
+    // treating embedded `\n` as Enter.
+    const submits: string[] = [];
+    await invokeRepl(
+      [
+        { key: "paste", text: "hello\nworld" } as any,
+        { key: "enter" },
+      ],
+      {
+        onSubmit: (p: string) => {
+          submits.push(p);
+          return false;
+        },
+      },
+    );
+    expect(submits).toEqual(["hello\nworld"]);
+  });
+
+  it("Shift+Enter inserts a newline into the buffer instead of submitting", async () => {
+    // `{ key: "enter", shift: true }` is the canonical shape produced
+    // by the terminal layer for Alt/Option+Enter (the portable
+    // fallback when the terminal can't send a distinct Shift+Enter
+    // code). It should add `\n` to the buffer; plain Enter still
+    // submits the multi-line result.
+    const submits: string[] = [];
+    await invokeRepl(
+      [
+        { key: "a" },
+        { key: "enter", shift: true } as any,
+        { key: "b" },
+        { key: "enter" },
+      ],
+      {
+        onSubmit: (p: string) => {
+          submits.push(p);
+          return false;
+        },
+      },
+    );
+    expect(submits).toEqual(["a\nb"]);
+  });
+
   it("ignores Enter on an empty buffer (no submit, no transcript noise)", async () => {
     // Pressing Enter on an empty input should NOT call onSubmit.
     // We then type "ok" and press Enter to exit — exactly one submit

--- a/packages/agency-lang/lib/stdlib/ui-smoke.test.ts
+++ b/packages/agency-lang/lib/stdlib/ui-smoke.test.ts
@@ -29,7 +29,7 @@ import { ScriptedInput } from "@/tui/input/scripted.js";
 import { FrameRecorder } from "@/tui/output/recorder.js";
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore – compiled-by-make Agency module; no .d.ts is emitted
-import { repl } from "../../stdlib/ui.js";
+import { repl, chooseOption } from "../../stdlib/ui.js";
 
 function makeTestCtx(): RuntimeContext<any> {
   return new RuntimeContext({
@@ -140,6 +140,153 @@ describe("std::ui — REPL state machine (Agency-driven)", () => {
       },
     );
     expect(submits).toEqual(["ok"]);
+  });
+
+  it("chooseOption opens a modal, navigates, and resolves with the picked key", async () => {
+    // We feed the modal-driving keys AFTER chooseOption has opened
+    // the prompt. The submit-trigger keys are pre-queued; the modal
+    // keys are fed from inside onSubmit so they don't race past the
+    // not-yet-open modal.
+    const picks: string[] = [];
+    const scripted = new ScriptedInput([
+      { key: "g" }, { key: "o" }, { key: "enter" },
+    ]);
+    _setInputSource(scripted);
+    _setOutputTarget(new FrameRecorder());
+    _setSize(80, 24);
+    const ctx = makeTestCtx();
+    try {
+      await runInTestContext(ctx, new StateStack(), new ThreadStore(), () =>
+        __call(repl, {
+          type: "named",
+          positionalArgs: [],
+          namedArgs: {
+            status: () => ({ left: "", right: "" }),
+            onSubmit: async (_p: string) => {
+              // Schedule modal keys after onSubmit has started; they'll
+              // land in the input queue only once `_openChoicePrompt`
+              // has flipped the bridge slot.
+              setTimeout(() => {
+                scripted.feedKey({ key: "down" });
+                scripted.feedKey({ key: "enter" });
+              }, 0);
+              const answer = await __call(chooseOption, {
+                type: "named",
+                positionalArgs: [],
+                namedArgs: {
+                  title: "Pick one",
+                  body: "context",
+                  items: [
+                    { key: "a", label: "alpha" },
+                    { key: "b", label: "beta" },
+                  ],
+                },
+              });
+              picks.push(answer as string);
+              return false;
+            },
+            paletteCommands: {},
+          },
+        }),
+      );
+    } finally {
+      _setInputSource(null);
+      _setOutputTarget(null);
+      _uninstallConsoleCapture();
+    }
+    expect(picks).toEqual(["b"]);
+  });
+
+  it("chooseOption resolves with the first item on plain Enter", async () => {
+    const picks: string[] = [];
+    const scripted = new ScriptedInput([
+      { key: "g" }, { key: "enter" },
+    ]);
+    _setInputSource(scripted);
+    _setOutputTarget(new FrameRecorder());
+    _setSize(80, 24);
+    const ctx = makeTestCtx();
+    try {
+      await runInTestContext(ctx, new StateStack(), new ThreadStore(), () =>
+        __call(repl, {
+          type: "named",
+          positionalArgs: [],
+          namedArgs: {
+            status: () => ({ left: "", right: "" }),
+            onSubmit: async (_p: string) => {
+              setTimeout(() => scripted.feedKey({ key: "enter" }), 0);
+              const answer = await __call(chooseOption, {
+                type: "named",
+                positionalArgs: [],
+                namedArgs: {
+                  title: "T",
+                  body: "",
+                  items: [
+                    { key: "yes", label: "Yes" },
+                    { key: "no", label: "No" },
+                  ],
+                },
+              });
+              picks.push(answer as string);
+              return false;
+            },
+            paletteCommands: {},
+          },
+        }),
+      );
+    } finally {
+      _setInputSource(null);
+      _setOutputTarget(null);
+      _uninstallConsoleCapture();
+    }
+    expect(picks).toEqual(["yes"]);
+  });
+
+  it("chooseOption escape cancels the modal as a Failure return", async () => {
+    // Agency wraps thrown errors from async functions into a Failure
+    // record (not a JS exception), so `await chooseOption(...)` returns
+    // a `{ success: false, error }` value when the user hits Escape.
+    const replies: any[] = [];
+    const scripted = new ScriptedInput([
+      { key: "g" }, { key: "enter" },
+    ]);
+    _setInputSource(scripted);
+    _setOutputTarget(new FrameRecorder());
+    _setSize(80, 24);
+    const ctx = makeTestCtx();
+    try {
+      await runInTestContext(ctx, new StateStack(), new ThreadStore(), () =>
+        __call(repl, {
+          type: "named",
+          positionalArgs: [],
+          namedArgs: {
+            status: () => ({ left: "", right: "" }),
+            onSubmit: async (_p: string) => {
+              setTimeout(() => scripted.feedKey({ key: "escape" }), 0);
+              const answer = await __call(chooseOption, {
+                type: "named",
+                positionalArgs: [],
+                namedArgs: {
+                  title: "T",
+                  body: "",
+                  items: [{ key: "a", label: "A" }],
+                },
+              });
+              replies.push(answer);
+              return false;
+            },
+            paletteCommands: {},
+          },
+        }),
+      );
+    } finally {
+      _setInputSource(null);
+      _setOutputTarget(null);
+      _uninstallConsoleCapture();
+    }
+    expect(replies.length).toBe(1);
+    expect(replies[0]?.success).toBe(false);
+    expect(String(replies[0]?.error ?? "")).toMatch(/cancel/i);
   });
 
   it("exits when onSubmit returns false", async () => {

--- a/packages/agency-lang/lib/stdlib/ui.test.ts
+++ b/packages/agency-lang/lib/stdlib/ui.test.ts
@@ -14,6 +14,12 @@ import {
   _uninstallConsoleCapture,
   BottomRegionOutputTarget,
   _writeScrollLine,
+  _openChoicePrompt,
+  _resolveChoice,
+  _cancelChoice,
+  _hasPendingChoice,
+  _peekReplExitSignal,
+  _resetReplExitSignal,
 } from "./ui.js";
 import { installRegion, resetRegion } from "./ui-region.js";
 import { ScriptedInput } from "@/tui/input/scripted.js";
@@ -24,6 +30,7 @@ afterEach(() => {
   _setInputSource(null);
   _setOutputTarget(null);
   _uninstallConsoleCapture();
+  _resetReplExitSignal();
 });
 
 describe("std::ui bridge — _runLoop", () => {
@@ -161,7 +168,7 @@ describe("std::ui bridge — _beginSubmit", () => {
 
     _beginSubmit(state, "hello", () => submitPromise);
 
-    expect(state.transcript.messages).toEqual(["{bright-blue You} hello"]);
+    expect(state.transcript.messages).toEqual(["{bright-blue-fg}You{/bright-blue-fg} hello"]);
     expect(state.submit.busy).toBe(true);
     expect(state.submit.label).toBe("Thinking");
 
@@ -171,22 +178,27 @@ describe("std::ui bridge — _beginSubmit", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(state.transcript.messages).toEqual([
-      "{bright-blue You} hello",
+      "{bright-blue-fg}You{/bright-blue-fg} hello",
       "agent reply",
     ]);
     expect(state.submit.busy).toBe(false);
   });
 
-  it("exits the REPL when the callback returns false", async () => {
+  it("exits the REPL by setting the bridge exit signal when the callback returns false", async () => {
     const state = makeState();
+    _resetReplExitSignal();
+    expect(_peekReplExitSignal()).toBe(false);
     _beginSubmit(state, "bye", () => false);
     // Resolve microtasks for the setTimeout(0) + the inner async IIFE.
     await new Promise((resolve) => setTimeout(resolve, 0));
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(state.done).toBe(true);
+    // The bridge flag is set instead of state.done — see
+    // `_signalReplExit` in lib/stdlib/ui.ts for why mutating
+    // `state.done` directly is unsafe across reducer-state turnover.
+    expect(_peekReplExitSignal()).toBe(true);
   });
 
-  it("surfaces thrown JS errors as {red Error} transcript entries", async () => {
+  it("surfaces thrown JS errors as {red-fg}Error{/red-fg} transcript entries", async () => {
     const state = makeState();
     _beginSubmit(state, "boom", () => {
       throw new Error("kaboom");
@@ -194,8 +206,8 @@ describe("std::ui bridge — _beginSubmit", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(state.transcript.messages).toEqual([
-      "{bright-blue You} boom",
-      "{red Error} kaboom",
+      "{bright-blue-fg}You{/bright-blue-fg} boom",
+      "{red-fg}Error{/red-fg} kaboom",
     ]);
     expect(state.submit.busy).toBe(false);
   });
@@ -206,8 +218,8 @@ describe("std::ui bridge — _beginSubmit", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(state.transcript.messages).toEqual([
-      "{bright-blue You} fail",
-      "{red Error} spec.tools cannot be spread",
+      "{bright-blue-fg}You{/bright-blue-fg} fail",
+      "{red-fg}Error{/red-fg} spec.tools cannot be spread",
     ]);
     expect(state.submit.busy).toBe(false);
   });
@@ -236,8 +248,8 @@ describe("std::ui bridge — console capture", () => {
     }
     expect(transcript).toEqual([
       "first",
-      "{yellow warn} watch out",
-      "{red error} nope",
+      "{yellow-fg}warn{/yellow-fg} watch out",
+      "{red-fg}error{/red-fg} nope",
       "hi",
     ]);
   });
@@ -388,5 +400,93 @@ describe("std::ui bridge — _writeScrollLine", () => {
   it("writes the text followed by a newline (no ANSI)", () => {
     _writeScrollLine("hello world");
     expect(stdoutWrites.join("")).toBe("hello world\n");
+  });
+});
+
+describe("std::ui bridge — choice prompts", () => {
+  afterEach(() => {
+    // Drain any pending prompt so a failed test doesn't leak state
+    // into the next one (the slot is module-level).
+    if (_hasPendingChoice()) _cancelChoice("test cleanup");
+  });
+
+  it("stores the request and resolves with the chosen key", async () => {
+    const promise = _openChoicePrompt({
+      title: "Pick one",
+      body: "context",
+      items: [
+        { key: "a", label: "Approve" },
+        { key: "r", label: "Reject" },
+      ],
+    });
+    expect(_hasPendingChoice()).toBe(true);
+    _resolveChoice("a");
+    await expect(promise).resolves.toBe("a");
+    expect(_hasPendingChoice()).toBe(false);
+  });
+
+  it("rejects with the supplied reason on cancel", async () => {
+    const promise = _openChoicePrompt({
+      title: "T",
+      body: "",
+      items: [{ key: "y", label: "yes" }],
+    });
+    _cancelChoice("user cancelled");
+    await expect(promise).rejects.toThrow("user cancelled");
+    expect(_hasPendingChoice()).toBe(false);
+  });
+
+  it("rejects when another prompt is already open", async () => {
+    const first = _openChoicePrompt({
+      title: "first",
+      body: "",
+      items: [{ key: "a", label: "A" }],
+    });
+    await expect(
+      _openChoicePrompt({
+        title: "second",
+        body: "",
+        items: [{ key: "b", label: "B" }],
+      }),
+    ).rejects.toThrow(/already open/);
+    _cancelChoice("cleanup");
+    await expect(first).rejects.toThrow();
+  });
+
+  it("_resolveChoice and _cancelChoice are no-ops with no pending prompt", () => {
+    expect(() => _resolveChoice("anything")).not.toThrow();
+    expect(() => _cancelChoice("anything")).not.toThrow();
+    expect(_hasPendingChoice()).toBe(false);
+  });
+
+  it("_runReplLoop cancels a dangling choice prompt on exit", async () => {
+    _setInputSource(new ScriptedInput([{ key: "q" }]));
+    _setOutputTarget(new FrameRecorder());
+    _setSize(40, 5);
+    const transcript: string[] = [];
+    // Open a prompt as soon as the first render runs — by the time
+    // the loop exits (key "q"), the prompt is still dangling and
+    // should be rejected by the finally block in _runReplLoop.
+    let dangling: Promise<string> | null = null;
+    await _runReplLoop(
+      { done: false },
+      (_s: any) => {
+        if (!dangling) {
+          dangling = _openChoicePrompt({
+            title: "t",
+            body: "",
+            items: [{ key: "a", label: "A" }],
+          });
+        }
+        return { type: "text", content: "x" };
+      },
+      (_s: any, ev: any) => ({ done: ev.key === "q" }),
+      (s: any) => s.done,
+      null,
+      transcript,
+    );
+    expect(dangling).not.toBeNull();
+    await expect(dangling).rejects.toThrow(/REPL loop exited/);
+    expect(_hasPendingChoice()).toBe(false);
   });
 });

--- a/packages/agency-lang/lib/stdlib/ui.test.ts
+++ b/packages/agency-lang/lib/stdlib/ui.test.ts
@@ -279,6 +279,49 @@ describe("std::ui bridge — console capture", () => {
     expect(realWrites).toEqual(["not captured\n"]);
   });
 
+  it("truncates a captured multi-line error to the first couple of lines", async () => {
+    // A `__log.error(stack)` from the runtime's catch-and-convert path
+    // can be a multi-page stack trace. With the truncation in place
+    // the transcript shows the error head plus a gray placeholder
+    // for the rest — keeps the TUI legible without dropping evidence
+    // that something went wrong.
+    const { truncateForTui } = await import("./ui.js");
+    const stack = [
+      "Error: kaboom",
+      "    at fn (file.ts:1:1)",
+      "    at caller (file.ts:2:2)",
+      "    at next (file.ts:3:3)",
+    ].join("\n");
+    const out = truncateForTui(stack);
+    const lines = out.split("\n");
+    expect(lines[0]).toBe("Error: kaboom");
+    expect(lines[1]).toBe("    at fn (file.ts:1:1)");
+    expect(lines[2]).toContain("2 more lines omitted");
+  });
+
+  it("leaves short messages untouched", async () => {
+    const { truncateForTui } = await import("./ui.js");
+    expect(truncateForTui("just one line")).toBe("just one line");
+    expect(truncateForTui("line one\nline two")).toBe("line one\nline two");
+  });
+
+  it("captured console.error of a multi-line payload renders truncated", () => {
+    // End-to-end of the truncation through the console capture so a
+    // regression in the prefix-join path doesn't slip past.
+    const transcript: string[] = [];
+    _installConsoleCapture(transcript);
+    try {
+      console.error("head\nframe1\nframe2\nframe3");
+    } finally {
+      _uninstallConsoleCapture();
+    }
+    // Captured as one entry per line of the truncated payload, each
+    // prefixed by the `error` tag.
+    expect(transcript[0]).toBe("{red-fg}error{/red-fg} head");
+    expect(transcript[1]).toContain("frame1");
+    expect(transcript[transcript.length - 1]).toContain("omitted");
+  });
+
   it("restores the original console sinks on uninstall", () => {
     const origLog = console.log;
     const origWarn = console.warn;

--- a/packages/agency-lang/lib/stdlib/ui.ts
+++ b/packages/agency-lang/lib/stdlib/ui.ts
@@ -155,10 +155,11 @@ async function callBridgeFn<T>(fn: unknown, ...args: unknown[]): Promise<T> {
 
 /** Shape of the `state` arg `_beginSubmit` mutates while the async
  *  onSubmit settles. Defined locally because the Agency `ReplState`
- *  is record-typed and the bridge only cares about these three
- *  fields. */
+ *  is record-typed and the bridge only cares about these two fields.
+ *  The exit-on-`false`-return path uses the `_signalReplExit` bridge
+ *  flag rather than mutating `state.done` here — see that function's
+ *  comment for why. */
 type SubmitTargetState = {
-  done?: boolean;
   submit?: {
     busy?: boolean;
     label?: string;
@@ -244,9 +245,9 @@ export function _installConsoleCapture(messages: string[]): void {
   console.debug = (...args: unknown[]) =>
     pushCaptured("", formatConsoleArgs(args));
   console.warn = (...args: unknown[]) =>
-    pushCaptured("{yellow warn}", formatConsoleArgs(args));
+    pushCaptured("{yellow-fg}warn{/yellow-fg}", formatConsoleArgs(args));
   console.error = (...args: unknown[]) =>
-    pushCaptured("{red error}", formatConsoleArgs(args));
+    pushCaptured("{red-fg}error{/red-fg}", formatConsoleArgs(args));
 
   // Deliberately NOT overriding `process.stdout.write` / `process.stderr.write`.
   // An earlier revision did, but `lib/tui/output/terminal.ts`'s renderer
@@ -283,12 +284,45 @@ export function _spinnerFrame(startedAtMs: number, nowMs = Date.now()): string {
   return frames[tick % frames.length];
 }
 
+// Module-level "exit signaled" flag for `repl()`. `_beginSubmit`
+// flips this when `onSubmit` returns `false`; the Agency
+// `_replIsDone` reads it via `_peekReplExitSignal()`. We cannot
+// mutate `state.done = true` directly because `done` is a primitive
+// boolean — `{...state, ...}` in subsequent reducer calls copies it
+// at the time of spread, so a later mutation on the stale record is
+// invisible to the current loop state.
+let replExitSignaled = false;
+
+/** Signal that the active `repl()` should exit on its next isDone
+ *  check. Called from `_beginSubmit` when `onSubmit` returns `false`,
+ *  and from any future "force exit" plumbing. Wakes the loop so
+ *  `_replIsDone` runs immediately. */
+export function _signalReplExit(): void {
+  replExitSignaled = true;
+  _triggerRender();
+}
+
+/** Read the exit signal without clearing it. The Agency `_replIsDone`
+ *  calls this on every tick; once true the loop terminates and the
+ *  flag is reset by `_runReplLoop` in its finally block so the next
+ *  REPL invocation starts fresh. */
+export function _peekReplExitSignal(): boolean {
+  return replExitSignaled;
+}
+
+/** Reset the exit signal. Called by `_runReplLoop` before and after
+ *  the loop runs, so a leftover signal from a prior REPL session
+ *  doesn't cause the next one to exit on first frame. */
+export function _resetReplExitSignal(): void {
+  replExitSignaled = false;
+}
+
 export function _beginSubmit(
   state: SubmitTargetState,
   submitted: string,
   onSubmit: unknown,
 ): void {
-  state.transcript.messages.push(`{bright-blue You} ${submitted}`);
+  state.transcript.messages.push(`{bright-blue-fg}You{/bright-blue-fg} ${submitted}`);
   if (state.submit) {
     state.submit.busy = true;
     state.submit.label = "Thinking";
@@ -300,10 +334,12 @@ export function _beginSubmit(
       try {
         const reply = await callBridgeFn<unknown>(onSubmit, submitted);
         if (reply === false) {
-          state.done = true;
-          // Wake the loop so isDone() runs and it exits — otherwise
-          // the user sees a hung REPL after `/exit`.
-          _triggerRender();
+          // Signal exit via the bridge instead of mutating
+          // `state.done`. The reducer can't see mutations on this
+          // stale `state` record once subsequent keys have produced
+          // new states (e.g. a modal that opened and closed during
+          // onSubmit). See `_signalReplExit` comment above.
+          _signalReplExit();
           return;
         }
         // Surface Failure-typed returns explicitly. Agency functions
@@ -326,7 +362,7 @@ export function _beginSubmit(
                       return String(err);
                     }
                   })();
-          state.transcript.messages.push(`{red Error} ${message}`);
+          state.transcript.messages.push(`{red-fg}Error{/red-fg} ${message}`);
           return;
         }
         if (typeof reply === "string" && reply.length > 0) {
@@ -334,7 +370,7 @@ export function _beginSubmit(
         }
       } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
-        state.transcript.messages.push(`{red Error} ${message}`);
+        state.transcript.messages.push(`{red-fg}Error{/red-fg} ${message}`);
       } finally {
         if (state.submit) {
           state.submit.busy = false;
@@ -401,11 +437,21 @@ export async function _runReplLoop(
   tickMs: number | null | undefined,
   transcriptMessages: string[],
 ): Promise<any> {
+  // Reset the exit signal so a leftover flag from a previous REPL
+  // doesn't immediately terminate this one.
+  _resetReplExitSignal();
   _installConsoleCapture(transcriptMessages);
   try {
     return await _runLoop(initialState, renderFn, handleKeyFn, isDoneFn, tickMs);
   } finally {
     _uninstallConsoleCapture();
+    // Clear the exit signal so it can't leak across REPL invocations
+    // in the same process (e.g. nested test runs).
+    _resetReplExitSignal();
+    // Cancel any choice prompt left dangling by an exception path so
+    // the awaiting Agency caller sees a rejection instead of a hang.
+    // No-op when no prompt is open.
+    _cancelChoice("REPL loop exited before choice was made");
   }
 }
 
@@ -465,58 +511,115 @@ export function _writeScrollLine(text: string): void {
   process.stdout.write(text + "\n");
 }
 
+// ---------------------------------------------------------------------------
+// Choice prompts (modal-style overlay inside an active `repl()`)
+//
+// `_openChoicePrompt` mutates the live REPL state record so the
+// renderer paints the modal on the next frame, then returns a Promise
+// that resolves when the Agency-side reducer calls back via
+// `_resolveChoice` (Enter pressed) or rejects via `_cancelChoice`
+// (Escape pressed / loop torn down). This sidesteps every problem the
+// old raw-stdout version had: keys come through `Screen.runLoop` (no
+// race with the REPL's `nextKey()` waiter), and we never write outside
+// the alt-screen.
+//
+// The slot is module-level — at most one prompt is open at a time.
+// Concurrent callers should serialize themselves.
+// ---------------------------------------------------------------------------
+
+type ChoiceItem = { key: string; label: string };
+type ChoiceRequest = {
+  title: string;
+  body: string;
+  items: ChoiceItem[];
+};
+
+let pendingChoice: {
+  resolve: (answer: string) => void;
+  reject: (err: Error) => void;
+} | null = null;
+// Module-level snapshot of the *request* (title, body, items) for
+// the currently-open prompt. The Agency reducer pulls this on every
+// tick to keep its `state.choice` synced — we cannot mutate the
+// live reducer state from TS because reducers return fresh records
+// on every keypress. `null` when no prompt is open.
+let pendingChoiceRequest: ChoiceRequest | null = null;
+
 /**
- * Prompt the user for one of `choices` while a REPL owns the screen.
- * Writes `text` (multi-line) to the scroll region, then reads keys
- * from the active screen's input source — accumulating printable
- * characters into a buffer that's committed on Enter. Loops until
- * the typed answer is one of `choices`. Backspace edits the buffer.
+ * Open a modal choice prompt over the currently-running REPL. Stores
+ * the request in a module-level slot that the Agency reducer reads
+ * via `_peekPendingChoiceRequest()` on every tick (so a fresh frame
+ * sees the modal even though reducers return new state records),
+ * then returns a Promise that the Agency reducer resolves via
+ * `_resolveChoice(answer)` (Enter) or rejects via `_cancelChoice`
+ * (Escape, or REPL torn down).
  *
- * Caller must verify `_hasActiveScreen()` first; this throws if no
- * REPL is active because the fallback path (raw stdin) lives in the
- * Agency-side wrapper `_routePrompt`.
- *
- * NB: when the REPL is running with `tickMs`, its `runLoop` may have
- * a leaked `nextKey()` promise registered from the most recent tick.
- * Since this function is called synchronously from inside `onSubmit`
- * (between `nextKey` awaits), the leaked waiter only matters if a
- * key is typed *while* a tick was racing, in which case that key
- * may be claimed by the loop instead of the prompt. Acceptable for
- * v1; production use should pause the loop while prompting.
+ * Rejects if another prompt is already open — the caller should
+ * serialize.
  */
-export async function _promptFromChoices(
-  text: string,
-  choices: string[],
-): Promise<string> {
-  const screen = bridgeActiveScreen;
-  if (!screen) {
-    throw new Error(
-      "_promptFromChoices: no active screen — callers must guard with _hasActiveScreen()",
+export function _openChoicePrompt(request: ChoiceRequest): Promise<string> {
+  if (pendingChoice) {
+    return Promise.reject(
+      new Error(
+        "_openChoicePrompt: a choice prompt is already open; serialize callers",
+      ),
     );
   }
-  for (const ln of text.split("\n")) {
-    process.stdout.write(ln + "\n");
-  }
-  while (true) {
-    let buf = "";
-    // Show what the user has typed so far on its own scroll-region line.
-    process.stdout.write("> ");
-    while (true) {
-      const ev = await screen.nextKey();
-      if (ev.key === "enter") break;
-      if (ev.key === "backspace") {
-        buf = buf.slice(0, -1);
-        continue;
-      }
-      if (ev.key.length === 1) {
-        buf += ev.key;
-      }
-    }
-    process.stdout.write(buf + "\n");
-    const answer = buf.trim();
-    if (choices.includes(answer)) return answer;
-    process.stdout.write(`(one of ${choices.join("/")})\n`);
-  }
+  pendingChoiceRequest = {
+    title: request.title,
+    body: request.body,
+    items: request.items,
+  };
+  return new Promise<string>((resolve, reject) => {
+    pendingChoice = { resolve, reject };
+    // Wake the loop so the modal paints immediately rather than
+    // waiting for the next user keypress. The reducer's TS-sync step
+    // runs on this synthetic key event and initializes state.choice.
+    _triggerRender();
+  });
+}
+
+/**
+ * Read the pending choice request without consuming it. Returns
+ * `null` when no prompt is open. The Agency reducer calls this on
+ * every keystroke to sync `state.choice` with the TS-side request:
+ * if TS has a request but state.choice is null, the reducer
+ * initializes it; if TS has no request but state.choice is set,
+ * the reducer clears it.
+ */
+export function _peekPendingChoiceRequest(): ChoiceRequest | null {
+  return pendingChoiceRequest;
+}
+
+/** Resolve the pending choice promise with `answer` and clear both
+ *  the promise slot and the request slot. Called by the Agency
+ *  reducer when Enter is pressed on a filtered, non-empty list.
+ *  No-op when no prompt is open. */
+export function _resolveChoice(answer: string): void {
+  if (!pendingChoice) return;
+  const { resolve } = pendingChoice;
+  pendingChoice = null;
+  pendingChoiceRequest = null;
+  resolve(answer);
+}
+
+/** Reject the pending choice promise with `reason` and clear both
+ *  the promise slot and the request slot. Called by the Agency
+ *  reducer on Escape, or by `_runReplLoop` in its finally block to
+ *  break out of any prompt left hanging by an exception. No-op when
+ *  no prompt is open. */
+export function _cancelChoice(reason: string): void {
+  if (!pendingChoice) return;
+  const { reject } = pendingChoice;
+  pendingChoice = null;
+  pendingChoiceRequest = null;
+  reject(new Error(reason || "choice prompt cancelled"));
+}
+
+/** Test/debug hook. Returns true while a choice prompt is awaiting a
+ *  reducer callback. */
+export function _hasPendingChoice(): boolean {
+  return pendingChoice !== null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/agency-lang/lib/stdlib/ui.ts
+++ b/packages/agency-lang/lib/stdlib/ui.ts
@@ -222,7 +222,7 @@ function formatConsoleArgs(args: unknown[]): string {
  * authored output that's meant to be shown in full.
  */
 const TUI_LOG_MAX_LINES = 2;
-function truncateForTui(text: string): string {
+export function truncateForTui(text: string): string {
   const lines = text.split("\n");
   if (lines.length <= TUI_LOG_MAX_LINES) return text;
   const omitted = lines.length - TUI_LOG_MAX_LINES;

--- a/packages/agency-lang/lib/stdlib/ui.ts
+++ b/packages/agency-lang/lib/stdlib/ui.ts
@@ -211,6 +211,27 @@ function formatConsoleArgs(args: unknown[]): string {
     .join(" ");
 }
 
+/**
+ * Cap a captured `warn` / `error` payload at a small number of lines.
+ * The runtime's catch-and-convert path logs the underlying exception's
+ * full stack as a second `__log.error(...)` call, which is great for
+ * headless debugging but a wall of red lines inside a TUI. Two visible
+ * lines keep the message and one stack frame; everything past that
+ * collapses to an ellipsis placeholder the user can ignore. Plain
+ * `log` / `info` / `debug` capture is left alone — those are caller-
+ * authored output that's meant to be shown in full.
+ */
+const TUI_LOG_MAX_LINES = 2;
+function truncateForTui(text: string): string {
+  const lines = text.split("\n");
+  if (lines.length <= TUI_LOG_MAX_LINES) return text;
+  const omitted = lines.length - TUI_LOG_MAX_LINES;
+  return (
+    lines.slice(0, TUI_LOG_MAX_LINES).join("\n") +
+    `\n{gray-fg}… ${omitted} more line${omitted === 1 ? "" : "s"} omitted{/gray-fg}`
+  );
+}
+
 function pushCaptured(prefix: string, text: string): void {
   if (!captureTarget) return;
   // Split on newlines so multi-line writes become one transcript row
@@ -245,9 +266,9 @@ export function _installConsoleCapture(messages: string[]): void {
   console.debug = (...args: unknown[]) =>
     pushCaptured("", formatConsoleArgs(args));
   console.warn = (...args: unknown[]) =>
-    pushCaptured("{yellow-fg}warn{/yellow-fg}", formatConsoleArgs(args));
+    pushCaptured("{yellow-fg}warn{/yellow-fg}", truncateForTui(formatConsoleArgs(args)));
   console.error = (...args: unknown[]) =>
-    pushCaptured("{red-fg}error{/red-fg}", formatConsoleArgs(args));
+    pushCaptured("{red-fg}error{/red-fg}", truncateForTui(formatConsoleArgs(args)));
 
   // Deliberately NOT overriding `process.stdout.write` / `process.stderr.write`.
   // An earlier revision did, but `lib/tui/output/terminal.ts`'s renderer

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/resultCheckpointSetup.mustache
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/resultCheckpointSetup.mustache
@@ -1,7 +1,16 @@
+// `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
 let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: "", label: "result-entry" });
-}
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/lib/templates/backends/typescriptGenerator/resultCheckpointSetup.ts
+++ b/packages/agency-lang/lib/templates/backends/typescriptGenerator/resultCheckpointSetup.ts
@@ -3,10 +3,19 @@
 // Any manual changes will be lost.
 import { apply } from "typestache";
 
-export const template = `let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: {{{moduleId}}}, scopeName: {{{scopeName}}}, stepPath: "", label: "result-entry" });
-}
+export const template = `// \`__resultCheckpointId\` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and \`runner.halt\`
+// builds a Failure carrying the entry checkpoint for \`result.retry(...)\`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// \`ctx.checkpoints.get(-1)\` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -15,8 +24,6 @@ if (__ctx._pendingArgOverrides) {
 `;
 
 export type TemplateType = {
-  moduleId: string | boolean | number;
-  scopeName: string | boolean | number;
   paramsStr: string | boolean | number;
 };
 

--- a/packages/agency-lang/lib/tui/elements.ts
+++ b/packages/agency-lang/lib/tui/elements.ts
@@ -48,6 +48,7 @@ export type Style = {
   fg?: Color;              // foreground color
   bg?: Color;              // background color
   bold?: boolean;
+  fill?: string;           // pad cell character (defaults to space); use "─" to draw a horizontal rule
 
   // Scrolling
   scrollable?: boolean;    // enable scroll viewport

--- a/packages/agency-lang/lib/tui/input/terminal.test.ts
+++ b/packages/agency-lang/lib/tui/input/terminal.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseKeypress,
+  readBracketed,
+  readEscapeSequence,
+} from "./terminal.js";
+
+// Bracketed-paste markers — repeated locally so test failures don't
+// drag in `terminal.ts` module internals just to read the constants.
+const PASTE_START = "\x1b[200~";
+const PASTE_END = "\x1b[201~";
+
+describe("parseKeypress", () => {
+  it("maps a known special key from KEY_MAP", () => {
+    expect(parseKeypress("\r")).toEqual({ key: "enter" });
+    expect(parseKeypress("\x7f")).toEqual({ key: "backspace" });
+    expect(parseKeypress("\t")).toEqual({ key: "tab" });
+  });
+
+  it("maps Ctrl+letter (0x01-0x1a) to lowercase ctrl key", () => {
+    // Ctrl+A = 0x01, Ctrl+U = 0x15, Ctrl+Z = 0x1a
+    expect(parseKeypress("\x01")).toEqual({ key: "a", ctrl: true });
+    expect(parseKeypress("\x15")).toEqual({ key: "u", ctrl: true });
+  });
+
+  it("treats unknown bytes as a literal printable key", () => {
+    expect(parseKeypress("q")).toEqual({ key: "q" });
+    expect(parseKeypress("@")).toEqual({ key: "@" });
+  });
+});
+
+describe("readBracketed", () => {
+  it("returns null when the open marker isn't at the start position", () => {
+    expect(readBracketed("hello", 0, PASTE_START, PASTE_END)).toBeNull();
+    // Open marker exists later in the string but not at `pos` — still
+    // null, because the contract is "is this position the start of a
+    // bracketed region", not "find one anywhere."
+    expect(
+      readBracketed(`xx${PASTE_START}body${PASTE_END}`, 0, PASTE_START, PASTE_END),
+    ).toBeNull();
+  });
+
+  it("returns a complete read when both markers are present", () => {
+    const input = `${PASTE_START}hello world${PASTE_END}trailing`;
+    const result = readBracketed(input, 0, PASTE_START, PASTE_END);
+    expect(result).toEqual({
+      kind: "complete",
+      body: "hello world",
+      end: PASTE_START.length + "hello world".length + PASTE_END.length,
+    });
+  });
+
+  it("returns a partial read when only the open marker is present", () => {
+    // A paste that spans two `data` chunks — the open marker arrived
+    // but the close marker hasn't yet. Caller is responsible for
+    // buffering `body` and re-reading on the next chunk.
+    const input = `${PASTE_START}half-pasted text`;
+    const result = readBracketed(input, 0, PASTE_START, PASTE_END);
+    expect(result).toEqual({ kind: "partial", body: "half-pasted text" });
+  });
+
+  it("respects `pos` and reads from that offset", () => {
+    const input = `abc${PASTE_START}body${PASTE_END}`;
+    expect(readBracketed(input, 0, PASTE_START, PASTE_END)).toBeNull();
+    expect(readBracketed(input, 3, PASTE_START, PASTE_END)).toMatchObject({
+      kind: "complete",
+      body: "body",
+    });
+  });
+
+  it("returns an empty body when open and close are adjacent", () => {
+    const input = `${PASTE_START}${PASTE_END}`;
+    expect(readBracketed(input, 0, PASTE_START, PASTE_END)).toEqual({
+      kind: "complete",
+      body: "",
+      end: PASTE_START.length + PASTE_END.length,
+    });
+  });
+
+  it("is marker-agnostic — any open/close pair works", () => {
+    // The helper is reusable for non-paste bracketed framing.
+    const input = "<<wrap>>X<<unwrap>>";
+    expect(readBracketed(input, 0, "<<wrap>>", "<<unwrap>>")).toMatchObject({
+      kind: "complete",
+      body: "X",
+    });
+  });
+});
+
+describe("readEscapeSequence", () => {
+  it("returns null when the byte at `pos` isn't ESC", () => {
+    expect(readEscapeSequence("hello", 0)).toBeNull();
+    expect(readEscapeSequence("abc", 1)).toBeNull();
+  });
+
+  it("matches a known sequence and reports bytes consumed", () => {
+    // Up arrow — CSI A
+    const result = readEscapeSequence("\x1b[A", 0);
+    expect(result).toEqual({
+      event: { key: "up" },
+      consumed: 3,
+    });
+  });
+
+  it("prefers the longest matching prefix (Shift+Up over plain Up)", () => {
+    // `\x1b[1;2A` is Shift+Up; the shorter `\x1b[A` (plain Up) is also
+    // in KEY_MAP. Longest-prefix match guarantees the modifier survives.
+    const result = readEscapeSequence("\x1b[1;2A", 0);
+    expect(result).toEqual({
+      event: { key: "up", shift: true },
+      consumed: 6,
+    });
+  });
+
+  it("returns null for an ESC followed by an unknown CSI", () => {
+    // `\x1b[Z` (Shift+Tab) IS known, but `\x1b[~` is not. The caller
+    // is responsible for treating null as "bare ESC, advance one byte"
+    // or "drop the sequence" depending on context.
+    expect(readEscapeSequence("\x1b[~unknown", 0)).toBeNull();
+  });
+
+  it("recognises Alt/Option+Enter as a portable Shift+Enter fallback", () => {
+    // Many terminals (Terminal.app, iTerm2) send `\x1b\r` when the
+    // user presses Option+Enter. We map it to Shift+Enter so users
+    // who can't get a distinct Shift+Enter code can still insert
+    // newlines into the input bar.
+    const result = readEscapeSequence("\x1b\r", 0);
+    expect(result).toEqual({
+      event: { key: "enter", shift: true },
+      consumed: 2,
+    });
+  });
+});

--- a/packages/agency-lang/lib/tui/input/terminal.ts
+++ b/packages/agency-lang/lib/tui/input/terminal.ts
@@ -40,6 +40,23 @@ const KEY_MAP: Record<string, KeyEvent> = {
 // terminal is being handed over to readline for nextLine().
 const LINE_MODE_CANCEL: KeyEvent = { key: "__line_mode_cancel__" };
 
+// Bracketed paste markers. When enabled with `\x1b[?2004h`, terminals
+// emit `PASTE_START ... PASTE_END` around any text the user pastes
+// (e.g. Cmd+V on macOS). We parse those out into a single synthetic
+// `{ key: "paste", text }` event so the reducer can append the whole
+// payload atomically instead of seeing one keystroke per character
+// (which would, among other things, treat embedded newlines as Enter
+// and prematurely submit the prompt).
+const PASTE_START = "\x1b[200~";
+const PASTE_END = "\x1b[201~";
+
+// Escape sequences from KEY_MAP, longest first — `readEscapeSequence`
+// does a longest-prefix match so `\x1b[1;2A` (Shift+Up) wins over the
+// shorter `\x1b[` prefix used by plain Up.
+const ESCAPE_SEQUENCES = Object.keys(KEY_MAP)
+  .filter((seq) => seq.startsWith("\x1b") && seq.length > 1)
+  .sort((a, b) => b.length - a.length);
+
 function parseKeypress(data: string): KeyEvent {
   const mapped = KEY_MAP[data];
   if (mapped) return mapped;
@@ -53,6 +70,65 @@ function parseKeypress(data: string): KeyEvent {
   return { key: data };
 }
 
+/**
+ * Try to read text bracketed by `open ... close` markers starting at
+ * `pos` in `str`. Three outcomes:
+ *
+ *  - `null`            — `str` doesn't begin the `open` marker at `pos`.
+ *  - `{ kind: "partial", body }` — the `open` marker was found but
+ *    `close` hasn't arrived yet. Caller should buffer `body` and
+ *    re-attempt with the next chunk prepended (or simply stash it
+ *    until the close marker turns up).
+ *  - `{ kind: "complete", body, end }` — both markers found. `body`
+ *    is the text between them; `end` is the index in `str` just past
+ *    `close`, ready to resume scanning from.
+ *
+ * Used for bracketed-paste payloads (`\x1b[200~ ... \x1b[201~`) but
+ * deliberately marker-agnostic — any future `open/close` framing can
+ * reuse this.
+ */
+type BracketedRead =
+  | null
+  | { kind: "partial"; body: string }
+  | { kind: "complete"; body: string; end: number };
+
+function readBracketed(
+  str: string,
+  pos: number,
+  open: string,
+  close: string,
+): BracketedRead {
+  if (!str.startsWith(open, pos)) return null;
+  const bodyStart = pos + open.length;
+  const closeIdx = str.indexOf(close, bodyStart);
+  if (closeIdx === -1) {
+    return { kind: "partial", body: str.slice(bodyStart) };
+  }
+  return {
+    kind: "complete",
+    body: str.slice(bodyStart, closeIdx),
+    end: closeIdx + close.length,
+  };
+}
+
+/**
+ * Longest-prefix match against the known escape-sequence table at
+ * `pos`. Returns the mapped `KeyEvent` plus the byte count consumed,
+ * or `null` if either `str[pos] !== ESC` or no entry matches.
+ */
+function readEscapeSequence(
+  str: string,
+  pos: number,
+): { event: KeyEvent; consumed: number } | null {
+  if (str[pos] !== "\x1b") return null;
+  for (const seq of ESCAPE_SEQUENCES) {
+    if (str.startsWith(seq, pos)) {
+      return { event: KEY_MAP[seq], consumed: seq.length };
+    }
+  }
+  return null;
+}
+
 export class TerminalInput implements InputSource {
   private keyWaiters: ((key: KeyEvent) => void)[] = [];
   private keyQueue: KeyEvent[] = [];
@@ -62,6 +138,10 @@ export class TerminalInput implements InputSource {
   private initialized = false;
   private inLineMode = false;
   private suspended = false;
+  // Accumulator for a bracketed paste that spans multiple `data`
+  // events. `null` when no paste is in progress; a string buffer
+  // collecting the body once `PASTE_START` has been seen.
+  private pasteBuffer: string | null = null;
 
   private ensureInitialized(): void {
     if (this.initialized) return;
@@ -78,30 +158,15 @@ export class TerminalInput implements InputSource {
     process.stdin.setRawMode(true);
     process.stdin.resume();
 
+    // Enable bracketed paste mode. The terminal will now wrap any
+    // pasted text in `\x1b[200~ ... \x1b[201~` markers, letting us
+    // distinguish a paste from rapid typing. Modern terminals
+    // (Terminal.app, iTerm2, Alacritty, kitty, VS Code, WezTerm) all
+    // honor this; older / dumb terminals silently ignore it.
+    process.stdout.write("\x1b[?2004h");
+
     this.dataHandler = (data: Buffer) => {
-      const str = data.toString("utf-8");
-      // In raw mode the TTY does not translate Ctrl+Z (0x1a) into SIGTSTP;
-      // the byte is delivered to us. Trigger suspend manually so the user's
-      // expectation of "Ctrl+Z suspends" still works.
-      if (str.length === 1 && str.charCodeAt(0) === 0x1a) {
-        this.handleSuspendKeypress();
-        return;
-      }
-      // Same story for Ctrl+C (0x03): raw mode swallows the SIGINT
-      // translation. Re-raise SIGINT so the process exits even when an
-      // in-progress handleKey callback is blocking the run loop. We also
-      // pass the keypress through so Agency-side handlers can react
-      // (the SIGINT only takes effect after the current tick yields).
-      if (str.length === 1 && str.charCodeAt(0) === 0x03) {
-        process.kill(process.pid, "SIGINT");
-      }
-      const key = parseKeypress(str);
-      const waiter = this.keyWaiters.shift();
-      if (waiter) {
-        waiter(key);
-      } else {
-        this.keyQueue.push(key);
-      }
+      this.parseAndEmit(data.toString("utf-8"));
     };
 
     process.stdin.on("data", this.dataHandler);
@@ -127,6 +192,10 @@ export class TerminalInput implements InputSource {
       process.stdin.removeListener("data", this.dataHandler);
     }
     if (process.stdin.isTTY && process.stdin.isRaw) {
+      // Turn off bracketed paste before handing control back to the
+      // shell, then turn it on again on resume. Otherwise the parent
+      // shell sees pastes wrapped in `\x1b[200~...` literals.
+      process.stdout.write("\x1b[?2004l");
       process.stdin.setRawMode(false);
     }
   }
@@ -137,6 +206,7 @@ export class TerminalInput implements InputSource {
     if (this.inLineMode) return; // readline owns stdin; don't re-grab it
     if (process.stdin.isTTY) {
       process.stdin.setRawMode(true);
+      process.stdout.write("\x1b[?2004h");
       process.stdin.resume();
     }
     if (this.dataHandler) {
@@ -168,11 +238,108 @@ export class TerminalInput implements InputSource {
    * is installed.
    */
   feedKey(key: KeyEvent): void {
+    this.emitKey(key);
+  }
+
+  /**
+   * Internal: route a parsed `KeyEvent` to the next waiter or queue.
+   * Shared by `feedKey` and the per-keystroke emissions in
+   * `parseAndEmit`.
+   */
+  private emitKey(key: KeyEvent): void {
     const waiter = this.keyWaiters.shift();
     if (waiter) {
       waiter(key);
     } else {
       this.keyQueue.push(key);
+    }
+  }
+
+  /**
+   * Parse one stdin chunk into zero or more `KeyEvent`s and emit
+   * them in order. Owns the side-band state machine across chunks:
+   * an unfinished bracketed paste is parked in `this.pasteBuffer`
+   * and resumed on the next call.
+   *
+   * Recognized units, tried in this order at each position:
+   *   1. Continuation of a paste opened by a prior chunk
+   *   2. A complete bracketed paste (`PASTE_START ... PASTE_END`)
+   *   3. Ctrl+Z (0x1a) — raises SIGTSTP and stops parsing
+   *   4. Ctrl+C (0x03) — raises SIGINT, emits, keeps parsing
+   *   5. A known escape sequence (longest-prefix match)
+   *   6. A single character (printable or ctrl+letter)
+   */
+  private parseAndEmit(input: string): void {
+    let str = input;
+
+    // 1. Mid-paste continuation. Treat the carried `pasteBuffer` as
+    //    text already inside the markers, and look for the close
+    //    marker anywhere in the current chunk.
+    if (this.pasteBuffer !== null) {
+      const closeIdx = str.indexOf(PASTE_END);
+      if (closeIdx === -1) {
+        this.pasteBuffer += str;
+        return;
+      }
+      this.emitKey({
+        key: "paste",
+        text: this.pasteBuffer + str.slice(0, closeIdx),
+      });
+      this.pasteBuffer = null;
+      str = str.slice(closeIdx + PASTE_END.length);
+    }
+
+    let i = 0;
+    while (i < str.length) {
+      // 2. Bracketed paste — start marker at this position.
+      const paste = readBracketed(str, i, PASTE_START, PASTE_END);
+      if (paste !== null) {
+        if (paste.kind === "partial") {
+          this.pasteBuffer = paste.body;
+          return;
+        }
+        this.emitKey({ key: "paste", text: paste.body });
+        i = paste.end;
+        continue;
+      }
+
+      // 3. Ctrl+Z: surface as SIGTSTP and stop processing — the
+      //    rest of this chunk is irrelevant once we're suspended.
+      const code = str.charCodeAt(i);
+      if (code === 0x1a) {
+        this.handleSuspendKeypress();
+        return;
+      }
+
+      // 4. Ctrl+C: re-raise SIGINT and ALSO emit the key so Agency
+      //    handlers can react before the signal actually lands.
+      if (code === 0x03) {
+        process.kill(process.pid, "SIGINT");
+        this.emitKey({ key: "c", ctrl: true });
+        i += 1;
+        continue;
+      }
+
+      // 5. Known escape sequence at this position.
+      const esc = readEscapeSequence(str, i);
+      if (esc !== null) {
+        this.emitKey(esc.event);
+        i += esc.consumed;
+        continue;
+      }
+
+      // 6a. Bare ESC (no recognized CSI/SS3 follow-up).
+      if (str[i] === "\x1b") {
+        this.emitKey({ key: "escape" });
+        i += 1;
+        continue;
+      }
+
+      // 6b. Plain character. UTF-16 code unit — surrogate pairs
+      //    emit as a 2-char key, which is fine for an input bar
+      //    that just appends to a string.
+      this.emitKey(parseKeypress(str[i]));
+      i += 1;
     }
   }
 
@@ -227,11 +394,16 @@ export class TerminalInput implements InputSource {
       this.sigcontHandler = null;
     }
     if (process.stdin.isTTY) {
+      // Disable bracketed paste before restoring raw mode so the
+      // following shell doesn't keep receiving `\x1b[200~`-wrapped
+      // pastes after we exit.
+      process.stdout.write("\x1b[?2004l");
       process.stdin.setRawMode(this.wasRaw);
     }
     process.stdin.pause();
     this.keyQueue = [];
     this.keyWaiters = [];
+    this.pasteBuffer = null;
     this.suspended = false;
     this.initialized = false;
   }

--- a/packages/agency-lang/lib/tui/input/terminal.ts
+++ b/packages/agency-lang/lib/tui/input/terminal.ts
@@ -67,7 +67,7 @@ const ESCAPE_SEQUENCES = Object.keys(KEY_MAP)
   .filter((seq) => seq.startsWith("\x1b") && seq.length > 1)
   .sort((a, b) => b.length - a.length);
 
-function parseKeypress(data: string): KeyEvent {
+export function parseKeypress(data: string): KeyEvent {
   const mapped = KEY_MAP[data];
   if (mapped) return mapped;
 
@@ -102,7 +102,7 @@ type BracketedRead =
   | { kind: "partial"; body: string }
   | { kind: "complete"; body: string; end: number };
 
-function readBracketed(
+export function readBracketed(
   str: string,
   pos: number,
   open: string,
@@ -126,7 +126,7 @@ function readBracketed(
  * `pos`. Returns the mapped `KeyEvent` plus the byte count consumed,
  * or `null` if either `str[pos] !== ESC` or no entry matches.
  */
-function readEscapeSequence(
+export function readEscapeSequence(
   str: string,
   pos: number,
 ): { event: KeyEvent; consumed: number } | null {

--- a/packages/agency-lang/lib/tui/input/terminal.ts
+++ b/packages/agency-lang/lib/tui/input/terminal.ts
@@ -4,8 +4,18 @@ import type { KeyEvent, InputSource } from "./types.js";
 const KEY_MAP: Record<string, KeyEvent> = {
   // Special keys
   "\x1b": { key: "escape" },
+  // Plain Enter submits. `\n` (LF) and `\x1b\r` / `\x1b\n` (Alt/Option+
+  // Enter, "Meta+Enter") are treated as Shift+Enter so users on
+  // terminals that don't transmit a distinct Shift+Enter code can
+  // still insert a newline. Alt+Enter is the most portable fallback —
+  // both Terminal.app and iTerm2 deliver it as `\x1b\r` out of the
+  // box; users who configure their terminal to send `\n` for
+  // Shift+Enter (iTerm2's "Report modifiers using CSI u" or similar)
+  // get the same behavior automatically.
   "\r": { key: "enter" },
-  "\n": { key: "enter" },
+  "\n": { key: "enter", shift: true },
+  "\x1b\r": { key: "enter", shift: true },
+  "\x1b\n": { key: "enter", shift: true },
   "\x7f": { key: "backspace" },
   "\t": { key: "tab" },
   // Arrow keys (CSI)

--- a/packages/agency-lang/lib/tui/input/types.ts
+++ b/packages/agency-lang/lib/tui/input/types.ts
@@ -2,6 +2,12 @@ export type KeyEvent = {
   key: string;
   shift?: boolean;
   ctrl?: boolean;
+  /**
+   * For `key: "paste"` events emitted when the terminal is in
+   * bracketed-paste mode, the full pasted text. Undefined for normal
+   * keypresses.
+   */
+  text?: string;
 };
 
 export type InputSource = {

--- a/packages/agency-lang/lib/tui/render/renderer.ts
+++ b/packages/agency-lang/lib/tui/render/renderer.ts
@@ -262,22 +262,39 @@ function renderListContent(
 function renderTextInputContent(
   value: string | undefined,
   innerWidth: number,
+  innerHeight: number,
   fg?: string,
   bg?: string,
 ): Cell[][] {
-  const text = (value ?? "").slice(0, innerWidth);
-  const row: Cell[] = [];
-  for (const ch of text) {
-    row.push({ char: ch, fg, bg });
+  // Multi-line input: each `\n` in `value` starts a new visual row.
+  // Long single lines are clipped at `innerWidth` (no soft wrap).
+  // Cursor sits at the end of the last line; if that line is already
+  // at `innerWidth`, the cursor is omitted rather than overflowing.
+  const text = value ?? "";
+  const lines = text.split("\n");
+  const grid: Cell[][] = [];
+  const lastIdx = lines.length - 1;
+
+  for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
+    const clipped = lines[lineIdx].slice(0, innerWidth);
+    const row: Cell[] = [];
+    for (const ch of clipped) {
+      row.push({ char: ch, fg, bg });
+    }
+    if (lineIdx === lastIdx && row.length < innerWidth) {
+      row.push({ char: "█", fg, bg });
+    }
+    while (row.length < innerWidth) {
+      row.push(emptyCell(bg));
+    }
+    grid.push(row);
   }
-  // Cursor position
-  if (row.length < innerWidth) {
-    row.push({ char: "█", fg, bg });
+
+  while (grid.length < innerHeight) {
+    grid.push(makeRow(innerWidth, bg));
   }
-  while (row.length < innerWidth) {
-    row.push(emptyCell(bg));
-  }
-  return [row];
+
+  return grid;
 }
 
 export function render(positioned: PositionedElement, parentScrollOffset = 0): Frame {
@@ -337,6 +354,7 @@ export function render(positioned: PositionedElement, parentScrollOffset = 0): F
     innerContent = renderTextInputContent(
       positioned.value,
       innerWidth,
+      innerHeight,
       style.fg,
       style.bg,
     );

--- a/packages/agency-lang/lib/tui/render/renderer.ts
+++ b/packages/agency-lang/lib/tui/render/renderer.ts
@@ -75,6 +75,7 @@ function renderTextContent(
   fg?: string,
   bg?: string,
   bold?: boolean,
+  fill?: string,
 ): Cell[][] {
   const lines = content.split("\n");
   // Clamp so that scrolling past the end stops at the last screenful, and
@@ -83,6 +84,15 @@ function renderTextContent(
   const effectiveOffset = Math.max(0, Math.min(scrollOffset, maxScroll));
   const visibleLines = lines.slice(effectiveOffset, effectiveOffset + innerHeight);
   const grid: Cell[][] = [];
+
+  // When `fill` is set, every padding cell (both end-of-row and trailing
+  // empty rows) gets the fill char with the text fg/bg, turning an
+  // empty `line("", fill: "─")` into a full-width horizontal rule. The
+  // standard space-pad is preserved when `fill` is unset.
+  const padCell = (): Cell =>
+    fill !== undefined && fill !== ""
+      ? { char: fill, fg, bg }
+      : emptyCell(bg);
 
   for (const line of visibleLines) {
     const spans = parseStyledText(line);
@@ -114,17 +124,62 @@ function renderTextContent(
     }
     // Pad to inner width
     while (row.length < innerWidth) {
-      row.push(emptyCell(bg));
+      row.push(padCell());
     }
     grid.push(row);
   }
 
   // Pad remaining rows
   while (grid.length < innerHeight) {
-    grid.push(makeRow(innerWidth, bg));
+    const newRow: Cell[] = [];
+    for (let i = 0; i < innerWidth; i++) newRow.push(padCell());
+    grid.push(newRow);
   }
 
   return grid;
+}
+
+// Render one item's text into one or more cell rows. Splits the
+// item on `\n` so a multi-line transcript entry (e.g. a markdown
+// reply) gets its own visual row per source line, parses styled-text
+// markup so spans like `{bright-blue-fg}You{/bright-blue-fg}` render
+// with color, and applies selection chrome to every produced row.
+//
+// Returned rows are NOT yet padded to `innerWidth`; the caller pads
+// them so selection chrome (`itemBg`) extends across the full row.
+function renderListItemRows(
+  rawText: string,
+  innerWidth: number,
+  itemFg: string | undefined,
+  itemBg: string | undefined,
+): Cell[][] {
+  const lines = rawText.split("\n");
+  const rows: Cell[][] = [];
+  for (const line of lines) {
+    const spans = parseStyledText(line);
+    const row: Cell[] = [];
+    let clipped = false;
+    outer: for (const span of spans) {
+      for (const ch of span.text) {
+        if (row.length >= innerWidth) {
+          clipped = true;
+          break outer;
+        }
+        row.push({
+          char: ch,
+          fg: span.fg ?? itemFg,
+          bg: span.bg ?? itemBg,
+          bold: span.bold,
+        });
+      }
+    }
+    if (clipped && row.length > 0) {
+      const last = row[row.length - 1];
+      row[row.length - 1] = { ...last, char: "…" };
+    }
+    rows.push(row);
+  }
+  return rows;
 }
 
 function renderListContent(
@@ -135,6 +190,22 @@ function renderListContent(
   fg?: string,
   bg?: string,
 ): Cell[][] {
+  // Expand each item into one-or-more visual rows up front so
+  // auto-scroll can target visual rows (not item indices) — a
+  // single long markdown reply might span 10 rows and we still
+  // want to keep the latest visual row in view.
+  type VisualRow = { itemIdx: number; row: Cell[] };
+  const visual: VisualRow[] = [];
+  for (let itemIdx = 0; itemIdx < items.length; itemIdx++) {
+    // We defer fg/bg selection chrome until we know which itemIdx
+    // is selected; for now render with neutral fg/bg and re-tint
+    // the cells later if the row's owning item is selected.
+    const rows = renderListItemRows(items[itemIdx], innerWidth, fg, bg);
+    for (const row of rows) {
+      visual.push({ itemIdx, row });
+    }
+  }
+
   // `selectedIndex >= items.length` is the "follow tail" sentinel:
   // auto-scroll so the most recent items are visible, but don't
   // draw any selection chrome (no row is actually the cursor). Used
@@ -142,36 +213,47 @@ function renderListContent(
   // list grows without highlighting it.
   const followTail =
     selectedIndex !== undefined && selectedIndex >= items.length;
-  // Auto-scroll to keep selected item visible. Clamp the scroll
-  // target to the last actual item so tiny inner heights (e.g. 1
-  // row) still render the last item instead of running off the end
-  // and drawing a blank grid.
+
+  // Auto-scroll: find the first visual row that belongs to the
+  // selected item (or the last visual row in follow-tail mode) and
+  // scroll just enough to keep it in the viewport.
   let scrollOffset = 0;
-  if (selectedIndex !== undefined && selectedIndex >= innerHeight) {
-    const target = Math.min(selectedIndex, items.length - 1);
-    scrollOffset = Math.max(0, target - innerHeight + 1);
+  if (followTail) {
+    scrollOffset = Math.max(0, visual.length - innerHeight);
+  } else if (selectedIndex !== undefined) {
+    // Find the LAST visual row owned by the selected item so multi-
+    // line items scroll to reveal their whole body when picked.
+    let lastRow = -1;
+    for (let i = 0; i < visual.length; i++) {
+      if (visual[i].itemIdx === selectedIndex) lastRow = i;
+    }
+    if (lastRow >= innerHeight) {
+      scrollOffset = Math.max(0, lastRow - innerHeight + 1);
+    }
   }
 
   const grid: Cell[][] = [];
   for (let i = 0; i < innerHeight; i++) {
-    const itemIdx = i + scrollOffset;
-    if (itemIdx >= items.length) {
+    const visualIdx = i + scrollOffset;
+    if (visualIdx >= visual.length) {
       grid.push(makeRow(innerWidth, bg));
       continue;
     }
-
+    const { itemIdx, row } = visual[visualIdx];
     const isSelected = !followTail && itemIdx === selectedIndex;
     const itemBg = isSelected ? "blue" : bg;
     const itemFg = isSelected ? "white" : fg;
-    const text = items[itemIdx].slice(0, innerWidth);
-    const row: Cell[] = [];
-    for (const ch of text) {
-      row.push({ char: ch, fg: itemFg, bg: itemBg });
+    // Re-tint cells for selected rows so the highlight extends
+    // across the whole row even when the original spans had their
+    // own colors. Untouched rows keep their per-span colors.
+    let outRow: Cell[] = row;
+    if (isSelected) {
+      outRow = row.map((c) => ({ ...c, fg: itemFg, bg: itemBg }));
     }
-    while (row.length < innerWidth) {
-      row.push(emptyCell(itemBg));
+    while (outRow.length < innerWidth) {
+      outRow.push(emptyCell(itemBg));
     }
-    grid.push(row);
+    grid.push(outRow);
   }
 
   return grid;
@@ -240,6 +322,7 @@ export function render(positioned: PositionedElement, parentScrollOffset = 0): F
       style.fg,
       style.bg,
       style.bold,
+      style.fill,
     );
   } else if (positioned.type === "list" && positioned.items) {
     innerContent = renderListContent(

--- a/packages/agency-lang/lib/tui/test/renderer.test.ts
+++ b/packages/agency-lang/lib/tui/test/renderer.test.ts
@@ -203,6 +203,17 @@ describe("render", () => {
     expect(row).toBe("hi────────");
   });
 
+  it("textInput renders multi-line value as one visual row per \\n", () => {
+    const el = box({ width: 8, height: 3 }, textInput({}, "ab\ncde"));
+    const frame = renderElement(el, 80, 24);
+    const grid = frame.children![0].content!;
+    expect(grid[0].slice(0, 2).map((c) => c.char).join("")).toBe("ab");
+    // Cursor sits at end of the last line, not the first.
+    expect(grid[0][2].char).toBe(" ");
+    expect(grid[1].slice(0, 3).map((c) => c.char).join("")).toBe("cde");
+    expect(grid[1][3].char).toBe("█");
+  });
+
   it("follow-tail keeps the last visual row of a multi-line item in view", () => {
     // A 3-row tall item followed by selectedIndex = length should
     // show the LAST visual row, not blank rows or the first row.

--- a/packages/agency-lang/lib/tui/test/renderer.test.ts
+++ b/packages/agency-lang/lib/tui/test/renderer.test.ts
@@ -140,4 +140,81 @@ describe("render", () => {
     const child = frame.children![0];
     expect(contentText(child)).toBe("abc       ");
   });
+
+  it("parses styled-text markup inside list items", () => {
+    // Before the fix, list rows ran raw chars into cells so
+    // `{red-fg}You{/red-fg}` rendered as the literal markup. After
+    // the fix the tag chars are gone and the inner text gets the
+    // span's color.
+    const items = ["{red-fg}You{/red-fg} hi"];
+    // Use follow-tail (selectedIndex == items.length) so the row
+    // isn't repainted with selection chrome — we want to inspect
+    // the spans' own colors.
+    const el = list({ width: 20, height: 1, key: "tx" }, items, items.length);
+    const frame = renderElement(el, 80, 24);
+    const txt = contentText(frame);
+    expect(txt.trim()).toBe("You hi");
+    // The "Y" cell should carry the parsed fg color.
+    expect(frame.content![0][0].char).toBe("Y");
+    expect(frame.content![0][0].fg).toBe("red");
+    // The space and "h" cells should NOT carry that color.
+    expect(frame.content![0][3].fg).toBeUndefined();
+    expect(frame.content![0][4].char).toBe("h");
+  });
+
+  it("splits multi-line list items into one visual row per source line", () => {
+    // A transcript entry like `highlight("\nreply\n", "markdown")`
+    // produces a multi-line string; each `\n`-separated line should
+    // get its own row instead of being smashed onto one.
+    const items = ["one\ntwo\nthree"];
+    const el = list({ width: 10, height: 3, key: "ml" }, items, items.length);
+    const frame = renderElement(el, 80, 24);
+    expect(frame.content![0].slice(0, 3).map((c) => c.char).join("")).toBe(
+      "one",
+    );
+    expect(frame.content![1].slice(0, 3).map((c) => c.char).join("")).toBe(
+      "two",
+    );
+    expect(frame.content![2].slice(0, 5).map((c) => c.char).join("")).toBe(
+      "three",
+    );
+  });
+
+  it("fill style pads empty text cells with the fill character", () => {
+    // Empty content + fill: "─" should produce a full-width horizontal rule.
+    const el = box({ width: 8, height: 1 }, {
+      type: "text",
+      content: "",
+      style: { fill: "─" },
+    } as any);
+    const frame = renderElement(el, 80, 24);
+    const ruleRow = frame.children![0].content![0].map((c) => c.char).join("");
+    expect(ruleRow).toBe("────────");
+  });
+
+  it("fill style pads end-of-line cells when content is shorter than width", () => {
+    const el = box({ width: 10, height: 1 }, {
+      type: "text",
+      content: "hi",
+      style: { fill: "─" },
+    } as any);
+    const frame = renderElement(el, 80, 24);
+    const row = frame.children![0].content![0].map((c) => c.char).join("");
+    expect(row).toBe("hi────────");
+  });
+
+  it("follow-tail keeps the last visual row of a multi-line item in view", () => {
+    // A 3-row tall item followed by selectedIndex = length should
+    // show the LAST visual row, not blank rows or the first row.
+    const items = ["one\ntwo\nthree", "tail"];
+    const el = list({ width: 10, height: 2, key: "ft" }, items, items.length);
+    const frame = renderElement(el, 80, 24);
+    // visual rows: 0:one 1:two 2:three 3:tail. height 2 → show rows 2 and 3.
+    expect(frame.content![0].slice(0, 5).map((c) => c.char).join("")).toBe(
+      "three",
+    );
+    expect(frame.content![1].slice(0, 4).map((c) => c.char).join("")).toBe(
+      "tail",
+    );
+  });
 });

--- a/packages/agency-lang/lib/typeChecker/fixtureTypeCheck.integration.test.ts
+++ b/packages/agency-lang/lib/typeChecker/fixtureTypeCheck.integration.test.ts
@@ -88,9 +88,19 @@ describe("Typechecker Integration Tests (stdlib)", () => {
   describe.each(stdlibFiles)(
     "stdlib: $name",
     ({ name, filePath }) => {
-      it("should have no type errors or warnings", () => {
-        assertNoTypeErrors(name, filePath);
-      });
+      // The larger stdlib modules (notably `policy` and `ui`) can
+      // exceed the 5s default when the full vitest suite is running
+      // in parallel and the typechecker is CPU-starved. Bumping the
+      // per-it timeout — run in isolation each finishes in ~2-4s, so
+      // 30s is comfortable headroom without masking a real
+      // regression.
+      it(
+        "should have no type errors or warnings",
+        () => {
+          assertNoTypeErrors(name, filePath);
+        },
+        30000,
+      );
     }
   );
 });

--- a/packages/agency-lang/makefile
+++ b/packages/agency-lang/makefile
@@ -26,6 +26,8 @@ stdlib:
 
 agents:
 	pnpm run agency compile dist/lib/agents/review/ && \
+	pnpm run agency compile dist/lib/agents/policy/ && \
+	pnpm run agency compile dist/lib/agents/agency-agent/ && \
 	pnpm run agency compile dist/lib/agents/judge.agency
 
 test:

--- a/packages/agency-lang/stdlib/policy.agency
+++ b/packages/agency-lang/stdlib/policy.agency
@@ -5,7 +5,7 @@ import {
  } from "agency-lang/stdlib-lib/policy.js"
 import { exists } from "std::shell"
 import { dirname, basename } from "std::path"
-import { _routePrompt } from "std::ui"
+import { chooseOption, ChoiceItem } from "std::ui"
 
 /** @module
   ## Overview
@@ -500,8 +500,9 @@ def describeScopedMatch(intr: any): string {
 
 // Present the (a)/(r)/(aa)/(ap)/(rr) menu for one interrupt and
 // return the user's choice as a `Decision`. `(ap)` is offered only
-// when `_opts.fields` has an entry for `intr.kind`. Loops until the
-// user enters a valid response.
+// when `_opts.fields` has an entry for `intr.kind`. Renders as a
+// modal over the active repl(); falls back to plain print + input
+// when no REPL is running (e.g. headless agent runs).
 def askUser(intr: any): Decision {
   // `!= null` compiles to `!== null` (Agency strict equality), so an
   // undefined entry would slip through. Use the explicit existence check.
@@ -509,26 +510,23 @@ def askUser(intr: any): Decision {
   if (_opts.fields[intr.kind] != undefined) { kindFields = _opts.fields[intr.kind] }
   const scopedAvailable = kindFields.length > 0
 
-  // Build the menu as a single string so the active-REPL renderer can
-  // emit it to the scroll region in one call, and the raw-input
-  // fallback can `print` it once.
-  let menuLines: string[] = []
-  menuLines.push("\n⚠ Interrupt: ${intr.kind}")
-  menuLines.push("  ${intr.message}")
-  menuLines.push("  data: ${JSON.stringify(intr.data)}")
-  menuLines.push("  (a)  approve once")
-  menuLines.push("  (r)  reject once")
-  menuLines.push("  (aa) approve always (every future ${intr.kind})")
+  const title = "⚠ Interrupt: ${intr.kind}"
+  const body = "${intr.message}\ndata: ${JSON.stringify(intr.data)}"
+
+  let items: ChoiceItem[] = [
+    { key: "a",  label: "approve once" },
+    { key: "r",  label: "reject once" },
+    { key: "aa", label: "approve always (every future ${intr.kind})" }
+  ]
   if (scopedAvailable) {
-    menuLines.push("  (ap) approve always here (${describeScopedMatch(intr)})")
+    items.push({
+      key: "ap",
+      label: "approve always here (${describeScopedMatch(intr)})"
+    })
   }
-  menuLines.push("  (rr) reject always")
-  const menuText = menuLines.join("\n")
+  items.push({ key: "rr", label: "reject always" })
 
-  let choices: string[] = ["a", "r", "aa", "rr"]
-  if (scopedAvailable) { choices = ["a", "r", "aa", "ap", "rr"] }
-
-  const answer = _routePrompt(menuText, choices)
+  const answer = chooseOption(title, body, items)
   match (answer) {
     "a"  => return "approve"
     "r"  => return "reject"

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -127,7 +127,13 @@ export type Element = {
 export type KeyEvent = {
   key: string;
   shift?: boolean;
-  ctrl?: boolean
+  ctrl?: boolean;
+  /**
+   * For `key: "paste"` events emitted while the terminal is in
+   * bracketed-paste mode, the full pasted text (e.g. the body of a
+   * Cmd+V on macOS). Undefined for normal keypresses.
+   */
+  text?: string
 }
 
 /**
@@ -1343,6 +1349,37 @@ def _appendInputCharacter(state: ReplState, character: string): ReplState {
   }
 }
 
+// Append pasted text to the input buffer wholesale. Newlines in the
+// paste are flattened to spaces so an accidentally-newline-bearing
+// paste doesn't immediately submit the prompt (the user can still
+// review and press Enter explicitly). Tab + other control bytes are
+// kept as-is — the renderer truncates them safely.
+def _appendPaste(state: ReplState, pasted: string): ReplState {
+  let normalized = pasted.replaceAll("\r\n", " ")
+  normalized = normalized.replaceAll("\n", " ")
+  normalized = normalized.replaceAll("\r", " ")
+  return {
+    ...state,
+    input: {
+      ...state.input,
+      buffer: state.input.buffer + normalized
+    }
+  }
+}
+
+// Clear the entire input buffer in one step. Bound to Ctrl+U to match
+// the bash readline / GNU Readline convention. Doesn't touch history
+// — the cleared content is gone, not pushed onto the history stack.
+def _clearInputBuffer(state: ReplState): ReplState {
+  return {
+    ...state,
+    input: {
+      ...state.input,
+      buffer: ""
+    }
+  }
+}
+
 def _removeInputCharacter(state: ReplState): ReplState {
   return {
     ...state,
@@ -1491,6 +1528,11 @@ def _replReduce(replState: ReplState, keyEvent: KeyEvent): ReplState {
 
   match (keyEvent) {
     { ctrl: true, key: "c" } => return { ...state, done: true }
+    { ctrl: true, key: "u" } => return _clearInputBuffer(state)
+    // Bracketed-paste payload from the terminal (e.g. Cmd+V on macOS).
+    // The full pasted body lives on `keyEvent.text` — see
+    // lib/tui/input/terminal.ts for how the markers are parsed.
+    { key: "paste" } => return _appendPaste(state, keyEvent.text ?? "")
     { key: "/" } if (state.input.buffer == "") => return _openPalette(state)
     { key: "up" } if (state.input.historyIdx > 0) => return _recallPreviousHistory(state)
     { key: "down" } if (state.input.historyIdx < state.input.history.length) => return _recallNextHistory(state)

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -10,7 +10,13 @@ import {
   _nowMs,
   _triggerRender,
  } from "agency-lang/stdlib-lib/ui.js"
-import { _promptFromChoices } from "agency-lang/stdlib-lib/ui.js"
+import {
+  _openChoicePrompt,
+  _peekPendingChoiceRequest,
+  _resolveChoice,
+  _cancelChoice,
+  _peekReplExitSignal,
+} from "agency-lang/stdlib-lib/ui.js"
 import { filter, map } from "std::array"
 
 /** @module
@@ -198,12 +204,17 @@ export def line(
   fg: string = "",
   bg: string = "",
   bold: boolean = false,
+  fill: string = "",
 ): Element {
   """
   Build a single-line text element with `height: 1`. The default keeps
   it from stretching via flex when placed inside a `column`. Style
   fields (`fg`, `bg`, `bold`) and layout fields (`flex`, `width`,
   `height`) merge on top of the height-1 default.
+
+  Set `fill` to a single character (e.g. `"─"`) to repeat that
+  character across the unused width, turning an empty-content line
+  into a horizontal rule.
 
   @param content - The text to render
   @param flex - Flex grow factor; omit for natural width
@@ -212,6 +223,7 @@ export def line(
   @param fg - Foreground color (named or hex like "#fff")
   @param bg - Background color (named or hex like "#000")
   @param bold - Render the text bold
+  @param fill - Character used to pad unused cells (default: space)
   """
   let h: number = 1
   if (height != null) {
@@ -225,6 +237,7 @@ export def line(
   _setStyleIfSet(style, "fg", fg)
   _setStyleIfSet(style, "bg", bg)
   _setStyleIfSet(style, "bold", bold)
+  _setStyleIfSet(style, "fill", fill)
   return {
     type: "text",
     content: content,
@@ -659,6 +672,7 @@ def _addLine(
   fg: string = "",
   bg: string = "",
   bold: boolean = false,
+  fill: string = "",
 ): Element {
   const elem = line(
     content: content,
@@ -668,6 +682,7 @@ def _addLine(
     fg: fg,
     bg: bg,
     bold: bold,
+    fill: fill,
   )
   kids.push(elem)
   return elem
@@ -822,33 +837,7 @@ export def runLoop(
 // view and closing it returns them.
 const _PALETTE_ROWS: number = 5
 
-export def _routePrompt(text: string, choices: string[]): string {
-  """
-  Route a prompt through the active REPL when one exists, or fall
-  back to raw `print` + `input` otherwise. Used by other stdlib
-  modules (notably `std::policy`) to surface interactive prompts
-  without fighting with the input bar.
 
-  @param text - The menu/question text shown to the user
-  @param choices - The set of strings the user's answer must match
-  """
-  if (_hasActiveScreen()) {
-    return _promptFromChoices(text, choices)
-  }
-  print(text)
-  const optsHint = "(one of ${choices.join("/")})"
-  let answer = ""
-  let valid = false
-  while (!valid) {
-    answer = input("> ").trim()
-    if (choices.includes(answer)) {
-      valid = true
-    } else {
-      print(optsHint)
-    }
-  }
-  return answer
-}
 
 type ReplInputState = {
   buffer: string;
@@ -881,12 +870,36 @@ type ReplConfigState = {
   onSubmit: any
 }
 
+/**
+ * One option in a `chooseOption()` modal. `key` is the value the
+ * Promise resolves to when the user picks this row; `label` is the
+ * human-readable text rendered in the modal.
+ */
+export type ChoiceItem = {
+  key: string;
+  label: string
+}
+
+// Internal: snapshot of an open choice modal. Lives on `ReplState`
+// so the reducer/view can see it on every frame. The TS bridge
+// (`_openChoicePrompt`) sets this slot and `_replReduce` clears it
+// after Enter/Escape; the deferred Promise it returns is what the
+// Agency caller awaits.
+type ReplChoiceState = {
+  title: string;
+  body: string;
+  items: ChoiceItem[];
+  filter: string;
+  cursor: number
+}
+
 type ReplState = {
   input: ReplInputState;
   palette: ReplPaletteState;
   transcript: ReplTranscriptState;
   submit: ReplSubmitState;
   config: ReplConfigState;
+  choice: ReplChoiceState | null;
   done: boolean
 }
 
@@ -935,6 +948,59 @@ export def clearMessages() {
   _triggerRender()
 }
 
+export def chooseOption(
+  title: string,
+  body: string,
+  items: ChoiceItem[],
+): string {
+  """
+  Show a modal choice prompt over the active repl() and block until
+  the user picks one. Returns the picked item's `key`. The modal
+  takes over key input — the REPL's input bar, palette, and history
+  navigation are inactive until the user confirms (Enter) or cancels
+  (Escape). The filter input narrows the visible items by substring
+  match on either `key` or `label`.
+
+  When no repl() is currently running, falls back to a plain
+  `print` + `input` loop that reprompts until the user types one of
+  the valid `key`s. Used by std::policy to surface its approve/reject
+  menus through the active REPL without fighting with the input bar.
+
+  @param title - Modal heading (e.g. "Approve interrupt: shell::exec")
+  @param body - Multi-line context shown above the choices (or "")
+  @param items - The set of {key, label} choices to pick from
+  """
+  if (_activeRepl != null) {
+    return _openChoicePrompt({
+      title: title,
+      body: body,
+      items: items
+    })
+  }
+  // No-REPL fallback: print the title + body once, then loop on
+  // `input()` until the answer matches one of the item keys. Same
+  // contract as the pre-modal `_routePrompt` had.
+  if (title != "") { print(title) }
+  if (body != "")  { print(body) }
+  let validKeys: string[] = []
+  for (item in items) {
+    print("  ${item.key}  ${item.label}")
+    validKeys.push(item.key)
+  }
+  const optsHint = "(one of ${validKeys.join("/")})"
+  let answer = ""
+  let valid = false
+  while (!valid) {
+    answer = input("> ").trim()
+    if (validKeys.includes(answer)) {
+      valid = true
+    } else {
+      print(optsHint)
+    }
+  }
+  return answer
+}
+
 def _entryKey(entry: any): string { return entry.key }
 
 // Returns the keys of palette commands whose name contains the
@@ -963,7 +1029,7 @@ def _busyLine(state: ReplState): string {
   const nowMs = _nowMs()
   const elapsedSeconds = _elapsedSeconds(state.submit.startedAtMs, nowMs)
   const spinnerFrame = _spinnerFrame(state.submit.startedAtMs, nowMs)
-  return "{bright-yellow ${spinnerFrame}} ${state.submit.label} ${elapsedSeconds}s"
+  return "{bright-yellow-fg}${spinnerFrame}{/bright-yellow-fg} ${state.submit.label} ${elapsedSeconds}s"
 }
 
 /**
@@ -973,8 +1039,73 @@ def _busyLine(state: ReplState): string {
  * them are flex; standard `flex-start` column layout packs flex:1
  * first, then the fixed-height tail items.
  */
+// Maximum height of an open choice modal. Generous enough to fit a
+// short body + a typical 4-6 choice list + footer without scrolling;
+// the wrapping transcript list shrinks accordingly because it owns
+// the `flex: 1` slot.
+const _CHOICE_ROWS: number = 15
+
+// Build the per-render projection of the choice modal state. Pulled
+// out of `_replView` so the view function stays linear and so the
+// projection (body lines, formatted item labels, clamped cursor) can
+// be unit-tested separately. When no modal is open, returns safe
+// defaults that render as an invisible empty box.
+def _choiceProjection(state: ReplState): any {
+  // Pull the value out into a local typed `any` so member accesses
+  // type-check (the Agency typechecker does not narrow union types
+  // across runtime null guards). The `null` branch returns before
+  // any member access happens.
+  const choice: any = state.choice
+  if (choice == null) {
+    return {
+      visible: false,
+      title: "",
+      bodyLines: [],
+      itemLabels: [],
+      cursor: 0,
+      filterText: ""
+    }
+  }
+  const filteredItems = _filteredChoiceItems(choice)
+  let cursor = choice.cursor
+  const maxCursor = filteredItems.length - 1
+  if (cursor > maxCursor) { cursor = maxCursor }
+  if (cursor < 0)         { cursor = 0 }
+  // Pad short keys so the labels line up — most choice menus mix
+  // single-char keys (`a`) with two-char keys (`aa`). 4 wide gives
+  // room for up to three-char keys (`yes`) with a trailing space.
+  let itemLabels: string[] = []
+  for (item in filteredItems) {
+    let pad = ""
+    let n = item.key.length
+    while (n < 4) {
+      pad = pad + " "
+      n = n + 1
+    }
+    itemLabels.push("${item.key}${pad}${item.label}")
+  }
+  let bodyLines: string[] = []
+  if (choice.body != "") {
+    bodyLines = choice.body.split("\n")
+  }
+  return {
+    visible: true,
+    title: choice.title,
+    bodyLines: bodyLines,
+    itemLabels: itemLabels,
+    cursor: cursor,
+    filterText: choice.filter
+  }
+}
+
 def _replView(state: ReplState): Element {
-  const status = state.config.status()
+  const status: any = state.config.status()
+  // `status.context` is optional — callers that pre-date the second
+  // status line return just `{left, right}`, so guard for null/empty.
+  let contextLine: string = ""
+  if (status.context != null) {
+    contextLine = status.context
+  }
   const paletteKeys = _filteredPaletteKeys(state)
   let paletteItems: string[] = []
   for (commandName in paletteKeys) {
@@ -995,11 +1126,35 @@ def _replView(state: ReplState): Element {
   const leftStatusWidth = status.left.length
   const rightStatusWidth = status.right.length
 
+  const choiceView = _choiceProjection(state)
+
   // Note: every container call here MUST pass at least one named arg.
   // The agency parser otherwise compiles `column() as mainCol { ... }`
   // as a positional call where the block lands in `flex`.
   return column(visible: true) as mainCol {
     mainCol.list(items: visibleMessages, selectedIndex: followIndex, flex: 1)
+    // Choice modal: bordered column above the status line. Keys are
+    // routed to `_replReduceChoice` when this is open, so the input
+    // bar / palette / history navigation can't fire. When closed the
+    // column collapses to zero rows via `visible: false`.
+    mainCol.column(
+      visible: choiceView.visible,
+      height: _CHOICE_ROWS,
+      border: true,
+      borderColor: "yellow",
+      label: choiceView.title,
+    ) as choiceBox {
+      for (bodyLine in choiceView.bodyLines) {
+        choiceBox.line(bodyLine)
+      }
+      choiceBox.line("> ${choiceView.filterText}", bold: true)
+      choiceBox.list(
+        items: choiceView.itemLabels,
+        selectedIndex: choiceView.cursor,
+        flex: 1,
+      )
+      choiceBox.line("↑↓ select · enter confirm · esc cancel", fg: "gray")
+    }
     mainCol.list(
       items: paletteItems,
       selectedIndex: state.palette.cursor,
@@ -1007,31 +1162,24 @@ def _replView(state: ReplState): Element {
       height: _PALETTE_ROWS,
       border: true,
     )
-    mainCol.row(bg: "#ffffff", fg: "#000000", height: 1) as statusLine {
-      // Use hex colors (`#fff` / `#000`) instead of named `white` /
-      // `black` because named colors map to the terminal theme.
-      // bg/fg are repeated on each child because child elements don't
-      // inherit parent style.
-      statusLine.line(
-        status.left,
-        width: leftStatusWidth,
-        bg: "#ffffff",
-        fg: "#000000",
-        bold: true,
-      )
-      statusLine.box(flex: 1, bg: "#ffffff") as _ {}
-      statusLine.line(
-        status.right,
-        width: rightStatusWidth,
-        bg: "#ffffff",
-        fg: "#000000",
-        bold: true,
-      )
-    }
+    // Bottom region: thin rule above and below the input bar, then
+    // two info lines beneath that. The first info line shows fixed
+    // `status.left` / `status.right` content; the second is reserved
+    // for context-specific hints (e.g. mode toggles, key reminders)
+    // populated via the optional `status.context` field returned by
+    // the caller's status callback.
+    mainCol.line("", fill: "─", fg: "gray")
     mainCol.row(height: 1) as inputRow {
       inputRow.line(state.input.prompt, width: promptWidth)
       inputRow.textInput(value: state.input.buffer, flex: 1)
     }
+    mainCol.line("", fill: "─", fg: "gray")
+    mainCol.row(height: 1) as statusLine {
+      statusLine.line(status.left, width: leftStatusWidth)
+      statusLine.box(flex: 1) as _ {}
+      statusLine.line(status.right, width: rightStatusWidth)
+    }
+    mainCol.line(contextLine, fg: "gray")
   }
 }
 
@@ -1217,7 +1365,126 @@ def _openPalette(state: ReplState): ReplState {
   }
 }
 
-def _replReduce(state: ReplState, keyEvent: KeyEvent): ReplState {
+// Filter the choice items by the (lowercased) typed filter substring.
+// Lists in insertion order. With an empty filter, returns all items.
+def _filteredChoiceItems(choice: ReplChoiceState): ChoiceItem[] {
+  if (choice.filter == "") {
+    return choice.items
+  }
+  const needle = choice.filter.toLowerCase()
+  return filter(choice.items, _matchesChoiceFilter.partial(needle: needle))
+}
+
+def _matchesChoiceFilter(item: ChoiceItem, needle: string): boolean {
+  return item.label.toLowerCase().includes(needle)
+    || item.key.toLowerCase().includes(needle)
+}
+
+// Reducer branch for the choice modal. Routes keystrokes:
+//   ↑/↓        — move cursor within the filtered set
+//   printable  — append to filter, reset cursor to 0
+//   backspace  — pop from filter (or close prompt if filter is empty)
+//   enter      — resolve the deferred Promise with the picked key,
+//                clear the slot
+//   escape     — reject the deferred Promise, clear the slot
+// All other keys (including the synthetic render-trigger) are no-ops.
+def _replReduceChoice(state: ReplState, keyEvent: KeyEvent): ReplState {
+  // Pull the value out into a local typed `any` so member accesses
+  // type-check (the Agency typechecker does not narrow union types
+  // across runtime null guards). The caller `_replReduce` already
+  // ensured `state.choice != null` before dispatching here.
+  const choice: any = state.choice
+  const visibleItems = _filteredChoiceItems(choice)
+  if (keyEvent.key == "escape") {
+    _cancelChoice("user cancelled")
+    return { ...state, choice: null }
+  }
+  if (keyEvent.key == "enter") {
+    if (visibleItems.length == 0) {
+      return state
+    }
+    let cursor = choice.cursor
+    if (cursor >= visibleItems.length) {
+      cursor = visibleItems.length - 1
+    }
+    _resolveChoice(visibleItems[cursor].key)
+    return { ...state, choice: null }
+  }
+  if (keyEvent.key == "up") {
+    let cursor = choice.cursor - 1
+    if (cursor < 0) { cursor = 0 }
+    return { ...state, choice: { ...choice, cursor: cursor } }
+  }
+  if (keyEvent.key == "down") {
+    let cursor = choice.cursor + 1
+    const maxCursor = visibleItems.length - 1
+    if (cursor > maxCursor) { cursor = maxCursor }
+    if (cursor < 0)         { cursor = 0 }
+    return { ...state, choice: { ...choice, cursor: cursor } }
+  }
+  if (keyEvent.key == "backspace") {
+    const currentFilter = choice.filter
+    if (currentFilter == "") {
+      return state
+    }
+    return {
+      ...state,
+      choice: {
+        ...choice,
+        filter: currentFilter[:currentFilter.length - 1],
+        cursor: 0
+      }
+    }
+  }
+  if (keyEvent.key.length == 1) {
+    return {
+      ...state,
+      choice: {
+        ...choice,
+        filter: choice.filter + keyEvent.key,
+        cursor: 0
+      }
+    }
+  }
+  return state
+}
+
+// Sync the modal slot from the TS bridge. The bridge owns the
+// pending-request slot because reducer states are returned as new
+// records on every keypress — TS cannot mutate them directly. The
+// reducer copies the bridge's request into `state.choice` once
+// (when a prompt opens) and clears it once (when a prompt is
+// resolved/cancelled externally or torn down by _runReplLoop).
+// Cursor/filter state lives on the agency side after that.
+def _syncChoiceFromBridge(state: ReplState): ReplState {
+  const tsRequest: any = _peekPendingChoiceRequest()
+  if (tsRequest != null && state.choice == null) {
+    return {
+      ...state,
+      choice: {
+        title: tsRequest.title,
+        body: tsRequest.body,
+        items: tsRequest.items,
+        filter: "",
+        cursor: 0
+      }
+    }
+  }
+  if (tsRequest == null && state.choice != null) {
+    return { ...state, choice: null }
+  }
+  return state
+}
+
+def _replReduce(replState: ReplState, keyEvent: KeyEvent): ReplState {
+  const state = _syncChoiceFromBridge(replState)
+  // Choice modal takes priority — locks out the input bar, palette,
+  // and history navigation until the user picks (Enter) or cancels
+  // (Escape). Ctrl-C still exits the whole REPL via the catch-all
+  // path below; we don't special-case it here.
+  if (state.choice != null) {
+    return _replReduceChoice(state, keyEvent)
+  }
   if (state.palette.open) {
     return _replReducePaletteOpen(state, keyEvent)
   }
@@ -1239,6 +1506,13 @@ def _replReduce(state: ReplState, keyEvent: KeyEvent): ReplState {
 }
 
 def _replIsDone(state: ReplState): boolean {
+  // Bridge signal (set by `_beginSubmit` when onSubmit returns false)
+  // takes priority. We can't rely on mutating `state.done` from TS
+  // because reducer states are returned as fresh records and `done`
+  // is a primitive — see `_signalReplExit` in lib/stdlib/ui.ts.
+  if (_peekReplExitSignal()) {
+    return true
+  }
   return state.done
 }
 
@@ -1305,6 +1579,7 @@ export def repl(
       status: status,
       onSubmit: onSubmit
     },
+    choice: null,
     done: false,
   }
   _activeRepl = initial

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -1175,7 +1175,18 @@ def _replView(state: ReplState): Element {
     // populated via the optional `status.context` field returned by
     // the caller's status callback.
     mainCol.line("", fill: "─", fg: "gray")
-    mainCol.row(height: 1) as inputRow {
+    // The input row grows vertically with the buffer: one row per
+    // `\n`-delimited line, minimum one. `line()` children inside the
+    // row keep `height: 1` and pin to the top via the default
+    // `alignItems: "stretch"` + `crossOffset: 0` layout, so the
+    // prompt only appears on the first row even as the textInput
+    // expands to cover the whole height.
+    const _bufferLines = state.input.buffer.split("\n")
+    let inputHeight = _bufferLines.length
+    if (inputHeight < 1) {
+      inputHeight = 1
+    }
+    mainCol.row(height: inputHeight) as inputRow {
       inputRow.line(state.input.prompt, width: promptWidth)
       inputRow.textInput(value: state.input.buffer, flex: 1)
     }
@@ -1349,15 +1360,14 @@ def _appendInputCharacter(state: ReplState, character: string): ReplState {
   }
 }
 
-// Append pasted text to the input buffer wholesale. Newlines in the
-// paste are flattened to spaces so an accidentally-newline-bearing
-// paste doesn't immediately submit the prompt (the user can still
-// review and press Enter explicitly). Tab + other control bytes are
-// kept as-is — the renderer truncates them safely.
+// Append pasted text to the input buffer wholesale. Newlines are
+// preserved as `\n` (the input box grows to fit), so a paste of a
+// multi-line snippet shows up exactly as it was on the clipboard.
+// Windows-style `\r\n` and bare `\r` are folded to `\n` so the
+// renderer + reducer only have to think about one line terminator.
 def _appendPaste(state: ReplState, pasted: string): ReplState {
-  let normalized = pasted.replaceAll("\r\n", " ")
-  normalized = normalized.replaceAll("\n", " ")
-  normalized = normalized.replaceAll("\r", " ")
+  let normalized = pasted.replaceAll("\r\n", "\n")
+  normalized = normalized.replaceAll("\r", "\n")
   return {
     ...state,
     input: {
@@ -1537,6 +1547,10 @@ def _replReduce(replState: ReplState, keyEvent: KeyEvent): ReplState {
     { key: "up" } if (state.input.historyIdx > 0) => return _recallPreviousHistory(state)
     { key: "down" } if (state.input.historyIdx < state.input.history.length) => return _recallNextHistory(state)
     { key: "backspace" } if (state.input.buffer != "") => return _removeInputCharacter(state)
+    // Shift+Enter inserts a literal newline. Must come before the
+    // plain `enter` arms — match arms with more specific predicates
+    // win, but only when listed before the more general one.
+    { key: "enter", shift: true } => return _appendInputCharacter(state, "\n")
     // Empty-buffer Enter is a no-op: skip writing a blank "You" row
     // and entering the busy/Thinking state for an empty prompt.
     { key: "enter" } if (state.input.buffer == "") => return state

--- a/packages/agency-lang/stdlib/ui.agency
+++ b/packages/agency-lang/stdlib/ui.agency
@@ -1360,6 +1360,20 @@ def _appendInputCharacter(state: ReplState, character: string): ReplState {
   }
 }
 
+// Extract the text payload from a `key: "paste"` `KeyEvent`,
+// defaulting to the empty string when the terminal sent a paste
+// marker with no body. Pulled out so the `_appendPaste` call site
+// can stay a single expression inside a match arm — the typechecker
+// doesn't narrow `keyEvent.text` to `string` across the arm's
+// `if (keyEvent.text != null)` guard, and `keyEvent.text ?? ""`
+// synths as `number` (no special case for `??` in synthType yet).
+def _pasteText(keyEvent: any): string {
+  if (keyEvent.text == null) {
+    return ""
+  }
+  return keyEvent.text
+}
+
 // Append pasted text to the input buffer wholesale. Newlines are
 // preserved as `\n` (the input box grows to fit), so a paste of a
 // multi-line snippet shows up exactly as it was on the clipboard.
@@ -1539,10 +1553,10 @@ def _replReduce(replState: ReplState, keyEvent: KeyEvent): ReplState {
   match (keyEvent) {
     { ctrl: true, key: "c" } => return { ...state, done: true }
     { ctrl: true, key: "u" } => return _clearInputBuffer(state)
-    // Bracketed-paste payload from the terminal (e.g. Cmd+V on macOS).
-    // The full pasted body lives on `keyEvent.text` — see
-    // lib/tui/input/terminal.ts for how the markers are parsed.
-    { key: "paste" } => return _appendPaste(state, keyEvent.text ?? "")
+    // Bracketed-paste payload from the terminal (e.g. Cmd+V on
+    // macOS). `_pasteText` coerces the optional `keyEvent.text` to a
+    // plain string so the match arm stays a single expression.
+    { key: "paste" } => return _appendPaste(state, _pasteText(keyEvent))
     { key: "/" } if (state.input.buffer == "") => return _openPalette(state)
     { key: "up" } if (state.input.historyIdx > 0) => return _recallPreviousHistory(state)
     { key: "down" } if (state.input.historyIdx < state.input.history.length) => return _recallNextHistory(state)

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -155,6 +155,9 @@ __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("tests/debugger/function-call-test.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("tests/debugger/function-call-test.agency")
 }
 __registerGlobalsInit("tests/debugger/function-call-test.agency", __initializeGlobals);
@@ -179,10 +182,19 @@ let __functionCompleted = false;
   __stack.args["b"] = b;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "tests/debugger/function-call-test.agency", scopeName: "add", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "tests/debugger/function-call-test.agency", scopeName: "add", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/debugger/if-else-test.ts
+++ b/packages/agency-lang/tests/debugger/if-else-test.ts
@@ -155,6 +155,9 @@ __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("tests/debugger/if-else-test.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("tests/debugger/if-else-test.agency")
 }
 __registerGlobalsInit("tests/debugger/if-else-test.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/debugger/interrupt-test.ts
+++ b/packages/agency-lang/tests/debugger/interrupt-test.ts
@@ -155,6 +155,9 @@ __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("tests/debugger/interrupt-test.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("tests/debugger/interrupt-test.agency")
 }
 __registerGlobalsInit("tests/debugger/interrupt-test.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/debugger/loop-test.ts
+++ b/packages/agency-lang/tests/debugger/loop-test.ts
@@ -155,6 +155,9 @@ __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("tests/debugger/loop-test.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("tests/debugger/loop-test.agency")
 }
 __registerGlobalsInit("tests/debugger/loop-test.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -155,6 +155,9 @@ __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("tests/debugger/nested-calls-test.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("tests/debugger/nested-calls-test.agency")
 }
 __registerGlobalsInit("tests/debugger/nested-calls-test.agency", __initializeGlobals);
@@ -178,10 +181,19 @@ let __functionCompleted = false;
   __stack.args["n"] = n;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "double", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "double", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -310,10 +322,19 @@ let __functionCompleted = false;
   __stack.args["b"] = b;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "addAndDouble", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "tests/debugger/nested-calls-test.agency", scopeName: "addAndDouble", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/debugger/step-test.ts
+++ b/packages/agency-lang/tests/debugger/step-test.ts
@@ -155,6 +155,9 @@ __registerTool(entries);
 __registerTool(emit);
 __registerTool(callback);
 async function __initializeGlobals(__ctx) {
+  if (__ctx.globals.isInitialized("tests/debugger/step-test.agency")) {
+    return;
+  }
   __ctx.globals.markInitialized("tests/debugger/step-test.agency")
 }
 __registerGlobalsInit("tests/debugger/step-test.agency", __initializeGlobals);

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -163,10 +163,19 @@ let __functionCompleted = false;
   __stack.args["id"] = id;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "safe-function.agency", scopeName: "safeLookup", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "safe-function.agency", scopeName: "safeLookup", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -294,10 +303,19 @@ let __functionCompleted = false;
   __stack.args["id"] = id;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "safe-function.agency", scopeName: "unsafeSave", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "safe-function.agency", scopeName: "unsafeSave", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -161,10 +161,19 @@ let __functionCompleted = false;
   __stack.args["val"] = val;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "asyncAssigned.agency", scopeName: "compute", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "asyncAssigned.agency", scopeName: "compute", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -162,10 +162,19 @@ let __functionCompleted = false;
   __stack.args["value"] = value;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "asyncUnassigned.agency", scopeName: "append", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "asyncUnassigned.agency", scopeName: "append", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -161,10 +161,19 @@ let __functionCompleted = false;
   __stack.args["data"] = data;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "bangParams.agency", scopeName: "process", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "bangParams.agency", scopeName: "process", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -161,10 +161,19 @@ let __functionCompleted = false;
   __stack.args["x"] = x;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "bangReturnType.agency", scopeName: "process", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "bangReturnType.agency", scopeName: "process", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -161,10 +161,19 @@ let __functionCompleted = false;
   __stack.args["block"] = block;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "blockBasic.agency", scopeName: "twice", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "blockBasic.agency", scopeName: "twice", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -162,10 +162,19 @@ let __functionCompleted = false;
   __stack.args["block"] = block;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "blockParams.agency", scopeName: "mapItems", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "blockParams.agency", scopeName: "mapItems", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/comments.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/comments.mjs
@@ -168,10 +168,19 @@ let __functionCompleted = false;
   let __funcStartTime: number = performance.now();
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "comments.agency", scopeName: "greet", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "comments.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -170,10 +170,19 @@ let __functionCompleted = false;
   __stack.args["greeting"] = (greeting === __UNSET ? (`Hello`) : (greeting));
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "defaultValues.agency", scopeName: "greet", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "defaultValues.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -165,10 +165,19 @@ let __functionCompleted = false;
   __stack.args["b"] = b;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "docstrings.agency", scopeName: "add", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "docstrings.agency", scopeName: "add", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -299,10 +308,19 @@ let __functionCompleted = false;
   __stack.args["name"] = name;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "docstrings.agency", scopeName: "greet", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "docstrings.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -423,10 +441,19 @@ let __functionCompleted = false;
   __stack.args["height"] = height;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "docstrings.agency", scopeName: "calculateArea", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "docstrings.agency", scopeName: "calculateArea", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -561,10 +588,19 @@ let __functionCompleted = false;
   let __funcStartTime: number = performance.now();
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "docstrings.agency", scopeName: "processData", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "docstrings.agency", scopeName: "processData", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -672,10 +708,19 @@ let __functionCompleted = false;
   let __funcStartTime: number = performance.now();
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "docstrings.agency", scopeName: "versionedTool", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "docstrings.agency", scopeName: "versionedTool", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -163,10 +163,19 @@ let __functionCompleted = false;
   __stack.args["n"] = n;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "euler-0004.agency", scopeName: "isPalindrome", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "euler-0004.agency", scopeName: "isPalindrome", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -164,10 +164,19 @@ let __functionCompleted = false;
   __stack.args["b"] = b;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "euler-0005.agency", scopeName: "gcd", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "euler-0005.agency", scopeName: "gcd", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -320,10 +329,19 @@ let __functionCompleted = false;
   __stack.args["b"] = b;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "euler-0005.agency", scopeName: "lcm", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "euler-0005.agency", scopeName: "lcm", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -163,10 +163,19 @@ let __functionCompleted = false;
   __stack.args["n"] = n;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "euler-0007.agency", scopeName: "isPrime", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "euler-0007.agency", scopeName: "isPrime", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -164,10 +164,19 @@ let __functionCompleted = false;
   __stack.args["c"] = c;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "euler-0008.agency", scopeName: "toDigit", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "euler-0008.agency", scopeName: "toDigit", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -163,10 +163,19 @@ let __functionCompleted = false;
   __stack.args["n"] = n;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "euler-0010.agency", scopeName: "isPrime", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "euler-0010.agency", scopeName: "isPrime", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -162,10 +162,19 @@ let __functionCompleted = false;
   __stack.args["y"] = y;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function-with-types.agency", scopeName: "add", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function-with-types.agency", scopeName: "add", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -320,10 +329,19 @@ let __functionCompleted = false;
   __stack.args["name"] = name;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function-with-types.agency", scopeName: "greet", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function-with-types.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -466,10 +484,19 @@ let __functionCompleted = false;
   __stack.args["label"] = label;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function-with-types.agency", scopeName: "mixed", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function-with-types.agency", scopeName: "mixed", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -621,10 +648,19 @@ let __functionCompleted = false;
   __stack.args["items"] = items;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function-with-types.agency", scopeName: "processArray", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function-with-types.agency", scopeName: "processArray", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -766,10 +802,19 @@ let __functionCompleted = false;
   __stack.args["value"] = value;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function-with-types.agency", scopeName: "flexible", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function-with-types.agency", scopeName: "flexible", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -160,10 +160,19 @@ let __functionCompleted = false;
   let __funcStartTime: number = performance.now();
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function.agency", scopeName: "test", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function.agency", scopeName: "test", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -276,10 +285,19 @@ let __functionCompleted = false;
   __stack.args["b"] = b;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "function.agency", scopeName: "add", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "function.agency", scopeName: "add", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -161,10 +161,19 @@ let __functionCompleted = false;
   __stack.args["name"] = name;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "functionRef.agency", scopeName: "greet", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "functionRef.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -289,10 +298,19 @@ let __functionCompleted = false;
   __stack.args["x"] = x;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "functionRef.agency", scopeName: "double", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "functionRef.agency", scopeName: "double", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -418,10 +436,19 @@ let __functionCompleted = false;
   __stack.args["transform"] = transform;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "functionRef.agency", scopeName: "applyToAll", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "functionRef.agency", scopeName: "applyToAll", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -162,10 +162,19 @@ let __functionCompleted = false;
   __stack.args["c"] = c;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "genericAliasValidation.agency", scopeName: "process", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "genericAliasValidation.agency", scopeName: "process", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -161,10 +161,19 @@ let __functionCompleted = false;
   __stack.args["block"] = block;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "inlineBlockBasic.agency", scopeName: "twice", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "inlineBlockBasic.agency", scopeName: "twice", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -162,10 +162,19 @@ let __functionCompleted = false;
   __stack.args["block"] = block;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "inlineBlockParams.agency", scopeName: "mapItems", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "inlineBlockParams.agency", scopeName: "mapItems", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -162,10 +162,19 @@ let __functionCompleted = false;
   __stack.args["age"] = age;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "interrupt-2-deep-in-function.agency", scopeName: "greet", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "interrupt-2-deep-in-function.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -342,10 +351,19 @@ let __functionCompleted = false;
   __stack.args["age"] = age;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "interrupt-2-deep-in-function.agency", scopeName: "foo2", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "interrupt-2-deep-in-function.agency", scopeName: "foo2", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -162,10 +162,19 @@ let __functionCompleted = false;
   __stack.args["age"] = age;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "interrupt-in-node.agency", scopeName: "greet", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "interrupt-in-node.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/multiLineComment.mjs
@@ -163,10 +163,19 @@ let __functionCompleted = false;
   let __funcStartTime: number = performance.now();
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "multiLineComment.agency", scopeName: "greet", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "multiLineComment.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -177,10 +177,19 @@ let __functionCompleted = false;
   __stack.args["greeting"] = (greeting === __UNSET ? (`Hello`) : (greeting));
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "namedArgs.agency", scopeName: "greet", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "namedArgs.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -163,10 +163,19 @@ let __functionCompleted = false;
   __stack.args["punctuation"] = (punctuation === __UNSET ? (`!`) : (punctuation));
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "namedArgsReorder.agency", scopeName: "greet", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "namedArgsReorder.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -170,10 +170,19 @@ let __functionCompleted = false;
   __stack.args["greeting"] = (greeting === __UNSET ? (null) : (greeting));
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "optionalParams.agency", scopeName: "greet", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "optionalParams.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -161,10 +161,19 @@ let __functionCompleted = false;
   __stack.args["x"] = x;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "pipe-operator.agency", scopeName: "double", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "pipe-operator.agency", scopeName: "double", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -290,10 +299,19 @@ let __functionCompleted = false;
   __stack.args["b"] = b;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "pipe-operator.agency", scopeName: "multiply", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "pipe-operator.agency", scopeName: "multiply", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -429,10 +447,19 @@ let __functionCompleted = false;
   __stack.args["b"] = b;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "pipe-operator.agency", scopeName: "safeDivide", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "pipe-operator.agency", scopeName: "safeDivide", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -161,10 +161,19 @@ let __functionCompleted = false;
   __stack.args["age"] = age;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "result-basic.agency", scopeName: "checkAge", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "result-basic.agency", scopeName: "checkAge", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -161,10 +161,19 @@ let __functionCompleted = false;
   __stack.args["r"] = r;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "result-guards.agency", scopeName: "checkValue", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "result-guards.agency", scopeName: "checkValue", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -167,10 +167,19 @@ let __functionCompleted = false;
   __stack.args["s"] = s;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "schemaParamInjection.agency", scopeName: "parseValue", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "schemaParamInjection.agency", scopeName: "parseValue", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;
@@ -307,10 +316,19 @@ let __functionCompleted = false;
   let __funcStartTime: number = performance.now();
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "schemaParamInjection.agency", scopeName: "wrapper", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "schemaParamInjection.agency", scopeName: "wrapper", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -161,10 +161,19 @@ let __functionCompleted = false;
   __stack.args["name"] = name;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "sourceMap.agency", scopeName: "greet", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "sourceMap.agency", scopeName: "greet", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/threadsAndSubthreads.mjs
@@ -160,10 +160,19 @@ let __functionCompleted = false;
   let __funcStartTime: number = performance.now();
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "threadsAndSubthreads.agency", scopeName: "foo", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "threadsAndSubthreads.agency", scopeName: "foo", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -166,10 +166,19 @@ let __functionCompleted = false;
   __stack.args["messages"] = messages;
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "variadic.agency", scopeName: "log", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "variadic.agency", scopeName: "log", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;

--- a/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/withModifier.mjs
@@ -160,10 +160,19 @@ let __functionCompleted = false;
   let __funcStartTime: number = performance.now();
   __self.__retryable = __self.__retryable ?? true;
   const runner = new Runner(__ctx, __stack, { state: __stack, moduleId: "withModifier.agency", scopeName: "foo", threads: __setupData.threads });
-  let __resultCheckpointId = -1;
-if (__ctx.stateStack.currentNodeId()) {
-  __resultCheckpointId = __ctx.checkpoints.createPinned(__stateStack(), __ctx, { moduleId: "withModifier.agency", scopeName: "foo", stepPath: "", label: "result-entry" });
-}
+  // `__resultCheckpointId` is referenced by interruptAssignment /
+// interruptReturn templates when an interrupt rejects and `runner.halt`
+// builds a Failure carrying the entry checkpoint for `result.retry(...)`.
+// We keep the variable declared (sentinel -1) but skip the createPinned
+// call: pinning at every function entry causes pinned checkpoints to
+// accumulate without bound (evictIfNeeded only evicts unpinned), and the
+// JSON deep-clone of stateStack + globals on each call is a measurable
+// per-keystroke cost inside std::ui's repl loop. The cost of always
+// pinning outweighs the retry-on-failure feature, so it is disabled.
+// `ctx.checkpoints.get(-1)` returns undefined, so the failure path
+// gracefully omits the embedded checkpoint and retry simply becomes a
+// no-op rather than failing.
+let __resultCheckpointId = -1;
 if (__ctx._pendingArgOverrides) {
   const __overrides = __ctx._pendingArgOverrides;
   __ctx._pendingArgOverrides = undefined;


### PR DESCRIPTION
## Summary

A bundle of fixes and quality-of-life improvements to the bundled `agency-agent` and the `std::ui` REPL it builds on. Each change is fairly self-contained but they share the same surface area, so shipping together avoids a fragmented review.

### Agent launch performance
- **Precompile the bundled agents on `make agents`.** `make` now compiles `dist/lib/agents/agency-agent/`, `dist/lib/agents/policy/`, and the existing review/judge agents. `runBundledAgent` prefers a precompiled `agent.js` when present and falls back to an on-the-fly compile, so `pnpm run agency agent` is now near-instant.

### Memory + lag
- **Disable the per-function pinned `result-entry` checkpoint.** Every Agency function entry was previously calling `ctx.checkpoints.createPinned(...)`, which `JSON.stringify`s the entire stateStack + globals and is never evicted (`evictIfNeeded` only touches unpinned checkpoints). Inside a `repl()` that means a snapshot per reducer/view/isDone call per keystroke, growing without bound. Disabling reclaimed ~2.5 GB of resident memory across a few turns and made per-keystroke work tractable. `result.retry()` becomes a no-op (no entry checkpoint to rewind to); we're explicitly trading the retry feature for normal interactive performance.
- **Default `withResumableScope({ pinResultCheckpoint: ... })` to `false`** to match. Callers who actually want retry must opt in.

### Status line redesign
- The status line moved beneath the input box and is now two rows: a fixed left/right info row (e.g. `agency-agent  …  $0.000481`) and a context line for ephemeral hints (`/help for commands · /exit to quit`). The input bar is bracketed by thin gray rules.
- New `fill?: string` style on text elements draws a horizontal rule by padding empty space with the fill char.

### Keyboard / input fixes
- **Bracketed paste support** (`\x1b[?2004h`). The terminal now wraps pasted text in `\x1b[200~ ... \x1b[201~`; the input layer parses that into a single `{ key: "paste", text }` event, and the reducer appends the body wholesale (so Cmd+V works, newlines preserved). Multi-chunk pastes are stitched across `data` events.
- **Fast-typing fix.** Previously, when the kernel coalesced multiple bytes into one `data` event, `parseKeypress("abc")` returned `{ key: "abc" }` and the reducer's `key.length == 1` guard silently dropped it. The new `parseAndEmit` walks the buffer one recognized unit at a time (longest-prefix match against escape sequences, single bytes otherwise), so every keystroke now lands.
- **Ctrl+U** clears the input buffer (bash readline convention).
- **Multi-line input**: Shift+Enter (or Alt/Option+Enter, the portable fallback) inserts a `\n`; plain Enter still submits. The input row grows vertically with the buffer; `renderTextInputContent` is now multi-line aware (one row per `\n`, cursor at end of last line). Paste preserves newlines.

### Error rendering inside the REPL
- The logger used to write directly to `process.stderr`, bypassing the REPL's console capture and tearing the rendered frame. It now routes through `console.*` (still goes to stderr in headless mode).
- Captured `warn` / `error` payloads are truncated to two visible lines with a gray `… N more lines omitted` trailer, so a route() Failure stack stays informative without flooding the transcript.

### Refactor: terminal-input parser
- `dataHandler` is now a one-liner; the buffer walk lives in a `parseAndEmit(input)` method.
- Two named, pure helpers carry the patterns:
  - `readBracketed(str, pos, open, close)` — returns `null | { kind: "partial", body } | { kind: "complete", body, end }`. Marker-agnostic.
  - `readEscapeSequence(str, pos)` — longest-prefix match against the known table.
- Each branch in `parseAndEmit` is now "try X, advance by what X consumed".

## Test plan
- [x] `pnpm test:run` — 4862 / 4862 passing
- [x] Manual: `pnpm run agency agent`, three-turn session — memory stays flat, no lag, status line renders correctly, Ctrl+U clears, Shift+Enter newline works, paste preserves multi-line, a forced Wikipedia error renders truncated inline rather than corrupting the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
