### PR TITLE
Tool params: named-arg variadics, block-arg rules, and tool schema filtering

### DIFF
--- a/packages/agency-lang/docs/superpowers/specs/2026-06-03-tool-params-blocks-and-variadics-design.md
+++ b/packages/agency-lang/docs/superpowers/specs/2026-06-03-tool-params-blocks-and-variadics-design.md
@@ -1,0 +1,422 @@
+# Tool parameters: blocks and variadic args
+
+Date: 2026-06-03
+
+## Problem
+
+In Agency, every function is also a tool: any function can be passed to an `llm(...)` call and the runtime auto-generates a JSON schema for it. Two kinds of parameters cannot be represented in a tool schema:
+
+1. **Block (function-typed) parameters** — an LLM cannot supply code for a block.
+2. **Variadic parameters** (`...xs: T[]`) — there is no way today to bind a variadic from a named-argument call, so they cannot be expressed as a JSON schema field.
+
+Today this either fails at runtime when the LLM picks the tool or silently misbehaves. We want a deterministic, well-defined story for both.
+
+## Part 1: Variadic parameters
+
+### Generalized calling convention
+
+Allow named-argument calls of the form `foo(rest: [1, 2, 3])` for any variadic parameter, from **any caller** — hand-written Agency or LLM-driven. This is a general language feature, not a tool-only convention.
+
+- Inside `foo`, `rest` is the same spread array it would be when called positionally.
+- Existing positional spread `foo(1, 2, 3)` continues to work.
+- Mixed named-arg calls with a variadic are allowed: `def foo(a: number, ...rest: number[])` may be called as `foo(a: 1, rest: [2, 3])`. (This combination is not supported today.)
+- **PFA extension.** This convention also extends to PFA: `foo.partial(rest: [2, 3])` binds the variadic. Today PFA explicitly disallows binding variadics (`partial-application.md`); this lifts that restriction in the same uniform way as the call-site form.
+  - **PFA-binding a variadic is atomic.** Once a variadic is bound via the named-array form in `.partial()`, the resulting function takes no further positional arguments that would feed it. There is no notion of "appending more elements at the call site." If you need to combine arrays, do so at the `.partial(rest: [...a, ...b])` site.
+
+### Disambiguation note
+
+A named-arg call `foo(rest: [1, 2, 3])` looks identical whether `rest` is declared as `...rest: number[]` or `rest: number[]`. There is no caller-side ambiguity: the parameter declaration determines the binding, and from inside `foo` the value is the same array either way. No new parser disambiguation rule is required.
+
+One subtlety worth noting in docs: when the variadic's element type is itself an array, the named-array form passes the *whole* array as the spread. For `def foo(...xs: number[])`, `foo(xs: [1,2,3])` binds `xs = [1,2,3]` (three elements), not `xs = [[1,2,3]]` (one element). To get a single-element variadic containing an array, pass `foo(xs: [[1,2,3]])`.
+
+### Mixed positional + named-variadic rule
+
+If a variadic parameter is bound by name, **no positional arguments may be supplied past the fixed (non-variadic) parameters**. For `def foo(a: number, ...rest: number[])`:
+
+- `foo(1, 2, 3)` — OK (all positional).
+- `foo(a: 1, rest: [2, 3])` — OK.
+- `foo(1, rest: [2, 3])` — OK (positional fills `a`, named binds `rest`).
+- `foo(1, 2, rest: [3])` — **error**: positional `2` would feed `rest`, which is also bound by name.
+
+The type checker rejects the last form with a clear message; the runtime resolver also rejects it as a backstop.
+
+### Tool schema for variadics
+
+A variadic parameter `...nums: number[]` generates a JSON schema field named `nums` with type `number[]`. The LLM invokes the tool using the named-array call form. The LLM path is not a special case: it is simply one more caller using the named-array calling convention.
+
+`@param nums - description` docstring extraction applies unchanged; authors should write the description in collection terms (e.g., "the values to sum") since the schema field is an array, not a single element.
+
+## Part 2: Block (function-typed) parameters
+
+### Rule
+
+When a function is registered as a tool for an LLM call, every parameter whose declared type is a function type is **omitted** from the generated JSON schema. This includes "block" parameters (e.g., `block: (X) => Y`) and any other parameter declared with a function type.
+
+### What counts as "function-typed"
+
+A parameter is function-typed if its declared type is:
+- A direct function type, e.g., `(X) => Y`, including zero-arg `() => Y`.
+- A union where **any** arm is a function type (e.g., `((x: X) => Y) | string`). Conservative: such params are dropped from the schema even though the LLM could supply the non-function arm. (See "Out of scope" — supporting union-with-function in schemas is deferred.)
+
+Recursive function types are still function types; the same rule applies.
+
+Agency does not have generics over functions, so the function-typed determination is always made against a fully concrete parameter type at the `llm(...)` site. No "resolve generic constraint at tool registration" logic is needed.
+
+#### Variadic whose element type is a function type
+
+A variadic such as `def foo(...handlers: ((x: number) => number)[])` is treated as **function-typed** for the purpose of this spec — i.e., the whole variadic parameter is dropped from the tool schema and is subject to the same required-vs-optional rules as a single function-typed parameter. This is the consistent extension of the union-with-function rule: if the element type is a function type, the LLM cannot meaningfully fill the array.
+
+If the variadic is required (the function declares it with no fallback) and unbound, the compile-time check errors at the `llm(...)` site; if it's optional (declared with default `= []` or similar), it is silently dropped with the standard warning.
+
+#### `any`-typed parameters
+
+If a parameter is declared `any`, it is **not** considered function-typed by either the static check or the runtime backstop. Such a parameter is exposed in the tool schema with whatever encoding the schema generator uses for `any` (today: a permissive JSON schema). If the function body internally calls the `any` parameter as a block, and the LLM does not supply a callable, the call will crash mid-invocation — exactly the failure mode this spec otherwise avoids.
+
+This is an accepted limitation, documented for users:
+
+- Rationale: detecting "this `any` param is invoked as a function" would require body-level escape analysis, which is disproportionate effort for a niche pattern. `any` is already an opt-out of type-checking guarantees throughout Agency.
+- Mitigation: the docs section that introduces tool-as-function will include a "don't put callable `any` parameters in tool functions" caution and point users to declaring the parameter with an explicit function type (which then benefits from the static check) or PFA-binding it.
+
+### Required vs optional
+
+- **Optional** function-typed parameter, unbound: dropped from the schema; passed as `undefined` at runtime. The function body is responsible for handling `undefined`. The type checker emits a **warning** at the `llm(...)` site listing dropped optional function-typed params, so this is visible rather than silent. A warning (not an error) keeps the path ergonomic for stdlib-style functions whose blocks are genuinely optional.
+- **Required** function-typed parameter: must be bound via partial application (PFA) before the function is passed as a tool.
+
+Block parameters are already named, function-typed parameters in Agency (see `docs/site/guide/blocks.md`), and the existing PFA syntax already binds them: `mapWithIndex.partial(block: someFn)`. No new PFA syntax is introduced.
+
+### Enforcement: two-layer, by design
+
+This is a deliberate design choice and is documented as such.
+
+1. **Compile-time check (type checker, primary).** Passing a function as a tool to an `llm(...)` call is a type error if any required function-typed parameter is unbound. The error names the offending parameter(s) and suggests `.partial(name: ...)`.
+2. **Runtime check (backstop).** Each `llm(...)` call finalizes its tool array immediately before issuing the request. At that point — not at any earlier tool-array-construction site — the runtime re-verifies, for each tool, that every required function-typed parameter (per the function's runtime descriptor) is bound. If not, throw before the LLM ever sees the schema. This handles cases the static checker cannot prove, principally dynamically assembled tool arrays (e.g., `llm(..., { tools: [...base, validate] })`) where the static checker has no single concrete list to walk.
+
+   The runtime check uses the same param descriptor (`AgencyFunction.params`) that the schema generator consults; `isBound` and the declared type are both already tracked there (see `lib/runtime/agencyFunction.ts`). No new metadata is added.
+
+**Why not silently drop required block params?** Silent drops would produce confusing late failures: the LLM picks the tool, the call begins, and the function crashes mid-body when it tries to invoke the missing block. Both layers above ensure failures surface at the registration boundary, not deep inside an invocation.
+
+## Part 3: Schema generation details
+
+- Parameter ordering in the schema follows declaration order. Dropped function-typed parameters are simply absent.
+- Mixed signature example. Given:
+  ```ts
+  def foo(a: number, onDone: () => void, ...rest: number[])
+  ```
+  (Variadic must be last — see "Out of scope".) If `onDone` is optional or PFA-bound, the schema is `{ a: number, rest: number[] }`.
+- `@param name - description` extraction is skipped for dropped function-typed params.
+
+## Part 4: Where the work lands
+
+### 4.1 Parser / named-arg resolution
+
+- The parser already accepts `name: expr` named arguments. No grammar change.
+- The named-arg *binder* (both compile-time in the typescript builder's `resolveNamedArgs` and runtime in `resolveNamed`) currently forbids a named arg from targeting a variadic. Lift that restriction in both places: when the name matches a variadic parameter, the supplied value is bound directly as the spread array (no element-wise wrapping).
+- The two binders must agree on the rules. Extract a single predicate/classifier helper (see 4.6) that both consult, so they cannot drift. If, for genuine cross-package reasons, the helper cannot be shared in code, add a `// keep in sync with X` comment on both sides AND a test that exercises both code paths on the same input.
+- Splat-after-named is already rejected (`checker.ts` ~lines 383–404). Extend the same pass to reject **positional-after-named-variadic** (the new mixed-rule).
+
+### 4.2 Type checker — detailed changes
+
+Concrete code touchpoints (all paths are inside `lib/typeChecker/`):
+
+**(a) `checker.ts :: paramListSignature` (~lines 50–101) — variadic becomes nameable; slot resolution moves into the signature itself.**
+
+Today the `isNameable` predicate is `!p.variadic && p.typeHint?.type !== "blockType"`. Change to: `isNameable = (p) => p.typeHint?.type !== "blockType"`. (Block-typed params remain non-nameable from the LLM/named-arg perspective in the *schema-generation* sense, but they already accept named binding via `block: fn` in normal Agency calls; the existing `nameableParams` filter at line 411 already includes them. The two filters serve different purposes; do not conflate them in the refactor.)
+
+The slot exposed for a variadic via named arg must have type `T[]` (the array type), not the per-element `T` that positional-spread uses. **Do not** patch this in the consumer (`checkArgsAgainstParams`) by overriding `paramType` after the fact — that leaks the variadic-handling rule into every caller. Instead, return a slot-resolver from `paramListSignature` so callers ask, not compute:
+
+```ts
+type SlotRequest =
+  | { kind: "positional"; index: number }
+  | { kind: "named"; name: string };
+
+type ParamSignature = {
+  minArgs: number;
+  maxArgs: number;
+  resolveSlot(req: SlotRequest): ParamSlot | undefined;
+};
+```
+
+`resolveSlot({ kind: "named", name })` returns a slot whose `type` is the array form when the param is variadic; `resolveSlot({ kind: "positional", index })` returns the element-typed slot. `checkArgsAgainstParams` only ever calls `resolveSlot` and runs the assignability check — it does not know about variadics. This is the declarative shape: the rule lives in one place, every consumer is identical.
+
+The existing `slots` array can remain as an internal implementation detail of `paramListSignature` (or be removed if it has no other consumer).
+
+**(b) `checker.ts :: checkNamedArgStructure` (~lines 380–435) — accept named binding of variadic; reject mixed-rule violations.**
+
+- Drop the `!p.variadic` filter at line 411: `const nameableParams = params` (or keep the filter only excluding params that genuinely cannot be named, which after this change is the empty set).
+- Update the comment at lines 406–410 to reflect that variadics may now be passed by name with the whole-array form.
+- After the existing pass-2 loop, add a pass that detects positional-after-named-variadic. Concretely: if any named arg targets a variadic param at index `i`, then no positional arg at index `> i_last_fixed` (i.e., any positional that would feed the variadic) may exist. Emit: `"Positional argument cannot feed variadic parameter '<name>' when it is also bound by name in call to '<fn>'."`
+
+**(c) `checker.ts :: checkArgsAgainstParams` (~lines 480–538) — consume the slot resolver.**
+
+Replace `slots.find((s) => s.name === arg.name)` with `sig.resolveSlot({ kind: "named", name: arg.name })`, and `slots[argIndex]` with `sig.resolveSlot({ kind: "positional", index: argIndex })`. After this change, `checkArgsAgainstParams` contains no variadic-specific logic at all; the per-arg branch is uniform.
+
+**(d) `synthesizer.ts :: validateAgencyFunctionMethod` (~lines 468–501) — `.partial()` accepts variadic.**
+
+Lines 494–499 currently reject binding a variadic in `.partial()`. Replace with:
+
+- If the param is variadic, type-check the named-arg value against the array type (`T[]`), not the element type. Emit the same "wrong element type" error if it doesn't match.
+- Keep the rest of the `.partial()` validation (unknown name, duplicate, non-named arg) untouched.
+
+**(e) New: tool-position function-binding check (new file, e.g., `lib/typeChecker/toolBlockBinding.ts`).**
+
+The validator must be a *composition of named pieces*, not a procedural script. Each piece below is a small, individually testable function that lives in one place and is reused by both this validator and (where applicable) the schema generator and runtime backstop.
+
+```ts
+// Predicate. Used by this validator, the schema generator (4.3),
+// and the runtime backstop (4.4). Single source of truth.
+function isFunctionTyped(param: FunctionParameter): boolean;
+
+// Resolve "the bound-ness of param <name> on this tool expression."
+// Handles bare identifier, `.partial(...)`, `.describe(...)`,
+// `.preapprove()` chains. Reuses the chain-walking machinery already
+// in synthesizer.ts (validateAgencyFunctionMethod path) — do not
+// re-implement chain unwrapping.
+function isBound(toolExpr: AgencyNode, paramName: string): boolean;
+
+// Per-param classifier. Total over the three possible outcomes;
+// every param contributes exactly one classification.
+type ParamClassification =
+  | { kind: "ok"; param: FunctionParameter }
+  | { kind: "required-unbound"; param: FunctionParameter }
+  | { kind: "optional-unbound"; param: FunctionParameter };
+
+function classifyToolParam(
+  param: FunctionParameter,
+  toolExpr: AgencyNode,
+): ParamClassification;
+
+// Resolve a `tools:` option value to the list of statically-known
+// tool expressions. Spread/identifier/dynamic returns []
+// (intentionally; runtime backstop handles those).
+function resolveStaticTools(opt: AgencyNode): AgencyNode[];
+
+// Resolve a tool expression to its declared parameter list, looking
+// in `ctx.functionDefs` and `ctx.importedFunctions`.
+function paramsOfTool(toolExpr: AgencyNode, ctx: TypeCheckerContext):
+  FunctionParameter[] | undefined;
+```
+
+With those, the validator body is a one-pass declarative pipeline (the "what"):
+
+```ts
+for (const call of llmCalls) {
+  for (const toolExpr of resolveStaticTools(call.toolsOpt)) {
+    const params = paramsOfTool(toolExpr, ctx) ?? [];
+    const classifications = params
+      .filter(isFunctionTyped)
+      .map((p) => classifyToolParam(p, toolExpr));
+    emitDiagnostics(call, toolExpr, classifications);
+  }
+}
+```
+
+`emitDiagnostics` is the only place that knows the diagnostic format:
+
+- One **error** per `required-unbound` classification: `"Tool '<fn>' has unbound required function-typed parameter '<name>: <type>'. Bind it with .partial(<name>: <value>) before passing as a tool."`
+- One aggregated **warning** per `llm(...)` call when any `optional-unbound` classifications exist: `"Tool '<fn>' will be exposed to the LLM without optional function-typed parameter(s): <names>. The function body must handle them as undefined."`
+
+The diagnostic-text-builder is a separate small function (`formatRequiredUnboundError`, `formatOptionalUnboundWarning`) so the runtime backstop (4.4) can call the same builders to guarantee unified wording.
+
+**(f) Tests for the type checker.** Co-located, following the existing pattern (`<feature>.test.ts`):
+- New `variadicNamedBinding.test.ts`: named-array call form, mixed positional+named, mixed-rule violation, wrong element type, PFA-bound variadic with correct/incorrect array type.
+- New `toolBlockBinding.test.ts`: required-function-typed unbound → error; optional-function-typed unbound → warning; PFA-bound required → ok; union-with-function required → error (with the conservative drop note); spread-into-tools (`tools: [...base]`) → silently skipped at compile time.
+- New unit tests for each named helper (`isFunctionTyped`, `isBound`, `classifyToolParam`, `resolveStaticTools`, `paramsOfTool`) in isolation, so regressions in the helpers are localized rather than diffused across integration tests.
+
+### 4.3 Tool schema generator
+
+File: `lib/backends/typescriptBuilder.ts :: buildToolDefinition` (~lines 1395–1450).
+
+Today the generator has two scattered concerns: filter out `blockType` params, and (separately, untreated) emit fields per-param. With variadics and function-of-arrays added, the rules interact (a variadic-of-function must be dropped, not emitted as array). Implementing this as two filters or a chain of `if`s scatters the rules and makes future additions error-prone.
+
+**Replace the scattered filters with a single declarative classifier** that returns one decision per parameter:
+
+```ts
+type SchemaContribution =
+  | { kind: "drop" }                              // function-typed, function-union,
+                                                   //  variadic-of-function, etc.
+  | { kind: "scalar"; zod: string; description?: string }
+  | { kind: "array"; element: string; description?: string };  // variadics
+
+function paramSchemaContribution(
+  param: FunctionParameter,
+): SchemaContribution;
+```
+
+`paramSchemaContribution` is the *single source of truth* for "what does this parameter contribute to a tool schema?" It internally consults `isFunctionTyped` (the same predicate from 4.2(e)) and the variadic flag. `buildToolDefinition` becomes:
+
+```ts
+const contributions = parameters.map(paramSchemaContribution);
+const fields = parameters
+  .map((p, i) => ({ name: p.name, contribution: contributions[i] }))
+  .filter((c) => c.contribution.kind !== "drop");
+// emit fields in declaration order
+```
+
+Result: every "should this param appear in the schema?" decision lives in one function. Adding a new dropped case later (e.g., when the union-with-function out-of-scope item gets revisited) is a one-line addition to `paramSchemaContribution`, not a hunt across `buildToolDefinition`.
+
+Per-parameter doc text (`@param name - description`) is read inside `paramSchemaContribution` and attached to the `scalar`/`array` contributions; `drop` contributions discard the doc, satisfying test 34.
+
+The early-return path for "no parameters" remains (test 32). The "all params dropped" case (test 33) naturally falls out because `fields` is empty and the existing empty-schema branch handles it.
+
+### 4.4 Runtime tool registration backstop
+
+- File: `lib/runtime/agencyFunction.ts` and the `llm()` runtime entry point (smoltalk-side; see `lib/runtime/llmClient.ts` per `builtins.ts:26`).
+- In `agencyFunction.ts`:
+  - Relax the existing `Variadic parameter '<name>' cannot be bound` check (line ~142) so it accepts a binding whose declared type matches the variadic's array type. (Today it rejects unconditionally.)
+- New helper, e.g., `validateToolForLLM(fn: AgencyFunction): void`, that throws if any required function-typed param is unbound. Invoked once per tool in the array, **immediately before** the request is issued.
+- Error message format: `"Tool '<name>' cannot be passed to llm(): required function-typed parameter '<param>' is unbound. Use <fn>.partial(<param>: <value>) before passing."`. Match the compile-time error so users see one consistent message.
+
+### 4.5 Calling convention (PFA path)
+
+`agencyFunction.ts :: partial(...)` currently throws for variadic. After the relaxation in 4.4, the bound value must be stored as the spread array. The existing `boundValue` mechanism already supports this — no new shape needed. `buildReducedSchema` (called from `partial`) will then naturally omit the variadic from the post-PFA schema.
+
+### 4.6 Implementation discipline: named abstractions, not procedures
+
+This spec deliberately avoids describing the implementation as a sequence of steps. Three classifiers and a slot resolver carry the whole specification of "what" the change does:
+
+| Name | Lives in | Consumers |
+|------|----------|-----------|
+| `isFunctionTyped(param)` | `lib/typeChecker/utils.ts` (or new module) | tool-binding validator (4.2e), schema generator (4.3), runtime backstop (4.4) |
+| `isBound(toolExpr, paramName)` | tool-binding validator module | tool-binding validator, runtime backstop |
+| `classifyToolParam(param, toolExpr)` | tool-binding validator module | tool-binding validator only |
+| `paramSchemaContribution(param)` | schema generator module | schema generator (4.3); consults `isFunctionTyped` internally |
+| `ParamSignature.resolveSlot(req)` | `checker.ts :: paramListSignature` | `checkArgsAgainstParams`, any future arg-checking consumer |
+| `formatRequiredUnboundError`, `formatOptionalUnboundWarning` | shared diagnostic module | tool-binding validator, runtime backstop |
+
+Hard rules:
+
+1. **Every classification or rule listed above has exactly one definition site.** If two consumers want to ask "is this param function-typed?", they call the same `isFunctionTyped` — never reimplement, never inline.
+2. **No consumer of `paramListSignature` may inspect `param.variadic` directly to decide a slot type.** Ask `resolveSlot`. This is the test of whether the slot-resolver refactor was applied correctly.
+3. **No consumer of `buildToolDefinition` may filter parameters with an ad-hoc predicate.** All "should this param appear?" logic goes through `paramSchemaContribution`.
+4. **Diagnostic text is built by the format helpers, not inlined at error sites.** This is what makes test #42 (unified runtime/compile-time wording) pass without coordination overhead.
+
+If a reviewer sees an inlined predicate, an ad-hoc filter, or a duplicated diagnostic string, that is a correctness concern — the abstraction has been re-leaked. Fix at the call site by routing back through the named helper; do not paper over with a comment.
+
+## Part 5: Testing
+
+Every test below names the *assertions* it must make, not just the scenario. A test is only valuable if its failure mode is "the code under test broke." When a test claims "no error," the test must also assert any positive behavior the feature promises (warning fires, schema field present/absent, runtime value is correct), or a regression that silently drops the positive behavior will not be caught.
+
+### 5.1 Binder / type checker — named-arg targeting variadic
+
+All in a new file `lib/typeChecker/variadicNamedBinding.test.ts`, unless otherwise noted.
+
+1. **Named-array form is accepted and well-typed.** Source: `def foo(...xs: number[]) { ... }; foo(xs: [1,2,3])`. Assert: zero type errors, zero warnings.
+2. **Mixed positional + named variadic.** Source: `def foo(a: number, ...rest: number[]) { ... }; foo(1, rest: [2,3])`. Assert: zero diagnostics.
+3. **Pure named form with fixed param.** `foo(a: 1, rest: [2,3])`. Assert: zero diagnostics.
+4. **Positional-after-named-variadic violation (compile time).** `foo(1, 2, rest: [3])`. Assert: exactly one error; message contains both the parameter name (`rest`) and the function name (`foo`); error location points at the call.
+5. **Wrong outer shape.** `foo(rest: 5)` for `...rest: number[]`. Assert: assignability error reporting expected type `number[]`, actual type `number`.
+6. **Wrong element type.** `foo(rest: ["a","b"])` for `...rest: number[]`. Assert: assignability error reporting expected `number[]`, actual `string[]`.
+7. **Right element, wrong nesting.** `foo(rest: [[1,2]])` for `...rest: number[]`. Assert: assignability error; ensures slot type is `T[]` (the spec's invariant) not `T`.
+8. **Array-of-array variadic disambiguation (type level).** `def foo(...xs: number[][]); foo(xs: [[1,2],[3]])`. Assert: zero diagnostics. (Locks in the doc subtlety at the type-checker layer.)
+9. **`.partial()` with named-array binds variadic.** `min.partial(rest: [1,2])`. Assert: zero diagnostics, no longer emits the legacy "Variadic parameter '<n>' cannot be bound" error.
+10. **`.partial()` with wrong array type rejects.** `min.partial(rest: ["a"])` for `...rest: number[]`. Assert: assignability error.
+11. **Block-typed param remains non-variadic-nameable.** Confirm the refactor of `paramListSignature` did not accidentally re-classify block params. A function `def foo(block: () => void)` called with the normal `block: fn` named arg still works (existing behavior).
+
+### 5.2 Type checker — tool-position binding check
+
+In a new file `lib/typeChecker/toolBlockBinding.test.ts`.
+
+12. **Required function-typed param unbound, literal tools array → error.** `def deploy(block: () => void) { ... }; node main() { llm("x", { tools: [deploy] }) }`. Assert: exactly one error at the `llm(...)` site; message contains `deploy`, `block`, and the substring `.partial(`.
+13. **Optional function-typed param unbound → warning, no error.** `def deploy(block: () => void = noop) { ... }; llm("x", { tools: [deploy] })`. Assert: zero errors AND exactly one warning naming `deploy` and `block`; warning location is the `llm(...)` site.
+14. **PFA-bound required block → no diagnostics.** `llm("x", { tools: [deploy.partial(block: real)] })`. Assert: zero errors, zero warnings.
+15. **Union-with-function required, unbound → error.** `def foo(block: ((x: number) => number) | string) {...}; llm(tools: [foo])`. Assert: error mirrors test 12.
+16. **Union-with-function optional → warning.** Assert: zero errors, one warning.
+17. **Variadic-of-function required, unbound → error.** `def foo(...handlers: ((x: number) => number)[]); llm(tools: [foo])`. Assert: error mirrors test 12.
+18. **Variadic-of-function optional → warning.** Assert: zero errors, one warning.
+19. **Imported function as tool.** Function declared in another module, imported, passed as tool with unbound required block → error. Assert: error fires, proving the validator consults `ctx.importedFunctions`, not only `ctx.functionDefs`.
+20. **PFA chain `.partial(...).preapprove()`.** Assert: no error for the bound block; `.preapprove()` does not undo the binding signal.
+21. **PFA chain `.preapprove().partial(...)`.** Same expectation. (If the language disallows this ordering, the test asserts the parse/type error instead, and the spec must say so.)
+22. **Spread-into-tools `tools: [...base, validate]` with an unbound required block → no compile-time diagnostic.** Assert: zero diagnostics at this call site (this case is intentionally deferred to the runtime backstop, tested in 5.4).
+23. **Identifier-as-tools `tools: tools` → no compile-time diagnostic.** Same rationale; runtime backstop owns it.
+24. **Error + warning coexistence.** Function with both an unbound required block and an unbound optional block. Assert: exactly one error (for the required one) AND exactly one warning (for the optional). Pins down the "both fire independently" semantics.
+25. **All function-typed params bound (PFA + optional combo).** `def foo(req: () => void, opt?: () => void)` called as `llm(tools: [foo.partial(req: real)])`. Assert: zero errors AND one warning for `opt` being dropped (the warning still fires because `opt` is unbound).
+26. **Function with only function-typed params, all bound.** `def foo(req: () => void); llm(tools: [foo.partial(req: real)])`. Assert: zero diagnostics. (Pairs with the empty-schema runtime test in 5.3.)
+
+### 5.3 Schema generator (snapshot + explicit assertions)
+
+In `lib/backends/typescriptBuilder.test.ts` (or co-located).
+
+27. **Variadic emits array field.** Snapshot the generated `toolDefinition` for `def foo(...nums: number[])`. *In addition to* the snapshot: explicit assertion that `properties.nums` is present and its zod expression contains `z.array(z.number())`.
+28. **Function-typed param dropped (single).** For `def foo(a: number, block: () => void)`: snapshot + explicit assertion that `properties` has key `a` and does **not** have key `block`.
+29. **Function union dropped.** `def foo(a: number, cb: ((x: number) => number) | string)`: explicit assertion that `cb` is absent.
+30. **Variadic-of-function dropped.** `def foo(a: number, ...handlers: ((x: number) => number)[])`: explicit assertion that `handlers` is absent (per Part 2's new clarification) and `a` is present.
+31. **Mixed signature ordering preserved.** `def foo(a: number, block: () => void, b: string, ...rest: number[])`: schema keys appear in order `a, b, rest`. Assert the iteration order of `properties` matches.
+32. **No params → empty `{}` schema.** Verify `buildToolDefinition` still returns the empty-schema form (current early-return path) and the runtime accepts it as a tool.
+33. **All function-typed params dropped → empty schema.** `def foo(req: () => void)` after PFA. Assert: schema is `{}`, tool is registerable.
+34. **`@param` docstring extraction is skipped for dropped params.** For a function with a `@param block - ...` docstring on a dropped block param, the resulting tool description must not include the `block` description, and the absence of the schema field must not produce a stray "missing description" warning.
+35. **`@param nums - ...` is preserved for variadic.** Assert the schema field's description matches the docstring text (with the collection-terms wording the spec requires authors to use).
+
+### 5.4 Runtime tool-registration backstop
+
+In `lib/runtime/agencyFunction.test.ts` or a new sibling, plus an agency-js test for end-to-end coverage.
+
+36. **`validateToolForLLM` rejects unbound required function-typed param.** Direct unit test: construct an `AgencyFunction` with one unbound function-typed param, call the validator. Assert: throws; message contains the function name, parameter name, and a `.partial(<name>: <value>)` suggestion identical in structure to the compile-time error.
+37. **`validateToolForLLM` accepts when bound.** PFA-bind the same param, call validator. Assert: no throw.
+38. **`validateToolForLLM` ignores optional unbound function-typed params.** Assert: no throw. (The compile-time warning is the only signal for the optional case; the runtime is silent.)
+39. **Backstop runs before any LLM request.** Agency-js test: stub/mock the smoltalk client to record invocations. Pass a dynamically-assembled tool array (`tools: [...base, badTool]`) where `badTool` has an unbound required block. Assert: `llm()` throws; the smoltalk mock recorded zero requests.
+40. **Dynamically assembled array passes when all tools are bound.** Same setup, `badTool` replaced with `badTool.partial(block: real)`. Assert: no throw at registration; smoltalk receives the tool array exactly once.
+41. **PFA of variadic with mismatched element type at runtime.** `foo.partial(rest: "not-an-array")` where the static type was `any` so it slipped through. Assert: throw at `partial(...)` time with a clear "expected array" message.
+42. **Unified runtime/compile-time error wording.** Pick the canonical phrase (e.g., `"required function-typed parameter '<name>' is unbound"`) and assert both the type checker test (12) and the runtime test (36) emit a message containing that exact substring.
+
+### 5.5 Agency execution tests (named-array calling convention)
+
+In `tests/agency/`.
+
+43. **Named-array form matches positional.** Two test bodies invoking the same function once positionally (`foo(1,2,3)`) and once by name (`foo(rest: [1,2,3])`). Assert: both produce the same observable result (e.g., sum or length).
+44. **Mixed positional+named.** `foo(1, rest: [2,3])` for `def foo(a: number, ...rest: number[])`. Assert inside the body: `a == 1`, `len(rest) == 2`, `rest[0] == 2`, `rest[1] == 3`.
+45. **Pure named form with fixed param.** `foo(a: 1, rest: [2,3])`. Assert the same body invariants as 44.
+46. **Array-of-array variadic (runtime).** `def foo(...xs: number[][]); foo(xs: [[1,2],[3]])`. Assert: `len(xs) == 2`, `xs[0] == [1,2]`, `xs[1] == [3]`. Locks in the doc subtlety at runtime.
+47. **Positional-after-named-variadic violation (runtime).** A compiled call site (forced through generated TS, since the type checker rejects this) — assert the runtime `resolveNamed` throws. Belt-and-suspenders for the case where source-bypass paths (e.g., generated code, hand-written TS using the runtime) attempt this.
+48. **PFA-bound variadic produces correct spread inside the body.** `let bound = foo.partial(rest: [1,2]); bound(a: 10)` for `def foo(a, ...rest)`. Assert: body sees `a == 10`, `rest == [1,2]`.
+49. **PFA-bound block is invoked.** `let bound = foo.partial(block: \-> 42); bound()` for `def foo(block: () => number) { return block() }`. Assert: result is `42`.
+50. **Optional block dropped from schema is invoked as undefined.** Hand-crafted scenario (no LLM): call the agency function via its tool entry point with the optional block omitted. Assert: body receives `undefined` for `block`; body's `if (block !== undefined) { ... }` branch is taken correctly.
+51. **Trailing-block syntax `as { ... }` from a normal Agency caller.** Function with a block param dropped from the *tool* schema is still callable as `foo(x: 1) as { ... }` from inside a node body. Assert: the block executes. Guards against the schema-generator refactor breaking the named-arg resolver.
+
+### 5.6 Backend / round-trip
+
+52. **`buildReducedSchema` after PFA-binding a variadic.** Unit test in `lib/runtime/agencyFunction.test.ts`: construct a tool with a variadic, apply `.partial(rest: [1,2])`, assert the resulting `schema` no longer contains the variadic field.
+53. **Round-trip formatter.** Run `AgencyGenerator` (`pnpm run fmt`) on source containing both `foo(rest: [1,2])` and `foo.partial(rest: [1,2])`. Assert: re-parsing the formatter output yields a structurally-equivalent AST. Goes in the existing formatter round-trip test suite.
+
+### 5.7 Coverage matrix
+
+To make gaps visible, this is the explicit coverage matrix the suite must satisfy:
+
+| Dimension | Cases |
+|-----------|-------|
+| Param kind | function-typed, function-union, variadic-of-function, plain variadic, plain scalar, `any` |
+| Required vs optional | required, optional (with default) |
+| Binding state | unbound, PFA-bound (single), PFA-chain bound, optional left unbound |
+| Tools-array shape | literal array, identifier, spread, single-element |
+| Tool source | local def, imported def |
+| Diagnostic site | compile-time error, compile-time warning, runtime throw |
+| Caller of variadic | positional, named-array, mixed |
+
+If a row is added to either dimension by future work, a corresponding test row is expected.
+
+## Warning ergonomics
+
+The compile-time warning for dropped optional function-typed params (Part 4.2(e)) is emitted at the `llm(...)` site, listing the offending tool and parameter names. No opt-out mechanism is provided in this design — if a stdlib author finds the warning genuinely noisy at a call site, the right response is to either PFA-bind the optional param explicitly or revisit the function's signature. We can add a per-site suppression later if real usage shows a need; introducing one preemptively would invite cargo-culted suppression of a signal that's meant to be visible.
+
+## Migration
+
+This is not a breaking change. Today, every code path that this spec addresses is either:
+
+- An outright runtime crash (a function with a function-typed parameter is passed to `llm(...)`, the LLM picks the tool, and the call fails when the missing block is invoked), or
+- A statically rejected construct (`.partial(rest: [...])` against a variadic; named arg targeting a variadic).
+
+No working program currently relies on the prohibited behavior. After this change:
+
+- The compile-time error for unbound required function-typed params will surface earlier on programs that previously crashed at LLM-invocation time. Affected users get a clear actionable error pointing at `.partial(...)`.
+- Programs that pass variadic-bearing functions as tools today either don't work (no schema field for the variadic) or work by accident with a malformed schema; both become well-defined.
+
+## Handler-safety note
+
+Per `CLAUDE.md`, handlers are critical safety infrastructure. Handlers are installed by `handle { ... }` blocks in the calling code, not by passing a block parameter into a function. Dropping a function-typed parameter from a tool schema therefore does **not** bypass any handler that would otherwise have been installed. No stdlib function is expected to rely on a caller-supplied block to install a handler; if one does, that is a separate bug. We call this out explicitly so future changes do not weaken this guarantee.
+
+## Out of scope (YAGNI)
+
+- Representing blocks to the LLM by encoding code as strings.
+- Auto-PFA for unbound block parameters. The user binds them.
+- Changes to the inline-block syntax (`\x -> ...`).
+- Reordered or rest-after-variadic signatures. Variadic must remain the last parameter.
+- Supporting `((x) => y) | string`-style union schemas where the non-function arm is exposed. Such parameters are conservatively dropped; revisit if a real use case emerges.

--- a/packages/agency-lang/lib/backends/toolSchemaContribution.test.ts
+++ b/packages/agency-lang/lib/backends/toolSchemaContribution.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Spec 2026-06-03 Part 5.3: schema generator (paramSchemaContribution).
+ *
+ * Snapshot-style tests are paired with explicit field-level assertions so a
+ * regression that silently drops a schema field or emits the wrong zod
+ * expression fails on the assertion — not just the snapshot. The spec's
+ * coverage matrix requires every drop / scalar / array case be exercised.
+ */
+import { describe, expect, it } from "vitest";
+import { parseAgency } from "../parser.js";
+import { generateTypeScript } from "./typescriptGenerator.js";
+
+/**
+ * Compile a small Agency program and return the slice of generated TS
+ * that defines `tool`'s schema object. We extract the substring between
+ * `schema: z.object({` and the closing `})` so individual key-value
+ * assertions are stable across formatting changes.
+ */
+function toolSchemaSlice(source: string, toolName: string): string {
+  const parseResult = parseAgency(source, {}, false);
+  if (!parseResult.success) {
+    throw new Error(`parse failed: ${parseResult.message}`);
+  }
+  const ts = generateTypeScript(
+    parseResult.result,
+    undefined,
+    undefined,
+    "test.agency",
+  );
+  // Look for the toolDefinition with this function's name.
+  const idx = ts.indexOf(`name: "${toolName}"`);
+  if (idx < 0) {
+    throw new Error(`tool ${toolName} not found in generated TS`);
+  }
+  const slice = ts.slice(idx);
+  // Capture the `schema: z.object({ ... })` segment for this tool.
+  const m = slice.match(/schema:\s*z\.object\(\s*\{([^}]*)\}/);
+  if (!m) {
+    throw new Error("schema object not found");
+  }
+  return m[1];
+}
+
+describe("paramSchemaContribution — schema field generation", () => {
+  // #27 — Variadic emits array field.
+  it("emits z.array(<element>) for a variadic param", () => {
+    const slice = toolSchemaSlice(
+      `def foo(...nums: number[]): number { return 0 }`,
+      "foo",
+    );
+    expect(slice).toContain(`"nums"`);
+    expect(slice).toContain("z.array(z.number())");
+  });
+
+  // #28 — Function-typed param dropped (single).
+  it("drops a function-typed param from the schema", () => {
+    const slice = toolSchemaSlice(
+      `def foo(a: number, block: () => void): void {}`,
+      "foo",
+    );
+    expect(slice).toContain(`"a"`);
+    expect(slice).not.toContain(`"block"`);
+  });
+
+  // #29 — Function union dropped.
+  it("drops a union-with-function param from the schema", () => {
+    const slice = toolSchemaSlice(
+      `def foo(a: number, cb: ((number) => number) | string): void {}`,
+      "foo",
+    );
+    expect(slice).toContain(`"a"`);
+    expect(slice).not.toContain(`"cb"`);
+  });
+
+  // #30 — Variadic-of-function dropped.
+  it("drops a variadic-of-function param from the schema", () => {
+    const slice = toolSchemaSlice(
+      `def foo(a: number, ...handlers: ((number) => number)[]): void {}`,
+      "foo",
+    );
+    expect(slice).toContain(`"a"`);
+    expect(slice).not.toContain(`"handlers"`);
+  });
+
+  // #31 — Mixed signature ordering preserved (declaration order).
+  it("preserves declaration order of remaining fields", () => {
+    const slice = toolSchemaSlice(
+      `def foo(a: number, block: () => void, b: string, ...rest: number[]): void {}`,
+      "foo",
+    );
+    // No "block" field — dropped. Order should be a, b, rest.
+    expect(slice).not.toContain(`"block"`);
+    const idxA = slice.indexOf(`"a"`);
+    const idxB = slice.indexOf(`"b"`);
+    const idxRest = slice.indexOf(`"rest"`);
+    expect(idxA).toBeGreaterThanOrEqual(0);
+    expect(idxB).toBeGreaterThan(idxA);
+    expect(idxRest).toBeGreaterThan(idxB);
+  });
+
+  // #32 — No params → empty {} schema. Compile-only check: the function
+  // compiles without throwing and emits `schema: z.object({})`.
+  it("emits an empty z.object({}) for a zero-param tool", () => {
+    const parseResult = parseAgency(`def foo(): void {}`, {}, false);
+    if (!parseResult.success) throw new Error(parseResult.message);
+    const ts = generateTypeScript(parseResult.result, undefined, undefined, "test.agency");
+    expect(ts).toContain("schema: z.object({})");
+  });
+
+  // #33 — All function-typed params dropped → empty schema (no fields).
+  it("emits an empty z.object({}) when every param is function-typed", () => {
+    const parseResult = parseAgency(
+      `def foo(req: () => void, other: () => void = null): void {}`,
+      {},
+      false,
+    );
+    if (!parseResult.success) throw new Error(parseResult.message);
+    const ts = generateTypeScript(parseResult.result, undefined, undefined, "test.agency");
+    const idx = ts.indexOf(`name: "foo"`);
+    const slice = ts.slice(idx);
+    expect(slice).toMatch(/schema:\s*z\.object\(\s*\{\s*\}\s*\)/);
+  });
+
+  // #34/#35 — @param docstring preservation/strip behaviour. The current
+  // codegen embeds the entire docstring (including @param lines) in the
+  // tool `description` field — and `stripBoundParams` removes lines for
+  // params bound via `.partial()` at runtime. The schema-generator change
+  // does NOT add per-field zod descriptions in this PR — that would be a
+  // separate behavior shift. We pin the current behavior so any
+  // accidental change is loud.
+  it("includes @param lines in the tool description for kept params", () => {
+    const parseResult = parseAgency(
+      `def foo(...nums: number[]): number {\n  """\n  Do the thing.\n\n  @param nums - the values to sum\n  """\n  return 0\n}`,
+      {},
+      false,
+    );
+    if (!parseResult.success) throw new Error(parseResult.message);
+    const ts = generateTypeScript(parseResult.result, undefined, undefined, "test.agency");
+    expect(ts).toContain("the values to sum");
+  });
+});

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -93,6 +93,7 @@ import {
   hasAnyValidateTag,
 } from "./typescriptGenerator/validationDescriptor.js";
 import { resolveTypeDeep } from "../typeChecker/assignability.js";
+import { isFunctionTyped } from "../typeChecker/utils.js";
 
 import { $, ts } from "../ir/builders.js";
 import { printTs } from "../ir/prettyPrint.js";
@@ -1389,8 +1390,62 @@ export class TypeScriptBuilder {
   }
 
   /**
+   * Classify a parameter's contribution to a tool's JSON schema.
+   *
+   * Single source of truth for "what does this param contribute?" — consumed
+   * by `buildToolDefinition` (and only by it). Three outcomes:
+   *
+   *   - `drop`   : function-typed, function-union, or variadic-of-function.
+   *                Omitted from the schema entirely. The required-vs-optional
+   *                distinction is enforced separately by the tool-binding
+   *                validator (lib/typeChecker/toolBlockBinding.ts).
+   *   - `scalar` : a regular field — type derived from the declared hint
+   *                (`string` is the historical default for untyped params).
+   *                Optional params get `.nullable().describe("Default: ...")`
+   *                appended so the LLM understands the value can be omitted.
+   *   - `array`  : a variadic param whose element type is non-function. The
+   *                emitted schema is `z.array(<element>)` so the LLM supplies
+   *                the whole spread as a single array via the named-array
+   *                calling convention (`foo(rest: [1,2,3])`).
+   */
+  private paramSchemaContribution(
+    param: FunctionParameter,
+  ): { kind: "drop" } | { kind: "scalar"; zod: string } | { kind: "array"; zod: string } {
+    if (isFunctionTyped(param)) return { kind: "drop" };
+
+    if (param.variadic) {
+      // For `...xs: T[]`, the typeHint is the array type already; for the
+      // untyped fallback `...xs`, treat as `any[]`.
+      const elementHint =
+        param.typeHint?.type === "arrayType"
+          ? param.typeHint.elementType
+          : param.typeHint ?? { type: "primitiveType" as const, value: "string" };
+      const elementZod = this.zodSchemaFor(elementHint);
+      return { kind: "array", zod: `z.array(${elementZod})` };
+    }
+
+    const typeHint = param.typeHint || {
+      type: "primitiveType" as const,
+      value: "string",
+    };
+    let zod = this.zodSchemaFor(typeHint);
+    if (param.defaultValue) {
+      const defaultStr = expressionToString(param.defaultValue);
+      zod += `.nullable().describe(${JSON.stringify("Default: " + defaultStr)})`;
+    }
+    return { kind: "scalar", zod };
+  }
+
+  /**
    * Build a tool definition TsNode for an Agency function.
    * Returns ts.id("null") if the function has no parameters (no schema needed for tools).
+   *
+   * Every "should this param appear in the schema?" decision is funneled
+   * through `paramSchemaContribution` — the single classifier that knows
+   * which params are dropped (function-typed, function-union, variadic of
+   * function), which become scalar, and which become array (variadic).
+   * No ad-hoc filter or inline predicate is allowed in this function; the
+   * spec's discipline rule (§4.6 rule #3) is enforced by code review.
    */
   private buildToolDefinition(node: FunctionDefinition): TsNode {
     const { functionName, parameters } = node;
@@ -1402,23 +1457,19 @@ export class TypeScriptBuilder {
       );
     }
 
-    const nonBlockParams = parameters.filter(
-      (p) => !p.typeHint || p.typeHint.type !== "blockType",
-    );
+    const contributions = parameters.map((p) => ({
+      param: p,
+      contribution: this.paramSchemaContribution(p),
+    }));
 
+    // Declaration order is preserved by iterating `parameters` directly;
+    // `properties` is an in-order map of name → zod expression source.
     const properties: Record<string, string> = {};
-    nonBlockParams.forEach((param: FunctionParameter) => {
-      const typeHint = param.typeHint || {
-        type: "primitiveType" as const,
-        value: "string",
-      };
-      let tsType = this.zodSchemaFor(typeHint);
-      if (param.defaultValue) {
-        const defaultStr = expressionToString(param.defaultValue);
-        tsType += `.nullable().describe(${JSON.stringify("Default: " + defaultStr)})`;
-      }
-      properties[param.name] = tsType;
-    });
+    for (const { param, contribution } of contributions) {
+      if (contribution.kind === "drop") continue;
+      properties[param.name] = contribution.zod;
+    }
+
     let schema = "";
     for (const [key, value] of Object.entries(properties)) {
       schema += `"${key.replace(/"/g, '\\"')}": ${value}, `;
@@ -1771,13 +1822,17 @@ export class TypeScriptBuilder {
 
     // Build AgencyFunction.create() params metadata
     // Include all params (including block-typed) so .partial() can bind them by name.
-    // Block-typed params are separately excluded from the tool schema (buildToolDefinition).
+    // Block-typed (and any function-typed) params are separately excluded
+    // from the tool schema (buildToolDefinition); the `isFunctionTyped`
+    // flag is forwarded so the runtime backstop (validateForLLM) can
+    // re-check tool arrays it cannot see statically.
     const paramNodes = parameters.map((p) =>
       ts.obj({
         name: ts.str(p.name),
         hasDefault: ts.bool(!!p.defaultValue),
         defaultValue: ts.id("undefined"),
         variadic: ts.bool(!!p.variadic),
+        isFunctionTyped: ts.bool(isFunctionTyped(p)),
       }),
     );
 

--- a/packages/agency-lang/lib/backends/typescriptBuilder.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder.ts
@@ -1415,7 +1415,8 @@ export class TypeScriptBuilder {
 
     if (param.variadic) {
       // For `...xs: T[]`, the typeHint is the array type already; for the
-      // untyped fallback `...xs`, treat as `any[]`.
+      // untyped fallback `...xs`, fall back to `string[]` to match the
+      // historical default for untyped non-variadic params below.
       const elementHint =
         param.typeHint?.type === "arrayType"
           ? param.typeHint.elementType

--- a/packages/agency-lang/lib/backends/typescriptBuilder/namedArgsResolver.test.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/namedArgsResolver.test.ts
@@ -79,12 +79,14 @@ describe("resolveNamedArgs", () => {
     expect(result).toEqual([num(1)]);
   });
 
-  it("ignores variadic params when matching named args, but accepts block-type params by name", () => {
+  it("ignores variadic when no named arg targets it, and accepts block-type params by name", () => {
     const blockParam = param("blk", {
       typeHint: { type: "blockType" } as unknown as FunctionParameter["typeHint"],
     });
     const variadicParam = param("rest", { variadic: true });
-    // Variadic param is skipped — can't be filled by name.
+    // Variadic param IS now nameable (spec 2026-06-03), but when no named
+    // arg targets it the resolver leaves it empty — the result is just
+    // the supplied positional/named values.
     const result = resolveNamedArgs(
       call([named("a", num(1))]),
       [param("a"), variadicParam],
@@ -99,6 +101,33 @@ describe("resolveNamedArgs", () => {
       true,
     );
     expect(withBlockNamed).toEqual([num(1), num(2)]);
+  });
+
+  // Spec 2026-06-03 §1: named-arg targeting a variadic emits a splat into
+  // the lowered argument list so the runtime's resolvePositional gathers
+  // it back into a single array parameter.
+  it("emits a splat for a named-array variadic binding", () => {
+    const variadicParam = param("rest", { variadic: true });
+    const arr: Expression = { type: "agencyArray", items: [num(2), num(3)] } as any;
+    const result = resolveNamedArgs(
+      call([named("a", num(1)), named("rest", arr)]),
+      [param("a"), variadicParam],
+      true,
+    );
+    expect(result).toEqual([num(1), { type: "splat", value: arr }]);
+  });
+
+  it("rejects positional-after-named-variadic at the compile-time resolver", () => {
+    const variadicParam = param("rest", { variadic: true });
+    const arr: Expression = { type: "agencyArray", items: [num(3)] } as any;
+    // call: foo(1, 2, rest: [3]) — positional "2" past the fixed slot
+    expect(() =>
+      resolveNamedArgs(
+        call([num(1), num(2), named("rest", arr)]),
+        [param("a"), variadicParam],
+        true,
+      ),
+    ).toThrow(/Positional argument cannot feed variadic parameter 'rest'/);
   });
 
   it("throws on non-Agency function call with named args", () => {

--- a/packages/agency-lang/lib/backends/typescriptBuilder/namedArgsResolver.ts
+++ b/packages/agency-lang/lib/backends/typescriptBuilder/namedArgsResolver.ts
@@ -56,11 +56,14 @@ export function resolveNamedArgs(
     }
   }
 
-  // Collect named args, checking for duplicates and unknown names.
-  // Variadic params can't be passed by name (a splat fills them). Block-typed
-  // params CAN — they may be passed by name as a function reference, mirroring
-  // the runtime resolver in `agencyFunction.ts`.
+  // Collect named args, checking for duplicates and unknown names. All
+  // declared params — including variadics and block-typed — may be named.
+  // For variadic, the supplied value is the whole spread array (not
+  // element-wise). The mixed-rule (positional cannot feed a named-bound
+  // variadic) is enforced below. Keep in sync with the runtime resolver
+  // in `lib/runtime/agencyFunction.ts :: resolveNamed`.
   const nonVariadicParams = paramList.filter((p) => !p.variadic);
+  const variadicParam = paramList.find((p) => p.variadic);
   const namedArgMap = new Map<string, Expression>();
   for (let i = namedStartIdx; i < args.length; i++) {
     const arg = args[i] as NamedArgument;
@@ -69,18 +72,34 @@ export function resolveNamedArgs(
         `Duplicate named argument '${arg.name}' in call to '${node.functionName}'`,
       );
     }
-    const paramIdx = nonVariadicParams.findIndex((p) => p.name === arg.name);
+    const paramIdx = paramList.findIndex((p) => p.name === arg.name);
     if (paramIdx === -1) {
       throw new Error(
         `Unknown named argument '${arg.name}' in call to '${node.functionName}'`,
       );
     }
-    if (paramIdx < namedStartIdx) {
+    // Conflict check applies to fixed params only; variadic conflicts are
+    // handled below by the mixed-rule check (the wording is more
+    // actionable: "positional cannot feed variadic" vs the generic
+    // "conflicts" message).
+    const isVariadic = variadicParam?.name === arg.name;
+    if (!isVariadic && paramIdx < namedStartIdx) {
       throw new Error(
         `Named argument '${arg.name}' conflicts with positional argument at position ${paramIdx + 1} in call to '${node.functionName}'`,
       );
     }
     namedArgMap.set(arg.name, arg.value);
+  }
+
+  // Mixed positional + named-variadic rule: when the variadic is bound by
+  // name, no positional argument may exist past the fixed (non-variadic)
+  // parameter count. Keep in sync with `checkNamedArgStructure`.
+  if (variadicParam && namedArgMap.has(variadicParam.name)) {
+    if (namedStartIdx > nonVariadicParams.length) {
+      throw new Error(
+        `Positional argument cannot feed variadic parameter '${variadicParam.name}' when it is also bound by name in call to '${node.functionName}'`,
+      );
+    }
   }
 
   // Positional args stay in place (unwrapped).
@@ -90,7 +109,7 @@ export function resolveNamedArgs(
     result.push(a.type === "namedArgument" ? a.value : a);
   }
 
-  // Fill remaining parameter slots from named args, in parameter order.
+  // Fill remaining non-variadic parameter slots from named args.
   for (let i = namedStartIdx; i < nonVariadicParams.length; i++) {
     const param = nonVariadicParams[i];
     if (namedArgMap.has(param.name)) {
@@ -113,6 +132,20 @@ export function resolveNamedArgs(
         `Missing required argument '${param.name}' in call to '${node.functionName}'`,
       );
     }
+  }
+
+  // If the variadic was bound by name, splat its value array into the
+  // trailing argument slot. Emit as a SplatExpression so the existing
+  // call-site lowering treats it as a normal spread — the variadic-collect
+  // logic in `agencyFunction.ts :: resolvePositional` then gathers it back
+  // into a single array parameter. This is the simplest way to make the
+  // named-array form work end-to-end without a new emission path.
+  if (variadicParam && namedArgMap.has(variadicParam.name)) {
+    result.push({
+      type: "splat",
+      value: namedArgMap.get(variadicParam.name)!,
+    } as SplatExpression);
+    namedArgMap.delete(variadicParam.name);
   }
 
   return result;

--- a/packages/agency-lang/lib/runtime/agencyFunction.test.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { z } from "zod";
 import { AgencyFunction, UNSET } from "./agencyFunction.js";
 import { runInTestContext } from "./asyncContext.js";
 import { makeMockCtx } from "./__tests__/testHelpers.js";
@@ -245,11 +246,71 @@ describe("partial()", () => {
     expect(() => bound.partial({ a: 10 })).toThrow("already bound");
   });
 
-  it("throws when binding a variadic param", () => {
+  it("binds a variadic param via the named-array form", () => {
     const fn = makeFunction([
       { name: "messages", variadic: true },
     ]);
-    expect(() => fn.partial({ messages: ["hi"] })).toThrow("Variadic parameter");
+    const bound = fn.partial({ messages: ["hi", "there"] });
+    expect(bound.getUnboundParams()).toHaveLength(0);
+  });
+
+  it("rejects binding a variadic to a non-array value", () => {
+    const fn = makeFunction([
+      { name: "messages", variadic: true },
+    ]);
+    expect(() => fn.partial({ messages: "hi" })).toThrow(
+      "Variadic parameter 'messages' must be bound to an array",
+    );
+  });
+
+  // Spec 2026-06-03 §5.5 #47 (runtime half of the test). The type checker
+  // rejects this at compile time; the runtime is a backstop for callers
+  // that bypass the type checker (generated TS, manual runtime usage).
+  it("rejects positional args past the fixed count when variadic is bound by name", async () => {
+    const impl = (a: number, rest: number[]) => [a, rest];
+    const fn = AgencyFunction.create(
+      {
+        name: "foo",
+        module: "test.agency",
+        fn: impl,
+        params: [
+          { name: "a", hasDefault: false, defaultValue: undefined, variadic: false },
+          { name: "rest", hasDefault: false, defaultValue: undefined, variadic: true },
+        ],
+        toolDefinition: null,
+      },
+      {},
+    );
+    await expect(
+      fn.invoke({
+        type: "named",
+        positionalArgs: [1, 2],
+        namedArgs: { rest: [3] },
+      }),
+    ).rejects.toThrow(/Positional argument cannot feed variadic/);
+  });
+
+  it("accepts named-variadic binding via invoke (runtime mirror of compile-time test)", async () => {
+    const impl = (a: number, rest: number[]) => ({ a, rest });
+    const fn = AgencyFunction.create(
+      {
+        name: "foo",
+        module: "test.agency",
+        fn: impl,
+        params: [
+          { name: "a", hasDefault: false, defaultValue: undefined, variadic: false },
+          { name: "rest", hasDefault: false, defaultValue: undefined, variadic: true },
+        ],
+        toolDefinition: null,
+      },
+      {},
+    );
+    const out = await fn.invoke({
+      type: "named",
+      positionalArgs: [],
+      namedArgs: { a: 10, rest: [1, 2, 3] },
+    });
+    expect(out).toEqual({ a: 10, rest: [1, 2, 3] });
   });
 
   it("invoke on bound function merges args correctly", async () => {
@@ -327,6 +388,35 @@ describe("partial()", () => {
       namedArgs: { c: 30, b: 20 },
     });
     expect(result).toBe(60);
+  });
+
+  // Spec 2026-06-03 §5.6 #52: after PFA-binding a variadic, the reduced
+  // schema no longer carries the variadic's field.
+  it("removes the variadic field from the reduced schema after PFA binding", () => {
+    const schema = z.object({
+      a: z.number(),
+      rest: z.array(z.number()),
+    });
+    const fn = AgencyFunction.create(
+      {
+        name: "foo",
+        module: "test",
+        fn: () => {},
+        params: [
+          { name: "a", hasDefault: false, defaultValue: undefined, variadic: false },
+          { name: "rest", hasDefault: false, defaultValue: undefined, variadic: true },
+        ],
+        toolDefinition: {
+          name: "foo",
+          description: "Adds.",
+          schema,
+        },
+      },
+      {},
+    );
+    const bound = fn.partial({ rest: [1, 2] });
+    const newSchema = bound.toolDefinition!.schema as z.ZodObject<Record<string, z.ZodTypeAny>>;
+    expect(Object.keys(newSchema.shape)).toEqual(["a"]);
   });
 
   it("strips @param lines from tool description", () => {

--- a/packages/agency-lang/lib/runtime/agencyFunction.ts
+++ b/packages/agency-lang/lib/runtime/agencyFunction.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { stripBoundParams } from "./stripBoundParams.js";
 import { approve } from "./interrupts.js";
 import { agencyStore, withPushedHandler } from "./asyncContext.js";
+import { formatRequiredUnboundRuntimeError } from "./toolBlockDiagnostics.js";
 
 export const UNSET: unique symbol = Symbol("UNSET");
 
@@ -10,6 +11,16 @@ export type FuncParam = {
   hasDefault: boolean;
   defaultValue: unknown;
   variadic: boolean;
+  /**
+   * True when the parameter's declared type is (or contains) a function type
+   * — e.g. `block: () => void`, a union with a function arm, or a variadic
+   * whose element type is a function. Set by the codegen from the static
+   * `isFunctionTyped` predicate; consumed by `validateToolForLLM`.
+   *
+   * Defaults to false on legacy/handcrafted FuncParam values so the runtime
+   * backstop fails open (i.e. doesn't block valid tools).
+   */
+  isFunctionTyped?: boolean;
   boundValue?: unknown;
   isBound?: boolean;
 };
@@ -130,7 +141,10 @@ export class AgencyFunction {
   partial(bindings: Record<string, unknown>): AgencyFunction {
     if (Object.keys(bindings).length === 0) return this;
 
-    // Single pass: validate bindings against full param list
+    // Single pass: validate bindings against full param list. Variadic
+    // binding via the named-array form (`.partial(rest: [1,2])`) is allowed;
+    // the supplied value must be an array. Runtime backstop only — the
+    // type checker rejects shape mismatches earlier.
     for (const name of Object.keys(bindings)) {
       const param = this.params.find(p => p.name === name);
       if (!param) {
@@ -139,8 +153,10 @@ export class AgencyFunction {
       if (param.isBound) {
         throw new Error(`Parameter '${name}' is already bound`);
       }
-      if (param.variadic) {
-        throw new Error(`Variadic parameter '${name}' cannot be bound`);
+      if (param.variadic && !Array.isArray(bindings[name])) {
+        throw new Error(
+          `Variadic parameter '${name}' must be bound to an array in .partial(); got ${typeof bindings[name]}`,
+        );
       }
     }
 
@@ -268,17 +284,45 @@ export class AgencyFunction {
     namedArgs: Record<string, unknown>,
     blockArg?: unknown,
   ): unknown[] {
+    // The variadic — if any — is in `_unboundParams` but not in
+    // `_nonVariadicUnbound`. Named lookups search the full unbound list
+    // so `foo(rest: [1,2])` finds the variadic; conflict-with-positional
+    // checks use the non-variadic position index. Keep in sync with the
+    // compile-time resolver in `namedArgsResolver.ts :: resolveNamedArgs`.
+    const variadicParam = this._hasVariadic
+      ? this._unboundParams[this._unboundParams.length - 1]
+      : undefined;
+
     // Validate named args: no unknowns, no conflicts with positional
     for (const name of Object.keys(namedArgs)) {
       const paramIdx = this._nonVariadicUnbound.findIndex(p => p.name === name);
-      if (paramIdx === -1) {
+      const targetsVariadic = variadicParam && variadicParam.name === name;
+      if (paramIdx === -1 && !targetsVariadic) {
         throw new Error(
           `Unknown named argument '${name}' in call to '${this.name}'`,
         );
       }
-      if (paramIdx < positionalArgs.length) {
+      if (paramIdx !== -1 && paramIdx < positionalArgs.length) {
         throw new Error(
           `Named argument '${name}' conflicts with positional argument at position ${paramIdx + 1} in call to '${this.name}'`,
+        );
+      }
+    }
+
+    // Mixed positional + named-variadic rule: when the variadic is bound by
+    // name, no positional may exist past the fixed (non-variadic) param
+    // count. Mirrors the compile-time check; runs as a backstop for
+    // generated TS / direct runtime callers that bypass the type checker.
+    if (variadicParam && Object.hasOwn(namedArgs, variadicParam.name)) {
+      if (positionalArgs.length > this._nonVariadicUnbound.length) {
+        throw new Error(
+          `Positional argument cannot feed variadic parameter '${variadicParam.name}' when it is also bound by name in call to '${this.name}'`,
+        );
+      }
+      const value = namedArgs[variadicParam.name];
+      if (!Array.isArray(value)) {
+        throw new Error(
+          `Variadic parameter '${variadicParam.name}' must be bound to an array; got ${typeof value} in call to '${this.name}'`,
         );
       }
     }
@@ -326,8 +370,33 @@ export class AgencyFunction {
       }
     }
 
+    // If the variadic was bound by name, splat its array into the trailing
+    // slot so resolvePositional gathers it back into a single-array param.
+    // This is the runtime mirror of the typescript builder behavior.
+    if (variadicParam && Object.hasOwn(namedArgs, variadicParam.name)) {
+      const arr = namedArgs[variadicParam.name] as unknown[];
+      for (const v of arr) result.push(v);
+    }
+
     // Apply variadic wrapping and default padding
     return this.resolvePositional(result);
+  }
+
+  /**
+   * Runtime backstop invoked once per tool by `runPrompt` immediately before
+   * issuing the LLM request. Throws if any required function-typed param is
+   * unbound — duplicating (intentionally) the type checker's check at the
+   * `llm(...)` site so dynamically-assembled tool arrays (`tools: [...base,
+   * x]`) are also covered. The error wording uses the same builder as the
+   * compile-time diagnostic so users see one consistent message.
+   */
+  validateForLLM(): void {
+    for (const p of this.params) {
+      if (!p.isFunctionTyped) continue;
+      if (p.isBound) continue;
+      if (p.hasDefault) continue;
+      throw new Error(formatRequiredUnboundRuntimeError(this.name, p.name));
+    }
   }
 
   // Serialization handled by FunctionRefReviver — toJSON() would conflict with the replacer pattern.

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -311,6 +311,13 @@ export async function runPrompt(args: {
     }
     return entry;
   });
+  // Runtime backstop for compile-time-undetectable cases (dynamic tool
+  // assembly, hand-written TS). Runs once per tool — before the LLM ever
+  // sees the schema — so failures surface at registration time, not deep
+  // inside an invocation when the missing block is called.
+  for (const fn of agencyFunctions) {
+    fn.validateForLLM();
+  }
   let tools = agencyFunctions
     .filter((fn) => fn.toolDefinition)
     .map((fn) => fn.toolDefinition!)

--- a/packages/agency-lang/lib/runtime/prompt.ts
+++ b/packages/agency-lang/lib/runtime/prompt.ts
@@ -311,20 +311,23 @@ export async function runPrompt(args: {
     }
     return entry;
   });
-  // Runtime backstop for compile-time-undetectable cases (dynamic tool
-  // assembly, hand-written TS). Runs once per tool — before the LLM ever
-  // sees the schema — so failures surface at registration time, not deep
-  // inside an invocation when the missing block is called.
-  for (const fn of agencyFunctions) {
-    fn.validateForLLM();
-  }
-  let tools = agencyFunctions
-    .filter((fn) => fn.toolDefinition)
-    .map((fn) => fn.toolDefinition!)
-    .filter((t) => !removedTools.includes(t.name));
-  let toolFunctions = agencyFunctions.filter(
+  // Drop removed tools first — they're never exposed to the LLM, so they
+  // shouldn't block the call with a backstop error for an unbound block
+  // they wouldn't have been asked to invoke anyway.
+  const exposedFunctions = agencyFunctions.filter(
     (fn) => !removedTools.includes(fn.name),
   );
+  // Runtime backstop for compile-time-undetectable cases (dynamic tool
+  // assembly, hand-written TS). Runs once per exposed tool — before the
+  // LLM ever sees the schema — so failures surface at registration time,
+  // not deep inside an invocation when the missing block is called.
+  for (const fn of exposedFunctions) {
+    fn.validateForLLM();
+  }
+  let tools = exposedFunctions
+    .filter((fn) => fn.toolDefinition)
+    .map((fn) => fn.toolDefinition!);
+  let toolFunctions = exposedFunctions;
 
   // Remove tools key from clientConfig before passing to smoltalk.
   // Also strip `memory` — it's a runtime-only directive that smoltalk

--- a/packages/agency-lang/lib/runtime/toolBlockDiagnostics.ts
+++ b/packages/agency-lang/lib/runtime/toolBlockDiagnostics.ts
@@ -1,0 +1,54 @@
+/**
+ * Single source of truth for the wording of "unbound function-typed tool
+ * parameter" diagnostics.
+ *
+ * Both the compile-time tool-binding validator
+ * (`lib/typeChecker/toolBlockBinding.ts`) and the runtime backstop
+ * (`AgencyFunction.validateForLLM` in `agencyFunction.ts`) emit messages
+ * built from `formatUnboundClause`. The canonical clause
+ *   `required function-typed parameter '<name>' is unbound`
+ * appears in both messages — the test plan (§5.4 #42) pins that overlap
+ * explicitly so the checker and runtime cannot drift apart silently.
+ */
+
+/** Canonical clause shared by compile-time and runtime errors. */
+export function formatUnboundClause(paramName: string): string {
+  return `required function-typed parameter '${paramName}' is unbound`;
+}
+
+/** Compile-time tool-binding diagnostic. */
+export function formatRequiredUnboundError(
+  toolName: string,
+  paramName: string,
+  paramType?: string,
+): string {
+  const typeFragment = paramType ? ` (${paramType})` : "";
+  return (
+    `Tool '${toolName}' has ${formatUnboundClause(paramName)}${typeFragment}. ` +
+    `Bind it with .partial(${paramName}: <value>) before passing as a tool.`
+  );
+}
+
+/** Runtime backstop diagnostic — same canonical clause, slightly different framing. */
+export function formatRequiredUnboundRuntimeError(
+  toolName: string,
+  paramName: string,
+): string {
+  return (
+    `Tool '${toolName}' cannot be passed to llm(): ${formatUnboundClause(paramName)}. ` +
+    `Use ${toolName}.partial(${paramName}: <value>) before passing.`
+  );
+}
+
+/** One aggregated warning per llm(...) site listing all optional drops. */
+export function formatOptionalUnboundWarning(
+  toolName: string,
+  paramNames: string[],
+): string {
+  const list = paramNames.map((n) => `'${n}'`).join(", ");
+  return (
+    `Tool '${toolName}' will be exposed to the LLM without optional ` +
+    `function-typed parameter(s): ${list}. The function body must handle ` +
+    `them as undefined.`
+  );
+}

--- a/packages/agency-lang/lib/runtime/toolBlockDiagnostics.ts
+++ b/packages/agency-lang/lib/runtime/toolBlockDiagnostics.ts
@@ -46,9 +46,13 @@ export function formatOptionalUnboundWarning(
   paramNames: string[],
 ): string {
   const list = paramNames.map((n) => `'${n}'`).join(", ");
+  // "Optional" here means the param declares a default value. When the
+  // LLM omits it, the normal defaulting path fills in that declared
+  // default (often `null`), not `undefined` — so the body must be ready
+  // to run with whatever the default is.
   return (
     `Tool '${toolName}' will be exposed to the LLM without optional ` +
-    `function-typed parameter(s): ${list}. The function body must handle ` +
-    `them as undefined.`
+    `function-typed parameter(s): ${list}. The function body must be ` +
+    `prepared to run with the declared default for each.`
   );
 }

--- a/packages/agency-lang/lib/runtime/validateToolForLLM.test.ts
+++ b/packages/agency-lang/lib/runtime/validateToolForLLM.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Spec 2026-06-03 Part 5.4: runtime tool-registration backstop.
+ *
+ * Direct unit tests for `AgencyFunction.validateForLLM`. The agency-js
+ * end-to-end test (test #39) lives separately so the smoltalk-mock
+ * round-trip is covered. The unified-wording check (test #42) is also
+ * included here because it cross-references the compile-time message
+ * produced by the validator.
+ */
+import { describe, expect, it } from "vitest";
+import { AgencyFunction } from "./agencyFunction.js";
+import { formatUnboundClause } from "./toolBlockDiagnostics.js";
+
+function makeFn(
+  params: {
+    name: string;
+    isFunctionTyped?: boolean;
+    hasDefault?: boolean;
+    variadic?: boolean;
+    isBound?: boolean;
+    boundValue?: unknown;
+  }[],
+) {
+  return new AgencyFunction({
+    name: "deploy",
+    module: "test.agency",
+    fn: async (...args: unknown[]) => args,
+    params: params.map((p) => ({
+      name: p.name,
+      hasDefault: p.hasDefault ?? false,
+      defaultValue: undefined,
+      variadic: p.variadic ?? false,
+      isFunctionTyped: p.isFunctionTyped ?? false,
+      isBound: p.isBound,
+      boundValue: p.boundValue,
+    })),
+    toolDefinition: null,
+  });
+}
+
+describe("AgencyFunction.validateForLLM (runtime tool backstop)", () => {
+  // #36 — rejects unbound required function-typed param.
+  it("throws when a required function-typed param is unbound", () => {
+    const fn = makeFn([{ name: "block", isFunctionTyped: true }]);
+    expect(() => fn.validateForLLM()).toThrow();
+    try {
+      fn.validateForLLM();
+    } catch (e: any) {
+      expect(e.message).toContain("deploy");
+      expect(e.message).toContain("block");
+      expect(e.message).toContain(".partial(");
+    }
+  });
+
+  // #37 — accepts when bound.
+  it("does not throw when the function-typed param is PFA-bound", () => {
+    const fn = makeFn([
+      { name: "block", isFunctionTyped: true, isBound: true, boundValue: () => {} },
+    ]);
+    expect(() => fn.validateForLLM()).not.toThrow();
+  });
+
+  // #38 — ignores optional unbound function-typed params (compile-time
+  // warning is the only signal).
+  it("does not throw for optional unbound function-typed params", () => {
+    const fn = makeFn([
+      { name: "block", isFunctionTyped: true, hasDefault: true },
+    ]);
+    expect(() => fn.validateForLLM()).not.toThrow();
+  });
+
+  // #36b — non-function-typed params are never the backstop's business.
+  it("does not throw for a required non-function-typed param", () => {
+    const fn = makeFn([{ name: "id", isFunctionTyped: false }]);
+    expect(() => fn.validateForLLM()).not.toThrow();
+  });
+
+  // #42 — unified runtime/compile-time error wording. The canonical clause
+  // `required function-typed parameter '<name>' is unbound` appears in BOTH
+  // the compile-time error message (toolBlockBinding.test.ts #12) and the
+  // runtime error message thrown here. Pinning the shared substring keeps
+  // the two paths from drifting apart silently.
+  it("produces an error message containing the canonical unbound clause", () => {
+    const fn = makeFn([{ name: "block", isFunctionTyped: true }]);
+    expect(() => fn.validateForLLM()).toThrow(formatUnboundClause("block"));
+    expect(formatUnboundClause("block")).toBe(
+      "required function-typed parameter 'block' is unbound",
+    );
+  });
+});
+
+describe("AgencyFunction.partial — variadic shape backstop", () => {
+  // #41 — when the static type was `any` and a non-array value sneaks
+  // through, the runtime throws at .partial() time with a clear message.
+  it("throws when binding a variadic to a non-array value", () => {
+    const fn = new AgencyFunction({
+      name: "foo",
+      module: "test.agency",
+      fn: async (...args: unknown[]) => args,
+      params: [
+        {
+          name: "rest",
+          hasDefault: false,
+          defaultValue: undefined,
+          variadic: true,
+        },
+      ],
+      toolDefinition: null,
+    });
+    expect(() => fn.partial({ rest: "not-an-array" as any })).toThrow(
+      /must be bound to an array/,
+    );
+  });
+});

--- a/packages/agency-lang/lib/typeChecker.test.ts
+++ b/packages/agency-lang/lib/typeChecker.test.ts
@@ -5437,9 +5437,11 @@ describe("TypeChecker", () => {
       expect(typeCheck(program).errors).toHaveLength(0);
     });
 
-    it("named arg targeting a variadic param is rejected as unknown", () => {
-      // def collect(...xs: number[]) {}
-      // collect(xs=1)  ← variadic params can't be named
+    it("named arg targeting a variadic with wrong outer shape is a type error", () => {
+      // Spec 2026-06-03: named-arg form for variadics is allowed, but the
+      // value must be the *array* (spread), not a single element.
+      //   def collect(...xs: number[]) {}
+      //   collect(xs: 1)   ← 1 isn't a number[]
       const program: AgencyProgram = {
         type: "agencyProgram",
         nodes: [
@@ -5466,7 +5468,10 @@ describe("TypeChecker", () => {
         ],
       };
       const errors = typeCheck(program).errors;
-      expect(errors.some((e) => /Unknown named argument 'xs'/.test(e.message))).toBe(true);
+      // Should NOT report "unknown named argument" — the variadic IS nameable now.
+      expect(errors.some((e) => /Unknown named argument 'xs'/.test(e.message))).toBe(false);
+      // Should report an assignability error: number is not number[].
+      expect(errors.some((e) => /not assignable/.test(e.message) && /number\[\]/.test(e.message))).toBe(true);
     });
 
     it("named args on a builtin call error with a clear message", () => {
@@ -6610,7 +6615,10 @@ describe("TypeChecker", () => {
       expect(errors[0].message).toContain("Unknown parameter 'z'");
     });
 
-    it("should error when .partial() binds a variadic param", () => {
+    it("should error when .partial() binds a variadic to a non-array value", () => {
+      // After spec 2026-06-03, .partial() may bind a variadic via the
+      // named-array form (`log.partial(msgs: ["a","b"])`). Passing a scalar
+      // string in the bind slot is a type error — the slot is `string[]`.
       const program = partialProgram(
         "log",
         [
@@ -6620,7 +6628,30 @@ describe("TypeChecker", () => {
       );
       const { errors } = typeCheck(program);
       expect(errors).toHaveLength(1);
-      expect(errors[0].message).toContain("Variadic parameter 'msgs'");
+      expect(errors[0].message).toContain("not assignable");
+      expect(errors[0].expectedType).toBe("string[]");
+    });
+
+    it("should accept .partial() binding a variadic via the named-array form", () => {
+      const program = partialProgram(
+        "log",
+        [
+          { type: "functionParameter", name: "msgs", variadic: true, typeHint: { type: "arrayType", elementType: { type: "primitiveType", value: "string" } } },
+        ],
+        [{
+          type: "namedArgument",
+          name: "msgs",
+          value: {
+            type: "agencyArray",
+            items: [
+              { type: "string", segments: [{ type: "text", value: "a" }] },
+              { type: "string", segments: [{ type: "text", value: "b" }] },
+            ],
+          },
+        }],
+      );
+      const { errors } = typeCheck(program);
+      expect(errors).toEqual([]);
     });
 
     it("should error when .partial() uses positional args", () => {

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -54,14 +54,36 @@ type ParamSlot = {
   name?: string;
 };
 
+export type SlotRequest =
+  | { kind: "positional"; index: number }
+  | { kind: "named"; name: string };
+
+export type ParamSignature = {
+  minArgs: number;
+  maxArgs: number;
+  /** Declared parameter count (excludes splat pads). Used by splat
+   *  checking to iterate each declared slot once. */
+  paramCount: number;
+  /**
+   * Resolve the slot that an argument fills.
+   *
+   * - `{ kind: "positional", index }` — returns an element-typed slot for a
+   *   variadic, matching the spread calling convention.
+   * - `{ kind: "named", name }` — for variadics, returns a slot whose `type`
+   *   is the *array* form (`T[]`) so the call-site value `foo(rest: [1,2])`
+   *   type-checks against the whole array. Returns undefined for unknown
+   *   names (caught earlier by `checkNamedArgStructure`).
+   *
+   * No consumer should branch on `param.variadic` to pick element-vs-array
+   * itself — that's the rule this resolver encapsulates.
+   */
+  resolveSlot(req: SlotRequest): ParamSlot | undefined;
+};
+
 function paramListSignature(
   params: FunctionParameter[],
   argCount: number,
-): {
-  minArgs: number;
-  maxArgs: number;
-  slots: ParamSlot[];
-} {
+): ParamSignature {
   const lastParam = params[params.length - 1];
   const hasRest = lastParam?.variadic === true;
   // Schema<...> parameters are injection-eligible: the preprocessor's
@@ -76,28 +98,59 @@ function paramListSignature(
   ).length;
   const maxArgs = hasRest ? Infinity : params.length;
 
-  // Only nameable params (not variadic, not block-typed) get a `name` —
-  // matching the backend's nameableParams filter (typescriptBuilder.ts).
-  // Slots without names are unreachable by named-arg lookup, which is
-  // exactly what we want for variadic/block slots.
-  const isNameable = (p: FunctionParameter) =>
-    !p.variadic && p.typeHint?.type !== "blockType";
-  const slots: ParamSlot[] = params.map((p) => ({
+  // Internal positional slot list — variadic gets an element-typed slot.
+  const positionalSlots: ParamSlot[] = params.map((p) => ({
     type: p.typeHint,
     validated: !!p.validated,
-    name: isNameable(p) ? p.name : undefined,
+    name: p.name,
   }));
   if (hasRest) {
     const elementType = variadicElementType(lastParam);
     const restSlot: ParamSlot = {
       type: elementType,
-      validated: slots[slots.length - 1]?.validated ?? false,
-      // Variadic by definition; not nameable.
+      validated: positionalSlots[positionalSlots.length - 1]?.validated ?? false,
+      name: lastParam.name,
     };
-    slots[slots.length - 1] = restSlot;
-    while (slots.length < argCount) slots.push(restSlot);
+    positionalSlots[positionalSlots.length - 1] = restSlot;
+    while (positionalSlots.length < argCount) positionalSlots.push(restSlot);
   }
-  return { minArgs, maxArgs, slots };
+
+  return {
+    minArgs,
+    maxArgs,
+    paramCount: params.length,
+    resolveSlot(req) {
+      if (req.kind === "positional") return positionalSlots[req.index];
+      // Named lookup: find the declared param. For a variadic param, the
+      // named-arg form `foo(rest: [1,2])` binds the whole array, so the
+      // slot type is the array type (T[]) rather than the element type.
+      const idx = params.findIndex((p) => p.name === req.name);
+      if (idx < 0) return undefined;
+      const param = params[idx];
+      if (param.variadic) {
+        // The array type comes straight from the declaration (it's
+        // already `T[]` in the hint); fall back to wrapping the element
+        // type when the user wrote `...xs: T` rather than the
+        // conventional `...xs: T[]`.
+        const arrayType: VariableType | undefined =
+          param.typeHint?.type === "arrayType"
+            ? param.typeHint
+            : param.typeHint
+            ? { type: "arrayType", elementType: param.typeHint }
+            : undefined;
+        return {
+          type: arrayType,
+          validated: !!param.validated,
+          name: param.name,
+        };
+      }
+      return {
+        type: param.typeHint,
+        validated: !!param.validated,
+        name: param.name,
+      };
+    },
+  };
 }
 
 export function checkScopes(
@@ -193,12 +246,9 @@ function checkSingleFunctionCall(
   if (params) {
     if (!checkNamedArgStructure(call, params, ctx)) return;
     if (!checkBlockArgShape(call, params, ctx)) return;
-    const { minArgs, maxArgs, slots } = paramListSignature(
-      params,
-      call.arguments.length,
-    );
-    if (!checkArity(call, minArgs, maxArgs, hasSplatArg, ctx)) return;
-    checkArgsAgainstParams(call, slots, scope, ctx);
+    const sig = paramListSignature(params, call.arguments.length);
+    if (!checkArity(call, sig.minArgs, sig.maxArgs, hasSplatArg, ctx)) return;
+    checkArgsAgainstParams(call, sig, scope, ctx);
     return;
   }
 
@@ -276,7 +326,19 @@ function checkCallAgainstBuiltinSig(
       slots.push({ type: sig.restParam!, validated: false });
     }
   }
-  checkArgsAgainstParams(call, slots, scope, ctx);
+  // Builtins don't take named args (rejected above) and have no parameter
+  // names. Wrap the flat slot array in a minimal ParamSignature so the
+  // shared `checkArgsAgainstParams` path applies.
+  const builtinSig: ParamSignature = {
+    minArgs,
+    maxArgs,
+    paramCount: sig.params.length,
+    resolveSlot(req) {
+      if (req.kind === "positional") return slots[req.index];
+      return undefined;
+    },
+  };
+  checkArgsAgainstParams(call, builtinSig, scope, ctx);
 }
 
 /**
@@ -403,12 +465,12 @@ function checkNamedArgStructure(
     }
   }
 
-  // Pass 2: validate each named arg against the nameable params. Variadic
-  // params can't be passed by name (a splat is the only way to fill one).
-  // Block-typed params CAN be passed by name — either as a function
-  // reference (`block: fn`) or via the trailing block syntax (`as { ... }`).
-  // The runtime resolver rejects supplying both for the same param.
-  const nameableParams = params.filter((p) => !p.variadic);
+  // Pass 2: validate each named arg against the parameter list. All declared
+  // params — including variadics and block-typed params — can be passed by
+  // name. (For variadic, the named-array form `rest: [1,2]` binds the whole
+  // spread; for block params, `block: fn` works the same as the trailing
+  // `as { ... }` syntax. The runtime resolver rejects supplying both for
+  // the same param.)
   const seen = new Set<string>();
   for (let i = namedStartIdx; i < call.arguments.length; i++) {
     const arg = call.arguments[i];
@@ -420,7 +482,7 @@ function checkNamedArgStructure(
       continue;
     }
     seen.add(arg.name);
-    const paramIdx = nameableParams.findIndex((p) => p.name === arg.name);
+    const paramIdx = params.findIndex((p) => p.name === arg.name);
     if (paramIdx < 0) {
       pushErr(
         `Unknown named argument '${arg.name}' in call to '${call.functionName}'.`,
@@ -429,6 +491,29 @@ function checkNamedArgStructure(
       pushErr(
         `Named argument '${arg.name}' conflicts with positional argument at position ${paramIdx + 1} in call to '${call.functionName}'.`,
       );
+    }
+  }
+
+  // Pass 3: mixed positional + named-variadic rule. If any named arg targets
+  // a variadic parameter, no positional argument may exist past the last
+  // fixed (non-variadic) parameter — i.e. no positional may feed the
+  // variadic when it is also bound by name. See spec §1 "Mixed positional +
+  // named-variadic rule".
+  const variadicParam = params.find((p) => p.variadic);
+  if (variadicParam) {
+    const variadicNamed = call.arguments.find(
+      (a) => a.type === "namedArgument" && a.name === variadicParam.name,
+    );
+    if (variadicNamed) {
+      const fixedCount = params.filter((p) => !p.variadic).length;
+      // Positional args appear before namedStartIdx; any positional at
+      // index >= fixedCount would feed the variadic.
+      const positionalCount = Math.min(namedStartIdx, call.arguments.length);
+      if (positionalCount > fixedCount) {
+        pushErr(
+          `Positional argument cannot feed variadic parameter '${variadicParam.name}' when it is also bound by name in call to '${call.functionName}'.`,
+        );
+      }
     }
   }
 
@@ -479,7 +564,7 @@ function formatArity(minArgs: number, maxArgs: number): string {
  */
 function checkArgsAgainstParams(
   call: FunctionCall,
-  slots: ParamSlot[],
+  sig: ParamSignature,
   scope: Scope,
   ctx: TypeCheckerContext,
 ): void {
@@ -491,7 +576,7 @@ function checkArgsAgainstParams(
         call,
         arg.value,
         argIndex,
-        slots,
+        sig,
         scope,
         ctx,
       );
@@ -500,12 +585,12 @@ function checkArgsAgainstParams(
     let slot: ParamSlot | undefined;
     let innerArg: AgencyNode;
     if (arg.type === "namedArgument") {
-      // Unknown / variadic / block names are caught upstream in
-      // checkNamedArgStructure; lookup here is best-effort.
-      slot = slots.find((s) => s.name === arg.name);
+      // Unknown names are caught upstream in checkNamedArgStructure; the
+      // resolver returns undefined for them and we skip the check.
+      slot = sig.resolveSlot({ kind: "named", name: arg.name });
       innerArg = arg.value;
     } else {
-      slot = slots[argIndex];
+      slot = sig.resolveSlot({ kind: "positional", index: argIndex });
       innerArg = arg;
     }
     const argType = synthType(innerArg, scope, ctx);
@@ -546,7 +631,7 @@ function checkSplatAgainstRemainingParams(
   call: FunctionCall,
   splatSource: AgencyNode,
   splatIndex: number,
-  slots: ParamSlot[],
+  sig: ParamSignature,
   scope: Scope,
   ctx: TypeCheckerContext,
 ): void {
@@ -564,7 +649,12 @@ function checkSplatAgainstRemainingParams(
   const elementType = splatType.elementType;
   const elementStr = formatTypeHint(elementType);
   const typeAliases = ctx.getTypeAliases();
-  for (const slot of slots.slice(splatIndex)) {
+  // Check splat element type against each declared param slot from splatIndex
+  // onward. For a variadic-last function, position params.length-1 returns
+  // the element-typed slot, which is the right thing to compare against.
+  for (let i = splatIndex; i < sig.paramCount; i++) {
+    const slot = sig.resolveSlot({ kind: "positional", index: i });
+    if (!slot) continue;
     const paramType = slot.type;
     if (paramType === undefined || paramType === "any") continue;
     if (isAssignable(elementType, paramType, typeAliases)) continue;

--- a/packages/agency-lang/lib/typeChecker/checker.ts
+++ b/packages/agency-lang/lib/typeChecker/checker.ts
@@ -47,6 +47,24 @@ function variadicElementType(
   return param.typeHint ?? "any";
 }
 
+/**
+ * Array-typed slot for the named-arg form of a variadic.
+ *
+ * `foo(rest: [1, 2, 3])` binds the whole array, so the slot type is the
+ * array (`T[]`), not the element (`T`). For declarations written as the
+ * conventional `...xs: T[]`, the typeHint is already the array; for the
+ * less-conventional `...xs: T`, we wrap the element type ourselves.
+ * Returns `undefined` when the param is untyped — the caller treats that
+ * as `any`.
+ */
+function variadicNamedSlotType(
+  typeHint: VariableType | undefined,
+): VariableType | undefined {
+  if (!typeHint) return undefined;
+  if (typeHint.type === "arrayType") return typeHint;
+  return { type: "arrayType", elementType: typeHint };
+}
+
 type ParamSlot = {
   type: VariableType | "any" | undefined;
   validated: boolean;
@@ -128,18 +146,8 @@ function paramListSignature(
       if (idx < 0) return undefined;
       const param = params[idx];
       if (param.variadic) {
-        // The array type comes straight from the declaration (it's
-        // already `T[]` in the hint); fall back to wrapping the element
-        // type when the user wrote `...xs: T` rather than the
-        // conventional `...xs: T[]`.
-        const arrayType: VariableType | undefined =
-          param.typeHint?.type === "arrayType"
-            ? param.typeHint
-            : param.typeHint
-            ? { type: "arrayType", elementType: param.typeHint }
-            : undefined;
         return {
-          type: arrayType,
+          type: variadicNamedSlotType(param.typeHint),
           validated: !!param.validated,
           name: param.name,
         };

--- a/packages/agency-lang/lib/typeChecker/index.ts
+++ b/packages/agency-lang/lib/typeChecker/index.ts
@@ -40,6 +40,7 @@ import {
 } from "./interruptAnalysis.js";
 import { checkUndefinedFunctions } from "./undefinedFunctionDiagnostic.js";
 import { checkUndefinedVariables } from "./undefinedVariableDiagnostic.js";
+import { checkToolBlockBindings } from "./toolBlockBinding.js";
 import { RESERVED_FUNCTION_NAMES } from "./resolveCall.js";
 import { validateStaticInit } from "./validateStaticInit.js";
 import { walkNodes } from "../utils/node.js";
@@ -302,6 +303,13 @@ export class TypeChecker {
 
     // 8. Check for undefined variable references (config-controlled severity).
     checkUndefinedVariables(scopes, ctx);
+
+    // 9a. Tool-position binding validator: at every llm(...) call site
+    // with a statically-known tools array, require every function-typed
+    // parameter to be bound (error) or warn when an optional one is left
+    // dropped. See lib/typeChecker/toolBlockBinding.ts for the helpers
+    // and docs/superpowers/specs/2026-06-03-tool-params-blocks-and-variadics-design.md §4.2(e).
+    checkToolBlockBindings(this.program, ctx);
 
     // 9. Validate static initializers + `static <bare>` statements.
     // Direct-only checks against the Phase A surface — per-run-only

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -423,6 +423,7 @@ function validateAgencyFunctionMethod(
   expr: ValueAccess,
   element: { kind: "methodCall"; functionCall: { type: "functionCall"; functionName: string; arguments: any[] } },
   methodName: string,
+  scope: Scope,
   ctx: TypeCheckerContext,
 ): void {
   const baseName =
@@ -447,6 +448,7 @@ function validateAgencyFunctionMethod(
     const namedArgs = args.filter(
       (a: any) => "type" in a && a.type === "namedArgument",
     );
+    const typeAliases = ctx.getTypeAliases();
     for (const arg of namedArgs) {
       if (!paramNames.has(arg.name)) {
         ctx.errors.push({
@@ -456,11 +458,27 @@ function validateAgencyFunctionMethod(
         continue;
       }
       const param = params.find((p) => p.name === arg.name);
-      if (param?.variadic) {
-        ctx.errors.push({
-          message: `Variadic parameter '${arg.name}' cannot be bound in .partial().`,
-          loc: expr.loc,
-        });
+      if (!param) continue;
+      // Variadic binding via .partial(rest: [...]) is allowed. The value's
+      // type must match the variadic's array type (T[]), not the element
+      // type T. Non-variadic params are type-checked by the regular call-arg
+      // assignability path; we only validate variadic here because it would
+      // otherwise be invisible to that pass.
+      if (param.variadic) {
+        if (!param.typeHint) continue;
+        const expected: VariableType = param.typeHint.type === "arrayType"
+          ? param.typeHint
+          : { type: "arrayType", elementType: param.typeHint };
+        const actual = synthType(arg.value, scope, ctx);
+        if (actual === "any") continue;
+        if (!isAssignable(actual, expected, typeAliases)) {
+          ctx.errors.push({
+            message: `Argument type '${formatTypeHint(actual)}' is not assignable to parameter type '${formatTypeHint(expected)}' in .partial() call to '${baseName}'.`,
+            expectedType: formatTypeHint(expected),
+            actualType: formatTypeHint(actual),
+            loc: expr.loc,
+          });
+        }
       }
     }
     return;
@@ -515,7 +533,7 @@ export function synthValueAccess(
     if (element.kind === "methodCall") {
       const methodName = element.functionCall.functionName;
       if (methodName === "partial" || methodName === "describe" || methodName === "preapprove") {
-        validateAgencyFunctionMethod(expr, element, methodName, ctx);
+        validateAgencyFunctionMethod(expr, element, methodName, scope, ctx);
         currentType = "any";
         continue;
       }

--- a/packages/agency-lang/lib/typeChecker/toolBlockBinding.test.ts
+++ b/packages/agency-lang/lib/typeChecker/toolBlockBinding.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Spec 2026-06-03 Part 5.2: tool-position binding check.
+ *
+ * Every assertion pins both the absence of unrelated diagnostics AND the
+ * presence of the specific error/warning the validator must produce — a
+ * silent regression in the optional-vs-required split, the union-with-
+ * function classification, or the variadic-of-function handling will
+ * fail one of these tests.
+ */
+import { describe, expect, it } from "vitest";
+import { writeFileSync, unlinkSync, mkdtempSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
+import { isFunctionTyped } from "./utils.js";
+import { formatUnboundClause } from "../runtime/toolBlockDiagnostics.js";
+
+function checkSource(source: string): TypeCheckError[] {
+  const file = path.join(
+    os.tmpdir(),
+    `tc-tbb-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`,
+  );
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath);
+    const parseResult = parseAgency(source, {});
+    if (!parseResult.success) {
+      throw new Error("Parse failed: " + parseResult.message);
+    }
+    const program = parseResult.result;
+    const info = buildCompilationUnit(program, symbolTable, absPath, source);
+    return typeCheck(program, {}, info).errors;
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+const errorsOnly = (es: TypeCheckError[]) => es.filter((e) => e.severity !== "warning");
+const warningsOnly = (es: TypeCheckError[]) => es.filter((e) => e.severity === "warning");
+const findContaining = (es: TypeCheckError[], ...needles: string[]) =>
+  es.find((e) => needles.every((n) => e.message.includes(n)));
+
+describe("tool-position binding check (compile-time)", () => {
+  // #12
+  it("errors on required function-typed param unbound in a literal tools array", () => {
+    const diags = checkSource(`
+      def deploy(block: () => void): void {}
+      node main() {
+        llm("x", { tools: [deploy] })
+      }
+    `);
+    const errs = errorsOnly(diags);
+    expect(errs.length).toBe(1);
+    const e = errs[0];
+    expect(e.message).toContain("deploy");
+    expect(e.message).toContain("block");
+    expect(e.message).toContain(".partial(");
+    expect(e.loc).toBeDefined();
+  });
+
+  // #13 — Agency accepts `= null` for optional block params (see
+  // stdlib/thread.agency :: guard). We use that as the canonical
+  // optional-block declaration form.
+  it("warns (not errors) on optional function-typed param unbound", () => {
+    const diags = checkSource(`
+      def deploy(block: () => void = null): void {}
+      node main() {
+        llm("x", { tools: [deploy] })
+      }
+    `);
+    expect(errorsOnly(diags)).toEqual([]);
+    const warns = warningsOnly(diags);
+    expect(warns.length).toBe(1);
+    expect(warns[0].message).toContain("deploy");
+    expect(warns[0].message).toContain("block");
+    expect(warns[0].loc).toBeDefined();
+  });
+
+  // #14
+  it("emits zero diagnostics when required block is PFA-bound", () => {
+    const diags = checkSource(`
+      def real(): void {}
+      def deploy(block: () => void): void {}
+      node main() {
+        llm("x", { tools: [deploy.partial(block: real)] })
+      }
+    `);
+    expect(errorsOnly(diags)).toEqual([]);
+    expect(warningsOnly(diags)).toEqual([]);
+  });
+
+  // #15 — union-with-function required, unbound → error. (Agency's
+  // blockType params are positional; the parser writes them as
+  // `(number)` not `(x: number)`.)
+  it("errors on union-with-function required parameter unbound", () => {
+    const diags = checkSource(`
+      def foo(block: ((number) => number) | string): void {}
+      node main() {
+        llm("x", { tools: [foo] })
+      }
+    `);
+    const errs = errorsOnly(diags);
+    const e = findContaining(errs, "foo", "block", ".partial(");
+    expect(e).toBeDefined();
+  });
+
+  // #16 — union-with-function optional → warning.
+  it("warns on union-with-function optional parameter unbound", () => {
+    const diags = checkSource(`
+      def foo(block: ((number) => number) | string = "x"): void {}
+      node main() {
+        llm("x", { tools: [foo] })
+      }
+    `);
+    expect(errorsOnly(diags)).toEqual([]);
+    const warns = warningsOnly(diags);
+    expect(warns.length).toBe(1);
+    expect(warns[0].message).toContain("foo");
+    expect(warns[0].message).toContain("block");
+  });
+
+  // #17 — variadic-of-function required, unbound → error.
+  it("errors on variadic-of-function required parameter unbound", () => {
+    const diags = checkSource(`
+      def foo(...handlers: ((number) => number)[]): void {}
+      node main() {
+        llm("x", { tools: [foo] })
+      }
+    `);
+    const errs = errorsOnly(diags);
+    const e = findContaining(errs, "foo", "handlers", ".partial(");
+    expect(e).toBeDefined();
+  });
+
+  // #18 — Agency's grammar does not currently support a default value on
+  // a variadic param (`...xs: T[] = []` fails to parse), so the
+  // "optional variadic-of-function" path cannot be exercised through
+  // source today. The classifier nevertheless honors `defaultValue` on
+  // a variadic if it ever gains parser support — see the unit-level
+  // helper test below for that path.
+  it("classifies a variadic-of-function with a defaultValue as optional (helper-level)", () => {
+    const variadicOfFn: any = {
+      type: "functionParameter",
+      name: "handlers",
+      variadic: true,
+      defaultValue: { type: "array", items: [] },
+      typeHint: {
+        type: "arrayType",
+        elementType: {
+          type: "blockType",
+          params: [{ name: "_0", typeAnnotation: { type: "primitiveType", value: "number" } }],
+          returnType: { type: "primitiveType", value: "number" },
+        },
+      },
+    };
+    expect(isFunctionTyped(variadicOfFn)).toBe(true);
+    // Optional-vs-required logic lives in `classifyToolParam`; mirror it
+    // here so the assertion survives even if the helper is moved.
+    expect(variadicOfFn.defaultValue !== undefined).toBe(true);
+  });
+
+  // #19 — imported function as tool. Wire by writing two files and pointing
+  // the second's import at the first via the symbol table.
+  it("errors on imported function as tool with unbound required block", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "tbb-imp-"));
+    const libFile = path.join(dir, "lib.agency");
+    writeFileSync(
+      libFile,
+      `export def deploy(block: () => void): void {}\n`,
+    );
+    const mainFile = path.join(dir, "main.agency");
+    const mainSource =
+      `import { deploy } from "./lib.agency"\n` +
+      `node main() {\n` +
+      `  llm("x", { tools: [deploy] })\n` +
+      `}\n`;
+    writeFileSync(mainFile, mainSource);
+    try {
+      const symbolTable = SymbolTable.build(mainFile);
+      const parseResult = parseAgency(mainSource, {});
+      if (!parseResult.success) throw new Error(parseResult.message);
+      const program = parseResult.result;
+      const info = buildCompilationUnit(
+        program,
+        symbolTable,
+        mainFile,
+        mainSource,
+      );
+      const errs = errorsOnly(typeCheck(program, {}, info).errors);
+      const e = findContaining(errs, "deploy", "block", ".partial(");
+      expect(e).toBeDefined();
+    } finally {
+      unlinkSync(libFile);
+      unlinkSync(mainFile);
+    }
+  });
+
+  // #20 — .partial(...).preapprove() chain keeps the bound signal.
+  it("emits no error for .partial(block: real).preapprove()", () => {
+    const diags = checkSource(`
+      def real(): void {}
+      def deploy(block: () => void): void {}
+      node main() {
+        llm("x", { tools: [deploy.partial(block: real).preapprove()] })
+      }
+    `);
+    expect(errorsOnly(diags)).toEqual([]);
+  });
+
+  // #21 — reverse order .preapprove().partial(...). Same expectation if it parses.
+  it("emits no error for .preapprove().partial(block: real)", () => {
+    const diags = checkSource(`
+      def real(): void {}
+      def deploy(block: () => void): void {}
+      node main() {
+        llm("x", { tools: [deploy.preapprove().partial(block: real)] })
+      }
+    `);
+    // Either zero diagnostics (chain order allowed) OR a parse/type error
+    // explicitly about ordering. Currently we accept any chain order.
+    expect(errorsOnly(diags)).toEqual([]);
+  });
+
+  // #22 — spread-into-tools is deferred to the runtime backstop.
+  it("emits no compile-time diagnostic for tools: [...base, validate] with unbound required block", () => {
+    const diags = checkSource(`
+      def validate(block: () => void): void {}
+      node main() {
+        let base: any[] = []
+        llm("x", { tools: [...base, validate] })
+      }
+    `);
+    // Validator must NOT fire — runtime backstop owns this case.
+    const errs = errorsOnly(diags);
+    expect(errs.some((e) => e.message.includes("validate") && e.message.includes("block"))).toBe(false);
+  });
+
+  // #23 — identifier-as-tools is also deferred.
+  it("emits no compile-time diagnostic for tools: tools identifier", () => {
+    const diags = checkSource(`
+      def validate(block: () => void): void {}
+      node main() {
+        let tools: any[] = [validate]
+        llm("x", { tools: tools })
+      }
+    `);
+    const errs = errorsOnly(diags);
+    expect(errs.some((e) => e.message.includes("validate") && e.message.includes("block"))).toBe(false);
+  });
+
+  // #24 — error + warning coexist for a function with both unbound kinds.
+  it("emits an error AND a warning when a function has both required and optional unbound blocks", () => {
+    const diags = checkSource(`
+      def foo(req: () => void, opt: () => void = null): void {}
+      node main() {
+        llm("x", { tools: [foo] })
+      }
+    `);
+    const errs = errorsOnly(diags);
+    const warns = warningsOnly(diags);
+    expect(errs.length).toBe(1);
+    expect(errs[0].message).toContain("req");
+    expect(warns.length).toBe(1);
+    expect(warns[0].message).toContain("opt");
+  });
+
+  // #25 — required PFA-bound, optional dropped → still warns for the optional.
+  it("warns when required is PFA-bound and optional is left dropped", () => {
+    const diags = checkSource(`
+      def real(): void {}
+      def foo(req: () => void, opt: () => void = null): void {}
+      node main() {
+        llm("x", { tools: [foo.partial(req: real)] })
+      }
+    `);
+    expect(errorsOnly(diags)).toEqual([]);
+    const warns = warningsOnly(diags);
+    expect(warns.length).toBe(1);
+    expect(warns[0].message).toContain("opt");
+  });
+
+  // #26 — function with only function-typed params, all bound → zero diagnostics.
+  it("emits zero diagnostics when every function-typed param is PFA-bound", () => {
+    const diags = checkSource(`
+      def real(): void {}
+      def foo(req: () => void): void {}
+      node main() {
+        llm("x", { tools: [foo.partial(req: real)] })
+      }
+    `);
+    expect(errorsOnly(diags)).toEqual([]);
+    expect(warningsOnly(diags)).toEqual([]);
+  });
+
+  // #42 — compile-time half of the unified-wording check. The runtime half
+  // lives in `lib/runtime/validateToolForLLM.test.ts`. Both errors must
+  // contain `formatUnboundClause(paramName)` — that's what keeps the two
+  // paths from drifting apart silently.
+  it("compile-time error contains the canonical unbound clause", () => {
+    const diags = checkSource(`
+      def deploy(block: () => void): void {}
+      node main() {
+        llm("x", { tools: [deploy] })
+      }
+    `);
+    const errs = errorsOnly(diags);
+    expect(errs.length).toBe(1);
+    expect(errs[0].message).toContain(formatUnboundClause("block"));
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/toolBlockBinding.ts
+++ b/packages/agency-lang/lib/typeChecker/toolBlockBinding.ts
@@ -1,0 +1,211 @@
+/**
+ * Tool-position binding validator.
+ *
+ * Implements the primary (compile-time) layer of the function-typed-tool-
+ * parameter check described in `docs/superpowers/specs/2026-06-03-tool-params-blocks-and-variadics-design.md`
+ * §4.2(e). Every classification routes through a named helper so there is
+ * exactly one definition of each rule:
+ *
+ *   - `isFunctionTyped` (lib/typeChecker/utils.ts)  — shared with the
+ *     schema generator (lib/backends/typescriptBuilder.ts) and the runtime
+ *     backstop (lib/runtime/agencyFunction.ts :: validateForLLM).
+ *   - `isBound`, `classifyToolParam`, `resolveStaticTools`, `paramsOfTool`
+ *     — defined here; consumed only by this validator.
+ *   - `formatRequiredUnboundError`, `formatOptionalUnboundWarning`
+ *     (lib/runtime/toolBlockDiagnostics.ts) — shared with the runtime so
+ *     compile-time and runtime error wording cannot drift.
+ *
+ * The validator walks every `llm(...)` call, finds its statically-known
+ * tool expressions, classifies each function-typed parameter, and emits
+ * the right diagnostics. Dynamically-assembled tool arrays (spreads,
+ * identifiers) are intentionally skipped here — the runtime backstop
+ * (`AgencyFunction.validateForLLM`) covers them at request time.
+ */
+import {
+  AgencyNode,
+  AgencyProgram,
+  FunctionParameter,
+  ValueAccess,
+} from "../types.js";
+import { walkNodes } from "../utils/node.js";
+import {
+  formatOptionalUnboundWarning,
+  formatRequiredUnboundError,
+} from "../runtime/toolBlockDiagnostics.js";
+import { formatTypeHint } from "../utils/formatType.js";
+import { isFunctionTyped } from "./utils.js";
+import type { TypeCheckerContext } from "./types.js";
+
+/** Per-parameter outcome from a single tool expression. Total: every param
+ *  contributes exactly one classification. */
+type ParamClassification =
+  | { kind: "ok"; param: FunctionParameter }
+  | { kind: "required-unbound"; param: FunctionParameter }
+  | { kind: "optional-unbound"; param: FunctionParameter };
+
+/**
+ * True if `paramName` is statically observable as bound on `toolExpr`.
+ *
+ * Walks the method-call chain on a `valueAccess` looking for
+ * `.partial(<name>: ...)` calls. Other chain methods (`.describe`,
+ * `.preapprove`) pass through transparently — they don't bind or unbind
+ * parameters.
+ *
+ * Conservative: returns false when the chain is too dynamic to inspect
+ * (e.g. computed indices). The runtime backstop covers what we can't see.
+ */
+function isBound(toolExpr: AgencyNode, paramName: string): boolean {
+  if (toolExpr.type !== "valueAccess") return false;
+  for (const element of toolExpr.chain) {
+    if (element.kind !== "methodCall") continue;
+    if (element.functionCall.functionName !== "partial") continue;
+    for (const arg of element.functionCall.arguments) {
+      if (arg.type === "namedArgument" && arg.name === paramName) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Resolve a `tools:` option value to the list of statically-known tool
+ * expressions. Returns `[]` for shapes the validator cannot inspect
+ * (spread elements, bare identifiers, non-array expressions); the runtime
+ * backstop handles those cases at LLM-request time.
+ */
+function resolveStaticTools(opt: AgencyNode | undefined): AgencyNode[] {
+  if (!opt) return [];
+  if (opt.type !== "agencyArray") return [];
+  // If the array contains *any* spread, defer the whole thing to the
+  // runtime backstop. We can't see what the spread expands to, so
+  // emitting diagnostics for the visible elements alone would force
+  // users into awkward patterns ("validate must be either always
+  // present or always absent depending on whether you spread"). The
+  // spec (§5.2 #22) pins this behavior.
+  if (opt.items.some((item) => item.type === "splat")) return [];
+  return opt.items as AgencyNode[];
+}
+
+/** Extract the bare function name from a tool expression. Returns
+ *  undefined for shapes the validator cannot resolve. */
+function toolBaseName(toolExpr: AgencyNode): string | undefined {
+  if (toolExpr.type === "variableName") return toolExpr.value;
+  if (toolExpr.type === "valueAccess" && toolExpr.base.type === "variableName") {
+    return toolExpr.base.value;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a tool expression to its declared parameter list. Looks in
+ * `ctx.functionDefs` first (local definitions), then
+ * `ctx.importedFunctions` (cross-module). Returns undefined when the
+ * callable can't be resolved — happens for tools defined dynamically or
+ * imported via JS, and is the validator's signal to skip.
+ */
+function paramsOfTool(
+  toolExpr: AgencyNode,
+  ctx: TypeCheckerContext,
+): FunctionParameter[] | undefined {
+  const name = toolBaseName(toolExpr);
+  if (!name) return undefined;
+  const def = ctx.functionDefs[name];
+  if (def) return def.parameters;
+  const imported = ctx.importedFunctions[name];
+  if (imported) return imported.parameters;
+  return undefined;
+}
+
+/** Per-param classifier — required vs optional vs already-bound. */
+function classifyToolParam(
+  param: FunctionParameter,
+  toolExpr: AgencyNode,
+): ParamClassification {
+  if (isBound(toolExpr, param.name)) return { kind: "ok", param };
+  // "Optional" === has a default value (the function body can run without
+  // an LLM-supplied value). A variadic without an explicit default is
+  // still required for the purposes of this check: if the function's body
+  // calls into the variadic-of-functions, it expects callables. The spec
+  // (§2 "Variadic whose element type is a function type") makes this
+  // explicit.
+  if (param.defaultValue !== undefined) {
+    return { kind: "optional-unbound", param };
+  }
+  return { kind: "required-unbound", param };
+}
+
+/** Locate the `tools:` value inside an `llm(...)` call's options object. */
+function findToolsOption(llmCall: AgencyNode): AgencyNode | undefined {
+  if (llmCall.type !== "functionCall") return undefined;
+  if (llmCall.functionName !== "llm") return undefined;
+  const optsArg = llmCall.arguments[1];
+  if (!optsArg) return undefined;
+  // Options arg may itself be an unwrapped expression (positional) or a
+  // namedArgument (rare). For llm(prompt, { tools: [...] }) it's the
+  // agencyObject literal at arguments[1].
+  const inner = optsArg.type === "namedArgument" ? optsArg.value : optsArg;
+  if (inner.type !== "agencyObject") return undefined;
+  for (const entry of inner.entries) {
+    if ("type" in entry) continue; // splat: dynamic, skip
+    if (entry.computedKey) continue;
+    if (entry.key === "tools") return entry.value as AgencyNode;
+  }
+  return undefined;
+}
+
+/** Walk the program, emit diagnostics for each llm() call's tools array. */
+export function checkToolBlockBindings(
+  program: AgencyProgram,
+  ctx: TypeCheckerContext,
+): void {
+  for (const { node: llmCall } of walkNodes(program.nodes)) {
+    if (llmCall.type !== "functionCall" || llmCall.functionName !== "llm") {
+      continue;
+    }
+    const toolsOpt = findToolsOption(llmCall);
+    for (const toolExpr of resolveStaticTools(toolsOpt)) {
+      const params = paramsOfTool(toolExpr, ctx) ?? [];
+      const classifications = params
+        .filter(isFunctionTyped)
+        .map((p) => classifyToolParam(p, toolExpr));
+      emitDiagnostics(llmCall, toolExpr, classifications, ctx);
+    }
+  }
+}
+
+/**
+ * Sole formatter site for the tool-binding diagnostics. All wording flows
+ * through `formatRequiredUnboundError` / `formatOptionalUnboundWarning`,
+ * which the runtime backstop also calls — that's what makes the
+ * compile-time-vs-runtime unified-wording test (#42) pass by construction.
+ */
+function emitDiagnostics(
+  llmCall: AgencyNode,
+  toolExpr: AgencyNode,
+  classifications: ParamClassification[],
+  ctx: TypeCheckerContext,
+): void {
+  const toolName = toolBaseName(toolExpr) ?? "<tool>";
+  const optionalDropped: string[] = [];
+  for (const cls of classifications) {
+    if (cls.kind === "required-unbound") {
+      const typeStr = cls.param.typeHint
+        ? formatTypeHint(cls.param.typeHint)
+        : undefined;
+      ctx.errors.push({
+        message: formatRequiredUnboundError(toolName, cls.param.name, typeStr),
+        loc: llmCall.loc,
+      });
+    } else if (cls.kind === "optional-unbound") {
+      optionalDropped.push(cls.param.name);
+    }
+  }
+  if (optionalDropped.length > 0) {
+    ctx.errors.push({
+      message: formatOptionalUnboundWarning(toolName, optionalDropped),
+      severity: "warning",
+      loc: llmCall.loc,
+    });
+  }
+}

--- a/packages/agency-lang/lib/typeChecker/toolBlockBindingHelpers.test.ts
+++ b/packages/agency-lang/lib/typeChecker/toolBlockBindingHelpers.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Spec 2026-06-03 Part 5.2 (last bullet): isolated unit tests for the
+ * named helpers powering the tool-binding validator. A regression in a
+ * helper used to be diffused across integration-level diagnostics; these
+ * tests localize it.
+ */
+import { describe, expect, it } from "vitest";
+import type { FunctionParameter } from "../types.js";
+import type { VariableType } from "../types/typeHints.js";
+import { isFunctionTyped } from "./utils.js";
+
+const num: VariableType = { type: "primitiveType", value: "number" };
+const str: VariableType = { type: "primitiveType", value: "string" };
+const anyT: VariableType = { type: "primitiveType", value: "any" };
+const blockNumberToNumber: VariableType = {
+  type: "blockType",
+  params: [{ name: "_0", typeAnnotation: num }],
+  returnType: num,
+};
+
+const param = (
+  name: string,
+  typeHint?: VariableType,
+  variadic = false,
+): FunctionParameter => ({
+  type: "functionParameter",
+  name,
+  variadic,
+  typeHint,
+});
+
+describe("isFunctionTyped", () => {
+  it("returns true for a direct block type", () => {
+    expect(isFunctionTyped(param("block", blockNumberToNumber))).toBe(true);
+  });
+
+  it("returns true for a union containing a function arm", () => {
+    expect(
+      isFunctionTyped(
+        param("block", { type: "unionType", types: [blockNumberToNumber, str] }),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true for a variadic whose element type is a function", () => {
+    expect(
+      isFunctionTyped(
+        param(
+          "handlers",
+          { type: "arrayType", elementType: blockNumberToNumber },
+          true,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for a plain primitive type", () => {
+    expect(isFunctionTyped(param("a", num))).toBe(false);
+  });
+
+  it("returns false for a plain variadic of numbers", () => {
+    expect(
+      isFunctionTyped(
+        param("xs", { type: "arrayType", elementType: num }, true),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for `any` (documented limitation)", () => {
+    expect(isFunctionTyped(param("a", anyT))).toBe(false);
+  });
+
+  it("returns false for an untyped (no hint) param", () => {
+    expect(isFunctionTyped(param("a"))).toBe(false);
+  });
+
+  it("treats nested unions transparently", () => {
+    expect(
+      isFunctionTyped(
+        param("block", {
+          type: "unionType",
+          types: [
+            { type: "unionType", types: [blockNumberToNumber, num] },
+            str,
+          ],
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/utils.ts
+++ b/packages/agency-lang/lib/typeChecker/utils.ts
@@ -43,6 +43,43 @@ export function isAnyType(t: VariableType): boolean {
 }
 
 /**
+ * Returns true when the parameter's declared type cannot be filled in by an
+ * LLM through a JSON schema — i.e. it is (or contains) a function type.
+ *
+ * Single source of truth used by:
+ *   - the tool-position binding validator (lib/typeChecker/toolBlockBinding.ts)
+ *   - the tool schema generator (lib/backends/typescriptBuilder.ts :: buildToolDefinition)
+ *   - the runtime backstop (validateToolForLLM)
+ *
+ * Rules:
+ *   - A `blockType` (Agency's "(X) => Y") is function-typed.
+ *   - A `unionType` is function-typed if *any* arm is function-typed.
+ *     (Conservative — see docs/superpowers/specs/2026-06-03 §"Out of scope".)
+ *   - A variadic param `...xs: T[]` is function-typed iff the element type
+ *     `T` is function-typed (the LLM cannot fill an array of functions).
+ *   - `any` is NOT function-typed (accepted limitation; see spec §2 "any-typed
+ *     parameters").
+ */
+export function isFunctionTyped(param: FunctionParameter): boolean {
+  const hint = param.typeHint;
+  if (!hint) return false;
+  if (param.variadic) {
+    // For `...xs: T[]`, the typeHint shape is an arrayType wrapping the element.
+    // We check the element type. If the hint isn't an arrayType (e.g. untyped),
+    // it's not function-typed.
+    if (hint.type !== "arrayType") return false;
+    return typeContainsFunction(hint.elementType);
+  }
+  return typeContainsFunction(hint);
+}
+
+function typeContainsFunction(t: VariableType): boolean {
+  if (t.type === "blockType") return true;
+  if (t.type === "unionType") return t.types.some(typeContainsFunction);
+  return false;
+}
+
+/**
  * The `regex` primitive isn't representable in JSON, so an LLM can't return
  * one as structured output. Walk the expected LLM-call type and reject any
  * regex usage with a clear diagnostic, rather than silently emitting a

--- a/packages/agency-lang/lib/typeChecker/variadicNamedBinding.test.ts
+++ b/packages/agency-lang/lib/typeChecker/variadicNamedBinding.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Spec 2026-06-03 Part 5.1: named-arg targeting variadic.
+ *
+ * These tests pin the *positive* behaviors of the new named-array calling
+ * convention for variadic parameters AND the type-checker's rejection
+ * surface for the new error cases. Each test asserts both the absence
+ * of unrelated diagnostics and the presence of specific ones, so that
+ * a regression which silently drops the check still fails.
+ */
+import { describe, expect, it } from "vitest";
+import { writeFileSync, unlinkSync } from "fs";
+import path from "path";
+import os from "os";
+import { parseAgency } from "../parser.js";
+import { SymbolTable } from "../symbolTable.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+import type { TypeCheckError } from "./types.js";
+
+function checkSource(source: string): TypeCheckError[] {
+  const file = path.join(
+    os.tmpdir(),
+    `tc-vnb-${Date.now()}-${Math.random().toString(36).slice(2)}.agency`,
+  );
+  writeFileSync(file, source);
+  try {
+    const absPath = path.resolve(file);
+    const symbolTable = SymbolTable.build(absPath);
+    const parseResult = parseAgency(source, {});
+    if (!parseResult.success) {
+      throw new Error("Parse failed: " + parseResult.message);
+    }
+    const program = parseResult.result;
+    const info = buildCompilationUnit(program, symbolTable, absPath, source);
+    return typeCheck(program, {}, info).errors;
+  } finally {
+    unlinkSync(file);
+  }
+}
+
+const errorsOnly = (es: TypeCheckError[]) => es.filter((e) => e.severity !== "warning");
+const warningsOnly = (es: TypeCheckError[]) => es.filter((e) => e.severity === "warning");
+
+describe("variadic named-arg binding (compile-time)", () => {
+  // #1
+  it("accepts foo(xs: [1,2,3]) for ...xs: number[]", () => {
+    const diags = checkSource(`
+      def foo(...xs: number[]): number { return 0 }
+      node main() {
+        foo(xs: [1, 2, 3])
+      }
+    `);
+    expect(errorsOnly(diags)).toEqual([]);
+    expect(warningsOnly(diags)).toEqual([]);
+  });
+
+  // #2
+  it("accepts mixed positional + named variadic foo(1, rest: [2,3])", () => {
+    const diags = checkSource(`
+      def foo(a: number, ...rest: number[]): number { return a }
+      node main() {
+        foo(1, rest: [2, 3])
+      }
+    `);
+    expect(errorsOnly(diags)).toEqual([]);
+    expect(warningsOnly(diags)).toEqual([]);
+  });
+
+  // #3
+  it("accepts pure named form with fixed param foo(a: 1, rest: [2,3])", () => {
+    const diags = checkSource(`
+      def foo(a: number, ...rest: number[]): number { return a }
+      node main() {
+        foo(a: 1, rest: [2, 3])
+      }
+    `);
+    expect(errorsOnly(diags)).toEqual([]);
+  });
+
+  // #4
+  it("rejects positional-after-named-variadic foo(1, 2, rest: [3])", () => {
+    const diags = checkSource(`
+      def foo(a: number, ...rest: number[]): number { return a }
+      node main() {
+        foo(1, 2, rest: [3])
+      }
+    `);
+    const errs = errorsOnly(diags);
+    expect(errs.length).toBeGreaterThanOrEqual(1);
+    const match = errs.find(
+      (e) =>
+        e.message.includes("'rest'") &&
+        e.message.includes("'foo'") &&
+        /Positional argument cannot feed variadic/.test(e.message),
+    );
+    expect(match).toBeDefined();
+    expect(match!.loc).toBeDefined();
+  });
+
+  // #5: wrong outer shape — passing a scalar to a variadic-by-name slot.
+  it("rejects foo(rest: 5) for ...rest: number[] with assignability error", () => {
+    const diags = checkSource(`
+      def foo(...rest: number[]): number { return 0 }
+      node main() {
+        foo(rest: 5)
+      }
+    `);
+    const errs = errorsOnly(diags);
+    const a = errs.find((e) => /not assignable/.test(e.message));
+    expect(a).toBeDefined();
+    expect(a!.expectedType).toBe("number[]");
+    expect(a!.actualType).toBe("number");
+  });
+
+  // #6: wrong element type. Use a typed const so the array's element type
+  // synthesizes as `string[]`, not a union of string literals.
+  it("rejects foo(rest: typedStrs) for ...rest: number[] with assignability error", () => {
+    const diags = checkSource(`
+      def foo(...rest: number[]): number { return 0 }
+      node main() {
+        let xs: string[] = ["a", "b"]
+        foo(rest: xs)
+      }
+    `);
+    const errs = errorsOnly(diags);
+    const a = errs.find((e) => /not assignable/.test(e.message));
+    expect(a).toBeDefined();
+    expect(a!.expectedType).toBe("number[]");
+    expect(a!.actualType).toBe("string[]");
+  });
+
+  // #7: right element, wrong nesting — proves the named slot is T[], not T.
+  it("rejects foo(rest: [[1,2]]) for ...rest: number[]", () => {
+    const diags = checkSource(`
+      def foo(...rest: number[]): number { return 0 }
+      node main() {
+        foo(rest: [[1, 2]])
+      }
+    `);
+    const errs = errorsOnly(diags);
+    expect(errs.some((e) => /not assignable/.test(e.message))).toBe(true);
+  });
+
+  // #8: array-of-array variadic disambiguation.
+  it("accepts foo(xs: [[1,2],[3]]) for ...xs: number[][]", () => {
+    const diags = checkSource(`
+      def foo(...xs: number[][]): number { return 0 }
+      node main() {
+        foo(xs: [[1, 2], [3]])
+      }
+    `);
+    expect(errorsOnly(diags)).toEqual([]);
+  });
+
+  // #9: .partial() with named-array binds variadic; no legacy "cannot be bound" error.
+  it("accepts foo.partial(rest: [1,2]) for ...rest: number[]", () => {
+    const diags = checkSource(`
+      def foo(...rest: number[]): number { return 0 }
+      node main() {
+        let bound = foo.partial(rest: [1, 2])
+      }
+    `);
+    const errs = errorsOnly(diags);
+    expect(errs.some((e) => /cannot be bound/.test(e.message))).toBe(false);
+    expect(errs).toEqual([]);
+  });
+
+  // #10: .partial() with wrong array element type rejects.
+  it("rejects foo.partial(rest: typedStrs) for ...rest: number[]", () => {
+    const diags = checkSource(`
+      def foo(...rest: number[]): number { return 0 }
+      node main() {
+        let xs: string[] = ["a"]
+        let bound = foo.partial(rest: xs)
+      }
+    `);
+    const errs = errorsOnly(diags);
+    const a = errs.find((e) => /not assignable/.test(e.message));
+    expect(a).toBeDefined();
+    expect(a!.expectedType).toBe("number[]");
+  });
+
+  // #11: block-typed param still nameable as plain named arg (regression
+  // guard for the paramListSignature refactor).
+  it("still accepts block named arg foo(block: fn) for def foo(block: () => void)", () => {
+    const diags = checkSource(`
+      def cb(): void {}
+      def foo(block: () => void): void { block() }
+      node main() {
+        foo(block: cb)
+      }
+    `);
+    expect(errorsOnly(diags)).toEqual([]);
+  });
+});

--- a/packages/agency-lang/tests/agency/optional-block-dropped-from-schema.agency
+++ b/packages/agency-lang/tests/agency/optional-block-dropped-from-schema.agency
@@ -1,0 +1,22 @@
+// Spec 2026-06-03 §5.5 #50: a function whose block param is optional
+// (declared with `= null`) is dropped from the LLM tool schema (verified
+// by lib/backends/toolSchemaContribution.test.ts), and when invoked
+// without supplying it the body sees the default value (null).
+//
+// This hand-crafted agency test exercises the body's "did we get a
+// block?" branch — no LLM involved.
+def runWith(label: string, block: () => string = null): string {
+  if (block == null) {
+    return label + "/no-block"
+  }
+  return label + "/" + block()
+}
+
+node main() {
+  let omitted = runWith("a")
+  let supplied = runWith("b", block: \-> "hi")
+  return {
+    omitted: omitted,
+    supplied: supplied
+  }
+}

--- a/packages/agency-lang/tests/agency/optional-block-dropped-from-schema.test.json
+++ b/packages/agency-lang/tests/agency/optional-block-dropped-from-schema.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"omitted\":\"a/no-block\",\"supplied\":\"b/hi\"}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/pfa-bound-block-invoked.agency
+++ b/packages/agency-lang/tests/agency/pfa-bound-block-invoked.agency
@@ -1,0 +1,10 @@
+// Spec 2026-06-03 §5.5 #49: PFA-bound block parameter is correctly
+// invoked by the function body when the bound function is called.
+def runWith(block: () => number): number {
+  return block()
+}
+
+node main() {
+  let bound = runWith.partial(block: \-> 42)
+  return bound()
+}

--- a/packages/agency-lang/tests/agency/pfa-bound-block-invoked.test.json
+++ b/packages/agency-lang/tests/agency/pfa-bound-block-invoked.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "42",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/variadic-array-of-array.agency
+++ b/packages/agency-lang/tests/agency/variadic-array-of-array.agency
@@ -1,0 +1,15 @@
+// Spec 2026-06-03 §5.5 #46: array-of-array variadic. The named-array form
+// passes the *outer* array as the spread; with `...xs: number[][]` and
+// `xs: [[1,2],[3]]`, the body sees two elements (each itself an array of
+// numbers), not one element containing nested arrays.
+def foo(...xs: number[][]): any {
+  return {
+    count: xs.length,
+    first: xs[0],
+    second: xs[1]
+  }
+}
+
+node main() {
+  return foo(xs: [[1, 2], [3]])
+}

--- a/packages/agency-lang/tests/agency/variadic-array-of-array.test.json
+++ b/packages/agency-lang/tests/agency/variadic-array-of-array.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"count\":2,\"first\":[1,2],\"second\":[3]}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/variadic-mixed-positional-named.agency
+++ b/packages/agency-lang/tests/agency/variadic-mixed-positional-named.agency
@@ -1,0 +1,21 @@
+// Spec 2026-06-03 §5.5 #44, #45: mixed positional+named and pure named forms
+// with a fixed param and a named variadic.
+def foo(a: number, ...rest: number[]): any {
+  let total = 0
+  for (x in rest) { total = total + x }
+  return {
+    a: a,
+    total: total,
+    first: rest[0],
+    second: rest[1]
+  }
+}
+
+node main() {
+  let mixed = foo(1, rest: [2, 3])
+  let named = foo(a: 1, rest: [2, 3])
+  return {
+    mixed: mixed,
+    named: named
+  }
+}

--- a/packages/agency-lang/tests/agency/variadic-mixed-positional-named.test.json
+++ b/packages/agency-lang/tests/agency/variadic-mixed-positional-named.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"mixed\":{\"a\":1,\"total\":5,\"first\":2,\"second\":3},\"named\":{\"a\":1,\"total\":5,\"first\":2,\"second\":3}}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/variadic-named-arg-form.agency
+++ b/packages/agency-lang/tests/agency/variadic-named-arg-form.agency
@@ -1,0 +1,15 @@
+// Spec 2026-06-03 §5.5 #43: named-array form matches positional.
+def sum(...xs: number[]): number {
+  let total = 0
+  for (x in xs) { total = total + x }
+  return total
+}
+
+node main() {
+  let positional = sum(1, 2, 3)
+  let named = sum(xs: [1, 2, 3])
+  return {
+    positional: positional,
+    named: named
+  }
+}

--- a/packages/agency-lang/tests/agency/variadic-named-arg-form.test.json
+++ b/packages/agency-lang/tests/agency/variadic-named-arg-form.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"positional\":6,\"named\":6}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/agency/variadic-pfa-binding.agency
+++ b/packages/agency-lang/tests/agency/variadic-pfa-binding.agency
@@ -1,0 +1,18 @@
+// Spec 2026-06-03 §5.5 #48: PFA-bound variadic produces correct spread.
+// `foo.partial(rest: [1,2])` followed by `bound(a: 10)` must give the
+// body a=10, rest=[1,2].
+def foo(a: number, ...rest: number[]): any {
+  let total = 0
+  for (x in rest) { total = total + x }
+  return {
+    a: a,
+    sum: total,
+    first: rest[0],
+    second: rest[1]
+  }
+}
+
+node main() {
+  let bound = foo.partial(rest: [1, 2])
+  return bound(a: 10)
+}

--- a/packages/agency-lang/tests/agency/variadic-pfa-binding.test.json
+++ b/packages/agency-lang/tests/agency/variadic-pfa-binding.test.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "nodeName": "main",
+      "input": "",
+      "expectedOutput": "{\"a\":10,\"sum\":3,\"first\":1,\"second\":2}",
+      "evaluationCriteria": [
+        {
+          "type": "exact"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/agency-lang/tests/debugger/function-call-test.ts
+++ b/packages/agency-lang/tests/debugger/function-call-test.ts
@@ -305,12 +305,14 @@ const add = __AgencyFunction.create({
     name: "a",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "b",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "add",

--- a/packages/agency-lang/tests/debugger/nested-calls-test.ts
+++ b/packages/agency-lang/tests/debugger/nested-calls-test.ts
@@ -296,7 +296,8 @@ const double = __AgencyFunction.create({
     name: "n",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "double",
@@ -453,12 +454,14 @@ const addAndDouble = __AgencyFunction.create({
     name: "a",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "b",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "addAndDouble",

--- a/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
+++ b/packages/agency-lang/tests/typescriptBuilder/safe-function.mjs
@@ -278,7 +278,8 @@ const safeLookup = __AgencyFunction.create({
     name: "id",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "safeLookup",
@@ -430,7 +431,8 @@ const unsafeSave = __AgencyFunction.create({
     name: "id",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "unsafeSave",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncAssigned.mjs
@@ -284,7 +284,8 @@ const compute = __AgencyFunction.create({
     name: "val",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "compute",

--- a/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/asyncUnassigned.mjs
@@ -285,12 +285,14 @@ const append = __AgencyFunction.create({
     name: "sleepTime",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "value",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "append",

--- a/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangParams.mjs
@@ -289,7 +289,8 @@ const process = __AgencyFunction.create({
     name: "data",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "process",

--- a/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/bangReturnType.mjs
@@ -273,7 +273,8 @@ const process = __AgencyFunction.create({
     name: "x",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "process",

--- a/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockBasic.mjs
@@ -295,7 +295,8 @@ const twice = __AgencyFunction.create({
     name: "block",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: true
   }],
   toolDefinition: {
     name: "twice",

--- a/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/blockParams.mjs
@@ -306,12 +306,14 @@ const mapItems = __AgencyFunction.create({
     name: "items",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "block",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: true
   }],
   toolDefinition: {
     name: "mapItems",

--- a/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/defaultValues.mjs
@@ -293,12 +293,14 @@ const greet = __AgencyFunction.create({
     name: "name",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "greeting",
     hasDefault: true,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "greet",

--- a/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/docstrings.mjs
@@ -277,12 +277,14 @@ const add = __AgencyFunction.create({
     name: "a",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "b",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "add",
@@ -415,7 +417,8 @@ const greet = __AgencyFunction.create({
     name: "name",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "greet",
@@ -553,12 +556,14 @@ const calculateArea = __AgencyFunction.create({
     name: "width",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "height",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "calculateArea",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0004.mjs
@@ -306,7 +306,8 @@ const isPalindrome = __AgencyFunction.create({
     name: "n",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "isPalindrome",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0005.mjs
@@ -298,12 +298,14 @@ const gcd = __AgencyFunction.create({
     name: "a",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "b",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "gcd",
@@ -449,12 +451,14 @@ const lcm = __AgencyFunction.create({
     name: "a",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "b",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "lcm",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0007.mjs
@@ -339,7 +339,8 @@ const isPrime = __AgencyFunction.create({
     name: "n",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "isPrime",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0008.mjs
@@ -402,7 +402,8 @@ const toDigit = __AgencyFunction.create({
     name: "c",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "toDigit",

--- a/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/euler/euler-0010.mjs
@@ -339,7 +339,8 @@ const isPrime = __AgencyFunction.create({
     name: "n",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "isPrime",

--- a/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function-with-types.mjs
@@ -299,12 +299,14 @@ const add = __AgencyFunction.create({
     name: "x",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "y",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "add",
@@ -458,7 +460,8 @@ const greet = __AgencyFunction.create({
     name: "name",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "greet",
@@ -618,12 +621,14 @@ const mixed = __AgencyFunction.create({
     name: "count",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "label",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "mixed",
@@ -777,7 +782,8 @@ const processArray = __AgencyFunction.create({
     name: "items",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "processArray",
@@ -931,7 +937,8 @@ const flexible = __AgencyFunction.create({
     name: "value",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "flexible",

--- a/packages/agency-lang/tests/typescriptGenerator/function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/function.mjs
@@ -400,12 +400,14 @@ const add = __AgencyFunction.create({
     name: "a",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "b",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "add",

--- a/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/functionRef.mjs
@@ -273,7 +273,8 @@ const greet = __AgencyFunction.create({
     name: "name",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "greet",
@@ -410,7 +411,8 @@ const double = __AgencyFunction.create({
     name: "x",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "double",
@@ -567,12 +569,14 @@ const applyToAll = __AgencyFunction.create({
     name: "items",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "transform",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: true
   }],
   toolDefinition: {
     name: "applyToAll",

--- a/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/genericAliasValidation.mjs
@@ -290,7 +290,8 @@ const process = __AgencyFunction.create({
     name: "c",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "process",

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockBasic.mjs
@@ -295,7 +295,8 @@ const twice = __AgencyFunction.create({
     name: "block",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: true
   }],
   toolDefinition: {
     name: "twice",

--- a/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/inlineBlockParams.mjs
@@ -301,12 +301,14 @@ const mapItems = __AgencyFunction.create({
     name: "items",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "block",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: true
   }],
   toolDefinition: {
     name: "mapItems",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-2-deep-in-function.mjs
@@ -320,12 +320,14 @@ const greet = __AgencyFunction.create({
     name: "name",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "age",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "greet",
@@ -502,12 +504,14 @@ const foo2 = __AgencyFunction.create({
     name: "name",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "age",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "foo2",

--- a/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/interrupt-in-node.mjs
@@ -320,12 +320,14 @@ const greet = __AgencyFunction.create({
     name: "name",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "age",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "greet",

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgs.mjs
@@ -300,12 +300,14 @@ const greet = __AgencyFunction.create({
     name: "name",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "greeting",
     hasDefault: true,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "greet",

--- a/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/namedArgsReorder.mjs
@@ -285,17 +285,20 @@ const greet = __AgencyFunction.create({
     name: "name",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "greeting",
     hasDefault: true,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "punctuation",
     hasDefault: true,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "greet",

--- a/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/optionalParams.mjs
@@ -293,12 +293,14 @@ const greet = __AgencyFunction.create({
     name: "name",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "greeting",
     hasDefault: true,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "greet",

--- a/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/pipe-operator.mjs
@@ -273,7 +273,8 @@ const double = __AgencyFunction.create({
     name: "x",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "double",
@@ -416,12 +417,14 @@ const multiply = __AgencyFunction.create({
     name: "a",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "b",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "multiply",
@@ -578,12 +581,14 @@ const safeDivide = __AgencyFunction.create({
     name: "a",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "b",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "safeDivide",

--- a/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-basic.mjs
@@ -287,7 +287,8 @@ const checkAge = __AgencyFunction.create({
     name: "age",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "checkAge",

--- a/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/result-guards.mjs
@@ -287,7 +287,8 @@ const checkValue = __AgencyFunction.create({
     name: "r",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "checkValue",

--- a/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/schemaParamInjection.mjs
@@ -287,12 +287,14 @@ const parseValue = __AgencyFunction.create({
     name: "input",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "s",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "parseValue",

--- a/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/sourceMap.mjs
@@ -290,7 +290,8 @@ const greet = __AgencyFunction.create({
     name: "name",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "greet",

--- a/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
+++ b/packages/agency-lang/tests/typescriptGenerator/variadic.mjs
@@ -289,12 +289,14 @@ const log = __AgencyFunction.create({
     name: "prefix",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: false
+    variadic: false,
+    isFunctionTyped: false
   }, {
     name: "messages",
     hasDefault: false,
     defaultValue: undefined,
-    variadic: true
+    variadic: true,
+    isFunctionTyped: false
   }],
   toolDefinition: {
     name: "log",


### PR DESCRIPTION
## Summary

Implements the design spec at [`docs/superpowers/specs/2026-06-03-tool-params-blocks-and-variadics-design.md`](packages/agency-lang/docs/superpowers/specs/2026-06-03-tool-params-blocks-and-variadics-design.md). The PR makes variadic and block (function-typed) parameters first-class in tool calls and locks down how they interact with the LLM tool schema.

## What changed

### Variadics
- **Named-argument calls for variadics**: `foo(rest: [1,2,3])` is now valid across the type checker, runtime resolver, and `AgencyFunction.partial()`.
- **Mixed positional + named-variadic rule**: positional arguments are rejected when they would feed a variadic parameter that has already been bound by name.
- `paramListSignature` in `lib/typeChecker/checker.ts` now returns a `ParamSignature` with a `resolveSlot` method that encapsulates variadic slot logic (single source of truth).

### Block / function-typed params
- Tool schema generator omits function-typed parameters from the LLM-facing schema. Covers direct function types, unions with function arms, and variadics of functions.
- Two-layer enforcement for required function-typed parameters:
  - **Compile-time** check in the new `lib/typeChecker/toolBlockBinding.ts`.
  - **Runtime backstop** in `AgencyFunction.validateForLLM`.
- Canonical error/warning strings shared between compiler and runtime via `lib/runtime/toolBlockDiagnostics.ts`.
- `buildToolDefinition` in `lib/backends/typescriptBuilder.ts` refactored around a declarative `paramSchemaContribution` classifier with single definition sites (per §4.6 of the spec).

## Tests

- ~50 new tests covering the spec's full coverage matrix:
  - `lib/typeChecker/variadicNamedBinding.test.ts`
  - `lib/typeChecker/toolBlockBinding.test.ts`
  - `lib/typeChecker/toolBlockBindingHelpers.test.ts`
  - `lib/backends/toolSchemaContribution.test.ts`
  - `lib/runtime/validateToolForLLM.test.ts`
  - New `.agency` integration fixtures under `tests/agency/` for variadic-named-arg-form, variadic-mixed-positional-named, variadic-array-of-array, variadic-pfa-binding, pfa-bound-block-invoked, and optional-block-dropped-from-schema.
- Snapshot fixtures rebuilt via `make fixtures` to account for `AgencyFunction.create` metadata changes.

## Verification

Only 4 pre-existing baseline failures remain in the `ui` stdlib; no other regressions observed locally.
