### PR TITLE
typechecker: synth `??` as non-nullable LHS instead of `number`

### DIFF
--- a/packages/agency-lang/lib/typeChecker/nullishCoalesce.test.ts
+++ b/packages/agency-lang/lib/typeChecker/nullishCoalesce.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { parseAgency } from "../parser.js";
+import { buildCompilationUnit } from "../compilationUnit.js";
+import { typeCheck } from "./index.js";
+
+function check(source: string): string[] {
+  const parsed = parseAgency(source);
+  if (!parsed.success) throw new Error(`parse failed: ${parsed.message}`);
+  const info = buildCompilationUnit(parsed.result, undefined, undefined, source);
+  return typeCheck(parsed.result, {}, info).errors.map((e) => e.message);
+}
+
+describe("?? type synthesis", () => {
+  it("strips undefined from a nullable LHS union", () => {
+    // Before this fix, `??` fell through synthBinOp's switch and synthed as
+    // `number`, so this assignment would incorrectly error with
+    // "Type 'number' is not assignable to type 'string'".
+    const errs = check(`
+type S = { context: string | undefined }
+def f(s: S): string {
+  const out: string = s.context ?? ""
+  return out
+}
+`);
+    expect(errs).toEqual([]);
+  });
+
+  it("strips null from a nullable LHS union", () => {
+    const errs = check(`
+type S = { name: string | null }
+def f(s: S): string {
+  const out: string = s.name ?? "anon"
+  return out
+}
+`);
+    expect(errs).toEqual([]);
+  });
+
+  it("returns the LHS type when it is already non-nullable", () => {
+    const errs = check(`
+def f(): string {
+  const x: string = "hello"
+  const out: string = x ?? "fallback"
+  return out
+}
+`);
+    expect(errs).toEqual([]);
+  });
+
+  it("falls back to the RHS type when LHS is any", () => {
+    const errs = check(`
+def f(s: any): string {
+  const out: string = s ?? ""
+  return out
+}
+`);
+    expect(errs).toEqual([]);
+  });
+
+  it("still rejects assigning a ?? result to an incompatible target type", () => {
+    const errs = check(`
+type S = { context: string | undefined }
+def f(s: S): string {
+  const out: number = s.context ?? ""
+  return out
+}
+`);
+    expect(
+      errs.some((m) => m.includes("not assignable") && m.includes("number")),
+    ).toBe(true);
+  });
+});

--- a/packages/agency-lang/lib/typeChecker/synthesizer.ts
+++ b/packages/agency-lang/lib/typeChecker/synthesizer.ts
@@ -189,6 +189,7 @@ function synthBinOp(
   const op = expr.operator;
   if (op === "catch") return synthCatch(expr, scope, ctx);
   if (op === "|>") return synthPipe(expr, scope, ctx);
+  if (op === "??") return synthNullishCoalesce(expr, scope, ctx);
 
   // Dimension mismatch check: only when both sides are direct unit literals
   if (DIMENSION_CHECK_OPS.has(op) &&
@@ -213,6 +214,44 @@ function synthBinOp(
     }
   }
   return NUMBER_T;
+}
+
+/**
+ * `lhs ?? rhs` returns lhs if it is non-null/undefined, otherwise rhs.
+ * Strip `null` / `undefined` from a nullable LHS union so e.g.
+ * `(string | undefined) ?? ""` synths as `string`. If the LHS is `any`
+ * or collapses to nothing (LHS was `null | undefined`), fall back to
+ * the RHS type.
+ *
+ * Before this, `??` fell through to the bottom of synthBinOp and synthed
+ * as `number`, which silently corrupted assignments like
+ * `const s: string = maybeString ?? ""`.
+ */
+function synthNullishCoalesce(
+  expr: AgencyNode & { type: "binOpExpression" },
+  scope: Scope,
+  ctx: TypeCheckerContext,
+): VariableType | "any" {
+  const left = synthType(expr.left, scope, ctx);
+  if (left === "any") return synthType(expr.right, scope, ctx);
+  const stripped = stripNullable(left);
+  if (stripped === undefined) return synthType(expr.right, scope, ctx);
+  return stripped;
+}
+
+function isNullishPrimitive(t: VariableType): boolean {
+  return (
+    t.type === "primitiveType" && (t.value === "null" || t.value === "undefined")
+  );
+}
+
+function stripNullable(t: VariableType): VariableType | undefined {
+  if (isNullishPrimitive(t)) return undefined;
+  if (t.type !== "unionType") return t;
+  const kept = t.types.filter((m) => !isNullishPrimitive(m));
+  if (kept.length === 0) return undefined;
+  if (kept.length === 1) return kept[0];
+  return { ...t, types: kept };
 }
 
 /**


### PR DESCRIPTION
## Problem

The nullish-coalesce operator (`??`) had no case in `synthBinOp`, so it fell through the bottom of the switch and synthed as `number`. That made the typechecker reject any otherwise-correct expression like:

```agency
const out: string = maybeString ?? ""
//                  ^^^^^^^^^^^^^^^^^^
// error: Type 'number' is not assignable to type 'string'
```

Runtime behavior was always correct — only the typechecker was wrong. This was hit in `stdlib/ui.agency` (`const contextLine: string = status.context ?? ""`) and surfaced as a typecheck failure in the `stdlib: 'ui'` fixture test. There was even a pre-existing comment in `stdlib/ui.agency` calling out the issue and working around it with an `if`/`return` instead of `??`.

## Fix

Add `synthNullishCoalesce` (in `lib/typeChecker/synthesizer.ts`) that:

- strips `null` / `undefined` members from a nullable LHS union, so `(string | undefined) ?? ""` synths as `string`,
- falls back to the RHS type if the LHS is `any`, or if stripping nullables leaves nothing (LHS was literally `null | undefined`),
- otherwise returns the LHS type unchanged.

## Tests

New `lib/typeChecker/nullishCoalesce.test.ts` covers:

- stripping `| undefined` from a record property
- stripping `| null` from a record property
- no-op on an already-non-nullable LHS
- `any` LHS falling back to the RHS type
- still rejecting an incompatible target type (regression guard)

Full typeChecker suite (`lib/typeChecker/**/*.test.ts`, 725 tests across 37 files) passes locally.
